### PR TITLE
[docs] fix diff file used on Runtime Versions doc page

### DIFF
--- a/docs/public/static/diffs/expo-update-strings-xml.diff
+++ b/docs/public/static/diffs/expo-update-strings-xml.diff
@@ -1,4 +1,5 @@
-diff --git android/app/src/main/res/values/strings.xml
+diff --git a/android/app/src/main/res/values/strings.xml b/android/app/src/main/res/values/strings.xml
+index ef1de86..d3d75b0 100644
 --- a/android/app/src/main/res/values/strings.xml
 +++ b/android/app/src/main/res/values/strings.xml
 @@ -1,3 +1,4 @@


### PR DESCRIPTION
# Why

<img width="1031" alt="Screenshot 2023-11-15 at 16 40 58" src="https://github.com/expo/expo/assets/719641/343516a1-fb64-4b3d-81e0-2f13d674eaa9">

# How

Fix diff file used on the Runtime Versions doc page, which seems to have invalid format.

# Test Plan

The chanage have been tested locally, diff blok is rendered correctly.

# Preview

<img width="647" alt="Screenshot 2023-11-15 at 16 39 12" src="https://github.com/expo/expo/assets/719641/a60cb845-0926-462b-9c15-1c6beb2e74b8">

