### PR TITLE
fix(cli): upgrade `arg` to fix uncaught user errors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `Runtime.callFunctionOn` messages from Vscode debugger to avoid Hermes crashes. ([#25270](https://github.com/expo/expo/pull/25270) by [@byCedric](https://github.com/byCedric))
+- Handle command input errors better. ([#25329](https://github.com/expo/expo/pull/25329) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -56,7 +56,7 @@
     "@urql/core": "2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",
-    "arg": "4.1.0",
+    "arg": "5.0.2",
     "better-opn": "~3.0.2",
     "bplist-parser": "^0.3.1",
     "cacache": "^15.3.0",

--- a/packages/@expo/cli/src/utils/__tests__/arg-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/arg-test.ts
@@ -1,0 +1,18 @@
+import * as Log from '../../log';
+import { assertWithOptionsArgs } from '../args';
+
+jest.mock('../../log');
+
+describe(assertWithOptionsArgs, () => {
+  it('handles unknown options errors', () => {
+    jest.mocked(Log.exit).mockImplementation();
+    expect(() => assertWithOptionsArgs({ '--help': Boolean }, { argv: ['--unknown'] })).toThrow();
+    expect(Log.exit).toHaveBeenCalledWith('Unknown or unexpected option: --unknown', 1);
+  });
+
+  it('handles missing arguments errors', () => {
+    jest.mocked(Log.exit).mockImplementation();
+    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow('kln');
+    expect(Log.exit).toHaveBeenCalledWith('Option requires argument: --name', 1);
+  });
+});

--- a/packages/@expo/cli/src/utils/__tests__/arg-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/arg-test.ts
@@ -7,12 +7,12 @@ describe(assertWithOptionsArgs, () => {
   it('handles unknown options errors', () => {
     jest.mocked(Log.exit).mockImplementation();
     expect(() => assertWithOptionsArgs({ '--help': Boolean }, { argv: ['--unknown'] })).toThrow();
-    expect(Log.exit).toHaveBeenCalledWith('Unknown or unexpected option: --unknown', 1);
+    expect(Log.exit).toHaveBeenCalledWith('unknown or unexpected option: --unknown', 1);
   });
 
   it('handles missing arguments errors', () => {
     jest.mocked(Log.exit).mockImplementation();
-    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow('kln');
-    expect(Log.exit).toHaveBeenCalledWith('Option requires argument: --name', 1);
+    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow();
+    expect(Log.exit).toHaveBeenCalledWith('option requires argument: --name', 1);
   });
 });

--- a/packages/@expo/cli/src/utils/args.ts
+++ b/packages/@expo/cli/src/utils/args.ts
@@ -40,8 +40,10 @@ export function assertWithOptionsArgs(
   try {
     return arg(schema, options);
   } catch (error: any) {
-    // Ensure unknown options are handled the same way.
-    if (error.code === 'ARG_UNKNOWN_OPTION') {
+    // Handle errors caused by user input.
+    // Only errors from `arg`, which does not start with `ARG_CONFIG_` are user input errors.
+    // See: https://github.com/vercel/arg/releases/tag/5.0.0
+    if ('code' in error && error.code.startsWith('ARG_') && !error.code.startsWith('ARG_CONFIG_')) {
       Log.exit(error.message, 1);
     }
     // Otherwise rethrow the error.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5538,15 +5538,15 @@ arg@4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
   integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
 
+arg@5.0.2, arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
-arg@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
-  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^1.0.7:
   version "1.0.10"


### PR DESCRIPTION
# Why

We currently still use `arg@4.x.x`, where some errors do not have a proper `.code` property. This results in the error handling not catching it, and making it feel that the CLI actually crashed instead of "denied" the command.

### Before this PR

<img width="986" alt="image" src="https://github.com/expo/expo/assets/1203991/ec893c11-fb9c-4764-8d12-07e3a32b3b58">

### After this PR

<img width="323" alt="image" src="https://github.com/expo/expo/assets/1203991/8b874ae6-87b1-4491-9c7b-beedbd07d989">

# How

- Upgraded to `arg@5.0.2`, which includes better errors ([with `.code` properties](https://github.com/vercel/arg/releases/tag/5.0.0))
- Updated the error handling to handle `ARG_` errors, which are not `ARG_CONFIG_` errors


# Test Plan

- Existing test cases
- Run `$ expo run:android --variant`
- ~~Run `$ expo run:android --port="hello"`~~ Well, forgot that `NaN` is actually a valid `Number`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
