### PR TITLE
[docs] Step-by-step how to migrate existing users to SSO

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -54,7 +54,7 @@ SSO users are like regular users. However, there are a few known exceptions:
 Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO and then direct new members to the SSO sign-in page, while existing users continue to use their current Expo credentials. To support external contributors, SSO-enabled organizations also allow inviting additional non-SSO users via email.
 
 ### Transitioning existing users to SSO
-Regular user accounts are owned by the individual user and joined to organizations as needed, while SSO users belong exclusively to their organization. Thus, existing users cannot be directly migrated to SSO. However, a user that's already a member of your organization can create a second account by going to the [SSO login page](https://expo.dev/sso-login). Then, their old user can be removed from the organization.
+Regular users may be a member of one or many personal, team, and organization accounts while SSO users belong exclusively to their organization account. Thus, existing users cannot be directly converted into SSO users. However, a regular user that's already a member of your organization may create a second user by going to the [SSO login page](https://expo.dev/sso-login). Then, their regular user can be removed from the organization.
 
 To transition from using a regular Expo account to an SSO account, follow these steps:
 1. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -62,7 +62,7 @@ To transition from using a regular Expo account to an SSO account, follow these 
 3. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.
 4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under your old user account.** It will not affect any projects owned by the organization.
 
-> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. You can also rename your SSO user account's Expo username later.
+> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user.
 
 
 ### Remove SSO users

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -60,7 +60,7 @@ To transition from using a regular Expo account to an SSO account, follow these 
 1. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.
 2. By default, your new SSO user will have the View Only role. If you need a different role, ask an Admin or Owner to update your role in [member settings](https://expo.dev/accounts/[account]/settings/members).
 3. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.
-4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under  your old user account.** It will not affect any projects owned by the organization.
+4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under your old user account.** It will not affect any projects owned by the organization.
 
 > If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. You can also rename your SSO user account's Expo username later.
 

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -51,9 +51,19 @@ SSO users are like regular users. However, there are a few known exceptions:
 
 ## SSO administration
 
-Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO, and both non-SSO users and SSO users can continue to be added as members of SSO organizations.
+Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO and then direct new members to the SSO sign-in page, while existing users continue to use their current Expo credentials. To support external contributors, SSO-enabled organizations also support inviting additional non-SSO users via email.
 
-People with existing non-SSO accounts can evaluate SSO by signing in with SSO, thus creating a second account, but we don't recommend this for all members. For simplicity, we recommend that new organization members use SSO to sign up but existing members continue to sign in as they normally would with their credentials. Migration of a non-SSO user to a SSO user is not currently supported.
+### Transitioning existing users to SSO
+Compared to regular users, SSO users have an exclusive relationship with their organization. Thus, existing users cannot be directly migrated to SSO. However, a user that's already a member of your organization can create a second account by going to the [SSO login page](https://expo.dev/sso-login). Then, their old user can be removed from the organization.
+
+To transition from using a regular Expo account to an SSO account, follow these steps:
+1. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.
+2. By default, your new SSO user will have the View Only role. If you need a different role, ask an Admin or Owner to update your role in [member settings](https://expo.dev/accounts/[account]/settings/members).
+3. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.
+4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under  your old user account.** It will not affect any projects owned by the organization.
+
+> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. You can also rename your SSO user account's Expo username later.
+
 
 ### Remove SSO users
 

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -54,7 +54,7 @@ SSO users are like regular users. However, there are a few known exceptions:
 Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO and then direct new members to the SSO sign-in page, while existing users continue to use their current Expo credentials. To support external contributors, SSO-enabled organizations also support inviting additional non-SSO users via email.
 
 ### Transitioning existing users to SSO
-Compared to regular users, SSO users have an exclusive relationship with their organization. Thus, existing users cannot be directly migrated to SSO. However, a user that's already a member of your organization can create a second account by going to the [SSO login page](https://expo.dev/sso-login). Then, their old user can be removed from the organization.
+Regular user accounts are owned by the individual user and joined to organizations as needed, while SSO users belong exclusively to their organization. Thus, existing users cannot be directly migrated to SSO. However, a user that's already a member of your organization can create a second account by going to the [SSO login page](https://expo.dev/sso-login). Then, their old user can be removed from the organization.
 
 To transition from using a regular Expo account to an SSO account, follow these steps:
 1. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -51,7 +51,7 @@ SSO users are like regular users. However, there are a few known exceptions:
 
 ## SSO administration
 
-Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO and then direct new members to the SSO sign-in page, while existing users continue to use their current Expo credentials. To support external contributors, SSO-enabled organizations also support inviting additional non-SSO users via email.
+Both new organizations and existing organizations can enable SSO as a sign in option. Organizations with existing non-SSO members can enable SSO and then direct new members to the SSO sign-in page, while existing users continue to use their current Expo credentials. To support external contributors, SSO-enabled organizations also allow inviting additional non-SSO users via email.
 
 ### Transitioning existing users to SSO
 Regular user accounts are owned by the individual user and joined to organizations as needed, while SSO users belong exclusively to their organization. Thus, existing users cannot be directly migrated to SSO. However, a user that's already a member of your organization can create a second account by going to the [SSO login page](https://expo.dev/sso-login). Then, their old user can be removed from the organization.
@@ -63,7 +63,6 @@ To transition from using a regular Expo account to an SSO account, follow these 
 4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under your old user account.** It will not affect any projects owned by the organization.
 
 > If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user. While Expo usernames need to be unique, it is OK if your email address on your identity provider matches the email address of your old user.
-
 
 ### Remove SSO users
 
@@ -78,6 +77,8 @@ If you wish to remove them ahead of that time or you wish to remove them to clea
 ### Change billing or discontinue use of SSO
 
 An active Enterprise Plan is required to continue using SSO. [Contact us](https://expo.dev/contact) if you wish to discontinue the use of SSO or change your plan.
+
+In order to ensure uninterrupted access to your organization whether or not SSO is enabled, SSO organizations must keep at least one non-SSO user with the Owner role as a member.
 
 ### Delete your SSO organization
 

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -62,7 +62,7 @@ To transition from using a regular Expo account to an SSO account, follow these 
 3. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.
 4. If you no longer need your old user account, log out of your new SSO account, then login to your old account and go to [user settings](https://expo.dev/settings). Scroll down and click **Delete Account**. **Note that this will delete any projects under your old user account.** It will not affect any projects owned by the organization.
 
-> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user.
+> If you wish to reuse your old username on your new SSO user account, you can go to [user settings](https://expo.dev/settings) under your old user and rename it prior to creating your SSO account. Alternatively, you can rename your SSO user account's Expo username after deleting your old user. While Expo usernames need to be unique, it is OK if your email address on your identity provider matches the email address of your old user.
 
 
 ### Remove SSO users


### PR DESCRIPTION
# Why
Due to corporate policies, often, once an organization is using SSO, it's not really practical for them to not transition everyone over to SSO, even if we recommend they don't. We get a lot of questions about how you make this transition, so let's spell it out how it could work. By outlining what you need to do, this should further reinforce the answer to questions about what is not currently possible (an automated migration).

# How
- Rework text about mixed SSO and non-SSO users to acknowledge the transition state
- Provide a step by step that individual users plus account administrators could follow to get transitioned over

NOTE: this mentions a visual indication of an SSO user that is in progress (https://github.com/expo/universe/pull/13867).
