### PR TITLE
[rfc][expo-updates][android] Add method executor queue for serial executor of asynchronous tasks

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/MethodExecutorQueue.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/MethodExecutorQueue.kt
@@ -1,0 +1,38 @@
+package expo.modules.updates
+
+typealias MethodExecution = (onFinished: () -> Unit) -> Unit
+
+class MethodExecutorQueue {
+  private data class MethodInvocationHolder(val block: MethodExecution, val onComplete: MethodInvocationHolder.() -> Unit) {
+    fun execute() {
+      block {
+        onComplete(this)
+      }
+    }
+  }
+
+  private val internalQueue = ArrayDeque<MethodInvocationHolder>()
+
+  private var currentMethodInvocation: MethodInvocationHolder? = null
+
+  fun execute(block: (onFinished: () -> Unit) -> Unit) {
+    internalQueue.add(MethodInvocationHolder(block) {
+      assert(currentMethodInvocation == this)
+      currentMethodInvocation = null
+      maybeProcessQueue()
+    })
+
+    maybeProcessQueue()
+  }
+
+  @Synchronized
+  private fun maybeProcessQueue() {
+    if (currentMethodInvocation != null) {
+      return
+    }
+
+    val nextMethodInvocation = internalQueue.removeFirstOrNull() ?: return
+    currentMethodInvocation = nextMethodInvocation
+    nextMethodInvocation.execute() // need to make sure this is asynchronous
+  }
+}


### PR DESCRIPTION
# Why

The current implementation of the state machine has one subtle bug: out of order events. This could occur when multiple methods are called at the same time (or during startup). 

The current implementation is set up to drop out-of-order events when this occurs: https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt#L59
In order to start enforcing valid state transitions, we need to serialize method calls so that events are only ever sent in a well-defined order (a valid order).

This PR adds a serial executor layer around API methods that update state. This means that two parallel calls to a method that uses the executor will only execute one at a time.

This is roughly step 4 from https://github.com/expo/expo/pull/22845#discussion_r1231423889.

# To Do

While this solves the problem for JS API methods, we still need to synchronize it with the startup procedure (i.e. the startup procedure needs to finish before any JS API methods can be executed (though they can be queued)).

I'm putting this PR in draft state until I isolate the startup procedure into something that can be wrapped by one of these tasks.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
