### PR TITLE
[android][file-system] Fix transformFilesFromSAF

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, handle using files from `SAF` correctly.
+- On `Android`, handle using files from `SAF` correctly. ([#25389](https://github.com/expo/expo/pull/25389) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, handle using files from `SAF` correctly.
+
 ### 💡 Others
 
 ## 15.8.0 — 2023-10-17

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -14,7 +14,6 @@ import android.util.Base64
 import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.documentfile.provider.DocumentFile
-import expo.modules.core.errors.InvalidArgumentException
 import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.Promise


### PR DESCRIPTION
# Why
Closes #25344
Closes ENG-10621
When using `SAF` we didn't handle move or copy correctly. We assumed the `to` argument would always be a directory even though our docs suggest it can be a file. This resulted in creating folders with file names. 
eg.
`files/contents/test.jpg/test.jpg` 

# How
Handle cases where we are handed a file instead of a directory. 

# Test Plan
Used the provided repro to verify the fix. 