### PR TITLE
[docs] Fix duplicate defaults for Android images

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -16,17 +16,15 @@ Here is the [up-to-date list of builder IP addresses](https://expo.dev/eas-build
 
 ## Configuring build environment
 
-Images for each platform have one specific version of Node.js, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json).
-If there is no dedicated configuration option you're looking for, you can use [npm hooks](npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Please consider that those customizations are applied during the build and will increase your build times.
+Images for each platform have one specific version of Node.js, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json). If there is no dedicated configuration option you are looking for, you can use [npm hooks](/build-reference/npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Consider that those customizations are applied during the build and will increase your build times.
 
 When selecting an image for the build you can use the full name provided below or one of the aliases: `default`, `latest`.
 
-- The use of a specific name guarantees the consistent environment with only minor updates.
+- The use of a specific name guarantees a consistent environment with only minor updates.
 - `default` alias will be assigned to the environment that most closely resembles the configuration used for Expo SDK development.
-- `latest` alias will be assigned to the image with the most up to date versions of the software.
+- `latest` alias will be assigned to the image with the most up-to-date versions of the software.
 
-> **info** **Note:** If you do not provide `image` in **eas.json**, your build will use `default` image. However, in some cases, we select a more appropriate image based on the Expo SDK version or React Native version.
-> You can check what image is used for a build in the "Spin up build environment" build logs section.
+> **info** **Note:** If you do not provide `image` in **eas.json**, your build will use `default` image. However, in some cases, we select a more appropriate image based on the Expo SDK version or React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
 
 ## Android build server configurations
 
@@ -36,8 +34,8 @@ Android builders run on virtual machines in an isolated environment. Every build
 
   <HardwareList platform="android" />
 
-- [npm cache deployed with Kubernetes](caching/#javascript-dependencies)
-- [Maven cache deployed with Kubernetes](caching/#android-dependencies)
+- [npm cache deployed with Kubernetes](/build-reference/caching/#javascript-dependencies)
+- [Maven cache deployed with Kubernetes](/build-reference/caching/#android-dependencies)
 - Global Gradle configuration in **~/.gradle/gradle.properties**:
 
   ```ini ~/.gradle/gradle.properties
@@ -181,8 +179,8 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
   <BuildResourceList platform="ios" />
 
-- [npm cache](caching/#javascript-dependencies)
-- [CocoaPods cache](caching/#ios-dependencies)
+- [npm cache](/build-reference/caching/#javascript-dependencies)
+- [CocoaPods cache](/build-reference/caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)
 - Global npm configuration in **~/.npmrc**:
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -6,7 +6,6 @@ description: Learn about the current build server infrastructure when using EAS.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import al from '@mdx-js/react';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
 > This document was last updated on **November 8, 2023**.
@@ -110,7 +109,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r21e` (alias `default`)
+#### `ubuntu-20.04-jdk-11-ndk-r21e`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #25249

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove the second default (did not update the last updated date since this is a typo and not a meaningful update)
- Remove unused import statement
- Improve verbiage to follow the writing style guide and fix minor grammatical issues

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/build-reference/infrastructure/#android-server-images

## Preview

![CleanShot 2023-11-13 at 16 00 11@2x](https://github.com/expo/expo/assets/10234615/17b145a5-6807-4180-8949-76d5e5da1fe9)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
