### PR TITLE
[expo-updates] Asset exclusion on iOS

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### 🎉 New features
 
+- [iOS] Make asset exclusion work. ([#25216](https://github.com/expo/expo/pull/25216) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix the E2E tests. ([#24865](https://github.com/expo/expo/pull/24865) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
@@ -13,7 +13,7 @@ public typealias AppLauncherCompletionBlock = (_ error: Error?, _ success: Bool)
 public protocol AppLauncher {
   @objc var launchedUpdate: Update? { get }
   @objc var launchAssetUrl: URL? { get }
-  @objc var assetFilesMap: [String: Any]? { get }
+  @objc var assetFilesMap: [String: String]? { get }
 
   @objc func isUsingEmbeddedAssets() -> Bool
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
@@ -17,7 +17,7 @@ import Foundation
 public final class AppLauncherNoDatabase: NSObject, AppLauncher {
   public var launchedUpdate: Update?
   public var launchAssetUrl: URL?
-  public var assetFilesMap: [String: Any]?
+  public var assetFilesMap: [String: String]?
 
   public override init() {}
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -1,9 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable type_body_length
 // swiftlint:disable closure_body_length
 // swiftlint:disable force_unwrapping
-// swiftlint:disable type_name
 
 import Foundation
 
@@ -41,6 +39,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
   private let config: UpdatesConfig
   private let database: UpdatesDatabase
   private let directory: URL
+  private let logger: UpdatesLogger
   public private(set) var completionQueue: DispatchQueue
   public private(set) var completion: AppLauncherCompletionBlock?
 
@@ -53,6 +52,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     self.database = database
     self.directory = directory
     self.completionQueue = completionQueue
+    self.logger = UpdatesLogger()
   }
 
   public func isUsingEmbeddedAssets() -> Bool {
@@ -171,7 +171,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       do {
         try self.database.markUpdateAccessed(self.launchedUpdate!)
       } catch {
-        NSLog("Failed to mark update as recently accessed: %@", error.localizedDescription)
+        self.logger.warn(message: "Failed to mark update as recently accessed: \(error.localizedDescription)")
       }
     }
   }
@@ -193,7 +193,9 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
         self.completion = nil
       }
       return
-    } else if launchedUpdate.status == UpdateStatus.StatusDevelopment {
+    }
+
+    if launchedUpdate.status == UpdateStatus.StatusDevelopment {
       completionQueue.async {
         self.completion!(nil, true)
         self.completion = nil
@@ -201,7 +203,8 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       return
     }
 
-    assetFilesMap = [:]
+    // Initialize asset map with the embedded assets that may not be part of this update
+    self.assetFilesMap = UpdatesUtils.embeddedAssetsMap(withConfig: config, database: database)
 
     let assets = launchedUpdate.assets()!
     let totalAssetCount = assets.count
@@ -245,7 +248,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
         }
 
         if let error = error {
-          NSLog("Error copying embedded asset %@: %@", [asset.key, error.localizedDescription])
+          self.logger.warn(message: "AppLauncherWithDatabase: Error copying embedded asset \(asset.key ?? ""): \(error.localizedDescription)")
         }
 
         self.downloadAsset(asset, withLocalUrl: assetLocalUrl) { downloadAssetError, downloadAssetAsset, _ in
@@ -255,7 +258,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
               // so we want to propagate this error
               self.launchAssetError = downloadAssetError
             }
-            NSLog("Failed to load missing asset %@: %@", [downloadAssetAsset.key, downloadAssetError.localizedDescription])
+            self.logger.warn(message: "AppLauncherWithDatabase: Failed to load missing asset \(downloadAssetAsset.key ?? ""): \(downloadAssetError.localizedDescription)")
             completion(false)
           } else {
             // attempt to update the database record to match the newly downloaded asset
@@ -264,7 +267,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
               do {
                 try self.database.updateAsset(downloadAssetAsset)
               } catch {
-                NSLog("Could not write data for downloaded asset to database: %@", [error.localizedDescription])
+                self.logger.warn(message: "AppLauncherWithDatabase: Could not write data for downloaded asset to database: \(error.localizedDescription)")
               }
             }
             completion(true)
@@ -332,10 +335,9 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
         }
       }
       return
