### PR TITLE
chore(cli): Consolidate logic for resolving Node.js built-in shims in browsers

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Consolidate logic for resolving Node.js built-in shims in browser environments.
+- Consolidate logic for resolving Node.js built-in shims in browser environments. ([#25511](https://github.com/expo/expo/pull/25511) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.15.0 — 2023-11-14

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Consolidate logic for resolving Node.js built-in shims in browser environments.
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.15.0 — 2023-11-14


### PR DESCRIPTION
# Why

Reduce the number of resolver passes so we only check against built-ins one time per resolution.
