### PR TITLE
[github] Skip CI on sdk-4x branch

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,6 +3,7 @@ name: CLI
 on:
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/cli.yml
       - packages/@expo/cli/**

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -28,6 +28,7 @@ on:
       - android/**/*.gradle
   push:
     branches: [main, sdk-*]
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/client-android-eas.yml
       - apps/eas-expo-go/**

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -31,6 +31,7 @@ on:
       - yarn.lock
   push:
     branches: [main, sdk-*]
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/client-ios-eas.yml
       - apps/eas-expo-go/**

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -18,6 +18,7 @@ on:
       - yarn.lock
   push:
     branches: [main, sdk-*]
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/client-ios.yml
       - ios/**

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -3,6 +3,7 @@ name: Create Expo App
 on:
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/create-expo-app.yml
       - packages/create-expo/**

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/expotools.yml
       - tools/**

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -3,6 +3,7 @@ name: Fingerprint
 on:
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/fingerprint.yml
       - packages/@expo/fingerprint/**

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -9,6 +9,7 @@ on:
       - yarn.lock
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/home.yml
       - home/**

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -9,6 +9,7 @@ on:
         default: ''
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/sdk.yml
       - tools/**

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch: {}
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/test-suite.yml
       - apps/bare-expo/**

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -22,6 +22,7 @@ on:
       - templates/expo-template-bare-minimum/**
   push:
     branches: [main, 'sdk-*']
+    branches-ignore: ['sdk-4*']
     paths:
       - .github/workflows/updates-e2e-basic.yml
       - packages/@expo/cli/**


### PR DESCRIPTION
# Why

We haven't paid very close attention to CI on our SDK branches. We plan to start doing this with SDK 50, let's save resources and not run jobs that are failing with false negatives.

# How

I wasn't exactly sure the best way to approach this, so I tried using `branches-ignore` everywhere that we run workflows on push, to skip any SDK ^40.0 branch (no point in applying this to ^30.0 etc. because we never push to those branches anyhow).