### PR TITLE
[fingerprint] Fix E2E npx test error

### DIFF
--- a/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
@@ -32,7 +32,7 @@ describe('bare project test', () => {
 
   it('should have same hash after adding js only library', async () => {
     const hash = await createProjectHashAsync(projectRoot);
-    await spawnAsync('npx', ['expo', 'install', '@react-navigation/core'], {
+    await spawnAsync('bunx', ['expo', 'install', '@react-navigation/core'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });
@@ -42,7 +42,7 @@ describe('bare project test', () => {
 
   it('should have different hash after adding native library', async () => {
     const hash = await createProjectHashAsync(projectRoot);
-    await spawnAsync('npx', ['expo', 'install', 'react-native-reanimated'], {
+    await spawnAsync('bunx', ['expo', 'install', 'react-native-reanimated'], {
       stdio: 'ignore',
       cwd: projectRoot,
     });


### PR DESCRIPTION
# Why

Fix ci failure: https://github.com/expo/expo/actions/runs/6806610728/job/18508119967?pr=25228

# How

Use `bunx` instead of `npx`

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
