### PR TITLE
[expo-updates] Asset exclusion on Android part 1

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 - [iOS] Make asset exclusion work. ([#25216](https://github.com/expo/expo/pull/25216) by [@douglowder](https://github.com/douglowder))
+- [Android] Asset exclusion on Android part 1. ([#25277](https://github.com/expo/expo/pull/25277) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 
@@ -26,7 +27,6 @@
 - Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
 - Remove ability for embedded manifests to be legacy manifests. ([#25195](https://github.com/expo/expo/pull/25195) by [@wschurman](https://github.com/wschurman))
 - Convert e2e setup scripts to typescript. ([#25271](https://github.com/expo/expo/pull/25271) by [@wschurman](https://github.com/wschurman))
-
 
 ## 0.18.17 — 2023-10-25
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -155,9 +155,11 @@ class DatabaseLauncher(
         }
         val filename = asset.relativePath
         if (filename != null) {
-          val file = when (asset.embeddedAssetFilename != null) {
-            true -> File(asset.embeddedAssetFilename)
-            false -> File(updatesDirectory, asset.relativePath)
+          val embeddedAssetFilename = asset.embeddedAssetFilename
+          val file = if (embeddedAssetFilename != null) {
+            File(embeddedAssetFilename)
+          } else {
+            File(updatesDirectory, asset.relativePath)
           }
           this[asset] = Uri.fromFile(file).toString()
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -159,7 +159,7 @@ class DatabaseLauncher(
           val file = if (embeddedAssetFilename != null) {
             File(embeddedAssetFilename)
           } else {
-            File(updatesDirectory, asset.relativePath)
+            File(updatesDirectory, asset.relativePath!!)
           }
           this[asset] = Uri.fromFile(file).toString()
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -100,7 +100,7 @@ class DatabaseLauncher(
 
     val assetEntities = database.assetDao().loadAssetsForUpdate(launchedUpdate!!.id)
 
-    localAssetFiles = mutableMapOf<AssetEntity, String>().apply {
+    localAssetFiles = embeddedAssetFileMap(context).apply {
       for (asset in assetEntities) {
         if (asset.id == launchAsset.id) {
           // we took care of this one above
@@ -135,7 +135,7 @@ class DatabaseLauncher(
     val filteredLaunchableUpdates = mutableListOf<UpdateEntity>()
     for (update in launchableUpdates) {
       if (update.status == UpdateStatus.EMBEDDED) {
-        if (embeddedUpdateManifest != null && embeddedUpdateManifest.updateEntity!!.id != update.id) {
+        if (embeddedUpdateManifest != null && embeddedUpdateManifest.updateEntity.id != update.id) {
           continue
         }
       }
@@ -145,8 +145,28 @@ class DatabaseLauncher(
     return selectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters)
   }
 
-  internal fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
-    val assetFile = File(updatesDirectory, asset.relativePath)
+  private fun embeddedAssetFileMap(context: Context): MutableMap<AssetEntity, String> {
+    val embeddedManifest = EmbeddedManifest.get(context, this.configuration)
+    val embeddedAssets: List<AssetEntity> = embeddedManifest?.assetEntityList ?: listOf()
+    return mutableMapOf<AssetEntity, String>().apply {
+      for (asset in embeddedAssets) {
+        if (asset.isLaunchAsset) {
+          continue
+        }
+        val filename = asset.relativePath
+        if (filename != null) {
+          val file = when (asset.embeddedAssetFilename != null) {
+            true -> File(asset.embeddedAssetFilename)
+            false -> File(updatesDirectory, asset.relativePath)
+          }
+          this[asset] = Uri.fromFile(file).toString()
+        }
+      }
+    }
+  }
+
+  private fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
+    val assetFile = File(updatesDirectory, asset.relativePath ?: "")
     var assetFileExists = assetFile.exists()
     if (!assetFileExists) {
       // something has gone wrong, we're missing this asset
@@ -195,7 +215,7 @@ class DatabaseLauncher(
 
           override fun onSuccess(assetEntity: AssetEntity, isNew: Boolean) {
             database.assetDao().updateAsset(assetEntity)
-            val assetFileLocal = File(updatesDirectory, assetEntity.relativePath)
+            val assetFileLocal = File(updatesDirectory, assetEntity.relativePath!!)
             maybeFinish(assetEntity, if (assetFileLocal.exists()) assetFileLocal else null)
           }
         }


### PR DESCRIPTION
# Why

Allow Android to make use of updates created with only some assets included (using the CLI changes in #25065 ).

# How

- Make Android work with updates that don't include all assets
- Limitations:
  - Android still needs to copy embedded assets to the updates folder
  - Fonts (which are packaged as resources in Android) still need to be part of updates

Limitations will be addressed in future PRs.

# Test Plan

- Manual testing with a custom test app
  - The app has Expo config with `extra.updates.assetPatternsToBeBundled = "assetsInUpdates/*"`
  - Start with some assets (images and fonts) in a different folder (e.g. `embeddedAssets`)
  - App starts up, embedded bundle works and shows all images and fonts
  - Add a new image in `embeddedAssets`, run `eas update` and download and launch update
  - App works, but image will not show in UI
  - Now move that image to the `assetsInUpdates` folder, and change `App.tsx` accordingly
  - Run `eas update` again, download and run update
  - The new image will now show up correctly in the UI
- Updates E2E should continue to pass (confirming that this does not break existing behavior)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).