### PR TITLE
[ci] Notify slack on scheduled job failure

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -106,7 +106,7 @@ jobs:
           path: ~/.gradle/daemon
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -97,7 +97,7 @@ jobs:
           path: ~/Library/Logs/fastlane
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -60,7 +60,7 @@ jobs:
           fi
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -67,7 +67,7 @@ jobs:
         run: git diff --exit-code
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}


### PR DESCRIPTION
# Why

I was trying to figure out why these didn't notify in slack: https://github.com/expo/expo/actions/workflows/sdk.yml?query=event%3Aschedule

It seems that `github.event.ref` isn't defined or something for scheduled. So I copied what we do at https://github.com/expo/expo/blob/main/.github/workflows/test-suite-nightly.yml#L73 for the rest of the scheduled jobs.

# Test Plan

Wait for CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
