### PR TITLE
fix(cli): prevent vscode from sending `Runtime.callFunctionOn` events to avoid Hermes crash

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix native polyfill import. ([#25203](https://github.com/expo/expo/pull/25203) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
+- Prevent `Runtime.callFunctionOn` messages from Vscode debugger to avoid Hermes crashes. ([#25270](https://github.com/expo/expo/pull/25270) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
@@ -7,6 +7,7 @@ import { PageReloadHandler } from './handlers/PageReload';
 import { VscodeDebuggerGetPossibleBreakpointsHandler } from './handlers/VscodeDebuggerGetPossibleBreakpoints';
 import { VscodeDebuggerScriptParsedHandler } from './handlers/VscodeDebuggerScriptParsed';
 import { VscodeDebuggerSetBreakpointByUrlHandler } from './handlers/VscodeDebuggerSetBreakpointByUrl';
+import { VscodeRuntimeCallFunctionOnHandler } from './handlers/VscodeRuntimeCallFunctionOn';
 import { VscodeRuntimeGetPropertiesHandler } from './handlers/VscodeRuntimeGetProperties';
 import { DeviceRequest, InspectorHandler, DebuggerRequest } from './handlers/types';
 import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
@@ -35,6 +36,7 @@ export function createInspectorDeviceClass(
       new VscodeDebuggerScriptParsedHandler(this),
       new VscodeDebuggerSetBreakpointByUrlHandler(),
       new VscodeRuntimeGetPropertiesHandler(),
+      new VscodeRuntimeCallFunctionOnHandler(),
     ];
 
     onDeviceMessage(message: any, info: DebuggerInfo): boolean {

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeDebuggerGetPossibleBreakpoints.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeDebuggerGetPossibleBreakpoints.ts
@@ -1,6 +1,7 @@
 import Protocol from 'devtools-protocol';
 
 import { CdpMessage, DebuggerRequest, DeviceResponse, InspectorHandler } from './types';
+import { respond } from './utils';
 import { ExpoDebuggerInfo } from '../device';
 
 /**
@@ -13,12 +14,10 @@ export class VscodeDebuggerGetPossibleBreakpointsHandler implements InspectorHan
     { socket, debuggerType }: ExpoDebuggerInfo
   ): boolean {
     if (debuggerType === 'vscode' && message.method === 'Debugger.getPossibleBreakpoints') {
-      const response: DeviceResponse<DebuggerGetPossibleBreakpoints> = {
+      return respond<DeviceResponse<DebuggerGetPossibleBreakpoints>>(socket, {
         id: message.id,
         result: { locations: [] },
-      };
-      socket.send(JSON.stringify(response));
-      return true;
+      });
     }
 
     return false;

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeRuntimeCallFunctionOn.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeRuntimeCallFunctionOn.ts
@@ -1,0 +1,38 @@
+import Protocol from 'devtools-protocol';
+
+import { CdpMessage, DebuggerRequest, DeviceResponse, InspectorHandler } from './types';
+import { respond } from './utils';
+import { ExpoDebuggerInfo } from '../device';
+
+/**
+ * Vscode is trying to inject a script to fetch information about "Stringy" variables.
+ * Unfortunately, this script causes a Hermes exception and crashes the app.
+ *
+ * @see https://github.com/expo/vscode-expo/issues/231
+ * @see https://github.com/microsoft/vscode-js-debug/blob/dcccaf3972d675cc1e5c776450bb4c3dc8c178c1/src/adapter/stackTrace.ts#L319-L324
+ */
+export class VscodeRuntimeCallFunctionOnHandler implements InspectorHandler {
+  onDebuggerMessage(
+    message: DebuggerRequest<RuntimeCallFunctionOn>,
+    { socket, debuggerType }: ExpoDebuggerInfo
+  ): boolean {
+    if (debuggerType === 'vscode' && message.method === 'Runtime.callFunctionOn') {
+      return respond<DeviceResponse<RuntimeCallFunctionOn>>(socket, {
+        id: message.id,
+        result: {
+          // We don't know the `type` and vscode allows `type: undefined`
+          result: { objectId: message.params.objectId } as any,
+        },
+      });
+    }
+
+    return false;
+  }
+}
+
+/** @see https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-callFunctionOn */
+export type RuntimeCallFunctionOn = CdpMessage<
+  'Runtime.callFunctionOn',
+  Protocol.Runtime.CallFunctionOnRequest,
+  Protocol.Runtime.CallFunctionOnResponse
+>;

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeRuntimeCallFunctionOn.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeRuntimeCallFunctionOn.test.ts
@@ -1,0 +1,52 @@
+import {
+  RuntimeCallFunctionOn,
+  VscodeRuntimeCallFunctionOnHandler,
+} from '../VscodeRuntimeCallFunctionOn';
+import { DebuggerRequest } from '../types';
+
+it('does not respond on non-vscode debugger type', () => {
+  const handler = new VscodeRuntimeCallFunctionOnHandler();
+  const debuggerInfo = {
+    debuggerType: 'generic',
+    socket: { send: jest.fn() },
+  };
+
+  // Message should be sent to the device
+  expect(handler.onDebuggerMessage(callFunctionOnMessage, debuggerInfo)).toBe(false);
+  // Handler should not respond
+  expect(debuggerInfo.socket.send).not.toBeCalled();
+});
+
+it('swallows `Runtime.callFunctionOn` debugger message and responds with object ID pointer', () => {
+  const handler = new VscodeRuntimeCallFunctionOnHandler();
+  const debuggerInfo = {
+    debuggerType: 'vscode',
+    socket: { send: jest.fn() },
+  };
+
+  // Message should NOT be sent to the device
+  expect(handler.onDebuggerMessage(callFunctionOnMessage, debuggerInfo)).toBe(true);
+  // Handler should respond with object ID pointer
+  expect(debuggerInfo.socket.send).toBeCalledWith(
+    JSON.stringify({
+      id: 420,
+      result: {
+        result: {
+          objectId: callFunctionOnMessage.params.objectId,
+        },
+      },
+    })
+  );
+});
+
+// Copied from the vscode trace logs
+const callFunctionOnMessage: DebuggerRequest<RuntimeCallFunctionOn> = {
+  id: 420,
+  method: 'Runtime.callFunctionOn',
+  params: {
+    objectId: '1337',
+    returnByValue: true,
+    functionDeclaration:
+      'function(...runtimeArgs){\n    let t = 64; let e = null;\n    if(e)try{let r="<<default preview>>",n=e.call(this,r);if(n!==r)return String(n)}catch(r){return`<<indescribable>>${JSON.stringify([String(r),"object"])}`}if(typeof this=="object"&&this){let r;for(let n of[Symbol.for("debug.description"),Symbol.for("nodejs.util.inspect.custom")])try{r=this[n]();break}catch{}if(!r&&!String(this.toString).includes("[native code]")&&(r=String(this)),r&&!r.startsWith("[object "))return r.length>=t?r.slice(0,t)+"\\u2026":r}\n  ;\n\n//# sourceURL=eval-0e67cb94.cdp\n}',
+  },
+};

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/utils.ts
@@ -1,0 +1,16 @@
+import type WS from 'ws';
+
+import { DebuggerResponse, DeviceResponse } from './types';
+
+/**
+ * Helper function to respond to a message from the debugger or device.
+ * The return value is used to stop the message propagation, "canceling" further handling.
+ *
+ * @example ```
+ *  return respond<DeviceResponse<CDP>>(socket, { id: message.id, result: {} });
+ * ```
+ */
+export function respond<T = DeviceResponse | DebuggerResponse>(socket: WS, message: T) {
+  socket.send(JSON.stringify(message));
+  return true;
+}


### PR DESCRIPTION
# Why

Fixes expo/vscode-expo#231

# How

The issue is that vscode sends `Runtime.callFunctionOn` with the `functionDeclaration` described in the added test. When this script is injected, Hermes seems to hard-crash. Luckily, this is only used to find additional info about the callstack, and can be "prevented" without affecting the DX in vscode.

Additional info:
- Hermes should never crash on any CDP message, but work is in progress (full native implementation of the CDP server)
- This started happening since `vscode@1.83.x`

# Test Plan

- `$ bun create expo ./test-vscode-debugger`
- `$ cd ./test-vscode-debugger`
- `$ bun expo start --clear`
- Open on device, simulator, or emulator
- Update `App.js` using the snippet below these steps
- Connect vscode debugger through the "Debug Expo app ..." command
- Add a breakpoint in vscode on line `7` (`return hello;`)
- Touch the text, this causes a hard-crash without this PR.

<details><summary><code>App.js</code> snippet</summary>

```js
import { StatusBar } from 'expo-status-bar';
import { Pressable, StyleSheet, Text, View } from 'react-native';

function onTextPress() {
  const hello = 'world';
  console.log({ hello });
  return hello;
}

export default function App() {
  return (
    <View style={styles.container}>
      <Pressable onPress={onTextPress}>
        <Text>Open up App.js to start working on your app!</Text>
      </Pressable>
      <StatusBar style="auto" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
