### PR TITLE
[go] update lottie-react-native to 6.4.1

### DIFF
--- a/android/vendored/unversioned/lottie-react-native/android/build.gradle
+++ b/android/vendored/unversioned/lottie-react-native/android/build.gradle
@@ -33,10 +33,12 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-    // Check AGP version for backward compatibility reasons
-    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
         namespace = "com.airbnb.android.react.lottie"
+    } else {
+        // print
+        println "DEPRECATION WARNING: The `namespace` property is not available in your version of AGP. Please upgrade to AGP 4.2+."
     }
 
     compileSdk getExtOrDefault('compileSdkVersion', 31)

--- a/android/vendored/unversioned/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
+++ b/android/vendored/unversioned/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
@@ -56,12 +56,26 @@ internal object LottieAnimationViewManagerImpl {
     }
 
     @JvmStatic
+    fun sendAnimationLoadedEvent(view: LottieAnimationView) {
+        val screenContext = view.context as ThemedReactContext
+        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(screenContext, view.id)
+        eventDispatcher?.dispatchEvent(
+            OnAnimationLoadedEvent(
+                screenContext.surfaceId,
+                view.id,
+            )
+        )
+    }
+
+    @JvmStatic
     fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.of(
             OnAnimationFinishEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onAnimationFinish"),
             OnAnimationFailureEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onAnimationFailure"),
+            OnAnimationLoadedEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onAnimationLoaded"),
         )
     }
 

--- a/android/vendored/unversioned/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/OnAnimationLoadedEvent.kt
+++ b/android/vendored/unversioned/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/OnAnimationLoadedEvent.kt
@@ -1,0 +1,21 @@
+package com.airbnb.android.react.lottie
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class OnAnimationLoadedEvent constructor(surfaceId: Int, viewId: Int) :
+    Event<OnAnimationLoadedEvent>(surfaceId, viewId) {
+
+    override fun getEventName(): String {
+        return EVENT_NAME
+    }
+
+    override fun getEventData(): WritableMap? {
+        return Arguments.createMap()
+    }
+
+    companion object {
+        const val EVENT_NAME = "topAnimationLoadedEvent"
+    }
+}

--- a/android/vendored/unversioned/lottie-react-native/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/android/vendored/unversioned/lottie-react-native/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -66,6 +66,9 @@ class LottieAnimationViewManager :
          view.setFailureListener {
             LottieAnimationViewManagerImpl.sendAnimationFailureEvent(view, it)
         }
