### PR TITLE
[expo-updates][e2e] Run android e2e tests in debug for assertions

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -67,7 +67,7 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   adb reverse tcp:4747 tcp:4747
 
   # Execute Android tests
-  detox test --configuration android.release 2>&1 | tee ./logs/detox-tests.log
+  detox test --configuration android.debug 2>&1 | tee ./logs/detox-tests.log
 else
   # Execute iOS tests
   detox test --configuration ios.debug 2>&1 | tee ./logs/detox-tests.log

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -24,7 +24,7 @@
       },
       "android": {
         "image": "ubuntu-22.04-jdk-17-ndk-r21e",
-        "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
+        "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
         "withoutCredentials": true,
         "resourceClass": "large"
       },


### PR DESCRIPTION
# Why

On iOS, we run the tests in debug mode so assertions from #25474 are thrown when invalid state transitions occur in the updates state machine. On Android, we were running it in release mode so the tests don't catch the issues (though android didn't suffer from any issues yet afaik).

# How

Change android to run in debug mode during detox build and test.

# Test Plan

Wait for CI. Verify that this doesn't cause issues in the build step.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
