### PR TITLE
[ios][android] Update react-native-view-shot to 3.8.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1220,7 +1220,7 @@ PODS:
     - React-Core
   - react-native-slider (4.4.2):
     - React-Core
-  - react-native-view-shot (3.7.0):
+  - react-native-view-shot (3.8.0):
     - React-Core
   - react-native-webview (13.6.2):
     - React-Core
@@ -2069,7 +2069,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
-  react-native-view-shot: f5507655f122e6b104888a11130f267a427f0d57
+  react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688
   react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
   React-nativeconfig: 59e6f9ddeb9d884de486d850a783b92cfebbe1b5
   React-NativeModulesApple: 0ab07d1155f6f522c6557532e89182d021717e7d

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -88,7 +88,7 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "13.9.0",
-    "react-native-view-shot": "3.7.0",
+    "react-native-view-shot": "3.8.0",
     "react-native-webview": "13.6.2",
     "test-suite": "*"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "13.9.0",
-    "react-native-view-shot": "3.7.0",
+    "react-native-view-shot": "3.8.0",
     "react-native-web": "~0.19.6",
     "react-native-webview": "13.6.2",
     "react-navigation": "^4.4.0",

--- a/home/metro.config.js
+++ b/home/metro.config.js
@@ -1,6 +1,7 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
 const path = require('path');
 
+/* global __dirname */
 const baseConfig = createMetroConfiguration(__dirname);
 
 // To test home from Expo Go, the react-native js source is from our fork.

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "react-native-screens": "~3.27.0",
   "react-native-safe-area-context": "4.6.3",
   "react-native-svg": "13.9.0",
-  "react-native-view-shot": "3.7.0",
+  "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.6.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15566,10 +15566,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.4, pirates@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
-  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
+  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
 pixi-gl-core@^1.1.4:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16751,10 +16751,10 @@ react-native-svg@13.9.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-view-shot@3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.7.0.tgz#0c773500e7aac5d115a9dee3b83fa5156c950ed0"
-  integrity sha512-tQruLNjs7Ee/p6xUgJqF6glnatHaq/UqaIQ6KdYIFG0+XpUZdhqmEM4WMLsYfayfFEhdlF86G1S3eXMOfDNzFg==
+react-native-view-shot@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.8.0.tgz#1aa1905f0e79428ca32bf80c16fd4abc719c600b"
+  integrity sha512-4cU8SOhMn3YQIrskh+5Q8VvVRxQOu8/s1M9NAL4z5BY1Rm0HXMWkQJ4N0XsZ42+Yca+y86ISF3LC5qdLPvPuiA==
   dependencies:
     html2canvas "^1.4.1"
 


### PR DESCRIPTION
# Why
Closes ENG-10672 

# How
`et uvm -m react-native-view-shot -c 3.8.0`

# Test Plan
- bare expo + NCL ✅
- unversioned expo go + NCL ✅
