### PR TITLE
[dev-launcher] Fix UrlDropdown typescript

### DIFF
--- a/packages/expo-dev-launcher/bundle/components/UrlDropdown.tsx
+++ b/packages/expo-dev-launcher/bundle/components/UrlDropdown.tsx
@@ -10,11 +10,17 @@ import {
   useCurrentTheme,
 } from 'expo-dev-client-components';
 import * as React from 'react';
-import { TextInput as NativeTextInput, Platform, StyleSheet } from 'react-native';
+import {
+  ImageStyle,
+  TextInput as NativeTextInput,
+  Platform,
+  StyleProp,
+  StyleSheet,
+} from 'react-native';
 
+import { ActivityIndicator } from './ActivityIndicator';
 import { debounce } from '../functions/debounce';
 import { validateUrl } from '../functions/validateUrl';
-import { ActivityIndicator } from './ActivityIndicator';
 
 type UrlDropdownProps = {
   isLoading?: boolean;
@@ -47,7 +53,7 @@ export function UrlDropdown({ onSubmit, isLoading, inputValue, setInputValue }: 
   const rotate = open ? '90deg' : '0deg';
   // slight visual adjustment for centering icon
   const translateX = -3;
-  const arrowStyle = { transform: [{ translateX }, { rotate }] };
+  const arrowStyle: StyleProp<ImageStyle> = { transform: [{ translateX }, { rotate }] };
 
   const onConnectPress = () => {
     onSubmit(inputValue);


### PR DESCRIPTION
# Why

While working on https://github.com/expo/expo/pull/25500 I noticed that typescript was failing

# How

Explicitly type `arrowStyle` as `ImageStyle`

# Test Plan

run `yarn tsc -p bundle/tsconfig.json`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
