### PR TITLE
[docs] Remove unnecessary Next steps/BoxLinks for next pages

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -680,13 +680,8 @@ Please add the following to your app config
 [config-docs]: /versions/latest/config/app/
 [prebuild-config]: https://github.com/expo/expo-cli/tree/main/packages/prebuild-config#readme
 [cli-prebuild]: /more/expo-cli//#expo-prebuild
-[configplugin]: https://github.com/expo/expo-cli/blob/3a0ef962a27525a0fe4b7e5567fb7b3fb18ec786/packages/config-plugins/src/Plugin.types.ts#L76
 [source-template]: https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum
-[expo-beta-docs]: https://github.com/expo/expo/tree/main/guides/releasing/Release%20Workflow.mdx#stage-5---beta-release
 [vscode-expo]: https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools
 [ems-plugin]: https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin
-[xml2js]: https://www.npmjs.com/package/xml2js
-[expo-plist]: https://www.npmjs.com/package/@expo/plist
 [memfs]: https://www.npmjs.com/package/memfs
-[emc]: https://github.com/expo/expo/tree/main/packages/expo-modules-core
 [autolinking]: /more/glossary-of-terms#autolinking

--- a/docs/pages/config-plugins/introduction.mdx
+++ b/docs/pages/config-plugins/introduction.mdx
@@ -5,8 +5,6 @@ sidebar_title: Introduction
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 An automatic setup for adding a native module to your project is possible. Sometimes, a module requires a more complex setup. A config plugin can be used to automatically configure your native project for a module and reduce the complexity by avoiding interaction with the native project.
 
@@ -59,12 +57,3 @@ On running the `npx expo prebuild`, the [`mods`]() are compiled, and the native 
 
 The changes don't take effect until you rebuild the native project, for example, with Xcode. **If you're using config plugins in a managed app,
 they will be applied during the prebuild phase on `eas build`**.
-
-## Next step
-
-<BoxLink
-  title="Create a plugin"
-  description="Learn about how you can create a config plugin."
-  href="/config-plugins/plugins-and-mods"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -5,9 +5,7 @@ description: Learn about what are plugins and mods when creating a config plugin
 
 import { YesIcon, NoIcon, WarningIcon } from '~/ui/components/DocIcons';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Plugins are **synchronous** functions that accept an [`ExpoConfig`](/versions/latest/config/app/) and return a modified [`ExpoConfig`](/versions/latest/config/app/).
 
@@ -503,15 +501,6 @@ This is because Node environments are often different to iOS, Android, or web JS
 Because of this reasoning, the root of a Node module is searched instead of right next to the **index.js**.
 Imagine you had a TypeScript Node module where the transpiled main file was located at **build/index.js**,
 if app config plugin resolution searched for **build/app.plugin.js** you'd lose the ability to transpile the file differently.
-
-## Next step
-
-<BoxLink
-  title="Development and debugging"
-  description="Learn about development best practices and debugging techniques for app config plugins."
-  href="/config-plugins/development-and-debugging"
-  Icon={BookOpen02Icon}
-/>
 
 [xml2js]: https://www.npmjs.com/package/xml2js
 [expo-plist]: https://www.npmjs.com/package/@expo/plist

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -4,8 +4,6 @@ description: Learn about Redbox errors and stack traces in your Expo project.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 When developing an application using Expo, you'll encounter a **Redbox** error or **Yellowbox** warning. These logging experiences are provided by [LogBox in React Native](https://reactnative.dev/blog/2020/07/06/version-0.63).
 
