### PR TITLE
[dev-launcher] Set launchModeExperimental to most-recent by default

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Launch directly into the previously opened project by default. ([#25500](https://github.com/expo/expo/pull/25500) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -222,7 +222,7 @@ class DevLauncherController private constructor() :
       }
 
     intent?.let {
-      val shouldTryToLaunchLastOpenedBundle = getMetadataValue(context, "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE").toBoolean()
+      val shouldTryToLaunchLastOpenedBundle = getMetadataValue(context, "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE", "true").toBoolean()
       val lastOpenedApp = recentlyOpedAppsRegistry.getMostRecentApp()
       if (shouldTryToLaunchLastOpenedBundle && lastOpenedApp != null && intent.action == Intent.ACTION_MAIN) {
         coroutineScope.launch {
@@ -338,11 +338,11 @@ class DevLauncherController private constructor() :
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
     @JvmStatic
-    fun getMetadataValue(context: Context, key: String): String {
+    fun getMetadataValue(context: Context, key: String, defaultValue: String = ""): String {
       val packageManager = context.packageManager
       val packageName = context.packageName
       val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-      var metaDataValue = ""
+      var metaDataValue = defaultValue
 
       if (applicationInfo.metaData != null) {
         val value = applicationInfo.metaData.get(key)

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -256,7 +256,8 @@
     return;
   }
 
-  BOOL shouldTryToLaunchLastOpenedBundle = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
+  NSNumber *devClientTryToLaunchLastBundleValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
+  BOOL shouldTryToLaunchLastOpenedBundle = (devClientTryToLaunchLastBundleValue != nil) ? [devClientTryToLaunchLastBundleValue boolValue] : YES;
   if (_lastOpenedAppUrl != nil && shouldTryToLaunchLastOpenedBundle) {
     [self loadApp:_lastOpenedAppUrl withProjectUrl:nil onSuccess:nil onError:^(NSError *error) {
        __weak typeof(self) weakSelf = self;
@@ -264,7 +265,7 @@
          typeof(self) self = weakSelf;
          if (!self) {
            return;
-         } 
+         }
 
          [self navigateToLauncher];
        });

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -29,7 +29,7 @@ export type PluginConfigOptions = {
      *
      * - `'launcher'` - Opens the launcher screen.
      *
-     * @default 'launcher'
+     * @default 'most-recent'
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
 };

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -5,16 +5,16 @@ const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
 exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
     (0, pluginConfig_1.validateConfig)(props);
-    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
+    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
-            config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = true;
+            config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
             return config;
         });
     }
-    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
+    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
-            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', true?.toString());
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', false?.toString());
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -33,7 +33,7 @@ export type PluginConfigOptions = {
    *
    * - `'launcher'` - Opens the launcher screen.
    *
-   * @default 'launcher'
+   * @default 'most-recent'
    */
   launchModeExperimental?: 'most-recent' | 'launcher';
 };

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -13,21 +13,21 @@ export default createRunOncePlugin<PluginConfigType>(
   (config, props = {}) => {
     validateConfig(props);
 
-    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
+    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
       config = withInfoPlist(config, (config) => {
-        config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = true;
+        config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
         return config;
       });
     }
 
-    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
+    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
       config = withAndroidManifest(config, (config) => {
         const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
         AndroidConfig.Manifest.addMetaDataItemToMainApplication(
           mainApplication,
           'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE',
-          true?.toString()
+          false?.toString()
         );
         return config;
       });


### PR DESCRIPTION
# Why

Closes ENG-10679

# How

 Set launchModeExperimental to most-recent by default

# Test Plan

Run bare-expo with dev-client locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
