### PR TITLE
chore(metro-runtime): improve url support testing

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Improve testing for URL support on native. ([#25240](https://github.com/expo/expo/pull/25240) by [@EvanBacon](https://github.com/EvanBacon))
 - Migrate to new standard `URL` support on native. ([#24941](https://github.com/expo/expo/pull/24941) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 3.0.3 — 2023-10-17

--- a/packages/@expo/metro-runtime/jest.config.js
+++ b/packages/@expo/metro-runtime/jest.config.js
@@ -1,0 +1,25 @@
+const {
+  getWebPreset,
+  //   getNodePreset,
+  getIOSPreset,
+  getAndroidPreset,
+} = require('jest-expo/config/getPlatformPreset');
+const { withWatchPlugins } = require('jest-expo/config/withWatchPlugins');
+
+function withDefaults({ watchPlugins, ...config }) {
+  return {
+    ...config,
+    clearMocks: true,
+    roots: ['src'],
+  };
+}
+
+module.exports = withWatchPlugins({
+  projects: [
+    // Create a new project for each platform.
+    getWebPreset(),
+    // getNodePreset(),
+    getIOSPreset(),
+    getAndroidPreset(),
+  ].map(withDefaults),
+});

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -35,21 +35,5 @@
   },
   "peerDependencies": {
     "react-native": "*"
-  },
-  "jest": {
-    "projects": [
-      {
-        "preset": "jest-expo/ios",
-        "clearMocks": true
-      },
-      {
-        "preset": "jest-expo/android",
-        "clearMocks": true
-      },
-      {
-        "preset": "jest-expo/web",
-        "clearMocks": true
-      }
-    ]
   }
 }

--- a/packages/@expo/metro-runtime/src/async-require/__tests__/buildUrlForBundle.test.native.ts
+++ b/packages/@expo/metro-runtime/src/async-require/__tests__/buildUrlForBundle.test.native.ts
@@ -38,7 +38,7 @@ it(`asserts in production that the origin was not specified at build-time`, () =
   // Don't mock the location object...
 
   expect(() => buildUrlForBundle('/foobar')).toThrow(
-    /Unable to determine the production URL where additional JavaScript chunks are hosted because the global \"location\" variable is not defined\./
+    /Unable to determine the production URL where additional JavaScript chunks are hosted because the global "location" variable is not defined\./
   );
 });
 it(`returns an expected URL in development`, () => {

--- a/packages/@expo/metro-runtime/src/async-require/__tests__/buildUrlForBundle.test.native.ts
+++ b/packages/@expo/metro-runtime/src/async-require/__tests__/buildUrlForBundle.test.native.ts
@@ -9,7 +9,41 @@ jest.mock('../../getDevServer', () => ({
   default: jest.fn(),
 }));
 
-it(`returns an expected URL`, () => {
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  delete window.location;
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+  delete window.location;
+});
+
+it(`returns an expected URL in production`, () => {
+  process.env.NODE_ENV = 'production';
+
+  // Mock the location object
+  window.location = {
+    origin: 'http://localhost:19000',
+  };
+
+  expect(buildUrlForBundle('/foobar')).toEqual('http://localhost:19000/foobar');
+});
+
+it(`asserts in production that the origin was not specified at build-time`, () => {
+  process.env.NODE_ENV = 'production';
+
+  // Don't mock the location object...
+
+  expect(() => buildUrlForBundle('/foobar')).toThrow(
+    /Unable to determine the production URL where additional JavaScript chunks are hosted because the global \"location\" variable is not defined\./
+  );
+});
+it(`returns an expected URL in development`, () => {
+  process.env.NODE_ENV = 'development';
+
   asMock(getDevServer).mockReturnValueOnce({
     bundleLoadedFromServer: true,
     fullBundleUrl:

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 ### 💡 Others
 
-- Improve testing for URL support on native.
 - Revert `URL` support. ([#25006](https://github.com/expo/expo/pull/25006) by [@EvanBacon](https://github.com/EvanBacon))
 - Encode Blob components in `URL.createObjectURL`. ([#25004](https://github.com/expo/expo/pull/25004) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 💡 Others
 
+- Improve testing for URL support on native.
 - Revert `URL` support. ([#25006](https://github.com/expo/expo/pull/25006) by [@EvanBacon](https://github.com/EvanBacon))
 - Encode Blob components in `URL.createObjectURL`. ([#25004](https://github.com/expo/expo/pull/25004) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))


### PR DESCRIPTION
# Why

Tests were technically failing, this fixes them. Related https://github.com/expo/expo/pull/25171
