### PR TITLE
chore: Make updates-e2e tests only bundle for the platform they're testing

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -67,9 +67,6 @@ jobs:
       - name: 🔎 Type Check CLI
         run: yarn typecheck
         working-directory: packages/@expo/cli
-      - name: 🛠 Build CLI
-        run: yarn prepare
-        working-directory: packages/@expo/cli
       - name: E2E Test CLI
         run: yarn test:e2e
         working-directory: packages/@expo/cli

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -72,9 +72,6 @@ jobs:
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🛠 Build local Expo CLI
-        working-directory: packages/@expo/cli
-        run: yarn prepare
       - name: Build expo-updates CLI
         working-directory: packages/expo-updates
         run: yarn build:cli

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -42,7 +42,7 @@ if [ -f "keys.tar" ]; then
 fi
 
 # Generate test bundles
-yarn generate-test-update-bundles
+yarn generate-test-update-bundles $EAS_BUILD_PLATFORM
 
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   # Start emulator

--- a/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
@@ -59,19 +59,19 @@ async function createTestUpdateBundles(
       'utf-8'
     );
     const manifest = JSON.parse(manifestJsonString);
-    const iosBundlePath = path.join(projectRoot, 'dist', manifest.fileMetadata.ios.bundle);
-    const androidBundlePath = path.join(projectRoot, 'dist', manifest.fileMetadata.android.bundle);
-    const iosBundleDestPath = path.join(testUpdateBundlesPath, path.basename(iosBundlePath));
-    const androidBundleDestPath = path.join(
-      testUpdateBundlesPath,
-      path.basename(androidBundlePath)
-    );
-    await fs.copyFile(iosBundlePath, iosBundleDestPath);
-    await fs.copyFile(androidBundlePath, androidBundleDestPath);
-    testUpdateJson[notifyString] = {
-      ios: path.basename(iosBundlePath),
-      android: path.basename(androidBundlePath),
-    };
+
+    const platforms = platform ? [platform] : ['ios', 'android'];
+
+    if (!testUpdateJson[notifyString]) {
+      testUpdateJson[notifyString] = {};
+    }
+
+    for (const platform of platforms) {
+      const bundlePath = path.join(projectRoot, 'dist', manifest.fileMetadata[platform].bundle);
+      const bundleDestPath = path.join(testUpdateBundlesPath, path.basename(bundlePath));
+      await fs.copyFile(bundlePath, bundleDestPath);
+      testUpdateJson[notifyString][platform] = path.basename(bundlePath);
+    }
   }
   const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
   await fs.writeFile(testUpdateBundlesJsonPath, JSON.stringify(testUpdateJson, null, 2), 'utf-8');

--- a/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
@@ -14,7 +14,9 @@ const notifyStrings = [
   'test-assets-1',
 ];
 
-createTestUpdateBundles(projectRoot, notifyStrings);
+const platform = process.argv[2];
+
+createTestUpdateBundles(projectRoot, notifyStrings, platform);
 
 ///////////////////////////////////////////////////////////////
 
@@ -25,9 +27,13 @@ createTestUpdateBundles(projectRoot, notifyStrings);
  * Since Hermes bundles are bytecode and not readable JS, we instead pre-generate Hermes bundles
  * corresponding to each test case, and save them in the `test-update-bundles` directory in the test app.
  */
-async function createTestUpdateBundles(projectRoot: string, notifyStrings: string[]) {
+async function createTestUpdateBundles(
+  projectRoot: string,
+  notifyStrings: string[],
+  platform?: string
+) {
   // export update for test server to host
-  await createUpdateBundleAsync(projectRoot);
+  await createUpdateBundleAsync(projectRoot, platform);
 
   // move exported update to "updates" directory for EAS testing
   await fs.rm(path.join(projectRoot, 'updates'), { recursive: true, force: true });
@@ -47,7 +53,7 @@ async function createTestUpdateBundles(projectRoot: string, notifyStrings: strin
     );
     await fs.rm(appJsPath);
     await fs.writeFile(appJsPath, modifiedAppJs, 'utf-8');
-    await createUpdateBundleAsync(projectRoot);
+    await createUpdateBundleAsync(projectRoot, platform);
     const manifestJsonString = await fs.readFile(
       path.join(projectRoot, 'dist', 'metadata.json'),
       'utf-8'
@@ -74,9 +80,13 @@ async function createTestUpdateBundles(projectRoot: string, notifyStrings: strin
   console.log('Done creating test bundles');
 }
 
-async function createUpdateBundleAsync(projectRoot: string) {
+async function createUpdateBundleAsync(projectRoot: string, platform?: string) {
   await fs.rm(path.join(projectRoot, 'dist'), { force: true, recursive: true });
-  await spawnAsync('npx', ['expo', 'export'], {
+  const args = ['expo', 'export'];
+  if (platform) {
+    args.push('--platform', platform);
+  }
+  await spawnAsync('npx', args, {
     cwd: projectRoot,
     stdio: 'inherit',
   });


### PR DESCRIPTION
# Why

Attempt to shave a minute or more from the core duration of the updates e2e tests.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Pass `$EAS_BUILD_PLATFORM` to expo export to skip bundling for unused platforms. We bundle many times in a workflow so this adds up, just the transformation time looks like this:

```
iOS Bundling complete 12074ms
iOS Bundling complete 7226ms
iOS Bundling complete 7420ms
iOS Bundling complete 7358ms
iOS Bundling complete 7446ms
iOS Bundling complete 7428ms
iOS Bundling complete 7532ms
iOS Bundling complete 7419ms
```

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tests should pass and shouldn't bundle unused platforms.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
