### PR TITLE
[ios] fix versioned expo-go runnning on rosetta still

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3377,6 +3377,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = C8D8QTF339;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				EX_BUNDLE_NAME = Expo;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Exponent/Supporting/Exponent-Prefix.pch";


### PR DESCRIPTION
# Why

ios versioned expo-go still requires rosetta. this pr tries to remove that.
![Screenshot 2023-11-13 at 10 07 21 PM](https://github.com/expo/expo/assets/46429/17c51baf-aec4-46a6-9511-f34572d4f243)

![Screenshot 2023-11-13 at 10 07 34 PM](https://github.com/expo/expo/assets/46429/51518d27-d6e7-4d87-915d-eb1a4127f894)

# How

update the `EXCLUDED_ARCHS`

# Test Plan

running versioned expo-go without rosetta

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
