### PR TITLE
fix(babel-preset-expo): fix platform inlining in test environments

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Only inline platforms when explicitly bundling for production.
+- Only inline platforms when explicitly bundling for production. ([#25275](https://github.com/expo/expo/pull/25275) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix jsx dev transform with React components that are defined in the function parameters. ([#25235](https://github.com/expo/expo/pull/25235) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Only inline platforms when explicitly bundling for production.
 - Fix jsx dev transform with React components that are defined in the function parameters. ([#25235](https://github.com/expo/expo/pull/25235) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/common.d.ts
+++ b/packages/babel-preset-expo/build/common.d.ts
@@ -4,5 +4,6 @@ export declare function getBundler(caller: any): any;
 export declare function getPlatform(caller: any): any;
 export declare function getPossibleProjectRoot(caller: any): any;
 export declare function getIsDev(caller: any): any;
+export declare function getIsProd(caller: any): boolean;
 export declare function getIsServer(caller: any): any;
 export declare function getInlineEnvVarsEnabled(caller: any): boolean;

--- a/packages/babel-preset-expo/build/common.js
+++ b/packages/babel-preset-expo/build/common.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInlineEnvVarsEnabled = exports.getIsServer = exports.getIsDev = exports.getPossibleProjectRoot = exports.getPlatform = exports.getBundler = exports.hasModule = void 0;
+exports.getInlineEnvVarsEnabled = exports.getIsServer = exports.getIsProd = exports.getIsDev = exports.getPossibleProjectRoot = exports.getPlatform = exports.getBundler = exports.hasModule = void 0;
 function hasModule(name) {
     try {
         return !!require.resolve(name);
@@ -59,6 +59,13 @@ function getIsDev(caller) {
     return process.env.BABEL_ENV === 'development' || process.env.NODE_ENV === 'development';
 }
 exports.getIsDev = getIsDev;
+function getIsProd(caller) {
+    if (caller?.isDev != null)
+        return caller.isDev === false;
+    // https://babeljs.io/docs/options#envname
+    return process.env.BABEL_ENV === 'production' || process.env.NODE_ENV === 'production';
+}
+exports.getIsProd = getIsProd;
 function getIsServer(caller) {
     return caller?.isServer ?? false;
 }

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -18,6 +18,9 @@ function babelPresetExpo(api, options = {}) {
     let platform = api.caller((caller) => caller?.platform);
     const engine = api.caller((caller) => caller?.engine) ?? 'default';
     const isDev = api.caller(common_1.getIsDev);
+    // Unlike `isDev`, this will be `true` when the bundler is explicitly set to `production`,
+    // i.e. `false` when testing, development, or used with a bundler that doesn't specify the correct inputs.
+    const isProduction = api.caller(common_1.getIsProd);
     const inlineEnvironmentVariables = api.caller(common_1.getInlineEnvVarsEnabled);
     // If the `platform` prop is not defined then this must be a custom config that isn't
     // defining a platform in the babel-loader. Currently this may happen with Next.js + Expo web.
@@ -57,7 +60,7 @@ function babelPresetExpo(api, options = {}) {
         // should retain the same behavior since it's hard to debug the differences.
         extraPlugins.push(require('@babel/plugin-transform-parameters'));
     }
-    if (!isDev && (0, common_1.hasModule)('metro-transform-plugins')) {
+    if (isProduction && (0, common_1.hasModule)('metro-transform-plugins')) {
         // Metro applies this plugin too but it does it after the imports have been transformed which breaks
         // the plugin. Here, we'll apply it before the commonjs transform, in production, to ensure `Platform.OS`
         // is replaced with a string literal and `__DEV__` is converted to a boolean.

--- a/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
@@ -2,7 +2,7 @@ import * as babel from '@babel/core';
 
 import preset from '..';
 
-function getCaller(props: Record<string, string>): babel.TransformCaller {
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
   return props as unknown as babel.TransformCaller;
 }
 
@@ -33,7 +33,7 @@ function stripReactNativeImport(code: string) {
 it(`removes Platform module usage on web`, () => {
   const options = {
     ...DEFAULT_OPTS,
-    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web' }),
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
   };
 
   const sourceCode = `
@@ -58,7 +58,7 @@ it(`removes Platform module usage on web`, () => {
 it(`removes Platform module usage on native`, () => {
   const options = {
     ...DEFAULT_OPTS,
-    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android' }),
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android', isDev: false }),
   };
 
   expect(
@@ -90,7 +90,7 @@ it(`removes Platform module usage on native`, () => {
 it(`removes __DEV__ usage`, () => {
   const options = {
     ...DEFAULT_OPTS,
-    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android' }),
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android', isDev: false }),
   };
 
   const sourceCode = `  

--- a/packages/babel-preset-expo/src/common.ts
+++ b/packages/babel-preset-expo/src/common.ts
@@ -52,6 +52,13 @@ export function getIsDev(caller: any) {
   return process.env.BABEL_ENV === 'development' || process.env.NODE_ENV === 'development';
 }
 
+export function getIsProd(caller: any) {
+  if (caller?.isDev != null) return caller.isDev === false;
+
+  // https://babeljs.io/docs/options#envname
+  return process.env.BABEL_ENV === 'production' || process.env.NODE_ENV === 'production';
+}
+
 export function getIsServer(caller: any) {
   return caller?.isServer ?? false;
 }

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -1,6 +1,6 @@
 import { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
 
-import { getBundler, getInlineEnvVarsEnabled, getIsDev, hasModule } from './common';
+import { getBundler, getInlineEnvVarsEnabled, getIsDev, getIsProd, hasModule } from './common';
 import { expoInlineManifestPlugin } from './expo-inline-manifest-plugin';
 import { expoRouterBabelPlugin } from './expo-router-plugin';
 import { expoInlineEnvVars } from './inline-env-vars';
@@ -53,6 +53,9 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   let platform = api.caller((caller) => (caller as any)?.platform);
   const engine = api.caller((caller) => (caller as any)?.engine) ?? 'default';
   const isDev = api.caller(getIsDev);
+  // Unlike `isDev`, this will be `true` when the bundler is explicitly set to `production`,
+  // i.e. `false` when testing, development, or used with a bundler that doesn't specify the correct inputs.
+  const isProduction = api.caller(getIsProd);
   const inlineEnvironmentVariables = api.caller(getInlineEnvVarsEnabled);
 
   // If the `platform` prop is not defined then this must be a custom config that isn't
@@ -98,7 +101,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     extraPlugins.push(require('@babel/plugin-transform-parameters'));
   }
 
-  if (!isDev && hasModule('metro-transform-plugins')) {
+  if (isProduction && hasModule('metro-transform-plugins')) {
     // Metro applies this plugin too but it does it after the imports have been transformed which breaks
     // the plugin. Here, we'll apply it before the commonjs transform, in production, to ensure `Platform.OS`
     // is replaced with a string literal and `__DEV__` is converted to a boolean.


### PR DESCRIPTION
# Why

- Only enable the platform inlining when explicitly bundling for production to allow jest tests to mock `__DEV__` and `process.env.NODE_ENV`.


# Test Plan

- Ensure `expo-updates` tests pass locally.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
