### PR TITLE
fix(ci): use `bun-version: latest` to avoid 400 responses

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -53,6 +53,8 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
+          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
+          # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.x
+          bun-version: latest
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches


### PR DESCRIPTION
# Why

This seems to be an issue introduced on Bun's backend, see oven-sh/setup-bun#37 for more info.

# How

- Workaround broken `1.x` selectors by using `latest`

# Test Plan

See CI passing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
