### PR TITLE
[tools] Update OpenAI integration to use gpt-4-turbo

### DIFF
--- a/tools/src/OpenAI.ts
+++ b/tools/src/OpenAI.ts
@@ -9,7 +9,7 @@ const openai = new OpenAIApi(configuration);
 
 export async function askChatGPTAsync(question: string): Promise<string | undefined> {
   const response = await openai.createChatCompletion({
-    model: 'gpt-4',
+    model: 'gpt-4-1106-preview',
     messages: [{ role: 'user', content: question }],
   });
 


### PR DESCRIPTION
# Why

Today OpenAI announced GPT-4 Turbo,  a more capable model that has knowledge of world events up to April 2023. With its optimized performance this new model can get [3x cheaper](https://openai.com/pricing#gpt-4-turbo) input tokens and a 2x cheaper price for output tokens when compared to GPT-4.

# How

Update the OpenAI integration to use the `gpt-4-1106-preview` model to generate the issue summary for Linear 

# Test Plan

`et igitl -i 19677`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
