### PR TITLE
feat(templates): toggle on metro web in templates for SDK 50

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -3,6 +3,9 @@
     "name": "HelloWorld",
     "slug": "expo-template-bare",
     "version": "1.0.0",
-    "assetBundlePatterns": ["**/*"]
+    "assetBundlePatterns": ["**/*"],
+    "web": {
+      "bundler": "metro"
+    }
   }
 }

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -22,7 +22,8 @@
       }
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "bundler": "metro"
     }
   }
 }

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -22,7 +22,8 @@
       }
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "bundler": "metro"
     }
   }
 }


### PR DESCRIPTION
# Why

- Partial solution for ENG-10580
- We don't spend any time working on Webpack, all of our bundling efforts (me), are spent on the universal bundling solution "metro" (our adaptation of Metro).
- Metro is lighter-weight to configure in Expo because we ship it by default, making it easier for users to get started with web, they just need to add `react-dom` and `react-native-web`.
- The main things that Webpack has that Metro doesn't are bundle splitting, unused-export removal (advanced tree-shaking), and plugins.
  - Development-mode bundle splitting is [available today](https://docs.expo.dev/router/reference/async-routes/) in Expo Router. Basic production bundle splitting for web is planned in SDK 50. Native production support is less of a priority due to the way Hermes bytecode works.
  - Regarding plugins, we have landed support and docs for custom resolvers and transformers for SDK 50. Serializers cannot be customized yet, but this part is far more cryptic for users. We may add hooks to extend things like bundle splitting to indicate vendor chunks.
  - Regarding tree shaking, we've enabled basic support for inline requires in SDK 50, this can be used to remove unused imports in production, but it doesn't respect package.json sideEffects. We have a prototype and plans release a more comprehensive tree-shaking solution in the future.

Metro for web is used in production today by Airbnb and a few other large brands, so it's not totally unproven, but we want a comprehensive solution for users before we fully switch over the default (e.g. is no `web.bundler` is defined, use Metro), and potentially deprecate Webpack support.

--

Edit: currently this change won't work (see CI failures) because it enables web and we don't want to ship react-dom by default. Will have to think about an alternative solution.

