### PR TITLE
Fix tests running in CI.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 💡 Others
 
+- Fix tests running in CI.
 - Drop support for running arbitrary Metro packages. ([#25197](https://github.com/expo/expo/pull/25197) by [@EvanBacon](https://github.com/EvanBacon))
 - Update tests. ([#25089](https://github.com/expo/expo/pull/25089) by [@EvanBacon](https://github.com/EvanBacon))
 - Memoize notice log about `src/app` directory to prevent spam. ([#25000](https://github.com/expo/expo/pull/25000) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### 💡 Others
 
-- Fix tests running in CI.
+- Fix tests running in CI. ([#25244](https://github.com/expo/expo/pull/25244) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for running arbitrary Metro packages. ([#25197](https://github.com/expo/expo/pull/25197) by [@EvanBacon](https://github.com/EvanBacon))
 - Update tests. ([#25089](https://github.com/expo/expo/pull/25089) by [@EvanBacon](https://github.com/EvanBacon))
 - Memoize notice log about `src/app` directory to prevent spam. ([#25000](https://github.com/expo/expo/pull/25000) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -17,7 +17,7 @@
     "lint": "expo-module lint",
     "typecheck": "expo-module typecheck",
     "test": "expo-module test",
-    "test:e2e": "jest --config e2e/jest.config.js",
+    "test:e2e": "jest --config e2e/jest.config.js --runInBand",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "generate-graphql-code": "graphql-codegen --config graphql-codegen.yml"

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -23,6 +23,7 @@ import {
   getRouterDirectoryWithManifest,
 } from '../start/server/metro/router';
 import { learnMore } from '../utils/link';
+import { getFreePortAsync } from '../utils/port';
 
 const debug = require('debug')('expo:export:generateStaticRoutes') as typeof console.log;
 
@@ -41,16 +42,21 @@ export async function unstable_exportStaticAsync(projectRoot: string, options: O
       learnMore('https://docs.expo.dev/router/reference/static-rendering/')
   );
 
+  // Useful for running parallel e2e tests in CI.
+  const port = await getFreePortAsync(8082);
+
   // TODO: Prevent starting the watcher.
   const devServerManager = new DevServerManager(projectRoot, {
     minify: options.minify,
     mode: 'production',
+    port,
     location: {},
   });
   await devServerManager.startAsync([
     {
       type: 'metro',
       options: {
+        port,
         location: {},
         isExporting: true,
       },

--- a/packages/@expo/cli/src/start/server/metro/externals.ts
+++ b/packages/@expo/cli/src/start/server/metro/externals.ts
@@ -39,7 +39,10 @@ export async function setupShimFiles(projectRoot: string) {
   // Copy the shims to the project folder in case we're running in a monorepo.
   const shimsFolder = path.join(require.resolve('@expo/cli/package.json'), '../static/shims');
 
-  await copyAsync(shimsFolder, path.join(projectRoot, METRO_SHIMS_FOLDER));
+  await copyAsync(shimsFolder, path.join(projectRoot, METRO_SHIMS_FOLDER), {
+    overwrite: true,
+    recursive: true,
+  });
 }
 
 export async function setupNodeExternals(projectRoot: string) {


### PR DESCRIPTION
# Why

Unclear why tests ever worked because they use the same ports to perform bundling. We can revisit in the future by removing the need for a port, but for now I'm making all e2e bundler tests run in band. Unblocks test issues here https://github.com/expo/expo/pull/25239