@@ -32,12 +30,3 @@ This stack trace is **extremely valuable** since it gives you the location of th
 When you look at that file, on line 7, you will see that a variable called `renderDescription` is referenced. The error message describes that the variable is not found because the variable is not declared in **HomeScreen.js**. This is a typical example of how helpful error messages and stack traces can be if you take the time to decipher them.
 
 Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The **Expo community** and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the [forums](https://chat.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
-
-## Next step
-
-<BoxLink
-  title="Debugging"
-  description="Learn about different techniques available to debug runtime issues in your Expo project."
-  href="/debugging/runtime-issues"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -4,11 +4,9 @@ description: Learn about different techniques available to debug your Expo proje
 sidebar_title: Runtime issues
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import Video from '~/components/plugins/Video';
 
 Whether you're developing your app locally, sending it out to select beta testers, or launching your app live to the app stores, you'll always find yourself debugging issues. It's useful to split errors into two categories:
@@ -172,12 +170,3 @@ This might indicate that there is a performance issue. You likely need to run yo
 ## Stuck?
 
 The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://chat.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
-
-## Next step
-
-<BoxLink
-  title="Debugging tools"
-  description="Learn about different tools available to debug runtime issues in your Expo project."
-  href="/debugging/tools"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -5,7 +5,7 @@ description: A brief overview of how to use EAS Metadata to automate and maintai
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { EasMetadataIcon, LayersTwo02Icon } from '@expo/styleguide-icons';
+import { EasMetadataIcon } from '@expo/styleguide-icons';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.
 
@@ -63,13 +63,6 @@ If EAS Metadata runs into any issues with your store config, it will warn you wh
 You can also re-use this command when you modify the **store.config.json** file and want to push the latest changes to the app stores.
 
 ## Next steps
-
-<BoxLink
-  title="Instant updates with EAS Update"
-  description="Learn how to automate and maintain your app store presence from the command line with EAS Metadata."
-  Icon={LayersTwo02Icon}
-  href="/deploy/instant-updates/"
-/>
 
 <BoxLink
   title="EAS Metadata schema"

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasSubmitIcon, EasMetadataIcon, BookOpen02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Whether you have built a native app binary using [EAS](/build/setup/) or [locally](/guides/local-app-development/), the next step in your app development journey is to submit your app to the stores. To do so, you need to create a **production build**.
 
@@ -114,14 +114,7 @@ These guides assume your project has **android** and/or **ios** directories cont
   href="https://reactnative.dev/docs/publishing-to-app-store"
 />
 
-## Next steps
-
-<BoxLink
-  title="App Store submissions"
-  description="Learn how to submit your app to app stores using EAS Submit."
-  Icon={EasSubmitIcon}
-  href="/deploy/submit-to-app-stores/"
-/>
+## Next step
 
 <BoxLink
   title="App stores best practices"

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -6,7 +6,7 @@ description: Learn how to submit your app to Google Play Store and Apple App Sto
 import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { EasSubmitIcon, EasMetadataIcon } from '@expo/styleguide-icons';
+import { EasSubmitIcon } from '@expo/styleguide-icons';
 import Video from '~/components/plugins/Video';
 
 **EAS Submit** is a hosted service that allows uploading and submitting app binaries to the app stores using EAS CLI. This guide describes how to submit your app to the Google Play Store and Apple App Store using EAS Submit.
@@ -97,14 +97,7 @@ The command will lead you through the process of submitting the app. It will per
 - A summary of the provided configuration is displayed and the submission process begins. The submission progress is displayed on the screen.
 - Your build should now be visible on [App Store Connect](https://appstoreconnect.apple.com). If something goes wrong, an appropriate message is displayed on the screen.
 
-## Next steps
-
-<BoxLink
-  title="App stores metadata"
-  description="Learn how to automate and maintain your app store presence from the command line with EAS Metadata."
-  Icon={EasMetadataIcon}
-  href="/deploy/app-stores-metadata/"
-/>
+## Next step
 
 <BoxLink
   title="EAS Submit configuration with eas.json"

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -6,11 +6,8 @@ sidebar_title: Create a build
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
-import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Development builds can be created with [EAS Build](/build/introduction/) or [locally](/guides/local-app-development/) on your computer if you have Android Studio and Xcode installed.
 
@@ -185,12 +182,3 @@ You can also find this QR code on the build page in the [Expo dashboard](https:/
 <Video url="https://www.youtube.com/embed/LUFHXsBcW6w" />
 
 </Step>
-
-## Next step
-
-<BoxLink
-  title="Use a development build"
-  description="Learn how to use development builds for a project."
-  href="/develop/development-builds/use-development-builds/"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -6,7 +6,6 @@ description: Learn more about different tools, workflows and extensions availabl
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
-import { Tab, Tabs } from '~/ui/components/Tabs';
 
 Development builds allow you to iterate quickly. However, you can extend the capabilities of your development build to provide a better developer experience when working in teams or customize the build to suit your needs.
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -4,17 +4,14 @@ sidebar_title: Introduction
 description: Development builds of your app are Debug builds of your project. It includes the expo-dev-client library, which allows you to develop and debug projects using Expo CLI.
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Building your project with Expo allows you to make most changes in JavaScript. This helps iterate quickly and safely and allows your team to [achieve web-like iteration speeds](https://blog.expo.dev/javascript-driven-development-with-custom-runtimes-eda87d574c9d) by dividing your application into:
 
 - **A native runtime**: A native binary that is built with Android Studio or Xcode. Expo Go is an example of a native runtime for iterating on React Native projects.
 - **An update**: A bundle of your application's JavaScript code and assets (images, video, fonts, and so on). An update can be served from your local computer with Expo CLI, embedded in the binary by EAS Build, or hosted on a publicly available server.
 
-When your project requires custom native code, a config plugin, a custom runtime version, or a reduced bundle size of the app, you can transition from using [Expo Go](https://expo.dev/client) to develop to a development build.
+When your project requires custom native code, a config plugin, a custom runtime version, or a reduced bundle size of the app, you can transition from using [Expo Go](https://expo.dev/client) to developing a development build.
 
 ## What is a development build
 
@@ -28,18 +25,4 @@ You can think of a development build as your fully customizable version of Expo 
 
 The [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) package replaces the default in-app development tools UI that React Native provides (the [Dev Menu](https://reactnative.dev/docs/debugging#accessing-the-dev-menu)) with [a more powerful and extensible UI](/debugging/tools/#developer-menu) and adds a launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows/#pr-previews)) and switch between development servers without needing to rebuild the app binary.
 
-## Next steps
-
-<BoxLink
-  title="Create development builds"
-  description="Learn about how you can create a development build."
-  href="/develop/development-builds/create-a-build/"
-  Icon={BookOpen02Icon}
-/>
-
-<BoxLink
-  title="Local app development"
-  description="Learn how to compile and build your app locally when using Expo."
-  href="/guides/local-app-development/"
-  Icon={BookOpen02Icon}
-/>
+> **info** If you are looking to learn how to compile and build your app locally when using Expo, see [Local app development](/guides/local-app-development/).

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -5,6 +5,8 @@ description: Development builds of your app are Debug builds of your project. It
 ---
 
 import Video from '~/components/plugins/Video';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Building your project with Expo allows you to make most changes in JavaScript. This helps iterate quickly and safely and allows your team to [achieve web-like iteration speeds](https://blog.expo.dev/javascript-driven-development-with-custom-runtimes-eda87d574c9d) by dividing your application into:
 
@@ -25,4 +27,11 @@ You can think of a development build as your fully customizable version of Expo 
 
 The [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) package replaces the default in-app development tools UI that React Native provides (the [Dev Menu](https://reactnative.dev/docs/debugging#accessing-the-dev-menu)) with [a more powerful and extensible UI](/debugging/tools/#developer-menu) and adds a launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows/#pr-previews)) and switch between development servers without needing to rebuild the app binary.
 
-> **info** If you are looking to learn how to compile and build your app locally when using Expo, see [Local app development](/guides/local-app-development/).
+## Next steps
+
+<BoxLink
+  title="Local app development"
+  description="If you are looking to learn how to compile and build your app locally when using Expo."
+  href="/guides/local-app-development/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -58,10 +58,3 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
   href="/guides/sharing-preview-releases"
   Icon={BookOpen02Icon}
 />
-
-<BoxLink
-  title="Tools, workflows and extensions"
-  description="Learn more about different tools, workflows and extensions available when working with development builds."
-  href="/develop/development-builds/development-workflows/"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -6,8 +6,6 @@ sidebar_title: Use a build
 
 import { Terminal } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { Tab, Tabs } from '~/ui/components/Tabs';
-import { BoxLink } from '~/ui/components/BoxLink';
 
 Usually, creating a new native build from scratch takes long enough that you'll be tempted to switch tasks and lose your focus. However, with the development build installed on your device or an emulator/simulator, you won't have to wait for the native build process until you [change the underlying native code](#rebuild-a-development-build) that powers your app.
 
@@ -55,11 +53,3 @@ If you add a library to your project that contains native code APIs, for example
 When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> or <kbd>Ctrl</kbd> + <kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, any debugging functionality you need, or switch to a different version of your app.
 
 See [Debugging](/debugging/runtime-issues/) guide for more information.
-
-## Next step
-
-<BoxLink
-  title="Share a development build with your team"
-  description="Learn how to install and share the development with your team or run it on multiple devices."
-  href="/develop/development-builds/share-with-your-team"
-/>

--- a/docs/pages/develop/project-structure.mdx
+++ b/docs/pages/develop/project-structure.mdx
@@ -3,8 +3,6 @@ title: Project structure
 description: Learn about the files and folder structure when a new Expo project is created.
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-
 When you create a new Expo project, a few files and folders are provided by default. This page lists out the essential files and folders that are necessary for you to understand when developing your app.
 
 ## App.js
@@ -42,11 +40,3 @@ Applies the `babel-preset-expo` preset that extends the default React Native pre
 The **package.json** file contains the project's dependencies, scripts and metadata. Anytime a new dependency is added to your project, it will be added to this file.
 
 You can also modify the `scripts` to add or remove them. Four default scripts are provided to trigger the development server of your project such as `expo start`, `expo start --android`, `expo start --ios`, and `expo start --web`.
-
-## Next step
-
-<BoxLink
-  title="Splash screen"
-  description="Splash screen is the first screen that users see when they open your app. Learn how to customize it."
-  href="/develop/user-interface/splash-screen"
-/>

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -4,8 +4,6 @@ description: Learn how to integrate the react-native-reanimated library and use 
 ---
 
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Animations are a great way to enhance and provide a better user experience. In your Expo projects, you can use the [Animated API](https://reactnative.dev/docs/next/animations) from React Native. However, if you want to use more advanced animations with better performance, you can use the [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) library. It provides an API that simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -109,12 +107,3 @@ const styles = StyleSheet.create({
 ### Other animation libraries
 
 Other animation packages are available, such as Moti, that you also use in your Expo project and work on Android, iOS, and the web. For more information on its API and usage, see [Moti's documentation](https://moti.fyi/).
-
-## Next step
-
-<BoxLink
-  title="Store data"
-  description="Learn about different libraries available to store data in your app."
-  href="/develop/user-interface/store-data"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -4,8 +4,6 @@ description: Learn about configuring the app's icon and best practices for Andro
 ---
 
 import Video from '~/components/plugins/Video';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 An app's icon is what your app users see on their device's home screen and app stores. Android and iOS have different and strict requirements.
 
@@ -52,12 +50,3 @@ For iOS, you app's icon should follow the [Apple Human Interface Guidelines](htt
 - 1024x1024 is a good size. If you have an Expo managed project, [EAS Build](/build/setup) will generate the other sizes for you. If you have a bare workflow project, you should generate the icons on your own. The largest size EAS Build generates is 1024x1024.
 - The icon must be exactly square. For example, a 1023x1024 icon is not valid.
 - Make sure the icon fills the whole square, with no rounded corners or other transparent pixels. The operating system will mask your icon when appropriate.
-
-## Next step
-
-<BoxLink
-  title="Safe areas"
-  description="Learn more about creating a safe area is a great way to ensure that your app's content is appropriately positioned around notches, status bars, home indicators, and other device and operating system interface elements."
-  href="/develop/user-interface/safe-areas"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -6,8 +6,6 @@ description: Learn how to support light and dark modes in your app.
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Whether you are personally on team light or team dark, it's becoming increasingly common for apps to support these two color schemes. Here is an example of how supporting both modes looks in an Expo project:
 
@@ -161,12 +159,3 @@ While you're developing your project, you can change your simulator's or device'
 - If working with an iOS emulator locally, you can use the <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>a</kbd> shortcut to toggle between light and dark modes.
 - If using an Android Emulator, you can run `adb shell "cmd uimode night yes"` to enable dark mode, and `adb shell "cmd uimode night no"` to disable dark mode.
 - If using a real device or an Android Emulator, you can toggle the system dark mode setting in the device's settings.
-
-## Next step
-
-<BoxLink
-  title="Animation"
-  description="Learn more about integrating the react-native-reanimated library to create animations in your app."
-  href="/develop/user-interface/animation"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -6,8 +6,6 @@ description: Learn about using custom fonts, supported font formats for each pla
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Both Android and iOS and most desktop operating systems come with their own set of platform fonts. However, if you want to inject some more brand personality into your app, a well-picked font can go a long way.
 
@@ -320,12 +318,3 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
-
-## Next step
-
-<BoxLink
-  title="Color themes"
-  description="Learn more about supporting light and dark modes in your app."
-  href="/develop/user-interface/color-themes"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -5,8 +5,6 @@ description: Learn how to add safe areas for your Expo project and other best pr
 
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Creating a safe area is a great way to ensure that your app's content is appropriately positioned around notches, status bars, home indicators, and other device and operating system interface elements.
 
@@ -111,12 +109,3 @@ By default, React Navigation supports safe areas and uses `react-native-safe-are
 ## Usage with web
 
 If you are targeting the web, you must set up `<SafeAreaProvider>` as described in the [hooks section](#use-usesafeareainsets-hook). If you are doing server-side rendering (SSR), we recommend checking out the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.
-
-## Next step
-
-<BoxLink
-  title="Fonts"
-  description="Learn more about different ways to import a custom font and use it in your app."
-  href="/develop/user-interface/fonts"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/develop/user-interface/splash-screen.mdx
+++ b/docs/pages/develop/user-interface/splash-screen.mdx
@@ -7,8 +7,6 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
 import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 A splash screen, also known as a launch screen, is the first screen a user sees when they open your app. It stays visible while the app is loading. You can also control the behavior of when a splash screen disappears by using the native [SplashScreen API](/versions/latest/sdk/splash-screen).
 
@@ -155,12 +153,3 @@ In custom iOS builds, launch screens can sometimes remain cached between builds,
 <Terminal cmd={['$ npx expo run:ios --no-build-cache']} />
 
 See [Apple's guide on testing launch screens](https://developer.apple.com/documentation/technotes/tn3118-debugging-your-apps-launch-screen) for more information.
-
-## Next step
-
-<BoxLink
-  title="App icons"
-  description="An app's icon is what your app users see on their device's home screen and app stores. Learn about how to customize your app's icon and what are the different requirements for Android and iOS."
-  href="/develop/user-interface/app-icons"
-  Icon={BookOpen02Icon}
-/>

--- a/docs/pages/distribution/introduction.mdx
+++ b/docs/pages/distribution/introduction.mdx
@@ -1,12 +1,18 @@
 ---
-title: Overview
+title: 'Distribution: Overview'
 hideTOC: true
 description: An overview of submitting an app to the app stores or with the internal distribution.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { AndroidIcon, AppleIcon, Earth02Icon, LayersTwo02Icon } from '@expo/styleguide-icons';
+import {
+  AndroidIcon,
+  AppleIcon,
+  BookOpen02Icon,
+  Earth02Icon,
+  LayersTwo02Icon,
+} from '@expo/styleguide-icons';
 
 Get your app into the hands of users by submitting it to the app stores or with [Internal Distribution](/build/internal-distribution).
 
@@ -48,6 +54,7 @@ This automatically manages **all native code signing** for Android and iOS for a
   title="Internal Distribution"
   description="Share your mobile app internally with testers using AdHoc builds."
   href="/build/internal-distribution"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -142,7 +142,3 @@ To create and publish an update, we can run the following command:
 <Terminal cmd={['$ eas update']} />
 
 After publishing, the output will display the branch and the runtime version. This information can help us verify that we're creating an update with the configuration we expect.
-
-## Next steps
-
-Read the [advanced guide](/eas-update/debug-advanced) to debug EAS Update when the basic steps don't resolve your issue.

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -123,6 +123,6 @@ Once the update is built and uploaded to EAS and the command completes, force cl
 
 </Step>
 
-## Next steps
+## Next step
 
 You can publish updates continuously with GitHub Actions. See [Using GitHub Actions with EAS Update](/eas-update/github-actions) for more information.

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -110,13 +110,6 @@ Expo Go is configured by default to automatically reload the app whenever a file
 ## Next step
 
 <BoxLink
-  title="Project structure"
-  description="Now that you have your first project up and running, in the next step, you will learn more about your Expo project's structure."
-  href="/develop/project-structure"
-  Icon={BookOpen02Icon}
-/>
-
-<BoxLink
   title="Tutorial"
   description="If you are new to Expo, learn more about the ecosystem by creating a universal app that runs on Android, iOS, and web."
   href="/tutorial/introduction"

--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -6,8 +6,6 @@ description: Learn about Expo Go, the free, open-source sandbox app for learning
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { Step } from '~/ui/components/Step';
 
 [Expo Go](https://expo.dev/client) is a free, [open-source](https://github.com/expo/expo/tree/main/home) sandbox for learning and experimenting with React Native on Android and iOS devices. You can install it directly from app stores, and get up and running within minutes &mdash; no need to install a native toolchain and compile an app.
@@ -93,13 +91,4 @@ A compatible version of Expo Go will be automatically installed on your device/s
 
 Open the Expo Go app after it has finished installing. If you have [created an account with Expo CLI](/more/expo-cli/#authentication), you can sign in by clicking the **Log In** button in the top header on the **Home** tab. Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the **Projects** section on the **Home** tab of the app.
 
-> Sometimes, it can be useful to run your app directly on your computer instead of on a separate physical device. If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator).
-
-## Next step
-
-<BoxLink
-  title="Create a new project"
-  description="Now that the Expo Go app is installed, let's create a new app and write some code."
-  href="/get-started/create-a-project"
-  Icon={BookOpen02Icon}
-/>
+> Sometimes, it can be useful to run your app directly on your computer instead of on a separate physical device. If you would like to set this up, you can learn more about installing an [Android Emulator](/workflow/android-studio-emulator) and an [iOS Simulator (macOS only)](/workflow/ios-simulator).

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -5,7 +5,6 @@ description: Learn how to get started creating a new universal app with Expo.
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { ExpoGoLogo } from '@expo/styleguide';
 import { CALLOUT } from '~/ui/components/Text';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
 
@@ -15,6 +14,7 @@ To develop applications with Expo, make sure to check out the following requirem
 
 To use Expo, you need to have the following tools installed on your machine:
 
+{/* prettier-ignore */}
 - [Node.js LTS release](https://nodejs.org/en/) - Only Node.js LTS releases (even-numbered) are recommended.
   <CALLOUT theme="secondary">As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases". You can install Node.js using a version management tool (such as `nvm` or `volta` or any other of your choice) to switch between different Node.js versions.</CALLOUT>
 - [Git](https://git-scm.com) for source control.
@@ -59,12 +59,3 @@ After installing Node.js, you can use `npx` to create a new app.
 If you are using Yarn, you can bootstrap a new app using the following command:
 
 <Terminal cmd={['$ yarn create expo']} />
-
-## Next step
-
-<BoxLink
-  title="Expo Go"
-  description="Now that Expo CLI is working, in the next step, let's learn about one of the fastest ways to test your project using Expo Go."
-  Icon={ExpoGoLogo}
-  href="/get-started/expo-go"
-/>

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -5,8 +5,6 @@ description: A tutorial on creating a native module with Expo modules API.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon, Grid01Icon } from '@expo/styleguide-icons';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 
@@ -456,20 +454,4 @@ We can see from the last line of the error message that `not-a-real-theme` is no
 
 ## Next steps
 
-Congratulations! You have created your first simple yet non-trivial Expo module for Android and iOS.
-
-You can con continue to the next tutorial to learn how to create a native view or see the Expo module API reference.
-
-<BoxLink
-  title="Creating a native view"
-  description="A tutorial on creating a native view that renders a WebView with Expo modules API."
-  href="/modules/native-view-tutorial/"
-  Icon={BookOpen02Icon}
-/>
-
-<BoxLink
-  title="Module API Reference"
-  description="Outline for the Expo Module API and common patterns like sending events from native code to JavaScript."
-  href="/modules/module-api/"
-  Icon={Grid01Icon}
-/>
+Congratulations! You have created your first simple yet non-trivial Expo module for Android and iOS. You can con continue to the next tutorial to learn how to create a native view.

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -499,4 +499,4 @@ function LoadingView({ isLoading }: { isLoading: boolean }) {
 
 Congratulations, you have created your first simple yet non-trivial Expo module with a native view for Android and iOS! Learn more about the API in the [Expo Module API reference](/modules/module-api/).
 
-If you enjoyed this tutorial and haven't done the native module tutorial, see [creating a native module](/modules/native-module-tutorial/) next.
+If you enjoyed this tutorial and haven't done the native module tutorial, see [creating a native module](/modules/native-module-tutorial/).

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -74,11 +74,3 @@ As we all, React Native developers, use high-level JavaScript on a daily basis, 
 Moreover, including C++ code in the library has a negative impact on build times, especially on Android, and can be more difficult to debug.
 
 We took these into account when designing the Expo Modules API with the goal in mind to make it renderer-agnostic, so that the module doesn't need to know whether the app is run on the new architecture or not, significantly reducing the cost for library developers.
-
-## Next steps
-
-<BoxLink
-  title="Get Started"
-  description="Learn how to create a new Expo module or setup existing library as an Expo module."
-  href="./get-started"
-/>

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -331,23 +331,6 @@ To make sure your app builds successfully on both platforms, rerun the build com
 
 </Step>
 
-## Next steps
+## Next step
 
-Congratulations! You have created your first simple wrapper around two separate third-party native libraries using Expo Modules!
-
-<BoxLink
-  href="/modules/native-module-tutorial/"
-  title="Creating a native module"
-  icon="arrow-right"
-  iconType="feather"
-  iconSize={16}
-  iconColor="#000"
-/>
-<BoxLink
-  href="/modules/module-api/"
-  title="Expo Module API reference"
-  icon="arrow-right"
-  iconType="feather"
-  iconSize={16}
-  iconColor="#000"
-/>
+Congratulations! You have created your first simple wrapper around two separate third-party native libraries using Expo Modules. Learn more about the API in the [Expo Module API reference](/modules/module-api/).

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -3,8 +3,6 @@ title: Overview
 hideTOC: true
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-
 Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
 - **Develop**: Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
@@ -16,11 +14,3 @@ Expo is an [open-source framework](https://github.com/expo/expo/) for apps that 
 - **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
 
 There are plenty of other features and best practices to continue exploring along the way, such as [collaborating with your team](/accounts/account-types/#organizations), using [Expo modules](/versions/latest/), [debugging](/debugging/runtime-issues/), and working on the command line with [Expo CLI](/more/expo-cli).
-
-## Next step
-
-<BoxLink
-  title="Getting started"
-  description="If you are new to Expo or looking to get started with a new project, check out the Getting started section."
-  href="/get-started/installation"
-/>

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -31,11 +31,3 @@ Expo makes implementing push notifications easy. All the hassle with device info
   description="A collection of common questions about Expo's push notification service."
   href="/push-notifications/faq"
 />
-
-## Next
-
-<BoxLink
-  title="Setup push notifications"
-  description="Learn how to setup push notifications, get credentials for development and production, and test sending push notifications."
-  href="/push-notifications/push-notifications-setup"
-/>

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -7,7 +7,6 @@ description: Learn how to setup push notifications, get credentials for developm
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
-import { BoxLink } from '~/ui/components/BoxLink';
 
 To utilize Expo's push notification service, you must configure your app by installing a set of libraries, implementing functions to handle notifications, and setting up credentials for Android and iOS. Once you have completed the steps mentioned in this guide, you'll be able to test sending and receiving notifications on a device.
 
@@ -308,11 +307,3 @@ After sending the notification from the tool, you should see the notification on
 />
 
 </Step>
-
-## Next step
-
-<BoxLink
-  title="Send notifications using Expo's Push API"
-  description="Learn how to set your back-end using Expo's Push API, implementation practices, common errors and security best practices."
-  href="/push-notifications/sending-notifications"
-/>

--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -3,8 +3,6 @@ title: Receive notifications
 description: Learn how to respond to a notification received by your app and take action based on the event.
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-
 The [`expo-notifications`](/versions/latest/sdk/notifications) library contains event listeners that handle how your app responds when receiving a notification.
 
 ## Notification event listeners
@@ -59,11 +57,3 @@ Notifications.setNotificationHandler({
 ## Closed notification behavior
 
 On Android, users can set certain OS-level settings, usually revolving around performance and battery optimization, that can prevent notifications from being delivered when the app is closed. For example, one such setting is the **Deep Clear** option on OnePlus devices using Android 9 and lower versions.
-
-## Next
-
-<BoxLink
-  title="Common questions and FAQs"
-  description="A collection of common questions about Expo's push notification service."
-  href="/push-notifications/faq"
-/>

--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -6,7 +6,6 @@ description: Learn how to call Expo's Push API with the token when you want to s
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { CODE } from '~/ui/components/Text';
-import { BoxLink } from '~/ui/components/BoxLink';
 
 The [`expo-notifications`](/versions/latest/sdk/notifications) library provides all the client-side functionality for push notifications. Expo also handles sending these notifications off to FCM and APNs. All you need to do is send the request to the Expo's Push API with the `ExpoPushToken` you grabbed in the last step.
 
@@ -337,16 +336,8 @@ Each message must be a JSON object with the given fields (only the `to` field is
 
 ## Delivery guarantees
 
-Expo makes the best effort to deliver notifications to the push notification services operated by Google and Apple. Expo's infrastructure is designed for at-least-once delivery to the underlying push notification services. It is more likely for a notification to be delivered to Google or Apple more than once rather than not at all, though both are uncommon and possible.
+Expo makes the best effort to deliver notifications to the push notification services operated by Google and Apple. Expo's infrastructure is designed for at least once delivery to the underlying push notification services. It is more likely for a notification to be delivered to Google or Apple more than once rather than not at all, though both are uncommon and possible.
 
 After a notification has been handed off to an underlying push notification service, Expo creates a "push receipt" that records whether the handoff was successful. A push receipt denotes whether the underlying push notification service received the notification.
 
-Finally, the push notification services from Google, Apple, and so on follow their policies to deliver the notification to the device.
-
-## Next
-
-<BoxLink
-  title="Receive notifications"
-  description="Learn how to set your project up for receiving notifications and take action based on those events."
-  href="/push-notifications/receiving-notifications/"
-/>
+Finally, the push notification services from Google, Apple, and so on follow their policies to deliver the notifications to the device.

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -4,8 +4,6 @@ description: Learn how to use the Drawer layout in Expo Router.
 hideTOC: true
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -53,24 +51,24 @@ To edit the drawer navigation menu labels, titles and screen options specific sc
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {
-  return ( 
+  return (
     <Drawer>
       <Drawer.Screen
         name="index" // This is the name of the page and must match the url from root
         options={{
-          drawerLabel: "Home",
-          title: "overview",
+          drawerLabel: 'Home',
+          title: 'overview',
         }}
       />
       <Drawer.Screen
         name="user/[id]" // This is the name of the page and must match the url from root
         options={{
-          drawerLabel: "User",
-          title: "overview",
+          drawerLabel: 'User',
+          title: 'overview',
         }}
       />
     </Drawer>
-  )
+  );
 }
 ```
 
@@ -100,26 +98,26 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {
-  return ( 
+  return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <Drawer>
         <Drawer.Screen
           name="index" // This is the name of the page and must match the url from root
           options={{
-            drawerLabel: "Home",
-            title: "overview",
+            drawerLabel: 'Home',
+            title: 'overview',
           }}
         />
         <Drawer.Screen
           name="user/[id]" // This is the name of the page and must match the url from root
           options={{
-            drawerLabel: "User",
-            title: "overview",
+            drawerLabel: 'User',
+            title: 'overview',
           }}
         />
       </Drawer>
     </GestureHandlerRootView>
-  )
+  );
 }
 ```
 
@@ -128,12 +126,3 @@ export default function Layout() {
 </Tab>
 
 </Tabs>
-
-## Next steps
-
-<BoxLink
-  title="Nesting navigators"
-  Icon={BookOpen02Icon}
-  description="Learn how to nest navigators in Expo Router."
-  href="/router/advanced/nesting-navigators/"
-/>

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -4,8 +4,6 @@ description: Learn how to use modals in Expo Router.
 hideTOC: true
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { FileTree } from '~/ui/components/FileTree';
 import Video from '~/components/plugins/Video';
 
@@ -76,12 +74,3 @@ export default function Modal() {
   );
 }
 ```
-
-## Next steps
-
-<BoxLink
-  title="Platform-specific Modules"
-  Icon={BookOpen02Icon}
-  description="Learn how to switch modules based on the platform in Expo Router."
-  href="/router/advanced/platform-specific-modules/"
-/>

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -4,8 +4,6 @@ description: Learn how to nest navigators in Expo Router.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 > **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
 
@@ -95,12 +93,3 @@ In Expo Router, you can use `router.push()` to achieve the same result. There is
 ```js Expo Router
 router.push('/root/settings/media');
 ```
-
-## Next steps
-
-<BoxLink
-  title="Modals"
-  Icon={BookOpen02Icon}
-  description="Learn how to use modals in Expo Router."
-  href="/router/advanced/modals"
-/>

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -4,8 +4,6 @@ description: Learn how to switch modules based on the platform in Expo Router.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 While building your app, you may want to show specific content based on the current platform. Platform-specific modules can make the experience more native to a given platform. The following sections describe the ways you can achieve this with Expo Router.
 
@@ -64,12 +62,3 @@ export { default } from '../components/about';
 ```
 
 > **info** **Best practice:** Always provide a file without a platform extension to ensure every platform has a default implementation.
-
-## Next steps
-
-<BoxLink
-  title="Shared routes"
-  Icon={BookOpen02Icon}
-  description="Learn how to define shared routes or use arrays to use the same route multiple times with different layouts using Expo Router."
-  href="/router/advanced/shared-routes/"
-/>

--- a/docs/pages/router/advanced/root-layout.mdx
+++ b/docs/pages/router/advanced/root-layout.mdx
@@ -4,22 +4,8 @@ description: Learn how to use the root layout to add global providers to your ap
 hideTOC: true
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
-
 Traditional React Native projects are structured with a single root component that is often defined in **./App.js** or **./index.js**. This pattern is often used to inject global providers such as Redux, Themes, Styles, and so on, into the app, and to delay rendering until assets and fonts are loaded.
 
 In Expo Router, you can use the **Root Layout** (**app/\_layout.js**) to add providers which can be accessed by any route in the app.
 
 > Try to reduce the scope of your providers to only the routes that need them. This will improve performance and cause fewer rerenders.
-
-## Next steps
-
-<BoxLink
-  title="Stack navigation"
-  Icon={BookOpen02Icon}
-  description={
-    'Render a stack of screens like a deck of cards with a header on top. This is a native stack navigator that uses native animations and gestures.'
-  }
-  href="/router/advanced/stack"
-/>

--- a/docs/pages/router/advanced/shared-routes.mdx
+++ b/docs/pages/router/advanced/shared-routes.mdx
@@ -5,8 +5,6 @@ hideTOC: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 To match the same URL with different layouts, use [**groups**](/routing/layouts#groups) with overlapping child routes. This pattern is very common in native apps. For example, in the Twitter app, a profile can be viewed in every tab (such as home, search, and profile). However, there is only one URL that is required to access this route.
 
@@ -45,12 +43,3 @@ export default function DynamicLayout({ segment }) {
   return <Stack />;
 }
 ```
-
-## Next steps
-
-<BoxLink
-  title="Router Settings"
-  Icon={BookOpen02Icon}
-  description="Learn how to configure layouts with static properties in Expo Router."
-  href="/router/advanced/router-settings/"
-/>

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -315,18 +315,11 @@ export default function Settings() {
 }
 ```
 
-## Next steps
+## Next step
 
 <BoxLink
   title="Native Stack Navigator: Options"
   Icon={BookOpen02Icon}
   description="For a list of all options, see React Navigation's documentation."
   href="https://reactnavigation.org/docs/native-stack-navigator#options"
-/>
-
-<BoxLink
-  title="Tabs layout"
-  Icon={BookOpen02Icon}
-  description="Learn how to use Tabs layout in Expo Router."
-  href="/router/advanced/tabs"
 />

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -3,9 +3,6 @@ title: Tabs
 description: Learn how to use the Tabs layout in Expo Router.
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
-
 The `Tabs` layout in Expo Router wraps the [Bottom Tabs](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation.
 
 Expo Router adds `href` screen option which can only be used with screen options that are an object (for example, `screenOptions={{ href: "/path" }}`) and cannot be used simultaneously with `tabBarButton`.
@@ -60,12 +57,3 @@ export default function AppLayout() {
   );
 }
 ```
-
-## Next steps
-
-<BoxLink
-  title="Drawer layout"
-  Icon={BookOpen02Icon}
-  description="Learn how to use Drawer layout in Expo Router."
-  href="/router/advanced/drawer/"
-/>

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -194,7 +194,7 @@ export default function Root({ children }: PropsWithChildren) {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        
+
         {/*
           Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
@@ -346,4 +346,4 @@ You can deploy your statically rendered website to any static hosting service. H
 - [Render](https://render.com/)
 - [Surge](https://surge.sh/)
 
-> Note: You don't need to add Single-Page Application styled redirects to your static hosting service. The static website is not a single-page application. It is a collection of static HTML files.
+> **Note:** You don't need to add Single-Page Application styled redirects to your static hosting service. The static website is not a single-page application. It is a collection of static HTML files.

--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -4,7 +4,6 @@ description: Learn how to use a splash screen, fonts and images in your app that
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 
@@ -146,13 +145,3 @@ To use it with Expo Router, you need to install the library:
 </Tabs>
 
 To learn more about the components and utilities the library provides, see [Elements library](https://reactnavigation.org/docs/elements/) documentation.
-
-## Next steps
-
-<BoxLink
-  title="Error handling"
-  description="Improve the user experience by gracefully handling unexpected errors."
-  href="/routing/error-handling/"
-  Icon={BookOpen02Icon}
-/>
-```

--- a/docs/pages/routing/create-pages.mdx
+++ b/docs/pages/routing/create-pages.mdx
@@ -4,8 +4,6 @@ description: Learn about the file-based routing convention used by Expo Router.
 sidebar_title: Create pages
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 When a file is created in the **app** directory, it automatically becomes a route in the app. For example, the following files will create the following routes:
@@ -85,12 +83,3 @@ export default function Page() {
   return <Text>Blog post: {slug}</Text>;
 }
 ```
-
-## Next steps
-
-<BoxLink
-  title="Navigate between pages"
-  Icon={BookOpen02Icon}
-  description="Learn how to use Expo Router library to navigate between different pages."
-  href="/routing/navigating-pages/"
-/>

--- a/docs/pages/routing/error-handling.mdx
+++ b/docs/pages/routing/error-handling.mdx
@@ -5,8 +5,6 @@ description: Learn how to handle unmatched routes and errors in your app when us
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIBox } from '~/components/plugins/APIBox';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 This guide specifies how to handle unmatched routes and errors in your app when using Expo Router.
 

--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -6,8 +6,6 @@ sidebar_title: Installation
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { GithubIcon, Map01Icon, BookOpen02Icon } from '@expo/styleguide-icons';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Find the steps below to create a new project with Expo Router library or add it to your existing project.
@@ -191,12 +189,3 @@ Expo Router requires at least `metro@0.76.0`. If you are using Expo SDK version 
 </Tab>
 
 </Tabs>
-
-## Next steps
-
-<BoxLink
-  title="Create pages with Expo Router"
-  Icon={BookOpen02Icon}
-  description=" Learn about the file-based routing convention used by Expo Router."
-  href="/routing/create-pages/"
-/>

--- a/docs/pages/routing/introduction.mdx
+++ b/docs/pages/routing/introduction.mdx
@@ -5,10 +5,8 @@ hideTOC: true
 sidebar_title: Introduction
 ---
 
-import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon, BookOpen02Icon, Rocket02Icon } from '@expo/styleguide-icons';
-import Video from '~/components/plugins/Video';
 
 Expo Router is a file-based router for React Native and web applications. It allows you to manage navigation between screens in your app, allowing users to move seamlessly between different parts of your app's UI, using the same components on multiple platforms (Android, iOS, and web).
 

--- a/docs/pages/routing/layouts.mdx
+++ b/docs/pages/routing/layouts.mdx
@@ -4,9 +4,8 @@ description: Learn how to define shared UI elements such as tab bars and headers
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
-import { GithubIcon, BookOpen02Icon, Rocket02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { CODE } from '~/ui/components/Text';
 
 By default, routes fill the entire screen. Moving between them is a full-page transition with no animation. In native apps, users expect shared elements like headers and tab bars to persist between pages. These are created using **layout routes**.
 
@@ -128,7 +127,7 @@ Learn more about the built-in layouts:
 
 ## Advanced
 
-Expo Router supports additional conventions and systems to build complex UIs that native app users expect. These are not required to use Expo Router, but are available if you need them.
+Expo Router supports additional conventions and systems to build complex UIs that native app users expect. These are not required to use Expo Router but are available if you need them.
 
 <BoxLink
   title="Nesting navigators"
@@ -142,13 +141,4 @@ Expo Router supports additional conventions and systems to build complex UIs tha
   Icon={BookOpen02Icon}
   description="Create routes which appear in multiple places simultaneously, while using the same URL."
   href="/router/advanced/shared-routes"
-/>
-
-## Next steps
-
-<BoxLink
-  title="Appearance elements"
-  Icon={BookOpen02Icon}
-  description="Learn how to use a splash screen, fonts and images in your app that is using Expo Router."
-  href="/routing/appearance/"
 />

--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -3,8 +3,6 @@ title: Navigate between pages
 description: Create links to move between pages.
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
 import { FileTree } from '~/ui/components/FileTree';
 
 Expo Router uses "links" to move between pages in the app. This is conceptually similar to how the web works with `<a>` tags and the `href` attribute.
@@ -148,12 +146,3 @@ Client-side navigation works with both single-page apps, and [static rendering](
 ## Usage in simulators
 
 See the [testing URLs](/guides/linking#testing-urls) guide to learn how you can emulate deep links in simulators and emulators.
-
-## Next steps
-
-<BoxLink
-  title="Layouts and UI"
-  Icon={BookOpen02Icon}
-  description="Learn how to create shared UI elements like headers and tab bars."
-  href="/routing/layouts/"
-/>

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -66,4 +66,4 @@ Example usage:
 
 ## Automating submissions
 
-To learn how to automatically submit your app after a successful build, refer to the ["Automating submissions" guide](/build/automate-submissions).
+To learn how to automatically submit your app after a successful build, refer to the [Automating submissions](/build/automate-submissions).

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -119,6 +119,6 @@ This process can take a few minutes, then another 10-15 minutes of processing on
 
 ## Automating submissions
 
-To learn how to automatically submit your app after a successful build, refer to the ["Automating submissions" guide](/build/automate-submissions).
+To learn how to automatically submit your app after a successful build, refer to the [Automating submissions](/build/automate-submissions).
 
 [asc]: https://appstoreconnect.apple.com/apps

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -64,7 +64,7 @@ The ability to use Expo web with these other React frameworks is what makes it t
 ## Next
 
 <BoxLink
-  title="Publishing websites"
+  title="Publish websites"
   description="Export your website and upload to any web host."
   href="/distribution/publishing-websites"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10687

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By removing NextSteps/BoxLinks from docs under Home and Guides.
- Also, fixes few minor grammatical mistakes

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and manually navigate through a section or multiple sections.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
