### PR TITLE
update tests to account for global reanimated version changing in CI

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -268,7 +268,7 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro supports reanimated worklets 1`] = `
-"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"3.5.4"};var
+"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"[GLOBAL]"};var
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
@@ -305,7 +305,7 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`metro+hermes supports reanimated worklets 1`] = `
-"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"3.5.4"};var
+"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"[GLOBAL]"};var
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
@@ -342,7 +342,7 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`webpack supports reanimated worklets 1`] = `
-"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"3.5.4"};var
+"var _worklet_549132292534_init_data={code:"function someWorklet(greeting){console.log(\\"Hey I'm running on the UI thread\\");}",location:"[mock]/worklet.js",sourceMap:"{\\"version\\":3,\\"mappings\\":\\"AAAA,+EACA\\",\\"names\\":[],\\"sources\\":[\\"[mock]/worklet.js\\"]}",version:"[GLOBAL]"};var
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -236,7 +236,7 @@ export * as default from './Animated';
     };
 
     function stablePaths(src) {
-      return src.replace(new RegExp(samplesPath, 'g'), '[mock]/worklet.js');
+      return src.replace(new RegExp(samplesPath, 'g'), '[mock]/worklet.js').replace(/version:".*"/, 'version:"[GLOBAL]"');
     }
 
     const code = stablePaths(babel.transformFileSync(samplesPath, options)!.code);

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -236,7 +236,9 @@ export * as default from './Animated';
     };
 
     function stablePaths(src) {
-      return src.replace(new RegExp(samplesPath, 'g'), '[mock]/worklet.js').replace(/version:".*"/, 'version:"[GLOBAL]"');
+      return src
+        .replace(new RegExp(samplesPath, 'g'), '[mock]/worklet.js')
+        .replace(/version:".*"/, 'version:"[GLOBAL]"');
     }
 
     const code = stablePaths(babel.transformFileSync(samplesPath, options)!.code);


### PR DESCRIPTION
# Why

The reanimated version changes in CI so we need to account for that in the CI test.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
