### PR TITLE
[iOS][image] Start loading the image before the view mounts

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `contentFit` not working for `SVG` images. ([#25187](https://github.com/expo/expo/pull/25187) by [@behenate](https://github.com/behenate))
+- [iOS] Start loading the image before the view mounts to fix issues with the PagerView. ([#25343](https://github.com/expo/expo/pull/25343) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -69,8 +69,8 @@ public final class ImageView: ExpoView {
 
   public override var bounds: CGRect {
     didSet {
-      // Reload the image when the bounds size has changed and the view is mounted.
-      if oldValue.size != bounds.size && window != nil {
+      // Reload the image when the bounds size has changed and is not empty.
+      if oldValue.size != bounds.size && bounds.size != .zero {
         reload()
       }
     }


### PR DESCRIPTION
# Why

Fixes #23830

# How

Currently the image view starts loading the image when it gets mounted (moved to a window). Some libraries such as PagerView may initialize the view eagerly without mounting which then results with a noticeable flicker. This PR relaxes the condition when the image is reloaded – now the view doesn't have to be mounted but its bounds must be of non-zero size.

# Test Plan

Reproducible example provided in the issue (https://github.com/henrymoulton/expo-image-pagerview-bug) seems to work as expected.