### PR TITLE
[expo-updates][android] Fix typo in CheckForUpdateProcedure

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -106,7 +106,7 @@ class CheckForUpdateProcedure(
                   LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
                 )
               )
-              UpdatesStateEvent.CheckCompleteUnavailable()
+              procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
               procedureContext.onComplete()
               return
             }


### PR DESCRIPTION
# Why

This callsite was missing the state machine function call. (just a typo in previous refactor)

Closes ENG-10703.

# How

Noticed this while doing a stacked refactor. Stacked refactor is being punted due to release procedure, but this bug still needs fixing.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
