### PR TITLE
feat(cli): Ensure invalid production iOS builds fail more predictably.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Ensure invalid production iOS builds fail more predictably.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Ensure invalid production iOS builds fail more predictably.
+- Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 🎉 New features
 
-- Ensure invalid production iOS builds fail more predictably.
-- Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode.
+- Ensure invalid production iOS builds fail more predictably. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
+- Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/embed/__tests__/xcodeCompilerLogger.test.ts
+++ b/packages/@expo/cli/src/export/embed/__tests__/xcodeCompilerLogger.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright © 2023 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { vol } from 'memfs';
+
+import { getXcodeCompilerErrorMessage } from '../xcodeCompilerLogger';
+
+jest.mock('fs');
+describe(getXcodeCompilerErrorMessage, () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+  it(`returns message for Metro resolution error`, () => {
+    vol.fromJSON(
+      {
+        'App.js': `
+        import React from 'react';
+        // hey
+        import 'invalid'
+
+        console.log('hello')
+        `,
+      },
+      '/foo/bar'
+    );
+
+    expect(
+      getXcodeCompilerErrorMessage('/foo/bar', {
+        message: `Error: Unable to resolve module invalid from /Users/evanbacon/Documents/GitHub/lab/nov15-err/App.js: invalid could not be found within the project or in these directories:
+            node_modules
+          [0m [90m 2 |[39m [36mimport[39m { [33mStyleSheet[39m[33m,[39m [33mText[39m[33m,[39m [33mView[39m } [36mfrom[39m [32m"react-native"[39m[33m;[39m[0m
+          [0m [90m 3 |[39m[0m
+          [0m[31m[1m>[22m[39m[90m 4 |[39m [36mimport[39m [32m"invalid"[39m[33m;[39m[0m
+          [0m [90m   |[39m         [31m[1m^[22m[39m[0m
+          [0m [90m 5 |[39m[0m
+          [0m [90m 6 |[39m [36mexport[39m [36mdefault[39m [36mfunction[39m [33mApp[39m() {[0m
+          [0m [90m 7 |[39m   [36mreturn[39m ([0m`,
+        name: 'Error',
+        originModulePath: '/foo/bar/App.js',
+        targetModuleName: 'invalid',
+      })
+    ).toBe(
+      '/foo/bar/App.js:3:16: error: Error: Unable to resolve module invalid from /Users/evanbacon/Documents/GitHub/lab/nov15-err/App.js: invalid could not be found within the project or in these directories:'
+    );
+  });
+  it(`returns message for Metro transform error`, () => {
+    expect(
+      getXcodeCompilerErrorMessage('/foo/bar', {
+        name: 'Error',
+        message: 'Invalid syntax',
+        filename: 'App.js',
+        lineNumber: 3,
+        column: 2,
+      })
+    ).toBe('/foo/bar/App.js:3:2: error: Invalid syntax');
+  });
+  it(`returns message for Metro transform error without column`, () => {
+    expect(
+      getXcodeCompilerErrorMessage('/foo/bar', {
+        name: 'Error',
+        message: 'Invalid syntax',
+        filename: 'App.js',
+        lineNumber: 3,
+      })
+    ).toBe('/foo/bar/App.js:3: error: Invalid syntax');
+  });
+  it(`returns message for unhandled Metro error`, () => {
+    expect(
+      getXcodeCompilerErrorMessage('/foo/bar', {
+        name: 'Error',
+        message: 'whoops!',
+      })
+    ).toBe('error: whoops!');
+  });
+});

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -1,17 +1,26 @@
+/**
+ * Copyright © 2023 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 import { getConfig } from '@expo/config';
 import fs from 'fs';
+import { sync as globSync } from 'glob';
 import Server from 'metro/src/Server';
 import output from 'metro/src/shared/output/bundle';
 import type { BundleOptions } from 'metro/src/shared/types';
 import path from 'path';
 
 import { Options } from './resolveOptions';
+import { isExecutingFromXcodebuild, logMetroErrorInXcode } from './xcodeCompilerLogger';
 import { Log } from '../../log';
 import { loadMetroConfigAsync } from '../../start/server/metro/instantiateMetro';
 import {
   getBaseUrlFromExpoConfig,
   getMetroDirectBundleOptions,
 } from '../../start/server/middleware/metroOptions';
+import { stripAnsi } from '../../utils/ansi';
 import { removeAsync } from '../../utils/dir';
 import { setNodeEnv } from '../../utils/nodeEnv';
 import { profile } from '../../utils/profile';
@@ -19,12 +28,40 @@ import { isEnableHermesManaged } from '../exportHermes';
 import { getAssets } from '../fork-bundleAsync';
 import { persistMetroAssetsAsync } from '../persistMetroAssets';
 
+const debug = require('debug')('expo:export:embed');
+
+function guessCopiedAppleBundlePath(bundleOutput: string) {
+  // Ensure the path is familiar before guessing.
+  if (!bundleOutput.match(/\/Xcode\/DerivedData\/.*\/Build\/Products\//)) {
+    debug('Bundling to non-standard location:', bundleOutput);
+    return false;
+  }
+  const bundleName = path.basename(bundleOutput);
+  const bundleParent = path.dirname(bundleOutput);
+  const possiblePath = globSync(path.join(bundleParent, `*.app/${bundleName}`), {
+    // bundle identifiers can start with dots.
+    dot: true,
+  })[0];
+  debug('Possible path for previous bundle:', possiblePath);
+  return possiblePath;
+}
+
 export async function exportEmbedAsync(projectRoot: string, options: Options) {
   setNodeEnv(options.dev ? 'development' : 'production');
   require('@expo/env').load(projectRoot);
 
   // Ensure we delete the old bundle to trigger a failure if the bundle cannot be created.
   await removeAsync(options.bundleOutput);
+
+  // The iOS bundle is copied in to the Xcode project, so we need to remove the old one
+  // to prevent Xcode from loading the old one after a build failure.
+  if (options.platform === 'ios') {
+    const previousPath = guessCopiedAppleBundlePath(options.bundleOutput);
+    if (previousPath && fs.existsSync(previousPath)) {
+      debug('Removing previous iOS bundle:', previousPath);
+      await removeAsync(previousPath);
+    }
+  }
 
   const { bundle, assets } = await exportEmbedBundleAsync(projectRoot, options);
 
@@ -53,7 +90,7 @@ export async function exportEmbedBundleAsync(projectRoot: string, options: Optio
     projectRoot,
     {
       maxWorkers: options.maxWorkers,
-      resetCache: options.resetCache,
+      resetCache: false, //options.resetCache,
       config: options.config,
     },
     {
@@ -108,13 +145,23 @@ export async function exportEmbedBundleAsync(projectRoot: string, options: Optio
       assets: outputAssets,
     };
   } catch (error: any) {
-    // Log using Xcode error format so the errors are picked up by xcodebuild.
-    // https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Log-errors-and-warnings-from-your-script
-    if (options.platform === 'ios') {
-      console.error('error: ' + error.message);
+    if (isError(error)) {
+      // Log using Xcode error format so the errors are picked up by xcodebuild.
+      // https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Log-errors-and-warnings-from-your-script
+      if (options.platform === 'ios') {
+        // If the error is about to be presented in Xcode, strip the ansi characters from the message.
+        if ('message' in error && isExecutingFromXcodebuild()) {
+          error.message = stripAnsi(error.message) as string;
+        }
+        logMetroErrorInXcode(projectRoot, error);
+      }
     }
     throw error;
   } finally {
     server.end();
   }
+}
+
+function isError(error: any): error is Error {
+  return error instanceof Error;
 }

--- a/packages/@expo/cli/src/export/embed/xcodeCompilerLogger.ts
+++ b/packages/@expo/cli/src/export/embed/xcodeCompilerLogger.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright © 2023 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import fs from 'fs';
+import path from 'path';
+
+function isPossiblyUnableToResolveError(
+  error: any
+): error is { message: string; originModulePath: string; targetModuleName: string } {
+  return (
+    'message' in error &&
+    typeof error.message === 'string' &&
+    'originModulePath' in error &&
+    typeof error.originModulePath === 'string' &&
+    'targetModuleName' in error &&
+    typeof error.targetModuleName === 'string'
+  );
+}
+function isPossiblyTransformError(
+  error: any
+): error is { message: string; filename: string; lineNumber: number; column?: number } {
+  return (
+    'message' in error &&
+    typeof error.message === 'string' &&
+    'filename' in error &&
+    typeof error.filename === 'string' &&
+    'lineNumber' in error &&
+    typeof error.lineNumber === 'number'
+  );
+}
+
+export function getXcodeCompilerErrorMessage(
+  projectRoot: string,
+  error: Error | any
+): string | null {
+  const makeFilepathAbsolute = (filepath: string) =>
+    filepath.startsWith('/') ? filepath : path.join(projectRoot, filepath);
+
+  if ('message' in error) {
+    // Metro's `UnableToResolveError`
+    if (isPossiblyUnableToResolveError(error)) {
+      const loc = getLineNumberForStringInFile(error.originModulePath, error.targetModuleName);
+      return makeXcodeCompilerLog('error', error.message, {
+        fileName: error.originModulePath,
+        lineNumber: loc?.lineNumber,
+        column: loc?.column,
+      });
+    } else if (isPossiblyTransformError(error)) {
+      return makeXcodeCompilerLog('error', error.message, {
+        // Metro generally returns the filename as relative from the project root.
+        fileName: makeFilepathAbsolute(error.filename),
+        lineNumber: error.lineNumber,
+        column: error.column,
+      });
+      // TODO: ResourceNotFoundError, GraphNotFoundError, RevisionNotFoundError, AmbiguousModuleResolutionError
+    } else {
+      // Unknown error
+      return makeXcodeCompilerLog('error', error.message);
+    }
+  }
+
+  return null;
+}
+
+export function logMetroErrorInXcode(projectRoot: string, error: Error) {
+  const message = getXcodeCompilerErrorMessage(projectRoot, error);
+  if (message != null) {
+    console.error(message);
+  }
+}
+
+// https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Access-script-related-files-from-environment-variables
+export function isExecutingFromXcodebuild() {
+  return !!process.env.BUILT_PRODUCTS_DIR;
+}
+
+function makeXcodeCompilerLog(
+  type: 'error' | 'fatal error' | 'warning' | 'note',
+  message: string,
+  {
+    fileName,
+    lineNumber,
+    column,
+  }: {
+    /** Absolute file path to link to in Xcode. */
+    fileName?: string;
+    lineNumber?: number;
+    column?: number;
+  } = {}
+) {
+  // TODO: Figure out how to support multi-line logs.
+  const firstLine = message.split('\n')[0];
+  if (fileName && !fileName?.includes(':')) {
+    return `${fileName}:${lineNumber || 0}:${
+      column != null ? column + ':' : ''
+    } ${type}: ${firstLine}`;
+  }
+  return `${type}: ${firstLine}`;
+}
+
+// TODO: Metro doesn't expose this info even though it knows it.
+function getLineNumberForStringInFile(originModulePath: string, targetModuleName: string) {
+  let file;
+  try {
+    file = fs.readFileSync(originModulePath, 'utf8');
+  } catch (error: any) {
+    if (error.code === 'ENOENT' || error.code === 'EISDIR') {
+      // We're probably dealing with a virtualised file system where
+      // `this.originModulePath` doesn't actually exist on disk.
+      // We can't show a code frame, but there's no need to let this I/O
+      // error shadow the original module resolution error.
+      return null;
+    }
+    throw error;
+  }
+  const lines = file.split('\n');
+  let lineNumber = 0;
+  let column = -1;
+  for (let line = 0; line < lines.length; line++) {
+    const columnLocation = lines[line].lastIndexOf(targetModuleName);
+    if (columnLocation >= 0) {
+      lineNumber = line;
+      column = columnLocation;
+      break;
+    }
+  }
+  return { lineNumber, column };
+}


### PR DESCRIPTION
# Why

- fix ENG-10524
- Guess where the iOS bundle was copied to and delete it.
- Strip ansi from error messages when the process is running in xcodebuild/compiler.
- Use xcode log compilation format to support first-class errors in Xcode.

<img width="1364" alt="Screenshot 2023-11-15 at 7 50 54 PM" src="https://github.com/expo/expo/assets/9664363/af3581cd-9cbc-4bd8-9973-117faa8b3f53">
<img width="954" alt="Screenshot 2023-11-15 at 7 52 48 PM" src="https://github.com/expo/expo/assets/9664363/dfd4244d-a1d7-45fe-8ffd-8891f64b39c6">
<img width="499" alt="Screenshot 2023-11-15 at 8 27 26 PM" src="https://github.com/expo/expo/assets/9664363/5cf4f41a-4cc8-4946-986f-3d49006bc96b">


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested Release builds in Xcode with CLI_PATH set to the local CLI:

```
  export CLI_PATH=/Users/evanbacon/Documents/GitHub/expo/packages/@expo/cli/build/bin/cli
```

Added some unit tests for the more fragile logic.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
