### PR TITLE
[docs] update `Add gestures` to use RNGH 2 API

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -86,13 +86,14 @@ Open the **EmojiSticker.js** file in the **components** directory. Inside it, im
 import Animated from 'react-native-reanimated';
 ```
 
-To make a double tap gesture work, we will apply animations to the `<Animated.Image>` component.
+The `Animated` component looks at the `style` prop of the component. It also determines which values to animate and applies updates to create an animation.
 
-The `Animated` components look at the `style` prop of the component. Then they determine which values to animate, and apply updates to create an animation.
-
-Reanimated exports animated components such as `<Animated.View>`, `<Animated.Text>`, or `<Animated.ScrollView>`. You can create custom animated components by using the `Animated.createAnimatedComponent()` method.
+Reanimated exports animated components such as `<Animated.View>`, `<Animated.Text>`, or `<Animated.ScrollView>`. We will apply animations to the `<Animated.Image>` component to make a double tap gesture work.
 
 Replace the `<Image>` component with `<Animated.Image>`.
+
+
+
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
@@ -109,7 +110,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 }
 ```
 
-> For a complete reference on the animated component API, refer to the [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent) documentation.
+> For a complete reference on the animated component API, see [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent) documentation.
 
 </Step>
 
@@ -135,7 +136,7 @@ const scaleImage = useSharedValue(imageSize);
 
 Creating a shared value using the `useSharedValue()` hook has many advantages. It helps to mutate a piece of data and allows running animations based on the current value.
 A shared value can be accessed and modified using the `.value` property. It will scale the initial value of `scaleImage` so that when a user double-taps the sticker,
-it scales to twice its original size. To do this, we will create an object and call it `doubleTap`, and this object will use the `Gesture.Tap()` to animate the transition while scaling the sticker image. The `numberOfTaps` method determines how many taps are required.
+it scales to twice its original size. To do this, we will create an object and call it `doubleTap`. This object will use the `Gesture.Tap()` to animate the transition while scaling the sticker image. The `numberOfTaps` method determines how many taps are required.
 
 Create the following object in the `<EmojiSticker>` component:
 
@@ -272,7 +273,7 @@ Create a `drag` object to handle the pan gesture.
     });
 ```
 
-The `onChange()` callback accepts `event` as parameter. `changeX` and `changeY` properties hold the change in position since the last event. Use them to update the values stored in `translateX` and `translateY`.
+The `onChange()` callback accepts `event` as a parameter. `changeX` and `changeY` properties hold the change in position since the last event. They are used to update the values stored in `translateX` and `translateY`.
 
 Next, use the `useAnimatedStyle()` hook to return an array of transforms. For the `<Animated.View>` component, we need to set the `transform` property to the `translateX` and `translateY` values. This will change the sticker's position when the gesture is active.
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -121,17 +121,12 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
 React Native Gesture Handler allows us to add behavior when it detects touch input, like a double tap event.
 
-In the **EmojiSticker.js** file, import `TapGestureHandler` from `react-native-gesture-handler` and the hooks below from `react-native-reanimated`.
+In the **EmojiSticker.js** file, import `Gesture` and `GestureDetector` from `react-native-gesture-handler` and the hooks below from `react-native-reanimated`.
 These hooks will animate the style on the `<AnimatedImage>` component for the sticker when the tap gesture is recognized.
 
 ```jsx EmojiSticker.js
-import { TapGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  useAnimatedGestureHandler,
-  withSpring,
-} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 ```
 
 Inside the `<EmojiSticker>` component, create a reference called `scaleImage` using the `useSharedValue()` hook. It will take the value of `imageSize` as its initial value.
@@ -142,27 +137,27 @@ const scaleImage = useSharedValue(imageSize);
 
 Creating a shared value using the `useSharedValue()` hook has many advantages. It helps to mutate a piece of data and allows running animations based on the current value.
 A shared value can be accessed and modified using the `.value` property. It will scale the initial value of `scaleImage` so that when a user double-taps the sticker,
-it scales to twice its original size. To do this, we will create a function and call it `onDoubleTap()`, and this function will use the `useAnimatedGestureHandler()` hook
-to animate the transition while scaling the sticker image.
+it scales to twice its original size. To do this, we will create an and call it `doubleTap`, and this object will use the `Gesture.Tap()` to animate the transition while scaling the sticker image. The `numberOfTaps` method determines how many taps are required.
 
-Create the following function in the `<EmojiSticker>` component:
+Create the following object in the `<EmojiSticker>` component:
 
 ```jsx EmojiSticker.js
