### PR TITLE
Documentation updates regarding handling of EAS build env vars for development client builds

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -54,7 +54,7 @@ Any reference to `process.env.EXPO_PUBLIC_API_URL` will be substituted for the a
 
 > `EXPO_PUBLIC_` variable replacement is available in SDK 49 and higher. See notes for [SDK 48 and lower](/guides/environment-variables#environment-variables-in-sdk-48-and-lower).
 
-> Regardless of naming convention, build profiles that use the Expo Development Client (e.g., `developmentClient: true`) cannot use these env values declared in `eas.json` from the build's runtime.  For more info, see [below](#how-do-environment-variables-work-for-my-expo-development-client-builds).
+> Regardless of naming convention, build profiles that use the Expo Development Client (that is, where `developmentClient: true`) cannot use env values declared in `eas.json` from that build's runtime. For more info, see [below](#how-do-environment-variables-work-for-my-expo-development-client-builds).
 
 ### For use by your Expo config
 
@@ -87,7 +87,7 @@ module.exports = {
 
 > All environment variables in your **eas.json** build profile are available when evaluating **app.config.js**. It's a good practice to only use the `EXPO_PUBLIC_` prefix for variables used within your application code.
 
-> Build profiles that use the Expo Development Client (e.g., `developmentClient: true`) will also reference the running metro server's enviroment variables even when resolving **app.config.js**.
+> Note that the same limitations when using the Expo Development Client apply to their use in **ap.config.js**. For more information, see [below](#how-do-environment-variables-work-for-my-expo-development-client-builds).
 
 ### For use by other build steps
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -54,6 +54,8 @@ Any reference to `process.env.EXPO_PUBLIC_API_URL` will be substituted for the a
 
 > `EXPO_PUBLIC_` variable replacement is available in SDK 49 and higher. See notes for [SDK 48 and lower](/guides/environment-variables#environment-variables-in-sdk-48-and-lower).
 
+> Regardless of naming convention, build profiles that use the Expo Development Client (e.g., `developmentClient: true`) cannot use these env values declared in `eas.json` from the build's runtime.  For more info, see [below](#how-do-environment-variables-work-for-my-expo-development-client-builds).
+
 ### For use by your Expo config
 
 You can use environment variables in a [dynamic config](/workflow/configuration/#dynamic-configuration) (**app.config.js**) to change how your app is built. For instance, you might want to change your app icon or short name for a test build.
@@ -84,6 +86,8 @@ module.exports = {
 ```
 
 > All environment variables in your **eas.json** build profile are available when evaluating **app.config.js**. It's a good practice to only use the `EXPO_PUBLIC_` prefix for variables used within your application code.
+
+> Build profiles that use the Expo Development Client (e.g., `developmentClient: true`) will also reference the running metro server's enviroment variables even when resolving **app.config.js**.
 
 ### For use by other build steps
 
@@ -229,7 +233,7 @@ For example, if you create a secret with the name `MY_TOKEN` and value `secret` 
 
 ### How do environment variables work for my Expo Development Client builds?
 
-Environment variables set in your build profile that impact **app.config.js** will be used for configuring the development build. When you run `npx expo start` to load your app inside of your development build, only environment variables that are available on your development machine will be used.
+Environment variables set in your build profile that impact **app.config.js** will be used for configuring the development build. When you run `npx expo start` to load your app inside of your development build, only environment variables that are available on your development machine will be used. No values delcared for the build profile in `eas.json` will be made available in the runtime.
 
 ### Can I just set my environment variables on a CI provider?
 


### PR DESCRIPTION
# Why

Basically, I lost a ton of time trying to get env var declarations for a build profile to be made available (mostly tried using `expo.extra.myValue`), only to eventually realize that no env values I declare in `eas.json` would ever be made available to builds with `developmentClient: true`.

I will concede that there is in fact a small note already about how environment variables are handles under the Expo Development Client, but this information could really be revealed much more locally to the docs that explain how environment variables are intended to be declared and consumed.

I'm erring on the side of being explicit as possible, but eager for feedback of any kind.

# How

Hoping to save others time and anguish ❤️

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
