### PR TITLE
[docs] Fix minor formatting issues and Overview in titles

### DIFF
--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: 'Bare React Native: Overview'
+sidebar_title: Overview
 hideTOC: true
 description: An overview of bare React Native apps with Expo tools.
 ---

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -7,13 +7,13 @@ description: An introduction to EAS Update which is a hosted service for project
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
-**EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.
+**EAS Update** is a hosted service that serves updates for projects using the [`expo-updates`](/versions/latest/sdk/updates) library.
 
 EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates.
 
-All apps running the `expo-updates` library have the ability to receive updates. To start using EAS Update, continue to the [Getting Started](/eas-update/getting-started.mdx) guide.
+All apps running the `expo-updates` library have the ability to receive updates. To start using EAS Update, continue to the [Getting Started](/eas-update/getting-started) guide.
 
-Still using Classic Updates? We moved those docs to [the archive](/archive/classic-updates/introduction).
+> Still, using Classic Updates? We moved those docs to [the archive](/archive/classic-updates/introduction).
 
 ## Pitch
 
@@ -31,12 +31,12 @@ EAS Update is designed for Expo apps, making integration easy and workflows effi
 
 ### Customizable update strategies
 
-Apply updates through [`expo-updates` API](/versions/latest/sdk/updates) and [app config](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
+Apply updates through [`expo-updates` API](/versions/latest/sdk/updates) and [app config](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You will always have the upper hand in shaping the update process without compromising your users' experience.
 
 ## Get started
 
 <BoxLink
-  title="Create your first build"
+  title="Get started with EAS Update"
   description="Get started with EAS Update and use it in your project."
   href="/eas-update/getting-started"
 />

--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: 'Guides: Overview'
+sidebar_title: Overview
 hideTOC: true
 ---
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -91,14 +91,11 @@ Open the files in **modules/my-module/ios/** directory in your favorite code edi
 
 Now, change the `hello` method to return a different string. For example, you can change it to return "Hello world! 🌎🍎".
 
-Rebuild the app or build a new development client and you should see your change. Remember you need to either run `npx expo prebuild` each time you make a native change or you reinstall the pods using `pod install --project-directory="example/ios"` (which should be way faster).
+Rebuild the app or build a new development client and you should see your change. Remember you need to either run `npx expo prebuild` each time you make a native change or reinstall the pods using `pod install --project-directory="example/ios"` (which should be way faster).
 
 </Step>
 
-> **Note**
->
-> There are also other flows for working on an Expo module in parallel with your application.
-> For example, you can use a monorepo or publish to npm, as described in [How to use a standalone Expo module in your project](/modules/use-standalone-expo-module-in-your-project) guide.
+> **Note**: There are also other flows for working on an Expo module in parallel with your application. For example, you can use a monorepo or publish to npm, as described in the [How to use a standalone Expo module in your project](/modules/use-standalone-expo-module-in-your-project) guide.
 
 ## Creating a new module with an example project
 

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Push notifications overview
+title: 'Push notifications: Overview'
 sidebar_title: Overview
 description: An overview of Expo's push notification service.
 ---


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

A few formatting and typos I've found over the week visiting our docs. It solves the multiple guides titled as "Overview" without any different between them (as discussed in the previous Docs sync with @Simek)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
