### PR TITLE
feat(cli)!: revisit prebuild package.json updates and drop expo-splash-screen dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 🛠 Breaking changes
 
+- `npx expo prebuild` will only install Node dependencies if the `dependencies` have changed.
+- `npx expo prebuild` will no longer modify `devDependencies` of the `package.json`.
+
 ### 🎉 New features
 
 - Add support for chaining the Metro resolver locally. ([#25148](https://github.com/expo/expo/pull/25148) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### 🛠 Breaking changes
 
-- `npx expo prebuild` will only install Node dependencies if the `dependencies` have changed.
-- `npx expo prebuild` will no longer modify `devDependencies` of the `package.json`.
+- `npx expo prebuild` will only install Node dependencies if the `dependencies` have changed. ([#25211](https://github.com/expo/expo/pull/25211) by [@EvanBacon](https://github.com/EvanBacon))
+- `npx expo prebuild` will no longer modify `devDependencies` of the `package.json`. ([#25211](https://github.com/expo/expo/pull/25211) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -110,7 +110,6 @@ it(
   'runs `npx expo prebuild`',
   async () => {
     const projectRoot = await setupTestProjectAsync('basic-prebuild', 'with-blank');
-    // `npx expo prebuild --no-install`
 
     const templateFolder = await ensureTemplatePathAsync();
     console.log('Using local template:', templateFolder);
@@ -136,8 +135,6 @@ it(
     // Added new packages
     expect(Object.keys(pkg.dependencies ?? {}).sort()).toStrictEqual([
       'expo',
-      'expo-splash-screen',
-      'expo-status-bar',
       'react',
       'react-native',
     ]);

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -15,7 +15,7 @@ import { joinWithCommasAnd } from '../utils/strings';
 
 /**
  * Installs versions of specified packages compatible with the current Expo SDK version, or
- * checks/ fixes dependendencies in project if they don't match compatible versions specified in bundledNativeModules or versions endpoints.
+ * checks/ fixes dependencies in project if they don't match compatible versions specified in bundledNativeModules or versions endpoints.
  *
  * @param packages list of packages to install, if installing specific packages and not checking/ fixing
  * @param options options, including check or fix

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -1,8 +1,13 @@
 import chalk from 'chalk';
+import { vol } from 'memfs';
 
 import * as Log from '../../log';
 import { isModuleSymlinked } from '../../utils/isModuleSymlinked';
-import { hashForDependencyMap, updatePkgDependencies } from '../updatePackageJson';
+import {
+  hashForDependencyMap,
+  updatePkgDependencies,
+  updatePackageJSONAsync,
+} from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
 jest.mock('../../log');
@@ -12,6 +17,129 @@ describe(hashForDependencyMap, () => {
     expect(hashForDependencyMap({ a: '1.0.0', b: 2, c: '~3.0' })).toBe(
       hashForDependencyMap({ c: '~3.0', b: 2, a: '1.0.0' })
     );
+  });
+});
+
+describe(updatePackageJSONAsync, () => {
+  beforeAll(() => {
+    (isModuleSymlinked as any).mockImplementation(() => false);
+  });
+
+  it(`has no changes`, async () => {
+    vol.fromJSON({}, '/');
+
+    expect(
+      await updatePackageJSONAsync('/', {
+        pkg: {
+          scripts: {
+            ios: 'expo run:ios',
+            android: 'expo run:android',
+          },
+          dependencies: {
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+          },
+        },
+        templateDirectory: '/template',
+        templatePkg: {
+          dependencies: {
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+            'expo-status-bar': '1.0.0',
+            'expo-splash-screen': '1.0.0',
+          },
+          devDependencies: {
+            'no-copy': '1.0.0',
+          },
+        },
+      })
+    ).toEqual({
+      changedDependencies: [],
+      scriptsChanged: false,
+    });
+
+    expect(vol.toJSON()).toEqual({});
+  });
+
+  it(`injects custom scripts`, async () => {
+    vol.fromJSON({}, '/');
+
+    expect(
+      await updatePackageJSONAsync('/', {
+        pkg: {
+          scripts: {
+            ios: 'expo start --ios',
+            android: 'expo start --android',
+          },
+          dependencies: {
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+          },
+        },
+        templateDirectory: '/template',
+        templatePkg: {
+          dependencies: {
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+            'expo-status-bar': '1.0.0',
+            'expo-splash-screen': '1.0.0',
+          },
+          devDependencies: {
+            'no-copy': '1.0.0',
+          },
+        },
+      })
+    ).toEqual({
+      changedDependencies: [],
+      scriptsChanged: true,
+    });
+
+    expect(JSON.parse(vol.toJSON()['/package.json'])).toEqual({
+      dependencies: { expo: '1.0.0', 'react-native': '0.1.0' },
+      scripts: { android: 'expo run:android', ios: 'expo run:ios' },
+    });
+  });
+
+  // TODO: We should change this functionality in the future to either require a custom dependency field
+  // or just not exist.
+  it(`updates dependencies if the template adds custom values`, async () => {
+    vol.fromJSON({}, '/');
+
+    expect(
+      await updatePackageJSONAsync('/', {
+        pkg: {
+          scripts: {
+            ios: 'expo run:ios',
+            android: 'expo run:android',
+          },
+          dependencies: {
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+          },
+        },
+        templateDirectory: '/template',
+        templatePkg: {
+          dependencies: {
+            unexpected: '1.0.0',
+            expo: '1.0.0',
+            'react-native': '0.1.0',
+            'expo-status-bar': '1.0.0',
+            'expo-splash-screen': '1.0.0',
+          },
+          devDependencies: {
+            'no-copy': '1.0.0',
+          },
+        },
+      })
+    ).toEqual({
+      changedDependencies: ['unexpected'],
+      scriptsChanged: false,
+    });
+
+    expect(JSON.parse(vol.toJSON()['/package.json'])).toEqual({
+      dependencies: { unexpected: '1.0.0', expo: '1.0.0', 'react-native': '0.1.0' },
+      scripts: { android: 'expo run:android', ios: 'expo run:ios' },
+    });
   });
 });
 

--- a/packages/@expo/cli/src/prebuild/configureProjectAsync.ts
+++ b/packages/@expo/cli/src/prebuild/configureProjectAsync.ts
@@ -14,19 +14,21 @@ export async function configureProjectAsync(
   projectRoot: string,
   {
     platforms,
+    exp,
   }: {
     platforms: ModPlatform[];
+    exp?: ExpoConfig;
   }
 ): Promise<ExpoConfig> {
   let bundleIdentifier: string | undefined;
   if (platforms.includes('ios')) {
     // Check bundle ID before reading the config because it may mutate the config if the user is prompted to define it.
-    bundleIdentifier = await getOrPromptForBundleIdentifier(projectRoot);
+    bundleIdentifier = await getOrPromptForBundleIdentifier(projectRoot, exp);
   }
   let packageName: string | undefined;
   if (platforms.includes('android')) {
     // Check package before reading the config because it may mutate the config if the user is prompted to define it.
-    packageName = await getOrPromptForPackage(projectRoot);
+    packageName = await getOrPromptForPackage(projectRoot, exp);
   }
 
   let { exp: config } = await getPrebuildConfigAsync(projectRoot, {

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 
-import { copySync, directoryExistsAsync } from '../utils/dir';
+import { copySync } from '../utils/dir';
 import { mergeGitIgnorePaths } from '../utils/mergeGitIgnorePaths';
 
 const debug = require('debug')('expo:prebuild:copyTemplateFiles') as typeof console.log;
@@ -56,7 +56,7 @@ export function createCopyFilesSuccessMessage(
 }
 
 /** Copy template files into the project and possibly merge the `.gitignore` files.  */
-export async function copyTemplateFilesAsync(
+export function copyTemplateFiles(
   projectRoot: string,
   {
     templateDirectory,
@@ -67,10 +67,18 @@ export async function copyTemplateFilesAsync(
     /** List of platforms to copy against. */
     platforms: ModPlatform[];
   }
-): Promise<CopyFilesResults> {
-  const copyResults = await copyPathsFromTemplateAsync(projectRoot, {
-    templateDirectory,
-    copyFilePaths: platforms,
+): CopyFilesResults {
+  const copiedPaths: string[] = [];
+  const skippedPaths: string[] = [];
+
+  platforms.forEach((copyFilePath) => {
+    const projectPath = path.join(projectRoot, copyFilePath);
+    if (fs.existsSync(projectPath)) {
+      skippedPaths.push(copyFilePath);
+    } else {
+      copiedPaths.push(copyFilePath);
+      copySync(path.join(templateDirectory, copyFilePath), projectPath);
+    }
   });
 
   const hasPlatformSpecificGitIgnores = hasAllPlatformSpecificGitIgnores(
@@ -87,34 +95,5 @@ export async function copyTemplateFilesAsync(
         path.join(templateDirectory, '.gitignore')
       );
 
-  return { ...copyResults, gitignore };
-}
-
-async function copyPathsFromTemplateAsync(
-  /** File path to the project. */
-  projectRoot: string,
-  {
-    templateDirectory,
-    copyFilePaths,
-  }: {
-    /** File path to the template project. */
-    templateDirectory: string;
-    /** List of relative paths to copy from the template to the project. */
-    copyFilePaths: string[];
-  }
-): Promise<Pick<CopyFilesResults, 'copiedPaths' | 'skippedPaths'>> {
-  const copiedPaths = [];
-  const skippedPaths = [];
-  for (const copyFilePath of copyFilePaths) {
-    const projectPath = path.join(projectRoot, copyFilePath);
-    if (!(await directoryExistsAsync(projectPath))) {
-      copiedPaths.push(copyFilePath);
-      copySync(path.join(templateDirectory, copyFilePath), projectPath);
-    } else {
-      skippedPaths.push(copyFilePath);
-    }
-  }
-  debug(`Copied files:`, copiedPaths);
-  debug(`Skipped files:`, copiedPaths);
-  return { copiedPaths, skippedPaths };
+  return { copiedPaths, skippedPaths, gitignore };
 }

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -36,19 +36,21 @@ export function createCopyFilesSuccessMessage(
   platforms: ModPlatform[],
   { skippedPaths, gitignore }: CopyFilesResults
 ): string {
-  let message = `Created native project${platforms.length > 1 ? 's' : ''}`;
+  const pluralized = platforms.length > 1 ? 'directories' : 'directory';
+  let message = `Created native ${pluralized}`;
 
   if (skippedPaths.length) {
     message += chalk.dim(
-      ` | ${skippedPaths.map((path) => chalk.bold(`/${path}`)).join(', ')} already created`
+      ` | reusing ${skippedPaths.map((path) => chalk.bold(`/${path}`)).join(', ')}`
     );
   }
   if (!gitignore) {
     // Add no additional message...
   } else if (!gitignore.didMerge) {
-    message += chalk.dim(` | gitignore already synced`);
+    message += chalk.dim(` | reusing gitignore`);
   } else if (gitignore.didMerge && gitignore.didClear) {
-    message += chalk.dim(` | synced gitignore`);
+    // This is legacy and for non-standard templates. The Expo template adds gitignores to the platform folders.
+    message += chalk.dim(` | updated gitignore`);
   }
   return message;
 }

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -44,7 +44,7 @@ export function createCopyFilesSuccessMessage(
     );
   }
   if (!gitignore) {
-    message += chalk.dim(` | gitignore skipped`);
+    // Add no additional message...
   } else if (!gitignore.didMerge) {
     message += chalk.dim(` | gitignore already synced`);
   } else if (gitignore.didMerge && gitignore.didClear) {

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
+import chalk from 'chalk';
 
 import { clearNativeFolder, promptToClearMalformedNativeProjectsAsync } from './clearNativeFolder';
 import { configureProjectAsync } from './configureProjectAsync';
@@ -7,11 +8,13 @@ import { ensureConfigAsync } from './ensureConfigAsync';
 import { assertPlatforms, ensureValidPlatforms, resolveTemplateOption } from './resolveOptions';
 import { updateFromTemplateAsync } from './updateFromTemplate';
 import { installAsync } from '../install/installAsync';
+import { Log } from '../log';
 import { env } from '../utils/env';
 import { setNodeEnv } from '../utils/nodeEnv';
 import { clearNodeModulesAsync } from '../utils/nodeModules';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';
+import { confirmAsync } from '../utils/prompts';
 
 const debug = require('debug')('expo:prebuild') as typeof console.log;
 
@@ -84,41 +87,54 @@ export async function prebuildAsync(
   const { exp, pkg } = await ensureConfigAsync(projectRoot, { platforms: options.platforms });
 
   // Create native projects from template.
-  const { hasNewProjectFiles, needsPodInstall, hasNewDependencies } = await updateFromTemplateAsync(
-    projectRoot,
-    {
+  const { hasNewProjectFiles, needsPodInstall, changedDependencies } =
+    await updateFromTemplateAsync(projectRoot, {
       exp,
       pkg,
       template: options.template != null ? resolveTemplateOption(options.template) : undefined,
       platforms: options.platforms,
       skipDependencyUpdate: options.skipDependencyUpdate,
-    }
-  );
+    });
 
   // Install node modules
   if (options.install) {
-    if (hasNewDependencies && options.packageManager?.npm) {
-      await clearNodeModulesAsync(projectRoot);
-    }
+    if (changedDependencies.length) {
+      if (options.packageManager?.npm) {
+        await clearNodeModulesAsync(projectRoot);
+      }
 
-    await installAsync([], {
-      npm: !!options.packageManager?.npm,
-      yarn: !!options.packageManager?.yarn,
-      pnpm: !!options.packageManager?.pnpm,
-      bun: !!options.packageManager?.bun,
-      silent: !(env.EXPO_DEBUG || env.CI),
-    });
+      Log.log(chalk.gray(chalk`Dependencies in the {bold package.json} changed:`));
+      Log.log(chalk.gray('  ' + changedDependencies.join(', ')));
+
+      // Installing dependencies is a legacy feature from the unversioned
+      // command. We know opt to not change dependencies unless a template
+      // indicates a new dependency is required, or if the core dependencies are wrong.
+      if (
+        await confirmAsync({
+          message: `Install the updated dependencies?`,
+          initial: true,
+        })
+      ) {
+        await installAsync([], {
+          npm: !!options.packageManager?.npm,
+          yarn: !!options.packageManager?.yarn,
+          pnpm: !!options.packageManager?.pnpm,
+          bun: !!options.packageManager?.bun,
+          silent: !(env.EXPO_DEBUG || env.CI),
+        });
+      }
+    }
   }
 
   // Apply Expo config to native projects
-  const configSyncingStep = logNewSection('Config syncing');
+  const configSyncingStep = logNewSection('Running prebuild');
   try {
     await profile(configureProjectAsync)(projectRoot, {
       platforms: options.platforms,
     });
-    configSyncingStep.succeed('Config synced');
+    configSyncingStep.succeed('Finished prebuild');
   } catch (error) {
-    configSyncingStep.fail('Config sync failed');
+    configSyncingStep.fail('Prebuild failed');
     throw error;
   }
 

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -131,6 +131,7 @@ export async function prebuildAsync(
   try {
     await profile(configureProjectAsync)(projectRoot, {
       platforms: options.platforms,
+      exp,
     });
     configSyncingStep.succeed('Finished prebuild');
   } catch (error) {

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -2,7 +2,7 @@ import { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
 import chalk from 'chalk';
 
-import { copyTemplateFilesAsync, createCopyFilesSuccessMessage } from './copyTemplateFiles';
+import { copyTemplateFiles, createCopyFilesSuccessMessage } from './copyTemplateFiles';
 import { cloneTemplateAsync } from './resolveTemplate';
 import { DependenciesModificationResults, updatePackageJSONAsync } from './updatePackageJson';
 import { validateTemplatePlatforms } from './validateTemplatePlatforms';
@@ -103,12 +103,12 @@ async function cloneTemplateAndCopyToProjectAsync({
   try {
     await cloneTemplateAsync({ templateDirectory, template, exp, ora });
 
-    const platforms = await validateTemplatePlatforms({
+    const platforms = validateTemplatePlatforms({
       templateDirectory,
       platforms: unknownPlatforms,
     });
 
-    const results = await copyTemplateFilesAsync(projectRoot, {
+    const results = copyTemplateFiles(projectRoot, {
       templateDirectory,
       platforms,
     });

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -69,10 +69,7 @@ export async function updateFromTemplateAsync(
   return {
     hasNewProjectFiles: !!copiedPaths.length,
     // If the iOS folder changes or new packages are added, we should rerun pod install.
-    needsPodInstall:
-      copiedPaths.includes('ios') ||
-      depsResults.hasNewDependencies ||
-      depsResults.hasNewDevDependencies,
+    needsPodInstall: copiedPaths.includes('ios') || !!depsResults.changedDependencies.length,
     ...depsResults,
   };
 }

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -98,9 +98,7 @@ async function cloneTemplateAndCopyToProjectAsync({
     .join(' and ');
 
   const pluralized = unknownPlatforms.length > 1 ? 'directories' : 'directory';
-  const ora = logNewSection(
-    `Creating native project ${pluralized} (${platformDirectories}) and updating .gitignore`
-  );
+  const ora = logNewSection(`Creating native ${pluralized} (${platformDirectories})`);
 
   try {
     await cloneTemplateAsync({ templateDirectory, template, exp, ora });
@@ -122,10 +120,10 @@ async function cloneTemplateAndCopyToProjectAsync({
     if (!(e instanceof AbortCommandError)) {
       Log.error(e.message);
     }
-    ora.fail('Failed to create the native project.');
+    ora.fail(`Failed to create the native ${pluralized}`);
     Log.log(
       chalk.yellow(
-        'You may want to delete the `./ios` and/or `./android` directories before trying again.'
+        chalk`You may want to delete the {bold ./ios} and/or {bold ./android} directories before trying again.`
       )
     );
     throw new SilentError(e);

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -31,9 +31,7 @@ export async function updatePackageJSONAsync(
     skipDependencyUpdate?: string[];
   }
 ): Promise<DependenciesModificationResults> {
-  const updatingPackageJsonStep = logNewSection(
-    'Updating your package.json scripts, dependencies, and main file'
-  );
+  const updatingPackageJsonStep = logNewSection('Updating package.json scripts, and dependencies');
 
   const templatePkg = getPackageJson(templateDirectory);
 
@@ -50,9 +48,7 @@ export async function updatePackageJSONAsync(
     JSON.stringify(pkg, null, 2) + '\n'
   );
 
-  updatingPackageJsonStep.succeed(
-    'Updated package.json and added index.js entry point for iOS and Android'
-  );
+  updatingPackageJsonStep.succeed('Updated package.json');
 
   return results;
 }
@@ -131,7 +127,7 @@ export function updatePkgDependencies(
   });
 
   // These dependencies are only added, not overwritten from the project
-  const requiredDependencies = ['expo', 'expo-splash-screen', 'react', 'react-native'].filter(
+  const requiredDependencies = ['expo', 'react-native'].filter(
     (depKey) => !!defaultDependencies[depKey]
   );
 

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -12,10 +12,8 @@ import { logNewSection } from '../utils/ora';
 export type DependenciesMap = { [key: string]: string | number };
 
 export type DependenciesModificationResults = {
-  /** Indicates that new values were added to the `dependencies` object in the `package.json`. */
-  hasNewDependencies: boolean;
-  /** Indicates that new values were added to the `devDependencies` object in the `package.json`. */
-  hasNewDevDependencies: boolean;
+  /** A list of new values were added to the `dependencies` object in the `package.json`. */
+  changedDependencies: string[];
 };
 
 /** Modifies the `package.json` with `modifyPackageJson` and format/displays the results. */
@@ -23,17 +21,17 @@ export async function updatePackageJSONAsync(
   projectRoot: string,
   {
     templateDirectory,
+    templatePkg = getPackageJson(templateDirectory),
     pkg,
     skipDependencyUpdate,
   }: {
     templateDirectory: string;
+    templatePkg?: PackageJSONConfig;
     pkg: PackageJSONConfig;
     skipDependencyUpdate?: string[];
   }
 ): Promise<DependenciesModificationResults> {
-  const updatingPackageJsonStep = logNewSection('Updating package.json scripts, and dependencies');
-
-  const templatePkg = getPackageJson(templateDirectory);
+  const updatingPackageJsonStep = logNewSection('Updating package.json');
 
   const results = modifyPackageJson(projectRoot, {
     templatePkg,
@@ -41,14 +39,21 @@ export async function updatePackageJSONAsync(
     skipDependencyUpdate,
   });
 
-  await fs.promises.writeFile(
-    path.resolve(projectRoot, 'package.json'),
-    // Add new line to match the format of running yarn.
-    // This prevents the `package.json` from changing when running `prebuild --no-install` multiple times.
-    JSON.stringify(pkg, null, 2) + '\n'
-  );
+  const hasChanges = results.changedDependencies.length || results.scriptsChanged;
 
-  updatingPackageJsonStep.succeed('Updated package.json');
+  // NOTE: This is effectively bundler caching and subject to breakage if the inputs don't match the mutations.
+  if (hasChanges) {
+    await fs.promises.writeFile(
+      path.resolve(projectRoot, 'package.json'),
+      // Add new line to match the format of running yarn.
+      // This prevents the `package.json` from changing when running `prebuild --no-install` multiple times.
+      JSON.stringify(pkg, null, 2) + '\n'
+    );
+  }
+
+  updatingPackageJsonStep.succeed(
+    'Updated package.json' + (hasChanges ? '' : chalk.dim(` | no changes`))
+  );
 
   return results;
 }
@@ -57,7 +62,7 @@ export async function updatePackageJSONAsync(
  * Make required modifications to the `package.json` file as a JSON object.
  *
  * 1. Update `package.json` `scripts`.
- * 2. Update `package.json` `dependencies` and `devDependencies`.
+ * 2. Update `package.json` `dependencies` (not `devDependencies`).
  * 3. Update `package.json` `main`.
  *
  * @param projectRoot The root directory of the project.
@@ -75,29 +80,26 @@ function modifyPackageJson(
   }: {
     templatePkg: PackageJSONConfig;
     pkg: PackageJSONConfig;
+    /** @deprecated Required packages are not overwritten, only added when missing */
     skipDependencyUpdate?: string[];
   }
 ) {
-  updatePkgScripts({ pkg });
+  const scriptsChanged = updatePkgScripts({ pkg });
 
   // TODO: Move to `npx expo-doctor`
-  return updatePkgDependencies(projectRoot, {
-    pkg,
-    templatePkg,
-    skipDependencyUpdate,
-  });
+  return {
+    scriptsChanged,
+    ...updatePkgDependencies(projectRoot, {
+      pkg,
+      templatePkg,
+      skipDependencyUpdate,
+    }),
+  };
 }
 
 /**
- * Update package.json dependencies by combining the dependencies in the project we are ejecting
- * with the dependencies in the template project. Does the same for devDependencies.
- *
- * - The template may have some dependencies beyond react/react-native/react-native-unimodules,
- *   for example RNGH and Reanimated. We should prefer the version that is already being used
- *   in the project for those, but swap the react/react-native/react-native-unimodules versions
- *   with the ones in the template.
- * - The same applies to expo-updates -- since some native project configuration may depend on the
- *   version, we should always use the version of expo-updates in the template.
+ * Update `package.json` dependencies by combining the `dependencies` in the
+ * project we are creating with the dependencies in the template project.
  *
  * > Exposed for testing.
  */
@@ -114,12 +116,20 @@ export function updatePkgDependencies(
     skipDependencyUpdate?: string[];
   }
 ): DependenciesModificationResults {
-  if (!pkg.devDependencies) {
-    pkg.devDependencies = {};
-  }
-  const { dependencies, devDependencies } = templatePkg;
+  const { dependencies } = templatePkg;
+  // The default values come from the bare-minimum template's package.json.
+  // Users can change this by using different templates with the `--template` flag.
+  // The main reason for allowing the changing of dependencies would be to include
+  // dependencies that are required for the native project to build. For example,
+  // it does not need to include dependencies that are used in the JS-code only.
   const defaultDependencies = createDependenciesMap(dependencies);
-  const defaultDevDependencies = createDependenciesMap(devDependencies);
+
+  // NOTE: This is a hack to ensure this doesn't trigger an extraneous change in the `package.json`
+  // it isn't required for anything in the `ios` and `android` folders.
+  delete defaultDependencies['expo-status-bar'];
+  // NOTE: Expo splash screen is installed by default in the template but the config plugin also lives in prebuild-config
+  // so we can delete it to prevent an extraneous change in the `package.json`.
+  delete defaultDependencies['expo-splash-screen'];
 
   const combinedDependencies: DependenciesMap = createDependenciesMap({
     ...defaultDependencies,
@@ -127,9 +137,12 @@ export function updatePkgDependencies(
   });
 
   // These dependencies are only added, not overwritten from the project
-  const requiredDependencies = ['expo', 'react-native'].filter(
-    (depKey) => !!defaultDependencies[depKey]
-  );
+  const requiredDependencies = [
+    // TODO: This is no longer required because it's this same package.
+    'expo',
+    // TODO: Drop this somehow.
+    'react-native',
+  ].filter((depKey) => !!defaultDependencies[depKey]);
 
   const symlinkedPackages: string[] = [];
   const nonRecommendedPackages: string[] = [];
@@ -176,30 +189,24 @@ export function updatePkgDependencies(
     );
   }
 
-  const combinedDevDependencies: DependenciesMap = createDependenciesMap({
-    ...defaultDevDependencies,
-    ...pkg.devDependencies,
-  });
-
   // Only change the dependencies if the normalized hash changes, this helps to reduce meaningless changes.
   const hasNewDependencies =
     hashForDependencyMap(pkg.dependencies) !== hashForDependencyMap(combinedDependencies);
-  const hasNewDevDependencies =
-    hashForDependencyMap(pkg.devDependencies) !== hashForDependencyMap(combinedDevDependencies);
   // Save the dependencies
+  let changedDependencies: string[] = [];
   if (hasNewDependencies) {
+    changedDependencies = diffKeys(combinedDependencies, pkg.dependencies ?? {}).sort();
     // Use Object.assign to preserve the original order of dependencies, this makes it easier to see what changed in the git diff.
     pkg.dependencies = Object.assign(pkg.dependencies ?? {}, combinedDependencies);
   }
-  if (hasNewDevDependencies) {
-    // Same as with dependencies
-    pkg.devDependencies = Object.assign(pkg.devDependencies ?? {}, combinedDevDependencies);
-  }
 
   return {
-    hasNewDependencies,
-    hasNewDevDependencies,
+    changedDependencies,
   };
+}
+
+function diffKeys(a: Record<string, any>, b: Record<string, any>): string[] {
+  return Object.keys(a).filter((key) => a[key] !== b[key]);
 }
 
 /**
@@ -236,15 +243,19 @@ export function createDependenciesMap(dependencies: any): DependenciesMap {
  * start --dev-client` rather than `expo start` after ejecting, for example.
  */
 function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
+  let hasChanged = false;
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
   if (!pkg.scripts.android?.includes('run')) {
     pkg.scripts.android = 'expo run:android';
+    hasChanged = true;
   }
   if (!pkg.scripts.ios?.includes('run')) {
     pkg.scripts.ios = 'expo run:ios';
+    hasChanged = true;
   }
+  return hasChanged;
 }
 
 function normalizeDependencyMap(deps: DependenciesMap): string[] {

--- a/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
+++ b/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
@@ -3,9 +3,9 @@ import chalk from 'chalk';
 import path from 'path';
 
 import * as Log from '../log';
-import { directoryExistsAsync } from '../utils/dir';
+import { directoryExistsSync } from '../utils/dir';
 
-export async function validateTemplatePlatforms({
+export function validateTemplatePlatforms({
   templateDirectory,
   platforms,
 }: {
@@ -15,7 +15,7 @@ export async function validateTemplatePlatforms({
   const existingPlatforms: ModPlatform[] = [];
 
   for (const platform of platforms) {
-    if (await directoryExistsAsync(path.join(templateDirectory, platform))) {
+    if (directoryExistsSync(path.join(templateDirectory, platform))) {
       existingPlatforms.push(platform);
     } else {
       Log.warn(

--- a/packages/@expo/cli/src/utils/cocoapods.ts
+++ b/packages/@expo/cli/src/utils/cocoapods.ts
@@ -116,7 +116,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
     });
     // Create cached list for later
     await hasPackageJsonDependencyListChangedAsync(projectRoot).catch(() => null);
-    step.succeed('Installed pods and initialized Xcode workspace.');
+    step.succeed('Installed CocoaPods');
     return true;
   } catch (error: any) {
     step.stopAndPersist({

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -30,9 +30,10 @@ const NO_PACKAGE_MESSAGE = `Project must have a \`android.package\` set in the E
  * Prompted value will be validated against the App Store and a local regex.
  * If the project Expo config is a static JSON file, the bundle identifier will be updated in the config automatically.
  */
-export async function getOrPromptForBundleIdentifier(projectRoot: string): Promise<string> {
-  const { exp } = getConfig(projectRoot);
-
+export async function getOrPromptForBundleIdentifier(
+  projectRoot: string,
+  exp: ExpoConfig = getConfig(projectRoot).exp
+): Promise<string> {
   const current = exp.ios?.bundleIdentifier;
   if (current) {
     assertValidBundleId(current);
@@ -138,9 +139,10 @@ async function getRecommendedPackageNameAsync(exp: ExpoConfig): Promise<string |
  * Prompted value will be validated against the Play Store and a local regex.
  * If the project Expo config is a static JSON file, the package name will be updated in the config automatically.
  */
-export async function getOrPromptForPackage(projectRoot: string): Promise<string> {
-  const { exp } = getConfig(projectRoot);
-
+export async function getOrPromptForPackage(
+  projectRoot: string,
+  exp: ExpoConfig = getConfig(projectRoot).exp
+): Promise<string> {
   const current = exp.android?.package;
   if (current) {
     assertValidPackage(current);

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update tests. ([#25211](https://github.com/expo/expo/pull/25211) by [@EvanBacon](https://github.com/EvanBacon))
+
 ## 7.6.0 — 2023-10-17
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/BundleIdentifier-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/BundleIdentifier-test.ts.snap
@@ -142,7 +142,6 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "HelloWorld" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
@@ -262,26 +261,6 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
 			showEnvVarsInLog = 0;
 		};
-		FD10A7F022414F080027D42C /* Start Packager */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Start Packager";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\nexport RCT_METRO_PORT=\\"\${RCT_METRO_PORT:=8081}\\"\\necho \\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\" > \`$NODE_BINARY --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\\"\`\\nif [ -z \\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\" ] ; then\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\n    if ! curl -s \\"http://localhost:\${RCT_METRO_PORT}/status\\" | grep -q \\"packager-status:running\\" ; then\\n      echo \\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\"\\n      exit 2\\n    fi\\n  else\\n    open \`$NODE_BINARY --print \\"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\\"\` || echo \\"Can't start packager automatically\\"\\n  fi\\nfi\\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -311,7 +290,7 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = HelloWorld/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -335,7 +314,7 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = HelloWorld/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -397,7 +376,7 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -446,7 +425,7 @@ exports[`BundleIdentifier module setBundleIdentifierForPbxproj sets the bundle i
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -208,7 +208,7 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
-platform :ios, podfile_properties['ios.deploymentTarget'] || '13.0'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '13.4'
 install! 'cocoapods',
   :deterministic_uuids => false
 

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/ProvisioningProfile-test.ts.snap
@@ -1456,7 +1456,6 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "HelloWorld" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
@@ -1578,26 +1577,6 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
 			showEnvVarsInLog = 0;
 		};
-		FD10A7F022414F080027D42C /* Start Packager */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Start Packager";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\nexport RCT_METRO_PORT=\\"\${RCT_METRO_PORT:=8081}\\"\\necho \\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\" > \`$NODE_BINARY --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\\"\`\\nif [ -z \\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\" ] ; then\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\n    if ! curl -s \\"http://localhost:\${RCT_METRO_PORT}/status\\" | grep -q \\"packager-status:running\\" ; then\\n      echo \\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\"\\n      exit 2\\n    fi\\n  else\\n    open \`$NODE_BINARY --print \\"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\\"\` || echo \\"Can't start packager automatically\\"\\n  fi\\nfi\\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1627,7 +1606,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = HelloWorld/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -1651,7 +1630,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = HelloWorld/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
@@ -1717,7 +1696,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1766,7 +1745,7 @@ exports[`ProvisioningProfile module setProvisioningProfileForPbxproj single targ
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update snapshot tests.
+
 ## 6.5.0 — 2023-10-17
 
 ### 💡 Others

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update snapshot tests.
+- Update snapshot tests. ([#25211](https://github.com/expo/expo/pull/25211) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 6.5.0 — 2023-10-17
 

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "expo": "~50.0.0-alpha.6",
-    "expo-splash-screen": "~0.24.0",
     "expo-status-bar": "~1.9.0",
     "react": "18.2.0",
     "react-native": "0.72.5"


### PR DESCRIPTION
# Why

This PR has a few revisions to prebuild's core functionality:

1. We originally had expo-splash-screen included because the prebuild template required it, this is no longer the case. One other reason we might keep it is because the app.json splash object is applied via its config plugin. However, the unversioned splash config plugin is technically now versioned and we haven't dropped it, meaning we can rely on it for applying basic splash screen updates.

2. We used to install a fork of `react-native` which was messy and required us to always install with the package manager. This is no longer the case. Now we only need to install if the dependencies in the package.json change (which is still possible given a custom template). This PR updates the logic to skip installing when no dependency modifications are made, which is a potentially breaking change as users could previously assume node modules would always be sync'd on prebuild.

3. The purpose of prebuild is to generate the `ios` and `android` folders with no added side-effects outside of the generated folders. Based on this reasoning and nothing else, I've removed support for updating the `devDependencies` based on the template `package.json`. The check should only add dependencies that are required in the ios and android directories, and there's no reason that those dependencies cannot be in the `dependencies` object of the package.json.

4. When dependencies do change, we'll now prompt the user if they'd like to install so they don't accidentally overwrite any changes that they might have made in the package.json. This prompt is automatically skipped in CI. Ideally we'll drop this in the future in favor of just not installing dependencies, but hopefully it never runs for the majority of users. This was also suggested by @gaearon

# Test Plan

Added some new tests for the `package.json` caching logic since it could be broken by a number of external factors.


Running on a fresh iOS project:

```
nov3 𝝠 nexpo prebuild -p ios

📝  iOS Bundle Identifier Learn more: https://expo.fyi/bundle-identifier

✔ What would you like your iOS bundle identifier to be? … com.bacon.nov3

✔ Created native project
✔ Updated package.json
✔ Finished prebuild
✔ Installed CocoaPods
```

Re-running with no changes:

```
nov3 𝝠 nexpo prebuild -p ios
✔ Created native project | /ios already created
✔ Updated package.json | no changes
✔ Finished prebuild
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
