### PR TITLE
[router][iOS] Remove unused dateModified field from MetadataOptions

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Disable suspense loader in production. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))
+- Removed unused `dateModified` field from `MetadataOptions` in the head module. ([#25467](https://github.com/expo/expo/pull/25467) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.2.0 — 2023-11-14
 

--- a/packages/expo-router/ios/ExpoHeadModule.swift
+++ b/packages/expo-router/ios/ExpoHeadModule.swift
@@ -28,8 +28,6 @@ struct MetadataOptions: Record {
   @Field
   var keywords: [String]?
   @Field
-  var dateModified: Date?
-  @Field
   var userInfo: [String: AnyHashable]?
   @Field
   var description: String?


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/actions/runs/6915407980/job/18814302536 that started failing due to #25390 
The MetadataOptions includes a `Field` that wraps a `Date` which is not conforming to `AnyArgument` because it's not a convertible type (yet).

# How

This field doesn't seem to be used on the iOS side, so I think we can just remove it.
I plan to make `Date` a convertible type in the future.

# Test Plan

Expo Go on iOS compiles