-const onDoubleTap = useAnimatedGestureHandler({
-  onActive: () => {
+const doubleTap = Gesture.Tap()
+  .numberOfTaps(2)
+  .onStart(() => {
     if (scaleImage.value !== imageSize * 2) {
       scaleImage.value = scaleImage.value * 2;
     }
-  },
-});
+  });
 ```
 
 To animate the transition, let's use a spring-based animation. This will make it feel alive because it's based on the real-world physics of a spring.
-We will use the `withSpring()` hook provided by `react-native-reanimated`.
+We will use the `withSpring()` function provided by `react-native-reanimated`.
 
 The `useAnimatedStyle()` hook from `react-native-reanimated` is used to create a style object that will be applied to the sticker image.
 It will update styles using the shared values when the animation happens. In this case, we are scaling the size of the image,
 which is done by manipulating the `width` and `height` properties. The initial values of these properties are set to `imageSize`.
+
 Create an `imageStyle` variable and add it to the `EmojiSticker` component:
 
 ```jsx EmojiSticker.js
@@ -174,7 +169,7 @@ const imageStyle = useAnimatedStyle(() => {
 });
 ```
 
-Next, wrap the `<AnimatedImage>` component that displays the sticker on the screen with the `<TapGestureHandler>` component.
+Next, wrap the `<AnimatedImage>` component that displays the sticker on the screen with the `<GestureDetector>` component.
 
 <SnackInline
 label="Handling tap gesture"
@@ -203,13 +198,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
   return (
     <View style={{ top: -350 }}>
-      /* @info Wrap the AnimatedImage component with TapGestureHandler*/ <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>/* @end */
+      /* @info Wrap the AnimatedImage component with GestureDetector*/ <GestureDetector gesture={doubleTap}>/* @end */
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           /* @info Modify the style prop on the AnimatedImage to pass the imageStyle.*/ style={[imageStyle, { width: imageSize, height: imageSize }]} /* @end */
         />
-      /* @info */</TapGestureHandler>/* @end */
+      /* @info */</GestureDetector>/* @end */
     </View>
   );
 }
@@ -217,8 +212,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
 </SnackInline>
 
-In the above snippet, the `onGestureEvent` prop takes the value of the `onDoubleTap()` function and triggers it when a user taps the sticker image.
-The `numberOfTaps` prop determines how many taps are required.
+In the above snippet, the `gesture` prop takes the value of the `doubleTap` which triggers a gesture when a user double-taps the sticker image.
 
 Let's take a look at our app on iOS, Android and the web:
 
@@ -234,14 +228,7 @@ Let's take a look at our app on iOS, Android and the web:
 
 A pan gesture allows recognizing a dragging gesture and tracking its movement. We will use this gesture handler to drag the sticker across the image.
 
-In the **EmojiSticker.js**, import `PanGestureHandler` from the `react-native-gesture-handler` library.
-
-{/* prettier-ignore */}
-```jsx EmojiSticker.js
-import { /* @info */ PanGestureHandler,/* @end */ TapGestureHandler} from "react-native-gesture-handler";
-```
-
-Create an `<AnimatedView>` component using the `Animated.createAnimatedComponent()` method. Then use it to wrap the `<TapGestureHandler>` component by replacing the `<View>` component.
+In the **EmojiSticker.js**, create an `<AnimatedView>` component using the `Animated.createAnimatedComponent()` method. Then use it to wrap the `<GestureDetector>` component by replacing the `<View>` component.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
@@ -253,9 +240,9 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     /* @info Replace the View component with AnimatedView */<AnimatedView style={{ top: -350 }}>/* @end */
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         {/* ...rest of the code remains same */}
-      </TapGestureHandler>
+      </GestureDetector>
     /* @info */</AnimatedView>/* @end */
   );
 }
@@ -277,31 +264,23 @@ These translation values will move the sticker around the screen. Since the stic
 In the `useSharedValue()` hooks, we have set both translation variables to have an initial position of `0`.
 This means that the position the sticker is initially placed is considered the starting point. This value sets the initial position of the sticker when the gesture starts.
 
-In the previous step, we triggered the `onActive()` callback for the tap gesture inside the `useAnimatedGestureHandler()` function.
-Similarly, for the pan gesture, we have to specify two callbacks:
+In the previous step, we triggered the `onStart()` callback for the tap gesture chained to the `Gesture.Tap()` method.
+Similarly, for the pan gesture, we have to specify an `onChange()` callback which runs when the gesture is active and is moving.
 
-- `onStart()`: when the gesture starts or is at its initial position
-- `onActive()`: when the gesture is active and is moving
-
-Create an `onDrag()` method to handle the pan gesture.
+Create a `drag` object to handle the pan gesture.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
-const onDrag = useAnimatedGestureHandler({
-  onStart: (event, context) => {
-    context.translateX = translateX.value;
-    context.translateY = translateY.value;
-  },
-  onActive: (event, context) => {
-    translateX.value = event.translationX + context.translateX;
-    translateY.value = event.translationY + context.translateY;
-  },
-});
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 ```
 
