### PR TITLE
[expo-updates] Fix updates instrumentation tests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix the E2E tests. ([#24865](https://github.com/expo/expo/pull/24865) by [@douglowder](https://github.com/douglowder))
 - [Android] Simplify UpdatesUtils.parseDateString, fix UpdatesLoggingTest. ([#24951](https://github.com/expo/expo/pull/24951) by [@douglowder](https://github.com/douglowder))
 - [iOS] Fix expo-localization tvOS compile, add CI. ([#25082](https://github.com/expo/expo/pull/25082) by [@douglowder](https://github.com/douglowder))
+- Fix instrumentation tests. ([#25367](https://github.com/expo/expo/pull/25367) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
@@ -24,6 +24,10 @@ class UpdatesConfigurationInstrumentationTest {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
           metaData = Bundle().apply {
             putString(
+              "expo.modules.updates.EXPO_UPDATE_URL",
+              "https://example.com"
+            )
+            putString(
               "expo.modules.updates.EXPO_RUNTIME_VERSION",
               String.format("string:%s", testRuntimeVersion)
             )
@@ -32,7 +36,7 @@ class UpdatesConfigurationInstrumentationTest {
       }
     }
     val config = UpdatesConfiguration(context, null)
-    Assert.assertEquals(config.runtimeVersion, testRuntimeVersion)
+    Assert.assertEquals(config.runtimeVersionRaw, testRuntimeVersion)
   }
 
   @Test
@@ -45,13 +49,17 @@ class UpdatesConfigurationInstrumentationTest {
       every { packageManager } returns mockk {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
           metaData = Bundle().apply {
+            putString(
+              "expo.modules.updates.EXPO_UPDATE_URL",
+              "https://example.com"
+            )
             putString("expo.modules.updates.EXPO_RUNTIME_VERSION", testRuntimeVersion)
           }
         }
       }
     }
     val config = UpdatesConfiguration(context, null)
-    Assert.assertEquals(config.runtimeVersion, testRuntimeVersion)
+    Assert.assertEquals(config.runtimeVersionRaw, testRuntimeVersion)
   }
 
   @Test
@@ -61,13 +69,17 @@ class UpdatesConfigurationInstrumentationTest {
       every { packageName } returns testPackageName
       every { packageManager } returns mockk {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
-          metaData = Bundle()
+          metaData = Bundle().apply {
+            putString(
+              "expo.modules.updates.EXPO_UPDATE_URL",
+              "https://example.com"
+            )
+          }
         }
       }
     }
 
     val config = UpdatesConfiguration(context, null)
-    Assert.assertEquals(true, config.isEnabled)
     Assert.assertEquals(false, config.expectsSignedManifest)
     Assert.assertEquals("default", config.releaseChannel)
     Assert.assertEquals(0, config.launchWaitMs)
@@ -84,7 +96,10 @@ class UpdatesConfigurationInstrumentationTest {
       every { packageManager } returns mockk {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
           metaData = Bundle().apply {
-            putBoolean("expo.modules.updates.ENABLED", false)
+            putString(
+              "expo.modules.updates.EXPO_UPDATE_URL",
+              "https://example.com"
+            )
             putInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 1000)
             putBoolean("expo.modules.updates.HAS_EMBEDDED_UPDATE", false)
             putBoolean("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN", true)
@@ -94,7 +109,6 @@ class UpdatesConfigurationInstrumentationTest {
     }
 
     val config = UpdatesConfiguration(context, null)
-    Assert.assertEquals(false, config.isEnabled)
     Assert.assertEquals(1000, config.launchWaitMs)
     Assert.assertEquals(false, config.hasEmbeddedUpdate)
     Assert.assertEquals(true, config.codeSigningIncludeManifestResponseCertificateChain)
@@ -145,12 +159,11 @@ class UpdatesConfigurationInstrumentationTest {
       )
     )
 
-    Assert.assertEquals(false, config.isEnabled)
     Assert.assertEquals(false, config.expectsSignedManifest)
     Assert.assertEquals("override", config.scopeKey)
     Assert.assertEquals(Uri.parse("http://override.com"), config.updateUrl)
     Assert.assertEquals("override", config.sdkVersion)
-    Assert.assertEquals("override", config.runtimeVersion)
+    Assert.assertEquals("override", config.runtimeVersionRaw)
     Assert.assertEquals("override", config.releaseChannel)
     Assert.assertEquals(1000, config.launchWaitMs)
     Assert.assertEquals(UpdatesConfiguration.CheckAutomaticallyConfiguration.NEVER, config.checkOnLaunch)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.launcher
 
 import android.content.Context
+import android.net.Uri
 import android.text.format.DateUtils
 import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
@@ -54,7 +55,13 @@ class DatabaseLauncherTest {
     db.assetDao().insertAssets(listOf(testAsset), testUpdate)
 
     val launcher = DatabaseLauncher(
-      UpdatesConfiguration(null, null),
+      UpdatesConfiguration(
+        null,
+        mapOf(
+          "updateUrl" to Uri.parse("https://example.com"),
+          "hasEmbeddedUpdate" to false,
+        )
+      ),
       File("test"),
       FileDownloader(context),
       SelectionPolicy(

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
@@ -21,7 +21,10 @@ class UpdateManifestFactoryTest {
     "{\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":1609975977832}"
 
   private fun createConfig(): UpdatesConfiguration {
-    val configMap = mapOf("updateUrl" to Uri.parse("https://exp.host/@esamelson/native-component-list"))
+    val configMap = mapOf(
+      "updateUrl" to Uri.parse("https://exp.host/@esamelson/native-component-list"),
+      "runtimeVersion" to "1",
+    )
     return UpdatesConfiguration(null, configMap)
   }
 
@@ -58,16 +61,6 @@ class UpdateManifestFactoryTest {
       null,
       createConfig()
     )
-  }
-
-  @Test
-  @Throws(JSONException::class)
-  fun testGetEmbeddedManifest_Legacy() {
-    val actual = getEmbeddedManifest(
-      JSONObject(legacyManifestJson),
-      createConfig()
-    )
-    Assert.assertTrue(actual is LegacyUpdateManifest)
   }
 
   @Test

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -167,7 +167,7 @@ class DatabaseLauncher(
     }
   }
 
-  private fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
+  fun ensureAssetExists(asset: AssetEntity, database: UpdatesDatabase, context: Context): File? {
     val assetFile = File(updatesDirectory, asset.relativePath ?: "")
     var assetFileExists = assetFile.exists()
     if (!assetFileExists) {

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -81,15 +81,10 @@ export async function androidNativeUnitTests({
       return false;
     }
 
-    let includesTests;
+    let includesTests: boolean = false;
     if (pkg.isSupportedOnPlatform('android') && !excludedInTests.includes(pkg.packageSlug)) {
       if (type === 'instrumented') {
-        // TODO: expo-updates instrumentation tests are broken at the moment
-        if (pkg.packageSlug === 'expo-updates') {
-          includesTests = false;
-        } else {
-          includesTests = await pkg.hasNativeInstrumentationTestsAsync('android');
-        }
+        includesTests = await pkg.hasNativeInstrumentationTestsAsync('android');
       } else {
         includesTests = await pkg.hasNativeTestsAsync('android');
       }


### PR DESCRIPTION
# Why

@douglowder indicated that these were broken by my recent refactors. I think the runner was broken ahead of those PRs, so we were flying blind for those PRs.

Either way, this fixes them and re-enables them.

# Test Plan

Run instrumented tests in android studio. Wait for CI to ensure command change works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
