### PR TITLE
[docs] fix edge case with Footer page navigation buttons

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -1,7 +1,8 @@
 import * as Utilities from '~/common/utilities';
+import { stripVersionFromPath } from '~/common/utilities';
 import { PageApiVersionContextType } from '~/providers/page-api-version';
 import navigation from '~/public/static/constants/navigation.json';
-import { NavigationRoute } from '~/types/common';
+import { NavigationRoute, NavigationRouteWithSection } from '~/types/common';
 
 export const getRoutes = (
   path: string,
@@ -72,4 +73,20 @@ export const getCanonicalUrl = (path: string) => {
   } else {
     return `https://docs.expo.dev${path}`;
   }
+};
+
+export const isRouteActive = (
+  info?: NavigationRoute | NavigationRouteWithSection,
+  asPath?: string,
+  pathname?: string
+) => {
+  // Special case for root url
+  if (info?.name === 'Introduction') {
+    if (asPath?.match(/\/versions\/[\w.]+\/$/) || asPath === '/versions/latest/') {
+      return true;
+    }
+  }
+
+  const linkUrl = stripVersionFromPath(info?.as || info?.href);
+  return linkUrl === stripVersionFromPath(pathname) || linkUrl === stripVersionFromPath(asPath);
 };

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/compat/router';
 import { useEffect, useState, createRef } from 'react';
 
 import * as RoutesUtils from '~/common/routes';
+import { isRouteActive } from '~/common/routes';
 import * as WindowUtils from '~/common/window';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
 import DocumentationSidebarRight, {
@@ -125,7 +126,10 @@ export default function DocumentationPage({
     .map(route => (route?.type === 'page' ? route : appendSectionToRoute(route)))
     .flat();
 
-  const pageIndex = flattenStructure.findIndex(page => page?.name === title);
+  const pageIndex = flattenStructure.findIndex(page =>
+    isRouteActive(page, router?.asPath, router?.pathname)
+  );
+
   const previousPage = flattenStructure[pageIndex - 1];
   const nextPage = flattenStructure[pageIndex + 1];
 

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -3,10 +3,9 @@ import { theme, typography, LinkBase } from '@expo/styleguide';
 import { spacing } from '@expo/styleguide-base';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
-import type { PropsWithChildren } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type PropsWithChildren } from 'react';
 
-import { stripVersionFromPath } from '~/common/utilities';
+import { isRouteActive } from '~/common/routes';
 import { NavigationRoute } from '~/types/common';
 
 type SidebarLinkProps = PropsWithChildren<{
@@ -29,22 +28,7 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
   const router = useRouter();
   const ref = useRef<HTMLAnchorElement>(null);
 
-  const checkSelection = () => {
-    // Special case for root url
-    if (info.name === 'Introduction') {
-      if (router?.asPath.match(/\/versions\/[\w.]+\/$/) || router?.asPath === '/versions/latest/') {
-        return true;
-      }
-    }
-
-    const linkUrl = stripVersionFromPath(info.as || info.href);
-    return (
-      linkUrl === stripVersionFromPath(router?.pathname) ||
-      linkUrl === stripVersionFromPath(router?.asPath)
-    );
-  };
-
-  const isSelected = checkSelection();
+  const isSelected = isRouteActive(info, router?.asPath, router?.pathname);
 
   useEffect(() => {
     if (isSelected && ref?.current && !isLinkInViewport(ref?.current)) {


### PR DESCRIPTION
# Why

Fixes edge case in the Next/Previous page `Footer` buttons, which lead to displaying incorrect sibling pages.

# How

Use URL instead of page title to detect siblings in the navigation structure.

# Test Plan

The changes have been tested locally. All lint checks and tests are passing.

# Preview

<img width="1226" alt="Screenshot 2023-11-20 at 14 43 11" src="https://github.com/expo/expo/assets/719641/f589bc5f-4df9-4abe-83da-071e9c6da653">


