### PR TITLE
[expo-updates][e2e] Convert scripts to typescript

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -96,10 +96,10 @@ jobs:
         run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E basic tests
         if: matrix.platform != 'tvos'
-        run: node packages/expo-updates/e2e/setup/create-eas-project.js
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
       - name: 📦 Setup test project for testing Apple TV build
         if: matrix.platform == 'tvos'
-        run: node packages/expo-updates/e2e/setup/create-eas-project-tv.js
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
         uses: ./.github/actions/eas-build
         id: build_eas

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Android: Backport ExpoGoUpdatesModule to SDK 49. ([#24974](https://github.com/expo/expo/pull/24974) by [@wschurman](https://github.com/wschurman))
 - Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
 - Remove ability for embedded manifests to be legacy manifests. ([#25195](https://github.com/expo/expo/pull/25195) by [@wschurman](https://github.com/wschurman))
+- Convert e2e setup scripts to typescript. ([#25271](https://github.com/expo/expo/pull/25271) by [@wschurman](https://github.com/wschurman))
+
 
 ## 0.18.17 — 2023-10-25
 

--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -133,7 +133,7 @@ mkdir $WORKING_DIR_ROOT
 - Then execute
 
 ```bash
-node packages/expo-updates/e2e/setup/create-updates-test.js
+./packages/expo-updates/e2e/setup/create-updates-test.ts
 ```
 
 - Change to the test project directory

--- a/packages/expo-updates/e2e/setup/create-eas-project-tv.ts
+++ b/packages/expo-updates/e2e/setup/create-eas-project-tv.ts
@@ -1,8 +1,11 @@
-const path = require('path');
+#!/usr/bin/env yarn --silent ts-node --transpile-only
 
-const { initAsync, setupE2EAppAsync } = require('./project');
+import nullthrows from 'nullthrows';
+import path from 'path';
 
-const repoRoot = process.env.EXPO_REPO_ROOT;
+import { initAsync, setupE2EAppAsync } from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
 const workingDir = path.resolve(repoRoot, '..');
 const runtimeVersion = '1.0.0';
 

--- a/packages/expo-updates/e2e/setup/create-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-eas-project.ts
@@ -1,8 +1,11 @@
-const path = require('path');
+#!/usr/bin/env yarn --silent ts-node --transpile-only
 
-const { initAsync, setupE2EAppAsync } = require('./project');
+import nullthrows from 'nullthrows';
+import path from 'path';
 
-const repoRoot = process.env.EXPO_REPO_ROOT;
+import { initAsync, setupE2EAppAsync } from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
 const workingDir = path.resolve(repoRoot, '..');
 const runtimeVersion = '1.0.0';
 

--- a/packages/expo-updates/e2e/setup/create-updates-test.ts
+++ b/packages/expo-updates/e2e/setup/create-updates-test.ts
@@ -1,8 +1,11 @@
-const path = require('path');
+#!/usr/bin/env yarn --silent ts-node --transpile-only
 
-const { initAsync, setupManualTestAppAsync } = require('./project');
+import nullthrows from 'nullthrows';
+import path from 'path';
 
-const repoRoot = process.env.EXPO_REPO_ROOT;
+import { initAsync, setupManualTestAppAsync } from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
 const workingDir = path.resolve(repoRoot, '..');
 
 /*
@@ -16,7 +19,7 @@ const EXPO_ACCOUNT_NAME = process.env.EXPO_ACCOUNT_NAME || 'myusername';
  * and can be used to test different expo-updates and EAS updates workflows.
  */
 
-function transformAppJson(appJson, projectName, runtimeVersion) {
+function transformAppJson(appJson: any, projectName: string, runtimeVersion: string): any {
   return {
     expo: {
       ...appJson.expo,


### PR DESCRIPTION
# Why

As I add more tests for disabled and dev client integration, it's easier, faster, and safer to do when there are types (they act as a sanity check before even needing to run it).

# How

Convert these files to typescript.

# Test Plan

Wait for CI.

Also run `./packages/expo-updates/e2e/setup/create-updates-test.ts` manually (from step in readme).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
