### PR TITLE
[tools][ios] Fix unversioned REACT_NATIVE_PATH env

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -934,7 +934,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSpeech (11.6.0):
     - ExpoModulesCore
-  - ExpoSQLite (11.8.0):
+  - ExpoSQLite (12.0.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.7.0):
@@ -2651,7 +2651,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 28a662c0718e2680510ca5a208817164944f1cca
   ExpoSMS: 86be39c17d0c6cb50c63271751deaa26381ce25d
   ExpoSpeech: 8a4624ecde6e27157db008d0cc88572a4f523bd5
-  ExpoSQLite: 4fc808cb9536c7bdf6621478a05ce04cbf1037b6
+  ExpoSQLite: f77ef48850c7b2e6573812f0ad2fb46bf0c6eefb
   ExpoStoreReview: 462e12ab98505c836fffe262965a0852f4b32260
   ExpoSystemUI: adb6c827f30566d132501518df24b5b7e4ed294c
   ExpoTrackingTransparency: a7cf99bb23fa213879c36552dda51b6aa63f0279
@@ -2736,7 +2736,7 @@ SPEC CHECKSUMS:
   React-RCTSettings: 2c8f56a3f43ee64f79e21bc3fbfd306a303759c4
   React-RCTText: ce4499e4f2d8f85dc4b93ff0559313a016c4f3e2
   React-RCTVibration: e9ac884f275dcc0d539b2fa7586444d54ac26e78
