### PR TITLE
[expo-updates][ios] Add state machine procedure serial runner

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -275,6 +275,8 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
+- (void)appLoaderTaskDidFinishAllLoading:(EXUpdatesAppLoaderTask *)appLoaderTask {}
+
 #pragma mark - internal
 
 + (NSURL *)_httpUrlFromManifestUrl:(NSURL *)url

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Add state machine procedure serial runner. ([#25386](https://github.com/expo/expo/pull/25386) by [@wschurman](https://github.com/wschurman))
+- Add state machine procedure serial runner. ([#25386](https://github.com/expo/expo/pull/25386), [#25431](https://github.com/expo/expo/pull/25431) by [@wschurman](https://github.com/wschurman))
 
 ### 🎉 New features
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -1,7 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 // swiftlint:disable force_unwrapping
-// swiftlint:disable closure_body_length
 
 import SwiftUI
 import ExpoModulesCore
@@ -9,8 +8,7 @@ import ExpoModulesCore
 /**
  * Updates controller for applications that have updates enabled and properly-configured.
  */
-public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDelegate,
-  ErrorRecoveryDelegate, UpdatesStateChangeDelegate, InternalAppControllerInterface {
+public class EnabledAppController: UpdatesStateChangeDelegate, InternalAppControllerInterface, StartupProcedureDelegate {
   private static let ErrorDomain = "EXUpdatesAppController"
   private static let EXUpdatesEventName = "Expo.nativeUpdatesEvent"
   private static let EXUpdatesStateChangeEventName = "Expo.nativeUpdatesStateChangeEvent"
@@ -23,26 +21,9 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
   public weak var delegate: AppControllerDelegate?
   public weak var bridge: AnyObject?
 
-  public func launchAssetUrl() -> URL? {
-    return launcher?.launchAssetUrl
-  }
-
-  public func assetFilesMap() -> [String: Any]? {
-    return launcher?.assetFilesMap
-  }
-
-  public func isUsingEmbeddedAssets() -> Bool {
-    guard let launcher = launcher else {
-      return true
-    }
-    return launcher.isUsingEmbeddedAssets()
-  }
-
   internal let config: UpdatesConfig
   private let database: UpdatesDatabase
 
-  private var launcher: AppLauncher?
-  private let errorRecovery = ErrorRecovery()
   public let updatesDirectory: URL? // internal for E2E test
   private let updatesDirectoryInternal: URL
   private let controllerQueue = DispatchQueue(label: "expo.controller.ControllerQueue")
@@ -52,16 +33,17 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
 
   private let stateMachine = UpdatesStateMachine()
 
-  private var loaderTask: AppLoaderTask?
-  private var candidateLauncher: AppLauncher?
-
-  private var isEmergencyLaunch: Bool = false
-
   private let selectionPolicy: SelectionPolicy
 
-  internal var remoteLoadStatus: RemoteLoadStatus = .Idle
-
   private let logger = UpdatesLogger()
+
+  // swiftlint:disable implicitly_unwrapped_optional
+  private var startupProcedure: StartupProcedure!
+  // swiftlint:enable implicitly_unwrapped_optional
+
+  public func launchAssetUrl() -> URL? {
+    return startupProcedure.launchAssetUrl()
+  }
 
   required init(config: UpdatesConfig, database: UpdatesDatabase, updatesDirectory: URL) {
     self.config = config
@@ -73,9 +55,7 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
     )
     self.logger.info(message: "AppController sharedInstance created")
 
-    self.errorRecovery.delegate = self
     self.stateMachine.changeEventDelegate = self
-    self.stateMachine.reset()
   }
 
   public func start() {
@@ -87,18 +67,16 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
 
     UpdatesBuildData.ensureBuildDataIsConsistentAsync(database: database, config: config)
 
-    errorRecovery.startMonitoring()
-
-    loaderTask = AppLoaderTask(
-      withConfig: config,
-      database: database,
-      directory: updatesDirectoryInternal,
-      selectionPolicy: selectionPolicy,
-      delegateQueue: controllerQueue
+    startupProcedure = StartupProcedure(
+      database: self.database,
+      config: self.config,
+      selectionPolicy: self.selectionPolicy,
+      controllerQueue: self.controllerQueue,
+      updatesDirectory: self.updatesDirectoryInternal,
+      logger: self.logger
     )
-    loaderTask!.delegate = self
-    loaderTask!.swiftDelegate = self
-    loaderTask!.start()
+    startupProcedure.delegate = self
+    stateMachine.queueExecution(stateMachineProcedure: startupProcedure)
   }
 
   /**
@@ -140,186 +118,74 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
     start()
   }
 
+  // MARK: - StartupProcedureDelegate
+
+  func startupProcedureDidLaunch(_ startupProcedure: StartupProcedure) {
+    delegate.let { _ in
+      DispatchQueue.main.async { [weak self] in
+        if let strongSelf = self {
+          strongSelf.delegate?.appController(strongSelf, didStartWithSuccess: strongSelf.startupProcedure.launchAssetUrl() != nil)
+          strongSelf.sendQueuedEventsToBridge()
+        }
+      }
+    }
+  }
+
+  func startupProcedure(_ startupProcedure: StartupProcedure, didEmitLegacyUpdateEventForBridge eventType: String, body: [String: Any]) {
+    sendLegacyUpdateEventToBridge(eventType, body: body)
+  }
+
+  func startupProcedure(_ startupProcedure: StartupProcedure, errorRecoveryDidRequestRelaunchWithCompletion completion: @escaping (Error?, Bool) -> Void) {
+    let procedure = RelaunchProcedure(
+      database: self.database,
+      config: self.config,
+      selectionPolicy: self.selectionPolicy,
+      controllerQueue: self.controllerQueue,
+      updatesDirectory: self.updatesDirectoryInternal,
+      logger: self.logger,
+      shouldRunReaper: false,
+      triggerReloadCommandListenersReason: "Relaunch after fatal error"
+    ) {
+      return self.startupProcedure.launchedUpdate()
+    } setLauncher: { newLauncher in
+      self.startupProcedure.setLauncher(newLauncher)
+    } requestStartErrorMonitoring: {
+      self.startupProcedure.requestStartErrorMonitoring()
+    } successBlock: {
+      completion(nil, true)
+    } errorBlock: { error in
+      completion(error, false)
+    }
+
+    stateMachine.queueExecution(stateMachineProcedure: procedure)
+  }
+
   public func requestRelaunch(
     success successBlockArg: @escaping () -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   ) {
-    stateMachine.processEvent(UpdatesStateEventRestart())
-    let launcherWithDatabase = AppLauncherWithDatabase(
-      config: config,
-      database: database,
-      directory: updatesDirectoryInternal,
-      completionQueue: controllerQueue
-    )
-    candidateLauncher = launcherWithDatabase
-    launcherWithDatabase.launchUpdate(withSelectionPolicy: selectionPolicy) { error, success in
-      if success {
-        self.launcher = self.candidateLauncher
-        successBlockArg()
-        self.errorRecovery.startMonitoring()
-        RCTReloadCommandSetBundleURL(self.launcher!.launchAssetUrl)
-        RCTTriggerReloadCommandListeners("Requested by JavaScript - Updates.reloadAsync()")
-        self.runReaper()
-        // Reset the state machine
-        self.stateMachine.reset()
-      } else {
-        NSLog("Failed to relaunch: %@", error!.localizedDescription)
-        errorBlockArg(UpdatesReloadException())
-      }
-    }
-  }
-
-  public func launchedUpdate() -> Update? {
-    return launcher?.launchedUpdate
-  }
-
-  // MARK: - AppLoaderTaskDelegate
-
-  public func appLoaderTask(_: AppLoaderTask, didLoadCachedUpdate update: Update) -> Bool {
-    return true
-  }
-
-  public func appLoaderTaskDidStartCheckingForRemoteUpdate(_: AppLoaderTask) {
-    stateMachine.processEvent(UpdatesStateEventCheck())
-  }
-
-  public func appLoaderTask(_: AppLoaderTask, didFinishCheckingForRemoteUpdateWithRemoteCheckResult remoteCheckResult: RemoteCheckResult) {
-    let event: UpdatesStateEvent
-    switch remoteCheckResult {
-    case .noUpdateAvailable: // Not using reason to update state yet
-      event = UpdatesStateEventCheckComplete()
-    case .updateAvailable(let manifest):
-      event = UpdatesStateEventCheckCompleteWithUpdate(manifest: manifest)
-    case .rollBackToEmbedded(let commitTime):
-      event = UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime)
-    case .error(let error):
-      event = UpdatesStateEventCheckError(message: error.localizedDescription)
-    }
-    stateMachine.processEvent(event)
-  }
-
-  public func appLoaderTask(_: AppLoaderTask, didStartLoadingUpdate update: Update?) {
-    logger.info(message: "AppController appLoaderTask didStartLoadingUpdate", code: .none, updateId: update?.loggingId(), assetId: nil)
-    stateMachine.processEvent(UpdatesStateEventDownload())
-  }
-
-  public func appLoaderTask(_: AppLoaderTask, didFinishWithLauncher launcher: AppLauncher, isUpToDate: Bool) {
-    let logMessage = String(
-      format: "AppController appLoaderTask didFinishWithLauncher, isUpToDate=%d, remoteLoadStatus=%ld",
-      isUpToDate,
-      remoteLoadStatus.rawValue
-    )
-    logger.info(message: logMessage)
-
-    // if isUpToDate is false, that means a remote update is still loading in the background (this
-    // method was called with a cached update because the timer ran out) so don't update the status
-
-    if remoteLoadStatus == .Loading && isUpToDate {
-      remoteLoadStatus = .Idle
+    let procedure = RelaunchProcedure(
+      database: self.database,
+      config: self.config,
+      selectionPolicy: self.selectionPolicy,
+      controllerQueue: self.controllerQueue,
+      updatesDirectory: self.updatesDirectoryInternal,
+      logger: self.logger,
+      shouldRunReaper: true,
+      triggerReloadCommandListenersReason: "Requested by JavaScript - Updates.reloadAsync()"
+    ) {
+      return self.startupProcedure.launchedUpdate()
+    } setLauncher: { newLauncher in
+      self.startupProcedure.setLauncher(newLauncher)
+    } requestStartErrorMonitoring: {
+      self.startupProcedure.requestStartErrorMonitoring()
+    } successBlock: {
+      successBlockArg()
+    } errorBlock: { error in
+      errorBlockArg(error)
     }
 
-    self.launcher = launcher
-
-    delegate.let { it in
-      UpdatesUtils.runBlockOnMainThread {
-        it.appController(self, didStartWithSuccess: true)
-        self.sendQueuedEventsToBridge()
-      }
-    }
-  }
-
-  public func appLoaderTask(_: AppLoaderTask, didLoadAsset asset: UpdateAsset, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) {
-    let body = [
-      "assetInfo": [
-        "name": asset.filename,
-        "successfulAssetCount": successfulAssetCount,
-        "failedAssetCount": failedAssetCount,
-        "totalAssetCount": totalAssetCount
-      ] as [String: Any]
-    ]
-    logger.info(
-      message: "AppController appLoaderTask didLoadAsset: \(body)",
-      code: .none,
-      updateId: nil,
-      assetId: asset.contentHash
-    )
-  }
-
-  public func appLoaderTask(_: AppLoaderTask, didFinishWithError error: Error) {
-    let logMessage = String(format: "AppController appLoaderTask didFinishWithError: %@", error.localizedDescription)
-    logger.error(message: logMessage, code: .updateFailedToLoad)
-    stateMachine.processEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
-    // Send legacy UpdateEvents to JS
-    sendLegacyUpdateEventToBridge(EnabledAppController.ErrorEventName, body: [
-      "message": error.localizedDescription
-    ])
-    emergencyLaunch(fatalError: error as NSError)
-  }
-
-  public func appLoaderTask(
-    _: AppLoaderTask,
-    didFinishBackgroundUpdateWithStatus status: BackgroundUpdateStatus,
-    update: Update?,
-    error: Error?
-  ) {
-    switch status {
-    case .error:
-      remoteLoadStatus = .Idle
-      guard let error = error else {
-        preconditionFailure("Background update with error status must have a nonnull error object")
-      }
-      logger.error(
-        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=Error",
-        code: .updateFailedToLoad,
-        updateId: update?.loggingId(),
-        assetId: nil
-      )
-      // Since errors can happen through a number of paths, we do these checks
-      // to make sure the state machine is valid
-      if stateMachine.state == .checking {
-        stateMachine.processEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
-      } else if stateMachine.state == .downloading {
-        // .downloading
-        stateMachine.processEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
-      }
-      // Send UpdateEvents to JS
-      sendLegacyUpdateEventToBridge(EnabledAppController.ErrorEventName, body: [
-        "message": error.localizedDescription
-      ])
-    case .updateAvailable:
-      remoteLoadStatus = .NewUpdateLoaded
-      guard let update = update else {
-        preconditionFailure("Background update with error status must have a nonnull update object")
-      }
-      logger.info(
-        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=NewUpdateLoaded",
-        code: .none,
-        updateId: update.loggingId(),
-        assetId: nil
-      )
-      stateMachine.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
-      // Send UpdateEvents to JS
-      sendLegacyUpdateEventToBridge(EnabledAppController.UpdateAvailableEventName, body: [
-        "manifest": update.manifest.rawManifestJSON()
-      ])
-    case .noUpdateAvailable:
-      remoteLoadStatus = .Idle
-      logger.info(
-        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=NoUpdateAvailable",
-        code: .noUpdatesAvailable,
-        updateId: update?.loggingId(),
-        assetId: nil
-      )
-      // TODO: handle rollbacks properly, but this works for now
-      if stateMachine.state == .downloading {
-        stateMachine.processEvent(UpdatesStateEventDownloadComplete())
-      }
-      // Otherwise, we don't need to call the state machine here, it already transitioned to .checkCompleteUnavailable
-      // Send UpdateEvents to JS
-      sendLegacyUpdateEventToBridge(EnabledAppController.NoUpdateAvailableEventName, body: [:])
-    }
-
-    errorRecovery.notify(newRemoteLoadStatus: remoteLoadStatus)
+    stateMachine.queueExecution(stateMachineProcedure: procedure)
   }
 
   // MARK: - Internal
@@ -328,40 +194,9 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
     UpdatesUtils.purgeUpdatesLogsOlderThanOneDay()
   }
 
-  internal func runReaper() {
-    if let launchedUpdate = launcher?.launchedUpdate {
-      UpdatesReaper.reapUnusedUpdates(
-        withConfig: config,
-        database: database,
-        directory: updatesDirectoryInternal,
-        selectionPolicy: selectionPolicy,
-        launchedUpdate: launchedUpdate
-      )
-    }
-  }
-
-  private func emergencyLaunch(fatalError error: NSError) {
-    isEmergencyLaunch = true
-
-    let launcherNoDatabase = AppLauncherNoDatabase()
-    launcher = launcherNoDatabase
-    launcherNoDatabase.launchUpdate()
-
-    delegate.let { _ in
-      DispatchQueue.main.async { [weak self] in
-        if let strongSelf = self {
-          strongSelf.delegate?.appController(strongSelf, didStartWithSuccess: strongSelf.launchAssetUrl() != nil)
-          strongSelf.sendQueuedEventsToBridge()
-        }
-      }
-    }
-
-    ErrorRecovery.writeErrorOrExceptionToLog(error)
-  }
-
   // MARK: - Send events to JS
 
-  internal func sendLegacyUpdateEventToBridge(_ eventType: String, body: [String: Any] ) {
+  internal func sendLegacyUpdateEventToBridge(_ eventType: String, body: [String: Any]) {
     logger.info(message: "sendLegacyUpdateEventToBridge(): type = \(eventType)")
     sendEventToBridge(EnabledAppController.EXUpdatesEventName, eventType, body: body)
   }
@@ -402,139 +237,20 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
     eventsToSendToJS = []
   }
 
-  // MARK: - ErrorRecoveryDelegate
-
-  public func relaunch(completion: @escaping (Error?, Bool) -> Void) {
-    let launcher = AppLauncherWithDatabase(
-      config: config,
-      database: database,
-      directory: updatesDirectoryInternal,
-      completionQueue: controllerQueue
-    )
-    candidateLauncher = launcher
-    launcher.launchUpdate(withSelectionPolicy: selectionPolicy) { error, success in
-      if success {
-        self.launcher = self.candidateLauncher
-        self.errorRecovery.startMonitoring()
-        RCTReloadCommandSetBundleURL(launcher.launchAssetUrl)
-        RCTTriggerReloadCommandListeners("Relaunch after fatal error")
-        completion(nil, true)
-      } else {
-        completion(error, false)
-      }
-    }
-  }
-
-  public func loadRemoteUpdate() {
-    if let loaderTask = loaderTask, loaderTask.isRunning {
-      return
-    }
-
-    remoteLoadStatus = .Loading
-
-    let remoteAppLoader = RemoteAppLoader(
-      config: config,
-      database: database,
-      directory: updatesDirectoryInternal,
-      launchedUpdate: launchedUpdate(),
-      completionQueue: controllerQueue
-    )
-    remoteAppLoader.loadUpdate(
-      fromURL: config.updateUrl
-    ) { updateResponse in
-      if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
-        switch updateDirective {
-        case is NoUpdateAvailableUpdateDirective:
-          return false
-        case is RollBackToEmbeddedUpdateDirective:
-          return false
-        default:
-          NSException(name: .internalInconsistencyException, reason: "Unhandled update directive type").raise()
-          return false
-        }
-      }
-
-      guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
-        return false
-      }
-
-      return self.selectionPolicy.shouldLoadNewUpdate(
-        update,
-        withLaunchedUpdate: self.launchedUpdate(),
-        filters: updateResponse.responseHeaderData?.manifestFilters
-      )
-    } asset: { _, _, _, _ in
-      // do nothing for now
-    } success: { updateResponse in
-      self.remoteLoadStatus = updateResponse != nil ? .NewUpdateLoaded : .Idle
-      self.errorRecovery.notify(newRemoteLoadStatus: self.remoteLoadStatus)
-    } error: { error in
-      self.logger.error(message: "AppController loadRemoteUpdate error: \(error.localizedDescription)", code: .updateFailedToLoad)
-      self.remoteLoadStatus = .Idle
-      self.errorRecovery.notify(newRemoteLoadStatus: self.remoteLoadStatus)
-    }
-  }
-
-  public func markFailedLaunchForLaunchedUpdate() {
-    if isEmergencyLaunch {
-      return
-    }
-
-    database.databaseQueue.async {
-      guard let launchedUpdate = self.launchedUpdate() else {
-        return
-      }
-
-      self.logger.error(
-        message: "AppController markFailedLaunchForUpdate",
-        code: .unknown,
-        updateId: launchedUpdate.loggingId(),
-        assetId: nil
-      )
-      do {
-        try self.database.incrementFailedLaunchCountForUpdate(launchedUpdate)
-      } catch {
-        NSLog("Unable to mark update as failed in the local DB: %@", error.localizedDescription)
-      }
-    }
-  }
-
-  public func markSuccessfulLaunchForLaunchedUpdate() {
-    if isEmergencyLaunch {
-      return
-    }
-
-    database.databaseQueue.async {
-      guard let launchedUpdate = self.launchedUpdate() else {
-        return
-      }
-
-      do {
-        try self.database.incrementSuccessfulLaunchCountForUpdate(launchedUpdate)
-      } catch {
-        NSLog("Failed to increment successful launch count for update: %@", error.localizedDescription)
-      }
-    }
-  }
-
-  public func throwException(_ exception: NSException) {
-    exception.raise()
-  }
-
   // MARK: - JS API
 
   public func getConstantsForModule() -> UpdatesModuleConstants {
     return UpdatesModuleConstants(
-      launchedUpdate: launchedUpdate(),
+      launchedUpdate: startupProcedure.launchedUpdate(),
       embeddedUpdate: getEmbeddedUpdate(),
-      isEmergencyLaunch: isEmergencyLaunch,
+      isEmergencyLaunch: startupProcedure.isEmergencyLaunch,
       isEnabled: true,
       releaseChannel: self.config.releaseChannel,
-      isUsingEmbeddedAssets: isUsingEmbeddedAssets(),
+      isUsingEmbeddedAssets: startupProcedure.isUsingEmbeddedAssets(),
       runtimeVersion: self.config.runtimeVersionRaw ?? "",
       checkOnLaunch: self.config.checkOnLaunch,
       requestHeaders: self.config.requestHeaders,
-      assetFilesMap: assetFilesMap(),
+      assetFilesMap: startupProcedure.assetFilesMap(),
       isMissingRuntimeVersion: false
     )
   }
@@ -543,204 +259,40 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
     success successBlockArg: @escaping (_ remoteCheckResult: RemoteCheckResult) -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   ) {
-    stateMachine.processEvent(UpdatesStateEventCheck())
-
-    database.databaseQueue.async {
-      let embeddedUpdate = EmbeddedAppLoader.embeddedManifest(withConfig: self.config, database: self.database)
-      let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
-        withDatabase: self.database,
-        config: self.config,
-        launchedUpdate: self.launchedUpdate(),
-        embeddedUpdate: embeddedUpdate
-      )
-
-      FileDownloader(config: self.config).downloadRemoteUpdate(
-        fromURL: self.config.updateUrl,
-        withDatabase: self.database,
-        extraHeaders: extraHeaders) { updateResponse in
-          let launchedUpdate = self.launchedUpdate()
-          let manifestFilters = updateResponse.responseHeaderData?.manifestFilters
-
-          if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
-            switch updateDirective {
-            case is NoUpdateAvailableUpdateDirective:
-              successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.noUpdateAvailableOnServer))
-              self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-              return
-            case let rollBackUpdateDirective as RollBackToEmbeddedUpdateDirective:
-              if !self.config.hasEmbeddedUpdate {
-                successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackNoEmbedded))
-                self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-                return
-              }
-
-              guard let embeddedUpdate = embeddedUpdate else {
-                successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackNoEmbedded))
-                self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-                return
-              }
-
-              if !self.selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
-                rollBackUpdateDirective,
-                withEmbeddedUpdate: embeddedUpdate,
-                launchedUpdate: launchedUpdate,
-                filters: manifestFilters
-              ) {
-                successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackRejectedBySelectionPolicy))
-                self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-                return
-              }
-
-              successBlockArg(RemoteCheckResult.rollBackToEmbedded(commitTime: rollBackUpdateDirective.commitTime))
-              self.stateMachine.processEvent(
-                UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: rollBackUpdateDirective.commitTime)
-              )
-              return
-            default:
-              let error = UpdatesUnsupportedDirectiveException()
-              self.stateMachine.processEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
-              successBlockArg(RemoteCheckResult.error(error: error))
-              return
-            }
-          }
-
-          guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
-            successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.noUpdateAvailableOnServer))
-            self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-            return
-          }
-
-          var shouldLaunch = false
-          var failedPreviously = false
-          if self.selectionPolicy.shouldLoadNewUpdate(
-            update,
-            withLaunchedUpdate: launchedUpdate,
-            filters: manifestFilters
-          ) {
-            // If "update" has failed to launch previously, then
-            // "launchedUpdate" will be an earlier update, and the test above
-            // will return true (incorrectly).
-            // We check to see if the new update is already in the DB, and if so,
-            // only allow the update if it has had no launch failures.
-            shouldLaunch = true
-            self.database.databaseQueue.sync {
-              do {
-                let storedUpdate = try self.database.update(withId: update.updateId, config: self.config)
-                if let storedUpdate = storedUpdate {
-                  shouldLaunch = storedUpdate.failedLaunchCount == 0 || storedUpdate.successfulLaunchCount > 0
-                  failedPreviously = !shouldLaunch
-                  self.logger.info(message: "Stored update found: ID = \(update.updateId), failureCount = \(storedUpdate.failedLaunchCount)")
-                }
-              } catch {}
-            }
-          }
-          if shouldLaunch {
-            successBlockArg(RemoteCheckResult.updateAvailable(manifest: update.manifest.rawManifestJSON()))
-            self.stateMachine.processEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
-          } else {
-            let reason = failedPreviously ?
-              RemoteCheckResultNotAvailableReason.updatePreviouslyFailed :
-              RemoteCheckResultNotAvailableReason.updateRejectedBySelectionPolicy
-            successBlockArg(RemoteCheckResult.noUpdateAvailable(reason: reason))
-            self.stateMachine.processEvent(UpdatesStateEventCheckComplete())
-          }
-        } errorBlock: { error in
-          self.stateMachine.processEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
-          successBlockArg(RemoteCheckResult.error(error: error))
-          return
-      }
+    let procedure = CheckForUpdateProcedure(
+      database: self.database,
+      config: self.config,
+      selectionPolicy: self.selectionPolicy,
+      logger: self.logger
+    ) {
+      return self.startupProcedure.launchedUpdate()
+    } successBlock: { remoteCheckResult in
+      successBlockArg(remoteCheckResult)
+    } errorBlock: { error in
+      errorBlockArg(error)
     }
+    self.stateMachine.queueExecution(stateMachineProcedure: procedure)
   }
 
   public func fetchUpdate(
     success successBlockArg: @escaping (_ fetchUpdateResult: FetchUpdateResult) -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   ) {
-    self.stateMachine.processEvent(UpdatesStateEventDownload())
-    let remoteAppLoader = RemoteAppLoader(
-      config: self.config,
+    let procedure = FetchUpdateProcedure(
       database: self.database,
-      directory: self.updatesDirectoryInternal,
-      launchedUpdate: self.launchedUpdate(),
-      completionQueue: controllerQueue
-    )
-    remoteAppLoader.loadUpdate(
-      fromURL: self.config.updateUrl
-    ) { updateResponse in
-      if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
-        switch updateDirective {
-        case is NoUpdateAvailableUpdateDirective:
-          return false
-        case is RollBackToEmbeddedUpdateDirective:
-          return true
-        default:
-          NSException(name: .internalInconsistencyException, reason: "Unhandled update directive type").raise()
-          return false
-        }
-      }
-
-      guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
-        return false
-      }
-
-      return self.selectionPolicy.shouldLoadNewUpdate(
-        update,
-        withLaunchedUpdate: self.launchedUpdate(),
-        filters: updateResponse.responseHeaderData?.manifestFilters
-      )
-    } asset: { asset, successfulAssetCount, failedAssetCount, totalAssetCount in
-      let body = [
-        "assetInfo": [
-          "assetName": asset.filename,
-          "successfulAssetCount": successfulAssetCount,
-          "failedAssetCount": failedAssetCount,
-          "totalAssetCount": totalAssetCount
-        ] as [String: Any]
-      ] as [String: Any]
-      self.logger.info(
-        message: "fetchUpdateAsync didLoadAsset: \(body)",
-        code: .none,
-        updateId: nil,
-        assetId: asset.contentHash
-      )
-    } success: { updateResponse in
-      RemoteAppLoader.processSuccessLoaderResult(
-        config: self.config,
-        database: self.database,
-        selectionPolicy: self.selectionPolicy,
-        launchedUpdate: self.launchedUpdate(),
-        directory: self.updatesDirectoryInternal,
-        loaderTaskQueue: DispatchQueue(label: "expo.loader.LoaderTaskQueue"),
-        updateResponse: updateResponse,
-        priorError: nil
-      ) { updateToLaunch, error, didRollBackToEmbedded in
-        if let error = error {
-          self.stateMachine.processEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
-          successBlockArg(FetchUpdateResult.error(error: error))
-          return
-        }
-
-        if didRollBackToEmbedded {
-          successBlockArg(FetchUpdateResult.rollBackToEmbedded)
-          self.stateMachine.processEvent(UpdatesStateEventDownloadCompleteWithRollback())
-          return
-        }
-
-        if let update = updateToLaunch {
-          successBlockArg(FetchUpdateResult.success(manifest: update.manifest.rawManifestJSON()))
-          self.stateMachine.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
-          return
-        }
-
-        successBlockArg(FetchUpdateResult.failure)
-        self.stateMachine.processEvent(UpdatesStateEventDownloadComplete())
-        return
-      }
-    } error: { error in
-      self.stateMachine.processEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
-      successBlockArg(FetchUpdateResult.error(error: error))
-      return
+      config: self.config,
+      selectionPolicy: self.selectionPolicy,
+      controllerQueue: self.controllerQueue,
+      updatesDirectory: self.updatesDirectoryInternal,
+      logger: self.logger
+    ) {
+      return self.startupProcedure.launchedUpdate()
+    } successBlock: { fetchUpdateResult in
+      successBlockArg(fetchUpdateResult)
+    } errorBlock: { error in
+      errorBlockArg(error)
     }
+    self.stateMachine.queueExecution(stateMachineProcedure: procedure)
   }
 
   public func getNativeStateMachineContext(
@@ -784,5 +336,4 @@ public class EnabledAppController: AppLoaderTaskDelegate, AppLoaderTaskSwiftDele
   }
 }
 
-// swiftlint:enable closure_body_length
 // swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
@@ -1,0 +1,158 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+// swiftlint:disable closure_body_length
+
+import ExpoModulesCore
+
+final class CheckForUpdateProcedure: StateMachineProcedure {
+  private let database: UpdatesDatabase
+  private let config: UpdatesConfig
+  private let selectionPolicy: SelectionPolicy
+  private let logger: UpdatesLogger
+  private let getLaunchedUpdate: () -> Update?
+  private let successBlock: (_ remoteCheckResult: RemoteCheckResult) -> Void
+  private let errorBlock: (_ error: Exception) -> Void
+
+  init(
+    database: UpdatesDatabase,
+    config: UpdatesConfig,
+    selectionPolicy: SelectionPolicy,
+    logger: UpdatesLogger,
+    getLaunchedUpdate: @escaping () -> Update?,
+    successBlock: @escaping (_: RemoteCheckResult) -> Void,
+    errorBlock: @escaping (_: Exception) -> Void
+  ) {
+    self.database = database
+    self.config = config
+    self.selectionPolicy = selectionPolicy
+    self.logger = logger
+    self.getLaunchedUpdate = getLaunchedUpdate
+    self.successBlock = successBlock
+    self.errorBlock = errorBlock
+  }
+
+  func run(procedureContext: ProcedureContext) {
+    procedureContext.processStateEvent(UpdatesStateEventCheck())
+
+    database.databaseQueue.async {
+      let embeddedUpdate = EmbeddedAppLoader.embeddedManifest(withConfig: self.config, database: self.database)
+      let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
+        withDatabase: self.database,
+        config: self.config,
+        launchedUpdate: self.getLaunchedUpdate(),
+        embeddedUpdate: embeddedUpdate
+      )
+
+      FileDownloader(config: self.config).downloadRemoteUpdate(
+        fromURL: self.config.updateUrl,
+        withDatabase: self.database,
+        extraHeaders: extraHeaders) { updateResponse in
+          let launchedUpdate = self.getLaunchedUpdate()
+          let manifestFilters = updateResponse.responseHeaderData?.manifestFilters
+
+          if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
+            switch updateDirective {
+            case is NoUpdateAvailableUpdateDirective:
+              self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.noUpdateAvailableOnServer))
+              procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+              procedureContext.onComplete()
+              return
+            case let rollBackUpdateDirective as RollBackToEmbeddedUpdateDirective:
+              if !self.config.hasEmbeddedUpdate {
+                self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackNoEmbedded))
+                procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+                procedureContext.onComplete()
+                return
+              }
+
+              guard let embeddedUpdate = embeddedUpdate else {
+                self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackNoEmbedded))
+                procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+                procedureContext.onComplete()
+                return
+              }
+
+              if !self.selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+                rollBackUpdateDirective,
+                withEmbeddedUpdate: embeddedUpdate,
+                launchedUpdate: launchedUpdate,
+                filters: manifestFilters
+              ) {
+                self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.rollbackRejectedBySelectionPolicy))
+                procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+                procedureContext.onComplete()
+                return
+              }
+
+              self.successBlock(RemoteCheckResult.rollBackToEmbedded(commitTime: rollBackUpdateDirective.commitTime))
+              procedureContext.processStateEvent(
+                UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: rollBackUpdateDirective.commitTime)
+              )
+              procedureContext.onComplete()
+              return
+            default:
+              let error = UpdatesUnsupportedDirectiveException()
+              procedureContext.processStateEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
+              self.successBlock(RemoteCheckResult.error(error: error))
+              procedureContext.onComplete()
+              return
+            }
+          }
+
+          guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
+            self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason.noUpdateAvailableOnServer))
+            procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+            procedureContext.onComplete()
+            return
+          }
+
+          var shouldLaunch = false
+          var failedPreviously = false
+          if self.selectionPolicy.shouldLoadNewUpdate(
+            update,
+            withLaunchedUpdate: launchedUpdate,
+            filters: manifestFilters
+          ) {
+            // If "update" has failed to launch previously, then
+            // "launchedUpdate" will be an earlier update, and the test above
+            // will return true (incorrectly).
+            // We check to see if the new update is already in the DB, and if so,
+            // only allow the update if it has had no launch failures.
+            shouldLaunch = true
+            self.database.databaseQueue.sync {
+              do {
+                let storedUpdate = try self.database.update(withId: update.updateId, config: self.config)
+                if let storedUpdate = storedUpdate {
+                  shouldLaunch = storedUpdate.failedLaunchCount == 0 || storedUpdate.successfulLaunchCount > 0
+                  failedPreviously = !shouldLaunch
+                  self.logger.info(message: "Stored update found: ID = \(update.updateId), failureCount = \(storedUpdate.failedLaunchCount)")
+                }
+              } catch {}
+            }
+          }
+
+          if shouldLaunch {
+            self.successBlock(RemoteCheckResult.updateAvailable(manifest: update.manifest.rawManifestJSON()))
+            procedureContext.processStateEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+            procedureContext.onComplete()
+            return
+          }
+
+          let reason = failedPreviously ?
+            RemoteCheckResultNotAvailableReason.updatePreviouslyFailed :
+            RemoteCheckResultNotAvailableReason.updateRejectedBySelectionPolicy
+          self.successBlock(RemoteCheckResult.noUpdateAvailable(reason: reason))
+          procedureContext.processStateEvent(UpdatesStateEventCheckComplete())
+          procedureContext.onComplete()
+          return
+        } errorBlock: { error in
+          procedureContext.processStateEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
+          self.successBlock(RemoteCheckResult.error(error: error))
+          procedureContext.onComplete()
+          return
+      }
+    }
+  }
+}
+
+// swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -1,0 +1,135 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+// swiftlint:disable closure_body_length
+
+import ExpoModulesCore
+
+final class FetchUpdateProcedure: StateMachineProcedure {
+  private let database: UpdatesDatabase
+  private let config: UpdatesConfig
+  private let selectionPolicy: SelectionPolicy
+  private let controllerQueue: DispatchQueue
+  private let updatesDirectory: URL
+  private let logger: UpdatesLogger
+  private let getLaunchedUpdate: () -> Update?
+  private let successBlock: (_ fetchUpdateResult: FetchUpdateResult) -> Void
+  private let errorBlock: (_ error: Exception) -> Void
+
+  init(
+    database: UpdatesDatabase,
+    config: UpdatesConfig,
+    selectionPolicy: SelectionPolicy,
+    controllerQueue: DispatchQueue,
+    updatesDirectory: URL,
+    logger: UpdatesLogger,
+    getLaunchedUpdate: @escaping () -> Update?,
+    successBlock: @escaping (_: FetchUpdateResult) -> Void,
+    errorBlock: @escaping (_: Exception) -> Void
+  ) {
+    self.database = database
+    self.config = config
+    self.selectionPolicy = selectionPolicy
+    self.controllerQueue = controllerQueue
+    self.updatesDirectory = updatesDirectory
+    self.logger = logger
+    self.getLaunchedUpdate = getLaunchedUpdate
+    self.successBlock = successBlock
+    self.errorBlock = errorBlock
+  }
+
+  func run(procedureContext: ProcedureContext) {
+    procedureContext.processStateEvent(UpdatesStateEventDownload())
+
+    let remoteAppLoader = RemoteAppLoader(
+      config: self.config,
+      database: self.database,
+      directory: self.updatesDirectory,
+      launchedUpdate: self.getLaunchedUpdate(),
+      completionQueue: controllerQueue
+    )
+    remoteAppLoader.loadUpdate(
+      fromURL: self.config.updateUrl
+    ) { updateResponse in
+      if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
+        switch updateDirective {
+        case is NoUpdateAvailableUpdateDirective:
+          return false
+        case is RollBackToEmbeddedUpdateDirective:
+          return true
+        default:
+          NSException(name: .internalInconsistencyException, reason: "Unhandled update directive type").raise()
+          return false
+        }
+      }
+
+      guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
+        return false
+      }
+
+      return self.selectionPolicy.shouldLoadNewUpdate(
+        update,
+        withLaunchedUpdate: self.getLaunchedUpdate(),
+        filters: updateResponse.responseHeaderData?.manifestFilters
+      )
+    } asset: { asset, successfulAssetCount, failedAssetCount, totalAssetCount in
+      let body = [
+        "assetInfo": [
+          "assetName": asset.filename,
+          "successfulAssetCount": successfulAssetCount,
+          "failedAssetCount": failedAssetCount,
+          "totalAssetCount": totalAssetCount
+        ] as [String: Any]
+      ] as [String: Any]
+      self.logger.info(
+        message: "fetchUpdateAsync didLoadAsset: \(body)",
+        code: .none,
+        updateId: nil,
+        assetId: asset.contentHash
+      )
+    } success: { updateResponse in
+      RemoteAppLoader.processSuccessLoaderResult(
+        config: self.config,
+        database: self.database,
+        selectionPolicy: self.selectionPolicy,
+        launchedUpdate: self.getLaunchedUpdate(),
+        directory: self.updatesDirectory,
+        loaderTaskQueue: DispatchQueue(label: "expo.loader.LoaderTaskQueue"),
+        updateResponse: updateResponse,
+        priorError: nil
+      ) { updateToLaunch, error, didRollBackToEmbedded in
+        if let error = error {
+          procedureContext.processStateEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
+          self.successBlock(FetchUpdateResult.error(error: error))
+          procedureContext.onComplete()
+          return
+        }
+
+        if didRollBackToEmbedded {
+          self.successBlock(FetchUpdateResult.rollBackToEmbedded)
+          procedureContext.processStateEvent(UpdatesStateEventDownloadCompleteWithRollback())
+          procedureContext.onComplete()
+          return
+        }
+
+        if let update = updateToLaunch {
+          self.successBlock(FetchUpdateResult.success(manifest: update.manifest.rawManifestJSON()))
+          procedureContext.processStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+          procedureContext.onComplete()
+          return
+        }
+
+        self.successBlock(FetchUpdateResult.failure)
+        procedureContext.processStateEvent(UpdatesStateEventDownloadComplete())
+        procedureContext.onComplete()
+        return
+      }
+    } error: { error in
+      procedureContext.processStateEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
+      self.successBlock(FetchUpdateResult.error(error: error))
+      procedureContext.onComplete()
+      return
+    }
+  }
+}
+
+// swiftlint:enable closure_body_length

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -1,0 +1,97 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+final class RelaunchProcedure: StateMachineProcedure {
+  private let database: UpdatesDatabase
+  private let config: UpdatesConfig
+  private let selectionPolicy: SelectionPolicy
+  private let controllerQueue: DispatchQueue
+  private let updatesDirectory: URL
+  private let logger: UpdatesLogger
+  private let shouldRunReaper: Bool
+  private let triggerReloadCommandListenersReason: String
+  private let getLaunchedUpdate: () -> Update?
+  private let setLauncher: (_ newLauncher: AppLauncher) -> Void
+  private let requestStartErrorMonitoring: () -> Void
+  private let successBlock: () -> Void
+  private let errorBlock: (_ error: Exception) -> Void
+
+  init(
+    database: UpdatesDatabase,
+    config: UpdatesConfig,
+    selectionPolicy: SelectionPolicy,
+    controllerQueue: DispatchQueue,
+    updatesDirectory: URL,
+    logger: UpdatesLogger,
+    shouldRunReaper: Bool,
+    triggerReloadCommandListenersReason: String,
+    getLaunchedUpdate: @escaping () -> Update?,
+    setLauncher: @escaping (_ setCurrentLauncher: AppLauncher) -> Void,
+    requestStartErrorMonitoring: @escaping () -> Void,
+    successBlock: @escaping () -> Void,
+    errorBlock: @escaping (_: Exception) -> Void
+  ) {
+    self.database = database
+    self.config = config
+    self.selectionPolicy = selectionPolicy
+    self.controllerQueue = controllerQueue
+    self.updatesDirectory = updatesDirectory
+    self.logger = logger
+    self.shouldRunReaper = shouldRunReaper
+    self.triggerReloadCommandListenersReason = triggerReloadCommandListenersReason
+    self.getLaunchedUpdate = getLaunchedUpdate
+    self.setLauncher = setLauncher
+    self.requestStartErrorMonitoring = requestStartErrorMonitoring
+    self.successBlock = successBlock
+    self.errorBlock = errorBlock
+  }
+
+  func run(procedureContext: ProcedureContext) {
+    procedureContext.processStateEvent(UpdatesStateEventRestart())
+    let launcherWithDatabase = AppLauncherWithDatabase(
+      config: config,
+      database: database,
+      directory: updatesDirectory,
+      completionQueue: controllerQueue
+    )
+    launcherWithDatabase.launchUpdate(withSelectionPolicy: selectionPolicy) { error, success in
+      if success {
+        self.setLauncher(launcherWithDatabase)
+        self.requestStartErrorMonitoring()
+        RCTReloadCommandSetBundleURL(launcherWithDatabase.launchAssetUrl)
+        RCTTriggerReloadCommandListeners(self.triggerReloadCommandListenersReason)
+
+        // TODO(wschurman): this was moved to after the RCT calls to unify reload
+        // code between JS API call and error recovery handler. double check that
+        // this is okay
+        self.successBlock()
+
+        if self.shouldRunReaper {
+          self.runReaper()
+        }
+
+        // Reset the state machine
+        procedureContext.resetState()
+        procedureContext.onComplete()
+      } else {
+        // swiftlint:disable:next force_unwrapping
+        NSLog("Failed to relaunch: %@", error!.localizedDescription)
+        self.errorBlock(UpdatesReloadException())
+        procedureContext.onComplete()
+      }
+    }
+  }
+
+  private func runReaper() {
+    if let launchedUpdate = getLaunchedUpdate() {
+      UpdatesReaper.reapUnusedUpdates(
+        withConfig: config,
+        database: database,
+        directory: updatesDirectory,
+        selectionPolicy: selectionPolicy,
+        launchedUpdate: launchedUpdate
+      )
+    }
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -1,0 +1,354 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+internal protocol StartupProcedureDelegate: AnyObject {
+  func startupProcedureDidLaunch(_ startupProcedure: StartupProcedure)
+  func startupProcedure(_ startupProcedure: StartupProcedure, didEmitLegacyUpdateEventForBridge eventType: String, body: [String: Any])
+  func startupProcedure(_ startupProcedure: StartupProcedure, errorRecoveryDidRequestRelaunchWithCompletion completion: @escaping (Error?, Bool) -> Void)
+}
+
+final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppLoaderTaskSwiftDelegate, ErrorRecoveryDelegate {
+  private let database: UpdatesDatabase
+  internal let config: UpdatesConfig
+  private let selectionPolicy: SelectionPolicy
+  private let controllerQueue: DispatchQueue
+  private let updatesDirectory: URL
+  private let logger: UpdatesLogger
+
+  init(
+    database: UpdatesDatabase,
+    config: UpdatesConfig,
+    selectionPolicy: SelectionPolicy,
+    controllerQueue: DispatchQueue,
+    updatesDirectory: URL,
+    logger: UpdatesLogger
+  ) {
+    self.database = database
+    self.config = config
+    self.selectionPolicy = selectionPolicy
+    self.controllerQueue = controllerQueue
+    self.updatesDirectory = updatesDirectory
+    self.logger = logger
+
+    self.errorRecovery.delegate = self
+  }
+
+  internal weak var delegate: StartupProcedureDelegate?
+
+  // swiftlint:disable implicitly_unwrapped_optional
+  private var procedureContext: ProcedureContext!
+  private var loaderTask: AppLoaderTask!
+  // swiftlint:enable implicitly_unwrapped_optional
+
+  private var candidateLauncher: AppLauncher?
+  internal private(set) var launcher: AppLauncher?
+  internal func setLauncher(_ launcher: AppLauncher) {
+    self.launcher = launcher
+  }
+
+  private let errorRecovery = ErrorRecovery()
+  internal func requestStartErrorMonitoring() {
+    errorRecovery.startMonitoring()
+  }
+
+  internal var remoteLoadStatus: RemoteLoadStatus = .Idle
+  internal private(set) var isEmergencyLaunch: Bool = false
+
+  internal func launchedUpdate() -> Update? {
+    return launcher?.launchedUpdate
+  }
+  internal func launchAssetUrl() -> URL? {
+    return launcher?.launchAssetUrl
+  }
+
+  internal func assetFilesMap() -> [String: Any]? {
+    return launcher?.assetFilesMap
+  }
+
+  internal func isUsingEmbeddedAssets() -> Bool {
+    guard let launcher = launcher else {
+      return true
+    }
+    return launcher.isUsingEmbeddedAssets()
+  }
+
+  func run(procedureContext: ProcedureContext) {
+    self.procedureContext = procedureContext
+
+    errorRecovery.startMonitoring()
+
+    // swiftlint:disable force_unwrapping
+    loaderTask = AppLoaderTask(
+      withConfig: config,
+      database: database,
+      directory: updatesDirectory,
+      selectionPolicy: selectionPolicy,
+      delegateQueue: controllerQueue
+    )
+    loaderTask!.delegate = self
+    loaderTask!.swiftDelegate = self
+    loaderTask!.start()
+    // swiftlint:enable force_unwrapping
+  }
+
+  private func emergencyLaunch(fatalError error: NSError) {
+    isEmergencyLaunch = true
+
+    let launcherNoDatabase = AppLauncherNoDatabase()
+    launcher = launcherNoDatabase
+    launcherNoDatabase.launchUpdate()
+
+    delegate?.startupProcedureDidLaunch(self)
+
+    ErrorRecovery.writeErrorOrExceptionToLog(error)
+  }
+
+  // MARK: - AppLoaderTaskDelegate
+
+  func appLoaderTask(_: AppLoaderTask, didLoadCachedUpdate update: Update) -> Bool {
+    return true
+  }
+
+  func appLoaderTaskDidStartCheckingForRemoteUpdate(_: AppLoaderTask) {
+    self.procedureContext.processStateEvent(UpdatesStateEventCheck())
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didFinishCheckingForRemoteUpdateWithRemoteCheckResult remoteCheckResult: RemoteCheckResult) {
+    let event: UpdatesStateEvent
+    switch remoteCheckResult {
+    case .noUpdateAvailable: // Not using reason to update state yet
+      event = UpdatesStateEventCheckComplete()
+    case .updateAvailable(let manifest):
+      event = UpdatesStateEventCheckCompleteWithUpdate(manifest: manifest)
+    case .rollBackToEmbedded(let commitTime):
+      event = UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime)
+    case .error(let error):
+      event = UpdatesStateEventCheckError(message: error.localizedDescription)
+    }
+    self.procedureContext.processStateEvent(event)
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didStartLoadingUpdate update: Update?) {
+    logger.info(message: "AppController appLoaderTask didStartLoadingUpdate", code: .none, updateId: update?.loggingId(), assetId: nil)
+    self.procedureContext.processStateEvent(UpdatesStateEventDownload())
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didFinishWithLauncher launcher: AppLauncher, isUpToDate: Bool) {
+    let logMessage = String(
+      format: "AppController appLoaderTask didFinishWithLauncher, isUpToDate=%d, remoteLoadStatus=%ld",
+      isUpToDate,
+      remoteLoadStatus.rawValue
+    )
+    logger.info(message: logMessage)
+
+    // if isUpToDate is false, that means a remote update is still loading in the background (this
+    // method was called with a cached update because the timer ran out) so don't update the status
+
+    if remoteLoadStatus == .Loading && isUpToDate {
+      remoteLoadStatus = .Idle
+    }
+
+    self.launcher = launcher
+
+    delegate?.startupProcedureDidLaunch(self)
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didLoadAsset asset: UpdateAsset, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) {
+    let body = [
+      "assetInfo": [
+        "name": asset.filename,
+        "successfulAssetCount": successfulAssetCount,
+        "failedAssetCount": failedAssetCount,
+        "totalAssetCount": totalAssetCount
+      ] as [String: Any]
+    ]
+    logger.info(
+      message: "AppController appLoaderTask didLoadAsset: \(body)",
+      code: .none,
+      updateId: nil,
+      assetId: asset.contentHash
+    )
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didFinishWithError error: Error) {
+    let logMessage = String(format: "AppController appLoaderTask didFinishWithError: %@", error.localizedDescription)
+    logger.error(message: logMessage, code: .updateFailedToLoad)
+    self.procedureContext.processStateEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
+    // Send legacy UpdateEvents to JS
+    delegate?.startupProcedure(self, didEmitLegacyUpdateEventForBridge: EnabledAppController.ErrorEventName, body: [
+      "message": error.localizedDescription
+    ])
+    emergencyLaunch(fatalError: error as NSError)
+  }
+
+  func appLoaderTask(
+    _: AppLoaderTask,
+    didFinishBackgroundUpdateWithStatus status: BackgroundUpdateStatus,
+    update: Update?,
+    error: Error?
+  ) {
+    switch status {
+    case .error:
+      remoteLoadStatus = .Idle
+      guard let error = error else {
+        preconditionFailure("Background update with error status must have a nonnull error object")
+      }
+      logger.error(
+        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=Error",
+        code: .updateFailedToLoad,
+        updateId: update?.loggingId(),
+        assetId: nil
+      )
+      // Since errors can happen through a number of paths, we do these checks
+      // to make sure the state machine is valid
+      if self.procedureContext.getCurrentState() == .checking {
+        self.procedureContext.processStateEvent(UpdatesStateEventCheckError(message: error.localizedDescription))
+      } else if self.procedureContext.getCurrentState() == .downloading {
+        // .downloading
+        self.procedureContext.processStateEvent(UpdatesStateEventDownloadError(message: error.localizedDescription))
+      }
+      // Send UpdateEvents to JS
+      delegate?.startupProcedure(self, didEmitLegacyUpdateEventForBridge: EnabledAppController.ErrorEventName, body: [
+        "message": error.localizedDescription
+      ])
+    case .updateAvailable:
+      remoteLoadStatus = .NewUpdateLoaded
+      guard let update = update else {
+        preconditionFailure("Background update with error status must have a nonnull update object")
+      }
+      logger.info(
+        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=NewUpdateLoaded",
+        code: .none,
+        updateId: update.loggingId(),
+        assetId: nil
+      )
+      self.procedureContext.processStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+      // Send UpdateEvents to JS
+      delegate?.startupProcedure(self, didEmitLegacyUpdateEventForBridge: EnabledAppController.UpdateAvailableEventName, body: [
+        "manifest": update.manifest.rawManifestJSON()
+      ])
+    case .noUpdateAvailable:
+      remoteLoadStatus = .Idle
+      logger.info(
+        message: "AppController appLoaderTask didFinishBackgroundUpdateWithStatus=NoUpdateAvailable",
+        code: .noUpdatesAvailable,
+        updateId: update?.loggingId(),
+        assetId: nil
+      )
+      // TODO: handle rollbacks properly, but this works for now
+      if self.procedureContext.getCurrentState() == .downloading {
+        self.procedureContext.processStateEvent(UpdatesStateEventDownloadComplete())
+      }
+      // Otherwise, we don't need to call the state machine here, it already transitioned to .checkCompleteUnavailable
+      // Send UpdateEvents to JS
+      delegate?.startupProcedure(self, didEmitLegacyUpdateEventForBridge: EnabledAppController.NoUpdateAvailableEventName, body: [:])
+    }
+
+    errorRecovery.notify(newRemoteLoadStatus: remoteLoadStatus)
+  }
+
+  func appLoaderTaskDidFinishAllLoading(_: AppLoaderTask) {
+    self.procedureContext.onComplete()
+  }
+
+  // MARK: - ErrorRecoveryDelegate
+
+  func relaunch(completion: @escaping (Error?, Bool) -> Void) {
+    delegate?.startupProcedure(self, errorRecoveryDidRequestRelaunchWithCompletion: completion)
+  }
+
+  func loadRemoteUpdate() {
+    if let loaderTask = loaderTask, loaderTask.isRunning {
+      return
+    }
+
+    remoteLoadStatus = .Loading
+
+    let remoteAppLoader = RemoteAppLoader(
+      config: config,
+      database: database,
+      directory: self.updatesDirectory,
+      launchedUpdate: launchedUpdate(),
+      completionQueue: controllerQueue
+    )
+    remoteAppLoader.loadUpdate(
+      fromURL: config.updateUrl
+    ) { updateResponse in
+      if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
+        switch updateDirective {
+        case is NoUpdateAvailableUpdateDirective:
+          return false
+        case is RollBackToEmbeddedUpdateDirective:
+          return false
+        default:
+          NSException(name: .internalInconsistencyException, reason: "Unhandled update directive type").raise()
+          return false
+        }
+      }
+
+      guard let update = updateResponse.manifestUpdateResponsePart?.updateManifest else {
+        return false
+      }
+
+      return self.selectionPolicy.shouldLoadNewUpdate(
+        update,
+        withLaunchedUpdate: self.launchedUpdate(),
+        filters: updateResponse.responseHeaderData?.manifestFilters
+      )
+    } asset: { _, _, _, _ in
+      // do nothing for now
+    } success: { updateResponse in
+      self.remoteLoadStatus = updateResponse != nil ? .NewUpdateLoaded : .Idle
+      self.errorRecovery.notify(newRemoteLoadStatus: self.remoteLoadStatus)
+    } error: { error in
+      self.logger.error(message: "AppController loadRemoteUpdate error: \(error.localizedDescription)", code: .updateFailedToLoad)
+      self.remoteLoadStatus = .Idle
+      self.errorRecovery.notify(newRemoteLoadStatus: self.remoteLoadStatus)
+    }
+  }
+
+  func markFailedLaunchForLaunchedUpdate() {
+    if isEmergencyLaunch {
+      return
+    }
+
+    database.databaseQueue.async {
+      guard let launchedUpdate = self.launchedUpdate() else {
+        return
+      }
+
+      self.logger.error(
+        message: "AppController markFailedLaunchForUpdate",
+        code: .unknown,
+        updateId: launchedUpdate.loggingId(),
+        assetId: nil
+      )
+      do {
+        try self.database.incrementFailedLaunchCountForUpdate(launchedUpdate)
+      } catch {
+        NSLog("Unable to mark update as failed in the local DB: %@", error.localizedDescription)
+      }
+    }
+  }
+
+  func markSuccessfulLaunchForLaunchedUpdate() {
+    if isEmergencyLaunch {
+      return
+    }
+
+    database.databaseQueue.async {
+      guard let launchedUpdate = self.launchedUpdate() else {
+        return
+      }
+
+      do {
+        try self.database.incrementSuccessfulLaunchCountForUpdate(launchedUpdate)
+      } catch {
+        NSLog("Failed to increment successful launch count for update: %@", error.localizedDescription)
+      }
+    }
+  }
+
+  func throwException(_ exception: NSException) {
+    exception.raise()
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineProcedure.swift
@@ -1,0 +1,83 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+internal class StateMachineProcedureContext {
+  private let processStateEventCallback: (_ event: UpdatesStateEvent) -> Void
+  private let getCurrentStateCallback: () -> UpdatesStateValue
+  private let resetStateCallback: () -> Void
+
+  required init(
+    processStateEventCallback: @escaping (_ event: UpdatesStateEvent) -> Void,
+    getCurrentStateCallback: @escaping () -> UpdatesStateValue,
+    resetStateCallback: @escaping () -> Void
+  ) {
+    self.processStateEventCallback = processStateEventCallback
+    self.getCurrentStateCallback = getCurrentStateCallback
+    self.resetStateCallback = resetStateCallback
+  }
+
+  /**
+   Transition the state machine forward to a new state.
+   */
+  func processStateEvent(_ event: UpdatesStateEvent) {
+    self.processStateEventCallback(event)
+  }
+
+  /**
+   Get the current state.
+   */
+  @available(*, deprecated, message: "Avoid needing to access current state to know how to transition to next state")
+  func getCurrentState() -> UpdatesStateValue {
+    return getCurrentStateCallback()
+  }
+
+  /**
+   Reset the machine to its starting state. Should only be called after the app restarts (reloadAsync()).
+   */
+  func resetState() {
+    self.resetStateCallback()
+  }
+}
+
+final class ProcedureContext: StateMachineProcedureContext {
+  private let onCompleteCallback: () -> Void
+
+  required init(
+    processStateEventCallback: @escaping (UpdatesStateEvent) -> Void,
+    getCurrentStateCallback: @escaping () -> UpdatesStateValue,
+    resetStateCallback: @escaping () -> Void,
+    onCompleteCallback: @escaping () -> Void
+  ) {
+    self.onCompleteCallback = onCompleteCallback
+    super.init(
+      processStateEventCallback: processStateEventCallback,
+      getCurrentStateCallback: getCurrentStateCallback,
+      resetStateCallback: resetStateCallback
+    )
+  }
+
+  @available(*, unavailable)
+  required init(
+    processStateEventCallback: @escaping (_ event: UpdatesStateEvent) -> Void,
+    getCurrentStateCallback: @escaping () -> UpdatesStateValue,
+    resetStateCallback: @escaping () -> Void
+  ) {
+    fatalError("init(processStateEventCallback:getCurrentStateCallback:resetStateCallback:) has not been implemented")
+  }
+
+  /**
+   Must be called when the StateMachineProcedure is done updating the state machine. Usually
+   at the end of work in the run method.
+   */
+  func onComplete() {
+    self.onCompleteCallback()
+  }
+}
+
+/**
+ Base class for all procedures that transition or reset state on the UpdatesStateMachine.
+ State machine state may only be mutated in subclasses of this class to ensure serial
+ (well-defined) ordering of state transitions.
+ */
+protocol StateMachineProcedure {
+  func run(procedureContext: ProcedureContext)
+}

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineSerialExecutorQueue.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineSerialExecutorQueue.swift
@@ -1,0 +1,90 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+private final class MethodInvocationHolder {
+  private let procedure: StateMachineProcedure
+  private let onMethodInvocationComplete: (_ invocationHolder: MethodInvocationHolder) -> Void
+
+  init(procedure: StateMachineProcedure, onMethodInvocationComplete: @escaping (_ invocationHolder: MethodInvocationHolder) -> Void) {
+    self.procedure = procedure
+    self.onMethodInvocationComplete = onMethodInvocationComplete
+  }
+
+  func execute(stateMachineProcedureContext: StateMachineProcedureContext) {
+    var isCompleted = false
+
+    procedure.run(procedureContext: ProcedureContext(
+      processStateEventCallback: { event in
+        assert(!isCompleted, "Cannot set state after procedure completion")
+        stateMachineProcedureContext.processStateEvent(event)
+      },
+      getCurrentStateCallback: {
+        assert(!isCompleted, "Cannot get state after procedure completion")
+        return stateMachineProcedureContext.getCurrentState()
+      },
+      resetStateCallback: {
+        assert(!isCompleted, "Cannot reset state after procedure completion")
+        stateMachineProcedureContext.resetState()
+      },
+      onCompleteCallback: {
+        isCompleted = true
+        self.onMethodInvocationComplete(self)
+      }
+    ))
+  }
+}
+
+/**
+ A serial task queue, where each task is an asynchronous task. Guarantees that all queued tasks
+ are run sequentially.
+ */
+final class StateMachineSerialExecutorQueue {
+  private let stateMachineProcedureContext: StateMachineProcedureContext
+
+  required init(stateMachineProcedureContext: StateMachineProcedureContext) {
+    self.stateMachineProcedureContext = stateMachineProcedureContext
+  }
+
+  private var internalQueue: [MethodInvocationHolder] = []
+  private var currentMethodInvocation: MethodInvocationHolder?
+
+  /**
+   Queue a procedure for execution.
+   */
+  func queueExecution(stateMachineProcedure: StateMachineProcedure) {
+    internalQueue.append(MethodInvocationHolder(
+      procedure: stateMachineProcedure,
+      onMethodInvocationComplete: { invocationHolder in
+        assert(self.currentMethodInvocation === invocationHolder)
+        self.currentMethodInvocation = nil
+        self.maybeProcessQueue()
+      }
+    ))
+
+    maybeProcessQueue()
+  }
+
+  private let dispatchQueue = DispatchQueue(label: "expo.statemachine.serialexecutorqueue")
+
+  private func maybeProcessQueue() {
+    dispatchQueue.sync {
+      if currentMethodInvocation != nil {
+        return
+      }
+
+      guard let nextMethodInvocation = internalQueue.dequeue() else {
+        return
+      }
+      currentMethodInvocation = nextMethodInvocation
+      nextMethodInvocation.execute(stateMachineProcedureContext: stateMachineProcedureContext) // need to make sure this is asynchronous
+    }
+  }
+}
+
+internal extension Array where Element: Any {
+  mutating func dequeue() -> Element? {
+    guard !self.isEmpty else {
+      return nil
+    }
+    return self.removeFirst()
+  }
+}

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -24,7 +24,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let testStateChangeDelegate = TestStateChangeDelegate()
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
-        expect(machine.state) == .idle
+        expect(machine.getStateForTesting()) == .idle
       }
 
       it("should handle check and checkCompleteAvailable") {
@@ -32,14 +32,14 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
 
-        machine.processEvent(UpdatesStateEventCheck())
-        expect(machine.state) == .checking
+        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.getStateForTesting()) == .checking
         expect(testStateChangeDelegate.lastEventType) == .check
 
-        machine.processEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: [
+        machine.processEventForTesting(UpdatesStateEventCheckCompleteWithUpdate(manifest: [
           "updateId": "0000-xxxx"
         ]))
-        expect(machine.state) == .idle
+        expect(machine.getStateForTesting()) == .idle
         expect(machine.context.isChecking) == false
         expect(machine.context.checkError).to(beNil())
         expect(machine.context.latestManifest?["updateId"] as? String ?? "") == "0000-xxxx"
@@ -55,11 +55,11 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
 
-        machine.processEvent(UpdatesStateEventCheck())
-        expect(machine.state) == .checking
+        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.getStateForTesting()) == .checking
 
-        machine.processEvent(UpdatesStateEventCheckComplete())
-        expect(machine.state) == .idle
+        machine.processEventForTesting(UpdatesStateEventCheckComplete())
+        expect(machine.getStateForTesting()) == .idle
         expect(machine.context.isChecking) == false
         expect(machine.context.checkError).to(beNil())
         expect(machine.context.latestManifest).to(beNil())
@@ -72,13 +72,13 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
 
-        machine.processEvent(UpdatesStateEventDownload())
-        expect(machine.state) == .downloading
+        machine.processEventForTesting(UpdatesStateEventDownload())
+        expect(machine.getStateForTesting()) == .downloading
 
-        machine.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
+        machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
           "updateId": "0000-xxxx"
         ]))
-        expect(machine.state) == .idle
+        expect(machine.getStateForTesting()) == .idle
         expect(machine.context.isChecking) == false
         expect(machine.context.downloadError).to(beNil())
         expect(machine.context.latestManifest?["updateId"] as? String ?? "") == "0000-xxxx"
@@ -93,11 +93,11 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
         let commitTime = Date()
-        machine.processEvent(UpdatesStateEventCheck())
-        expect(machine.state) == .checking
+        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.getStateForTesting()) == .checking
 
