### PR TITLE
[image][Android] Changed how the `tintColor` is applied to the SVG

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 💡 Others
 
 - Collapse re-export of `react-native/Libraries/Image/AssetRegistry` to `@react-native/assets-registry/registry`. ([#25265](https://github.com/expo/expo/pull/25265) by [@EvanBacon](https://github.com/EvanBacon))
-- [Android] Changed how the `tintColor` is applied to the SVG.
+- [Android] Changed how the `tintColor` is applied to the SVG. ([#25377](https://github.com/expo/expo/pull/25377) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.8.0 — 2023-11-13
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - Collapse re-export of `react-native/Libraries/Image/AssetRegistry` to `@react-native/assets-registry/registry`. ([#25265](https://github.com/expo/expo/pull/25265) by [@EvanBacon](https://github.com/EvanBacon))
+- [Android] Changed how the `tintColor` is applied to the SVG.
 
 ## 1.8.0 — 2023-11-13
 

--- a/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
+++ b/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
@@ -1,43 +1,43 @@
 package com.caverock.androidsvg
 
-internal fun replaceColour(paint: SVG.SvgPaint?, newColour: Int) {
+internal fun replaceColor(paint: SVG.SvgPaint?, newColor: Int) {
   if (paint is SVG.Colour && paint !== SVG.Colour.TRANSPARENT) {
-    paint.colour = newColour
+    paint.colour = newColor
   }
 }
 
-internal fun replaceStyles(style: SVG.Style?, newColour: Int) {
+internal fun replaceStyles(style: SVG.Style?, newColor: Int) {
   if (style == null) {
     return
   }
 
-  replaceColour(style.color, newColour)
-  replaceColour(style.fill, newColour)
-  replaceColour(style.stroke, newColour)
-  replaceColour(style.stopColor, newColour)
-  replaceColour(style.solidColor, newColour)
-  replaceColour(style.viewportFill, newColour)
+  replaceColor(style.color, newColor)
+  replaceColor(style.fill, newColor)
+  replaceColor(style.stroke, newColor)
+  replaceColor(style.stopColor, newColor)
+  replaceColor(style.solidColor, newColor)
+  replaceColor(style.viewportFill, newColor)
 }
 
-internal fun applyTintColor(element: SVG.SvgObject, newColour: Int) {
+internal fun applyTintColor(element: SVG.SvgObject, newColor: Int) {
   if (element is SVG.SvgElementBase) {
-    replaceStyles(element.baseStyle, newColour)
-    replaceStyles(element.style, newColour)
+    replaceStyles(element.baseStyle, newColor)
+    replaceStyles(element.style, newColor)
   }
 
   if (element is SVG.SvgContainer) {
     for (child in element.children) {
-      applyTintColor(child, newColour)
+      applyTintColor(child, newColor)
     }
   }
 }
 
-fun applyTintColor(svg: SVG, newColour: Int) {
+fun applyTintColor(svg: SVG, newColor: Int) {
   val root = svg.rootElement
 
-  replaceStyles(root.style, newColour)
+  replaceStyles(root.style, newColor)
 
   for (child in root.children) {
-    applyTintColor(child, newColour)
+    applyTintColor(child, newColor)
   }
 }

--- a/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
+++ b/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
@@ -1,0 +1,43 @@
+package com.caverock.androidsvg
+
+internal fun replaceColour(paint: SVG.SvgPaint?, newColour: Int) {
+  if (paint is SVG.Colour && paint !== SVG.Colour.TRANSPARENT) {
+    paint.colour = newColour
+  }
+}
+
+internal fun replaceStyles(style: SVG.Style?, newColour: Int) {
+  if (style == null) {
+    return
+  }
+
+  replaceColour(style.color, newColour)
+  replaceColour(style.fill, newColour)
+  replaceColour(style.stroke, newColour)
+  replaceColour(style.stopColor, newColour)
+  replaceColour(style.solidColor, newColour)
+  replaceColour(style.viewportFill, newColour)
+}
+
+internal fun applyTintColor(element: SVG.SvgObject, newColour: Int) {
+  if (element is SVG.SvgElementBase) {
+    replaceStyles(element.baseStyle, newColour)
+    replaceStyles(element.style, newColour)
+  }
+
+  if (element is SVG.SvgContainer) {
+    for (child in element.children) {
+      applyTintColor(child, newColour)
+    }
+  }
+}
+
+fun applyTintColor(svg: SVG, newColour: Int) {
+  val root = svg.rootElement
+
+  replaceStyles(root.style, newColour)
+
+  for (child in root.children) {
+    applyTintColor(child, newColour)
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomOptions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomOptions.kt
@@ -1,0 +1,8 @@
+package expo.modules.image
+
+import com.bumptech.glide.load.Option
+
+object CustomOptions {
+  // To pass the tint color to the SVG decoder, we need to wrap it in a custom Glide option.
+  val tintColor = Option.memory<Int>("ExpoTintColor")
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -536,6 +536,13 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
         .encodeQuality(100)
         .apply(propOptions)
 
+      tintColor?.let {
+        val tintColorOptions = RequestOptions().apply {
+          set(CustomOptions.tintColor, it)
+        }
+        request.apply(tintColorOptions)
+      }
+
       val cookie = Trace.getNextCookieValue()
       beginAsyncTraceBlock(Trace.tag, Trace.loadNewImageBlock, cookie)
       newTarget.setCookie(cookie)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
@@ -12,7 +12,7 @@ import expo.modules.image.enums.ImageCacheType
 import expo.modules.image.records.ImageErrorEvent
 import expo.modules.image.records.ImageLoadEvent
 import expo.modules.image.records.ImageSource
-import expo.modules.image.svg.SVGPircureDrowable
+import expo.modules.image.svg.SVGPictureDrawable
 import java.lang.ref.WeakReference
 import java.util.Locale
 
@@ -49,8 +49,8 @@ class GlideRequestListener(
     dataSource: DataSource,
     isFirstResource: Boolean
   ): Boolean {
-    val intrinsicWidth = (resource as? SVGPircureDrowable)?.svgIntrinsicWidth ?: resource.intrinsicWidth
-    val intrinsicHeight = (resource as? SVGPircureDrowable)?.svgIntrinsicHeight ?: resource.intrinsicHeight
+    val intrinsicWidth = (resource as? SVGPictureDrawable)?.svgIntrinsicWidth ?: resource.intrinsicWidth
+    val intrinsicHeight = (resource as? SVGPictureDrawable)?.svgIntrinsicHeight ?: resource.intrinsicHeight
     expoImageViewWrapper.get()?.onLoad?.invoke(
       ImageLoadEvent(
         cacheType = ImageCacheType.fromNativeValue(dataSource).name.lowercase(Locale.getDefault()),

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
@@ -12,9 +12,9 @@ import expo.modules.image.enums.ImageCacheType
 import expo.modules.image.records.ImageErrorEvent
 import expo.modules.image.records.ImageLoadEvent
 import expo.modules.image.records.ImageSource
-import expo.modules.image.svg.SVGBitmapDrawable
+import expo.modules.image.svg.SVGPircureDrowable
 import java.lang.ref.WeakReference
-import java.util.*
+import java.util.Locale
 
 class GlideRequestListener(
   private val expoImageViewWrapper: WeakReference<ExpoImageViewWrapper>
@@ -49,8 +49,8 @@ class GlideRequestListener(
     dataSource: DataSource,
     isFirstResource: Boolean
   ): Boolean {
-    val intrinsicWidth = (resource as? SVGBitmapDrawable)?.svgIntrinsicWidth ?: resource.intrinsicWidth
-    val intrinsicHeight = (resource as? SVGBitmapDrawable)?.svgIntrinsicHeight ?: resource.intrinsicHeight
+    val intrinsicWidth = (resource as? SVGPircureDrowable)?.svgIntrinsicWidth ?: resource.intrinsicWidth
+    val intrinsicHeight = (resource as? SVGPircureDrowable)?.svgIntrinsicHeight ?: resource.intrinsicHeight
     expoImageViewWrapper.get()?.onLoad?.invoke(
       ImageLoadEvent(
         cacheType = ImageCacheType.fromNativeValue(dataSource).name.lowercase(Locale.getDefault()),

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -2,7 +2,6 @@ package expo.modules.image.records
 
 import android.content.Context
 import android.net.Uri
-import android.util.TypedValue
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.load.model.LazyHeaders

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -39,27 +39,6 @@ data class SourceMap(
 
   private fun isLocalFileUri() = parsedUri?.scheme?.startsWith("file") ?: false
 
-  private fun isSvg(context: Context): Boolean {
-    var uri = parsedUri?.toString()
-    if (uri?.startsWith("res:/") == true) {
-      val id = uri.removePrefix("res:/")
-      try {
-        val typedValue = TypedValue()
-        context.resources.getValue(id, typedValue, true)
-        uri = typedValue.string.toString()
-      } catch (e: Throwable) {
-        return false
-      }
-    }
-
-    val lastDotIndex = uri?.lastIndexOf('.')
-    // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
-    if (lastDotIndex == -1 || lastDotIndex == null) {
-      return false
-    }
-    return uri?.substring(lastDotIndex)?.startsWith(".svg") ?: false
-  }
-
   fun isBlurhash() = parsedUri?.scheme?.startsWith("blurhash") ?: false
 
   fun isThumbhash() = parsedUri?.scheme?.startsWith("thumbhash") ?: false
@@ -124,7 +103,7 @@ data class SourceMap(
 
         // Override the size for local assets (apart from SVGs). This ensures that
         // resizeMode "center" displays the image in the correct size.
-        if (width != 0 && height != 0 && !isSvg(context)) {
+        if (width != 0 && height != 0) {
           override((width * scale).toInt(), (height * scale).toInt())
         }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
@@ -16,7 +16,7 @@ import expo.modules.image.CustomOptions
  * We have to use the intrinsicWidth/Height from the Picture to render the image at a high enough resolution, but at the same time we want to return the actual
  * preferred width and height of the SVG to JS. This class allows us to do that.
  */
-class SVGPircureDrowable(picture: Picture, val svgIntrinsicWidth: Int, val svgIntrinsicHeight: Int) : PictureDrawable(picture)
+class SVGPictureDrawable(picture: Picture, val svgIntrinsicWidth: Int, val svgIntrinsicHeight: Int) : PictureDrawable(picture)
 
 /**
  * Convert the [SVG]'s internal representation to an Android-compatible one ([Picture]).
@@ -35,7 +35,7 @@ class SVGDrawableTranscoder(val context: Context) : ResourceTranscoder<SVG?, Dra
       applyTintColor(svgData, tintColor)
     }
 
-    val picture = SVGPircureDrowable(
+    val picture = SVGPictureDrawable(
       svgData.renderToPicture(),
       intrinsicWidth,
       intrinsicHeight

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
@@ -1,26 +1,22 @@
 package expo.modules.image.svg
 
 import android.content.Context
-import android.content.res.Resources
-import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.graphics.Picture
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
 import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.engine.Resource
 import com.bumptech.glide.load.resource.SimpleResource
 import com.bumptech.glide.load.resource.transcode.ResourceTranscoder
-import com.caverock.androidsvg.PreserveAspectRatio
-import com.caverock.androidsvg.RenderOptions
 import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.applyTintColor
+import expo.modules.image.CustomOptions
 
 /**
-* We have to use the intrinsicWidth/Height from the bitmap to render the image at a high enough resolution, but at the same time we want to return the actual
-* preferred width and height of the SVG to JS. This class allows us to do that.
-*/
-class SVGBitmapDrawable(res: Resources?, bitmap: Bitmap?, val svgIntrinsicWidth: Int, val svgIntrinsicHeight: Int) : BitmapDrawable(res, bitmap)
+ * We have to use the intrinsicWidth/Height from the Picture to render the image at a high enough resolution, but at the same time we want to return the actual
+ * preferred width and height of the SVG to JS. This class allows us to do that.
+ */
+class SVGPircureDrowable(picture: Picture, val svgIntrinsicWidth: Int, val svgIntrinsicHeight: Int) : PictureDrawable(picture)
 
 /**
  * Convert the [SVG]'s internal representation to an Android-compatible one ([Picture]).
@@ -31,29 +27,21 @@ class SVGBitmapDrawable(res: Resources?, bitmap: Bitmap?, val svgIntrinsicWidth:
 class SVGDrawableTranscoder(val context: Context) : ResourceTranscoder<SVG?, Drawable> {
   override fun transcode(toTranscode: Resource<SVG?>, options: Options): Resource<Drawable> {
     val svgData = toTranscode.get()
-    val svgIntrinsicWidth = svgData.documentViewBox.width()
-    val svgIntrinsicHeight = svgData.documentViewBox.height()
-    val documentWidth = svgData.documentWidth
-    val documentHeight = svgData.documentHeight
-    val aspectRatio = svgIntrinsicWidth / svgIntrinsicHeight
+    val intrinsicWidth = svgData.documentViewBox.width().toInt()
+    val intrinsicHeight = svgData.documentViewBox.height().toInt()
 
-    // We have no information on what content fit the user wants, so when choosing render resolution we assume
-    // "cover" in order to prevent loss of quality after the bitmap is transformed to appropriate `contentFit` later.
-    val shouldUseHeightReference = documentWidth / aspectRatio > documentHeight
-    val renderWidth = if (shouldUseHeightReference) documentWidth else documentHeight * aspectRatio
-    val renderHeight = if (shouldUseHeightReference) documentWidth / aspectRatio else documentHeight
-    val renderOptions = RenderOptions().apply {
-      viewPort(0f, 0f, renderWidth, renderHeight)
-      preserveAspectRatio(PreserveAspectRatio.FULLSCREEN_START)
+    val tintColor = options.get(CustomOptions.tintColor)
+    if (tintColor != null) {
+      applyTintColor(svgData, tintColor)
     }
 
-    val picture = svgData.renderToPicture(renderWidth.toInt(), renderHeight.toInt(), renderOptions)
-    val drawable = PictureDrawable(picture)
-    val bitmap = Bitmap.createBitmap(renderWidth.toInt(), renderHeight.toInt(), Bitmap.Config.ARGB_8888)
-    val canvas = Canvas(bitmap)
-    drawable.setBounds(0, 0, canvas.width, canvas.height)
-    drawable.draw(canvas)
-
-    return SimpleResource(SVGBitmapDrawable(context.resources, bitmap, svgIntrinsicWidth.toInt(), svgIntrinsicHeight.toInt()))
+    val picture = SVGPircureDrowable(
+      svgData.renderToPicture(),
+      intrinsicWidth,
+      intrinsicHeight
+    )
+    return SimpleResource(
+      picture
+    )
   }
 }


### PR DESCRIPTION
# Why

 Changes how the `tintColor` is applied to the SVG

# How

Handling tint color in SVG required us to implement a lot of custom logic, which led to several bugs and inconsistent behavior. To address this, I've introduced a new approach in this PR. Instead of decoding the SVG into the bitmap to use filters, I modify the content of the parsed SVG to change color. Although most of the API is package private, I have applied a quick workaround for now. I plan to submit a PR to the Android library to change it upstream. However, for now, this solution should be enough.

# Test Plan

- bare-expo with NCL ✅