### PR TITLE
[sqlite] Fix iOS crash on int overflow

### DIFF
--- a/apps/test-suite/tests/SQLiteNext.ts
+++ b/apps/test-suite/tests/SQLiteNext.ts
@@ -48,6 +48,18 @@ CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       await db.closeAsync();
     });
 
+    it('should support bigger integers than int32_t', async () => {
+      const db = await SQLite.openDatabaseAsync(':memory:');
+      const value = 1700007974511;
+      const row = await db.getAsync<{ value: number }>(`SELECT ${value} as value`);
+      expect(row['value']).toBe(value);
+      const row2 = await db.getAsync<{ value: number }>('SELECT $value as value', {
+        $value: value,
+      });
+      expect(row2['value']).toBe(value);
+      await db.closeAsync();
+    });
+
     it('should support PRAGMA statements', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       await db.execAsync(`

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -444,6 +444,9 @@ public final class SQLiteModuleNext: Module {
     case let param as NSNull:
       sqlite3_bind_null(instance, index)
     case let param as Int:
+      guard param >= Int(Int32.min) && param <= Int(Int32.max) else {
+        throw InvalidConvertibleException("\(param) does not conform to Int32")
+      }
       sqlite3_bind_int(instance, index, Int32(param))
     case let param as Double:
       sqlite3_bind_double(instance, index, param)

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -415,7 +415,7 @@ public final class SQLiteModuleNext: Module {
 
     switch type {
     case SQLITE_INTEGER:
-      return sqlite3_column_int(instance, index)
+      return sqlite3_column_int64(instance, index)
     case SQLITE_FLOAT:
       return sqlite3_column_double(instance, index)
     case SQLITE_TEXT:
@@ -443,11 +443,8 @@ public final class SQLiteModuleNext: Module {
       sqlite3_bind_null(instance, index)
     case let param as NSNull:
       sqlite3_bind_null(instance, index)
-    case let param as Int:
-      guard param >= Int(Int32.min) && param <= Int(Int32.max) else {
-        throw InvalidConvertibleException("\(param) does not conform to Int32")
-      }
-      sqlite3_bind_int(instance, index, Int32(param))
+    case let param as Int64:
+      sqlite3_bind_int64(instance, index, Int64(param))
     case let param as Double:
       sqlite3_bind_double(instance, index, param)
     case let param as String:

--- a/packages/expo-sqlite/src/next/__tests__/Database-test.node.ts
+++ b/packages/expo-sqlite/src/next/__tests__/Database-test.node.ts
@@ -229,6 +229,14 @@ describe('Database - Synchronous calls', () => {
     expect(result?.intValue).toBe(123);
   });
 
+  it('runSync should throw error on int64 input as int', () => {
+    db = openDatabaseSync(':memory:');
+    db.execSync(
+      'CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER)'
+    );
+    expect(db.runSync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'test', Date.now())).toThrow(Error);
+  });
+
   it('eachSync should return iterable', () => {
     db = openDatabaseSync(':memory:');
     db.execSync(`

--- a/packages/expo-sqlite/src/next/__tests__/Database-test.node.ts
+++ b/packages/expo-sqlite/src/next/__tests__/Database-test.node.ts
@@ -229,14 +229,6 @@ describe('Database - Synchronous calls', () => {
     expect(result?.intValue).toBe(123);
   });
 
-  it('runSync should throw error on int64 input as int', () => {
-    db = openDatabaseSync(':memory:');
-    db.execSync(
-      'CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER)'
-    );
-    expect(db.runSync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'test', Date.now())).toThrow(Error);
-  });
-
   it('eachSync should return iterable', () => {
     db = openDatabaseSync(':memory:');
     db.execSync(`


### PR DESCRIPTION
Fixes #25321 by adding a guard in `bindStatementParam`