### PR TITLE
[expo-updates] Remove unused method storedUpdateIdsWithConfiguration

### DIFF
--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updatesinterface/UpdatesInterface.java
@@ -26,11 +26,6 @@ public interface UpdatesInterface {
      */
     boolean onManifestLoaded(JSONObject manifest);
   }
-
-  interface QueryCallback {
-    void onFailure(Exception e);
-    void onSuccess(List<UUID> updateIds);
-  }
   
   interface Update {
     JSONObject getManifest();
@@ -40,6 +35,4 @@ public interface UpdatesInterface {
   void reset();
 
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
-
-  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, QueryCallback callback);
 }

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public typealias AppLauncherUpdateCompletionBlock = (_ error: Error?, _ update: Update?) -> Void
-public typealias AppLauncherQueryCompletionBlock = (_ error: Error?, _ updateIds: [UUID]?) -> Void
 
 /**
  * Implementation of AppLauncher that uses the SQLite database and expo-updates file store
@@ -156,20 +155,6 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       }
     } else {
       finishLaunch()
-    }
-  }
-
-  public static func storedUpdateIds(
-    inDatabase database: UpdatesDatabase,
-    completion: @escaping AppLauncherQueryCompletionBlock
-  ) {
-    database.databaseQueue.async {
-      do {
-        let readyUpdateIds = try database.allUpdateIds(withStatus: .StatusReady)
-        completion(nil, readyUpdateIds)
-      } catch {
-        completion(error, nil)
-      }
     }
   }
 

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
@@ -401,15 +401,6 @@ public final class UpdatesDatabase: NSObject {
     }
   }
 
-  public func allUpdateIds(withStatus status: UpdateStatus) throws -> [UUID] {
-    let sql = "SELECT id FROM updates WHERE status = ?1;"
-    let rows = try execute(sql: sql, withArgs: [status.rawValue])
-    return rows.map { row in
-      // swiftlint:disable:next force_cast
-      row["id"] as! UUID
-    }
-  }
-
   public func launchableUpdates(withConfig config: UpdatesConfig) throws -> [Update] {
     // if an update has successfully launched at least once, we treat it as launchable
     // even if it has also failed to launch at least once

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/DevLauncherController.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/DevLauncherController.swift
@@ -117,29 +117,8 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
     }
   }
 
-  public func storedUpdateIds(
-    withConfiguration configuration: [String: Any],
-    success successBlock: @escaping UpdatesQuerySuccessBlock,
-    error errorBlock: @escaping UpdatesErrorBlock
-  ) {
-    guard setup(configuration: configuration, error: errorBlock) != nil else {
-      successBlock([])
-      return
-    }
-
-    AppLauncherWithDatabase.storedUpdateIds(
-      inDatabase: AppController.sharedInstance.database
-    ) { error, storedUpdateIds in
-      if let error = error {
-        errorBlock(error)
-      } else {
-        successBlock(storedUpdateIds!)
-      }
-    }
-  }
-
   /**
-   Common initialization for both fetchUpdateWithConfiguration: and storedUpdateIdsWithConfiguration:
+   Common initialization for fetchUpdateWithConfiguration:
    Sets up ABI49_0_0EXUpdatesAppController shared instance
    Returns the updatesConfiguration
    */

--- a/ios/versioned/sdk49/EXUpdatesInterface/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/ios/versioned/sdk49/EXUpdatesInterface/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -4,7 +4,6 @@ import Foundation
 
 public typealias UpdatesErrorBlock = (_ error: Error) -> Void
 public typealias UpdatesUpdateSuccessBlock = (_ manifest: [String: Any]?) -> Void
