### PR TITLE
[metro-config] add missing dependency

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing dependency. ([#25446](https://github.com/expo/expo/pull/25446) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.15.0 — 2023-11-14

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -42,6 +42,7 @@
     "getenv": "^1.0.0",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "~1.19.0",
+    "path-to-regexp": "~1.8.0",
     "postcss": "~8.4.21",
     "resolve-from": "^5.0.0",
     "sucrase": "^3.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15374,7 +15374,7 @@ path-to-regexp@2.2.1:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
   integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
-path-to-regexp@^1.7.0, path-to-regexp@^1.8.0:
+path-to-regexp@^1.7.0, path-to-regexp@^1.8.0, path-to-regexp@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==


### PR DESCRIPTION
# Why

Changes in #25369 in metro-config have broken `npx expo export` and therefore `eas update`, due to a new reference to the `path-to-regexp` module.

# How

Add the correct dependency in `@expo/metro-config`.

# Test Plan

Manual testing with an app generated with `packages/expo-updates/e2e/setup/create-updates-test.ts`, to verify that `eas update` works again.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
