### PR TITLE
[docs] Add more instructions to third party dependency docs

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -3,6 +3,7 @@ title: Use third-party native libraries in Expo
 description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules.
 ---
 
+import { CODE } from '~/ui/components/Text';
 import { Collapsible } from '~/ui/components/Collapsible';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
@@ -95,9 +96,9 @@ dependencies {
     # Swift/Objective-C compatibility
 ```
 
-<Collapsible summary="Are you trying to use a .framework dependency?">
+<Collapsible summary={<>Are you trying to use a <CODE>.framework</CODE> dependency?</>}>
 
-On iOS you can also use dependencies bundled as a framework by using the `vendored_framework` config option.
+On iOS, you can also use dependencies bundled as a framework by using the `vendored_framework` config option.
 
 ```diff ios/ExpoRadialChart.podspec
     s.static_framework = true
@@ -108,11 +109,9 @@ On iOS you can also use dependencies bundled as a framework by using the `vendor
 
 </Collapsible>
 
-<Collapsible summary="Are you trying to use a .aar dependency?">
+<Collapsible summary={<>Are you trying to use a <CODE>.aar</CODE> dependency?</>}>
 
-Create a `libs` folder in the `android` folder of your Expo module. Place your `aar` file there.
-
-Next add the folder as a repository like so:
+Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the folder as a repository:
 
 ```diff android/build.grade
   repositories {
@@ -123,7 +122,7 @@ Next add the folder as a repository like so:
   }
 ```
 
-Last, add the dependency to the `dependencies` list (using a package path, not a filename, but note the `@aar` at the end):
+Finally, add the dependency to the `dependencies` list. Instead of the filename, use the package path, which includes the `@aar` at the end:
 
 ```diff android/build.grade
 dependencies {

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -96,7 +96,7 @@ dependencies {
     # Swift/Objective-C compatibility
 ```
 
-<Collapsible summary={<>Are you trying to use a <CODE>.framework</CODE> dependency?</>}>
+<Collapsible summary={<>Are you trying to use an <CODE>.xcframework</CODE> or <CODE>.framework</CODE> dependency?</>}>
 
 On iOS, you can also use dependencies bundled as a framework by using the `vendored_framework` config option.
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -3,6 +3,7 @@ title: Use third-party native libraries in Expo
 description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -93,6 +94,46 @@ dependencies {
 
     # Swift/Objective-C compatibility
 ```
+
+<Collapsible summary="Are you trying to use a .framework dependency?">
+
+On iOS you can also use dependencies bundled as a framework by using the `vendored_framework` config option.
+
+```diff ios/ExpoRadialChart.podspec
+    s.static_framework = true
+    s.dependency 'ExpoModulesCore'
++   s.vendored_frameworks 'Frameworks/MyFramework.framework'
+    # Swift/Objective-C compatibility
+```
+
+</Collapsible>
+
+<Collapsible summary="Are you trying to use a .aar dependency?">
+
+Create a `libs` folder in the `android` folder of your Expo module. Place your `aar` file there.
+
+Next add the folder as a repository like so:
+
+```diff android/build.grade
+  repositories {
+    mavenCentral()
++   flatDir {
++       dirs 'libs'
++   }
+  }
+```
+
+Last, add the dependency to the `dependencies` list (using a package path, not a filename, but note the `@aar` at the end):
+
+```diff android/build.grade
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
++ implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0@aar'
+}
+```
+
+</Collapsible>
 
 </Step>
 


### PR DESCRIPTION
# Why

We want it to be clearer how to use other native dependency types.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
