### PR TITLE
[ci] fix flaky fingerprint ci

### DIFF
--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -49,5 +49,5 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: E2E Test @expo/fingerprint
-        run: bun test:e2e
+        run: bun test:e2e --ci --runInBand
         working-directory: packages/@expo/fingerprint


### PR DESCRIPTION
# Why

try to fix flaky fingerprint ci job, e.g. https://github.com/expo/expo/actions/runs/6806610728/job/18511568835

# How

the other hypothesis is that we cannot run `(yarn|bun) install` parallel, otherwise it will break in file system.
e.g. that is the error log
```
error: moving "metro-resolver" to cache dir failed: PathAlreadyExists
  From: .156c506ec4779a71metro-resolver
    To: metro-resolver@0.76.8
```

the pr adds the `--runInBand` to run tests in sequence and also `--ci` for ci snapshots.

# Test Plan

fingerprint ci passed