### PR TITLE
[docs] fix EAS Build url on submit/android

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -27,7 +27,7 @@ For more information, see [expo.fyi/first-android-submission](https://expo.fyi/f
 
 ## 1. Build a standalone app
 
-You'll need a native app binary signed for store submission. You can either use [EAS Build](introduction.mdx) or do it on your own.
+You'll need a native app binary signed for store submission. You can either use [EAS Build](/build/introduction.mdx) or do it on your own.
 
 ## 2. Start the submission
 

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -239,7 +239,7 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
   return (
     <LinkBase
       css={[link, !isStyled && linkStyled]}
-      {...(shouldLeakReferrer && { target: '_blank', referrerpolicy: 'origin' })}
+      {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
       openInNewTab={(!shouldLeakReferrer && openInNewTab) ?? isExternalLink(props.href)}
       {...rest}
     />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests
-->
1. fixes: https://github.com/expo/expo/issues/25200 - fix EAS Build url on submit/android
2. fix - Warning: Invalid DOM property `referrerpolicy`. Did you mean `referrerPolicy`? at Text/index.tsx

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