-  React-rncore: 446a0d6fddbd0cfd9f2b626e228b4953d5185d98
+  React-rncore: 31a4000daac4fee2c6bed0044ec094ff3599bb62
   React-runtimeexecutor: 7e31e2bc6d0ecc83d4ba05eadc98401007abc10c
   React-runtimescheduler: cc32add98c45c5df18436a6a52a7e1f6edec102c
   React-utils: 7a9918a1ffdd39aba67835d42386f592ea3f8e76

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/Libraries/AppDelegate/ABI49_0_0React-RCTAppDelegate.podspec
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/Libraries/AppDelegate/ABI49_0_0React-RCTAppDelegate.podspec
@@ -93,13 +93,13 @@ Pod::Spec.new do |s|
     s.script_phases = {
       :name => "Generate Legacy Components Interop",
       :script => "
-WITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"
+WITH_ENVIRONMENT=\"$ABI49_0_0REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"
 source $WITH_ENVIRONMENT
-${NODE_BINARY} ${REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{ENV['APP_PATH']} -o ${REACT_NATIVE_PATH}/Libraries/AppDelegate
+${NODE_BINARY} ${ABI49_0_0REACT_NATIVE_PATH}/scripts/codegen/generate-legacy-interop-components.js -p #{ENV['APP_PATH']} -o ${ABI49_0_0REACT_NATIVE_PATH}/Libraries/AppDelegate
       ",
       :execution_position => :before_compile,
       :input_files => ["#{ENV['APP_PATH']}/react-native.config.js"],
-      :output_files => ["${REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
+      :output_files => ["${ABI49_0_0REACT_NATIVE_PATH}/Libraries/AppDelegate/RCTLegacyInteropComponents.mm"],
     }
   end
 end

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/ABI49_0_0React-rncore.podspec
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/ABI49_0_0React-rncore.podspec
@@ -16,7 +16,7 @@ version = package['version']
 # We should rethink this approach in T148704916
 
 # Relative path to react native from iOS project root (e.g. <ios-project-root>/../node_modules/react-native)
-react_native_dependency_path = ENV['REACT_NATIVE_PATH']
+react_native_dependency_path = ENV['ABI49_0_0REACT_NATIVE_PATH']
 # Relative path to react native from current podspec
 react_native_sources_path = '..'
 

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/cocoapods/utils.rb
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/cocoapods/utils.rb
@@ -74,7 +74,7 @@ class ReactNativePodsUtils
 
         projects.each do |project|
             project.build_configurations.each do |config|
-                config.build_settings["REACT_NATIVE_PATH"] = File.join("${PODS_ROOT}", "..", react_native_path)
+                config.build_settings["ABI49_0_0REACT_NATIVE_PATH"] = File.join("${PODS_ROOT}", "..", react_native_path)
             end
 
             project.save()

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/react_native_pods.rb
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/react_native_pods.rb
@@ -77,7 +77,7 @@ def use_react_native_ABI49_0_0! (
 
   # Set the app_path as env variable so the podspecs can access it.
   ENV['APP_PATH'] = app_path
-  ENV['REACT_NATIVE_PATH'] = path
+  ENV['ABI49_0_0REACT_NATIVE_PATH'] = path
 
   # Current target definition is provided by Cocoapods and it refers to the target
   # that has invoked the `use_react_native!` function.

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/xcode/with-environment.sh
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/scripts/xcode/with-environment.sh
@@ -38,7 +38,7 @@ else
        'in the ios folder. This is needed by React Native to work correctly. ' \
        'We fallback to the DEPRECATED behavior of finding `node`. This will be REMOVED in a future version. ' \
        'You can read more about this here: https://reactnative.dev/docs/environment-setup#optional-configuring-your-environment' >&2
-    source "${REACT_NATIVE_PATH}/scripts/find-node-for-xcode.sh"
+    source "${ABI49_0_0REACT_NATIVE_PATH}/scripts/find-node-for-xcode.sh"
 fi
 
 # Execute argument, if present

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/sdks/hermes-engine/ABI49_0_0hermes-engine.podspec
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/sdks/hermes-engine/ABI49_0_0hermes-engine.podspec
@@ -98,7 +98,7 @@ Pod::Spec.new do |spec|
         :script => <<-EOS
         . ${PODS_ROOT}/../.xcode.env
         export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
+        . ${ABI49_0_0REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermesc-xcode.sh #{hermesc_path}
         EOS
       },
       {
@@ -106,7 +106,7 @@ Pod::Spec.new do |spec|
         :script => <<-EOS
         . ${PODS_ROOT}/../.xcode.env
         export CMAKE_BINARY=${CMAKE_BINARY:-#{CMAKE_BINARY}}
-        . ${REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
+        . ${ABI49_0_0REACT_NATIVE_PATH}/sdks/hermes-engine/utils/build-hermes-xcode.sh #{version} #{hermesc_path}/ImportHermesc.cmake
         EOS
       }
     ]

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -394,6 +394,10 @@ async function generateReactNativePodScriptAsync(
       find: /\$(CODEGEN_OUTPUT_DIR)\b/g,
       replaceWith: `$${versionName}$1`,
     },
+    {
+      find: /(REACT_NATIVE_PATH)\b/g,
+      replaceWith: `${versionName}$1`,
+    },
     { find: /\b(React-Codegen)\b/g, replaceWith: `${versionName}$1` },
     { find: /(\$\(PODS_ROOT\)\/Headers\/Private\/)React-/g, replaceWith: `$1${versionName}React-` },
     {


### PR DESCRIPTION
# Why

Upgrading to react-native 0.73 revealed an issue with the `REACT_NATIVE_PATH` env value when running `pod install` for Expo Go. This problem happens due to the order that `use_react_native`(unversioned) and `use_versioned_abis!` are invoked. 

`use_versioned_abis!` is invoked after `use_react_native`, given that it is only inside the `Expo Go (versioned)` target, causing the `REACT_NATIVE_PATH` env to be `versioned-react-native/ABI49_0_0/ReactNative` instead of  `'../react-native-lab/react-native/packages/react-native'` and resulting in codegen generating `rncore` headers in the wrong folder

<img width="1022" alt="image" src="https://github.com/expo/expo/assets/11707729/f47b02bf-65a1-44a3-8275-46dd1cfbb1c4">

Making this env value ABI-specific should fix this problem

Necessary for https://github.com/expo/expo/pull/24971

# How

Update the versioning script to replace all occurrences of `REACT_NATIVE_PATH` 

# Test Plan

Run Expo Go Versioned 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
