### PR TITLE
[image][Android] Allow users to turn on logs from Glide

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -43,3 +43,5 @@ newArchEnabled=false
 hermesEnabled=true
 
 EX_DEV_CLIENT_NETWORK_INSPECTOR=true
+
+EXPO_ALLOW_GLIDE_LOGS=true

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -69,6 +69,8 @@ android {
     versionCode 1
     versionName "1.6.0"
     consumerProguardFiles("proguard-rules.pro")
+
+    buildConfigField("boolean", "ALLOW_GLIDE_LOGS", project.properties.get("EXPO_ALLOW_GLIDE_LOGS", "false"))
   }
   publishing {
     singleVariant("release") {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
@@ -14,6 +14,11 @@ import com.bumptech.glide.module.AppGlideModule
 class ExpoImageAppGlideModule : AppGlideModule() {
   override fun applyOptions(context: Context, builder: GlideBuilder) {
     super.applyOptions(context, builder)
-    builder.setLogLevel(Log.ERROR)
+
+    builder.setLogLevel(if (BuildConfig.ALLOW_GLIDE_LOGS) {
+      Log.VERBOSE
+    } else {
+      Log.ERROR
+    })
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
@@ -15,10 +15,12 @@ class ExpoImageAppGlideModule : AppGlideModule() {
   override fun applyOptions(context: Context, builder: GlideBuilder) {
     super.applyOptions(context, builder)
 
-    builder.setLogLevel(if (BuildConfig.ALLOW_GLIDE_LOGS) {
-      Log.VERBOSE
-    } else {
-      Log.ERROR
-    })
+    builder.setLogLevel(
+      if (BuildConfig.ALLOW_GLIDE_LOGS) {
+        Log.VERBOSE
+      } else {
+        Log.ERROR
+      }
+    )
   }
 }


### PR DESCRIPTION
# Why

Right now, logs from Glide are suppressed by our package. It may not be ideal for all users. So I've added a way of turning them on. 

# How

Adds a flag (`EXPO_ALLOW_GLIDE_LOGS )` that can be specified in the `gradle.properties` to enable logs from glide. 

# Test Plan

- bare-expo 