### PR TITLE
[expo-updates] Remove ability for embedded manifests to be legacy manifests

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -300,7 +300,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
   }
 
   private fun launchWithNoDatabase(context: Context, e: Exception?) {
-    this.launcher = NoDatabaseLauncher(context, updatesConfiguration, e)
+    this.launcher = NoDatabaseLauncher(context, e)
     var manifestJson = EmbeddedManifest.get(context, updatesConfiguration)!!.manifest.getRawJson()
     try {
       manifestJson = processManifestJson(manifestJson)
@@ -313,7 +313,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }
     callback.onManifestCompleted(Manifest.fromManifestJson(manifestJson))
     // ReactInstanceManagerBuilder accepts embedded assets as strings with "assets://" prefixed
-    val launchAssetFile = launcher.launchAssetFile ?: "assets://" + launcher.bundleAssetName
+    val launchAssetFile = launcher.launchAssetFile ?: ("assets://" + launcher.bundleAssetName)
     callback.onBundleCompleted(launchAssetFile)
   }
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Android: Refactor responsibility of app controller. ([#24954](https://github.com/expo/expo/pull/24954), [#24975](https://github.com/expo/expo/pull/24975) by [@wschurman](https://github.com/wschurman))
 - Android: Backport ExpoGoUpdatesModule to SDK 49. ([#24974](https://github.com/expo/expo/pull/24974) by [@wschurman](https://github.com/wschurman))
 - Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
+- Remove ability for embedded manifests to be legacy manifests. ([#25195](https://github.com/expo/expo/pull/25195) by [@wschurman](https://github.com/wschurman))
 
 ## 0.18.17 — 2023-10-25
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -243,7 +243,7 @@ class UpdatesController private constructor(
     isStarted = true
 
     if (!updatesConfiguration.isEnabled) {
-      launcher = NoDatabaseLauncher(context, updatesConfiguration)
+      launcher = NoDatabaseLauncher(context)
       notifyController()
       return
     }
@@ -251,7 +251,7 @@ class UpdatesController private constructor(
       throw AssertionError("expo-updates is enabled, but no valid URL is configured in AndroidManifest.xml. If you are making a release build for the first time, make sure you have run `expo publish` at least once.")
     }
     if (updatesDirectory == null) {
-      launcher = NoDatabaseLauncher(context, updatesConfiguration, updatesDirectoryException)
+      launcher = NoDatabaseLauncher(context, updatesDirectoryException)
       isEmergencyLaunch = true
       notifyController()
       return
@@ -275,7 +275,7 @@ class UpdatesController private constructor(
       object : LoaderTaskCallback {
         override fun onFailure(e: Exception) {
           logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
-          launcher = NoDatabaseLauncher(context, updatesConfiguration, e)
+          launcher = NoDatabaseLauncher(context, e)
           isEmergencyLaunch = true
           notifyController()
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -3,12 +3,8 @@ package expo.modules.updates.launcher
 import android.content.Context
 import android.os.AsyncTask
 import android.util.Log
-import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.EmbeddedLoader
-import expo.modules.updates.manifest.BareUpdateManifest
-import expo.modules.updates.manifest.EmbeddedManifest
 import org.apache.commons.io.FileUtils
 import java.io.File
 
@@ -22,18 +18,13 @@ import java.io.File
  */
 class NoDatabaseLauncher @JvmOverloads constructor(
   context: Context,
-  configuration: UpdatesConfiguration,
   fatalException: Exception? = null
 ) : Launcher {
-  override var bundleAssetName: String? = null
-  override val launchedUpdate: UpdateEntity?
-    get() = null
-  override val launchAssetFile: String?
-    get() = null
-  override var localAssetFiles: Map<AssetEntity, String>? = null
-    private set
-  override val isUsingEmbeddedAssets: Boolean
-    get() = localAssetFiles == null
+  override val bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
+  override val launchedUpdate = null
+  override val launchAssetFile = null
+  override val localAssetFiles: Map<AssetEntity, String>? = null
+  override val isUsingEmbeddedAssets = true
 
   private fun writeErrorToLog(context: Context, fatalException: Exception) {
     try {
@@ -67,21 +58,6 @@ class NoDatabaseLauncher @JvmOverloads constructor(
   }
 
   init {
-    val embeddedUpdateManifest = EmbeddedManifest.get(context, configuration)
-      ?: throw RuntimeException("Failed to launch with embedded update because the embedded manifest was null")
-
-    if (embeddedUpdateManifest is BareUpdateManifest) {
-      bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
-      localAssetFiles = null
-    } else {
-      bundleAssetName = EmbeddedLoader.BUNDLE_FILENAME
-      localAssetFiles = mutableMapOf<AssetEntity, String>().apply {
-        for (asset in embeddedUpdateManifest.assetEntityList) {
-          this[asset] = "asset:///" + asset.embeddedAssetFilename
-        }
-      }
-    }
-
     if (fatalException != null) {
       AsyncTask.execute { writeErrorToLog(context, fatalException) }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifest.kt
@@ -14,9 +14,9 @@ object EmbeddedManifest {
 
   private const val MANIFEST_FILENAME = "app.manifest"
 
-  private var sEmbeddedManifest: UpdateManifest? = null
+  private var sEmbeddedManifest: BareUpdateManifest? = null
 
-  fun get(context: Context, configuration: UpdatesConfiguration): UpdateManifest? {
+  fun get(context: Context, configuration: UpdatesConfiguration): BareUpdateManifest? {
     if (!configuration.hasEmbeddedUpdate) {
       return null
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -29,11 +29,7 @@ object ManifestFactory {
   }
 
   @Throws(JSONException::class)
-  fun getEmbeddedManifest(manifestJson: JSONObject, configuration: UpdatesConfiguration?): UpdateManifest {
-    return if (manifestJson.has("releaseId")) {
-      LegacyUpdateManifest.fromLegacyManifest(LegacyManifest(manifestJson), configuration!!)
-    } else {
-      BareUpdateManifest.fromBareManifest(BareManifest(manifestJson), configuration!!)
-    }
+  fun getEmbeddedManifest(manifestJson: JSONObject, configuration: UpdatesConfiguration?): BareUpdateManifest {
+    return BareUpdateManifest.fromBareManifest(BareManifest(manifestJson), configuration!!)
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
@@ -23,27 +23,12 @@ public final class AppLauncherNoDatabase: NSObject, AppLauncher {
 
   public func launchUpdate(withConfig config: UpdatesConfig) {
     launchedUpdate = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: nil)
-    if let launchedUpdate = launchedUpdate {
-      if launchedUpdate.status == UpdateStatus.StatusEmbedded {
-        precondition(assetFilesMap == nil, "assetFilesMap should be null for embedded updates")
-        launchAssetUrl = Bundle.main.url(
-          forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
-          withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType
-        )
-      } else {
-        launchAssetUrl = Bundle.main.url(
-          forResource: EmbeddedAppLoader.EXUpdatesEmbeddedBundleFilename,
-          withExtension: EmbeddedAppLoader.EXUpdatesEmbeddedBundleFileType
-        )
-
-        var assetFilesMapLocal: [String: String] = [:]
-        for asset in launchedUpdate.assets()! {
-          if let assetKey = asset.key, let localUrl = UpdatesUtils.url(forBundledAsset: asset) {
-            assetFilesMapLocal[assetKey] = localUrl.absoluteString
-          }
-        }
-        assetFilesMap = assetFilesMapLocal
-      }
+    if launchedUpdate != nil {
+      precondition(assetFilesMap == nil, "assetFilesMap should be null for embedded updates")
+      launchAssetUrl = Bundle.main.url(
+        forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
+        withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType
+      )
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -30,8 +30,8 @@ public final class EmbeddedAppLoader: AppLoader {
 
   private static let ErrorDomain = "EXUpdatesEmbeddedAppLoader"
 
-  private static var embeddedManifestInternal: Update?
-  public static func embeddedManifest(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> Update? {
+  private static var embeddedManifestInternal: BareUpdate?
+  public static func embeddedManifest(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> BareUpdate? {
     guard config.hasEmbeddedUpdate else {
       return nil
     }

--- a/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
@@ -15,7 +15,7 @@ public final class BareUpdate: Update {
     withBareManifest: BareManifest,
     config: UpdatesConfig,
     database: UpdatesDatabase?
-  ) -> Update {
+  ) -> BareUpdate {
     let manifest = withBareManifest
 
     let updateId = manifest.rawId()
@@ -46,7 +46,7 @@ public final class BareUpdate: Update {
       processedAssets.append(asset)
     }
 
-    let update = Update.init(
+    let update = BareUpdate.init(
       manifest: manifest,
       config: config,
       database: database,

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -159,20 +159,12 @@ public class Update: NSObject {
     withEmbeddedManifest: [String: Any],
     config: UpdatesConfig,
     database: UpdatesDatabase?
-  ) -> Update {
-    if withEmbeddedManifest["releaseId"] != nil {
-      return LegacyUpdate.update(
-        withLegacyManifest: LegacyManifest(rawManifestJSON: withEmbeddedManifest),
-        config: config,
-        database: database
-      )
-    } else {
-      return BareUpdate.update(
-        withBareManifest: BareManifest(rawManifestJSON: withEmbeddedManifest),
-        config: config,
-        database: database
-      )
-    }
+  ) -> BareUpdate {
+    return BareUpdate.update(
+      withBareManifest: BareManifest(rawManifestJSON: withEmbeddedManifest),
+      config: config,
+      database: database
+    )
   }
 
   /**


### PR DESCRIPTION
# Why

Legacy manifest code is only kept around for Expo Go 49 compatibility (for one more expo go release). Legacy manifests are no longer possible in normal builds, so we can remove the code that loads embedded updates as legacy manifests.

This is required as part of the refactor (https://github.com/expo/expo/pull/25085, https://github.com/expo/expo/pull/25192) as loading the embedded update in NoDatabaseLauncher cannot require a valid configuration.

# How

Remove the code, improve the types.

# Test Plan

On both platforms, create a project with the libraries using `et gba`, and then build release versions of both. Ensure embedded manifest is loaded and the embedded bundle is loaded as well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
