### PR TITLE
[updates-e2e] Fix R8 errors

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -663,6 +663,9 @@ export async function initAsync(
       '-keep class org.apache.commons.** { *; }',
       '-dontwarn androidx.appcompat.graphics.drawable.DrawableWrapper',
       '-dontwarn com.facebook.react.views.slider.**',
+      '-dontwarn javax.lang.model.element.Modifier',
+      '-dontwarn org.checkerframework.checker.nullness.qual.EnsuresNonNullIf',
+      '-dontwarn org.checkerframework.dataflow.qual.Pure',
       '',
     ].join('\n'),
     'utf-8'


### PR DESCRIPTION
# Why

Fix Updates e2e CI

# How

Update `proguard-rules.pro` rules 

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
