### PR TITLE
[core][iOS] Make dynamic type creation faster

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [iOS] Made dynamic types creation faster. ([#25390](https://github.com/expo/expo/pull/25390) by [@tsapeta](https://github.com/tsapeta))
+
 ## 1.10.0 — 2023-11-14
 
 ### 🛠 Breaking changes

--- a/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
@@ -3,10 +3,15 @@
 /**
  A protocol for classes/structs accepted as an argument of functions.
  */
-public protocol AnyArgument {}
+public protocol AnyArgument {
+  static func getDynamicType() -> AnyDynamicType
+}
 
-// Extend the optional type - this is required to support optional arguments.
-extension Optional: AnyArgument where Wrapped: AnyArgument {}
+extension AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicRawType(innerType: Self.self)
+  }
+}
 
 // Extend the primitive types — these may come from React Native bridge.
 extension Bool: AnyArgument {}
@@ -28,6 +33,16 @@ extension Double: AnyArgument {}
 extension CGFloat: AnyArgument {}
 
 extension String: AnyArgument {}
-extension Array: AnyArgument {}
 extension Dictionary: AnyArgument {}
 
+extension Optional: AnyArgument where Wrapped: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicOptionalType(wrappedType: ~Wrapped.self)
+  }
+}
+
+extension Array: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicArrayType(elementType: ~Element.self)
+  }
+}

--- a/packages/expo-modules-core/ios/Arguments/Convertible.swift
+++ b/packages/expo-modules-core/ios/Arguments/Convertible.swift
@@ -14,5 +14,11 @@ public protocol Convertible: AnyArgument {
   static func convert(from value: Any?, appContext: AppContext) throws -> Self
 }
 
+extension Convertible {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicConvertibleType(innerType: Self.self)
+  }
+}
+
 @available(*, deprecated, renamed: "Convertible")
 public typealias ConvertibleArgument = Convertible

