### PR TITLE
fix(cli): prebuild log spinner spam when running prebuild in debug mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent log-spew when running prebuild in debug mode.
+- Prevent log-spew when running prebuild in debug mode. ([#25434](https://github.com/expo/expo/pull/25434) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent log-spew when running prebuild in debug mode.
+
 ### 💡 Others
 
 ## 0.15.0 — 2023-11-14

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -126,8 +126,18 @@ export async function prebuildAsync(
     }
   }
 
-  // Apply Expo config to native projects
-  const configSyncingStep = logNewSection('Running prebuild');
+  // Apply Expo config to native projects. Prevent log-spew from ora when running in debug mode.
+  const configSyncingStep: { succeed(text?: string): unknown; fail(text?: string): unknown } =
+    env.EXPO_DEBUG
+      ? {
+          succeed(text) {
+            Log.log(text!);
+          },
+          fail(text) {
+            Log.error(text!);
+          },
+        }
+      : logNewSection('Running prebuild');
   try {
     await profile(configureProjectAsync)(projectRoot, {
       platforms: options.platforms,


### PR DESCRIPTION
# Why

Make updates e2e CI logs easier to read.