### PR TITLE
[docs] Note that SSO Expo CLI support only in 50+

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -22,7 +22,7 @@ SSO is available for [Enterprise Plan](https://expo.dev/pricing) customers. To g
 
 ### Expo CLI
 
-> Available from SDK 50. For previous versions, the Expo CLI will use your SSO account after logging in via the EAS CLI.
+> Only available with SDK 50+. For previous versions, the Expo CLI will use your SSO account after logging in via the EAS CLI.
 
 When using the Expo CLI, you can run the following command to log in to your Expo account.
 

--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -22,6 +22,8 @@ SSO is available for [Enterprise Plan](https://expo.dev/pricing) customers. To g
 
 ### Expo CLI
 
+> Available from SDK 50. For previous versions, the Expo CLI will use your SSO account after logging in via the EAS CLI.
+
 When using the Expo CLI, you can run the following command to log in to your Expo account.
 
 <Terminal cmd={["$ npx expo login --sso"]} />


### PR DESCRIPTION
# Why
Per conversation with @wschurman, we will not cherry pick this to SDK 49.

Thought about removing the reference to the Expo CLI entirely, but figured some folks might wonder how SSO login even works with the Expo CLI.

