### PR TITLE
Fix CI: Android instrumentation

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -13,6 +13,7 @@ on:
       - packages/expo-json-utils/android/**
       - packages/expo-manifests/android/**
       - packages/expo-updates/android/**
+      - tools/src/commands/AndroidNativeUnitTests.ts
       - yarn.lock
       - '!packages/@expo/cli/**'
   pull_request:
@@ -25,6 +26,7 @@ on:
       - packages/expo-json-utils/android/**
       - packages/expo-manifests/android/**
       - packages/expo-updates/android/**
+      - tools/src/commands/AndroidNativeUnitTests.ts
       - yarn.lock
       - '!packages/@expo/cli/**'
 
@@ -63,7 +65,6 @@ jobs:
           gradle: 'true'
           yarn-workspace: 'true'
           yarn-tools: 'true'
-          hermes-engine-aar: 'true'
           react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           yarn-workspace: 'true'
           yarn-tools: 'true'
-          hermes-engine-aar: 'true'
           react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
# Why

Android instrumentation tests are very slow and currently failing due to changes in `android` gradle project.

# How

- Changed the Expo tools script to test all packages in `bare-expo`
- Script adds `expo-updates` to `bare-expo` autolinking to make sure it gets tested, then restores project on completion
- `expo-updates` instrumentation tests are temporarily disabled until refactoring work complete
- Remove hermes build from the cache restore step in workflows

# Test Plan

CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