-        machine.processEvent(UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime))
-        expect(machine.state) == .idle
+        machine.processEventForTesting(UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime))
+        expect(machine.getStateForTesting()) == .idle
         expect(machine.context.isChecking) == false
         expect(machine.context.checkError).to(beNil())
         expect(machine.context.latestManifest).to(beNil())
@@ -111,8 +111,8 @@ class UpdatesStateMachineSpec: ExpoSpec {
         let machine = UpdatesStateMachine()
         machine.changeEventDelegate = testStateChangeDelegate
 
-        machine.processEvent(UpdatesStateEventCheck())
-        expect(machine.state) == .checking
+        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.getStateForTesting()) == .checking
         // Reset the test delegate
         testStateChangeDelegate.lastEventBody = nil
         testStateChangeDelegate.lastEventType = nil
@@ -120,33 +120,33 @@ class UpdatesStateMachineSpec: ExpoSpec {
         // In .checking state, download events should be ignored,
         // state should not change, context should not change,
         // no events should be sent to JS
-        machine.processEvent(UpdatesStateEventDownload())
+        machine.processEventForTesting(UpdatesStateEventDownload())
 
-        expect(machine.state) == .checking
+        expect(machine.getStateForTesting()) == .checking
         expect(testStateChangeDelegate.lastEventType).to(beNil())
         expect(testStateChangeDelegate.lastEventBody).to(beNil())
 
-        machine.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
+        machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
           "updateId": "0000-xxxx"
         ]))
 
-        expect(machine.state) == .checking
+        expect(machine.getStateForTesting()) == .checking
         expect(machine.context.downloadedManifest).to(beNil())
 
-        machine.reset() // go back to .idle
+        machine.resetForTesting() // go back to .idle
 
-        machine.processEvent(UpdatesStateEventRestart())
-        expect(machine.state) == .restarting
+        machine.processEventForTesting(UpdatesStateEventRestart())
+        expect(machine.getStateForTesting()) == .restarting
 
         // If restarting, all events should be ignored
-        machine.processEvent(UpdatesStateEventCheck())
-        expect(machine.state) == .restarting
+        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.getStateForTesting()) == .restarting
 
-        machine.processEvent(UpdatesStateEventDownload())
-        expect(machine.state) == .restarting
+        machine.processEventForTesting(UpdatesStateEventDownload())
+        expect(machine.getStateForTesting()) == .restarting
 
-        machine.processEvent(UpdatesStateEventDownloadComplete())
-        expect(machine.state) == .restarting
+        machine.processEventForTesting(UpdatesStateEventDownloadComplete())
+        expect(machine.getStateForTesting()) == .restarting
       }
     }
   }


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/25386.

# How

Same strategy as android.

# Test Plan

Same as android.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
