### PR TITLE
[expo-updates] Asset exclusion on Android part 2

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [Android] Asset exclusion on Android part 2. ([#25504](https://github.com/expo/expo/pull/25504) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.launcher
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.UpdatesDatabase
@@ -152,7 +151,7 @@ class DatabaseLauncher(
         }
         val filename = UpdatesUtils.createFilenameForAsset(asset)
         asset.relativePath = filename
-        val assetFile = File(updatesDirectory, asset.relativePath)
+        val assetFile = File(updatesDirectory, filename)
         if (!assetFile.exists()) {
           loaderFiles.copyAssetAndGetHash(asset, assetFile, context)
         }
@@ -232,7 +231,7 @@ class DatabaseLauncher(
     assetsToDownloadFinished++
     if (asset.isLaunchAsset) {
       launchAssetFile = if (assetFile == null) {
-        logger?.error( "Could not launch; failed to load update from disk or network", UpdatesErrorCode.UpdateFailedToLoad)
+        logger?.error("Could not launch; failed to load update from disk or network", UpdatesErrorCode.UpdateFailedToLoad)
         null
       } else {
         assetFile.toString()

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -237,7 +237,8 @@ async function preparePackageJson(
       };
 
   const extraScriptsAssetExclusion = {
-    'reset-to-embedded': 'npx ts-node ./scripts/reset-app.ts App.tsx.embedded',
+    'reset-to-embedded':
+      'npx ts-node ./scripts/reset-app.ts App.tsx.embedded; (rm -rf android/build android/app/build)',
     'set-to-update-1':
       'npx ts-node ./scripts/reset-app.ts App.tsx.update1; eas update --branch=main --message=Update1',
     'set-to-update-2':


### PR DESCRIPTION
# Why

Identified and fixed issues that prevented the changes in #25277 from fully working.

# How

- Corrected the code that generates the embedded part of `localAssetFiles` created in `DatabaseLauncher.kt`
- Moved plain logging to an `UpdatesLogger`
- Adjusted a script used in a generated project for manually testing the feature

# Test Plan

- Tested with an EAS app generated with `packages/expo-updates/e2e/setup/create-updates-test.ts`
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
