### PR TITLE
[secure-store][android] Enforce minimum authentication tag length

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Enforce minimum authentication tag length for the `AESEncryptor` for improved security.
+- [Android] Enforce minimum authentication tag length for the `AESEncryptor` for improved security. ([#25294](https://github.com/expo/expo/pull/25294) by [@behenate](https://github.com/behenate))
 
 ## 12.6.0 — 2023-10-17
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Enforce minimum authentication tag length for the `AESEncryptor` for improved security.
+
 ## 12.6.0 — 2023-10-17
 
 ### 🛠 Breaking changes

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
@@ -126,12 +126,12 @@ open class SecureStoreModule : Module() {
         AESEncryptor.NAME -> {
           val secretKeyEntry = getPreferredKeyEntry(SecretKeyEntry::class.java, mAESEncryptor, options, requireAuthentication, usesKeystoreSuffix)
             ?: throw DecryptException("Could not find a keychain for key $key$legacyReadFailedWarning", key, options.keychainService)
-          return mAESEncryptor.decryptItem(encryptedItem, secretKeyEntry, options, authenticationHelper)
+          return mAESEncryptor.decryptItem(key, encryptedItem, secretKeyEntry, options, authenticationHelper)
         }
         HybridAESEncryptor.NAME -> {
           val privateKeyEntry = getPreferredKeyEntry(PrivateKeyEntry::class.java, hybridAESEncryptor, options, requireAuthentication, usesKeystoreSuffix)
             ?: throw DecryptException("Could not find a keychain for key $key$legacyReadFailedWarning", key, options.keychainService)
-          return hybridAESEncryptor.decryptItem(encryptedItem, privateKeyEntry, options, authenticationHelper)
+          return hybridAESEncryptor.decryptItem(key, encryptedItem, privateKeyEntry, options, authenticationHelper)
         }
         else -> {
           throw DecryptException("The item for key $key in SecureStore has an unknown encoding scheme $scheme)", key, options.keychainService)

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
@@ -5,6 +5,7 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
 import expo.modules.securestore.AuthenticationHelper
+import expo.modules.securestore.DecryptException
 import expo.modules.securestore.SecureStoreModule
 import expo.modules.securestore.SecureStoreOptions
 import org.json.JSONException
@@ -108,6 +109,7 @@ class AESEncryptor : KeyBasedEncryptor<KeyStore.SecretKeyEntry> {
 
   @Throws(GeneralSecurityException::class, JSONException::class)
   override suspend fun decryptItem(
+    key: String,
     encryptedItem: JSONObject,
     keyStoreEntry: KeyStore.SecretKeyEntry,
     options: SecureStoreOptions,
@@ -122,6 +124,9 @@ class AESEncryptor : KeyBasedEncryptor<KeyStore.SecretKeyEntry> {
     val cipher = Cipher.getInstance(AES_CIPHER)
     val requiresAuthentication = encryptedItem.optBoolean(AuthenticationHelper.REQUIRE_AUTHENTICATION_PROPERTY)
 
+    if (authenticationTagLength < MIN_GCM_AUTHENTICATION_TAG_LENGTH) {
+      throw DecryptException("Authentication tag length must be at least $MIN_GCM_AUTHENTICATION_TAG_LENGTH", key, options.keychainService)
+    }
     cipher.init(Cipher.DECRYPT_MODE, keyStoreEntry.secretKey, gcmSpec)
     val unlockedCipher = authenticationHelper.authenticateCipher(cipher, requiresAuthentication, options.authenticationPrompt)
     return String(unlockedCipher.doFinal(ciphertextBytes), StandardCharsets.UTF_8)
@@ -134,5 +139,6 @@ class AESEncryptor : KeyBasedEncryptor<KeyStore.SecretKeyEntry> {
     private const val CIPHERTEXT_PROPERTY = "ct"
     const val IV_PROPERTY = "iv"
     private const val GCM_AUTHENTICATION_TAG_LENGTH_PROPERTY = "tlen"
+    private const val MIN_GCM_AUTHENTICATION_TAG_LENGTH = 96
   }
 }

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/AESEncryptor.kt
@@ -125,7 +125,7 @@ class AESEncryptor : KeyBasedEncryptor<KeyStore.SecretKeyEntry> {
     val requiresAuthentication = encryptedItem.optBoolean(AuthenticationHelper.REQUIRE_AUTHENTICATION_PROPERTY)
 
     if (authenticationTagLength < MIN_GCM_AUTHENTICATION_TAG_LENGTH) {
-      throw DecryptException("Authentication tag length must be at least $MIN_GCM_AUTHENTICATION_TAG_LENGTH", key, options.keychainService)
+      throw DecryptException("Authentication tag length must be at least $MIN_GCM_AUTHENTICATION_TAG_LENGTH bits long", key, options.keychainService)
     }
     cipher.init(Cipher.DECRYPT_MODE, keyStoreEntry.secretKey, gcmSpec)
     val unlockedCipher = authenticationHelper.authenticateCipher(cipher, requiresAuthentication, options.authenticationPrompt)

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/HybridAESEncryptor.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/HybridAESEncryptor.kt
@@ -80,7 +80,13 @@ class HybridAESEncryptor(private var mContext: Context, private val mAESEncrypto
   }
 
   @Throws(GeneralSecurityException::class, JSONException::class)
-  override suspend fun decryptItem(encryptedItem: JSONObject, keyStoreEntry: KeyStore.PrivateKeyEntry, options: SecureStoreOptions, authenticationHelper: AuthenticationHelper): String {
+  override suspend fun decryptItem(
+    key: String,
+    encryptedItem: JSONObject,
+    keyStoreEntry: KeyStore.PrivateKeyEntry,
+    options: SecureStoreOptions,
+    authenticationHelper: AuthenticationHelper
+  ): String {
     // Decrypt the encrypted symmetric key
     val encryptedSecretKeyString = encryptedItem.getString(ENCRYPTED_SECRET_KEY_PROPERTY)
     val encryptedSecretKeyBytes = Base64.decode(encryptedSecretKeyString, Base64.DEFAULT)
@@ -92,7 +98,7 @@ class HybridAESEncryptor(private var mContext: Context, private val mAESEncrypto
 
     // Decrypt the value with the symmetric key
     val secretKeyEntry = KeyStore.SecretKeyEntry(secretKey)
-    return mAESEncryptor.decryptItem(encryptedItem, secretKeyEntry, options, authenticationHelper)
+    return mAESEncryptor.decryptItem(key, encryptedItem, secretKeyEntry, options, authenticationHelper)
   }
 
   @get:Throws(NoSuchAlgorithmException::class, NoSuchProviderException::class, NoSuchPaddingException::class)

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/KeyBasedEncryptor.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/encryptors/KeyBasedEncryptor.kt
@@ -30,6 +30,7 @@ interface KeyBasedEncryptor<E : KeyStore.Entry> {
 
   @Throws(GeneralSecurityException::class, JSONException::class)
   suspend fun decryptItem(
+    key: String,
     encryptedItem: JSONObject,
     keyStoreEntry: E,
     options: SecureStoreOptions,


### PR DESCRIPTION
# Why
ENG-7278
In theory it is possible to perform attacks by overriding the saved tag length of an item and then repeatedly trying to decrypt it with the  new (much shorter) tag length, in practice this kind of attack is really hard to execute, but we should still protect against it just in case. 

# How

If the tag length is lower than 96 bits we reject the decryption attempt. This should not break any valid existing data, as `secure-store` encrypts the data with a 128 bit long tag

# Test Plan

Tested in BareExpo in Android 14 Emulator
