### PR TITLE
[docs] Add section about selecting large worker

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -176,9 +176,9 @@ To use workers of a specific resource class in your project, add [`android.resou
         "resourceClass": "medium"
       }
     }
-     /* @hide ... */ /* @end */
+    /* @hide ... */ /* @end */
   }
-   /* @hide ... */ /* @end */
+  /* @hide ... */ /* @end */
 }
 ```
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -160,9 +160,9 @@ It's common to want to share build tool configuration between profiles, and we c
 
 ### Selecting resource class
 
-If your project requires extensive resources due to its complexity or size, or if you want your builds to run faster, you can use `large` workers to run your jobs. These workers have access to a more powerful CPU and bigger memory.
+Resource class is the virtual machine resources configuration (CPU cores, RAM size) EAS Build provides to your jobs. By default, resource class is set to `medium` which is usually sufficient for both small and bigger projects. However, if your project requires more powerful CPU or bigger memory, or if you want your builds to finish faster, you can switch to `large` workers.
 
-To use workers of a specific resource class in your project, add [`android.resourceClass`](/eas/json/#resourceclass-1) or [`ios.resourceClass`](/eas/json/#resourceclass-2) property to your build profile:
+For more details on resources provided to each class, see [`android.resourceClass`](/eas/json/#resourceclass-1) and [`ios.resourceClass`](/eas/json/#resourceclass-2) property documentations. To run your build on a worker of specific resource class, configure this property in your build profile:
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -160,10 +160,11 @@ It's common to want to share build tool configuration between profiles, and we c
 
 ### Selecting resource class
 
-If your project requires extensive resources due to its complexity or size or if you want your builds to run faster, you can choose to run your jobs on `large` workers, which have access to a more powerful CPU and bigger memory. For more details on class-specific resources, see [Android](/eas/json/#resourceclass-1) and [iOS](/eas/json/#resourceclass-2) `resourceClass` property documentations.
+If your project requires extensive resources due to its complexity or size, or if you want your builds to run faster, you can use `large` workers to run your jobs. These workers have access to a more powerful CPU and bigger memory.
 
-To use workers of specific resource class in your project, add `[platform].resourceClass` property to your build profile:
+To use workers of a specific resource class in your project, add [`android.resourceClass`](/eas/json/#resourceclass-1) or [`ios.resourceClass`](/eas/json/#resourceclass-2) property to your build profile:
 
+{/* prettier-ignore */}
 ```json eas.json
 {
   "build": {
@@ -175,13 +176,13 @@ To use workers of specific resource class in your project, add `[platform].resou
         "resourceClass": "medium"
       }
     }
-    // ...
+     /* @hide ... */ /* @end */
   }
-  // ...
+   /* @hide ... */ /* @end */
 }
 ```
 
-> Note: running jobs on `large` workers requires paid EAS plan. [Subscribe here](https://expo.dev/accounts/[account]/settings/billing).
+> **Note**: Running jobs on a `large` worker requires a paid EAS plan. [Subscribe here](https://expo.dev/accounts/[account]/settings/billing).
 
 ### Selecting a base image
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -160,9 +160,9 @@ It's common to want to share build tool configuration between profiles, and we c
 
 ### Selecting resource class
 
-Resource class is the virtual machine resources configuration (CPU cores, RAM size) EAS Build provides to your jobs. By default, resource class is set to `medium` which is usually sufficient for both small and bigger projects. However, if your project requires more powerful CPU or bigger memory, or if you want your builds to finish faster, you can switch to `large` workers.
+Resource class is the virtual machine resources configuration (CPU cores, RAM size) EAS Build provides to your jobs. By default, the resource class is set to `medium`, which is usually sufficient for both small and bigger projects. However, if your project requires a more powerful CPU or bigger memory, or if you want your builds to finish faster, you can switch to `large` workers.
 
-For more details on resources provided to each class, see [`android.resourceClass`](/eas/json/#resourceclass-1) and [`ios.resourceClass`](/eas/json/#resourceclass-2) property documentations. To run your build on a worker of specific resource class, configure this property in your build profile:
+For more details on resources provided to each class, see [`android.resourceClass`](/eas/json/#resourceclass-1) and [`ios.resourceClass`](/eas/json/#resourceclass-2) property documentations. To run your build on a worker of a specific resource class, configure this property in your build profile:
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -158,6 +158,31 @@ It's common to want to share build tool configuration between profiles, and we c
 }
 ```
 
+### Selecting resource class
+
+If your project requires extensive resources due to its complexity or size or if you want your builds to run faster, you can choose to run your jobs on `large` workers, which have access to a more powerful CPU and bigger memory. For more details on class-specific resources, see [Android](/eas/json/#resourceclass-1) and [iOS](/eas/json/#resourceclass-2) `resourceClass` property documentations.
+
+To use workers of specific resource class in your project, add `[platform].resourceClass` property to your build profile:
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "ios": {
+        "resourceClass": "large"
+      },
+      "android": {
+        "resourceClass": "medium"
+      }
+    }
+    // ...
+  }
+  // ...
+}
+```
+
+> Note: running jobs on `large` workers requires paid EAS plan. [Subscribe here](https://expo.dev/accounts/[account]/settings/billing).
+
 ### Selecting a base image
 
 The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and CocoaPods. You can override them using the specific named fields as described in the previous section. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.


### PR DESCRIPTION
# Why

I want to be able to provide users with more information when explaining they should use a large worker.

# How

Added a section to the docs.

# Test Plan

You tell me if it's clear enough!

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