+        view.addLottieOnCompositionLoadedListener {
+            LottieAnimationViewManagerImpl.sendAnimationLoadedEvent(view)
+        }
         view.addAnimatorListener(object : Animator.AnimatorListener {
             override fun onAnimationStart(animation: Animator) {
                 //do nothing

--- a/android/vendored/unversioned/lottie-react-native/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/android/vendored/unversioned/lottie-react-native/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -55,6 +55,9 @@ class LottieAnimationViewManager : SimpleViewManager<LottieAnimationView>() {
         view.setFailureListener {
             LottieAnimationViewManagerImpl.sendAnimationFailureEvent(view, it)
         }
+        view.addLottieOnCompositionLoadedListener {
+            LottieAnimationViewManagerImpl.sendAnimationLoadedEvent(view)
+        }
         view.addAnimatorListener(
             object : Animator.AnimatorListener {
                 override fun onAnimationStart(animation: Animator) {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -133,7 +133,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "6.1.2",
+    "lottie-react-native": "6.4.1",
     "moment": "^2.29.4",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/ios/ExpoKit.podspec
+++ b/ios/ExpoKit.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
     ss.dependency 'CocoaLumberjack', '~> 3.5.3'
     ss.dependency 'GoogleMaps', '~> 3.3'
     ss.dependency 'Google-Maps-iOS-Utils', '~> 2.1.0'
-    ss.dependency 'lottie-ios', '~> 3.2.3'
+    ss.dependency 'lottie-ios', '~> 4.3.3'
     ss.dependency 'JKBigInteger', '0.0.6'
     ss.dependency 'MBProgressHUD', '~> 1.2.0'
     ss.dependency 'React-Core' # explicit dependency required for CocoaPods >= 1.5.0

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -291,7 +291,7 @@ PODS:
   - ABI49_0_0hermes-engine/Pre-built (0.72.4)
   - ABI49_0_0lottie-react-native (5.1.6):
     - ABI49_0_0React-Core
-    - lottie-ios (~> 4.2.0)
+    - lottie-ios (~> 4.3.3)
   - ABI49_0_0RCTRequired (0.72.4)
   - ABI49_0_0RCTTypeSafety (0.72.4):
     - ABI49_0_0FBLazyVector (= 0.72.4)
@@ -1133,9 +1133,9 @@ PODS:
   - libwebp/sharpyuv (1.3.2)
   - libwebp/webp (1.3.2):
     - libwebp/sharpyuv
-  - lottie-ios (4.2.0)
-  - lottie-react-native (6.1.2):
-    - lottie-ios (~> 4.2.0)
+  - lottie-ios (4.3.3)
+  - lottie-react-native (6.4.1):
+    - lottie-ios (~> 4.3.3)
     - React-Core
   - MBProgressHUD (1.2.0)
   - nanopb (2.30909.0):
@@ -3196,7 +3196,7 @@ SPEC CHECKSUMS:
   ABI49_0_0FBLazyVector: da60aaea175d16a8330337280f76fec9da53d91a
   ABI49_0_0FBReactNativeSpec: b7437b60d3ebba4d9e39b4030e5d26c42939218e
   ABI49_0_0hermes-engine: e916653d0b2ac178975ec2572231bbbb2ca2119e
-  ABI49_0_0lottie-react-native: 0edfba12ae9edef9a697bccc5d5f36bf06cb7ffb
+  ABI49_0_0lottie-react-native: d6975893da5cd58e714647bd1826727263b2515a
   ABI49_0_0RCTRequired: 9223110a54e996a0a081efaf3bcc6a307e63b108
   ABI49_0_0RCTTypeSafety: 01b4a6f17ca487924c5e2ec95e75c51e48c115de
   ABI49_0_0React: 1770db255e07b4e5ab9aa6eb9c7ae47a01e8ceb2
@@ -3343,8 +3343,8 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
-  lottie-ios: 809ecf2d460ed650a6aed7aa88b2ec45fab4779c
-  lottie-react-native: 3d6f1b0db1fd9e18b92af1fbfbf67037611bae67
+  lottie-ios: 25e7b2675dad5c3ddad369ac9baab03560c5bfdd
+  lottie-react-native: a2ae9c27c273b060b2affff2957bc0ff7fdca353
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7

--- a/ios/vendored/sdk49/lottie-react-native/ABI49_0_0lottie-react-native.podspec.json
+++ b/ios/vendored/sdk49/lottie-react-native/ABI49_0_0lottie-react-native.podspec.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ABI49_0_0React-Core": [],
     "lottie-ios": [
-      "~> 4.2.0"
+      "~> 4.3.3"
     ]
   },
   "swift_version": "5.0"

--- a/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieAnimationViewComponentView.mm
+++ b/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieAnimationViewComponentView.mm
@@ -153,6 +153,17 @@ using namespace facebook::react;
     std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationFailure(event);
 }
 
+- (void)onAnimationLoaded
+{
+    if(!_eventEmitter) {
+        return;
+    }
+
+    LottieAnimationViewEventEmitter::OnAnimationLoaded event = {};
+
+    std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationLoaded(event);
+}
+
 @end
 
 Class<RCTComponentViewProtocol> LottieAnimationViewCls(void)

--- a/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieContainerView.h
+++ b/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieContainerView.h
@@ -8,6 +8,7 @@
 @protocol LottieContainerViewDelegate
 - (void)onAnimationFinishWithIsCancelled:(BOOL)isCancelled;
 - (void)onAnimationFailureWithError:(NSString*)error;
+- (void)onAnimationLoaded;
 @end
 
 @interface LottieContainerView : RCTView

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -18,21 +18,21 @@ class AnimationViewManagerModule: RCTViewManager {
         return ContainerView()
     }
 
-    @objc override func constantsToExport() -> [AnyHashable : Any]! {
+    @objc override func constantsToExport() -> [AnyHashable: Any]! {
         return ["VERSION": 1]
     }
 
     @objc(play:fromFrame:toFrame:)
     public func play(_ reactTag: NSNumber, startFrame: NSNumber, endFrame: NSNumber) {
-        self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
+        self.bridge.uiManager.addUIBlock { (_, viewRegistry) in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
             }
 
-            if (startFrame.intValue != -1 && endFrame.intValue != -1) {
+            if startFrame.intValue != -1 && endFrame.intValue != -1 {
                 view.play(fromFrame: AnimationFrameTime(truncating: startFrame), toFrame: AnimationFrameTime(truncating: endFrame))
             } else {
                 view.play()
@@ -42,9 +42,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(reset:)
     public func reset(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -56,9 +56,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(pause:)
     public func pause(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -70,9 +70,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(resume:)
     public func resume(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
@@ -2,8 +2,9 @@ import Lottie
 import Foundation
 
 @objc protocol LottieContainerViewDelegate {
-    func onAnimationFinish(isCancelled: Bool);
-    func onAnimationFailure(error: String);
+    func onAnimationFinish(isCancelled: Bool)
+    func onAnimationFailure(error: String)
+    func onAnimationLoaded()
 }
 
 /* There are Two Views being implemented here:
@@ -22,215 +23,226 @@ class ContainerView: RCTView {
     private var colorFilters: [NSDictionary] = []
     private var textFilters: [NSDictionary] = []
     private var renderMode: RenderingEngineOption = .automatic
-    @objc weak var delegate: LottieContainerViewDelegate? = nil
+    @objc weak var delegate: LottieContainerViewDelegate?
     var animationView: LottieAnimationView?
     @objc var onAnimationFinish: RCTBubblingEventBlock?
     @objc var onAnimationFailure: RCTBubblingEventBlock?
-    
+    @objc var onAnimationLoaded: RCTBubblingEventBlock?
+
     @objc var completionCallback: LottieCompletionBlock {
         return { [weak self] animationFinished in
             guard let self = self else { return }
-            
+
             if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
-            
-            self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
-        };
+
+            self.delegate?.onAnimationFinish(isCancelled: !animationFinished)
+        }
     }
-    
+
     @objc var failureCallback: (_ error: String) -> Void {
         return { [weak self] error in
             guard let self = self else { return }
-            
+
             if let onFinish = self.onAnimationFailure {
                 onFinish(["error": error])
             }
-            
+
             self.delegate?.onAnimationFailure(error: error)
-        };
+        }
     }
-    
+
+    @objc var loadedCallback: () -> Void {
+        return { [weak self] in
+            guard let self = self else { return }
+
+            if let onLoaded = self.onAnimationLoaded {
+                onLoaded([:])
+            }
+
+            self.delegate?.onAnimationLoaded()
+        }
+    }
+
 #if !(os(OSX))
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, tvOS 13.0, *) {
-            if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
-                if(!colorFilters.isEmpty) {
+            if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                if !colorFilters.isEmpty {
                     applyColorProperties()
                 }
             }
         }
     }
 #endif
-    
+
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
-        
-        if (newSpeed != 0.0) {
+
+        if newSpeed != 0.0 {
             animationView?.animationSpeed = newSpeed
-            if (!(animationView?.isAnimationPlaying ?? true)) {
+            if !(animationView?.isAnimationPlaying ?? true) {
                 animationView?.play()
             }
-        } else if (animationView?.isAnimationPlaying ?? false) {
+        } else if animationView?.isAnimationPlaying ?? false {
             animationView?.pause()
         }
     }
-    
+
     @objc func setProgress(_ newProgress: CGFloat) {
         progress = newProgress
         animationView?.currentProgress = progress
     }
-    
+
     @objc func setLoop(_ isLooping: Bool) {
         loop = isLooping ? .loop : .playOnce
         animationView?.loopMode = loop
     }
-    
+
     @objc func setAutoPlay(_ autoPlay: Bool) {
         self.autoPlay = autoPlay
         playIfNeeded()
     }
-    
+
     @objc func setTextFiltersIOS(_ newTextFilters: [NSDictionary]) {
         textFilters = newTextFilters
-        
-        if (textFilters.count > 0) {
-            var filters = [String:String]()
+
+        if textFilters.count > 0 {
+            var filters = [String: String]()
             for filter in textFilters {
-                let key = filter.value(forKey: "keypath") as! String
-                let value = filter.value(forKey: "text") as! String
-                filters[key] = value;
+                guard let key = filter.value(forKey: "keypath") as? String,
+                      let value = filter.value(forKey: "text") as? String else { break }
+                filters[key] = value
             }
-            
-            let nextAnimationView = LottieAnimationView()
+
+            let nextAnimationView = LottieAnimationView(
+                animation: animationView?.animation,
+                configuration: lottieConfiguration
+            )
             nextAnimationView.textProvider = DictionaryTextProvider(filters)
-            nextAnimationView.animation = animationView?.animation
             replaceAnimationView(next: nextAnimationView)
         }
     }
-    
+
     var lottieConfiguration: LottieConfiguration {
         return LottieConfiguration(
             renderingEngine: renderMode
         )
     }
-    
+
     @objc func setRenderMode(_ newRenderMode: String) {
         switch newRenderMode {
         case "SOFTWARE":
-            if (renderMode == .mainThread) {
+            if renderMode == .mainThread {
                 return
             }
             renderMode = .mainThread
         case "HARDWARE":
-            if (renderMode == .coreAnimation) {
+            if renderMode == .coreAnimation {
                 return
             }
             renderMode = .coreAnimation
-        case "AUTOMATIC":
-            fallthrough
         default:
-            if (renderMode == .automatic) {
+            if renderMode == .automatic {
                 return
             }
             renderMode = .automatic
         }
-        
-        if (animationView != nil) {
+
+        if animationView != nil {
             let nextAnimationView = LottieAnimationView(
                 animation: animationView?.animation,
                 configuration: lottieConfiguration
             )
-            
+
             replaceAnimationView(next: nextAnimationView)
         }
     }
-    
+
     @objc func setSourceDotLottieURI(_ uri: String) {
-        if(checkReactSourceString(uri)) {
+        if checkReactSourceString(uri) {
             return
         }
-        
+
         guard let url = URL(string: uri) else {
             return
         }
-        
+
         _ = LottieAnimationView(
             dotLottieUrl: url,
             configuration: lottieConfiguration,
             completion: { [weak self] view, error in
                 guard let self = self else { return }
-                
                 if let error = error {
                     self.failureCallback(error.localizedDescription)
                     return
                 }
-                
                 self.replaceAnimationView(next: view)
             }
         )
     }
-    
+
     @objc func setSourceURL(_ newSourceURLString: String) {
-        if(checkReactSourceString(newSourceURLString)) {
+        if checkReactSourceString(newSourceURLString) {
             return
         }
-        
+
         var url = URL(string: newSourceURLString)
-        
-        if(url?.scheme == nil) {
+
+        if url?.scheme == nil {
             // interpret raw URL paths as relative to the resource bundle
             url = URL(fileURLWithPath: newSourceURLString, relativeTo: Bundle.main.resourceURL)
         }
-        
+
         guard let url = url else { return }
-        
+
         self.fetchRemoteAnimation(from: url)
     }
-    
+
     @objc func setSourceJson(_ newSourceJson: String) {
-        if(checkReactSourceString(newSourceJson)) {
+        if checkReactSourceString(newSourceJson) {
             return
         }
-        
+
         sourceJson = newSourceJson
-        
+
         guard let data = sourceJson.data(using: String.Encoding.utf8),
               let animation = try? JSONDecoder().decode(LottieAnimation.self, from: data) else {
             failureCallback("Unable to create the lottie animation object from the JSON source")
             return
         }
-        
+
         let nextAnimationView = LottieAnimationView(
             animation: animation,
             configuration: lottieConfiguration
         )
-        
+
         replaceAnimationView(next: nextAnimationView)
     }
-    
+
     @objc func setSourceName(_ newSourceName: String) {
-        if(checkReactSourceString(newSourceName)) {
+        if checkReactSourceString(newSourceName) {
             return
         }
-        
-        if (newSourceName == sourceName) {
+
+        if newSourceName == sourceName {
             return
         }
-        
+
         sourceName = newSourceName
-        
+
         let nextAnimationView = LottieAnimationView(
             name: sourceName,
             configuration: lottieConfiguration
         )
-        
+
         replaceAnimationView(next: nextAnimationView)
     }
-    
+
     @objc func setResizeMode(_ resizeMode: String) {
-        switch (resizeMode) {
+        switch resizeMode {
         case "cover":
             animationView?.contentMode = .scaleAspectFill
         case "contain":
@@ -240,121 +252,126 @@ class ContainerView: RCTView {
         default: break
         }
     }
-    
+
     @objc func setColorFilters(_ newColorFilters: [NSDictionary]) {
         colorFilters = newColorFilters
         applyColorProperties()
     }
-    
+
     // There is no Nullable CGFloat in Objective-C, so this function uses a Nullable NSNumber and converts it later
     @objc(playFromFrame:toFrame:)
     func objcCompatiblePlay(fromFrame: NSNumber? = nil, toFrame: AnimationFrameTime) {
-        let convertedFromFrame = fromFrame != nil ? CGFloat(truncating: fromFrame!) : nil;
-        play(fromFrame: convertedFromFrame, toFrame: toFrame);
+        let convertedFromFrame = fromFrame != nil ? CGFloat(truncating: fromFrame!) : nil
+        play(fromFrame: convertedFromFrame, toFrame: toFrame)
     }
-    
+
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
-        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completionCallback);
+        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completionCallback)
     }
-    
+
     @objc func play() {
         animationView?.play(completion: completionCallback)
     }
-    
+
     @objc func reset() {
-        animationView?.currentProgress = 0;
+        animationView?.currentProgress = 0
         animationView?.pause()
     }
-    
+
     @objc func pause() {
         animationView?.pause()
     }
-    
+
     @objc func resume() {
         play()
     }
-    
+
     // The animation view is a child of the RCTView, so if the bounds ever change, add those changes to the animation view as well
     override var bounds: CGRect {
         didSet {
             animationView?.frame = self.bounds
         }
     }
-    
+
     // MARK: Private
     func replaceAnimationView(next: LottieAnimationView) {
         super.removeReactSubview(animationView)
-        
+
         let contentMode = animationView?.contentMode ?? .scaleAspectFit
-        
+
         animationView = next
-        
+
         animationView?.contentMode = contentMode
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.animationSpeed = speed
         animationView?.loopMode = loop
         animationView?.frame = self.bounds
-        
+
         addSubview(next)
-        
+
         applyColorProperties()
         playIfNeeded()
+
+        animationView?.animationLoaded = { [weak self] animationView, animation in
+            guard let self = self else { return }
+            self.loadedCallback()
+        }
     }
-    
-    
-    
+
     func applyColorProperties() {
         guard let animationView = animationView else { return }
-        
-        if (colorFilters.count > 0) {
+
+        if colorFilters.count > 0 {
             for filter in colorFilters {
-                let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
+                guard let key = filter.value(forKey: "keypath") as? String,
+                      let platformColor = filter.value(forKey: "color") as? PlatformColor else { break }
+                let keypath: String = "\(key).**.Color"
                 let fillKeypath = AnimationKeypath(keypath: keypath)
-                let colorFilterValueProvider = ColorValueProvider((filter.value(forKey: "color") as! PlatformColor).lottieColorValue)
+                let colorFilterValueProvider = ColorValueProvider(platformColor.lottieColorValue)
                 animationView.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
             }
         }
     }
-    
+
     func playIfNeeded() {
-        if(autoPlay && animationView?.isAnimationPlaying == false) {
+        if autoPlay && animationView?.isAnimationPlaying == false {
             self.play()
         }
     }
-    
+
     private func checkReactSourceString(_ sourceStr: String?) -> Bool {
         guard let sourceStr = sourceStr else {
             return false
         }
-        
+
         return sourceStr.isEmpty
     }
-    
+
     private func fetchRemoteAnimation(from url: URL) {
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let self = self else { return }
 
             if let error = error {
                 self.failureCallback("Unable to fetch the Lottie animation from the URL: \(error.localizedDescription)")
                 return
             }
-            
+
             guard let data = data else {
                 self.failureCallback("No data received for the Lottie animation from the URL.")
                 return
             }
-            
+
             do {
                 let animation = try JSONDecoder().decode(LottieAnimation.self, from: data)
-                
+
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self else { return }
-                    
+
                     let nextAnimationView = LottieAnimationView(
                         animation: animation,
                         configuration: self.lottieConfiguration
                     )
-                    
+
                     self.replaceAnimationView(next: nextAnimationView)
                 }
             } catch {

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/LRNAnimationViewManagerObjC.m
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/LRNAnimationViewManagerObjC.m
@@ -14,6 +14,7 @@ RCT_EXPORT_VIEW_PROPERTY(autoPlay, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(speed, CGFloat);
 RCT_EXPORT_VIEW_PROPERTY(onAnimationFinish, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAnimationFailure, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onAnimationLoaded, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(colorFilters, LRNColorFilters);
 RCT_EXPORT_VIEW_PROPERTY(textFiltersIOS, NSArray);
 RCT_EXPORT_VIEW_PROPERTY(renderMode, NSString);

--- a/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
+++ b/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "6.1.2",
+  "version": "6.4.1",
   "summary": "React Native bindings for Lottie",
   "license": "Apache-2.0",
   "authors": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
@@ -12,12 +12,12 @@
   },
   "source": {
     "git": "https://github.com/lottie-react-native/lottie-react-native.git",
-    "tag": "v6.1.2"
+    "tag": "v6.4.1"
   },
   "source_files": "ios/**/*.{h,m,mm,swift}",
   "dependencies": {
     "lottie-ios": [
-      "~> 4.2.0"
+      "~> 4.3.3"
     ],
     "React-Core": []
   },

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -80,7 +80,7 @@
   "expo-video-thumbnails": "~7.8.0",
   "expo-web-browser": "~12.8.0",
   "jest-expo": "~50.0.0-alpha.4",
-  "lottie-react-native": "6.1.2",
+  "lottie-react-native": "6.4.1",
   "react": "18.2.0",
   "react-dom": "18.2.0",
   "react-native": "0.73.0-rc.5",

--- a/template-files/ios/dependencies.json
+++ b/template-files/ios/dependencies.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "lottie-ios",
-    "version": "~> 3.2.3"
+    "version": "~> 4.3.3"
   },
   {
     "name": "JKBigInteger",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13469,10 +13469,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react-native@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-6.1.2.tgz#3f2e51afa31d6f09fcac0e0a976bce29dc5aa01f"
-  integrity sha512-OXBTJVahCPEZvd89g4BCzZb96sy060qToBKJPaZM/A0Q+ebHF2YaAXBflkgjiMFOmUWXxlKmg6fabMrOgbgeYQ==
+lottie-react-native@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-6.4.1.tgz#0b3202a0fb914db4f236c4b0658f21b97cb997d7"
+  integrity sha512-DPsUPSxLc3ZffeRQ/AtKtcUl4PzmJEEPt965tNpWSE4vhDkoGFxRe0TPZ45xX8/3HbGsUl48aMdLlAu28MEDsQ==
 
 lower-case-first@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
# Why

update vendoring modules for sdk 50
close ENG-10670

# How

- `et uvm -m lottie-react-native -c 6.4.1`
- update lottie-ios to 4.3.3 in sdk 49 versioned podspec

# Test Plan

unversioned NCL lottie + android/ios expo-go

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---------

Co-authored-by: Matin Zadeh Dolatabad <zadehdolatabad@gmail.com>