### PR TITLE
[android][ios] Upgrade @react-native-community/netinfo to 11.1.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/AmazonFireDeviceConnectivityPoller.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/AmazonFireDeviceConnectivityPoller.java
@@ -90,7 +90,7 @@ public class AmazonFireDeviceConnectivityPoller {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_INTERNET_DOWN);
         filter.addAction(ACTION_INTERNET_UP);
-        context.registerReceiver(receiver, filter);
+        NetInfoUtils.compatRegisterReceiver(context, receiver, filter, false);
 
         receiver.registered = true;
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/BroadcastReceiverConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/BroadcastReceiverConnectivityReceiver.java
@@ -39,7 +39,12 @@ public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver 
     public void register() {
         IntentFilter filter = new IntentFilter();
         filter.addAction(CONNECTIVITY_ACTION);
-        getReactContext().registerReceiver(mConnectivityBroadcastReceiver, filter);
+        NetInfoUtils.compatRegisterReceiver(
+                getReactContext(),
+                mConnectivityBroadcastReceiver,
+                filter,
+                false
+        );
         mConnectivityBroadcastReceiver.setRegistered(true);
         updateAndSendConnectionType();
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetInfoUtils.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/NetInfoUtils.java
@@ -7,8 +7,12 @@
 package versioned.host.exp.exponent.modules.api.netinfo;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.core.content.ContextCompat;
 
@@ -24,5 +28,23 @@ public class NetInfoUtils {
     public static boolean isAccessWifiStatePermissionGranted(Context context) {
         return ContextCompat.checkSelfPermission(context,
                 Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED;
+    }
+
+
+    /**
+     * Starting with Android 14, apps and services that target Android 14 and use context-registered
+     * receivers are required to specify a flag to indicate whether or not the receiver should be
+     * exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED
+     * <a href="https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported"/>
+     */
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    public static void compatRegisterReceiver(
+            Context context, BroadcastReceiver receiver, IntentFilter filter, boolean exported) {
+        if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
+            context.registerReceiver(
+                    receiver, filter, exported ? Context.RECEIVER_EXPORTED : Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(receiver, filter);
+        }
     }
 }

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1202,7 +1202,7 @@ PODS:
   - React-Mapbuffer (0.73.0-rc.4):
     - glog
     - React-debug
-  - react-native-netinfo (9.3.10):
+  - react-native-netinfo (11.1.0):
     - React-Core
   - react-native-pager-view (6.2.0):
     - React-Core
@@ -2036,7 +2036,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 5548901692ef4a1943f7f4208abbf77a35c58bc7
   React-logger: 5761d3b499c34ff905d47eba897ccb033242eb57
   React-Mapbuffer: 9bfeeae0a1637598fc6697ec674cfbecb581af7d
-  react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
+  react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
@@ -2069,7 +2069,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 3942382593f104af226ad9c56e16166960c7ae30
   RNFlashList: 4b4b6b093afc0df60ae08f9cbf6ccd4c836c667a
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
-  RNReanimated: 44d8524115fc3a5e809609a302944055934e3611
+  RNReanimated: 11cb84f23cf2443b8bf1806b83d77dd470e23158
   RNScreens: 5f4df9babb21d30723580377b5f52d9f9baf0005
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "7.2.0",
-    "@react-native-community/netinfo": "9.3.10",
+    "@react-native-community/netinfo": "11.1.0",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.3.0",
     "@react-native-picker/picker": "2.5.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -45,7 +45,7 @@
     "@expo/video": "~0.2.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "7.2.0",
-    "@react-native-community/netinfo": "9.3.10",
+    "@react-native-community/netinfo": "11.1.0",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.3.0",
     "@react-native-picker/picker": "2.5.1",

--- a/home/package.json
+++ b/home/package.json
@@ -24,7 +24,7 @@
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "1.18.2",
-    "@react-native-community/netinfo": "9.3.10",
+    "@react-native-community/netinfo": "11.1.0",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/elements": "~1.3.6",
     "@react-navigation/material-bottom-tabs": "~6.2.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2020,7 +2020,7 @@ PODS:
   - React-Mapbuffer (0.73.0-rc.4):
     - glog
     - React-debug
-  - react-native-netinfo (9.3.10):
+  - react-native-netinfo (11.1.0):
     - React-Core
   - react-native-pager-view (6.2.0):
     - React-Core
@@ -3284,7 +3284,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: 1c589accb47d99cd7c6e20590b34b489bd2b6594
   EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
   EXTaskManager: 81b2dfaaba6d9f9a4bc3e3e2a786a98004eb9e98
-  EXUpdates: e9f30b5fde2bbeabaf340081ecae3eca3a3312c2
+  EXUpdates: 7cadb6e8aa941a409d1110c49ebf6d106cf52943
   EXUpdatesInterface: 4f787eeabc62c258f978ea4865c67adfb6b2f19f
   FBAEMKit: 4763aa27b8f69eb9d2c274189e91388de1dbd88a
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06
@@ -3345,7 +3345,7 @@ SPEC CHECKSUMS:
   React-jsinspector: d73cab717d8339f4f9519023415ca3416407cfbf
   React-logger: ad5efbc68ad8d9d2ba3de2010fd0d44c06ac1705
   React-Mapbuffer: bd11535c681b3d60cf5c0c05acb7b8c7f0841d50
-  react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
+  react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "9.3.10",
+  "version": "11.1.0",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v9.3.10"
+    "tag": "v11.1.0"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@react-native-async-storage/async-storage": "1.18.2",
   "@react-native-community/datetimepicker": "7.2.0",
   "@react-native-masked-view/masked-view": "0.3.0",
-  "@react-native-community/netinfo": "9.3.10",
+  "@react-native-community/netinfo": "11.1.0",
   "@react-native-community/slider": "4.4.2",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.5.1",

--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -34,7 +34,6 @@ async function main() {
   const pinnedPackages = {
     'react-native': nightlyVersion,
     '@react-native-async-storage/async-storage': '~1.19.1', // fix AGP 8 build error
-    '@react-native-community/netinfo': '~9.4.1', // fix AGP 8 build error
   };
   await addPinnedPackagesAsync(pinnedPackages);
 

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -244,7 +244,9 @@ const config: VendoringTargetConfig = {
     },
     '@react-native-community/netinfo': {
       source: 'https://github.com/react-native-netinfo/react-native-netinfo',
-      ios: {},
+      ios: {
+        excludeFiles: 'example/**/*',
+      },
     },
     'react-native-webview': {
       source: 'https://github.com/react-native-webview/react-native-webview.git',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,10 +3326,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/netinfo@9.3.10":
-  version "9.3.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.10.tgz#9b6cc2aec9329b5ccf35e866094c43aa420d927a"
-  integrity sha512-OwnqoJUp/4sa9e3ju+wQavAa8l0fiA3DheeLMKzKxtKeAe0CA7bNxWRM752JvRQ6A/igPnt1V0zSlu5owvQEuA==
+"@react-native-community/netinfo@11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-11.1.0.tgz#b3b2ab741a5d935e445685ade8a53d48775e082b"
+  integrity sha512-pIbCuqgrY7SkngAcjUs9fMzNh1h4soQMVw1IeGp1HN5//wox3fUVOuvyIubTscUbdLFKiltJAiuQek7Nhx1bqA==
 
 "@react-native-community/slider@4.4.2":
   version "4.4.2"


### PR DESCRIPTION
# Why

upgrade react-native-netinfo to 11.1.0for sdk 50.
close ENG-10674

# How

`et uvm -m @react-native-community/netinfo -c "v11.1.0"` 

# Test Plan

- unversioned Expo Go + NCL
- Bare expo + NCL

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

