### PR TITLE
[docs] Update runtime-issues.mdx

### DIFF
--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -54,7 +54,7 @@ This will add an **android** directory at the root of your project.
 
 Open the project in Android Studio by running the command:
 
-<Terminal cmd={['$ open -a /Applications/Android Studio.app ./android']} />
+<Terminal cmd={['$ open -a "/Applications/Android Studio.app" ./android']} />
 
 </Step>
 


### PR DESCRIPTION
Add quotes around "Android Studio" filename so command runs correctly when copied

# Why
The docs are wrong

# How
See above

# Test Plan
Created the correct command locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
