### PR TITLE
[docs] automated next/previous page links

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -65,3 +65,11 @@ export const getPageSection = (path: string) => {
 
   return 'home';
 };
+
+export const getCanonicalUrl = (path: string) => {
+  if (isReferencePath(path)) {
+    return `https://docs.expo.dev${Utilities.replaceVersionInUrl(path, 'latest')}`;
+  } else {
+    return `https://docs.expo.dev${path}`;
+  }
+};

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/compat/router';
 import { useEffect, useState, createRef } from 'react';
 
 import * as RoutesUtils from '~/common/routes';
-import * as Utilities from '~/common/utilities';
 import * as WindowUtils from '~/common/window';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
 import DocumentationSidebarRight, {
@@ -13,6 +12,7 @@ import DocumentationSidebarRight, {
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
+import { NavigationRouteWithSection } from '~/types/common';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { PageTitle } from '~/ui/components/PageTitle';
@@ -41,24 +41,37 @@ type Props = React.PropsWithChildren<{
   hideFromSearch?: boolean;
 }>;
 
-const getCanonicalUrl = (path: string) => {
-  if (RoutesUtils.isReferencePath(path)) {
-    return `https://docs.expo.dev${Utilities.replaceVersionInUrl(path, 'latest')}`;
-  } else {
-    return `https://docs.expo.dev${path}`;
+function appendSectionToRoute(route?: NavigationRouteWithSection) {
+  if (route?.children) {
+    return route.children.map((entry: NavigationRouteWithSection) =>
+      route.type !== 'page'
+        ? Object.assign(entry, {
+            section: route.section ? `${route.section} - ${route.name}` : route.name,
+          })
+        : route
+    );
   }
-};
+  return route;
+}
 
-export default function DocumentationPage(props: Props) {
+export default function DocumentationPage({
+  title,
+  description,
+  packageName,
+  sourceCodeUrl,
+  iconUrl,
+  children,
+  hideFromSearch,
+  tocVisible,
+}: Props) {
+  const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
   const { version } = usePageApiVersion();
   const router = useRouter();
-  const pathname = router?.pathname ?? '/';
 
   const layoutRef = createRef<DocumentationNestedScrollLayout>();
   const sidebarRightRef = createRef<SidebarRightComponentType>();
 
-  const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
-
+  const pathname = router?.pathname ?? '/';
   const routes = RoutesUtils.getRoutes(pathname, version);
   const sidebarActiveGroup = RoutesUtils.getPageSection(pathname);
   const sidebarScrollPosition = process.browser ? window.__sidebarScroll : 0;
@@ -106,6 +119,16 @@ export default function DocumentationPage(props: Props) {
     />
   );
 
+  const flattenStructure = routes
+    .map(route => appendSectionToRoute(route))
+    .flat()
+    .map(route => (route?.type === 'page' ? route : appendSectionToRoute(route)))
+    .flat();
+
+  const pageIndex = flattenStructure.findIndex(page => page?.name === title);
+  const previousPage = flattenStructure[pageIndex - 1];
+  const nextPage = flattenStructure[pageIndex + 1];
+
   return (
     <DocumentationNestedScrollLayout
       ref={layoutRef}
@@ -113,15 +136,17 @@ export default function DocumentationPage(props: Props) {
       sidebar={sidebarElement}
       sidebarRight={sidebarRightElement}
       sidebarActiveGroup={sidebarActiveGroup}
-      tocVisible={props.tocVisible}
+      tocVisible={tocVisible}
       isMobileMenuVisible={isMobileMenuVisible}
       onContentScroll={handleContentScroll}
       sidebarScrollPosition={sidebarScrollPosition}>
       <Head
-        title={props.title}
-        description={props.description}
-        canonicalUrl={version !== 'unversioned' ? getCanonicalUrl(pathname) : undefined}>
-        {props.hideFromSearch !== true && (
+        title={title}
+        description={description}
+        canonicalUrl={
+          version !== 'unversioned' ? RoutesUtils.getCanonicalUrl(pathname) : undefined
+        }>
+        {hideFromSearch !== true && (
           <meta
             name="docsearch:version"
             content={RoutesUtils.isReferencePath(pathname) ? version : 'none'}
@@ -132,26 +157,28 @@ export default function DocumentationPage(props: Props) {
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
       </Head>
       <div css={STYLES_DOCUMENT}>
-        {props.title && (
+        {title && (
           <PageTitle
-            title={props.title}
-            sourceCodeUrl={props.sourceCodeUrl}
-            packageName={props.packageName}
-            iconUrl={props.iconUrl}
+            title={title}
+            sourceCodeUrl={sourceCodeUrl}
+            packageName={packageName}
+            iconUrl={iconUrl}
           />
         )}
-        {props.description && (
+        {description && (
           <P theme="secondary" data-description="true">
-            {props.description}
+            {description}
           </P>
         )}
-        {props.title && <Separator />}
-        {props.children}
-        {props.title && (
+        {title && <Separator />}
+        {children}
+        {title && (
           <Footer
-            title={props.title}
-            sourceCodeUrl={props.sourceCodeUrl}
-            packageName={props.packageName}
+            title={title}
+            sourceCodeUrl={sourceCodeUrl}
+            packageName={packageName}
+            previousPage={previousPage}
+            nextPage={nextPage}
           />
         )}
       </div>

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -43,6 +43,8 @@ export type NavigationRoute = {
   children?: NavigationRoute[];
 };
 
+export type NavigationRouteWithSection = NavigationRoute & { section?: string };
+
 /**
  * Available platforms supported by our APIs.
  * Temporarily it also accepts other strings for compatibility reasons.

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -50,7 +50,7 @@ export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPa
               </div>
             </LinkBase>
           ) : (
-            <div />
+            <div className="w-full" />
           )}
           {nextPage ? (
             <LinkBase
@@ -68,9 +68,9 @@ export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPa
               <ArrowRightIcon className="text-icon-secondary shrink-0" />
             </LinkBase>
           ) : (
-            <div />
+            <div className="w-full" />
           )}
-        </div>
+        </div >
       )}
       <div className="flex flex-row max-md-gutters:flex-col">
         <UL className="flex-1 !mt-0 !ml-0 mb-5 !list-none">

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -70,7 +70,7 @@ export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPa
           ) : (
             <div className="w-full" />
           )}
-        </div >
+        </div>
       )}
       <div className="flex flex-row max-md-gutters:flex-col">
         <UL className="flex-1 !mt-0 !ml-0 mb-5 !list-none">

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -1,10 +1,13 @@
+import { LinkBase, mergeClasses } from '@expo/styleguide';
+import { ArrowLeftIcon, ArrowRightIcon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { ForumsLink, EditPageLink, IssuesLink } from './Links';
 
+import { NavigationRouteWithSection } from '~/types/common';
 import { NewsletterSignUp } from '~/ui/components/Footer/NewsletterSignUp';
 import { PageVote } from '~/ui/components/Footer/PageVote';
-import { UL } from '~/ui/components/Text';
+import { P, FOOTNOTE, UL } from '~/ui/components/Text';
 
 const NEWSLETTER_DISABLED = true as const;
 
@@ -12,24 +15,74 @@ type Props = {
   title: string;
   sourceCodeUrl?: string;
   packageName?: string;
+  previousPage?: NavigationRouteWithSection;
+  nextPage?: NavigationRouteWithSection;
 };
 
-export const Footer = ({ title, sourceCodeUrl, packageName }: Props) => {
+export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPage }: Props) => {
   const router = useRouter();
   const isAPIPage = router?.pathname.includes('/sdk/') ?? false;
   const isExpoPackage = packageName && packageName.startsWith('expo-');
 
   return (
-    <footer className="flex flex-row border-t border-solid border-default mt-10 pt-10 max-md-gutters:flex-col">
-      <UL className="flex-1 !mt-0 !ml-0 mb-5 !list-none">
-        <ForumsLink isAPIPage={isAPIPage} title={title} />
-        {isAPIPage && (
-          <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
-        )}
-        {router?.pathname && <EditPageLink pathname={router.pathname} />}
-      </UL>
-      <PageVote />
-      {!NEWSLETTER_DISABLED && <NewsletterSignUp />}
+    <footer className="flex flex-col border-t border-default mt-10 pt-8 gap-8">
+      {title && (previousPage || nextPage) && (
+        <div
+          className={mergeClasses(
+            'flex gap-4',
+            'max-xl-gutters:flex-col-reverse',
+            'max-lg-gutters:flex-row',
+            'max-md-gutters:flex-col-reverse'
+          )}>
+          {previousPage ? (
+            <LinkBase
+              href={previousPage.href}
+              className={mergeClasses(
+                'flex border items-center gap-3 border-solid border-default rounded-md py-3 px-4 w-full transition',
+                'hocus:shadow-xs hocus:bg-subtle'
+              )}>
+              <ArrowLeftIcon className="text-icon-secondary shrink-0" />
+              <div>
+                <FOOTNOTE theme="secondary">
+                  Previous{previousPage.section ? ` (${previousPage.section})` : ''}
+                </FOOTNOTE>
+                <P weight="medium">{previousPage.sidebarTitle ?? previousPage.name}</P>
+              </div>
+            </LinkBase>
+          ) : (
+            <div />
+          )}
+          {nextPage ? (
+            <LinkBase
+              href={nextPage.href}
+              className={mergeClasses(
+                'flex border justify-between items-center gap-3 border-solid border-default rounded-md py-3 px-4 w-full transition',
+                'hocus:shadow-xs hocus:bg-subtle'
+              )}>
+              <div>
+                <FOOTNOTE theme="secondary">
+                  Next{nextPage?.section ? ` (${nextPage.section})` : ''}
+                </FOOTNOTE>
+                <P weight="medium">{nextPage.sidebarTitle ?? nextPage.name}</P>
+              </div>
+              <ArrowRightIcon className="text-icon-secondary shrink-0" />
+            </LinkBase>
+          ) : (
+            <div />
+          )}
+        </div>
+      )}
+      <div className="flex flex-row max-md-gutters:flex-col">
+        <UL className="flex-1 !mt-0 !ml-0 mb-5 !list-none">
+          <ForumsLink isAPIPage={isAPIPage} title={title} />
+          {isAPIPage && (
+            <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
+          )}
+          {router?.pathname && <EditPageLink pathname={router.pathname} />}
+        </UL>
+        <PageVote />
+        {!NEWSLETTER_DISABLED && <NewsletterSignUp />}
+      </div>
     </footer>
   );
 };

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -4,7 +4,7 @@ import { githubUrl } from './utils';
 import { A, CALLOUT, LI } from '../Text';
 
 const LINK_CLASSES = 'inline-flex items-center mb-1 focus-visible:outline-offset-4';
-const ICON_CLASSES = 'flex items-center mr-2.5 text-icon-secondary';
+const ICON_CLASSES = 'flex items-center mr-2.5 text-icon-secondary shrink-0';
 
 export const IssuesLink = ({ title, repositoryUrl }: { title: string; repositoryUrl?: string }) => (
   <LI>


### PR DESCRIPTION
# Why

Fixes ENG-1706.

# How

This PR adds automatically generated next and previous page links to the page Footer based on the sidebar navigation structure.

In the future we might want to revise some of the "Next" section `BoxLinks`, since in some cases they feel a bit redundant.

# Test Plan

The changes have been tested locally. All lint checks and tests are passing.

# Preview

<img width="1180" alt="Screenshot 2023-11-14 at 21 45 02" src="https://github.com/expo/expo/assets/719641/08c3b00d-3882-4157-ae52-2a8ac48cbf27">

<img width="574" alt="Screenshot 2023-11-14 at 21 34 59" src="https://github.com/expo/expo/assets/719641/6e83205c-5758-4438-b961-0ef8485dcffc">
