### PR TITLE
[tools] Publishing canary versions

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -40,6 +40,26 @@ export type ProfileType = null | {
 };
 
 /**
+ * Represents an object returned by `npm pack --json`.
+ */
+export type PackResult = {
+  id: string;
+  name: string;
+  version: string;
+  size: number;
+  unpackedSize: number;
+  shasum: string;
+  integrity: string;
+  filename: string;
+  files: {
+    path: string;
+    size: number;
+    mode: number;
+  }[];
+  entryCount: number;
+};
+
+/**
  * Runs `npm view` for package with given name. Returns null if package is not published yet.
  */
 export async function getPackageViewAsync(
@@ -89,22 +109,44 @@ export async function downloadPackageTarballAsync(
 }
 
 /**
+ * Creates a tarball from a package.
+ */
+export async function packToTarballAsync(packageDir: string): Promise<PackResult> {
+  const [result] = await spawnJSONCommandAsync<PackResult[]>('npm', ['pack', '--json'], {
+    cwd: packageDir,
+  });
+  return result;
+}
+
+type PublishOptions = {
+  source?: string;
+  tagName?: string;
+  dryRun?: boolean;
+  spawnOptions?: SpawnOptions;
+};
+
+/**
  * Publishes a package at given directory to the global npm registry.
  */
 export async function publishPackageAsync(
   packageDir: string,
-  tagName: string = 'latest',
-  dryRun: boolean = false,
-  spawnOptions: SpawnOptions = {}
+  options: PublishOptions = {}
 ): Promise<void> {
-  const args = ['publish', '--tag', tagName, '--access', 'public'];
+  const args = [
+    'publish',
+    options.source ?? '.',
+    '--tag',
+    options.tagName ?? 'latest',
+    '--access',
+    'public',
+  ];
 
-  if (dryRun) {
+  if (options.dryRun) {
     args.push('--dry-run');
   }
   await spawnAsync('npm', args, {
     cwd: packageDir,
-    ...spawnOptions,
+    ...options.spawnOptions,
   });
 }
 

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -379,7 +379,13 @@ export async function getListOfPackagesAsync(): Promise<Package[]> {
   if (!cachedPackages) {
     const paths = await glob('**/package.json', {
       cwd: PACKAGES_DIR,
-      ignore: ['**/example/**', '**/node_modules/**', '**/__tests__/**', '**/__mocks__/**'],
+      ignore: [
+        '**/example/**',
+        '**/node_modules/**',
+        '**/__tests__/**',
+        '**/__mocks__/**',
+        '**/__fixtures__/**',
+      ],
     });
     cachedPackages = paths
       .map((packageJsonPath) => {

--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -15,6 +15,7 @@ import { checkPackagesIntegrity } from '../publish-packages/tasks/checkPackagesI
 import { grantTeamAccessToPackages } from '../publish-packages/tasks/grantTeamAccessToPackages';
 import { listUnpublished } from '../publish-packages/tasks/listUnpublished';
 import { getCachedParcel } from '../publish-packages/tasks/loadRequestedParcels';
+import { publishCanaryPipeline } from '../publish-packages/tasks/publishCanary';
 import { publishPackagesPipeline } from '../publish-packages/tasks/publishPackagesPipeline';
 import { CommandOptions, Parcel, TaskArgs, PublishBackupData } from '../publish-packages/types';
 
@@ -64,6 +65,7 @@ export default (program: Command) => {
       'Checks integrity of packages. These checks must pass to clearly identify changes that have been made since previous publish.',
       false
     )
+    .option('-C, --canary', 'Whether to publish all packages as canary versions.', false)
 
     /* debug options */
     .option(
@@ -205,6 +207,9 @@ function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
   }
   if (options.checkIntegrity) {
     return [checkPackagesIntegrity];
+  }
+  if (options.canary) {
+    return [publishCanaryPipeline];
   }
   return [publishPackagesPipeline];
 }

--- a/tools/src/publish-packages/helpers.ts
+++ b/tools/src/publish-packages/helpers.ts
@@ -31,7 +31,7 @@ export function pickBackupableOptions(options: CommandOptions): BackupableOption
  * Whether tasks backup can be used to retry previous command invocation.
  */
 export async function shouldUseBackupAsync(options: CommandOptions): Promise<boolean> {
-  if (process.env.CI) {
+  if (process.env.CI || options.canary) {
     return false;
   }
   if (options.retry) {

--- a/tools/src/publish-packages/tasks/packPackageToTarball.ts
+++ b/tools/src/publish-packages/tasks/packPackageToTarball.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import { packToTarballAsync } from '../../Npm';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { Parcel, TaskArgs } from '../types';
+import { loadRequestedParcels } from './loadRequestedParcels';
+
+/**
+ * Runs `npm pack` on each package to prepare tarballs to publish.
+ */
+export const packPackageToTarball = new Task<TaskArgs>(
+  {
+    name: 'packPackageToTarball',
+    dependsOn: [loadRequestedParcels],
+  },
+  async (parcels: Parcel[]) => {
+    return await runWithSpinner(
+      `Packing packages to tarballs`,
+      async (step) => {
+        try {
+          for (const { pkg, state } of parcels) {
+            step.start(`Packing ${chalk.green(pkg.packageName)} to tarball`);
+
+            const packResult = await packToTarballAsync(pkg.path);
+
+            state.packageTarballFilename = packResult.filename;
+          }
+          return;
+        } catch (error) {
+          step.fail();
+          logger.error(error.stderr);
+          return Task.STOP;
+        }
+      },
+      `Packed all packages to tarballs`
+    );
+  }
+);

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -1,0 +1,139 @@
+import chalk from 'chalk';
+import semver from 'semver';
+
+import Git from '../../Git';
+import logger from '../../Logger';
+import { sdkVersionAsync } from '../../ProjectVersions';
+import { Task } from '../../TasksRunner';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { checkEnvironmentTask } from './checkEnvironmentTask';
+import { loadRequestedParcels } from './loadRequestedParcels';
+import { packPackageToTarball } from './packPackageToTarball';
+import { publishPackages } from './publishPackages';
+import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
+import { updateModuleTemplate } from './updateModuleTemplate';
+import { updatePackageVersions } from './updatePackageVersions';
+import { updateWorkspaceProjects } from './updateWorkspaceProjects';
+
+const { cyan } = chalk;
+
+/**
+ * An array of packages whose version is constrained to the SDK version.
+ */
+const SDK_CONSTRAINED_PACKAGES = ['expo', 'jest-expo', '@expo/config-types'];
+
+/**
+ * Prepare packages to be published as canaries.
+ */
+export const prepareCanaries = new Task<TaskArgs>(
+  {
+    name: 'prepareCanaries',
+    dependsOn: [loadRequestedParcels],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    const canaryVersion = await generateCanaryVersion();
+    const nextSdkVersion = await getNextSdkVersion();
+
+    for (const { pkg, state, pkgView } of parcels) {
+      const version = findNextAvailableCanaryVersion(canaryVersion, pkgView?.versions ?? []);
+
+      if (SDK_CONSTRAINED_PACKAGES.includes(pkg.packageName)) {
+        state.releaseVersion = version.replace('0.0.0', nextSdkVersion);
+      } else {
+        state.releaseVersion = version;
+      }
+    }
+
+    // Override the tag option – canary releases should always use `canary` tag
+    options.tag = 'canary';
+    options.dry = true;
+  }
+);
+
+/**
+ * Pipeline with a bunch of tasks required to publish canaries.
+ */
+export const publishCanaryPipeline = new Task<TaskArgs>(
+  {
+    name: 'publishCanaryPipeline',
+    dependsOn: [
+      checkEnvironmentTask,
+      loadRequestedParcels,
+      prepareCanaries,
+      updatePackageVersions,
+      updateBundledNativeModulesFile,
+      updateModuleTemplate,
+      updateWorkspaceProjects,
+      packPackageToTarball,
+      publishPackages,
+    ],
+  },
+  async (parcels: Parcel[]) => {
+    const count = parcels.length;
+
+    logger.success(
+      `\n✅ Successfully published ${cyan.bold(count + '')} package${count > 1 ? 's' : ''}.\n`
+    );
+  }
+);
+
+/**
+ * Generates a canary version for the current date and HEAD commit hash.
+ */
+async function generateCanaryVersion() {
+  const shortCommitHash = (await Git.getHeadCommitHashAsync()).slice(0, 7);
+  const date = new Date();
+  const year = date.toLocaleString('default', {
+    year: 'numeric',
+  });
+  const month = date.toLocaleString('default', {
+    month: '2-digit',
+  });
+  const day = date.toLocaleString('default', {
+    day: '2-digit',
+  });
+
+  return `0.0.0-canary-${year}${month}${day}-${shortCommitHash}`;
+}
+
+/**
+ * Finds the next available revision if the current canary version was already published.
+ */
+function findNextAvailableCanaryVersion(
+  canaryVersion: string,
+  publishedVersions: string[]
+): string {
+  // Filter versions that start with the original version
+  const publishedCanaryVersions = publishedVersions.filter((version) => {
+    return version.startsWith(canaryVersion);
+  });
+
+  // If the original canary version was not published yet, just use it
+  if (publishedCanaryVersions.length === 0) {
+    return canaryVersion;
+  }
+
+  // Otherwise look for the next available revision number
+  for (let i = 1; i <= publishedCanaryVersions.length; i++) {
+    const canaryRevision = `${canaryVersion}-${i}`;
+
+    if (publishedCanaryVersions.includes(canaryRevision)) {
+      return canaryRevision;
+    }
+  }
+  throw new Error(`Unable to find an available canary revision for ${canaryVersion}`);
+}
+
+/**
+ * Reads the current SDK version and increments its major version following semver rules,
+ * that is, if the current version is already a prerelease, the major number stays the same.
+ */
+async function getNextSdkVersion(): Promise<string> {
+  const currentSdkVersion = await sdkVersionAsync();
+  const nextMajorVersion = semver.inc(currentSdkVersion, 'major');
+
+  if (!nextMajorVersion) {
+    throw new Error('Unable to obtain the next major SDK version');
+  }
+  return nextMajorVersion;
+}

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -1,10 +1,12 @@
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
+import fs from 'fs-extra';
 import path from 'path';
 
 import Git from '../../Git';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
+import { Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -36,13 +38,21 @@ export const publishPackages = new Task<TaskArgs>(
         `${green(pkg.packageName)} version ${cyan(state.releaseVersion!)} as ${yellow(options.tag)}`
       );
 
+      // If there is a tarball already built, use it instead of packing it again
+      const packageSource = await findPackageSource(pkg, state.packageTarballFilename);
+
       // Update `gitHead` property so it will be available to read using `npm view --json`.
       // Next publish will depend on this to properly get changes made after that.
       await JsonFile.setAsync(packageJsonPath, 'gitHead', gitHead);
 
       // Publish the package.
-      await Npm.publishPackageAsync(pkg.path, options.tag, options.dry, {
-        stdio: requiresOTP ? 'inherit' : undefined,
+      await Npm.publishPackageAsync(pkg.path, {
+        source: packageSource,
+        tagName: options.tag,
+        dryRun: options.dry,
+        spawnOptions: {
+          stdio: requiresOTP ? 'inherit' : undefined,
+        },
       });
 
       // Delete `gitHead` from `package.json` – no need to clutter it.
@@ -52,3 +62,18 @@ export const publishPackages = new Task<TaskArgs>(
     }
   }
 );
+
+/**
+ * Finds the package source to publish from. If the tarball filename is provided and the file exists, it's returned.
+ * Otherwise the source is the current directory.
+ */
+async function findPackageSource(pkg: Package, tarballFilename?: string): Promise<string> {
+  if (tarballFilename) {
+    const tarballPath = path.join(pkg.path, tarballFilename);
+
+    if (await fs.pathExists(tarballPath)) {
+      return tarballFilename;
+    }
+  }
+  return '.';
+}

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -30,6 +30,11 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
     dependsOn: [loadRequestedParcels],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    // Skip this task for canary releases
+    if (options.canary) {
+      return;
+    }
+
     // A set of parcels to prompt for.
     const parcelsToSelect = new Set<Parcel>(parcels);
 

--- a/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
+++ b/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
-import { Parcel, TaskArgs } from '../types';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { magenta, green, gray, cyan } = chalk;
@@ -20,7 +20,7 @@ export const updateBundledNativeModulesFile = new Task<TaskArgs>(
     dependsOn: [selectPackagesToPublish],
     filesToStage: ['packages/expo/bundledNativeModules.json'],
   },
-  async (parcels: Parcel[]) => {
+  async (parcels: Parcel[], options: CommandOptions) => {
     const bundledNativeModulesPath = path.join(EXPO_DIR, 'packages/expo/bundledNativeModules.json');
     const bundledNativeModules = await JsonFile.readAsync<Record<string, string>>(
       bundledNativeModulesPath
@@ -30,7 +30,8 @@ export const updateBundledNativeModulesFile = new Task<TaskArgs>(
 
     for (const { pkg, state } of parcels) {
       const currentRange = bundledNativeModules[pkg.packageName];
-      const newRange = `~${state.releaseVersion}`;
+      const rangePrefix = options.canary ? '' : '~';
+      const newRange = rangePrefix + state.releaseVersion;
 
       if (!currentRange) {
         logger.log('  ', green(pkg.packageName), gray('is not defined.'));

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -7,7 +7,7 @@ import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import * as Workspace from '../../Workspace';
-import { Parcel, TaskArgs } from '../types';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { green, yellow, cyan } = chalk;
 
@@ -19,7 +19,7 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
     name: 'updateWorkspaceProjects',
     filesToStage: ['**/package.json', 'yarn.lock'],
   },
-  async (parcels: Parcel[]) => {
+  async (parcels: Parcel[], options: CommandOptions) => {
     logger.info('\n📤 Updating workspace projects...');
 
     const workspaceInfo = await Workspace.getInfoAsync();
@@ -75,10 +75,10 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
             }
 
             // Leave tilde and caret as they are, just replace the version.
-            const newVersionRange = currentVersionRange.replace(
-              /([\^~]?).*/,
-              `$1${state.releaseVersion}`
-            );
+            const newVersionRange = options.canary
+              ? state.releaseVersion
+              : currentVersionRange.replace(/([\^~]?).*/, `$1${state.releaseVersion}`);
+
             dependenciesObject[pkg.packageName] = newVersionRange;
 
             batch.log(

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -17,6 +17,7 @@ export type CommandOptions = {
   skipRepoChecks: boolean;
   dry: boolean;
   force: boolean;
+  canary: boolean;
   deps: boolean;
 
   /* exclusive options that affect what the command does */
@@ -65,6 +66,11 @@ export type PublishState = {
    * Whether the package was requested to be published (was listed in command's arguments).
    */
   isRequested?: boolean;
+
+  /**
+   * Name of the tarball the package was packed to.
+   */
+  packageTarballFilename?: string;
 };
 
 export type BaseParcel<State> = {


### PR DESCRIPTION
# Why

Releasing packages for testing/dogfooding is a bit complicated and often causes a confusion among users. It's not very clear whether the package can be used with the current SDK and if the package is in a releasable state.

# How

Introducing `--canary` flag for `et publish-packages` script that makes a few differences:
- uses versions like `0.0.0-canary-YYYYMMDD-GitHead`, except SDK constrained packages (`expo`, `jest-expo`, `@expo/config-types`) where the next SDK major version is used instead of `0`
- uses `canary` tag on npm instead of `next`
- doesn't run integrity nor repository status checks
- doesn't prompt for anything – should be safe to run it on the CI at some point
- doesn't commit and push changes to the remote repo
- doesn't reinstall pods as it's not needed if changes are not being pushed
- runs `npm pack` on all packages before `npm publish` to earlier detect failures caused by for example `prepublish` hook

# Test Plan

Ran `et publish --canary` and reviewed the changes that the script has made.

# Future plans

- Update and publish project and module templates after publishing the packages
- Use the same technique with pre-packing packages in the non-canary flow