### PR TITLE
[docs] Search: fix dialog position on viewport resize

### DIFF
--- a/docs/ui/components/CommandMenu/styles.ts
+++ b/docs/ui/components/CommandMenu/styles.ts
@@ -37,12 +37,11 @@ export const commandMenuStyles = css`
     z-index: 1001;
 
     @media screen and (max-width: ${breakpoints.medium}px) {
-      width: 100vw;
-      min-width: 100vw;
-      position: absolute;
-      min-height: 84vh;
-      max-height: 84vh;
-      margin-top: -16px;
+      top: 50%;
+      width: 96vw;
+      min-width: 96vw;
+      min-height: 96dvh;
+      max-height: 96dvh;
     }
   }
 
@@ -124,8 +123,8 @@ export const commandMenuStyles = css`
     margin: ${spacing[3]}px 0 0;
 
     @media screen and (max-width: ${breakpoints.medium}px) {
-      height: calc(84vh - 50px - 50px - 20px);
-      max-height: calc(84vh - 50px - 50px - 20px);
+      height: calc(96dvh - 50px - 50px - 20px);
+      max-height: calc(96dvh - 50px - 50px - 20px);
     }
   }
 


### PR DESCRIPTION
# Why

Fixes ENG-10572

# How

Alter mobile styles so they also work as expected when dynamically modifying the viewport, switch to using `dvh` units (they like `vh` but with safe area excluded, mostly viable for mobile devices).

# Test Plan

The changes have been reviewed locally.

# Preview

https://github.com/expo/expo/assets/719641/38df5c8c-303d-49f8-8879-1fdb71c44b09

![IMG_FE7526D6D46E-1](https://github.com/expo/expo/assets/719641/7e94d91f-7f9f-4b02-a804-a0f1b408148d)
