### PR TITLE
[docs] Add Changelog link in the top navbar

### DIFF
--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -35,8 +35,8 @@ export const Header = ({
             openInNewTab
             theme="quaternary"
             className="px-2 text-secondary"
-            href="https://blog.expo.dev">
-            Blog
+            href="https://expo.dev/changelog">
+            Changelog
           </Button>
           <Button
             openInNewTab
@@ -45,14 +45,6 @@ export const Header = ({
             className="px-2 text-secondary"
             href="https://expo.dev/mailing-list/signup">
             Newsletter
-          </Button>
-          <Button
-            openInNewTab
-            theme="quaternary"
-            css={hideOnMobileStyle}
-            className="px-2 text-secondary"
-            href="https://expo.dev/changelog">
-            Changelog
           </Button>
           <Button
             openInNewTab

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -93,7 +93,7 @@ export const Header = ({
         <div css={mobileSidebarStyle}>
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
-          <SidebarFooter isMobileMenuVisible />
+          <SidebarFooter isMobileMenuVisible={isMobileMenuVisible} />
         </div>
       )}
     </>

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -93,7 +93,7 @@ export const Header = ({
         <div css={mobileSidebarStyle}>
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
-          <SidebarFooter />
+          <SidebarFooter isMobileMenuVisible />
         </div>
       )}
     </>

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -43,6 +43,22 @@ export const Header = ({
             theme="quaternary"
             css={hideOnMobileStyle}
             className="px-2 text-secondary"
+            href="https://expo.dev/mailing-list/signup">
+            Newsletter
+          </Button>
+          <Button
+            openInNewTab
+            theme="quaternary"
+            css={hideOnMobileStyle}
+            className="px-2 text-secondary"
+            href="https://expo.dev/changelog">
+            Changelog
+          </Button>
+          <Button
+            openInNewTab
+            theme="quaternary"
+            css={hideOnMobileStyle}
+            className="px-2 text-secondary"
             leftSlot={<Star01Icon className="icon-sm" />}
             href="https://github.com/expo/expo">
             Star Us on GitHub

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -35,16 +35,16 @@ export const Header = ({
             openInNewTab
             theme="quaternary"
             className="px-2 text-secondary"
-            href="https://expo.dev/changelog">
-            Changelog
+            href="https://blog.expo.dev">
+            Blog
           </Button>
           <Button
             openInNewTab
             theme="quaternary"
             css={hideOnMobileStyle}
             className="px-2 text-secondary"
-            href="https://expo.dev/mailing-list/signup">
-            Newsletter
+            href="https://expo.dev/changelog">
+            Changelog
           </Button>
           <Button
             openInNewTab

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -7,7 +7,11 @@ import { ArchiveIcon } from './icons/Archive';
 
 import { getPageSection } from '~/common/routes';
 
-export const SidebarFooter = () => {
+type SideBarFooterProps = {
+  isMobileMenuVisible: boolean;
+};
+
+export const SidebarFooter = ({ isMobileMenuVisible }: SideBarFooterProps) => {
   const router = useRouter();
   const isArchive = router?.pathname ? getPageSection(router.pathname) === 'archive' : false;
   return (
@@ -34,6 +38,15 @@ export const SidebarFooter = () => {
         isExternal
         shouldLeakReferrer
       />
+      {isMobileMenuVisible && (
+        <SidebarSingleEntry
+          secondary
+          href="https://expo.dev/changelog"
+          title="Changelog"
+          Icon={ChangelogIcon}
+          isExternal
+        />
+      )}
       <SidebarSingleEntry
         secondary
         href="https://expo.dev/mailing-list/signup"

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -36,13 +36,6 @@ export const SidebarFooter = () => {
       />
       <SidebarSingleEntry
         secondary
-        href="https://expo.dev/changelog"
-        title="Changelog"
-        Icon={ChangelogIcon}
-        isExternal
-      />
-      <SidebarSingleEntry
-        secondary
         href="https://expo.dev/mailing-list/signup"
         title="Newsletter"
         Icon={Mail01Icon}

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -8,7 +8,7 @@ import { ArchiveIcon } from './icons/Archive';
 import { getPageSection } from '~/common/routes';
 
 type SideBarFooterProps = {
-  isMobileMenuVisible: boolean;
+  isMobileMenuVisible?: boolean;
 };
 
 export const SidebarFooter = ({ isMobileMenuVisible }: SideBarFooterProps) => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

@brentvatne mentioned we should have Newsletter and Changelog links in the docs top menu bar since they are easily missed in the Docs side footer bar. This will help us drive more engagement to those pages and also make them more visible since the docs site is an integral part of our users' experience.

Also, closes ENG-10583

### Update

- Since we'll have a our own blog soon, decided against to remove the blog link from top navbar. Added the Changelog link:

![CleanShot 2023-11-29 at 00 51 34](https://github.com/expo/expo/assets/10234615/d68525bf-1b09-4d22-839b-0f260d4f36b6)

- Removed the Changelog link from the sidebar footer and only show it in the sidebar footer from mobile view

![CleanShot 2023-11-29 at 00 53 42](https://github.com/expo/expo/assets/10234615/f45319b6-9ae4-42ab-9580-df7143f11166)

- Didn't remove the Newsletter link or added it to the top nav bar since #25604 PR will add the Newsletter form on every docs page and also remove it from the sidebar footer

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace Changelog with Blog.

Add Changelog link in the top nav bar for only desktop view. This button is hidden on mobile view (since on mobile the sidebar has to be toggled, folks can still use the existing links in the sidebar footer).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
