### PR TITLE
[docs] Remove comma usage from example code snippet

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1308,9 +1308,9 @@ For example, to trigger a build that creates internal distribution build for And
 
 ```json eas.json
 {
-  ...,
+  /* @hide ... */ /* @end */
   "build": {
-    ...,
+    /* @hide ... */ /* @end */
     "developmentBuild": {
       "distribution": "internal",
       "android": {
@@ -1320,10 +1320,10 @@ For example, to trigger a build that creates internal distribution build for And
         "simulator": true,
         "config": "development-build-ios.yml"
       }
-    },
-    ...
-  },
-  ...
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
 }
 ```
 
@@ -1366,13 +1366,13 @@ build:
     - eas/find_and_upload_build_artifacts
 ```
 
-To create Play Store build for Android and App Store build for iOS you can use the following configuration:
+To create a Google Play Store build for Android and an Apple App Store build for iOS you can use the following configuration:
 
 ```json eas.json
 {
-  ...,
+  /* @hide ... */ /* @end */
   "build": {
-    ...,
+    /* @hide ... */ /* @end */
     "productionBuild": {
       "android": {
         "config": "production-build-android.yml"
@@ -1380,10 +1380,10 @@ To create Play Store build for Android and App Store build for iOS you can use t
       "ios": {
         "config": "production-build-ios.yml"
       }
-    },
-    ...
-  },
-  ...
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
 }
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some of the example code snippets use `...,` which is incorrect usage.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR uses `/* @hide ... */ /* @end */` in the example code snippets and also apply writing style guide for referencing app stores.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and go to http://localhost:3002/custom-builds/schema/#using-built-in-eas-functions-to-build-an-app to see the updated code snippet.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
