### PR TITLE
[core][Android] Improve boot time on low-end devices

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects. ([#25075](https://github.com/expo/expo/pull/25075) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed concurrent functions (async/await) not supporting an owner argument (view and class functions). ([#25141](https://github.com/expo/expo/pull/25141) by [@tsapeta](https://github.com/tsapeta))
 - Fixed UIView arguments not being resolved correctly when passed in with findNodeHandle ([#24703](https://github.com/expo/expo/pull/24703) by [@javache](https://github.com/javache))
+- [Android] Improve boot time on low-end devices.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects. ([#25075](https://github.com/expo/expo/pull/25075) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed concurrent functions (async/await) not supporting an owner argument (view and class functions). ([#25141](https://github.com/expo/expo/pull/25141) by [@tsapeta](https://github.com/tsapeta))
 - Fixed UIView arguments not being resolved correctly when passed in with findNodeHandle ([#24703](https://github.com/expo/expo/pull/24703) by [@javache](https://github.com/javache))
-- [Android] Improve boot time on low-end devices.
+- [Android] Improve boot time on low-end devices. ([#25267](https://github.com/expo/expo/pull/25267) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import android.view.View
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.tracing.trace
@@ -7,9 +8,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
-import kotlin.reflect.full.declaredMemberProperties
 
 class ModuleRegistry(
   private val appContext: WeakReference<AppContext>
@@ -33,18 +32,6 @@ class ModuleRegistry(
     holder.apply {
       post(EventName.MODULE_CREATE)
       registerContracts()
-
-      // The initial invocation of `declaredMemberProperties` appears to be slow,
-      // as Kotlin must deserialize metadata internally.
-      // This is a known issue that may be resolved by the new K2 compiler in the future.
-      // However, until then, we must find a way to address this problem.
-      // Therefore, we have decided to dispatch a lambda
-      // that invokes `declaredMemberProperties` during module creation.
-      viewClass()?.let { viewType ->
-        appContext.get()?.backgroundCoroutineScope?.launch {
-          viewType.declaredMemberProperties
-        }
-      }
     }
 
     registry[holder.name] = holder
@@ -73,6 +60,16 @@ class ModuleRegistry(
 
   fun getModuleHolder(module: Module): ModuleHolder? =
     registry.values.find { it.module === module }
+
+  fun <T : View> getModuleHolder(viewClass: Class<T>): ModuleHolder? {
+    return registry.firstNotNullOfOrNull { (_, holder) ->
+      if (holder.definition.viewManagerDefinition?.viewType == viewClass) {
+        holder
+      } else {
+        null
+      }
+    }
+  }
 
   fun post(eventName: EventName) {
     forEach {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -4,7 +4,8 @@ import android.view.View
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import expo.modules.adapters.react.NativeModulesProxy
-import expo.modules.kotlin.modules.Module
+import expo.modules.core.utilities.ifNull
+import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.putGeneric
 import kotlin.reflect.KType
@@ -13,13 +14,13 @@ fun interface ViewEventCallback<T> {
   operator fun invoke(arg: T)
 }
 
-class ViewEvent<T>(
+open class ViewEvent<T>(
   private val name: String,
   private val type: KType,
   private val view: View,
   private val coalescingKey: CoalescingKey<T>?
 ) : ViewEventCallback<T> {
-  internal lateinit var module: Module
+  private var isValidated = false
 
   override operator fun invoke(arg: T) {
     val reactContext = view.context as ReactContext
@@ -28,6 +29,24 @@ class ViewEvent<T>(
       ?.getNativeModule("NativeUnimoduleProxy") as? NativeModulesProxy
       ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
+
+    if (!isValidated) {
+      val holder = appContext.registry.getModuleHolder(view::class.java).ifNull {
+        logger.warn("⚠️ Cannot get module holder for ${view::class.java}")
+        return
+      }
+      val callbacks = holder.definition.viewManagerDefinition?.callbacksDefinition.ifNull {
+        logger.warn("⚠️ Cannot get callbacks for ${holder.module::class.java}")
+        return
+      }
+
+      if (!callbacks.names.any { it == name }) {
+        logger.warn("⚠️ Event $name wasn't exported from ${holder.module::class.java}")
+        return
+      }
+
+      isValidated = true
+    }
 
     appContext
       .callbackInvoker

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
@@ -14,13 +14,8 @@ class ViewEventDelegate<T>(
   private val coalescingKey: CoalescingKey<T>?
 ) {
   private val viewHolder = WeakReference(view)
-  internal var isValidated = false
 
   operator fun getValue(thisRef: View, property: KProperty<*>): ViewEventCallback<T> {
-    if (!isValidated) {
-      throw IllegalStateException("You have to export '${property.name}' property as a event in the `View` component")
-    }
-
     val view = viewHolder.get()
       ?: throw IllegalStateException("Can't send the '${property.name}' event from the view that is deallocated")
     return ViewEvent(property.name, type, view, coalescingKey)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -4,16 +4,12 @@ import android.content.Context
 import android.view.View
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
-import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.exception.OnViewDidUpdatePropsException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.logger
-import expo.modules.kotlin.viewevent.ViewEventDelegate
-import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.jvm.isAccessible
 
 class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   private val definition: ViewManagerDefinition
@@ -31,9 +27,6 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
   fun createView(context: Context): View {
     return definition
       .createView(context, moduleHolder.module.appContext)
-      .also {
-        configureView(it)
-      }
   }
 
   fun onViewDidUpdateProps(view: View) {
@@ -125,34 +118,5 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
         )
       }
     return builder.build()
-  }
-
-  private fun configureView(view: View) {
-    val callbacks = definition.callbacksDefinition?.names ?: return
-
-    val kClass = view.javaClass.kotlin
-    val propertiesMap = kClass
-      .declaredMemberProperties
-      .associateBy { it.name }
-
-    callbacks.forEach {
-      val property = propertiesMap[it].ifNull {
-        logger.warn("⚠️ Property `$it` does not exist in ${kClass.simpleName}")
-        return@forEach
-      }
-      property.isAccessible = true
-
-      val delegate = property.getDelegate(view).ifNull {
-        logger.warn("⚠️ Property delegate for `$it` in ${kClass.simpleName} does not exist")
-        return@forEach
-      }
-
-      val viewDelegate = (delegate as? ViewEventDelegate<*>).ifNull {
-        logger.warn("⚠️ Property delegate for `$it` cannot be cased to `ViewCallbackDelegate`")
-        return@forEach
-      }
-
-      viewDelegate.isValidated = true
-    }
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/25201.

# How

I discovered that the previous solution to load `declaredMemberProperties` in the background is not always effective. On low-end devices, this approach can be slower due to the background thread's limited speed. When we need to initialize the view, two threads - the main and the background - attempt to deserialize the Kotlin metadata annotation, leading to poor performance (there is a mutex that forces the main thread to wait for the background job). To resolve this issue, I needed to alter the logic for validating event dispatchers.

> Note: There will be one more PR that aims to improve the boot time on low-end devices. 

# Test Plan

- bare-expo ✅
- [bluesky-social/social-app@expo-bug-image-stall-repro](https://github.com/bluesky-social/social-app/tree/expo-bug-image-stall-repro?rgh-link-date=2023-11-03T04%3A28%3A07Z) ✅