### PR TITLE
[docs] Fixed typo in building-from-github.mdx

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -93,7 +93,7 @@ settings for this project.
 You can trigger a build from a GitHub PR by adding a label to the PR. The label must be in the form
 of `eas-build-[platform]:[profile]` where `[platform]` is either `android`, `ios`, or `all` and
 `[profile]` is the name of a build profile specified in your **eas.json** file. If you don't specify
-a build platform, it will default to `all`. If you don't speficy
+a build platform, it will default to `all`. If you don't specify
 a build profile, it will default to `production`.
 
 For example, if


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Mispelling found in building-from-github.mdx.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Corrected "speficy" to "specify" in document.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