-    } else {
-      self.launcherQueue.async {
-        completion(false, nil)
-      }
+    }
+    self.launcherQueue.async {
+      completion(false, nil)
     }
   }
 
@@ -380,3 +382,5 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     FileDownloader(config: config)
   }()
 }
+// swiftlint:enable closure_body_length
+// swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -32,7 +32,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
 
   public var launchedUpdate: Update?
   public var launchAssetUrl: URL?
-  public var assetFilesMap: [String: Any]?
+  public var assetFilesMap: [String: String]?
 
   private let launcherQueue: DispatchQueue
   private var completedAssets: Int
@@ -204,7 +204,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     }
 
     // Initialize asset map with the embedded assets that may not be part of this update
-    self.assetFilesMap = UpdatesUtils.embeddedAssetsMap(withConfig: config, database: database)
+    self.assetFilesMap = UpdatesUtils.embeddedAssetsMap(withConfig: config, database: database, logger: logger)
 
     let assets = launchedUpdate.assets()!
     let totalAssetCount = assets.count

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -323,8 +323,17 @@ open class AppLoader: NSObject {
           // the database and filesystem have gotten out of sync
           // do our best to create a new entry for this file even though it already existed on disk
           // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-          let contents = try? Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename)) ??
-            UpdatesUtils.url(forBundledAsset: existingAsset).let { it in try? Data(contentsOf: it) }
+          var contents: Data?
+          do {
+            contents = try Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename))
+          } catch {}
+          if contents == nil {
+            do {
+              if let embeddedUrl = UpdatesUtils.url(forBundledAsset: existingAsset) {
+                contents = try Data(contentsOf: embeddedUrl)
+              }
+            } catch {}
+          }
           // This replaces the old force try
           assert(contents != nil)
           if let contents = contents {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -4,8 +4,6 @@
 // swiftlint:disable unavailable_function
 
 // swiftlint:disable closure_body_length
-// swiftlint:disable function_body_length
-// swiftlint:disable type_body_length
 
 // this class uses a lot of implicit non-null stuff across function calls. not worth refactoring to just satisfy lint
 // swiftlint:disable force_unwrapping
@@ -325,13 +323,24 @@ open class AppLoader: NSObject {
           // the database and filesystem have gotten out of sync
           // do our best to create a new entry for this file even though it already existed on disk
           // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-
-          // this has always force-tried implicitly, could probably do some better error handling
-          // swiftlint:disable:next force_try
-          let contents = try! Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename))
-          existingAsset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(contents)
-          existingAsset.downloadTime = Date()
-          self.finishedAssets.append(existingAsset)
+          var contents: Data?
+          do {
+            contents = try Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename))
+          } catch {}
+          if contents == nil {
+            do {
+              if let embeddedUrl = UpdatesUtils.url(forBundledAsset: existingAsset) {
+                contents = try Data(contentsOf: embeddedUrl)
+              }
+            } catch {}
+          }
+          // This replaces the old force try
+          assert(contents != nil)
+          if let contents = contents {
+            existingAsset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(contents)
+            existingAsset.downloadTime = Date()
+            self.finishedAssets.append(existingAsset)
+          }
         }
       }
 
@@ -387,3 +396,7 @@ open class AppLoader: NSObject {
     }
   }
 }
+
+// swiftlint:enable unavailable_function
+// swiftlint:enable closure_body_length
+// swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -323,17 +323,8 @@ open class AppLoader: NSObject {
           // the database and filesystem have gotten out of sync
           // do our best to create a new entry for this file even though it already existed on disk
           // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-          var contents: Data?
