### PR TITLE
[tools] Check package access before publishing

### DIFF
--- a/tools/src/Utils.ts
+++ b/tools/src/Utils.ts
@@ -187,7 +187,7 @@ export async function runWithSpinner<Result>(
   try {
     const result = await action(step);
 
-    if (succeedText) {
+    if (step.isSpinning && succeedText) {
       step.succeed(succeedText);
     }
     return result;

--- a/tools/src/publish-packages/tasks/checkPackageAccess.ts
+++ b/tools/src/publish-packages/tasks/checkPackageAccess.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import * as Npm from '../../Npm';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { Parcel, TaskArgs } from '../types';
+import { checkEnvironmentTask } from './checkEnvironmentTask';
+import { loadRequestedParcels } from './loadRequestedParcels';
+
+/**
+ * Checks if the currently logged in user has access to publish packages.
+ */
+export const checkPackageAccess = new Task<TaskArgs>(
+  {
+    name: 'checkPackageAccess',
+    dependsOn: [
+      checkEnvironmentTask, // Checks if the user is logged in to npm.
+      loadRequestedParcels,
+    ],
+  },
+  async (parcels: Parcel[]) => {
+    return await runWithSpinner(
+      'Checking write access to the packages',
+      async (step): Promise<any> => {
+        const npmUser = await Npm.whoamiAsync();
+        const packagesWithoutAccess: string[] = [];
+
+        for (const { pkgView } of parcels) {
+          if (npmUser && pkgView && !isPackageMaintainer(pkgView, npmUser)) {
+            packagesWithoutAccess.push(pkgView.name);
+          }
+        }
+
+        if (packagesWithoutAccess.length > 0) {
+          const formattedPackageNames = packagesWithoutAccess
+            .map((pkgName) => chalk.green(pkgName))
+            .join(', ');
+
+          step.fail();
+          logger.error(
+            `You don't have write access to the following packages: ${formattedPackageNames}.`
+          );
+          logger.error(
+            'Ask someone from the team to ensure that you and these packages are added to expo organization.'
+          );
+          return Task.STOP;
+        }
+      },
+      'Checked that write access is granted'
+    );
+  }
+);
+
+/**
+ * Checks whether the user with given name is a maintainer of the package.
+ *
+ * Package view has a list of maintainers represented as a concatenation of the user name and his email,
+ * e.g. `brentvatne <brentvatne@gmail.com>`.
+ */
+function isPackageMaintainer(pkgView: NonNullable<Npm.PackageViewType>, user: string): boolean {
+  return pkgView.maintainers.some((maintainer) => {
+    return maintainer.startsWith(user + ' ');
+  });
+}

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -7,6 +7,7 @@ import { sdkVersionAsync } from '../../ProjectVersions';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
+import { checkPackageAccess } from './checkPackageAccess';
 import { loadRequestedParcels } from './loadRequestedParcels';
 import { packPackageToTarball } from './packPackageToTarball';
 import { publishPackages } from './publishPackages';
@@ -60,6 +61,7 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
       checkEnvironmentTask,
       loadRequestedParcels,
       prepareCanaries,
+      checkPackageAccess,
       updatePackageVersions,
       updateBundledNativeModulesFile,
       updateModuleTemplate,

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -9,6 +9,7 @@ import * as Npm from '../../Npm';
 import { Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { checkPackageAccess } from './checkPackageAccess';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { green, cyan, yellow } = chalk;
@@ -19,7 +20,7 @@ const { green, cyan, yellow } = chalk;
 export const publishPackages = new Task<TaskArgs>(
   {
     name: 'publishPackages',
-    dependsOn: [selectPackagesToPublish],
+    dependsOn: [selectPackagesToPublish, checkPackageAccess],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
     logger.info('\n🚀 Publishing packages...');


### PR DESCRIPTION
# Why

The publish script should check if the user has write access to all selected packages before publishing.

# How

Added another task that checks if the current user appears in the maintainers list.

# Test Plan

Ran `et publish --canary` and confirmed that it fails on `create-expo` package that I don't have access to.