--- a/packages/expo-modules-core/ios/Arguments/Enumerable.swift
+++ b/packages/expo-modules-core/ios/Arguments/Enumerable.swift
@@ -24,6 +24,12 @@ public protocol Enumerable: AnyArgument, CaseIterable {
 @available(*, deprecated, renamed: "Enumerable")
 public typealias EnumArgument = Enumerable
 
+extension Enumerable {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicEnumType(innerType: Self.self)
+  }
+}
+
 /**
  Extension for `Enumerable` that also conforms to `RawRepresentable`.
  This constraint allows us to reference the associated `RawValue` type.

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicArrayType.swift
@@ -51,6 +51,6 @@ internal protocol AnyArray {
  */
 extension Array: AnyArray {
   static func getElementDynamicType() -> AnyDynamicType {
-    return DynamicType(Element.self)
+    return ~Element.self
   }
 }

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicOptionalType.swift
@@ -56,7 +56,7 @@ internal protocol AnyOptional {
  */
 extension Optional: AnyOptional {
   static func getWrappedDynamicType() -> AnyDynamicType {
-    return DynamicType(Wrapped.self)
+    return ~Wrapped.self
   }
 
   static func isNil(_ object: Wrapped) -> Bool {

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicSharedObjectType.swift
@@ -4,7 +4,7 @@
  A dynamic type representing the `SharedObject` type and its subclasses.
  */
 internal struct DynamicSharedObjectType: AnyDynamicType {
-  let innerType: SharedObject.Type
+  let innerType: AnySharedObject.Type
 
   /**
    A unique identifier of the wrapped type.
@@ -13,7 +13,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
     return ObjectIdentifier(innerType)
   }
 
-  init(innerType: SharedObject.Type) {
+  init(innerType: AnySharedObject.Type) {
     self.innerType = innerType
   }
 

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
@@ -7,12 +7,14 @@
 /**
  Factory creating an instance of the dynamic type wrapper conforming to `AnyDynamicType`.
  Depending on the given type, it may return one of `DynamicArrayType`, `DynamicOptionalType`, `DynamicConvertibleType`, etc.
+ Note that this goes through many type checks, thus it might be a bit more expensive than using generic type constraints,
+ see the `~` prefix operator below that handles types conforming to `AnyArgument` in a faster way.
  */
-internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
+private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let ArrayType = T.self as? AnyArray.Type {
     return DynamicArrayType(elementType: ArrayType.getElementDynamicType())
   }
-  if let OptionalType = T.self as? AnyOptional.Type {
+  if let OptionalType = T.self as? any AnyOptional.Type {
     return DynamicOptionalType(wrappedType: OptionalType.getWrappedDynamicType())
   }
   if let ConvertibleType = T.self as? Convertible.Type {
@@ -40,6 +42,10 @@ internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
  Handy prefix operator that makes the dynamic type from the static type.
  */
 prefix operator ~
-public prefix func ~ <T>(type: T.Type) -> AnyDynamicType {
+internal prefix func ~ <T>(type: T.Type) -> AnyDynamicType {
   return DynamicType(type)
+}
+
+internal prefix func ~ <T>(type: T.Type) -> AnyDynamicType where T: AnyArgument {
+  return T.getDynamicType()
 }

--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -18,11 +18,17 @@ public enum JavaScriptValueKind: String {
 /**
  A protocol that JavaScript values, objects and functions can conform to.
  */
-protocol AnyJavaScriptValue {
+protocol AnyJavaScriptValue: AnyArgument {
   /**
    Tries to convert a raw JavaScript value to the conforming type.
    */
   static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self
+}
+
+extension AnyJavaScriptValue {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicJavaScriptType(innerType: Self.self)
+  }
 }
 
 extension JavaScriptValue: AnyJavaScriptValue, AnyArgument {

--- a/packages/expo-modules-core/ios/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Records/Field.swift
@@ -2,7 +2,7 @@
  Property wrapper for `Record`'s data members that takes part in the process of serialization to and deserialization from the dictionary.
  */
 @propertyWrapper
-public final class Field<Type>: AnyFieldInternal {
+public final class Field<Type: AnyArgument>: AnyFieldInternal {
   /**
    The wrapped value.
    */

--- a/packages/expo-modules-core/ios/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/SharedObjects/SharedObject.swift
@@ -4,6 +4,12 @@ public protocol AnySharedObject: AnyArgument {
   var sharedObjectId: SharedObjectId { get }
 }
 
+extension AnySharedObject {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicSharedObjectType(innerType: Self.self)
+  }
+}
+
 open class SharedObject: AnySharedObject {
   /**
    An identifier of the native shared object that maps to the JavaScript object.

--- a/packages/expo-modules-core/ios/TypedArrays/AnyTypedArray.swift
+++ b/packages/expo-modules-core/ios/TypedArrays/AnyTypedArray.swift
@@ -9,3 +9,10 @@ internal protocol AnyTypedArray: AnyArgument {
    */
   init(_ jsTypedArray: JavaScriptTypedArray)
 }
+
+// Extend the protocol to provide custom dynamic type
+extension AnyTypedArray {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicTypedArrayType(innerType: Self.self)
+  }
+}

--- a/packages/expo-modules-core/ios/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Views/ViewDefinition.swift
@@ -97,7 +97,11 @@ extension ConcurrentFunctionDefinition: ViewDefinitionFunctionElement {
   public typealias ViewType = FirstArgType
 }
 
-extension UIView: AnyArgument {}
+extension UIView: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicViewType(innerType: Self.self)
+  }
+}
 
 /**
  Creates a view definition describing the native view exported to React.


### PR DESCRIPTION
# Why

Currently we use the `DynamicType` function as a factory to create an appropriate dynamic type, depending on the given type. This function already does a lot of type checks which seem to be expensive, especially that for the most common types (primitives) we need to go through all these checks.

# How

I added a static function `getDynamicType` to `AnyArgument` protocol and some other necessary types (e.g. `Convertible`, `Enumerable`, `SharedObject`) where the custom dynamic type will be returned. This basically moves some type checks to the compiler, thus theoretically it should perform faster in runtime.

Unfortunately, we still need runtime type checks for types that are not conforming to `AnyArgument` – e.g. Either types or function return types don't have generic type requirements for `AnyArgument`. I'll try to improve this in the future.

# Test Plan

- Native unit tests are passing
- I went through some tests in test-suite and native-component-list, it seems to work fine
- Dynamic types are mostly initialized together with definitions, so I measured the time of registering all modules and invoking the `definition` function and in the first run on the simulator it went down from ~180ms to ~145ms.
