### PR TITLE
[ci] Increase Updates E2E tests timeout to 60 min

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -52,7 +52,7 @@ jobs:
           - platform: tvos
             mode: disabled
     runs-on: ubuntu-22.04
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       UPDATES_PORT: 4747
     steps:


### PR DESCRIPTION
Why
---
We were hitting the 40 min limit and jobs were failing.
