### PR TITLE
chore: Update E2E tests to use local copies of fundamental bundling packages

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Update E2E tests to use local copies of `@expo/metro-config`, `@expo/env`, `@expo/config`.
 - Add e2e tests for disabled mode. ([#25301](https://github.com/expo/expo/pull/25301) by [@wschurman](https://github.com/wschurman))
 - Modify E2E manual test for asset exclusion. ([#25406](https://github.com/expo/expo/pull/25406) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update E2E tests to use local copies of `@expo/metro-config`, `@expo/env`, `@expo/config`.
+- Update E2E tests to use local copies of `@expo/metro-config`, `@expo/env`, `@expo/config`. ([#25430](https://github.com/expo/expo/pull/25430) by [@EvanBacon](https://github.com/EvanBacon))
 - Add e2e tests for disabled mode. ([#25301](https://github.com/expo/expo/pull/25301) by [@wschurman](https://github.com/wschurman))
 - Modify E2E manual test for asset exclusion. ([#25406](https://github.com/expo/expo/pull/25406) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -11,16 +11,10 @@ const dirName = __dirname; /* eslint-disable-line */
 
 // Package dependencies in chunks based on peer dependencies.
 const expoDependencyChunks = [
-  ['@expo/config-types'],
-  [
-    '@expo/cli',
-    '@expo/config',
-    '@expo/config-plugins',
-    'expo',
-    'expo-modules-core',
-    'expo-modules-autolinking',
-  ],
-  ['@expo/prebuild-config', '@expo/env', '@expo/metro-config', 'expo-constants'],
+  ['@expo/config-types', '@expo/env'],
+  ['@expo/config'],
+  ['@expo/cli', '@expo/config-plugins', 'expo', 'expo-modules-core', 'expo-modules-autolinking'],
+  ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants'],
   [
     'babel-preset-expo',
     'expo-application',

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -9,6 +9,7 @@ import path from 'path';
 const dirName = __dirname; /* eslint-disable-line */
 
 const expoDependencyNames = [
+  'babel-preset-expo',
   'expo',
   '@expo/cli',
   '@expo/config',

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -11,8 +11,11 @@ const dirName = __dirname; /* eslint-disable-line */
 const expoDependencyNames = [
   'expo',
   '@expo/cli',
+  '@expo/config',
   '@expo/config-plugins',
   '@expo/config-types',
+  '@expo/env',
+  '@expo/metro-config',
   '@expo/prebuild-config',
   'expo-application',
   'expo-av',


### PR DESCRIPTION
# Why

Expo CLI is versioned together with a number of packages, when we test updates E2E, we aren't pulling in the latest `expo/metro-config` and `expo/env` which are both used in the `npx expo export` process.

# Test Plan

Hopefully these tests keep passing but if they don't, it should reveal some problematic issues.