### PR TITLE
[docs] Update error-utilities.test.ts

### DIFF
--- a/docs/common/error-utilities.test.ts
+++ b/docs/common/error-utilities.test.ts
@@ -53,10 +53,10 @@ test('adds forward slash to end of path', () => {
 });
 
 test('redirects old versions to latest', () => {
-  const redirectPath = '/versions/v32.0.0/sdk/admob/';
+  const redirectPath = '/versions/v32.0.0/sdk/camera/';
   const newPath = getRedirectPath(redirectPath);
 
-  expect(newPath).toEqual('/versions/latest/sdk/admob/');
+  expect(newPath).toEqual('/versions/latest/sdk/camera/');
 });
 
 test('redirects versionless SDK paths to new version', () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

During home and guides organization, we updated a few redirect tests cases in `error-utilties.test.ts` file.  There is one test currently that leads to the package that has been deprecated and removed from the latest SDK. The library name always throws me off.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the `redirects old versions to latest` test to refer an existing library.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run test` in the `docs` repo, and all tests should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
