### PR TITLE
fix(template): use correct sdk 50 alpha version for `jest-expo`

### DIFF
--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~18.0.14",
     "jest": "^29.2.1",
-    "jest-expo": "~49.0.0-alpha.4",
+    "jest-expo": "~50.0.0-alpha.3",
     "react-test-renderer": "18.2.0",
     "typescript": "^5.1.3"
   },


### PR DESCRIPTION
# Why

When creating a new project through `bun create expo ./awesome-project --template tabs`, it installs the SDK 49 alpha version of `jest-expo`. This should be the SDK 50 alpha.

# How

- Updated version in template **package.json**

# Test Plan

- `bun expo install --fix` installs the right version, I just matched that version in this **package.json**.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
