### PR TITLE
chore(babel-preset-expo, jest-expo, cli)!: Move react-native-vector-icons alias to resolvers

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver.
+- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver. ([#25512](https://github.com/expo/expo/pull/25512) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure invalid production iOS builds fail more predictably. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 - Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver.
 - Ensure invalid production iOS builds fail more predictably. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 - Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -140,6 +140,108 @@ describe(withExtendedResolver, () => {
     );
   });
 
+  it(`resolves to @expo/vector-icons on any platform`, async () => {
+    vol.fromJSON(
+      {
+        'node_modules/@react-native/assets-registry/registry.js': '',
+        'node_modules/@expo/vector-icons/index.js': '',
+      },
+      '/'
+    );
+
+    ['ios', 'web'].forEach((platform) => {
+      const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+        platforms: ['ios', 'web'],
+        tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
+        isTsconfigPathsEnabled: true,
+      });
+
+      modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        'react-native-vector-icons',
+        platform
+      );
+
+      expect(getResolveFunc()).toBeCalledWith(expect.anything(), '@expo/vector-icons', platform);
+    });
+  });
+
+  it(`does not alias react-native-vector-icons if @expo/vector-icons is not installed`, async () => {
+    vol.fromJSON(
+      {
+        'node_modules/@react-native/assets-registry/registry.js': '',
+      },
+      '/'
+    );
+
+    ['ios', 'web'].forEach((platform) => {
+      const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+        platforms: ['ios', 'web'],
+        tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
+        isTsconfigPathsEnabled: true,
+      });
+
+      modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        'react-native-vector-icons',
+        platform
+      );
+
+      expect(getResolveFunc()).toBeCalledWith(
+        expect.anything(),
+        'react-native-vector-icons',
+        platform
+      );
+    });
+  });
+
+  it(`does not alias sub paths of react-native-vector-icons`, async () => {
+    vol.fromJSON(
+      {
+        'node_modules/@react-native/assets-registry/registry.js': '',
+        'node_modules/@expo/vector-icons/index.js': '',
+      },
+      '/'
+    );
+    const platform = 'ios';
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+      platforms: ['ios', 'web'],
+      tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
+      isTsconfigPathsEnabled: true,
+    });
+
+    modified.resolver.resolveRequest!(
+      getDefaultRequestContext(),
+      'react-native-vector-icons/index.js',
+      platform
+    );
+
+    expect(getResolveFunc()).toBeCalledWith(
+      expect.anything(),
+      'react-native-vector-icons/index.js',
+      platform
+    );
+  });
+
+  it(`allows importing @expo/vector-icons`, async () => {
+    vol.fromJSON(
+      {
+        'node_modules/@react-native/assets-registry/registry.js': '',
+        'node_modules/@expo/vector-icons/index.js': '',
+      },
+      '/'
+    );
+    const platform = 'ios';
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+      platforms: ['ios', 'web'],
+      tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
+      isTsconfigPathsEnabled: true,
+    });
+
+    modified.resolver.resolveRequest!(getDefaultRequestContext(), '@expo/vector-icons', platform);
+    expect(getResolveFunc()).toBeCalledWith(expect.anything(), '@expo/vector-icons', platform);
+  });
+
   it(`resolves a node.js built-in as a shim on web`, async () => {
     mockMinFs();
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -166,6 +166,36 @@ describe(withExtendedResolver, () => {
     });
   });
 
