### PR TITLE
chore(repo): use bun for e2e CLI tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,6 +40,10 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.x
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -88,10 +88,10 @@ it(
       'App.js',
       'app.json',
       'babel.config.js',
+      'bun.lockb',
       'package.json',
       'web/index.html',
       'web/serve.json',
-      'yarn.lock',
     ]);
   },
   // Could take 45s depending on how fast npm installs

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -103,7 +103,7 @@ it(
       'react-native',
     ]);
 
-    expect(files).toStrictEqual(['App.js', 'app.json', 'package.json', 'yarn.lock']);
+    expect(files).toStrictEqual(['App.js', 'app.json', 'bun.lockb', 'package.json']);
   },
   // Could take 45s depending on how fast npm installs
   60 * 1000

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -183,6 +183,7 @@ it(
         "android/gradlew.bat",
         "android/settings.gradle",
         "app.json",
+        "bun.lockb",
         "ios/.gitignore",
         "ios/.xcode.env",
         "ios/Podfile",
@@ -205,7 +206,6 @@ it(
         "ios/basicprebuild.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist",
         "ios/basicprebuild.xcodeproj/xcshareddata/xcschemes/basicprebuild.xcscheme",
         "package.json",
-        "yarn.lock",
       ]
     `);
   },

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -65,7 +65,7 @@ function isSpawnResult(errorOrResult: Error): errorOrResult is Error & SpawnResu
 }
 
 export async function installAsync(projectRoot: string, pkgs: string[] = []) {
-  return abortingSpawnAsync('yarn', pkgs, {
+  return abortingSpawnAsync('bun', ['install', ...pkgs], {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
   });


### PR DESCRIPTION
# Why

A lot of time is spent in the CLI e2e tests installing node modules. This should theoretically speed up some of the subsequent installs. Locally, the install tests are some 2x faster.

# Test Plan

CI should pass