### PR TITLE
[ios][expo-media-library] Fix iOS 14 limited library picker presentation

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, fix iOS 14 limited library picker presentation, using `presentPermissionsPickerAsync`, on nested views and `reject` Promise if state is not `limited`. ([#25521](https://github.com/expo/expo/pull/25521) by [@exodusanto](https://github.com/exodusanto))
+
 ### 💡 Others
 
 ## 15.8.0 — 2023-11-14

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -148,7 +148,7 @@ EX_EXPORT_METHOD_AS(presentPermissionsPickerAsync,
       // Get the top-most presented view controller
       UIViewController *topViewController = rootViewController;
       while (topViewController.presentedViewController) {
-          topViewController = topViewController.presentedViewController;
+        topViewController = topViewController.presentedViewController;
       }
       
       // Present the PHPickerViewController modally from the top-most view controller

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -139,7 +139,21 @@ EX_EXPORT_METHOD_AS(presentPermissionsPickerAsync,
 #ifdef __IPHONE_14_0
   if (@available(iOS 14, *)) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:[[[[UIApplication sharedApplication] delegate] window] rootViewController]];
+      if ([PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite] != PHAuthorizationStatusLimited) {
+        return reject(@"E_ACCESS_LEVEL_PERMISSIONS", @"Photo library permission isn't limited", nil);
+      }
+
+      UIViewController *rootViewController = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    
+      // Get the top-most presented view controller
+      UIViewController *topViewController = rootViewController;
+      while (topViewController.presentedViewController) {
+          topViewController = topViewController.presentedViewController;
+      }
+      
+      // Present the PHPickerViewController modally from the top-most view controller
+      [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:topViewController];
+
       resolve(nil);
     });
   } else {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
1. After asking the first time the `presentPermissionsPickerAsync` all after requests fails with this message

> Attempt to present <PHPickerViewController: 0x108b0db30> on <UIViewController: 0x12be10a90> (from
<UIViewController: 0x12be10a90>) which is already presenting <RNSScreen: 0x1579c0c00>.

2. If the status wasn't in limited state no rejection handle the case

# How

<!--
How did you build this feature or fix this bug and why?
-->
1. Find the `topViewController` to attach `presentLimitedLibraryPickerFromViewController` call (this will handle request of it in a Modal Screen)
2. Add a check before request picker presentation


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Use `MediaLibrary` SDK and test the `presentPermissionsPickerAsync` across different situations.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
