### PR TITLE
[ENG-10566][docs] use Node 18 in the `latest` images docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import al from '@mdx-js/react';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **October 24, 2023**.
+> This document was last updated on **November 8, 2023**.
 
 ## Builder IP addresses
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -71,7 +71,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:jammy-20220531`
 - NDK 21.4.7075529
-- Node.js 16.18.1
+- Node.js 18.18.0
 - Bun 1.0.2
 - Yarn 1.22.17
 - pnpm 8.9.2
@@ -208,7 +208,7 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Ventura 13.6
 - Xcode 15.0 (15A240d)
-- Node.js 16.18.1
+- Node.js 18.18.0
 - Bun 1.0.2
 - Yarn 1.22.17
 - pnpm 8.7.6


### PR DESCRIPTION
# Why

Use Node 18 in the `latest` images docs

# How

Use Node 18 in the `latest` images docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
