### PR TITLE
Revert "[expo-updates] Assert valid state transitions in debug (#25474)"

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Add e2e tests for disabled mode. ([#25301](https://github.com/expo/expo/pull/25301) by [@wschurman](https://github.com/wschurman))
 - Modify E2E manual test for asset exclusion. ([#25406](https://github.com/expo/expo/pull/25406) by [@douglowder](https://github.com/douglowder))
 - Move tvOS compile test out of updates E2E test matrix. ([#25438](https://github.com/expo/expo/pull/25438) by [@douglowder](https://github.com/douglowder))
-- Assert valid state transitions in debug. ([#25474](https://github.com/expo/expo/pull/25474) by [@wschurman](https://github.com/wschurman))
 
 ## 0.23.0 — 2023-11-14
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -13,7 +13,6 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.lang.reflect.Field
-import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.util.Date
 
@@ -22,12 +21,7 @@ class UpdatesStateMachineInstrumentationTest {
   private fun UpdatesStateMachine.processEventTest(event: UpdatesStateEvent) {
     val method: Method = UpdatesStateMachine::class.java.getDeclaredMethod("processEvent", UpdatesStateEvent::class.java)
     method.isAccessible = true
-
-    try {
-      method.invoke(this, event)
-    } catch (e: InvocationTargetException) {
-      throw e.targetException
-    }
+    method.invoke(this, event)
   }
 
   private fun UpdatesStateMachine.getState(): UpdatesStateValue {
@@ -170,16 +164,10 @@ class UpdatesStateMachineInstrumentationTest {
     val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
     machine.processEventTest(UpdatesStateEvent.Check())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
-
     // Test invalid transitions and ensure that state does not change
-    Assert.assertThrows(AssertionError::class.java) {
-      machine.processEventTest(UpdatesStateEvent.Download())
-    }
+    machine.processEventTest(UpdatesStateEvent.Download())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
-
-    Assert.assertThrows(AssertionError::class.java) {
-      machine.processEventTest(UpdatesStateEvent.DownloadComplete())
-    }
+    machine.processEventTest(UpdatesStateEvent.DownloadComplete())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -76,7 +76,7 @@ class UpdatesStateMachine(
   private fun transition(event: UpdatesStateEvent): Boolean {
     val allowedEvents: Set<UpdatesStateEventType> = updatesStateAllowedEvents[state] ?: setOf()
     if (!allowedEvents.contains(event.type)) {
-      assert(false) { "UpdatesState: invalid transition requested: state = $state, event = ${event.type}" }
+      // Optionally put an assert here when testing to catch bad state transitions in E2E tests
       return false
     }
     state = updatesStateTransitions[event.type] ?: UpdatesStateValue.Idle

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -368,7 +368,11 @@ internal class UpdatesStateMachine {
   private func transition(_ event: UpdatesStateEvent) -> Bool {
     let allowedEvents: Set<UpdatesStateEventType> = UpdatesStateMachine.updatesStateAllowedEvents[state] ?? []
     if !allowedEvents.contains(event.type) {
+      // Uncomment the line below to halt execution on invalid state transitions,
+      // very useful for testing
+      /*
       assertionFailure("UpdatesState: invalid transition requested: state = \(state), event = \(event.type)")
+       */
       return false
     }
     // Successful transition

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -120,17 +120,15 @@ class UpdatesStateMachineSpec: ExpoSpec {
         // In .checking state, download events should be ignored,
         // state should not change, context should not change,
         // no events should be sent to JS
-        expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
+        machine.processEventForTesting(UpdatesStateEventDownload())
 
         expect(machine.getStateForTesting()) == .checking
         expect(testStateChangeDelegate.lastEventType).to(beNil())
         expect(testStateChangeDelegate.lastEventBody).to(beNil())
 
-        expect(
-          machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
-            "updateId": "0000-xxxx"
-          ]))
-        ).to(throwAssertion())
+        machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
+          "updateId": "0000-xxxx"
+        ]))
 
         expect(machine.getStateForTesting()) == .checking
         expect(machine.context.downloadedManifest).to(beNil())
@@ -141,13 +139,13 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.getStateForTesting()) == .restarting
 
         // If restarting, all events should be ignored
-        expect(machine.processEventForTesting(UpdatesStateEventCheck())).to(throwAssertion())
+        machine.processEventForTesting(UpdatesStateEventCheck())
         expect(machine.getStateForTesting()) == .restarting
 
-        expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
+        machine.processEventForTesting(UpdatesStateEventDownload())
         expect(machine.getStateForTesting()) == .restarting
 
-        expect(machine.processEventForTesting(UpdatesStateEventDownloadComplete())).to(throwAssertion())
+        machine.processEventForTesting(UpdatesStateEventDownloadComplete())
         expect(machine.getStateForTesting()) == .restarting
       }
     }


### PR DESCRIPTION
# Why

e904b95ae4da209c37af769c1d72dde57ba6550b broke `Updates e2e (enabled) EAS` workflow 


# How

`git revert e904b95ae4da209c37af769c1d72dde57ba6550b`

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
