### PR TITLE
[docs] Clarify what causes EAS Build to run / not run Prebuild

### DIFF
--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -24,7 +24,7 @@ We highly recommend using prebuild for the reasons listed in the [pitch](#pitch)
 
 ### Usage with EAS Build
 
-If your project does not contain **android** and **ios** directories, EAS Build will run Prebuild to generate these native directories before compilation. This is the default for any project created from `npx create-expo-app`.
+If your project does not contain **android** and **ios** directories, EAS Build will run Prebuild to generate these native directories before compilation. This is the default behavior for any project created using `npx create-expo-app`.
 
 For a project that has **android** and **ios** directories, EAS Build will not run Prebuild by default to avoid overwriting any changes you've made to the native directories.
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -24,7 +24,16 @@ We highly recommend using prebuild for the reasons listed in the [pitch](#pitch)
 
 ### Usage with EAS Build
 
-You can configure EAS Build to run `npx expo prebuild` before building by [using the managed preset](/build-reference/ios-builds/).
+If your project does not contain **ios** and **android** folders, then EAS Build will run Prebuild to generate your native code just before compilation. This is the default for any project started from `npx create-expo-app`.
+
+If you have a project that contains **android** and **ios** folders, then EAS Build will not run Prebuild by default in order to avoid overwriting any changes you've made to your native code.
+
+If you sometimes run `npx expo prebuild`, `npx expo run:android`, or `npx expo run:ios` locally to troubleshoot your native code but still want EAS Build to continue running Prebuild to generate fresh native projects during build, then you should add the **android** and **ios** folders to your **.gitignore** or **.easignore** files:
+
+  ```diff .gitignore
+  + android
+  + ios
+  ```
 
 ### Usage with Expo CLI run commands
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -26,7 +26,7 @@ We highly recommend using prebuild for the reasons listed in the [pitch](#pitch)
 
 If your project does not contain **android** and **ios** directories, EAS Build will run Prebuild to generate these native directories before compilation. This is the default for any project created from `npx create-expo-app`.
 
-If you have a project that contains **android** and **ios** folders, then EAS Build will not run Prebuild by default in order to avoid overwriting any changes you've made to your native code.
+For a project that has **android** and **ios** directories, EAS Build will not run Prebuild by default to avoid overwriting any changes you've made to the native directories.
 
 If you sometimes run `npx expo prebuild`, `npx expo run:android`, or `npx expo run:ios` locally to troubleshoot your native code but still want EAS Build to continue running Prebuild to generate fresh native projects during build, then you should add the **android** and **ios** folders to your **.gitignore** or **.easignore** files:
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -24,7 +24,7 @@ We highly recommend using prebuild for the reasons listed in the [pitch](#pitch)
 
 ### Usage with EAS Build
 
-If your project does not contain **ios** and **android** folders, then EAS Build will run Prebuild to generate your native code just before compilation. This is the default for any project started from `npx create-expo-app`.
+If your project does not contain **android** and **ios** directories, EAS Build will run Prebuild to generate these native directories before compilation. This is the default for any project created from `npx create-expo-app`.
 
 If you have a project that contains **android** and **ios** folders, then EAS Build will not run Prebuild by default in order to avoid overwriting any changes you've made to your native code.
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -28,7 +28,7 @@ If your project does not contain **android** and **ios** directories, EAS Build 
 
 For a project that has **android** and **ios** directories, EAS Build will not run Prebuild by default to avoid overwriting any changes you've made to the native directories.
 
-If you sometimes run `npx expo prebuild`, `npx expo run:android`, or `npx expo run:ios` locally to troubleshoot your native code but still want EAS Build to continue running Prebuild to generate fresh native projects during build, then you should add the **android** and **ios** folders to your **.gitignore** or **.easignore** files:
+If you troubleshoot your app by [compiling it locally](/guides/local-app-development/#local-app-compilation) (running `npx expo prebuild`, or `npx expo run:android` or `npx expo run:ios`), you can still use Prebuild with EAS Build to generate fresh native directories during the build process. In this scenario, add the **android** and **ios** directories to **.gitignore** or **.easignore** files:
 
   ```diff .gitignore
   + android


### PR DESCRIPTION
# Why
I couldn't find a place where we straight-up said "if you want EAS Build to run prebuild, don't commit your android / ios folders". This doc mentioned a managed preset that I've never heard of and don't think is a thing anymore.

# How
Updated the Usage with EAS Build section to say what I tell folks with support questions over and over and over again.