### PR TITLE
chore(repo): split up fingerprint e2e tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -7,8 +7,13 @@ on:
       - .github/workflows/cli.yml
       - packages/@expo/cli/**
       - packages/@expo/metro-runtime/**
-      - packages/@expo/metro-config/**
-      - packages/@expo/fingerprint/**
+      - packages/@expo/metro-config/src/**
+      - packages/@expo/config/src/**
+      - packages/@expo/config-plugins/src/**
+      - packages/@expo/env/src/**
+      - packages/@expo/package-manager/src/**
+      - packages/@expo/prebuild-config/src/**
+      - packages/@expo/server/src/**
       - packages/create-expo/**
       - packages/expo-router/**
       - yarn.lock
@@ -17,8 +22,13 @@ on:
       - .github/workflows/cli.yml
       - packages/@expo/cli/**
       - packages/@expo/metro-runtime/**
-      - packages/@expo/metro-config/**
-      - packages/@expo/fingerprint/**
+      - packages/@expo/metro-config/src/**
+      - packages/@expo/config/src/**
+      - packages/@expo/config-plugins/src/**
+      - packages/@expo/env/src/**
+      - packages/@expo/package-manager/src/**
+      - packages/@expo/prebuild-config/src/**
+      - packages/@expo/server/src/**
       - packages/create-expo/**
       - packages/expo-router/**
       - yarn.lock
@@ -57,9 +67,6 @@ jobs:
       - name: E2E Test CLI
         run: yarn test:e2e
         working-directory: packages/@expo/cli
-      - name: E2E Test @expo/fingerprint
-        run: yarn test:e2e
-        working-directory: packages/@expo/fingerprint
       # - name: 🔔 Notify on Slack
       #   uses: 8398a7/action-slack@v3
       #   if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -1,0 +1,45 @@
+name: Fingerprint
+
+on:
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/fingerprint.yml
+      - packages/@expo/fingerprint/**
+      - packages/create-expo/**
+      - yarn.lock
+  pull_request:
+    paths:
+      - .github/workflows/fingerprint.yml
+      - packages/@expo/fingerprint/**
+      - packages/create-expo/**
+      - yarn.lock
+  schedule:
+    - cron: 0 14 * * *
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Install node modules in root dir
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: E2E Test @expo/fingerprint
+        run: yarn test:e2e
+        working-directory: packages/@expo/fingerprint


### PR DESCRIPTION
# Why

CLI e2e is getting long, we can reduce the time and complexity by splitting out fingerprint tests to a new job.
