### PR TITLE
[docs] Update verbiage in the Splash screen guide's iOS section

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen.mdx
+++ b/docs/pages/develop/user-interface/splash-screen.mdx
@@ -30,7 +30,9 @@ Android screen sizes vary greatly with the massive variety of devices on the mar
 
 ### iOS
 
-The [iOS Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/foundations/layout#specifications) list the device's screen sizes. In the video example, we use `1242` pixels wide (the width of the widest iPhone at the moment of writing) and `2436` pixels tall (the height of the tallest iPhone at the moment of writing). Expo will resize the image for you depending on the size of the device's size, and you can specify the strategy used to resize the image with [`splash.resizeMode`](/versions/latest/config/app/#resizemode).
+In the video example, we use `1242` pixels as the width and `2346` pixels as the height of an iOS device. You can see the [Device screens and sizes specifications](https://developer.apple.com/design/human-interface-guidelines/layout#Specifications) from the iOS Human Interface Guidelines for an up-to-date list of screen sizes.
+
+Expo will resize the image for your app depending on the size of the device's screen. You can specify the strategy used to resize the image with [`splash.resizeMode`](/versions/latest/config/app/#resizemode).
 
 ## Export the splash image as a .png
 

--- a/docs/pages/develop/user-interface/splash-screen.mdx
+++ b/docs/pages/develop/user-interface/splash-screen.mdx
@@ -30,9 +30,7 @@ Android screen sizes vary greatly with the massive variety of devices on the mar
 
 ### iOS
 
-In the video example, we use `1242` pixels as the width and `2346` pixels as the height of an iOS device. You can see the [Device screens and sizes specifications](https://developer.apple.com/design/human-interface-guidelines/layout#Specifications) from the iOS Human Interface Guidelines for an up-to-date list of screen sizes.
-
-Expo will resize the image for your app depending on the size of the device's screen. You can specify the strategy used to resize the image with [`splash.resizeMode`](/versions/latest/config/app/#resizemode).
+Expo will resize the image for your app depending on the size of the device's screen. You can specify the strategy used to resize the image with [`splash.resizeMode`](/versions/latest/config/app/#resizemode). You can see the [Device screens and sizes specifications](https://developer.apple.com/design/human-interface-guidelines/layout#Specifications) from the iOS Human Interface Guidelines for an up-to-date list of screen sizes.
 
 ## Export the splash image as a .png
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1700255002229289)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing the mention of pixels for iOS screen size and updating verbiage to make it clearer to see the device screen size in Apple's doc for the up-to-date info.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/user-interface/splash-screen/

### Preview

![CleanShot 2023-11-19 at 12 50 01@2x](https://github.com/expo/expo/assets/10234615/cec3069b-cf23-4531-877f-c4693decdcce)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
