### PR TITLE
[ios][tools] fix crash from evaluating invalid js in hermes debugger

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -564,6 +564,7 @@ PODS:
   - ABI49_0_0React-jsc/Fabric (0.72.4):
     - ABI49_0_0React-jsi (= 0.72.4)
   - ABI49_0_0React-jsi (0.72.4):
+    - ABI49_0_0hermes-engine
     - boost (= 1.83.0)
     - DoubleConversion
     - glog
@@ -3203,7 +3204,7 @@ SPEC CHECKSUMS:
   ABI49_0_0React-debug: d964e2660e1f189b51ddc117d38c69c3430d7000
   ABI49_0_0React-hermes: dd5d24d6ff6d2f354136670806cd6767455f6826
   ABI49_0_0React-jsc: 681c9e048a4cac7fe6bad3b44068092fb653c7d4
-  ABI49_0_0React-jsi: 99f8cecdf41a3bc6066be55cb0662a8c954de1c3
+  ABI49_0_0React-jsi: 00c6a38a4da4b923293884d357a5eb647be0f955
   ABI49_0_0React-jsiexecutor: f1ade9eb9dffdf94ab12da79ede4e975ecebc199
   ABI49_0_0React-jsinspector: e2458e307f4208e402869557b2a4517b97cefc0b
   ABI49_0_0React-logger: 2e90d10adecb4719c9511a0302b1998516fc3ff9

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/hermes/inspector/ABI49_0_0Inspector.h
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/hermes/inspector/ABI49_0_0Inspector.h
@@ -372,10 +372,6 @@ std::optional<UserCallbackException> runUserCallback(C &cb, A &&...arg) {
     cb(std::forward<A>(arg)...);
   } catch (const std::exception &e) {
     return UserCallbackException(e);
-  } catch (const std::runtime_error &e) {
-    // NOTE(kudo): Adding this to catch Hermes inspector exceptions after SDK 49.
-    // I still not figure out why the std::runtime_error is not catched by the std::exception above.
-    return UserCallbackException(e);
   }
 
   return {};

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/jsi/ABI49_0_0React-jsi.podspec
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/jsi/ABI49_0_0React-jsi.podspec
@@ -18,8 +18,6 @@ folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 
 folly_version = '2022.05.16.00'
 boost_compiler_flags = '-Wno-documentation'
 
-# using jsc to expose jsi.h
-js_engine = :jsc
 Pod::Spec.new do |s|
   s.name                   = "ABI49_0_0React-jsi"
   s.version                = version
@@ -50,7 +48,7 @@ Pod::Spec.new do |s|
   elsif js_engine == :hermes
     # JSI is provided by hermes-engine when Hermes is enabled
     # Just need to provide JSIDynamic in this case.
-    s.source_files = "jsi/JSIDynamic.{cpp,h}"
+    s.source_files = "jsi/ABI49_0_0JSIDynamic.{cpp,h}"
     s.dependency "ABI49_0_0hermes-engine"
   end
 end

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -73,10 +73,9 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         with: `.exclude_files$1${versionName}$2$3`,
       },
       {
-        // using jsc to expose jsi.h
         paths: 'React-jsi.podspec',
-        replace: /^(\s+Pod::Spec.new do \|s\|.*)$/gm,
-        with: '\n# using jsc to expose jsi.h\njs_engine = :jsc$1',
+        replace: /(s\.source_files\s*=\s*"jsi\/)(JSIDynamic)/g,
+        with: `$1${versionName}$2`,
       },
       {
         paths: 'React-jsc.podspec',

--- a/tools/src/versioning/ios/versionHermes.ts
+++ b/tools/src/versioning/ios/versionHermes.ts
@@ -181,11 +181,17 @@ function buildHermesAsync(hermesRoot: string, options?: VersionHermesOptions) {
   });
 }
 
-async function removeUnusedHeaders(hermesRoot: string, versionName: string) {
+async function updateDistHeaders(hermesRoot: string, versionName: string) {
   const destRoot = path.join(hermesRoot, 'destroot');
+  const versionedJsiDir = path.join(hermesRoot, VERSIONED_JSI_DIR);
 
   // remove jsi headers
   await fs.remove(path.join(destRoot, 'include', 'jsi'));
+
+  // copy versioned jsi headers
+  const versionedJsiHeaderDestdir = path.join(destRoot, 'include', `${versionName}jsi`);
+  const jsiHeaders = Array.from(await searchFilesAsync(versionedJsiDir, [`**/${versionName}*/*.h`], { absolute: true }));
+  await Promise.all(jsiHeaders.map((file) => fs.copy(file, path.join(versionedJsiHeaderDestdir, path.basename(file)))));
 
   // remove unused and unversioned headers
   const files = Array.from(
@@ -224,7 +230,7 @@ export async function createVersionedHermesTarball(
 
     const tarball = path.join(EXPO_DIR, `${versionName}hermes.tar.gz`);
     logger.log(`Archiving hermes tarball: ${tarball}`);
-    await removeUnusedHeaders(hermesRoot, versionName);
+    await updateDistHeaders(hermesRoot, versionName);
     // NOTE(kudo): we should include the _LICENSE_ file in the tarball, otherwise CocoaPods will get empty result from tarball extraction.
     await spawnAsync('tar', ['cvfz', tarball, 'destroot', 'LICENSE'], {
       cwd: hermesRoot,


### PR DESCRIPTION
# Why

close ENG-10604

# How

i found my issue from versioning that the `jsi.h` is not reading from correct file. we should use the same jsi.h for both react-native and hermes-engine. this pr tries to export versioned jsi headers in versioned hermes tarball and use the headers.

also re-upload the ABI49_0_0hermes.tar.gz to just include the following new files
```
./destroot/include/ABI49_0_0jsi/ABI49_0_0decorator.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0jsi-inl.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0threadsafe.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0instrumentation.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0JSIDynamic.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0jsi.h
./destroot/include/ABI49_0_0jsi/ABI49_0_0jsilib.h
```

# Test Plan

versioned expo go + sdk 49 blank project + hermes debugger with invalid js

 **Note** since cocoapods will cache the tarball and i didn't change the version of the tarball. please follow the steps to make sure you install the latest tarball:

```sh
$ cd /path/to/expo/expo/ios
$ pod cache clean ABI49_0_0hermes-engine
$ rm -rf Pods build
$ pod install
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