-          do {
-            contents = try Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename))
-          } catch {}
-          if contents == nil {
-            do {
-              if let embeddedUrl = UpdatesUtils.url(forBundledAsset: existingAsset) {
-                contents = try Data(contentsOf: embeddedUrl)
-              }
-            } catch {}
-          }
+          let contents = try? Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename)) ??
+            UpdatesUtils.url(forBundledAsset: existingAsset).let { it in try? Data(contentsOf: it) }
           // This replaces the old force try
           assert(contents != nil)
           if let contents = contents {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -323,8 +323,12 @@ open class AppLoader: NSObject {
           // the database and filesystem have gotten out of sync
           // do our best to create a new entry for this file even though it already existed on disk
           // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-          let contents = try? Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename)) ??
-            UpdatesUtils.url(forBundledAsset: existingAsset).let { it in try? Data(contentsOf: it) }
+          var contents = try? Data(contentsOf: self.directory.appendingPathComponent(existingAsset.filename))
+          if contents == nil {
+            if let embeddedUrl = UpdatesUtils.url(forBundledAsset: existingAsset) {
+              contents = try? Data(contentsOf: embeddedUrl)
+            }
+          }
           // This replaces the old force try
           assert(contents != nil)
           if let contents = contents {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -128,7 +128,9 @@ public final class EmbeddedAppLoader: AppLoader {
   }
 
   override public func downloadAsset(_ asset: UpdateAsset) {
-    let destinationPath = UpdatesUtils.path(forBundledAsset: asset) ?? ""
+    guard let destinationPath = UpdatesUtils.path(forBundledAsset: asset) else {
+      // do something when this is nil. it's less clear what the behavior for `fileExists(atPath: "")` is 
+    }
     assert(FileManager.default.fileExists(atPath: destinationPath))
     FileDownloader.assetFilesQueue.async {
       self.handleAssetDownloadAlreadyExists(asset)

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -128,10 +128,6 @@ public final class EmbeddedAppLoader: AppLoader {
   }
 
   override public func downloadAsset(_ asset: UpdateAsset) {
-    guard let destinationPath = UpdatesUtils.path(forBundledAsset: asset) else {
-      // do something when this is nil. it's less clear what the behavior for `fileExists(atPath: "")` is 
-    }
-    assert(FileManager.default.fileExists(atPath: destinationPath))
     FileDownloader.assetFilesQueue.async {
       self.handleAssetDownloadAlreadyExists(asset)
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -1,6 +1,5 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable identifier_name
 // swiftlint:disable legacy_objc_type
 
 // this class uses an abstract class pattern
@@ -129,35 +128,10 @@ public final class EmbeddedAppLoader: AppLoader {
   }
 
   override public func downloadAsset(_ asset: UpdateAsset) {
-    let destinationUrl = directory.appendingPathComponent(asset.filename)
+    let destinationPath = UpdatesUtils.path(forBundledAsset: asset) ?? ""
+    assert(FileManager.default.fileExists(atPath: destinationPath))
     FileDownloader.assetFilesQueue.async {
-      if FileManager.default.fileExists(atPath: destinationUrl.path) {
-        DispatchQueue.global().async {
-          self.handleAssetDownloadAlreadyExists(asset)
-        }
-      } else {
-        let mainBundleFilename = asset.mainBundleFilename.require("embedded asset mainBundleFilename must be nonnull")
-        let bundlePath = UpdatesUtils.path(forBundledAsset: asset).require(
-          String(
-            format: "Could not find the expected embedded asset in NSBundle %@.%@. " +
-              "Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
-            mainBundleFilename,
-            asset.type ?? ""
-          )
-        )
-
-        do {
-          try FileManager.default.copyItem(atPath: bundlePath, toPath: destinationUrl.path)
-          let data = try NSData(contentsOfFile: bundlePath) as Data
-          DispatchQueue.global().async {
-            self.handleAssetDownload(withData: data, response: nil, asset: asset)
-          }
-        } catch {
-          DispatchQueue.global().async {
-            self.handleAssetDownload(withError: error, asset: asset)
-          }
-        }
-      }
+      self.handleAssetDownloadAlreadyExists(asset)
     }
   }
 
@@ -171,3 +145,6 @@ public final class EmbeddedAppLoader: AppLoader {
     preconditionFailure("Should not call EmbeddedAppLoader#loadUpdateFromUrl")
   }
 }
+
+// swiftlint:enable legacy_objc_type
+// swiftlint:enable unavailable_function

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -1,8 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 // swiftlint:disable force_unwrapping
-// swiftlint:disable closure_body_length
-// swiftlint:disable superfluous_else
 
 import Foundation
 import SystemConfiguration
@@ -89,6 +87,26 @@ public final class UpdatesUtils: NSObject {
     }
   }
 
+  internal static func embeddedAssetsMap(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> [String: Any] {
+    var assetFilesMap: [String: Any] = [:]
+    let embeddedManifest: Update? = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database)
+    let embeddedAssets = embeddedManifest?.assets() ?? []
+
+    // Prepopulate with embedded assets
+    for asset in embeddedAssets {
+      if let assetKey: String = asset.key {
+        if !asset.isLaunchAsset {
+          let absolutePath = path(forBundledAsset: asset)
+          let message = "AppLauncherWithDatabase: embedded asset key = \(asset.key ?? ""), main bundle filename = \(asset.mainBundleFilename ?? ""), path = \(absolutePath ?? "")"
+          NSLog(message)
+          assetFilesMap[assetKey] = absolutePath
+        }
+      }
+    }
+
+    return assetFilesMap
+  }
+
   internal static func url(forBundledAsset asset: UpdateAsset) -> URL? {
     guard let mainBundleDir = asset.mainBundleDir else {
       return Bundle.main.url(forResource: asset.mainBundleFilename, withExtension: asset.type)
@@ -156,5 +174,3 @@ public final class UpdatesUtils: NSObject {
 }
 
 // swiftlint:enable force_unwrapping
-// swiftlint:enable closure_body_length
-// swiftlint:enable superfluous_else

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -87,8 +87,8 @@ public final class UpdatesUtils: NSObject {
     }
   }
 
-  internal static func embeddedAssetsMap(withConfig config: UpdatesConfig, database: UpdatesDatabase) -> [String: String?] {
-    var assetFilesMap: [String: String?] = [:]
+  internal static func embeddedAssetsMap(withConfig config: UpdatesConfig, database: UpdatesDatabase, logger: UpdatesLogger) -> [String: String] {
+    var assetFilesMap: [String: String] = [:]
     let embeddedManifest: Update? = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database)
     let embeddedAssets = embeddedManifest?.assets() ?? []
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -87,20 +87,19 @@ public final class UpdatesUtils: NSObject {
     }
   }
 
-  internal static func embeddedAssetsMap(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> [String: Any] {
-    var assetFilesMap: [String: Any] = [:]
+  internal static func embeddedAssetsMap(withConfig config: UpdatesConfig, database: UpdatesDatabase) -> [String: String?] {
+    var assetFilesMap: [String: String?] = [:]
     let embeddedManifest: Update? = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database)
     let embeddedAssets = embeddedManifest?.assets() ?? []
 
     // Prepopulate with embedded assets
     for asset in embeddedAssets {
-      if let assetKey: String = asset.key {
-        if !asset.isLaunchAsset {
-          let absolutePath = path(forBundledAsset: asset)
-          let message = "AppLauncherWithDatabase: embedded asset key = \(asset.key ?? ""), main bundle filename = \(asset.mainBundleFilename ?? ""), path = \(absolutePath ?? "")"
-          NSLog(message)
-          assetFilesMap[assetKey] = absolutePath
-        }
+      if let assetKey = asset.key,
+        !asset.isLaunchAsset {
+        let absolutePath = path(forBundledAsset: asset)
+        let message = "AppLauncherWithDatabase: embedded asset key = \(asset.key ?? ""), main bundle filename = \(asset.mainBundleFilename ?? ""), path = \(absolutePath ?? "")"
+        logger.debug(message: message)
+        assetFilesMap[assetKey] = absolutePath
       }
     }
 


### PR DESCRIPTION
# Why

Allow iOS to make use of updates created with only some assets included (using the CLI changes in #25065 ).

# How

- Make iOS work with updates that don't include all assets
- Remove unneeded copy of embedded assets to the updates folder on first launch

# Test Plan

- Manual testing with a custom test app
  - The app has Expo config with `extra.updates.assetPatternsToBeBundled = "assetsInUpdates/*"`
  - Start with some assets (images and fonts) in a different folder (e.g. `embeddedAssets`)
  - App starts up, embedded bundle works and shows all images and fonts
  - Add a new image in `embeddedAssets`, run `eas update` and download and launch update
  - App works, but image will not show in UI
  - Now move that image to the `assetsInUpdates` folder, and change `App.tsx` accordingly
  - Run `eas update` again, download and run update
  - The new image will now show up correctly in the UI
- Updates E2E should continue to pass (confirming that this does not break existing behavior)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
