### PR TITLE
[ci] Enable code-review CI step for all PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,8 +6,7 @@ on:
       pullNumber:
         description: 'Number of the pull request to review'
         required: true
-  pull_request_target:
-    branches: [main, sdk-*]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pullNumber || github.event.number }}


### PR DESCRIPTION
# Why

When I make a stack of PRs, I expect the linter to run on each member of the stack. Otherwise I don't find out about lint errors until that one becomes the base, but the problem is that it's only the base momentarily during landing of the full stack.

The intention is to run this step on all PRs, no matter the base.

# How

Change the condition.

# Test Plan

Tried this in one of my stacked PRs and it seemed to work fine.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
