### PR TITLE
[expo-updates][android] Isolate startup procedure code

### DIFF
--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updates/UpdatesModule.kt
@@ -46,7 +46,7 @@ class UpdatesModule : Module() {
       UpdatesLogger(context).info("UpdatesModule: getConstants called", UpdatesErrorCode.None)
       val constants = mutableMapOf<String, Any>()
       try {
-        val constantsForModule = UpdatesController.instance.getConstantsForModule(context)
+        val constantsForModule = UpdatesController.instance.getConstantsForModule()
         val launchedUpdate = constantsForModule.launchedUpdate
         val embeddedUpdate = constantsForModule.embeddedUpdate
         val isEmbeddedLaunch = launchedUpdate?.id?.equals(embeddedUpdate?.id) ?: false
@@ -93,7 +93,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("reload") { promise: Promise ->
       UpdatesController.instance.relaunchReactApplicationForModule(
-        context,
         object : IUpdatesController.ModuleCallback<Unit> {
           override fun onSuccess(result: Unit) {
             promise.resolve(null)
@@ -121,7 +120,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("checkForUpdateAsync") { promise: Promise ->
       UpdatesController.instance.checkForUpdate(
-        context,
         object : IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult> {
           override fun onSuccess(result: IUpdatesController.CheckForUpdateResult) {
             when (result) {
@@ -170,7 +168,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("fetchUpdateAsync") { promise: Promise ->
       UpdatesController.instance.fetchUpdate(
-        context,
         object : IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult> {
           override fun onSuccess(result: IUpdatesController.FetchUpdateResult) {
             when (result) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -18,7 +18,11 @@ import java.io.File
  * - Internal database initialization errors
  * - Configuration errors (missing required configuration)
  */
-class DisabledUpdatesController(private val fatalException: Exception?, private val isMissingRuntimeVersion: Boolean) : IUpdatesController {
+class DisabledUpdatesController(
+  private val context: Context,
+  private val fatalException: Exception?,
+  private val isMissingRuntimeVersion: Boolean
+) : IUpdatesController {
   private var isStarted = false
   private var launcher: Launcher? = null
   private var isLoaderTaskFinished = false
@@ -46,7 +50,7 @@ class DisabledUpdatesController(private val fatalException: Exception?, private 
   override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {}
 
   @Synchronized
-  override fun start(context: Context) {
+  override fun start() {
     if (isStarted) {
       return
     }
@@ -60,7 +64,7 @@ class DisabledUpdatesController(private val fatalException: Exception?, private 
 
   class UpdatesDisabledException(message: String) : CodedException(message)
 
-  override fun getConstantsForModule(context: Context): IUpdatesController.UpdatesModuleConstants {
+  override fun getConstantsForModule(): IUpdatesController.UpdatesModuleConstants {
     return IUpdatesController.UpdatesModuleConstants(
       launchedUpdate = launcher?.launchedUpdate,
       embeddedUpdate = null,
@@ -76,7 +80,7 @@ class DisabledUpdatesController(private val fatalException: Exception?, private 
     )
   }
 
-  override fun relaunchReactApplicationForModule(context: Context, callback: IUpdatesController.ModuleCallback<Unit>) {
+  override fun relaunchReactApplicationForModule(callback: IUpdatesController.ModuleCallback<Unit>) {
     callback.onFailure(UpdatesDisabledException("You cannot reload when expo-updates is not enabled."))
   }
 
@@ -85,14 +89,12 @@ class DisabledUpdatesController(private val fatalException: Exception?, private 
   }
 
   override fun checkForUpdate(
-    context: Context,
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
     callback.onFailure(UpdatesDisabledException("You cannot check for updates when expo-updates is not enabled."))
   }
 
   override fun fetchUpdate(
-    context: Context,
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
     callback.onFailure(UpdatesDisabledException("You cannot fetch update when expo-updates is not enabled."))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -3,51 +3,31 @@ package expo.modules.updates
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
-import android.os.Handler
-import android.os.HandlerThread
-import android.os.Looper
 import android.util.Log
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.updates.db.BuildData
 import expo.modules.updates.db.DatabaseHolder
-import expo.modules.updates.db.Reaper
 import expo.modules.updates.db.UpdatesDatabase
-import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.errorrecovery.ErrorRecovery
-import expo.modules.updates.errorrecovery.ErrorRecoveryDelegate
-import expo.modules.updates.launcher.DatabaseLauncher
-import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.launcher.Launcher.LauncherCallback
-import expo.modules.updates.launcher.NoDatabaseLauncher
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.Loader
-import expo.modules.updates.loader.LoaderTask
-import expo.modules.updates.loader.LoaderTask.LoaderTaskCallback
-import expo.modules.updates.loader.LoaderTask.RemoteUpdateStatus
-import expo.modules.updates.loader.RemoteLoader
-import expo.modules.updates.loader.UpdateDirective
-import expo.modules.updates.loader.UpdateResponse
-import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifest
 import expo.modules.updates.manifest.ManifestMetadata
-import expo.modules.updates.manifest.UpdateManifest
+import expo.modules.updates.procedures.CheckForUpdateProcedure
+import expo.modules.updates.procedures.FetchUpdateProcedure
 import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
+import expo.modules.updates.procedures.StartupProcedure
 import expo.modules.updates.statemachine.UpdatesStateChangeEventSender
 import expo.modules.updates.statemachine.UpdatesStateContext
-import expo.modules.updates.statemachine.UpdatesStateEvent
 import expo.modules.updates.statemachine.UpdatesStateEventType
 import expo.modules.updates.statemachine.UpdatesStateMachine
-import expo.modules.updates.statemachine.UpdatesStateValue
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -55,7 +35,7 @@ import java.lang.ref.WeakReference
  * Updates controller for applications that have updates enabled and properly-configured.
  */
 class EnabledUpdatesController(
-  context: Context,
+  private val context: Context,
   private val updatesConfiguration: UpdatesConfiguration,
   override val updatesDirectory: File
 ) : IUpdatesController, UpdatesStateChangeEventSender {
@@ -64,23 +44,15 @@ class EnabledUpdatesController(
   } else {
     null
   }
-
+  private val logger = UpdatesLogger(context)
+  private val fileDownloader = FileDownloader(context)
+  private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
+    updatesConfiguration.getRuntimeVersion()
+  )
   private val stateMachine = UpdatesStateMachine(context, this)
-
-  private var launcher: Launcher? = null
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
 
-  // TODO: move away from DatabaseHolder pattern to Handler thread
-  private val databaseHandlerThread = HandlerThread("expo-updates-database")
-  private lateinit var databaseHandler: Handler
-  private fun initializeDatabaseHandler() {
-    if (!::databaseHandler.isInitialized) {
-      databaseHandlerThread.start()
-      databaseHandler = Handler(databaseHandlerThread.looper)
-    }
-  }
-
-  private fun purgeUpdatesLogsOlderThanOneDay(context: Context) {
+  private fun purgeUpdatesLogsOlderThanOneDay() {
     UpdatesLogReader(context).purgeLogEntries {
       if (it != null) {
         Log.e(TAG, "UpdatesLogReader: error in purgeLogEntries", it)
@@ -88,377 +60,91 @@ class EnabledUpdatesController(
     }
   }
 
-  private val logger = UpdatesLogger(context)
   private var isStarted = false
-  private var loaderTask: LoaderTask? = null
-  private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
 
-  private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
-    updatesConfiguration.getRuntimeVersion()
-  )
-  private val fileDownloader = FileDownloader(context)
-  private val errorRecovery = ErrorRecovery(context)
+  private var isStartupFinished = false
 
-  private fun setRemoteLoadStatus(status: ErrorRecoveryDelegate.RemoteLoadStatus) {
-    remoteLoadStatus = status
-    errorRecovery.notifyNewRemoteLoadStatus(status)
-  }
+  private val startupProcedure = StartupProcedure(
+    context,
+    updatesConfiguration,
+    databaseHolder,
+    updatesDirectory,
+    fileDownloader,
+    selectionPolicy,
+    stateMachine,
+    logger,
+    object : StartupProcedure.StartupProcedureCallback {
+      @Synchronized
+      override fun onFinished() {
+        isStartupFinished = true
+        (this as java.lang.Object).notify()
+      }
 
-  // launch conditions
-  private var isLoaderTaskFinished = false
-  override var isEmergencyLaunch = false
-    private set
-
-  override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
-    if (isEmergencyLaunch) {
-      return
+      override fun onLegacyJSEvent(event: StartupProcedure.StartupProcedureCallback.LegacyJSEvent) {
+        when (event) {
+          is StartupProcedure.StartupProcedureCallback.LegacyJSEvent.Error -> sendLegacyUpdateEventToJS(
+            UPDATE_ERROR_EVENT,
+            Arguments.createMap().apply {
+              putString("message", event.exception.message)
+            }
+          )
+          is StartupProcedure.StartupProcedureCallback.LegacyJSEvent.NoUpdateAvailable -> sendLegacyUpdateEventToJS(UPDATE_NO_UPDATE_AVAILABLE_EVENT, null)
+          is StartupProcedure.StartupProcedureCallback.LegacyJSEvent.UpdateAvailable -> sendLegacyUpdateEventToJS(
+            UPDATE_AVAILABLE_EVENT,
+            Arguments.createMap().apply {
+              putString("manifestString", event.manifest.toString())
+            }
+          )
+        }
+      }
     }
-    errorRecovery.startMonitoring(reactInstanceManager)
-  }
+  )
+
+  private val launchedUpdate
+    get() = startupProcedure.launchedUpdate
+  private val isUsingEmbeddedAssets
+    get() = startupProcedure.isUsingEmbeddedAssets
+  private val localAssetFiles
+    get() = startupProcedure.localAssetFiles
+  override val isEmergencyLaunch: Boolean
+    get() = startupProcedure.isEmergencyLaunch
 
   @get:Synchronized
   override val launchAssetFile: String?
     get() {
-      while (!isLoaderTaskFinished) {
+      while (!isStartupFinished) {
         try {
           (this as java.lang.Object).wait()
         } catch (e: InterruptedException) {
           Log.e(TAG, "Interrupted while waiting for launch asset file", e)
         }
       }
-      return launcher?.launchAssetFile
+      return startupProcedure.launchAssetFile
     }
-
   override val bundleAssetName: String?
-    get() = launcher?.bundleAssetName
+    get() = startupProcedure.bundleAssetName
 
-  private val localAssetFiles: Map<AssetEntity, String>?
-    get() = launcher?.localAssetFiles
-
-  private val isUsingEmbeddedAssets: Boolean
-    get() = launcher?.isUsingEmbeddedAssets ?: false
-
-  /**
-   * Any process that calls this *must* manually release the lock by calling `releaseDatabase()` in
-   * every possible case (success, error) as soon as it is finished.
-   */
-  private fun getDatabase(): UpdatesDatabase = databaseHolder.database
-
-  private fun releaseDatabase() {
-    databaseHolder.releaseDatabase()
+  override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
+    startupProcedure.onDidCreateReactInstanceManager(reactInstanceManager)
   }
 
-  val launchedUpdate: UpdateEntity?
-    get() = launcher?.launchedUpdate
-
   @Synchronized
-  override fun start(context: Context) {
+  override fun start() {
     if (isStarted) {
       return
     }
     isStarted = true
 
-    purgeUpdatesLogsOlderThanOneDay(context)
+    purgeUpdatesLogsOlderThanOneDay()
 
-    initializeDatabaseHandler()
-    initializeErrorRecovery(context)
+    BuildData.ensureBuildDataIsConsistent(updatesConfiguration, databaseHolder.database)
+    databaseHolder.releaseDatabase()
 
-    val databaseLocal = getDatabase()
-    BuildData.ensureBuildDataIsConsistent(updatesConfiguration, databaseLocal)
-    releaseDatabase()
-
-    loaderTask = LoaderTask(
-      updatesConfiguration,
-      databaseHolder,
-      updatesDirectory,
-      fileDownloader,
-      selectionPolicy,
-      object : LoaderTaskCallback {
-        override fun onFailure(e: Exception) {
-          logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
-          launcher = NoDatabaseLauncher(context, e)
-          isEmergencyLaunch = true
-          notifyController()
-        }
-
-        override fun onCachedUpdateLoaded(update: UpdateEntity): Boolean {
-          return true
-        }
-
-        override fun onRemoteCheckForUpdateStarted() {
-          stateMachine.processEvent(UpdatesStateEvent.Check())
-        }
-
-        override fun onRemoteCheckForUpdateFinished(result: LoaderTask.RemoteCheckResult) {
-          val event = when (result) {
-            is LoaderTask.RemoteCheckResult.NoUpdateAvailable -> UpdatesStateEvent.CheckCompleteUnavailable()
-            is LoaderTask.RemoteCheckResult.UpdateAvailable -> UpdatesStateEvent.CheckCompleteWithUpdate(result.manifest)
-            is LoaderTask.RemoteCheckResult.RollBackToEmbedded -> UpdatesStateEvent.CheckCompleteWithRollback(result.commitTime)
-          }
-          stateMachine.processEvent(event)
-        }
-
-        override fun onRemoteUpdateManifestResponseManifestLoaded(updateManifest: UpdateManifest) {
-          remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
-        }
-
-        override fun onSuccess(launcher: Launcher, isUpToDate: Boolean) {
-          if (remoteLoadStatus == ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING && isUpToDate) {
-            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-          }
-          this@EnabledUpdatesController.launcher = launcher
-          notifyController()
-        }
-
-        override fun onRemoteUpdateLoadStarted() {
-          stateMachine.processEvent(UpdatesStateEvent.Download())
-        }
-
-        override fun onRemoteUpdateAssetLoaded(
-          asset: AssetEntity,
-          successfulAssetCount: Int,
-          failedAssetCount: Int,
-          totalAssetCount: Int
-        ) {
-          val body = mapOf(
-            "assetInfo" to mapOf(
-              "name" to asset.embeddedAssetFilename,
-              "successfulAssetCount" to successfulAssetCount,
-              "failedAssetCount" to failedAssetCount,
-              "totalAssetCount" to totalAssetCount
-            )
-          )
-          logger.info("AppController appLoaderTask didLoadAsset: $body", UpdatesErrorCode.None, null, asset.expectedHash)
-        }
-
-        override fun onRemoteUpdateFinished(
-          status: RemoteUpdateStatus,
-          update: UpdateEntity?,
-          exception: Exception?
-        ) {
-          when (status) {
-            RemoteUpdateStatus.ERROR -> {
-              if (exception == null) {
-                throw AssertionError("Background update with error status must have a nonnull exception object")
-              }
-              logger.error("UpdatesController onBackgroundUpdateFinished: Error: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
-              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-              val params = Arguments.createMap()
-              params.putString("message", exception.message)
-              sendLegacyUpdateEventToJS(UPDATE_ERROR_EVENT, params)
-
-              // Since errors can happen through a number of paths, we do these checks
-              // to make sure the state machine is valid
-              when (stateMachine.state) {
-                UpdatesStateValue.Idle -> {
-                  stateMachine.processEvent(UpdatesStateEvent.Download())
-                  stateMachine.processEvent(
-                    UpdatesStateEvent.DownloadError(exception.message ?: "")
-                  )
-                }
-                UpdatesStateValue.Checking -> {
-                  stateMachine.processEvent(
-                    UpdatesStateEvent.CheckError(exception.message ?: "")
-                  )
-                }
-                else -> {
-                  // .downloading
-                  stateMachine.processEvent(
-                    UpdatesStateEvent.DownloadError(exception.message ?: "")
-                  )
-                }
-              }
-            }
-            RemoteUpdateStatus.UPDATE_AVAILABLE -> {
-              if (update == null) {
-                throw AssertionError("Background update with error status must have a nonnull update object")
-              }
-              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
-              logger.info("UpdatesController onBackgroundUpdateFinished: Update available", UpdatesErrorCode.None)
-              val params = Arguments.createMap()
-              params.putString("manifestString", update.manifest.toString())
-              sendLegacyUpdateEventToJS(UPDATE_AVAILABLE_EVENT, params)
-              stateMachine.processEvent(
-                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
-              )
-            }
-            RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {
-              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-              logger.error("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
-              sendLegacyUpdateEventToJS(UPDATE_NO_UPDATE_AVAILABLE_EVENT, null)
-              // TODO: handle rollbacks properly, but this works for now
-              if (stateMachine.state == UpdatesStateValue.Downloading) {
-                stateMachine.processEvent(UpdatesStateEvent.DownloadComplete())
-              }
-            }
-          }
-          errorRecovery.notifyNewRemoteLoadStatus(remoteLoadStatus)
-        }
-      }
-    )
-    loaderTask!!.start(context)
+    startupProcedure.run()
   }
 
-  @Synchronized
-  private fun notifyController() {
-    if (launcher == null) {
-      throw AssertionError("UpdatesController.notifyController was called with a null launcher, which is an error. This method should only be called when an update is ready to launch.")
-    }
-    isLoaderTaskFinished = true
-    (this as java.lang.Object).notify()
-  }
-
-  private fun initializeErrorRecovery(context: Context) {
-    errorRecovery.initialize(object : ErrorRecoveryDelegate {
-      override fun loadRemoteUpdate() {
-        if (loaderTask?.isRunning == true) {
-          return
-        }
-        remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
-        val database = getDatabase()
-        val remoteLoader = RemoteLoader(context, updatesConfiguration, database, fileDownloader, updatesDirectory, launchedUpdate)
-        remoteLoader.start(object : Loader.LoaderCallback {
-          override fun onFailure(e: Exception) {
-            logger.error("UpdatesController loadRemoteUpdate onFailure: ${e.localizedMessage}", UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
-            setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
-            releaseDatabase()
-          }
-
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
-            setRemoteLoadStatus(
-              if (loaderResult.updateEntity != null || loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
-              else ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-            )
-            releaseDatabase()
-          }
-
-          override fun onAssetLoaded(asset: AssetEntity, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) { }
-
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            if (updateDirective != null) {
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                }
-              )
-            }
-
-            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(updateManifest.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
-          }
-        })
-      }
-
-      override fun relaunch(callback: LauncherCallback) { relaunchReactApplication(context, false, callback) }
-      override fun throwException(exception: Exception) { throw exception }
-
-      override fun markFailedLaunchForLaunchedUpdate() {
-        if (isEmergencyLaunch) {
-          return
-        }
-        databaseHandler.post {
-          val launchedUpdate = launchedUpdate ?: return@post
-          val database = getDatabase()
-          database.updateDao().incrementFailedLaunchCount(launchedUpdate)
-          releaseDatabase()
-        }
-      }
-
-      override fun markSuccessfulLaunchForLaunchedUpdate() {
-        if (isEmergencyLaunch) {
-          return
-        }
-        databaseHandler.post {
-          val launchedUpdate = launchedUpdate ?: return@post
-          val database = getDatabase()
-          database.updateDao().incrementSuccessfulLaunchCount(launchedUpdate)
-          releaseDatabase()
-        }
-      }
-
-      override fun getRemoteLoadStatus() = remoteLoadStatus
-      override fun getCheckAutomaticallyConfiguration() = updatesConfiguration.checkOnLaunch
-      override fun getLaunchedUpdateSuccessfulLaunchCount() = launchedUpdate?.successfulLaunchCount ?: 0
-    })
-  }
-
-  private fun runReaper() {
-    AsyncTask.execute {
-      val databaseLocal = getDatabase()
-      Reaper.reapUnusedUpdates(
-        updatesConfiguration,
-        databaseLocal,
-        updatesDirectory,
-        launchedUpdate,
-        selectionPolicy
-      )
-      releaseDatabase()
-    }
-  }
-
-  private fun relaunchReactApplication(context: Context, callback: LauncherCallback) {
-    relaunchReactApplication(context, true, callback)
-  }
-
-  private fun relaunchReactApplication(context: Context, shouldRunReaper: Boolean, callback: LauncherCallback) {
-    val host = reactNativeHost?.get()
-    if (host == null) {
-      callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
-      return
-    }
-
-    stateMachine.processEvent(UpdatesStateEvent.Restart())
-
-    val oldLaunchAssetFile = launcher!!.launchAssetFile
-
-    val databaseLocal = getDatabase()
-    val newLauncher = DatabaseLauncher(
-      updatesConfiguration,
-      updatesDirectory,
-      fileDownloader,
-      selectionPolicy
-    )
-    newLauncher.launch(
-      databaseLocal, context,
-      object : LauncherCallback {
-        override fun onFailure(e: Exception) {
-          callback.onFailure(e)
-        }
-
-        override fun onSuccess() {
-          launcher = newLauncher
-          releaseDatabase()
-
-          val instanceManager = host.reactInstanceManager
-
-          val newLaunchAssetFile = launcher!!.launchAssetFile
-          if (newLaunchAssetFile != null && newLaunchAssetFile != oldLaunchAssetFile) {
-            // Unfortunately, even though RN exposes a way to reload an application,
-            // it assumes that the JS bundle will stay at the same location throughout
-            // the entire lifecycle of the app. Since we need to change the location of
-            // the bundle, we need to use reflection to set an otherwise inaccessible
-            // field of the ReactInstanceManager.
-            try {
-              val newJSBundleLoader = JSBundleLoader.createFileLoader(newLaunchAssetFile)
-              val jsBundleLoaderField = instanceManager.javaClass.getDeclaredField("mBundleLoader")
-              jsBundleLoaderField.isAccessible = true
-              jsBundleLoaderField[instanceManager] = newJSBundleLoader
-            } catch (e: Exception) {
-              Log.e(TAG, "Could not reset JSBundleLoader in ReactInstanceManager", e)
-            }
-          }
-          callback.onSuccess()
-          val handler = Handler(Looper.getMainLooper())
-          handler.post { instanceManager.recreateReactContextInBackground() }
-          if (shouldRunReaper) {
-            runReaper()
-          }
-          stateMachine.reset()
-        }
-      }
-    )
+  private fun relaunchReactApplication(callback: LauncherCallback) {
+    startupProcedure.relaunchReactApplication(true, callback)
   }
 
   override fun sendUpdateStateChangeEventToBridge(eventType: UpdatesStateEventType, context: UpdatesStateContext) {
@@ -473,7 +159,7 @@ class EnabledUpdatesController(
     UpdatesUtils.sendEventToReactNative(reactNativeHost, logger, eventName, eventType, params)
   }
 
-  override fun getConstantsForModule(context: Context): IUpdatesController.UpdatesModuleConstants {
+  override fun getConstantsForModule(): IUpdatesController.UpdatesModuleConstants {
     return IUpdatesController.UpdatesModuleConstants(
       launchedUpdate = launchedUpdate,
       embeddedUpdate = EmbeddedManifest.get(context, updatesConfiguration)?.updateEntity,
@@ -489,13 +175,12 @@ class EnabledUpdatesController(
     )
   }
 
-  override fun relaunchReactApplicationForModule(context: Context, callback: IUpdatesController.ModuleCallback<Unit>) {
+  override fun relaunchReactApplicationForModule(callback: IUpdatesController.ModuleCallback<Unit>) {
     val canRelaunch = launchedUpdate != null
     if (!canRelaunch) {
       callback.onFailure(object : CodedException("ERR_UPDATES_RELOAD", "Cannot relaunch without a launched update.", null) {})
     } else {
       relaunchReactApplication(
-        context,
         object : LauncherCallback {
           override fun onFailure(e: Exception) {
             callback.onFailure(e.toCodedException())
@@ -513,211 +198,18 @@ class EnabledUpdatesController(
     callback.onSuccess(stateMachine.context)
   }
 
-  override fun checkForUpdate(context: Context, callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>) {
-    stateMachine.processEvent(UpdatesStateEvent.Check())
-
-    AsyncTask.execute {
-      val embeddedUpdate = EmbeddedManifest.get(context, updatesConfiguration)?.updateEntity
-      val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(
-        databaseHolder.database,
-        updatesConfiguration,
-        launchedUpdate,
-        embeddedUpdate
-      )
-      databaseHolder.releaseDatabase()
-      fileDownloader.downloadRemoteUpdate(
-        updatesConfiguration,
-        extraHeaders,
-        context,
-        object : FileDownloader.RemoteUpdateDownloadCallback {
-          override fun onFailure(message: String, e: Exception) {
-            stateMachine.processEvent(UpdatesStateEvent.CheckError(message))
-            callback.onSuccess(IUpdatesController.CheckForUpdateResult.ErrorResult(e, message))
-          }
-
-          override fun onSuccess(updateResponse: UpdateResponse) {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
-
-            if (updateDirective != null) {
-              if (updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-                if (!updatesConfiguration.hasEmbeddedUpdate) {
-                  callback.onSuccess(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED))
-                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  return
-                }
-
-                if (embeddedUpdate == null) {
-                  callback.onSuccess(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED))
-                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  return
-                }
-
-                if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
-                    updateDirective,
-                    embeddedUpdate,
-                    launchedUpdate,
-                    updateResponse.responseHeaderData?.manifestFilters
-                  )
-                ) {
-                  callback.onSuccess(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY))
-                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  return
-                }
-
-                callback.onSuccess(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
-                stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
-                return
-              }
-            }
-
-            if (updateManifest == null) {
-              callback.onSuccess(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER))
-              UpdatesStateEvent.CheckCompleteUnavailable()
-              return
-            }
-
-            if (launchedUpdate == null) {
-              // this shouldn't ever happen, but if we don't have anything to compare
-              // the new manifest to, let the user know an update is available
-              callback.onSuccess(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
-              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
-              return
-            }
-
-            var shouldLaunch = false
-            var failedPreviously = false
-            if (selectionPolicy.shouldLoadNewUpdate(
-                updateManifest.updateEntity,
-                launchedUpdate,
-                updateResponse.responseHeaderData?.manifestFilters
-              )
-            ) {
-              // If "update" has failed to launch previously, then
-              // "launchedUpdate" will be an earlier update, and the test above
-              // will return true (incorrectly).
-              // We check to see if the new update is already in the DB, and if so,
-              // only allow the update if it has had no launch failures.
-              shouldLaunch = true
-              updateManifest.updateEntity?.let { updateEntity ->
-                val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
-                  updateEntity.id
-                )
-                databaseHolder.releaseDatabase()
-                storedUpdateEntity?.let {
-                  shouldLaunch = it.failedLaunchCount == 0
-                  logger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
-                  failedPreviously = !shouldLaunch
-                }
-              }
-            }
-            if (shouldLaunch) {
-              callback.onSuccess(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
-              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
-              return
-            } else {
-              val reason = when (failedPreviously) {
-                true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
-                else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
-              }
-              callback.onSuccess(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason))
-              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-              return
-            }
-          }
-        }
-      )
+  override fun checkForUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>) {
+    val procedure = CheckForUpdateProcedure(context, updatesConfiguration, databaseHolder, logger, fileDownloader, selectionPolicy, stateMachine, launchedUpdate) {
+      callback.onSuccess(it)
     }
+    procedure.run()
   }
 
-  override fun fetchUpdate(context: Context, callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>) {
-    stateMachine.processEvent(UpdatesStateEvent.Download())
-
-    AsyncTask.execute {
-      val database = databaseHolder.database
-      RemoteLoader(
-        context,
-        updatesConfiguration,
-        database,
-        fileDownloader,
-        updatesDirectory,
-        launchedUpdate
-      )
-        .start(
-          object : Loader.LoaderCallback {
-            override fun onFailure(e: Exception) {
-              databaseHolder.releaseDatabase()
-              callback.onSuccess(IUpdatesController.FetchUpdateResult.ErrorResult(e))
-              stateMachine.processEvent(
-                UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
-              )
-            }
-
-            override fun onAssetLoaded(
-              asset: AssetEntity,
-              successfulAssetCount: Int,
-              failedAssetCount: Int,
-              totalAssetCount: Int
-            ) {
-            }
-
-            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-              if (updateDirective != null) {
-                return Loader.OnUpdateResponseLoadedResult(
-                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                  }
-                )
-              }
-
-              val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
-                ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
-                  updateManifest.updateEntity,
-                  launchedUpdate,
-                  updateResponse.responseHeaderData?.manifestFilters
-                )
-              )
-            }
-
-            override fun onSuccess(loaderResult: Loader.LoaderResult) {
-              RemoteLoader.processSuccessLoaderResult(
-                context,
-                updatesConfiguration,
-                database,
-                selectionPolicy,
-                updatesDirectory,
-                launchedUpdate,
-                loaderResult
-              ) { availableUpdate, didRollBackToEmbedded ->
-                databaseHolder.releaseDatabase()
-
-                if (didRollBackToEmbedded) {
-                  callback.onSuccess(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
-                  stateMachine.processEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
-                } else {
-                  if (availableUpdate == null) {
-                    callback.onSuccess(IUpdatesController.FetchUpdateResult.Failure())
-                    stateMachine.processEvent(UpdatesStateEvent.DownloadComplete())
-                  } else {
-                    // We need the explicit casting here because when in versioned expo-updates,
-                    // the UpdateEntity and UpdatesModule are in different package namespace,
-                    // Kotlin cannot do the smart casting for that case.
-                    val updateEntity = loaderResult.updateEntity as UpdateEntity
-
-                    callback.onSuccess(IUpdatesController.FetchUpdateResult.Success(updateEntity))
-                    stateMachine.processEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest))
-                  }
-                }
-              }
-            }
-          }
-        )
+  override fun fetchUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>) {
+    val procedure = FetchUpdateProcedure(context, updatesConfiguration, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, stateMachine, launchedUpdate) {
+      callback.onSuccess(it)
     }
+    procedure.run()
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -1,6 +1,5 @@
 package expo.modules.updates
 
-import android.content.Context
 import android.os.Bundle
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
@@ -48,7 +47,7 @@ interface IUpdatesController {
    * the application's lifecycle.
    * @param context the base context of the application, ideally a [ReactApplication]
    */
-  fun start(context: Context)
+  fun start()
 
   interface ModuleCallback<T> {
     fun onSuccess(result: T)
@@ -80,9 +79,9 @@ interface IUpdatesController {
      */
     val isMissingRuntimeVersion: Boolean,
   )
-  fun getConstantsForModule(context: Context): UpdatesModuleConstants
+  fun getConstantsForModule(): UpdatesModuleConstants
 
-  fun relaunchReactApplicationForModule(context: Context, callback: ModuleCallback<Unit>)
+  fun relaunchReactApplicationForModule(callback: ModuleCallback<Unit>)
 
   fun getNativeStateMachineContext(callback: ModuleCallback<UpdatesStateContext>)
 
@@ -99,7 +98,7 @@ interface IUpdatesController {
     class RollBackToEmbedded(val commitTime: Date) : CheckForUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception, val message: String) : CheckForUpdateResult(Status.ERROR)
   }
-  fun checkForUpdate(context: Context, callback: ModuleCallback<CheckForUpdateResult>)
+  fun checkForUpdate(callback: ModuleCallback<CheckForUpdateResult>)
 
   sealed class FetchUpdateResult(private val status: Status) {
     private enum class Status {
@@ -114,7 +113,7 @@ interface IUpdatesController {
     class RollBackToEmbedded : FetchUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception) : FetchUpdateResult(Status.ERROR)
   }
-  fun fetchUpdate(context: Context, callback: ModuleCallback<FetchUpdateResult>)
+  fun fetchUpdate(callback: ModuleCallback<FetchUpdateResult>)
 
   fun getExtraParams(callback: ModuleCallback<Bundle>)
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -39,7 +39,7 @@ class UpdatesController {
           val updatesConfiguration = UpdatesConfiguration(context, null)
           EnabledUpdatesController(context, updatesConfiguration, updatesDirectory)
         } else {
-          DisabledUpdatesController(updatesDirectoryException, UpdatesConfiguration.isMissingRuntimeVersion(context, configuration))
+          DisabledUpdatesController(context, updatesDirectoryException, UpdatesConfiguration.isMissingRuntimeVersion(context, configuration))
         }
       }
     }
@@ -81,7 +81,7 @@ class UpdatesController {
     @JvmStatic fun initialize(context: Context, configuration: Map<String, Any>? = null) {
       if (singletonInstance == null) {
         initializeWithoutStarting(context, configuration)
-        singletonInstance!!.start(context)
+        singletonInstance!!.start()
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -38,7 +38,7 @@ import java.io.File
  * expo-dev-client to compile without needing expo-updates to be installed.
  */
 class UpdatesDevLauncherController(
-  context: Context,
+  private val context: Context,
   initialUpdatesConfiguration: UpdatesConfiguration?,
   override val updatesDirectory: File?,
   private val updatesDirectoryException: Exception?,
@@ -79,7 +79,7 @@ class UpdatesDevLauncherController(
 
   override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {}
 
-  override fun start(context: Context) {
+  override fun start() {
     throw Exception("IUpdatesController.start should not be called in dev client")
   }
 
@@ -264,7 +264,7 @@ class UpdatesDevLauncherController(
 
   class NotAvailableInDevClientException(message: String) : CodedException(message)
 
-  override fun getConstantsForModule(context: Context): IUpdatesController.UpdatesModuleConstants {
+  override fun getConstantsForModule(): IUpdatesController.UpdatesModuleConstants {
     return IUpdatesController.UpdatesModuleConstants(
       launchedUpdate = launchedUpdate,
       embeddedUpdate = updatesConfiguration?.let { EmbeddedManifest.get(context, it) }?.updateEntity,
@@ -281,7 +281,6 @@ class UpdatesDevLauncherController(
   }
 
   override fun relaunchReactApplicationForModule(
-    context: Context,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
     callback.onFailure(NotAvailableInDevClientException("Cannot reload update in a development client"))
@@ -292,14 +291,12 @@ class UpdatesDevLauncherController(
   }
 
   override fun checkForUpdate(
-    context: Context,
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
     callback.onFailure(NotAvailableInDevClientException("Cannot check for update in a development client"))
   }
 
   override fun fetchUpdate(
-    context: Context,
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
     callback.onFailure(NotAvailableInDevClientException("Cannot fetch update in a development client"))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -41,7 +41,7 @@ class UpdatesModule : Module() {
 
       val constants = mutableMapOf<String, Any>()
       try {
-        val constantsForModule = UpdatesController.instance.getConstantsForModule(context)
+        val constantsForModule = UpdatesController.instance.getConstantsForModule()
         val launchedUpdate = constantsForModule.launchedUpdate
         val embeddedUpdate = constantsForModule.embeddedUpdate
         val isEmbeddedLaunch = launchedUpdate?.id?.equals(embeddedUpdate?.id) ?: false
@@ -88,7 +88,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("reload") { promise: Promise ->
       UpdatesController.instance.relaunchReactApplicationForModule(
-        context,
         object : IUpdatesController.ModuleCallback<Unit> {
           override fun onSuccess(result: Unit) {
             promise.resolve(null)
@@ -116,7 +115,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("checkForUpdateAsync") { promise: Promise ->
       UpdatesController.instance.checkForUpdate(
-        context,
         object : IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult> {
           override fun onSuccess(result: IUpdatesController.CheckForUpdateResult) {
             when (result) {
@@ -165,7 +163,6 @@ class UpdatesModule : Module() {
 
     AsyncFunction("fetchUpdateAsync") { promise: Promise ->
       UpdatesController.instance.fetchUpdate(
-        context,
         object : IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult> {
           override fun onSuccess(result: IUpdatesController.FetchUpdateResult) {
             when (result) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -1,0 +1,162 @@
+package expo.modules.updates.procedures
+
+import android.content.Context
+import android.os.AsyncTask
+import expo.modules.updates.IUpdatesController
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.db.DatabaseHolder
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.loader.LoaderTask
+import expo.modules.updates.loader.UpdateDirective
+import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.manifest.EmbeddedManifest
+import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.statemachine.UpdatesStateEvent
+import expo.modules.updates.statemachine.UpdatesStateMachine
+
+class CheckForUpdateProcedure(
+  private val context: Context,
+  private val updatesConfiguration: UpdatesConfiguration,
+  private val databaseHolder: DatabaseHolder,
+  private val updatesLogger: UpdatesLogger,
+  private val fileDownloader: FileDownloader,
+  private val selectionPolicy: SelectionPolicy,
+  private val stateMachine: UpdatesStateMachine,
+  private val launchedUpdate: UpdateEntity?,
+  private val callback: (IUpdatesController.CheckForUpdateResult) -> Unit
+) {
+  fun run() {
+    stateMachine.processEvent(UpdatesStateEvent.Check())
+
+    AsyncTask.execute {
+      val embeddedUpdate = EmbeddedManifest.get(context, updatesConfiguration)?.updateEntity
+      val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(
+        databaseHolder.database,
+        updatesConfiguration,
+        launchedUpdate,
+        embeddedUpdate
+      )
+      databaseHolder.releaseDatabase()
+      fileDownloader.downloadRemoteUpdate(
+        updatesConfiguration,
+        extraHeaders,
+        context,
+        object : FileDownloader.RemoteUpdateDownloadCallback {
+          override fun onFailure(message: String, e: Exception) {
+            stateMachine.processEvent(UpdatesStateEvent.CheckError(message))
+            callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e, message))
+          }
+
+          override fun onSuccess(updateResponse: UpdateResponse) {
+            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+
+            if (updateDirective != null) {
+              if (updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
+                if (!updatesConfiguration.hasEmbeddedUpdate) {
+                  callback(
+                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                    )
+                  )
+                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                  return
+                }
+
+                if (embeddedUpdate == null) {
+                  callback(
+                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                    )
+                  )
+                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                  return
+                }
+
+                if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+                    updateDirective,
+                    embeddedUpdate,
+                    launchedUpdate,
+                    updateResponse.responseHeaderData?.manifestFilters
+                  )
+                ) {
+                  callback(
+                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
+                    )
+                  )
+                  stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                  return
+                }
+
+                callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
+                stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
+                return
+              }
+            }
+
+            if (updateManifest == null) {
+              callback(
+                IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                  LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
+                )
+              )
+              UpdatesStateEvent.CheckCompleteUnavailable()
+              return
+            }
+
+            if (launchedUpdate == null) {
+              // this shouldn't ever happen, but if we don't have anything to compare
+              // the new manifest to, let the user know an update is available
+              callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
+              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
+              return
+            }
+
+            var shouldLaunch = false
+            var failedPreviously = false
+            if (selectionPolicy.shouldLoadNewUpdate(
+                updateManifest.updateEntity,
+                launchedUpdate,
+                updateResponse.responseHeaderData?.manifestFilters
+              )
+            ) {
+              // If "update" has failed to launch previously, then
+              // "launchedUpdate" will be an earlier update, and the test above
+              // will return true (incorrectly).
+              // We check to see if the new update is already in the DB, and if so,
+              // only allow the update if it has had no launch failures.
+              shouldLaunch = true
+              updateManifest.updateEntity?.let { updateEntity ->
+                val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
+                  updateEntity.id
+                )
+                databaseHolder.releaseDatabase()
+                storedUpdateEntity?.let {
+                  shouldLaunch = it.failedLaunchCount == 0
+                  updatesLogger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
+                  failedPreviously = !shouldLaunch
+                }
+              }
+            }
+            if (shouldLaunch) {
+              callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
+              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
+              return
+            } else {
+              val reason = when (failedPreviously) {
+                true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
+                else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
+              }
+              callback(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason))
+              stateMachine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+              return
+            }
+          }
+        }
+      )
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -1,0 +1,115 @@
+package expo.modules.updates.procedures
+
+import android.content.Context
+import android.os.AsyncTask
+import expo.modules.updates.IUpdatesController
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.db.DatabaseHolder
+import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.loader.Loader
+import expo.modules.updates.loader.RemoteLoader
+import expo.modules.updates.loader.UpdateDirective
+import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.statemachine.UpdatesStateEvent
+import expo.modules.updates.statemachine.UpdatesStateMachine
+import java.io.File
+
+class FetchUpdateProcedure(
+  private val context: Context,
+  private val updatesConfiguration: UpdatesConfiguration,
+  private val databaseHolder: DatabaseHolder,
+  private val updatesDirectory: File,
+  private val fileDownloader: FileDownloader,
+  private val selectionPolicy: SelectionPolicy,
+  private val stateMachine: UpdatesStateMachine,
+  private val launchedUpdate: UpdateEntity?,
+  private val callback: (IUpdatesController.FetchUpdateResult) -> Unit
+) {
+  fun run() {
+    stateMachine.processEvent(UpdatesStateEvent.Download())
+
+    AsyncTask.execute {
+      val database = databaseHolder.database
+      RemoteLoader(
+        context,
+        updatesConfiguration,
+        database,
+        fileDownloader,
+        updatesDirectory,
+        launchedUpdate
+      )
+        .start(
+          object : Loader.LoaderCallback {
+            override fun onFailure(e: Exception) {
+              databaseHolder.releaseDatabase()
+              callback(IUpdatesController.FetchUpdateResult.ErrorResult(e))
+              stateMachine.processEvent(
+                UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
+              )
+            }
+
+            override fun onAssetLoaded(
+              asset: AssetEntity,
+              successfulAssetCount: Int,
+              failedAssetCount: Int,
+              totalAssetCount: Int
+            ) {
+            }
+
+            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+              if (updateDirective != null) {
+                return Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+                  }
+                )
+              }
+
+              val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+                ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
+              return Loader.OnUpdateResponseLoadedResult(
+                shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
+                  updateManifest.updateEntity,
+                  launchedUpdate,
+                  updateResponse.responseHeaderData?.manifestFilters
+                )
+              )
+            }
+
+            override fun onSuccess(loaderResult: Loader.LoaderResult) {
+              RemoteLoader.processSuccessLoaderResult(
+                context,
+                updatesConfiguration,
+                database,
+                selectionPolicy,
+                updatesDirectory,
+                launchedUpdate,
+                loaderResult
+              ) { availableUpdate, didRollBackToEmbedded ->
+                databaseHolder.releaseDatabase()
+
+                if (didRollBackToEmbedded) {
+                  callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
+                  stateMachine.processEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
+                } else {
+                  if (availableUpdate == null) {
+                    callback(IUpdatesController.FetchUpdateResult.Failure())
+                    stateMachine.processEvent(UpdatesStateEvent.DownloadComplete())
+                  } else {
+                    callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
+                    stateMachine.processEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
+                  }
+                }
+              }
+            }
+          }
+        )
+    }
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -1,0 +1,404 @@
+package expo.modules.updates.procedures
+
+import android.content.Context
+import android.os.AsyncTask
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.util.Log
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.bridge.JSBundleLoader
+import expo.modules.updates.EnabledUpdatesController
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.db.DatabaseHolder
+import expo.modules.updates.db.Reaper
+import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.errorrecovery.ErrorRecovery
+import expo.modules.updates.errorrecovery.ErrorRecoveryDelegate
+import expo.modules.updates.launcher.DatabaseLauncher
+import expo.modules.updates.launcher.Launcher
+import expo.modules.updates.launcher.NoDatabaseLauncher
+import expo.modules.updates.loader.FileDownloader
+import expo.modules.updates.loader.Loader
+import expo.modules.updates.loader.LoaderTask
+import expo.modules.updates.loader.RemoteLoader
+import expo.modules.updates.loader.UpdateDirective
+import expo.modules.updates.loader.UpdateResponse
+import expo.modules.updates.logging.UpdatesErrorCode
+import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.manifest.UpdateManifest
+import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.statemachine.UpdatesStateEvent
+import expo.modules.updates.statemachine.UpdatesStateMachine
+import expo.modules.updates.statemachine.UpdatesStateValue
+import org.json.JSONObject
+import java.io.File
+import java.lang.ref.WeakReference
+
+class StartupProcedure(
+  private val context: Context,
+  private val updatesConfiguration: UpdatesConfiguration,
+  private val databaseHolder: DatabaseHolder,
+  private val updatesDirectory: File,
+  private val fileDownloader: FileDownloader,
+  private val selectionPolicy: SelectionPolicy,
+  private val stateMachine: UpdatesStateMachine,
+  private val logger: UpdatesLogger,
+  private val callback: StartupProcedureCallback
+) {
+  interface StartupProcedureCallback {
+    fun onFinished()
+
+    sealed class LegacyJSEvent(private val type: Type) {
+      private enum class Type {
+        ERROR,
+        UPDATE_AVAILABLE,
+        NO_UPDATE_AVAILABLE
+      }
+
+      class NoUpdateAvailable : LegacyJSEvent(Type.NO_UPDATE_AVAILABLE)
+      class UpdateAvailable(val manifest: JSONObject) : LegacyJSEvent(Type.UPDATE_AVAILABLE)
+      class Error(val exception: Exception) : LegacyJSEvent(Type.ERROR)
+    }
+    fun onLegacyJSEvent(event: LegacyJSEvent)
+  }
+
+  private var reactNativeHost: WeakReference<ReactNativeHost>? = if (context is ReactApplication) {
+    WeakReference(context.reactNativeHost)
+  } else {
+    null
+  }
+
+  private var launcher: Launcher? = null
+
+  val launchAssetFile
+    get() = launcher?.launchAssetFile
+  val bundleAssetName: String?
+    get() = launcher?.bundleAssetName
+  val localAssetFiles: Map<AssetEntity, String>?
+    get() = launcher?.localAssetFiles
+  val isUsingEmbeddedAssets: Boolean
+    get() = launcher?.isUsingEmbeddedAssets ?: false
+  val launchedUpdate: UpdateEntity?
+    get() = launcher?.launchedUpdate
+
+  var isEmergencyLaunch = false
+    private set
+  private val errorRecovery = ErrorRecovery(context)
+  private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+
+  // TODO: move away from DatabaseHolder pattern to Handler thread
+  private val databaseHandlerThread = HandlerThread("expo-updates-database")
+  private lateinit var databaseHandler: Handler
+  private fun initializeDatabaseHandler() {
+    if (!::databaseHandler.isInitialized) {
+      databaseHandlerThread.start()
+      databaseHandler = Handler(databaseHandlerThread.looper)
+    }
+  }
+
+  private val loaderTask = LoaderTask(
+    updatesConfiguration,
+    databaseHolder,
+    updatesDirectory,
+    fileDownloader,
+    selectionPolicy,
+    object : LoaderTask.LoaderTaskCallback {
+      override fun onFailure(e: Exception) {
+        logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
+        launcher = NoDatabaseLauncher(context, e)
+        isEmergencyLaunch = true
+        notifyController()
+      }
+
+      override fun onCachedUpdateLoaded(update: UpdateEntity): Boolean {
+        return true
+      }
+
+      override fun onRemoteCheckForUpdateStarted() {
+        stateMachine.processEvent(UpdatesStateEvent.Check())
+      }
+
+      override fun onRemoteCheckForUpdateFinished(result: LoaderTask.RemoteCheckResult) {
+        val event = when (result) {
+          is LoaderTask.RemoteCheckResult.NoUpdateAvailable -> UpdatesStateEvent.CheckCompleteUnavailable()
+          is LoaderTask.RemoteCheckResult.UpdateAvailable -> UpdatesStateEvent.CheckCompleteWithUpdate(result.manifest)
+          is LoaderTask.RemoteCheckResult.RollBackToEmbedded -> UpdatesStateEvent.CheckCompleteWithRollback(result.commitTime)
+        }
+        stateMachine.processEvent(event)
+      }
+
+      override fun onRemoteUpdateManifestResponseManifestLoaded(updateManifest: UpdateManifest) {
+        remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
+      }
+
+      override fun onSuccess(launcher: Launcher, isUpToDate: Boolean) {
+        if (remoteLoadStatus == ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING && isUpToDate) {
+          remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+        }
+        this@StartupProcedure.launcher = launcher
+        notifyController()
+      }
+
+      override fun onRemoteUpdateLoadStarted() {
+        stateMachine.processEvent(UpdatesStateEvent.Download())
+      }
+
+      override fun onRemoteUpdateAssetLoaded(
+        asset: AssetEntity,
+        successfulAssetCount: Int,
+        failedAssetCount: Int,
+        totalAssetCount: Int
+      ) {
+        val body = mapOf(
+          "assetInfo" to mapOf(
+            "name" to asset.embeddedAssetFilename,
+            "successfulAssetCount" to successfulAssetCount,
+            "failedAssetCount" to failedAssetCount,
+            "totalAssetCount" to totalAssetCount
+          )
+        )
+        logger.info("AppController appLoaderTask didLoadAsset: $body", UpdatesErrorCode.None, null, asset.expectedHash)
+      }
+
+      override fun onRemoteUpdateFinished(
+        status: LoaderTask.RemoteUpdateStatus,
+        update: UpdateEntity?,
+        exception: Exception?
+      ) {
+        when (status) {
+          LoaderTask.RemoteUpdateStatus.ERROR -> {
+            if (exception == null) {
+              throw AssertionError("Background update with error status must have a nonnull exception object")
+            }
+            logger.error("UpdatesController onBackgroundUpdateFinished: Error: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
+            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.Error(exception))
+
+            // Since errors can happen through a number of paths, we do these checks
+            // to make sure the state machine is valid
+            when (stateMachine.state) {
+              UpdatesStateValue.Idle -> {
+                stateMachine.processEvent(UpdatesStateEvent.Download())
+                stateMachine.processEvent(
+                  UpdatesStateEvent.DownloadError(exception.message ?: "")
+                )
+              }
+              UpdatesStateValue.Checking -> {
+                stateMachine.processEvent(
+                  UpdatesStateEvent.CheckError(exception.message ?: "")
+                )
+              }
+              else -> {
+                // .downloading
+                stateMachine.processEvent(
+                  UpdatesStateEvent.DownloadError(exception.message ?: "")
+                )
+              }
+            }
+          }
+          LoaderTask.RemoteUpdateStatus.UPDATE_AVAILABLE -> {
+            if (update == null) {
+              throw AssertionError("Background update with error status must have a nonnull update object")
+            }
+            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
+            logger.info("UpdatesController onBackgroundUpdateFinished: Update available", UpdatesErrorCode.None)
+            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.UpdateAvailable(update.manifest))
+            stateMachine.processEvent(
+              UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
+            )
+          }
+          LoaderTask.RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {
+            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+            logger.error("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
+            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.NoUpdateAvailable())
+            // TODO: handle rollbacks properly, but this works for now
+            if (stateMachine.state == UpdatesStateValue.Downloading) {
+              stateMachine.processEvent(UpdatesStateEvent.DownloadComplete())
+            }
+          }
+        }
+        errorRecovery.notifyNewRemoteLoadStatus(remoteLoadStatus)
+      }
+    }
+  )
+
+  fun run() {
+    initializeDatabaseHandler()
+    initializeErrorRecovery()
+    loaderTask.start(context)
+  }
+
+  @Synchronized
+  private fun notifyController() {
+    if (launcher == null) {
+      throw AssertionError("UpdatesController.notifyController was called with a null launcher, which is an error. This method should only be called when an update is ready to launch.")
+    }
+
+    callback.onFinished()
+  }
+
+  fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
+    if (isEmergencyLaunch) {
+      return
+    }
+    errorRecovery.startMonitoring(reactInstanceManager)
+  }
+
+  private fun setRemoteLoadStatus(status: ErrorRecoveryDelegate.RemoteLoadStatus) {
+    remoteLoadStatus = status
+    errorRecovery.notifyNewRemoteLoadStatus(status)
+  }
+
+  private fun initializeErrorRecovery() {
+    errorRecovery.initialize(object : ErrorRecoveryDelegate {
+      override fun loadRemoteUpdate() {
+        if (loaderTask.isRunning) {
+          return
+        }
+        remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
+        val remoteLoader = RemoteLoader(context, updatesConfiguration, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
+        remoteLoader.start(object : Loader.LoaderCallback {
+          override fun onFailure(e: Exception) {
+            logger.error("UpdatesController loadRemoteUpdate onFailure: ${e.localizedMessage}", UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
+            setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
+            databaseHolder.releaseDatabase()
+          }
+
+          override fun onSuccess(loaderResult: Loader.LoaderResult) {
+            setRemoteLoadStatus(
+              if (loaderResult.updateEntity != null || loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
+              else ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+            )
+            databaseHolder.releaseDatabase()
+          }
+
+          override fun onAssetLoaded(asset: AssetEntity, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) { }
+
+          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+            if (updateDirective != null) {
+              return Loader.OnUpdateResponseLoadedResult(
+                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+                }
+              )
+            }
+
+            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(updateManifest.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
+          }
+        })
+      }
+
+      override fun relaunch(callback: Launcher.LauncherCallback) { relaunchReactApplication(false, callback) }
+      override fun throwException(exception: Exception) { throw exception }
+
+      override fun markFailedLaunchForLaunchedUpdate() {
+        if (isEmergencyLaunch) {
+          return
+        }
+        databaseHandler.post {
+          val launchedUpdate = launchedUpdate ?: return@post
+          databaseHolder.database.updateDao().incrementFailedLaunchCount(launchedUpdate)
+          databaseHolder.releaseDatabase()
+        }
+      }
+
+      override fun markSuccessfulLaunchForLaunchedUpdate() {
+        if (isEmergencyLaunch) {
+          return
+        }
+        databaseHandler.post {
+          val launchedUpdate = launchedUpdate ?: return@post
+          databaseHolder.database.updateDao().incrementSuccessfulLaunchCount(launchedUpdate)
+          databaseHolder.releaseDatabase()
+        }
+      }
+
+      override fun getRemoteLoadStatus() = remoteLoadStatus
+      override fun getCheckAutomaticallyConfiguration() = updatesConfiguration.checkOnLaunch
+      override fun getLaunchedUpdateSuccessfulLaunchCount() = launchedUpdate?.successfulLaunchCount ?: 0
+    })
+  }
+
+  fun relaunchReactApplication(shouldRunReaper: Boolean, callback: Launcher.LauncherCallback) {
+    val host = reactNativeHost?.get()
+    if (host == null) {
+      callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
+      return
+    }
+
+    stateMachine.processEvent(UpdatesStateEvent.Restart())
+
+    val oldLaunchAssetFile = launcher!!.launchAssetFile
+
+    val newLauncher = DatabaseLauncher(
+      updatesConfiguration,
+      updatesDirectory,
+      fileDownloader,
+      selectionPolicy
+    )
+    newLauncher.launch(
+      databaseHolder.database,
+      context,
+      object : Launcher.LauncherCallback {
+        override fun onFailure(e: Exception) {
+          callback.onFailure(e)
+        }
+
+        override fun onSuccess() {
+          launcher = newLauncher
+          databaseHolder.releaseDatabase()
+
+          val instanceManager = host.reactInstanceManager
+
+          val newLaunchAssetFile = launcher!!.launchAssetFile
+          if (newLaunchAssetFile != null && newLaunchAssetFile != oldLaunchAssetFile) {
+            // Unfortunately, even though RN exposes a way to reload an application,
+            // it assumes that the JS bundle will stay at the same location throughout
+            // the entire lifecycle of the app. Since we need to change the location of
+            // the bundle, we need to use reflection to set an otherwise inaccessible
+            // field of the ReactInstanceManager.
+            try {
+              val newJSBundleLoader = JSBundleLoader.createFileLoader(newLaunchAssetFile)
+              val jsBundleLoaderField = instanceManager.javaClass.getDeclaredField("mBundleLoader")
+              jsBundleLoaderField.isAccessible = true
+              jsBundleLoaderField[instanceManager] = newJSBundleLoader
+            } catch (e: Exception) {
+              Log.e(TAG, "Could not reset JSBundleLoader in ReactInstanceManager", e)
+            }
+          }
+          callback.onSuccess()
+          val handler = Handler(Looper.getMainLooper())
+          handler.post { instanceManager.recreateReactContextInBackground() }
+          if (shouldRunReaper) {
+            runReaper()
+          }
+          stateMachine.reset()
+        }
+      }
+    )
+  }
+
+  private fun runReaper() {
+    AsyncTask.execute {
+      Reaper.reapUnusedUpdates(
+        updatesConfiguration,
+        databaseHolder.database,
+        updatesDirectory,
+        launchedUpdate,
+        selectionPolicy
+      )
+      databaseHolder.releaseDatabase()
+    }
+  }
+
+  companion object {
+    private val TAG = EnabledUpdatesController::class.java.simpleName
+  }
+}


### PR DESCRIPTION
# Why

This is the prerequisite step for https://github.com/expo/expo/pull/25258. Namely, we need to isolate the startup code into a self-contained container that has a easy-to-distinguish start and end so that we can serialize calls of the JS API with it.

# How

Move code for the startup process and JS API methods into "procedure" classes. I'm not sure that this is exactly what the isolation classes will look like in the end, but this is good enough to prove that they can be isolated.

# Test Plan

Build and run, wait for E2E tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
