### PR TITLE
feature(cli): add `--mode` alias for `--variant` and `--configuration` flags

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Added Expo CLI devtools plugins support. ([#24650](https://github.com/expo/expo/pull/24650) by [@kudo](https://github.com/kudo))
 - Optionally export only selected assets. ([#25065](https://github.com/expo/expo/pull/25065) by [@douglowder](https://github.com/douglowder))
 - Added Brave Browser debugger support. ([#25109](https://github.com/expo/expo/pull/25109) by [@kapobajza](https://github.com/kapobajza))
-- Add `--mode` aliases for `--variant` and `--configuration` flags for `expo run:` commands.
+- Add `--mode` aliases for `--variant` and `--configuration` flags for `expo run:` commands. ([#25330](https://github.com/expo/expo/pull/25330) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added Expo CLI devtools plugins support. ([#24650](https://github.com/expo/expo/pull/24650) by [@kudo](https://github.com/kudo))
 - Optionally export only selected assets. ([#25065](https://github.com/expo/expo/pull/25065) by [@douglowder](https://github.com/douglowder))
 - Added Brave Browser debugger support. ([#25109](https://github.com/expo/expo/pull/25109) by [@kapobajza](https://github.com/kapobajza))
+- Add `--mode` aliases for `--variant` and `--configuration` flags for `expo run:` commands.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `Runtime.callFunctionOn` messages from Vscode debugger to avoid Hermes crashes. ([#25270](https://github.com/expo/expo/pull/25270) by [@byCedric](https://github.com/byCedric))
+- Handle command input errors better. ([#25329](https://github.com/expo/expo/pull/25329) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -56,7 +56,7 @@
     "@urql/core": "2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",
-    "arg": "4.1.0",
+    "arg": "5.0.2",
     "better-opn": "~3.0.2",
     "bplist-parser": "^0.3.1",
     "cacache": "^15.3.0",

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -19,6 +19,7 @@ export const expoRunAndroid: Command = async (argv) => {
 
     '--port': Number,
     // Aliases
+    '--mode': '--variant',
     '-p': '--port',
 
     '-h': '--help',
@@ -40,14 +41,14 @@ export const expoRunAndroid: Command = async (argv) => {
   {bold Usage}
     $ npx expo run:android <dir>
 
-  {bold Options} 
-    --no-build-cache       Clear the native build cache
-    --no-install           Skip installing dependencies
-    --no-bundler           Skip starting the bundler
-    --variant <name>       Build variant. {dim Default: debug}
-    -d, --device [device]  Device name to run the app on
-    -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
-    -h, --help             Output usage information
+  {bold Options}
+    --no-build-cache          Clear the native build cache
+    --no-install              Skip installing dependencies
+    --no-bundler              Skip starting the bundler
+    --variant, --mode <name>  Build variant. {dim Default: debug}
+    -d, --device [device]     Device name to run the app on
+    -p, --port <port>         Port to start the dev server on. {dim Default: 8081}
+    -h, --help                Output usage information
 `,
       0
     );

--- a/packages/@expo/cli/src/run/ios/index.ts
+++ b/packages/@expo/cli/src/run/ios/index.ts
@@ -19,6 +19,7 @@ export const expoRunIos: Command = async (argv) => {
 
     '--port': Number,
     // Aliases
+    '--mode': '--configuration',
     '-p': '--port',
 
     '-h': '--help',
@@ -37,14 +38,14 @@ export const expoRunIos: Command = async (argv) => {
       `Run the iOS app binary locally`,
       `npx expo run:ios`,
       [
-        `--no-build-cache                 Clear the native derived data before building`,
-        `--no-install                     Skip installing dependencies`,
-        `--no-bundler                     Skip starting the Metro bundler`,
-        `--scheme [scheme]                Scheme to build`,
-        chalk`--configuration <configuration>  Xcode configuration to use. Debug or Release. {dim Default: Debug}`,
-        `-d, --device [device]            Device name or UDID to build the app on`,
-        chalk`-p, --port <port>                Port to start the Metro bundler on. {dim Default: 8081}`,
-        `-h, --help                       Usage info`,
+        `--no-build-cache                         Clear the native derived data before building`,
+        `--no-install                             Skip installing dependencies`,
+        `--no-bundler                             Skip starting the Metro bundler`,
+        `--scheme [scheme]                        Scheme to build`,
+        chalk`--configuration, --mode <configuration>  Xcode configuration to use. Debug or Release. {dim Default: Debug}`,
+        `-d, --device [device]                    Device name or UDID to build the app on`,
+        chalk`-p, --port <port>                        Port to start the Metro bundler on. {dim Default: 8081}`,
+        `-h, --help                               Usage info`,
       ].join('\n'),
       [
         '',

--- a/packages/@expo/cli/src/utils/__tests__/arg-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/arg-test.ts
@@ -1,0 +1,18 @@
+import * as Log from '../../log';
+import { assertWithOptionsArgs } from '../args';
+
+jest.mock('../../log');
+
+describe(assertWithOptionsArgs, () => {
+  it('handles unknown options errors', () => {
+    jest.mocked(Log.exit).mockImplementation();
+    expect(() => assertWithOptionsArgs({ '--help': Boolean }, { argv: ['--unknown'] })).toThrow();
+    expect(Log.exit).toHaveBeenCalledWith('Unknown or unexpected option: --unknown', 1);
+  });
+
+  it('handles missing arguments errors', () => {
+    jest.mocked(Log.exit).mockImplementation();
+    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow('kln');
+    expect(Log.exit).toHaveBeenCalledWith('Option requires argument: --name', 1);
+  });
+});

--- a/packages/@expo/cli/src/utils/__tests__/arg-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/arg-test.ts
@@ -7,12 +7,12 @@ describe(assertWithOptionsArgs, () => {
   it('handles unknown options errors', () => {
     jest.mocked(Log.exit).mockImplementation();
     expect(() => assertWithOptionsArgs({ '--help': Boolean }, { argv: ['--unknown'] })).toThrow();
-    expect(Log.exit).toHaveBeenCalledWith('Unknown or unexpected option: --unknown', 1);
+    expect(Log.exit).toHaveBeenCalledWith('unknown or unexpected option: --unknown', 1);
   });
 
   it('handles missing arguments errors', () => {
     jest.mocked(Log.exit).mockImplementation();
-    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow('kln');
-    expect(Log.exit).toHaveBeenCalledWith('Option requires argument: --name', 1);
+    expect(() => assertWithOptionsArgs({ '--name': String }, { argv: ['--name'] })).toThrow();
+    expect(Log.exit).toHaveBeenCalledWith('option requires argument: --name', 1);
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -17,6 +17,18 @@ describe(collapseAliases, () => {
     const actual = collapseAliases(arg, args);
     expect(actual).toEqual(['--basic', '--help']);
   });
+
+  it(`will collapse long-aliases into arguments`, () => {
+    const arg = {
+      '--basic': Boolean,
+      '--help': Boolean,
+      '-h': '--help',
+      '--plain': '--basic',
+    };
+    const args = ['--plain', '-h'];
+    const actual = collapseAliases(arg, args);
+    expect(actual).toEqual(['--basic', '--help']);
+  });
 });
 
 describe(_resolveStringOrBooleanArgs, () => {
@@ -97,6 +109,28 @@ describe(resolveStringOrBooleanArgsAsync, () => {
         '--scheme': true,
       },
       projectRoot: 'custom-root',
+    });
+  });
+  it(`parses aliases from main arguments properly`, async () => {
+    await expect(
+      resolveStringOrBooleanArgsAsync(
+        ['-d', 'my-device', '--mode', 'release'],
+        {
+          '--variant': String,
+          '--mode': '--variant',
+        },
+        {
+          '--scheme': Boolean,
+          '--device': Boolean,
+          '-d': '--device',
+        }
+      )
+    ).resolves.toEqual({
+      args: {
+        '--device': 'my-device',
+        '--variant': 'release',
+      },
+      projectRoot: '.',
     });
   });
 });

--- a/packages/@expo/cli/src/utils/args.ts
+++ b/packages/@expo/cli/src/utils/args.ts
@@ -40,8 +40,10 @@ export function assertWithOptionsArgs(
   try {
     return arg(schema, options);
   } catch (error: any) {
-    // Ensure unknown options are handled the same way.
-    if (error.code === 'ARG_UNKNOWN_OPTION') {
+    // Handle errors caused by user input.
+    // Only errors from `arg`, which does not start with `ARG_CONFIG_` are user input errors.
+    // See: https://github.com/vercel/arg/releases/tag/5.0.0
+    if ('code' in error && error.code.startsWith('ARG_') && !error.code.startsWith('ARG_CONFIG_')) {
       Log.exit(error.message, 1);
     }
     // Otherwise rethrow the error.

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -47,7 +47,7 @@ export async function resolveStringOrBooleanArgsAsync(
   );
 
   // Collapse aliases into fully qualified arguments.
-  args = collapseAliases(extraArgs, args);
+  args = collapseAliases({ ...rawMap, ...extraArgs }, args);
 
   // Resolve all of the string or boolean arguments and the project root.
   return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5538,15 +5538,15 @@ arg@4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
   integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
 
+arg@5.0.2, arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
-
-arg@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
-  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^1.0.7:
   version "1.0.10"


### PR DESCRIPTION
# Why

[React Native Community CLI v12](https://github.com/react-native-community/cli/releases/tag/v12.0.0) has switched from `--variant` and `--configuration`, to just `--mode` for both.

![image](https://github.com/expo/expo/assets/1203991/fca7c140-d38b-4997-acf8-d23979fd86d0)

This adds support for the same `--mode` flag, to allow using identical flags for both RNC CLI and Expo CLI. But, instead of dropping the old flag (and likely breaking some workflows) this only adds `--mode` as alias for the original ones.

# How

- Stacked on top of #25329.
- Fixed an issue with `resolveStringOrBooleanArgsAsync` not knowing aliases from the base spec (causing `--mode debug` to be parsed as `projectRoot: debug`).
- Added `--mode` aliases in flag specs for both `expo run:android` and `expo run:ios`.

# Test Plan

- `$ expo run:android --mode release` should work as `$ expo run:android --variant release`
- `$ expo run:ios --mode Release` should work as `expo run:ios --configuration Release`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
