### PR TITLE
[docs] remove duplicate content from github build guide

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -6,6 +6,8 @@ description: Learn how to trigger builds on EAS for your app using the Expo GitH
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
+This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
+
 ## Prerequisites
 
 > **warning** While in preview, this feature is only available to EAS subscribers.

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -6,10 +6,6 @@ description: Learn how to trigger builds on EAS for your app using the Expo GitH
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-You can trigger builds on EAS for your app from a CI environment such as GitHub Actions, Travis CI, and more.
-
-Before building with EAS on CI, you'll need to install and configure `eas-cli`. Then, you can trigger new builds with the `eas build` command.
-
 ## Prerequisites
 
 > **warning** While in preview, this feature is only available to EAS subscribers.


### PR DESCRIPTION
# Why

Duplicate text from the CI docs got into the GitHub guide.

<img width="952" alt="Screenshot 2023-11-08 at 16 26 58" src="https://github.com/expo/expo/assets/12488826/0f6dba4f-4677-4d9c-a627-af3b7a825d22">

# How

I deleted that section.

# Test Plan

Inspect the diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
