### PR TITLE
[docs] Fix broken link formatting in "Edit rich text"

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -100,7 +100,7 @@ You can also wrap any native rich text editor using [Expo Modules](/modules/over
 
 > Rich text is usually represented using [abstract syntax trees](https://en.wikipedia.org/wiki/Abstract_syntax_tree). For example, a bullet list can be a node of type `bulleted-list` with several children of type `list-item`. You can convert both HTML and markdown to a suitable AST format.
 
-There is also an effort to [port the lexical editor to Android and iOS and provide a React Native wrapper](track it here: https://github.com/facebook/lexical/discussions/2410)
+There is also an effort to port the lexical editor to Android and iOS and provide a React Native wrapper, track it [here](https://github.com/facebook/lexical/discussions/2410).
 
 ## Summary
 


### PR DESCRIPTION
# Why

Fix broken link formatting in "Edit rich text" article.

# How

I corrected Markdown formatting

# Test Plan

See the change with your eyes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
