### PR TITLE
fix(expo-module-scripts): fixes for test runners

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Remove watchPlugins from sub-projects when using multi-project runner.
-- Default to using jest-preset-plugin when running `yarn test plugin` with no `plugin/jest.config.js` file.
+- Remove watchPlugins from sub-projects when using multi-project runner. ([#25302](https://github.com/expo/expo/pull/25302) by [@EvanBacon](https://github.com/EvanBacon))
+- Default to using jest-preset-plugin when running `yarn test plugin` with no `plugin/jest.config.js` file. ([#25302](https://github.com/expo/expo/pull/25302) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Remove watchPlugins from sub-projects when using multi-project runner.
+- Default to using jest-preset-plugin when running `yarn test plugin` with no `plugin/jest.config.js` file.
+
 ### 💡 Others
 
 ## 3.2.0 — 2023-10-17

--- a/packages/expo-module-scripts/bin/expo-module-test
+++ b/packages/expo-module-scripts/bin/expo-module-test
@@ -15,6 +15,9 @@ if [ "$1" == "plugin" ]; then
   if [[ -f plugin/jest.config.js ]]; then
     args+=("--config")
     args+=("plugin/jest.config.js")
+  else
+    args+=("--config")
+    args+=("$(node --print "require.resolve('expo-module-scripts/jest-preset-plugin.js')")")
   fi
 
   # Push the rest of the arguments minus the `plugin` arg

--- a/packages/expo-module-scripts/jest-preset-plugin.js
+++ b/packages/expo-module-scripts/jest-preset-plugin.js
@@ -4,7 +4,10 @@ const nodePreset = {
   transform: {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: require.resolve('./babel.config.base.js') }],
   },
-  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+  watchPlugins: [
+    require.resolve('jest-watch-typeahead/filename'),
+    require.resolve('jest-watch-typeahead/testname'),
+  ],
 };
 
 module.exports = nodePreset;

--- a/packages/expo-module-scripts/jest-preset.js
+++ b/packages/expo-module-scripts/jest-preset.js
@@ -6,5 +6,6 @@ module.exports = withWatchPlugins({
     createJestPreset(require('jest-expo/android/jest-preset')),
     createJestPreset(require('jest-expo/web/jest-preset')),
     createJestPreset(require('jest-expo/node/jest-preset')),
-  ],
+    // Remove sub-watch-plugins from the preset when using multi-project runner.
+  ].map(({ watchPlugins, ...config }) => config),
 });


### PR DESCRIPTION
# Why

- Fix test failures in #25279 which were introduced by the URL support. We were unintentionally using the native jest config for config plugin testing when no `plugin/jest.config.js` file existed. Now we'll default to using the jest preset plugin.
- Dismiss warning about jest watch plugins being invalid by stripping them in the multi-runner like we do for `expo-router`.
