### PR TITLE
[expo] fix missing concurrentRoot initialProps on new arch mode

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `concurrentRoot` is missing from intialProps when running on New Architecture mode. ([#25415](https://github.com/expo/expo/pull/25415) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 50.0.0-alpha.7 — 2023-11-14

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -135,7 +135,7 @@ class ReactActivityDelegateWrapper(
       // the calls to `createRootView()` or `getMainComponentName()` have no chances to be our wrapped methods.
       // Instead we intercept `ReactActivityDelegate.onCreate` and replace the `mReactDelegate` with our version.
       // That's not ideal but works.
-      val launchOptions = composeLaunchOptions()
+      val launchOptions = composeLaunchOptions() as Bundle? // composeLaunchOptions() is nullable but older react-native declares as nonnull.
       val reactDelegate = object : ReactDelegate(
         plainActivity, reactNativeHost, mainComponentName, launchOptions
       ) {

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -135,6 +135,7 @@ class ReactActivityDelegateWrapper(
       // the calls to `createRootView()` or `getMainComponentName()` have no chances to be our wrapped methods.
       // Instead we intercept `ReactActivityDelegate.onCreate` and replace the `mReactDelegate` with our version.
       // That's not ideal but works.
+      val launchOptions = composeLaunchOptions()
       val reactDelegate = object : ReactDelegate(
         plainActivity, reactNativeHost, mainComponentName, launchOptions
       ) {
@@ -268,6 +269,10 @@ class ReactActivityDelegateWrapper(
 
   override fun getPlainActivity(): Activity {
     return invokeDelegateMethod("getPlainActivity")
+  }
+
+  override fun isFabricEnabled(): Boolean {
+    return invokeDelegateMethod("isFabricEnabled")
   }
 
   //endregion


### PR DESCRIPTION
# Why

fixes #25024
close ENG-10499

# How

i missed aligning the ReactActivityDelegate changes during react native upgrade. this pr tried to fill the `launchOptions` from  `composeLaunchOptions()` as upstream: https://github.com/facebook/react-native/blob/5029cef0a99469e37bc2f4d72ca2e1f3d6791511/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java#L102-L109

# Test Plan

test repro from #25024

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
