### PR TITLE
fix(cli)!: update tsconfig aliases resolution

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -188,29 +188,29 @@ In SDK 49 projects, you'll need to enable absolute imports in the project's [app
 }
 ```
 
-Absolute imports from the project root directory are enabled automatically when the project contains a **tsconfig.json** or **jsconfig.json** file. For example:
-
-```tsx
-import Button from 'src/components/Button';
-// Imports `<project root>/src/components/Button`
-```
-
-You can modify the base directory in the tsconfig.json (or jsconfig.json) using the [baseUrl](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) option:
+Absolute imports from the project root directory are enabled when [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) is defined in the project's **tsconfig.json** or **jsconfig.json** file. For example:
 
 ```json tsconfig.json
 {
   "compilerOptions": {
-    "baseUrl": "src"
+    "baseUrl": "./"
   }
 }
 ```
 
+Will enable the following import:
+
+```tsx
+import Button from 'src/components/Button';
+// Imports `<compilerOptions.baseUrl>/src/components/Button`
+```
+
 Consider the following when using absolute imports:
 
-- [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) is automatically set to `.` when the `tsconfig.json` or **jsconfig.json** file exists.
-- Absolute imports in Node modules cannot be overwritten by absolute imports, as they take precedence.
-- Restarting Expo CLI is necessary to update [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) after modifying **the tsconfig.json**.
-- If not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
+- `compilerOptions.paths` are resolved relative to the `compilerOptions.baseUrl` if it is defined, otherwise they're resolved against the project root directory.
+- `compilerOptions.baseUrl` is resolved before node modules. This means if you have a file named `./path.js` in the project, it may be imported instead of a node module named `path`.
+- Restarting Expo CLI is necessary to update [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) after modifying the **tsconfig.json**.
+- If you're not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
 - Absolute imports are only supported by Metro (including Metro web) and not by `@expo/webpack-config`.
 - Bare projects require additional setup for this feature. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 🛠 Breaking changes
 
+- `tsconfig.json` attribute `baseUrl` will no longer default to enabled when `paths` are defined.
+- `tsconfig.json` attribute `baseUrl` will now be resolved _before_ node modules instead of after.
+- `tsconfig.json` attribute `baseUrl` will no longer be resolved if a group from `paths` are matched first.
 - Change default CSS reset in template HTML to align with `react-native-web@0.19.8`. ([#25429](https://github.com/expo/expo/pull/25429) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### 🛠 Breaking changes
 
-- `tsconfig.json` attribute `baseUrl` will no longer default to enabled when `paths` are defined.
-- `tsconfig.json` attribute `baseUrl` will now be resolved _before_ node modules instead of after.
-- `tsconfig.json` attribute `baseUrl` will no longer be resolved if a group from `paths` are matched first.
+- `tsconfig.json` attribute `baseUrl` will no longer default to enabled when `paths` are defined. ([#25510](https://github.com/expo/expo/pull/25510) by [@EvanBacon](https://github.com/EvanBacon))
+- `tsconfig.json` attribute `baseUrl` will now be resolved _before_ node modules instead of after. ([#25510](https://github.com/expo/expo/pull/25510) by [@EvanBacon](https://github.com/EvanBacon))
+- `tsconfig.json` attribute `baseUrl` will no longer be resolved if a group from `paths` are matched first. ([#25510](https://github.com/expo/expo/pull/25510) by [@EvanBacon](https://github.com/EvanBacon))
 - Change default CSS reset in template HTML to align with `react-native-web@0.19.8`. ([#25429](https://github.com/expo/expo/pull/25429) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -100,19 +100,20 @@ describe(withExtendedResolver, () => {
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
     expect(getResolveFunc()).toBeCalledTimes(1);
-    expect(getResolveFunc()).toBeCalledWith(
+
+    expect(getResolveFunc()).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
-        nodeModulesPaths: ['/node_modules', '/src'],
         extraNodeModules: {},
         mainFields: ['react-native', 'browser', 'main'],
         preferNativePlatform: true,
       }),
-      'react-native',
+      '/src/react-native',
       platform
     );
   });
 
-  it(`resolves to react-native-web on web`, async () => {
+  it(`does not alias react-native-web in initial resolution with baseUrl on web`, async () => {
     mockMinFs();
 
     const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
@@ -128,10 +129,33 @@ describe(withExtendedResolver, () => {
     expect(getResolveFunc()).toBeCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
-        nodeModulesPaths: ['/node_modules', '/src'],
-        extraNodeModules: {
-          'react-native': expect.stringContaining('node_modules/react-native-web'),
-        },
+        mainFields: ['browser', 'module', 'main'],
+        preferNativePlatform: false,
+      }),
+      '/src/react-native',
+      platform
+    );
+  });
+
+  it(`resolves to react-native-web on web`, async () => {
+    mockMinFs();
+
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+      platforms: ['ios', 'web'],
+      tsconfig: {
+        // No baseUrl
+        paths: { '/*': ['*'] },
+      },
+      isTsconfigPathsEnabled: true,
+    });
+
+    const platform = 'web';
+
+    modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
+
+    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toBeCalledWith(
+      expect.objectContaining({
         mainFields: ['browser', 'module', 'main'],
         preferNativePlatform: false,
       }),
@@ -165,10 +189,6 @@ describe(withExtendedResolver, () => {
     expect(getResolveFunc()).toBeCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
-        nodeModulesPaths: ['/node_modules'],
-        extraNodeModules: {
-          'react-native': expect.stringContaining('node_modules/react-native-web'),
-        },
         mainFields: ['browser', 'module', 'main'],
         preferNativePlatform: false,
       }),
@@ -207,9 +227,6 @@ describe(withExtendedResolver, () => {
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         nodeModulesPaths: ['/node_modules'],
-        extraNodeModules: {
-          'react-native': expect.stringContaining('node_modules/react-native-web'),
-        },
         mainFields: ['browser', 'module', 'main'],
         preferNativePlatform: false,
       }),
@@ -243,9 +260,6 @@ describe(withExtendedResolver, () => {
     expect(getResolveFunc()).toBeCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
-        extraNodeModules: {
-          'react-native': expect.stringContaining('node_modules/react-native-web'),
-        },
         mainFields: ['main', 'module'],
         preferNativePlatform: false,
         // Moved mjs to the back

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -79,7 +79,6 @@ describe(withExtendedResolver, () => {
         sourceExts: ['mjs', 'ts', 'tsx', 'js', 'jsx', 'json', 'css'],
         customResolverOptions: {},
         originModulePath: expect.anything(),
-        getPackageMainPath: expect.any(Function),
       }),
       'react-native',
       platform

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -160,7 +160,8 @@ export function withExtendedResolver(
   let tsConfigResolve = tsconfig?.paths
     ? resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
         paths: tsconfig.paths ?? {},
-        baseUrl: tsconfig.baseUrl,
+        baseUrl: tsconfig.baseUrl ?? config.projectRoot,
+        hasBaseUrl: !!tsconfig.baseUrl,
       })
     : null;
 
@@ -181,7 +182,8 @@ export function withExtendedResolver(
             debug('Enabling tsconfig.json paths support');
             tsConfigResolve = resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
               paths: tsConfigPaths.paths ?? {},
-              baseUrl: tsConfigPaths.baseUrl,
+              baseUrl: tsConfigPaths.baseUrl ?? config.projectRoot,
+              hasBaseUrl: !!tsConfigPaths.baseUrl,
             });
           } else {
             debug('Disabling tsconfig.json paths support');
@@ -388,34 +390,6 @@ export function withExtendedResolver(
         if (!env.EXPO_METRO_NO_MAIN_FIELD_OVERRIDE && platform && platform in preferredMainFields) {
           context.mainFields = preferredMainFields[platform];
         }
-      }
-
-      // TODO: We may be able to remove this in the future, it's doing no harm
-      // by staying here.
-      // Conditionally remap `react-native` to `react-native-web`
-      if (platform && platform in extraNodeModules) {
-        context.extraNodeModules = {
-          ...extraNodeModules[platform],
-          ...context.extraNodeModules,
-        };
-      }
-
-      if (tsconfig?.baseUrl && isTsconfigPathsEnabled) {
-        const nodeModulesPaths: string[] = [...immutableContext.nodeModulesPaths];
-
-        if (isFastResolverEnabled) {
-          // add last to ensure node modules are resolved first
-          nodeModulesPaths.push(
-            path.isAbsolute(tsconfig.baseUrl)
-              ? tsconfig.baseUrl
-              : path.join(config.projectRoot, tsconfig.baseUrl)
-          );
-        } else {
-          // add last to ensure node modules are resolved first
-          nodeModulesPaths.push(tsconfig.baseUrl);
-        }
-
-        context.nodeModulesPaths = nodeModulesPaths;
       }
 
       // TODO: We can drop this in the next version upgrade (SDK 50).

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -364,11 +364,9 @@ export function withExtendedResolver(
       moduleName: string,
       platform: string | null
     ): CustomResolutionContext => {
-      const context = {
+      const context: Mutable<CustomResolutionContext> = {
         ...immutableContext,
-      } as Mutable<ResolutionContext> & {
-        mainFields: string[];
-        customResolverOptions?: Record<string, string>;
+        preferNativePlatform: platform !== 'web',
       };
 
       if (context.customResolverOptions?.environment === 'node') {
@@ -392,22 +390,7 @@ export function withExtendedResolver(
         }
       }
 
-      // TODO: We can drop this in the next version upgrade (SDK 50).
-      const mainFields: string[] = context.mainFields;
-
-      return {
-        ...context,
-        preferNativePlatform: platform !== 'web',
-        // Passing `mainFields` directly won't be considered (in certain version of Metro)
-        // we need to extend the `getPackageMainPath` directly to
-        // use platform specific `mainFields`.
-        // @ts-ignore
-        getPackageMainPath(packageJsonPath) {
-          // @ts-expect-error: mainFields is not on type
-          const package_ = context.moduleCache.getPackage(packageJsonPath);
-          return package_.getMain(mainFields);
-        },
-      };
+      return context;
     }
   );
 

--- a/packages/@expo/cli/src/utils/tsconfig/__tests__/loadTsConfigPaths.test.ts
+++ b/packages/@expo/cli/src/utils/tsconfig/__tests__/loadTsConfigPaths.test.ts
@@ -26,7 +26,7 @@ describe(loadTsConfigPathsAsync, () => {
       },
       '/'
     );
-    expect(await loadTsConfigPathsAsync('/')).toEqual({ baseUrl: '/', paths: undefined });
+    expect(await loadTsConfigPathsAsync('/')).toEqual({ baseUrl: undefined, paths: undefined });
   });
   it(`returns jsconfig paths`, async () => {
     vol.fromJSON(

--- a/packages/@expo/cli/src/utils/tsconfig/loadTsConfigPaths.ts
+++ b/packages/@expo/cli/src/utils/tsconfig/loadTsConfigPaths.ts
@@ -6,7 +6,7 @@ import { fileExistsAsync } from '../dir';
 
 export type TsConfigPaths = {
   paths?: Record<string, string[]>;
-  baseUrl: string;
+  baseUrl?: string;
 };
 
 type ConfigReadResults = [
@@ -24,17 +24,12 @@ const debug = require('debug')('expo:utils:tsconfig:load') as typeof console.log
 export async function loadTsConfigPathsAsync(dir: string): Promise<TsConfigPaths | null> {
   const options = (await readTsconfigAsync(dir)) ?? (await readJsconfigAsync(dir));
   if (options) {
-    const [filepath, config] = options;
-    if (config.compilerOptions?.baseUrl) {
-      return {
-        paths: config.compilerOptions?.paths,
-        baseUrl: path.resolve(dir, config.compilerOptions.baseUrl),
-      };
-    }
-    debug(`No baseUrl found in ${filepath}`);
+    const [, config] = options;
     return {
       paths: config.compilerOptions?.paths,
-      baseUrl: dir,
+      baseUrl: config.compilerOptions?.baseUrl
+        ? path.resolve(dir, config.compilerOptions.baseUrl)
+        : undefined,
     };
   }
   return null;

--- a/packages/@expo/cli/src/utils/tsconfig/resolveWithTsConfigPaths.ts
+++ b/packages/@expo/cli/src/utils/tsconfig/resolveWithTsConfigPaths.ts
@@ -10,7 +10,7 @@ const debug = require('debug')('expo:metro:tsconfig-paths') as typeof console.lo
 const isAbsolute = process.platform === 'win32' ? path.win32.isAbsolute : path.posix.isAbsolute;
 
 export function resolveWithTsConfigPaths(
-  config: { paths: Paths; baseUrl: string },
+  config: { paths: Paths; baseUrl: string; hasBaseUrl: boolean },
   request: {
     /** Import request */
     moduleName: string;
@@ -23,7 +23,7 @@ export function resolveWithTsConfigPaths(
 
   if (
     // If no aliases are added bail out
-    !aliases.length ||
+    (!aliases.length && !config.hasBaseUrl) ||
     // Library authors cannot utilize this feature in userspace.
     /node_modules/.test(request.originModulePath) ||
     // Absolute paths are not supported
@@ -35,22 +35,32 @@ export function resolveWithTsConfigPaths(
   }
 
   const matched = matchTsConfigPathAlias(aliases, request.moduleName);
-  if (!matched) {
-    return null;
-  }
+  if (matched) {
+    for (const alias of config.paths[matched.text]) {
+      const nextModuleName = matched.star ? alias.replace('*', matched.star) : alias;
 
-  for (const alias of config.paths[matched.text]) {
-    const nextModuleName = matched.star ? alias.replace('*', matched.star) : alias;
+      if (/\.d\.ts$/.test(nextModuleName)) continue;
 
-    if (/\.d\.ts$/.test(nextModuleName)) continue;
+      const possibleResult = path.join(config.baseUrl, nextModuleName);
 
-    const possibleResult = path.join(config.baseUrl, nextModuleName);
-
-    const result = resolve(possibleResult);
-    if (result) {
-      debug(`${request.moduleName} -> ${possibleResult}`);
-      return result;
+      const result = resolve(possibleResult);
+      if (result) {
+        debug(`${request.moduleName} -> ${possibleResult}`);
+        return result;
+      }
+    }
+  } else {
+    // Only resolve against baseUrl if no `paths` groups were matched.
+    // Base URL is resolved after paths, and before node_modules.
+    if (config.hasBaseUrl) {
+      const possibleResult = path.join(config.baseUrl, request.moduleName);
+      const result = resolve(possibleResult);
+      if (result) {
+        debug(`baseUrl: ${request.moduleName} -> ${possibleResult}`);
+        return result;
+      }
     }
   }
+
   return null;
 }


### PR DESCRIPTION
# Why

The resolution was different to upstream behavior, causing there to be a fork in how vs code analyzed performed type checking.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- baseUrl must now be defined in order to resolve against it.
- baseUrl will now resolve before node modules are resolved. Meaning if you have a file `util.js` and import `util`, it will be resolved instead of `node_modules/util/index.js`.
- baseUrl will only be tested if no matcher group in `paths` is matched.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added more tests to cover the logic I added above. The logic was all tested in VS Code as well to ensure things matched up as expected.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
