### PR TITLE
[image][Android] Improved the stability of the memory cache key generation

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### 🎉 New features
 
+- [Android] The stability of the memory cache key generation has been improved.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 🎉 New features
 
-- [Android] The stability of the memory cache key generation has been improved.
+- [Android] The stability of the memory cache key generation has been improved. ([#25372](https://github.com/expo/expo/pull/25372) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
@@ -1,0 +1,108 @@
+package expo.modules.image
+
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
+import com.bumptech.glide.request.target.Target
+import expo.modules.image.enums.ContentFit
+import kotlin.math.min
+
+/**
+ * Glide uses `hashCode` and `equals` of the `DownsampleStrategy` to calculate the cache key.
+ * However, we generate this object dynamically, which means that each instance will be different.
+ * Unfortunately, this behaviour is not correct since Glide will not load
+ * the image from memory no matter what.
+ * To fix this issue, we set the `hashCode` to a fixed number and
+ * override `equals` to only check if objects have the common type.
+ */
+abstract class CustomDownsampleStrategy : DownsampleStrategy() {
+  override fun equals(other: Any?): Boolean {
+    return other is CustomDownsampleStrategy
+  }
+
+  override fun hashCode(): Int {
+    return 302008237
+  }
+}
+
+class NoopDownsampleStrategy : DownsampleStrategy() {
+  override fun getScaleFactor(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ): Float = 1f
+
+  override fun getSampleSizeRounding(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ): SampleSizeRounding = SampleSizeRounding.QUALITY
+}
+
+class ContentFitDownsampleStrategy(private val target: ImageViewWrapperTarget, private val contentFit: ContentFit) : CustomDownsampleStrategy() {
+  private var wasTriggered = false
+  override fun getScaleFactor(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ): Float {
+    // The method is invoked twice per asset, but we only need to preserve the original dimensions for the first call.
+    // As Glide uses Android downsampling, it can only adjust dimensions by a factor of two,
+    // and hence two distinct scaling factors are computed to achieve greater accuracy.
+    if (!wasTriggered) {
+      target.sourceWidth = sourceWidth
+      target.sourceHeight = sourceHeight
+      wasTriggered = true
+    }
+
+    // The size of the container is unknown, we don't know what to do, so we just run the default scale.
+    if (requestedWidth == Target.SIZE_ORIGINAL || requestedHeight == Target.SIZE_ORIGINAL) {
+      return 1f
+    }
+
+    val aspectRation = calculateScaleFactor(
+      sourceWidth.toFloat(),
+      sourceHeight.toFloat(),
+      requestedWidth.toFloat(),
+      requestedHeight.toFloat()
+    )
+
+    // We don't want to upscale the image
+    return min(1f, aspectRation)
+  }
+
+  private fun calculateScaleFactor(
+    sourceWidth: Float,
+    sourceHeight: Float,
+    requestedWidth: Float,
+    requestedHeight: Float
+  ): Float = when (contentFit) {
+    ContentFit.Contain -> min(
+      requestedWidth / sourceWidth,
+      requestedHeight / sourceHeight
+    )
+    ContentFit.Cover -> java.lang.Float.max(
+      requestedWidth / sourceWidth,
+      requestedHeight / sourceHeight
+    )
+    ContentFit.Fill, ContentFit.None -> 1f
+    ContentFit.ScaleDown -> if (requestedWidth < sourceWidth || requestedHeight < sourceHeight) {
+      // The container is smaller than the image — scale it down and behave like `contain`
+      min(
+        requestedWidth / sourceWidth,
+        requestedHeight / sourceHeight
+      )
+    } else {
+      // The container is bigger than the image — don't scale it and behave like `none`
+      1f
+    }
+  }
+
+  override fun getSampleSizeRounding(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ) = SampleSizeRounding.QUALITY
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -40,6 +40,9 @@ class ExpoImageModule : Module() {
         Glide
           .with(context)
           .load(GlideUrl(it)) //  Use `load` instead of `download` to store the asset in the memory cache
+          // We added `quality` and `downsample` to create the same cache key as in final image load.
+          .encodeQuality(100)
+          .downsample(NoopDownsampleStrategy())
           .apply {
             if (cachePolicy == CachePolicy.MEMORY) {
               diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -52,7 +52,7 @@ data class SourceMap(
       }
     }
 
-    var lastDotIndex = uri?.lastIndexOf('.')
+    val lastDotIndex = uri?.lastIndexOf('.')
     // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
     if (lastDotIndex == -1 || lastDotIndex == null) {
       return false


### PR DESCRIPTION
# Why

The memory cache key generated by Glide uses all the options the request manager provides. In our code, we have implemented a custom downsample strategy, which makes the generation very unstable. Consequently, two identical requests result in different cache keys, causing the memory cache to be unused.

# How 

I ensured the custom downsample strategy didn't affect the cache key generation.

# Test Plan

- bare-expo ✅