### PR TITLE
Revert "Revert "[expo-updates] Assert valid state transitions in debug (#25474)" (#25527)"

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add e2e tests for disabled mode. ([#25301](https://github.com/expo/expo/pull/25301) by [@wschurman](https://github.com/wschurman))
 - Modify E2E manual test for asset exclusion. ([#25406](https://github.com/expo/expo/pull/25406) by [@douglowder](https://github.com/douglowder))
 - Move tvOS compile test out of updates E2E test matrix. ([#25438](https://github.com/expo/expo/pull/25438) by [@douglowder](https://github.com/douglowder))
+- Assert valid state transitions in debug. ([#25474](https://github.com/expo/expo/pull/25474) by [@wschurman](https://github.com/wschurman))
 
 ## 0.23.0 — 2023-11-14
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -53,50 +53,62 @@ class CheckForUpdateProcedure(
             val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
 
             if (updateDirective != null) {
-              if (updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-                if (!updatesConfiguration.hasEmbeddedUpdate) {
+              when (updateDirective) {
+                is UpdateDirective.NoUpdateAvailableUpdateDirective -> {
                   callback(
                     IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                      LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
                     )
                   )
                   procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
                   procedureContext.onComplete()
                   return
                 }
-
-                if (embeddedUpdate == null) {
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                is UpdateDirective.RollBackToEmbeddedUpdateDirective -> {
+                  if (!updatesConfiguration.hasEmbeddedUpdate) {
+                    callback(
+                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                      )
                     )
-                  )
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                    procedureContext.onComplete()
+                    return
+                  }
+
+                  if (embeddedUpdate == null) {
+                    callback(
+                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+                      )
+                    )
+                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                    procedureContext.onComplete()
+                    return
+                  }
+
+                  if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+                      updateDirective,
+                      embeddedUpdate,
+                      launchedUpdate,
+                      updateResponse.responseHeaderData?.manifestFilters
+                    )
+                  ) {
+                    callback(
+                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
+                      )
+                    )
+                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+                    procedureContext.onComplete()
+                    return
+                  }
+
+                  callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
+                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
                   procedureContext.onComplete()
                   return
                 }
-
-                if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
-                    updateDirective,
-                    embeddedUpdate,
-                    launchedUpdate,
-                    updateResponse.responseHeaderData?.manifestFilters
-                  )
-                ) {
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
-                    )
-                  )
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  procedureContext.onComplete()
-                  return
-                }
-
-                callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
-                procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
-                procedureContext.onComplete()
-                return
               }
             }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -76,7 +76,7 @@ class UpdatesStateMachine(
   private fun transition(event: UpdatesStateEvent): Boolean {
     val allowedEvents: Set<UpdatesStateEventType> = updatesStateAllowedEvents[state] ?: setOf()
     if (!allowedEvents.contains(event.type)) {
-      // Optionally put an assert here when testing to catch bad state transitions in E2E tests
+      assert(false) { "UpdatesState: invalid transition requested: state = $state, event = ${event.type}" }
       return false
     }
     state = updatesStateTransitions[event.type] ?: UpdatesStateValue.Idle

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -30,6 +30,13 @@ public struct UpdatesModuleConstants {
   let isMissingRuntimeVersion: Bool
 }
 
+public enum CheckForUpdateResult {
+  case noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason)
+  case updateAvailable(manifest: [String: Any])
+  case rollBackToEmbedded(commitTime: Date)
+  case error(error: Error)
+}
+
 public enum FetchUpdateResult {
   case success(manifest: [String: Any])
   case failure
@@ -81,7 +88,7 @@ public protocol InternalAppControllerInterface: AppControllerInterface {
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   )
   func checkForUpdate(
-    success successBlockArg: @escaping (_ remoteCheckResult: RemoteCheckResult) -> Void,
+    success successBlockArg: @escaping (_ checkForUpdateResult: CheckForUpdateResult) -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   )
   func fetchUpdate(

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -68,7 +68,6 @@ public enum RemoteCheckResult {
   case noUpdateAvailable(reason: RemoteCheckResultNotAvailableReason)
   case updateAvailable(manifest: [String: Any])
   case rollBackToEmbedded(commitTime: Date)
-  case error(error: Error)
 }
 
 public protocol AppLoaderTaskSwiftDelegate: AnyObject {
@@ -448,11 +447,6 @@ public final class AppLoaderTask: NSObject {
     } success: { updateResponse in
       completion(nil, updateResponse)
     } error: { error in
-      if let swiftDelegate = self.swiftDelegate {
-        self.delegateQueue.async {
-          swiftDelegate.appLoaderTask(self, didFinishCheckingForRemoteUpdateWithRemoteCheckResult: RemoteCheckResult.error(error: error))
-        }
-      }
       completion(error, nil)
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -293,7 +293,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     errorBlockArg(NotAvailableInDevClientException())
   }
 
-  public func checkForUpdate(success successBlockArg: @escaping (RemoteCheckResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
+  public func checkForUpdate(success successBlockArg: @escaping (CheckForUpdateResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
     errorBlockArg(NotAvailableInDevClientException())
   }
 

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -79,7 +79,7 @@ public class DisabledAppController: InternalAppControllerInterface {
   }
 
   public func checkForUpdate(
-    success successBlockArg: @escaping (RemoteCheckResult) -> Void,
+    success successBlockArg: @escaping (CheckForUpdateResult) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
     errorBlockArg(UpdatesDisabledException())

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -256,7 +256,7 @@ public class EnabledAppController: UpdatesStateChangeDelegate, InternalAppContro
   }
 
   public func checkForUpdate(
-    success successBlockArg: @escaping (_ remoteCheckResult: RemoteCheckResult) -> Void,
+    success successBlockArg: @escaping (_ checkForUpdateResult: CheckForUpdateResult) -> Void,
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   ) {
     let procedure = CheckForUpdateProcedure(
@@ -266,8 +266,8 @@ public class EnabledAppController: UpdatesStateChangeDelegate, InternalAppContro
       logger: self.logger
     ) {
       return self.startupProcedure.launchedUpdate()
-    } successBlock: { remoteCheckResult in
-      successBlockArg(remoteCheckResult)
+    } successBlock: { checkForUpdateResult in
+      successBlockArg(checkForUpdateResult)
     } errorBlock: { error in
       errorBlockArg(error)
     }

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -121,8 +121,11 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
       event = UpdatesStateEventCheckCompleteWithUpdate(manifest: manifest)
     case .rollBackToEmbedded(let commitTime):
       event = UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime)
-    case .error(let error):
-      event = UpdatesStateEventCheckError(message: error.localizedDescription)
+    case .error:
+      // skip updating state when this delegate method reports an error since this can be called either during
+      // the check or download phase of the AppLoaderTask, and either way the failure state will be recorded with the delegate
+      // call to didFinishBackgroundUpdateWithStatus
+      return
     }
     self.procedureContext.processStateEvent(event)
   }

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -121,11 +121,6 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
       event = UpdatesStateEventCheckCompleteWithUpdate(manifest: manifest)
     case .rollBackToEmbedded(let commitTime):
       event = UpdatesStateEventCheckCompleteWithRollback(rollbackCommitTime: commitTime)
-    case .error:
-      // skip updating state when this delegate method reports an error since this can be called either during
-      // the check or download phase of the AppLoaderTask, and either way the failure state will be recorded with the delegate
-      // call to didFinishBackgroundUpdateWithStatus
-      return
     }
     self.procedureContext.processStateEvent(event)
   }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -72,8 +72,8 @@ public final class UpdatesModule: Module {
     }
 
     AsyncFunction("checkForUpdateAsync") { (promise: Promise) in
-      AppController.sharedInstance.checkForUpdate { remoteCheckResult in
-        switch remoteCheckResult {
+      AppController.sharedInstance.checkForUpdate { checkForUpdateResult in
+        switch checkForUpdateResult {
         case .noUpdateAvailable(let reason):
           promise.resolve([
             "isAvailable": false,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -368,11 +368,7 @@ internal class UpdatesStateMachine {
   private func transition(_ event: UpdatesStateEvent) -> Bool {
     let allowedEvents: Set<UpdatesStateEventType> = UpdatesStateMachine.updatesStateAllowedEvents[state] ?? []
     if !allowedEvents.contains(event.type) {
-      // Uncomment the line below to halt execution on invalid state transitions,
-      // very useful for testing
-      /*
       assertionFailure("UpdatesState: invalid transition requested: state = \(state), event = \(event.type)")
-       */
       return false
     }
     // Successful transition

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -120,15 +120,17 @@ class UpdatesStateMachineSpec: ExpoSpec {
         // In .checking state, download events should be ignored,
         // state should not change, context should not change,
         // no events should be sent to JS
-        machine.processEventForTesting(UpdatesStateEventDownload())
+        expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
 
         expect(machine.getStateForTesting()) == .checking
         expect(testStateChangeDelegate.lastEventType).to(beNil())
         expect(testStateChangeDelegate.lastEventBody).to(beNil())
 
-        machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
-          "updateId": "0000-xxxx"
-        ]))
+        expect(
+          machine.processEventForTesting(UpdatesStateEventDownloadCompleteWithUpdate(manifest: [
+            "updateId": "0000-xxxx"
+          ]))
+        ).to(throwAssertion())
 
         expect(machine.getStateForTesting()) == .checking
         expect(machine.context.downloadedManifest).to(beNil())
@@ -139,13 +141,13 @@ class UpdatesStateMachineSpec: ExpoSpec {
         expect(machine.getStateForTesting()) == .restarting
 
         // If restarting, all events should be ignored
-        machine.processEventForTesting(UpdatesStateEventCheck())
+        expect(machine.processEventForTesting(UpdatesStateEventCheck())).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
 
-        machine.processEventForTesting(UpdatesStateEventDownload())
+        expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
 
-        machine.processEventForTesting(UpdatesStateEventDownloadComplete())
+        expect(machine.processEventForTesting(UpdatesStateEventDownloadComplete())).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
       }
     }


### PR DESCRIPTION
This reverts commit 2c346e0f00eee1ca8c7fa5df8287f0a796fb1dba.

# Why

This attempts to re-revert #25527 in order to figure out and address why it's failing.

# How

revert.

Find source of invalid state transition. See inline note.

# Test Plan

wait for CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