-Both the `onStart` and `onActive` methods accept `event` and `context` as parameters. In the `onStart` method, we'll use `context` to store the initial values of `translateX` and `translateY`. In the `onActive` callback, we'll use the `event` to get the current position of the pan gesture and `context` to get the previously stored values of `translateX` and `translateY`.
+The `onChange()` callback accepts `event` as parameter. `changeX` and `changeY` properties hold the change in position since the last event. Use them to update the values stored in `translateX` and `translateY`.
 
-Next, use the `useAnimatedStyle()` hook to return an array of transforms.For the `<AnimatedView>` component, we need to set the `transform` property to the `translateX` and `translateY` values. This will change the sticker's position when the gesture is active.
+Next, use the `useAnimatedStyle()` hook to return an array of transforms. For the `<AnimatedView>` component, we need to set the `transform` property to the `translateX` and `translateY` values. This will change the sticker's position when the gesture is active.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
@@ -320,7 +299,7 @@ const containerStyle = useAnimatedStyle(() => {
 ```
 
 Then add the `containerStyle` from the above snippet on the `<AnimatedView>` component to apply the transform styles.
-Also, update the `<EmojiSticker>` component so that the `<PanGestureHandler>` component becomes the top-level component.
+Also, update the `<EmojiSticker>` component so that the `<GestureDetector>` component becomes the top-level component.
 
 <SnackInline
 label="Handle pan gesture"
@@ -349,17 +328,17 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // rest of the code
 
   return (
-    /* @info Wrap all components inside PanGestureHandler. */<PanGestureHandler onGestureEvent={onDrag}>/* @end */
+    /* @info Wrap all components inside GestureDetector. */<GestureDetector gesture={drag}>/* @end */
       /* @info Add containerStyle to the AnimatedView style prop. */<AnimatedView style={[containerStyle, { top: -350 }]}>/* @end */
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    /* @info */</PanGestureHandler>/* @end */
+    /* @info */</GestureDetector>/* @end */
   );
 }
 ```

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -135,7 +135,7 @@ const scaleImage = useSharedValue(imageSize);
 
 Creating a shared value using the `useSharedValue()` hook has many advantages. It helps to mutate a piece of data and allows running animations based on the current value.
 A shared value can be accessed and modified using the `.value` property. It will scale the initial value of `scaleImage` so that when a user double-taps the sticker,
-it scales to twice its original size. To do this, we will create an and call it `doubleTap`, and this object will use the `Gesture.Tap()` to animate the transition while scaling the sticker image. The `numberOfTaps` method determines how many taps are required.
+it scales to twice its original size. To do this, we will create an object and call it `doubleTap`, and this object will use the `Gesture.Tap()` to animate the transition while scaling the sticker image. The `numberOfTaps` method determines how many taps are required.
 
 Create the following object in the `<EmojiSticker>` component:
 
@@ -224,7 +224,7 @@ Let's take a look at our app on iOS, Android and the web:
 
 ## Add a pan gesture
 
-A pan gesture allows recognizing a dragging gesture and tracking its movement. We will use this gesture handler to drag the sticker across the image.
+A pan gesture allows recognizing a dragging gesture and tracking its movement. We will use it to drag the sticker across the image.
 
 In the **EmojiSticker.js**, replace the `<View>` component with the `<Animated.View>` component.
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -198,11 +198,11 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
   return (
     <View style={{ top: -350 }}>
-      /* @info Wrap the AnimatedImage component with GestureDetector*/ <GestureDetector gesture={doubleTap}>/* @end */
+      /* @info Wrap the AnimatedImage component with GestureDetector. */ <GestureDetector gesture={doubleTap}>/* @end */
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
-          /* @info Modify the style prop on the AnimatedImage to pass the imageStyle.*/ style={[imageStyle, { width: imageSize, height: imageSize }]} /* @end */
+          /* @info Modify the style prop on the AnimatedImage to pass the imageStyle. */ style={[imageStyle, { width: imageSize, height: imageSize }]} /* @end */
         />
       /* @info */</GestureDetector>/* @end */
     </View>
@@ -239,7 +239,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
 
   return (
-    /* @info Replace the View component with AnimatedView */<AnimatedView style={{ top: -350 }}>/* @end */
+    /* @info Replace the View component with AnimatedView. */<AnimatedView style={{ top: -350 }}>/* @end */
       <GestureDetector gesture={doubleTap}>
         {/* ...rest of the code remains same */}
       </GestureDetector>

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -78,32 +78,28 @@ export default function App() {
 
 <Step label="2">
 
-## Create animated components
+## Use animated components
 
-Open the **EmojiSticker.js** file in the **components** directory. Inside it, import `Animated` from the `react-native-reanimated` library to create animated components.
+Open the **EmojiSticker.js** file in the **components** directory. Inside it, import `Animated` from the `react-native-reanimated` library to use animated components.
 
 ```jsx EmojiSticker.js
 import Animated from 'react-native-reanimated';
 ```
 
-To make a double tap gesture work, we will apply animations to the `<Image>` component by passing it as an argument to the `Animated.createAnimatedComponent()` method.
+To make a double tap gesture work, we will apply animations to the `<Animated.Image>` component.
 
-```jsx EmojiSticker.js
-// after import statements, add the following line
+The `Animated` components look at the `style` prop of the component. Then they determine which values to animate, and apply updates to create an animation.
 
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-```
+Reanimated exports animated components such as `<Animated.View>`, `<Animated.Text>`, or `<Animated.ScrollView>`. You can create custom animated components by using the `Animated.createAnimatedComponent()` method.
 
-The `createAnimatedComponent()` can wrap any component. It looks at the `style` prop of the component, determines which value is animated, and then applies updates to create an animation.
-
-Replace the `<Image>` component with `<AnimatedImage>`.
+Replace the `<Image>` component with `<Animated.Image>`.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
 export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
-      /* @info Replace the Image component with AnimatedImage. */<AnimatedImage /* @end */
+      /* @info Replace the Image component with Animated.Image. */<Animated.Image /* @end */
         source={stickerSource}
         resizeMode="contain"
         style={{ width: imageSize, height: imageSize }}
@@ -112,6 +108,8 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   );
 }
 ```
+
+> For a complete reference on the animated component API, refer to the [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/core/createAnimatedComponent) documentation.
 
 </Step>
 
@@ -122,7 +120,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 React Native Gesture Handler allows us to add behavior when it detects touch input, like a double tap event.
 
 In the **EmojiSticker.js** file, import `Gesture` and `GestureDetector` from `react-native-gesture-handler` and the hooks below from `react-native-reanimated`.
-These hooks will animate the style on the `<AnimatedImage>` component for the sticker when the tap gesture is recognized.
+These hooks will animate the style on the `<Animated.Image>` component for the sticker when the tap gesture is recognized.
 
 ```jsx EmojiSticker.js
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -169,7 +167,7 @@ const imageStyle = useAnimatedStyle(() => {
 });
 ```
 
-Next, wrap the `<AnimatedImage>` component that displays the sticker on the screen with the `<GestureDetector>` component.
+Next, wrap the `<Animated.Image>` component that displays the sticker on the screen with the `<GestureDetector>` component.
 
 <SnackInline
 label="Handling tap gesture"
@@ -198,8 +196,8 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
   return (
     <View style={{ top: -350 }}>
-      /* @info Wrap the AnimatedImage component with GestureDetector. */ <GestureDetector gesture={doubleTap}>/* @end */
-        <AnimatedImage
+      /* @info Wrap the Animated.Image component with GestureDetector. */ <GestureDetector gesture={doubleTap}>/* @end */
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           /* @info Modify the style prop on the AnimatedImage to pass the imageStyle. */ style={[imageStyle, { width: imageSize, height: imageSize }]} /* @end */
@@ -228,22 +226,18 @@ Let's take a look at our app on iOS, Android and the web:
 
 A pan gesture allows recognizing a dragging gesture and tracking its movement. We will use this gesture handler to drag the sticker across the image.
 
-In the **EmojiSticker.js**, create an `<AnimatedView>` component using the `Animated.createAnimatedComponent()` method. Then use it to wrap the `<GestureDetector>` component by replacing the `<View>` component.
+In the **EmojiSticker.js**, replace the `<View>` component with the `<Animated.View>` component.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
-// ...rest of the code remains same
-/* @info */ const AnimatedView = Animated.createAnimatedComponent(View); /* @end */
-
 export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
-
   return (
-    /* @info Replace the View component with AnimatedView. */<AnimatedView style={{ top: -350 }}>/* @end */
+    /* @info Replace the View component with Animated.View. */<Animated.View style={{ top: -350 }}>/* @end */
       <GestureDetector gesture={doubleTap}>
         {/* ...rest of the code remains same */}
       </GestureDetector>
-    /* @info */</AnimatedView>/* @end */
+    /* @info */</Animated.View>/* @end */
   );
 }
 ```
@@ -280,7 +274,7 @@ Create a `drag` object to handle the pan gesture.
 
 The `onChange()` callback accepts `event` as parameter. `changeX` and `changeY` properties hold the change in position since the last event. Use them to update the values stored in `translateX` and `translateY`.
 
-Next, use the `useAnimatedStyle()` hook to return an array of transforms. For the `<AnimatedView>` component, we need to set the `transform` property to the `translateX` and `translateY` values. This will change the sticker's position when the gesture is active.
+Next, use the `useAnimatedStyle()` hook to return an array of transforms. For the `<Animated.View>` component, we need to set the `transform` property to the `translateX` and `translateY` values. This will change the sticker's position when the gesture is active.
 
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
@@ -298,7 +292,7 @@ const containerStyle = useAnimatedStyle(() => {
 });
 ```
 
-Then add the `containerStyle` from the above snippet on the `<AnimatedView>` component to apply the transform styles.
+Then add the `containerStyle` from the above snippet on the `<Animated.View>` component to apply the transform styles.
 Also, update the `<EmojiSticker>` component so that the `<GestureDetector>` component becomes the top-level component.
 
 <SnackInline
@@ -329,15 +323,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     /* @info Wrap all components inside GestureDetector. */<GestureDetector gesture={drag}>/* @end */
-      /* @info Add containerStyle to the AnimatedView style prop. */<AnimatedView style={[containerStyle, { top: -350 }]}>/* @end */
+      /* @info Add containerStyle to the AnimatedView style prop. */<Animated.View style={[containerStyle, { top: -350 }]}>/* @end */
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     /* @info */</GestureDetector>/* @end */
   );
 }

--- a/docs/public/static/examples/unversioned/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/unversioned/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,13 +1,9 @@
-import { View, Image } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-const AnimatedView = Animated.createAnimatedComponent(View);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const translateX = useSharedValue(0);
@@ -50,15 +46,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <GestureDetector gesture={drag}>
-      <AnimatedView style={[containerStyle, { top: -350 }]}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     </GestureDetector>
   );
 }

--- a/docs/public/static/examples/unversioned/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/unversioned/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,9 +1,8 @@
 import { View, Image } from 'react-native';
-import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  useAnimatedGestureHandler,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -22,24 +21,19 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
     };
   });
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
-  const onDrag = useAnimatedGestureHandler({
-    onStart: (event, context) => {
-      context.translateX = translateX.value;
-      context.translateY = translateY.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = event.translationX + context.translateX;
-      translateY.value = event.translationY + context.translateY;
-    },
-  });
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 
   const containerStyle = useAnimatedStyle(() => {
     return {
@@ -55,16 +49,16 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={onDrag}>
+    <GestureDetector gesture={drag}>
       <AnimatedView style={[containerStyle, { top: -350 }]}>
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/docs/public/static/examples/unversioned/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/unversioned/tutorial/06-gestures/EmojiSticker.js
@@ -1,8 +1,7 @@
 import { View, Image } from 'react-native';
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
@@ -12,13 +11,13 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
   const imageStyle = useAnimatedStyle(() => {
     return {
@@ -29,13 +28,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <View style={{ top: -350 }}>
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}
         />
-      </TapGestureHandler>
+      </GestureDetector>
     </View>
   );
 }

--- a/docs/public/static/examples/unversioned/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/unversioned/tutorial/06-gestures/EmojiSticker.js
@@ -1,12 +1,10 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
@@ -29,7 +27,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
       <GestureDetector gesture={doubleTap}>
-        <AnimatedImage
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}

--- a/docs/public/static/examples/v46.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,13 +1,9 @@
-import { View, Image } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-const AnimatedView = Animated.createAnimatedComponent(View);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const translateX = useSharedValue(0);
@@ -50,15 +46,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <GestureDetector gesture={drag}>
-      <AnimatedView style={[containerStyle, { top: -350 }]}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v46.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,9 +1,8 @@
 import { View, Image } from 'react-native';
-import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  useAnimatedGestureHandler,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -22,24 +21,19 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
     };
   });
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
-  const onDrag = useAnimatedGestureHandler({
-    onStart: (event, context) => {
-      context.translateX = translateX.value;
-      context.translateY = translateY.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = event.translationX + context.translateX;
-      translateY.value = event.translationY + context.translateY;
-    },
-  });
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 
   const containerStyle = useAnimatedStyle(() => {
     return {
@@ -55,16 +49,16 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={onDrag}>
+    <GestureDetector gesture={drag}>
       <AnimatedView style={[containerStyle, { top: -350 }]}>
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v46.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,8 +1,7 @@
 import { View, Image } from 'react-native';
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
@@ -12,13 +11,13 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
   const imageStyle = useAnimatedStyle(() => {
     return {
@@ -29,13 +28,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <View style={{ top: -350 }}>
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}
         />
-      </TapGestureHandler>
+      </GestureDetector>
     </View>
   );
 }

--- a/docs/public/static/examples/v46.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,12 +1,10 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
@@ -29,7 +27,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
       <GestureDetector gesture={doubleTap}>
-        <AnimatedImage
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}

--- a/docs/public/static/examples/v47.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v47.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,13 +1,9 @@
-import { View, Image } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-const AnimatedView = Animated.createAnimatedComponent(View);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const translateX = useSharedValue(0);
@@ -50,15 +46,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <GestureDetector gesture={drag}>
-      <AnimatedView style={[containerStyle, { top: -350 }]}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v47.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v47.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,9 +1,8 @@
 import { View, Image } from 'react-native';
-import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  useAnimatedGestureHandler,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -22,24 +21,19 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
     };
   });
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
-  const onDrag = useAnimatedGestureHandler({
-    onStart: (event, context) => {
-      context.translateX = translateX.value;
-      context.translateY = translateY.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = event.translationX + context.translateX;
-      translateY.value = event.translationY + context.translateY;
-    },
-  });
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 
   const containerStyle = useAnimatedStyle(() => {
     return {
@@ -55,16 +49,16 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={onDrag}>
+    <GestureDetector gesture={drag}>
       <AnimatedView style={[containerStyle, { top: -350 }]}>
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v47.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v47.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,8 +1,7 @@
 import { View, Image } from 'react-native';
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
@@ -12,13 +11,13 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
   const imageStyle = useAnimatedStyle(() => {
     return {
@@ -29,13 +28,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <View style={{ top: -350 }}>
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}
         />
-      </TapGestureHandler>
+      </GestureDetector>
     </View>
   );
 }

--- a/docs/public/static/examples/v47.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v47.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,12 +1,10 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
@@ -29,7 +27,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
       <GestureDetector gesture={doubleTap}>
-        <AnimatedImage
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}

--- a/docs/public/static/examples/v48.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v48.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,13 +1,9 @@
-import { View, Image } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-const AnimatedView = Animated.createAnimatedComponent(View);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const translateX = useSharedValue(0);
@@ -50,15 +46,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <GestureDetector gesture={drag}>
-      <AnimatedView style={[containerStyle, { top: -350 }]}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v48.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v48.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,9 +1,8 @@
 import { View, Image } from 'react-native';
-import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  useAnimatedGestureHandler,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -22,24 +21,19 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
     };
   });
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
-  const onDrag = useAnimatedGestureHandler({
-    onStart: (event, context) => {
-      context.translateX = translateX.value;
-      context.translateY = translateY.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = event.translationX + context.translateX;
-      translateY.value = event.translationY + context.translateY;
-    },
-  });
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 
   const containerStyle = useAnimatedStyle(() => {
     return {
@@ -55,16 +49,16 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={onDrag}>
+    <GestureDetector gesture={drag}>
       <AnimatedView style={[containerStyle, { top: -350 }]}>
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v48.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v48.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,8 +1,7 @@
 import { View, Image } from 'react-native';
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
@@ -12,13 +11,13 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
   const imageStyle = useAnimatedStyle(() => {
     return {
@@ -29,13 +28,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <View style={{ top: -350 }}>
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}
         />
-      </TapGestureHandler>
+      </GestureDetector>
     </View>
   );
 }

--- a/docs/public/static/examples/v48.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v48.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,12 +1,10 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
@@ -29,7 +27,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
       <GestureDetector gesture={doubleTap}>
-        <AnimatedImage
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}

--- a/docs/public/static/examples/v49.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v49.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,13 +1,9 @@
-import { View, Image } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
-const AnimatedView = Animated.createAnimatedComponent(View);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const translateX = useSharedValue(0);
@@ -50,15 +46,15 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <GestureDetector gesture={drag}>
-      <AnimatedView style={[containerStyle, { top: -350 }]}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
         <GestureDetector gesture={doubleTap}>
-          <AnimatedImage
+          <Animated.Image
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
         </GestureDetector>
-      </AnimatedView>
+      </Animated.View>
     </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v49.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
+++ b/docs/public/static/examples/v49.0.0/tutorial/06-gestures/CompleteEmojiSticker.js
@@ -1,9 +1,8 @@
 import { View, Image } from 'react-native';
-import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  useAnimatedGestureHandler,
   withSpring,
 } from 'react-native-reanimated';
 
@@ -22,24 +21,19 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
     };
   });
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
-  const onDrag = useAnimatedGestureHandler({
-    onStart: (event, context) => {
-      context.translateX = translateX.value;
-      context.translateY = translateY.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = event.translationX + context.translateX;
-      translateY.value = event.translationY + context.translateY;
-    },
-  });
+  const drag = Gesture.Pan()
+    .onChange((event) => {
+      translateX.value += event.changeX;
+      translateY.value += event.changeY;
+    });
 
   const containerStyle = useAnimatedStyle(() => {
     return {
@@ -55,16 +49,16 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   });
 
   return (
-    <PanGestureHandler onGestureEvent={onDrag}>
+    <GestureDetector gesture={drag}>
       <AnimatedView style={[containerStyle, { top: -350 }]}>
-        <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+        <GestureDetector gesture={doubleTap}>
           <AnimatedImage
             source={stickerSource}
             resizeMode="contain"
             style={[imageStyle, { width: imageSize, height: imageSize }]}
           />
-        </TapGestureHandler>
+        </GestureDetector>
       </AnimatedView>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/docs/public/static/examples/v49.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v49.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,8 +1,7 @@
 import { View, Image } from 'react-native';
-import { TapGestureHandler } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
-  useAnimatedGestureHandler,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
@@ -12,13 +11,13 @@ const AnimatedImage = Animated.createAnimatedComponent(Image);
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
 
-  const onDoubleTap = useAnimatedGestureHandler({
-    onActive: () => {
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
       if (scaleImage.value !== imageSize * 2) {
         scaleImage.value = scaleImage.value * 2;
       }
-    },
-  });
+    });
 
   const imageStyle = useAnimatedStyle(() => {
     return {
@@ -29,13 +28,13 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     <View style={{ top: -350 }}>
-      <TapGestureHandler onGestureEvent={onDoubleTap} numberOfTaps={2}>
+      <GestureDetector gesture={doubleTap}>
         <AnimatedImage
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}
         />
-      </TapGestureHandler>
+      </GestureDetector>
     </View>
   );
 }

--- a/docs/public/static/examples/v49.0.0/tutorial/06-gestures/EmojiSticker.js
+++ b/docs/public/static/examples/v49.0.0/tutorial/06-gestures/EmojiSticker.js
@@ -1,12 +1,10 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
-
-const AnimatedImage = Animated.createAnimatedComponent(Image);
 
 export default function EmojiSticker({ imageSize, stickerSource }) {
   const scaleImage = useSharedValue(imageSize);
@@ -29,7 +27,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
       <GestureDetector gesture={doubleTap}>
-        <AnimatedImage
+        <Animated.Image
           source={stickerSource}
           resizeMode="contain"
           style={[imageStyle, { width: imageSize, height: imageSize }]}


### PR DESCRIPTION
# Why

The Expo documentation in [Add gestures](https://docs.expo.dev/tutorial/gestures/) pages teaches the old React Native Gesture Handler v1 API with now [deprecated useAnimatedGestureHandler](https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/hook/useAnimatedGestureHandler.ts#L73) hook.

Since the release [RNGH 2.0](https://www.npmjs.com/package/react-native-gesture-handler/v/2.0.0) (2 years ago) we started recommending to use the new `Gesture`/`GestureDetector` API.

This PR migrates the `Add gestures` section of Expo documentation to the simpler v2 API.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I've updated `docs/pages/tutorial/gestures.mdx` in `docs/` alongside `CompleteEmojiSticker.js` and `EmojiSticker.js` in all the consecutive documentation versions up to SDK46

# Test Plan

I've run the updated code in a Snack and locally in a new expo project. Here's the link to Snack:

https://snack.expo.dev/@kacperkapusciak/handle-pan-gesture---rngh-2-api

The updated code should work exactly the same as the old one.


https://github.com/expo/expo/assets/39658211/70681626-49bf-4b23-9b4f-8e2533208d91



# Checklist



- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<!-- disable:changelog-checks -->
