### PR TITLE
[docs] Add logout step to SSO transition process so you're not confused when the SSO login page redirects you

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -57,7 +57,8 @@ Both new organizations and existing organizations can enable SSO as a sign in op
 Regular users may be a member of one or many personal, team, and organization accounts while SSO users belong exclusively to their organization account. Thus, existing users cannot be directly converted into SSO users. However, a regular user that's already a member of your organization may create a second user by going to the [SSO login page](https://expo.dev/sso-login). Then, their regular user can be removed from the organization.
 
 To transition from using a regular Expo account to an SSO account, follow these steps:
-1. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.
+1. Check if you're already logged in at [expo.dev](https://expo.dev). If so, log out.
+2. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.
 2. By default, your new SSO user will have the View Only role. If you need a different role, ask an Admin or Owner to update your role in [member settings](https://expo.dev/accounts/[account]/settings/members).
 3. Run `eas login --sso` to switch to your new account on the CLI.
 4. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -58,7 +58,7 @@ Regular users may be a member of one or many personal, team, and organization ac
 
 To transition from using a regular Expo account to an SSO account, follow these steps:
 1. Check if you're already logged in at [expo.dev](https://expo.dev). If so, log out.
-2. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, entering your organization name, creating a new Expo username, and logging in to your identity provider.
+2. Go to the [SSO login page](https://expo.dev/sso-login) and follow the prompts, such as entering your organization name, creating a new Expo username, and logging in to your identity provider.
 2. By default, your new SSO user will have the View Only role. If you need a different role, ask an Admin or Owner to update your role in [member settings](https://expo.dev/accounts/[account]/settings/members).
 3. Run `eas login --sso` to switch to your new account on the CLI.
 4. At this time, the Admin or Owner can remove your old user from the organization. In [member settings](https://expo.dev/accounts/[account]/settings/members), the list of organization members indicates whether a user is an SSO or non-SSO user. The Admin or Owner can click the dropdown next to the old user and click **Remove member**.


### PR DESCRIPTION
# Why
Found one more hitch when testing this out. It sounds basic, but there's no feedback when going to the SSO login page but you're already logged in. I'll suggest a change to tweak this, but in the meantime, we should document it.

# How
Added a step.