### PR TITLE
[expo-updates][e2e] Add e2e test for disabled mode

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -47,6 +47,10 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android, tvos]
+        mode: [enabled, disabled]
+        exclude:
+          - platform: tvos
+            mode: disabled
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     env:
@@ -95,10 +99,13 @@ jobs:
       - name: 📦 Set test project location
         run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project for updates E2E basic tests
-        if: matrix.platform != 'tvos'
+        if: matrix.platform != 'tvos' && matrix.mode == 'enabled'
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
+      - name: 📦 Setup test project for updates E2E disabled tests
+        if: matrix.platform != 'tvos' && matrix.mode == 'disabled'
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
       - name: 📦 Setup test project for testing Apple TV build
-        if: matrix.platform == 'tvos'
+        if: matrix.platform == 'tvos' && matrix.mode == 'enabled'
         run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
         uses: ./.github/actions/eas-build

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add e2e tests for disabled mode. ([#25301](https://github.com/expo/expo/pull/25301) by [@wschurman](https://github.com/wschurman))
+
 ## 0.23.0 — 2023-11-14
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/e2e/fixtures/App-updates-disabled.tsx
+++ b/packages/expo-updates/e2e/fixtures/App-updates-disabled.tsx
@@ -1,0 +1,107 @@
+import { Inter_900Black } from '@expo-google-fonts/inter';
+import { StatusBar } from 'expo-status-bar';
+import * as Updates from 'expo-updates';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+require('./test.png');
+// eslint-disable-next-line no-unused-expressions
+Inter_900Black;
+
+function TestValue(props: { testID: string; value: string }) {
+  return (
+    <View>
+      <View style={{ flexDirection: 'row' }}>
+        <Text style={styles.labelText}>{props.testID}</Text>
+        <Text style={styles.labelText}>&nbsp;</Text>
+        <Text style={styles.labelText} testID={props.testID}>
+          {props.value}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function TestButton(props: { testID: string; onPress: () => void }) {
+  return (
+    <Pressable testID={props.testID} style={styles.button} onPress={props.onPress}>
+      <Text style={styles.buttonText}>{props.testID}</Text>
+    </Pressable>
+  );
+}
+
+export default function App() {
+  const [jsAPIDidThrowError, setJSAPIDidThrowError] = React.useState(false);
+
+  const { currentlyRunning, availableUpdate } = Updates.useUpdates();
+
+  const handleCallJSAPI = async () => {
+    try {
+      await Updates.fetchUpdateAsync();
+    } catch (e) {
+      setJSAPIDidThrowError(true);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TestValue testID="updateString" value="test" />
+      <TestValue testID="updateID" value={`${Updates.updateId}`} />
+      <TestValue testID="runtimeVersion" value={`${currentlyRunning.runtimeVersion}`} />
+      <TestValue testID="checkAutomatically" value={`${Updates.checkAutomatically}`} />
+      <TestValue testID="isEmbeddedLaunch" value={`${currentlyRunning.isEmbeddedLaunch}`} />
+      <TestValue testID="availableUpdateID" value={`${availableUpdate?.updateId}`} />
+
+      <TestValue testID="lastJSAPIErrorMessage" value={`${jsAPIDidThrowError}`} />
+      <View style={{ flexDirection: 'row' }}>
+        <View>
+          <TestButton testID="callJSAPI" onPress={handleCallJSAPI} />
+        </View>
+      </View>
+
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: 100,
+    marginBottom: 100,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 5,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    borderRadius: 4,
+    elevation: 3,
+    backgroundColor: '#4630EB',
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 6,
+  },
+  labelText: {
+    fontSize: 6,
+  },
+  logEntriesContainer: {
+    margin: 10,
+    height: 50,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
+    width: '90%',
+    minWidth: '90%',
+    borderColor: '#4630EB',
+    borderWidth: 1,
+    borderRadius: 4,
+  },
+  logEntriesText: {
+    fontSize: 6,
+  },
+});

--- a/packages/expo-updates/e2e/fixtures/Updates-disabled.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-disabled.e2e.ts
@@ -1,0 +1,49 @@
+import { by, device, element, waitFor } from 'detox';
+import jestExpect from 'expect';
+import { setTimeout } from 'timers/promises';
+
+const platform = device.getPlatform();
+const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
+
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
+  return attributes?.text || '';
+};
+
+const pressTestButtonAsync = async (testID: string) => await element(by.id(testID)).tap();
+
+const waitForAppToBecomeVisible = async () => {
+  await waitFor(element(by.id('updateString')))
+    .toBeVisible()
+    .withTimeout(2000);
+};
+
+describe('Basic tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+  });
+
+  it('starts app, shows info when updates are disabled', async () => {
+    console.warn(`Platform = ${platform}`);
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+
+    jestExpect(await testElementValueAsync('updateString')).toBe('test');
+    jestExpect(await testElementValueAsync('updateID')).toBeTruthy();
+    jestExpect(await testElementValueAsync('runtimeVersion')).toBe('');
+    jestExpect(await testElementValueAsync('checkAutomatically')).toBe('NEVER');
+    jestExpect(await testElementValueAsync('isEmbeddedLaunch')).toBe('false');
+    jestExpect(await testElementValueAsync('availableUpdateID')).toBe('undefined');
+    jestExpect(await testElementValueAsync('lastJSAPIErrorMessage')).toBe('false');
+
+    await pressTestButtonAsync('callJSAPI');
+    await setTimeout(2000);
+    jestExpect(await testElementValueAsync('lastJSAPIErrorMessage')).toBe('true');
+
+    await device.terminateApp();
+  });
+});

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -23,7 +23,7 @@ if [[ "$TEST_TV_BUILD" == "1" ]]; then
   echo "TV built successfully" > ./logs/detox-tests.log
   exit 0
 fi
- 
+
 ANDROID_EMULATOR=pixel_4
 
 #export UPDATES_HOST=$(ifconfig -l | xargs -n1 ipconfig getifaddr)
@@ -37,7 +37,10 @@ export NO_FLIPPER=1
 mkdir ./logs
 
 # Unpack keys
-tar xf keys.tar
+if [ -f "keys.tar" ]; then
+  tar xf keys.tar
+fi
+
 # Generate test bundles
 yarn generate-test-update-bundles
 

--- a/packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import {
+  initAsync,
+  setupUpdatesDisabledE2EAppAsync,
+  transformAppJsonForUpdatesDisabledE2E,
+} from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: true,
+    transformAppJson: transformAppJsonForUpdatesDisabledE2E,
+    shouldGenerateTestUpdateBundles: false,
+    shouldConfigureCodeSigning: false,
+  });
+
+  await setupUpdatesDisabledE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();


### PR DESCRIPTION
# Why

This adds a e2e test build for when updates are disabled (which is an independent system in the expo-updates library as of https://github.com/expo/expo/pull/25085 and https://github.com/expo/expo/pull/25192).

# How

Add test that is mostly a sanity check that it starts up with an empty configuration but expo-updates installed, and fails with an expected error when the JS API is called.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