-public typealias UpdatesQuerySuccessBlock = (_ updateIds: [UUID]) -> Void
 public typealias UpdatesProgressBlock = (_ successfulAssetCount: UInt, _ failedAssetCount: UInt, _ totalAssetCount: UInt) -> Void
 
 /**
@@ -30,16 +29,6 @@ public protocol UpdatesExternalInterface {
     onManifest manifestBlock: @escaping UpdatesManifestBlock,
     progress progressBlock: @escaping UpdatesProgressBlock,
     success successBlock: @escaping UpdatesUpdateSuccessBlock,
-    error errorBlock: @escaping UpdatesErrorBlock
-  )
-
-  /**
-   * Obtains a list of UUIDs for updates already in the updates DB that are in the READY state.
-   * The success block will pass in the array of UUIDs
-   */
-  @objc func storedUpdateIds(
-    withConfiguration configuration: [String: Any],
-    success successBlock: @escaping UpdatesQuerySuccessBlock,
     error errorBlock: @escaping UpdatesErrorBlock
   )
 }

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Renamed `unimodule.json` to `expo-module.config.json`. ([#25100](https://github.com/expo/expo/pull/25100) by [@reichhartd](https://github.com/reichhartd))
+- Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
 
 ## 0.14.0 — 2023-10-17
 

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.java
@@ -26,11 +26,6 @@ public interface UpdatesInterface {
      */
     boolean onManifestLoaded(JSONObject manifest);
   }
-
-  interface QueryCallback {
-    void onFailure(Exception e);
-    void onSuccess(List<UUID> updateIds);
-  }
   
   interface Update {
     JSONObject getManifest();
@@ -40,6 +35,4 @@ public interface UpdatesInterface {
   void reset();
 
   void fetchUpdateWithConfiguration(HashMap<String, Object> configuration, Context context, UpdateCallback callback);
-
-  void storedUpdateIdsWithConfiguration(HashMap<String, Object> configuration, Context context, QueryCallback callback);
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -4,7 +4,6 @@ import Foundation
 
 public typealias UpdatesErrorBlock = (_ error: Error) -> Void
 public typealias UpdatesUpdateSuccessBlock = (_ manifest: [String: Any]?) -> Void
-public typealias UpdatesQuerySuccessBlock = (_ updateIds: [UUID]) -> Void
 public typealias UpdatesProgressBlock = (_ successfulAssetCount: UInt, _ failedAssetCount: UInt, _ totalAssetCount: UInt) -> Void
 
 /**
@@ -30,16 +29,6 @@ public protocol UpdatesExternalInterface {
     onManifest manifestBlock: @escaping UpdatesManifestBlock,
     progress progressBlock: @escaping UpdatesProgressBlock,
     success successBlock: @escaping UpdatesUpdateSuccessBlock,
-    error errorBlock: @escaping UpdatesErrorBlock
-  )
-
-  /**
-   * Obtains a list of UUIDs for updates already in the updates DB that are in the READY state.
-   * The success block will pass in the array of UUIDs
-   */
-  @objc func storedUpdateIds(
-    withConfiguration configuration: [String: Any],
-    success successBlock: @escaping UpdatesQuerySuccessBlock,
     error errorBlock: @escaping UpdatesErrorBlock
   )
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,6 +20,7 @@
 - iOS: Refactor responsibility of app controller. ([#24934](https://github.com/expo/expo/pull/24934), [#24949](https://github.com/expo/expo/pull/24949) by [@wschurman](https://github.com/wschurman))
 - Android: Refactor responsibility of app controller. ([#24954](https://github.com/expo/expo/pull/24954), [#24975](https://github.com/expo/expo/pull/24975) by [@wschurman](https://github.com/wschurman))
 - Android: Backport ExpoGoUpdatesModule to SDK 49. ([#24974](https://github.com/expo/expo/pull/24974) by [@wschurman](https://github.com/wschurman))
+- Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
 
 ## 0.18.17 — 2023-10-25
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -9,7 +9,6 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -40,69 +39,6 @@ class DatabaseLauncherTest {
   @After
   fun closeDb() {
     db.close()
-  }
-
-  @Test
-  fun testGetUpdateIds_EmptyDB() {
-    val launcher = DatabaseLauncher(
-      UpdatesConfiguration(null, null),
-      File("test"),
-      FileDownloader(context),
-      SelectionPolicy(
-        mockk(),
-        mockk(),
-        mockk()
-      )
-    )
-    val readyUpdateIds = launcher.getReadyUpdateIds(db)
-    Assert.assertEquals(0, readyUpdateIds.size)
-  }
-
-  @Test
-  fun testGetUpdateIds_DBWithOneUpdate() {
-    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
-    testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
-    testUpdate.status = UpdateStatus.READY
-    db.updateDao().insertUpdate(testUpdate)
-
-    val launcher = DatabaseLauncher(
-      UpdatesConfiguration(null, null),
-      File("test"),
-      FileDownloader(context),
-      SelectionPolicy(
-        mockk(),
-        mockk(),
-        mockk()
-      )
-    )
-    val readyUpdateIds = launcher.getReadyUpdateIds(db)
-    Assert.assertEquals(1, readyUpdateIds.size)
-  }
-
-  @Test
-  fun testGetUpdateIds_DBWithOneReadyUpdate() {
-    val testUpdate1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
-    testUpdate1.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
-    testUpdate1.status = UpdateStatus.READY
-    db.updateDao().insertUpdate(testUpdate1)
-
-    val testUpdate2 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
-    testUpdate2.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
-    testUpdate2.status = UpdateStatus.PENDING
-    db.updateDao().insertUpdate(testUpdate2)
-
-    val launcher = DatabaseLauncher(
-      UpdatesConfiguration(null, null),
-      File("test"),
-      FileDownloader(context),
-      SelectionPolicy(
-        mockk(),
-        mockk(),
-        mockk()
-      )
-    )
-    val readyUpdateIds = launcher.getReadyUpdateIds(db)
-    Assert.assertEquals(1, readyUpdateIds.size)
   }
 
   @Test

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -1021,30 +1021,6 @@ class UpdatesController private constructor(
       )
     }
 
-    override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdatesInterface.QueryCallback) {
-      val controller = UpdatesController.instance
-      val updatesConfiguration = UpdatesConfiguration(context, configuration)
-      if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
-        callback.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
-        return
-      }
-      val updatesDirectory = controller.updatesDirectory
-      if (updatesDirectory == null) {
-        callback.onFailure(controller.updatesDirectoryException)
-        return
-      }
-      val databaseHolder = controller.databaseHolder
-      val launcher = DatabaseLauncher(
-        updatesConfiguration,
-        updatesDirectory,
-        controller.fileDownloader,
-        controller.selectionPolicy
-      )
-      val readyUpdateIds = launcher.getReadyUpdateIds(databaseHolder.database)
-      controller.databaseHolder.releaseDatabase()
-      callback.onSuccess(readyUpdateIds)
-    }
-
     companion object {
       private var singletonInstance: UpdatesDevLauncherController? = null
       val instance: UpdatesDevLauncherController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -145,10 +145,6 @@ class DatabaseLauncher(
     return selectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters)
   }
 
-  fun getReadyUpdateIds(database: UpdatesDatabase): List<UUID> {
-    return database.updateDao().loadAllUpdateIdsWithStatus(UpdateStatus.READY)
-  }
-
   internal fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
     val assetFile = File(updatesDirectory, asset.relativePath)
     var assetFileExists = assetFile.exists()

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -1065,29 +1065,8 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
     }
   }
 
-  public func storedUpdateIds(
-    withConfiguration configuration: [String: Any],
-    success successBlock: @escaping UpdatesQuerySuccessBlock,
-    error errorBlock: @escaping UpdatesErrorBlock
-  ) {
-    guard setup(configuration: configuration, error: errorBlock) != nil else {
-      successBlock([])
-      return
-    }
-
-    AppLauncherWithDatabase.storedUpdateIds(
-      inDatabase: AppController.sharedInstance.database
-    ) { error, storedUpdateIds in
-      if let error = error {
-        errorBlock(error)
-      } else {
-        successBlock(storedUpdateIds!)
-      }
-    }
-  }
-
   /**
-   Common initialization for both fetchUpdateWithConfiguration: and storedUpdateIdsWithConfiguration:
+   Common initialization for both fetchUpdateWithConfiguration:
    Sets up EXUpdatesAppController shared instance
    Returns the updatesConfiguration
    */

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public typealias AppLauncherUpdateCompletionBlock = (_ error: Error?, _ update: Update?) -> Void
-public typealias AppLauncherQueryCompletionBlock = (_ error: Error?, _ updateIds: [UUID]?) -> Void
 
 /**
  * Implementation of AppLauncher that uses the SQLite database and expo-updates file store
@@ -156,20 +155,6 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       }
     } else {
       finishLaunch()
-    }
-  }
-
-  public static func storedUpdateIds(
-    inDatabase database: UpdatesDatabase,
-    completion: @escaping AppLauncherQueryCompletionBlock
-  ) {
-    database.databaseQueue.async {
-      do {
-        let readyUpdateIds = try database.allUpdateIds(withStatus: .StatusReady)
-        completion(nil, readyUpdateIds)
-      } catch {
-        completion(error, nil)
-      }
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -401,15 +401,6 @@ public final class UpdatesDatabase: NSObject {
     }
   }
 
-  public func allUpdateIds(withStatus status: UpdateStatus) throws -> [UUID] {
-    let sql = "SELECT id FROM updates WHERE status = ?1;"
-    let rows = try execute(sql: sql, withArgs: [status.rawValue])
-    return rows.map { row in
-      // swiftlint:disable:next force_cast
-      row["id"] as! UUID
-    }
-  }
-
   public func launchableUpdates(withConfig config: UpdatesConfig) throws -> [Update] {
     // if an update has successfully launched at least once, we treat it as launchable
     // even if it has also failed to launch at least once

--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseSpec.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseSpec.swift
@@ -22,11 +22,11 @@ class AppLauncherWithDatabaseMock : AppLauncherWithDatabase {
       assetsFromManifest: []
     )
   }()
-  
+
   override func launchableUpdate(selectionPolicy: SelectionPolicy, completion: @escaping AppLauncherUpdateCompletionBlock) {
     completion(nil, AppLauncherWithDatabaseMock.testUpdate)
   }
-  
+
   override func ensureAllAssetsExist() {
     self.completionQueue.async {
       self.completion!(nil, true)
@@ -38,62 +38,31 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
   override func spec() {
     var testDatabaseDir: URL!
     var db: UpdatesDatabase!
-    
+
     beforeEach {
       let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
       testDatabaseDir = applicationSupportDir!.appendingPathComponent("UpdatesDatabaseTests")
-      
+
       try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
-      
+
       if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
         try! FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
       }
-      
+
       db = UpdatesDatabase()
       db.databaseQueue.sync {
         try! db.openDatabase(inDirectory: testDatabaseDir)
       }
     }
-    
+
     afterEach {
       db.databaseQueue.sync {
         db.closeDatabase()
       }
-      
+
       try! FileManager.default.removeItem(atPath: testDatabaseDir.path)
     }
-    
-    describe("get stored updates") {
-      func getStoredUpdatesInTestDB() -> [UUID] {
-        var storedUpdateIds: [UUID] = []
-        let semaphore = DispatchSemaphore(value: 0)
-        AppLauncherWithDatabase.storedUpdateIds(inDatabase: db) { error, storedUpdateIdsInner in
-          storedUpdateIds = storedUpdateIdsInner!
-          semaphore.signal()
-        }
-        _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(5))
-        return storedUpdateIds
-      }
-      
-      it("works in empty db") {
-        let storedUpdateIds = getStoredUpdatesInTestDB()
-        expect(storedUpdateIds.count) == 0
-      }
-      
-      it("gets correct ids") {
-        let testUpdate = AppLauncherWithDatabaseMock.testUpdate
-        let yesterday = Date(timeIntervalSinceNow: 24 * 60 * 60 * -1)
-        testUpdate.lastAccessed = yesterday
-        db.databaseQueue.sync {
-          try! db.addUpdate(testUpdate)
-        }
-        
-        let storedUpdateIds = getStoredUpdatesInTestDB()
-        expect(storedUpdateIds.count) == 1
-        expect(storedUpdateIds.first!.uuidString) == testUpdate.updateId.uuidString
-      }
-    }
-    
+
     describe("launch update") {
       it("works") {
         let testUpdate = AppLauncherWithDatabaseMock.testUpdate
@@ -102,7 +71,7 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
         db.databaseQueue.sync {
           try! db.addUpdate(testUpdate)
         }
-        
+
         let testAsset = UpdateAsset(key: "bundle-1234", type: "js")
         testAsset.isLaunchAsset = true
         testAsset.downloadTime = Date()
@@ -110,7 +79,7 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
         db.databaseQueue.sync {
           try! db.addNewAssets([testAsset], toUpdateWithId: testUpdate.updateId)
         }
-        
+
         let config = UpdatesConfig.config(fromDictionary: [UpdatesConfig.EXUpdatesConfigScopeKeyKey:"dummyScope"])
         let launcher = AppLauncherWithDatabaseMock(
           config: config,
@@ -122,13 +91,13 @@ class AppLauncherWithDatabaseSpec : ExpoSpec {
         launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1")) { error, success in
           successValue = success
         }
-        
+
         while successValue == nil {
           Thread.sleep(forTimeInterval: 0.1)
         }
-        
+
         expect(successValue) == true
-        
+
         db.databaseQueue.sync {
           let sameUpdate = try! db.update(withId: testUpdate.updateId, config: config)
           expect(yesterday) != sameUpdate?.lastAccessed


### PR DESCRIPTION
# Why

The `storedUpdateIdsWithConfiguration` isn't called from anywhere.

# How

Remove.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
