### PR TITLE
[expo][dev-client] fix android crash from accessFlags reflection

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed crash from accessing the `accessFlags` attribute on Android API 22. ([#25248](https://github.com/expo/expo/pull/25248) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.4.13 — 2023-09-25

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReflectionExtensions.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherReflectionExtensions.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher.helpers
 import java.lang.Exception
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
+import expo.modules.devmenu.helpers.removeFinalModifier
 
 fun <T> Class<T>.getFieldInClassHierarchy(fieldName: String): Field? {
   var currentClass: Class<*>? = this
@@ -19,15 +20,8 @@ fun <T> Class<T>.getFieldInClassHierarchy(fieldName: String): Field? {
 
 fun <T> Class<out T>.setProtectedDeclaredField(obj: T, filedName: String, newValue: Any, predicate: (Any?) -> Boolean = { true }) {
   val field = getDeclaredField(filedName)
-  val modifiersField = Field::class.java.getDeclaredField("accessFlags")
-
+  removeFinalModifier(field)
   field.isAccessible = true
-  modifiersField.isAccessible = true
-
-  modifiersField.setInt(
-    field,
-    field.modifiers and Modifier.FINAL.inv()
-  )
 
   if (!predicate.invoke(field.get(obj))) {
     return

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed crash from accessing the `accessFlags` attribute on Android API 22. ([#25248](https://github.com/expo/expo/pull/25248) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 3.2.1 — 2023-09-25

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/helpers/DevMenuReflectionExtensions.kt
@@ -1,5 +1,6 @@
 package expo.modules.devmenu.helpers
 
+import android.os.Build
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
@@ -12,15 +13,23 @@ fun <T, R> Class<out T>.getPrivateDeclaredFieldValue(filedName: String, obj: T):
 
 fun <T> Class<out T>.setPrivateDeclaredFieldValue(filedName: String, obj: T, newValue: Any) {
   val field = getDeclaredField(filedName)
-  val modifiersField = Field::class.java.getDeclaredField("accessFlags")
-
+  removeFinalModifier(field)
   field.isAccessible = true
-  modifiersField.isAccessible = true
-
-  modifiersField.setInt(
-    field,
-    field.modifiers and Modifier.FINAL.inv()
-  )
-
   field.set(obj, newValue)
+}
+
+@Suppress("DiscouragedPrivateApi")
+fun removeFinalModifier(field: Field) {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+    val artField = Field::class.java.getDeclaredField("artField")
+    artField.isAccessible = true
+    val modifiers = Class.forName("java.lang.reflect.ArtField").getDeclaredField("accessFlags")
+    modifiers.isAccessible = true
+    modifiers.setInt(artField.get(field), field.modifiers and Modifier.FINAL.inv())
+    return
+  }
+
+  val modifiers = Field::class.java.getDeclaredField("accessFlags")
+  modifiers.isAccessible = true
+  modifiers.setInt(field, field.modifiers and Modifier.FINAL.inv())
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed crash from accessing the `accessFlags` attribute on Android API 22. ([#25248](https://github.com/expo/expo/pull/25248) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 49.0.16 — 2023-10-20

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -3,6 +3,7 @@ package expo.modules
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.ViewGroup
@@ -123,9 +124,7 @@ class ReactActivityDelegateWrapper(
     if (newDelegate != null && newDelegate != this) {
       val mDelegateField = ReactActivity::class.java.getDeclaredField("mDelegate")
       mDelegateField.isAccessible = true
-      val modifiers = Field::class.java.getDeclaredField("accessFlags")
-      modifiers.isAccessible = true
-      modifiers.setInt(mDelegateField, mDelegateField.modifiers and Modifier.FINAL.inv())
+      removeFinalModifier(mDelegateField)
       mDelegateField.set(activity, newDelegate)
       delegate = newDelegate
 
@@ -298,6 +297,25 @@ class ReactActivityDelegateWrapper(
       methodMap[name] = method
     }
     return method!!.invoke(delegate, *args) as T
+  }
+
+  /**
+   * Remove the Java `final` modifier from the field
+   */
+  @Suppress("DiscouragedPrivateApi")
+  private fun removeFinalModifier(field: Field) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      val artField = Field::class.java.getDeclaredField("artField")
+      artField.isAccessible = true
+      val modifiers = Class.forName("java.lang.reflect.ArtField").getDeclaredField("accessFlags")
+      modifiers.isAccessible = true
+      modifiers.setInt(artField.get(field), field.modifiers and Modifier.FINAL.inv())
+      return
+    }
+
+    val modifiers = Field::class.java.getDeclaredField("accessFlags")
+    modifiers.isAccessible = true
+    modifiers.setInt(field, field.modifiers and Modifier.FINAL.inv())
   }
 
   //endregion


### PR DESCRIPTION
# Why

fixes #24896 
close ENG-10366

# How

the `accessFlags` is presented from android api 23. older api should use different way to do the reflection
reference:
- http://androidxref.com/5.1.0_r1/xref/libcore/libart/src/main/java/java/lang/reflect/Field.java#94
- http://androidxref.com/5.1.0_r1/xref/libcore/libart/src/main/java/java/lang/reflect/ArtField.java#56

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