+  it(`resolves nested imports to @expo/vector-icons on any platform`, async () => {
+    vol.fromJSON(
+      {
+        'node_modules/@react-native/assets-registry/registry.js': '',
+        'node_modules/@expo/vector-icons/index.js': '',
+      },
+      '/'
+    );
+
+    ['ios', 'web'].forEach((platform) => {
+      const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+        platforms: ['ios', 'web'],
+        tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
+        isTsconfigPathsEnabled: true,
+      });
+
+      modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        'react-native-vector-icons/FontAwesome',
+        platform
+      );
+
+      expect(getResolveFunc()).toBeCalledWith(
+        expect.anything(),
+        '@expo/vector-icons/FontAwesome',
+        platform
+      );
+    });
+  });
+
   it(`does not alias react-native-vector-icons if @expo/vector-icons is not installed`, async () => {
     vol.fromJSON(
       {
@@ -193,34 +223,6 @@ describe(withExtendedResolver, () => {
         platform
       );
     });
-  });
-
-  it(`does not alias sub paths of react-native-vector-icons`, async () => {
-    vol.fromJSON(
-      {
-        'node_modules/@react-native/assets-registry/registry.js': '',
-        'node_modules/@expo/vector-icons/index.js': '',
-      },
-      '/'
-    );
-    const platform = 'ios';
-    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
-      platforms: ['ios', 'web'],
-      tsconfig: { baseUrl: '/src', paths: { '/*': ['*'] } },
-      isTsconfigPathsEnabled: true,
-    });
-
-    modified.resolver.resolveRequest!(
-      getDefaultRequestContext(),
-      'react-native-vector-icons/index.js',
-      platform
-    );
-
-    expect(getResolveFunc()).toBeCalledWith(
-      expect.anything(),
-      'react-native-vector-icons/index.js',
-      platform
-    );
   });
 
   it(`allows importing @expo/vector-icons`, async () => {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -141,6 +141,14 @@ export function withExtendedResolver(
     },
   };
 
+  const universalAliases: Record<string, string> = {};
+
+  // This package is currently always installed as it is included in the `expo` package.
+  if (resolveFrom.silent(config.projectRoot, '@expo/vector-icons')) {
+    debug('Enabling alias: react-native-vector-icons -> @expo/vector-icons');
+    universalAliases['react-native-vector-icons'] = '@expo/vector-icons';
+  }
+
   // TODO: We can probably drop this resolution hack.
   const isWebEnabled = platforms.includes('web');
   if (isWebEnabled) {
@@ -298,6 +306,12 @@ export function withExtendedResolver(
         const redirectedModuleName = aliases[platform][moduleName];
         const doResolve = getStrictResolver(context, platform);
         return doResolve(redirectedModuleName);
+      }
+
+      // Alias `react-native-vector-icons` to `@expo/vector-icons` on all platforms if installed.
+      const alias = universalAliases[moduleName];
+      if (alias) {
+        return getStrictResolver(context, platform)(alias);
       }
 
       return null;

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Move `babel-plugin-module-resolver` alias for `react-native-vector-icons` to `@expo/vector-icons` to individual implementations in Metro (via `@expo/cli`) and `jest-expo`.
+
 ### 🎉 New features
 
 - Moved `react-refresh` babel plugin from Metro/Webpack to `babel-preset-expo`. ([#25461](https://github.com/expo/expo/pull/25461) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Move `babel-plugin-module-resolver` alias for `react-native-vector-icons` to `@expo/vector-icons` to individual implementations in Metro (via `@expo/cli`) and `jest-expo`.
+- Move `babel-plugin-module-resolver` alias for `react-native-vector-icons` to `@expo/vector-icons` to individual implementations in Metro (via `@expo/cli`) and `jest-expo`. ([#25512](https://github.com/expo/expo/pull/25512) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -79,10 +79,6 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.useTransformReactJSXExperimental != null) {
         throw new Error(`babel-preset-expo: The option 'useTransformReactJSXExperimental' has been removed in favor of { jsxRuntime: 'classic' }.`);
     }
-    const aliasPlugin = getAliasPlugin();
-    if (aliasPlugin) {
-        extraPlugins.push(aliasPlugin);
-    }
     // Allow jest tests to redefine the environment variables.
     if (process.env.NODE_ENV !== 'test') {
         extraPlugins.push([
@@ -195,19 +191,6 @@ function babelPresetExpo(api, options = {}) {
                 platformOptions.reanimated !== false && [require.resolve('react-native-reanimated/plugin')],
         ].filter(Boolean),
     };
-}
-function getAliasPlugin() {
-    if (!(0, common_1.hasModule)('@expo/vector-icons')) {
-        return null;
-    }
-    return [
-        require.resolve('babel-plugin-module-resolver'),
-        {
-            alias: {
-                'react-native-vector-icons': '@expo/vector-icons',
-            },
-        },
-    ];
 }
 exports.default = babelPresetExpo;
 module.exports = babelPresetExpo;

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -48,7 +48,6 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/plugin-transform-parameters": "^7.22.15",
     "@react-native/babel-preset": "^0.73.18",
-    "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-react-native-web": "~0.18.10",
     "react-refresh": "0.14.0"
   },

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -28,7 +28,7 @@ console.log('Calling InlineFuncFromFile()');
 console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
-_expoAsset.Asset.loadAsync([require("./assets/icon.png")]);
+_expoAsset.Asset.loadAsync([require('./assets/icon.png')]);
 }},{key:"render",value:
 
 function render(){
@@ -77,7 +77,7 @@ console.log('Calling InlineFuncFromFile()');
 console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
-_expoAsset().Asset.loadAsync([require("./assets/icon.png")]);
+_expoAsset().Asset.loadAsync([require('./assets/icon.png')]);
 }},{key:"render",value:
 
 function render(){
@@ -126,7 +126,7 @@ console.log('Calling InlineFuncFromFile()');
 console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
-_expoAsset.Asset.loadAsync([require("./assets/icon.png")]);
+_expoAsset.Asset.loadAsync([require('./assets/icon.png')]);
 }},{key:"render",value:
 
 function render(){
@@ -175,7 +175,7 @@ console.log('Calling InlineFuncFromFile()');
 console.log('Calling Boo.myFunc()');
 Boo.myFunc();
 
-_expoAsset.Asset.loadAsync([require("./assets/icon.png")]);
+_expoAsset.Asset.loadAsync([require('./assets/icon.png')]);
 }},{key:"render",value:
 
 function render(){
@@ -224,7 +224,7 @@ console.log('Calling InlineFuncFromFile()');
 console.log('Calling Boo.myFunc()');
 Boo().myFunc();
 
-_expoAsset.Asset.loadAsync([require("./assets/icon.png")]);
+_expoAsset.Asset.loadAsync([require('./assets/icon.png')]);
 }},{key:"render",value:
 
 function render(){
@@ -245,18 +245,10 @@ function unusedFunction(){
 (0,_reactRedux().connect)()(Lazy);exports.default=_default;"
 `;
 
-exports[`metro aliases @expo/vector-icons 1`] = `
-"
-require("@expo/vector-icons");
-require("@expo/vector-icons");
-imposter.require('react-native-vector-icons');
-imposter.import('react-native-vector-icons');"
-`;
-
 exports[`metro composes with babel-plugin-module-resolver 1`] = `
 "
 require("react-native");
-require("@expo/vector-icons");"
+require("react-native-vector-icons");"
 `;
 
 exports[`metro supports disabling reanimated 1`] = `
@@ -282,18 +274,10 @@ exports[`metro uses the platform's react-native import 1`] = `
 var _reactNative=require("react-native");"
 `;
 
-exports[`metro+hermes aliases @expo/vector-icons 1`] = `
-"
-require("@expo/vector-icons");
-require("@expo/vector-icons");
-imposter.require('react-native-vector-icons');
-imposter.import('react-native-vector-icons');"
-`;
-
 exports[`metro+hermes composes with babel-plugin-module-resolver 1`] = `
 "
 require("react-native");
-require("@expo/vector-icons");"
+require("react-native-vector-icons");"
 `;
 
 exports[`metro+hermes supports disabling reanimated 1`] = `
@@ -319,18 +303,10 @@ exports[`metro+hermes uses the platform's react-native import 1`] = `
 var _reactNative=require("react-native");"
 `;
 
-exports[`webpack aliases @expo/vector-icons 1`] = `
-"
-import"@expo/vector-icons";
-require("@expo/vector-icons");
-imposter.require('react-native-vector-icons');
-imposter.import('react-native-vector-icons');"
-`;
-
 exports[`webpack composes with babel-plugin-module-resolver 1`] = `
 "
 import"react-native";
-import"@expo/vector-icons";"
+import'react-native-vector-icons';"
 `;
 
 exports[`webpack supports disabling reanimated 1`] = `
@@ -350,8 +326,8 @@ console.log("Hey I'm running on the UI thread");
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `
-"import*as _default from"./Animated";export{_default as
-default};"
+"import*as _default from
+'./Animated';export{_default as default};"
 `;
 
 exports[`webpack uses the platform's react-native import 1`] = `"import View from"react-native-web/dist/exports/View";"`;

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -256,7 +256,7 @@ export * as default from './Animated';
     ).toBe(code);
   });
 
-  it(`aliases @expo/vector-icons`, () => {
+  it(`does not alias @expo/vector-icons in the transformer`, () => {
     const options = {
       babelrc: false,
       presets: [preset],
@@ -274,8 +274,7 @@ imposter.import('react-native-vector-icons');
 `;
     const { code } = babel.transform(sourceCode, options)!;
 
-    expect(code).toMatch(/"@expo\/vector-icons"/);
-    expect(code).toMatchSnapshot();
+    expect(code).not.toMatch(/"@expo\/vector-icons"/);
   });
 
   it(`composes with babel-plugin-module-resolver`, () => {
@@ -303,7 +302,8 @@ import 'react-native-vector-icons';
     const { code } = babel.transform(sourceCode, options)!;
 
     expect(code).toMatch(/"react-native"/);
-    expect(code).toMatch(/"@expo\/vector-icons"/);
+    // This is aliased later in the resolver for faster lookups and better caching.
+    expect(code).toMatch(/react-native-vector-icons/);
     expect(code).toMatchSnapshot();
   });
 });

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -133,11 +133,6 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     );
   }
 
-  const aliasPlugin = getAliasPlugin();
-  if (aliasPlugin) {
-    extraPlugins.push(aliasPlugin);
-  }
-
   // Allow jest tests to redefine the environment variables.
   if (process.env.NODE_ENV !== 'test') {
     extraPlugins.push([
@@ -265,20 +260,6 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
         platformOptions.reanimated !== false && [require.resolve('react-native-reanimated/plugin')],
     ].filter(Boolean) as PluginItem[],
   };
-}
-
-function getAliasPlugin(): PluginItem | null {
-  if (!hasModule('@expo/vector-icons')) {
-    return null;
-  }
-  return [
-    require.resolve('babel-plugin-module-resolver'),
-    {
-      alias: {
-        'react-native-vector-icons': '@expo/vector-icons',
-      },
-    },
-  ];
 }
 
 export default babelPresetExpo;

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver.
+- Alias `react-native-vector-icons` to `@expo/vector-icons` in the Metro resolver. ([#25512](https://github.com/expo/expo/pull/25512) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -11,6 +11,7 @@ const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
 jestPreset.moduleNameMapper = {
   ...(jestPreset.moduleNameMapper || {}),
   '^react-native-vector-icons$': '@expo/vector-icons',
+  '^react-native-vector-icons/(.*)': '@expo/vector-icons/$1',
 };
 
 // transform

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -7,6 +7,12 @@ const jestPreset = cloneDeep(require('react-native/jest-preset'));
 
 const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
 
+// Emulate the alias behavior of Expo's Metro resolver.
+jestPreset.moduleNameMapper = {
+  ...(jestPreset.moduleNameMapper || {}),
+  '^react-native-vector-icons$': '@expo/vector-icons',
+};
+
 // transform
 if (!jestPreset.transform) {
   jestPreset.transform = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15566,10 +15566,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.4, pirates@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
-  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
+  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
 pixi-gl-core@^1.1.4:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15566,10 +15566,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
-  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
+pirates@^4.0.4, pirates@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
+  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
 
 pixi-gl-core@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
# Why

Aliases in the resolver are more resilient (no chance of differences in importing logic between babel plugin and bundler), faster (no additional AST traversal needed), and easier to cache (cache based on input context rather than AST).


# How

This PR removes the need to perform an additional import traversal to replace `react-native-vector-icons` with `@expo/vector-icons` by moving the alias to a conditional resolver in both Metro and Jest as opposed to having it in `babel-preset-expo` with `babel-plugin-module-resolver`.

To preserve backwards compatibility, I've also added support for nested imports, e.g. `react-native-vector-icons/FontAwesome` -> `@expo/vector-icons/FontAwesome`, even though we don't perform a strict check on the import existence.

# Test Plan

- Added new tests for the resolver.
- Removed old tests for babel.
- Existing code using Jest should continue to work.
