### PR TITLE
[test-suite] Fix metro config

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -25,8 +25,6 @@ PODS:
   - EXImageLoader (4.5.0):
     - ExpoModulesCore
     - React-Core
-  - EXInAppPurchases (14.6.0):
-    - ExpoModulesCore
   - EXJSONUtils (0.11.0)
   - EXJSONUtils/Tests (0.11.0)
   - EXLocation (16.4.0):
@@ -235,7 +233,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSpeech (11.6.0):
     - ExpoModulesCore
-  - ExpoSQLite (11.8.0):
+  - ExpoSQLite (12.0.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.7.0):
@@ -827,7 +825,6 @@ DEPENDENCIES:
   - EXContacts (from `../../../packages/expo-contacts/ios`)
   - EXFont (from `../../../packages/expo-font/ios`)
   - EXImageLoader (from `../../../packages/expo-image-loader/ios`)
-  - EXInAppPurchases (from `../../../packages/expo-in-app-purchases/ios`)
   - EXJSONUtils (from `../../../packages/expo-json-utils/ios`)
   - EXJSONUtils/Tests (from `../../../packages/expo-json-utils/ios`)
   - EXLocation (from `../../../packages/expo-location/ios`)
@@ -1003,9 +1000,6 @@ EXTERNAL SOURCES:
   EXImageLoader:
     inhibit_warnings: false
     :path: "../../../packages/expo-image-loader/ios"
-  EXInAppPurchases:
-    inhibit_warnings: false
-    :path: "../../../packages/expo-in-app-purchases/ios"
   EXJSONUtils:
     inhibit_warnings: false
     :path: "../../../packages/expo-json-utils/ios"
@@ -1302,7 +1296,6 @@ SPEC CHECKSUMS:
   EXContacts: 24e46f5cf1ba9776a2f301c4f3aa821848035a10
   EXFont: e5fa244ad8c8d6fcf3a215e1fdcaedbc9b580aad
   EXImageLoader: 6ffefe300f6f1a5be46f3722944d7f48a44f36bf
-  EXInAppPurchases: 16897367eb7e5e04f3b1d4ccba4169187f1b0e00
   EXJSONUtils: d15120ce0e8967b0822880162039dd75e5867086
   EXLocation: db102a331d49b1f55a82409f9d53a22684093c0c
   EXManifests: b658c34011f90e3379b515fb50680acb49ba099a
@@ -1349,7 +1342,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 28a662c0718e2680510ca5a208817164944f1cca
   ExpoSMS: 86be39c17d0c6cb50c63271751deaa26381ce25d
   ExpoSpeech: 8a4624ecde6e27157db008d0cc88572a4f523bd5
-  ExpoSQLite: 4fc808cb9536c7bdf6621478a05ce04cbf1037b6
+  ExpoSQLite: f77ef48850c7b2e6573812f0ad2fb46bf0c6eefb
   ExpoStoreReview: 462e12ab98505c836fffe262965a0852f4b32260
   ExpoSystemUI: adb6c827f30566d132501518df24b5b7e4ed294c
   ExpoTrackingTransparency: a7cf99bb23fa213879c36552dda51b6aa63f0279

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -1,7 +1,5 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
-
 const baseConfig = createMetroConfiguration(__dirname);
-
 const path = require('path');
 
 const root = path.join(__dirname, '../..');

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -1,6 +1,7 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
 const path = require('path');
 
+/* global __dirname */
 /** @type {import('expo/metro-config').MetroConfig} */
 const baseConfig = createMetroConfiguration(__dirname);
 

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -1,7 +1,17 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
-
+const path = require('path');
 /* global __dirname */
 const baseConfig = createMetroConfiguration(__dirname);
+
+const root = path.join(__dirname, '../..');
+
+const reactNativeRoot = path.join(
+  root,
+  'react-native-lab',
+  'react-native',
+  'packages',
+  'react-native'
+);
 
 module.exports = {
   ...baseConfig,
@@ -30,5 +40,25 @@ module.exports = {
         return middleware(req, res, next);
       };
     },
+  },
+  resolver: {
+    ...baseConfig.resolver,
+    assetExts: [...baseConfig.resolver.assetExts, 'kml'],
+    blockList: [
+      ...baseConfig.resolver.blockList,
+
+      // Exclude react-native-lab from haste map.
+      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+      // we should use the one from node_modules for bare-expo.
+      /\bnode_modules\/react-native\//,
+      /\breact-native-lab\/react-native\/node_modules\b/,
+    ],
+  },
+  serializer: {
+    ...baseConfig.serializer,
+    getModulesRunBeforeMainModule: () => [
+      require.resolve(path.join(reactNativeRoot, 'Libraries/Core/InitializeCore')),
+    ],
+    getPolyfills: () => require(path.join(reactNativeRoot, 'rn-get-polyfills'))(),
   },
 };


### PR DESCRIPTION
# Why
`test-suite` wouldn't run in expo go

# How
Added the `resolver` and `serializer` options to the metro config.

# Test Plan
`test-suite` now loads correctly in expo go