### PR TITLE
[docs] New architecture landing page

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -156,6 +156,7 @@ const general = [
         makePage('workflow/common-development-errors.mdx'),
         makePage('workflow/android-studio-emulator.mdx'),
         makePage('workflow/ios-simulator.mdx'),
+        makePage('guides/new-architecture.mdx'),
       ],
       { expanded: false }
     ),

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: New Architecture
-description: Learn about React Native's "New Architecture" and how and why to migrate to it
+description: Learn about React Native's "New Architecture" and how and why to migrate to it.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons';
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The New Architecture is a name that we use to describe a complete refactoring of the internals of React Native, to solve limitations of the original React Native architecture that were discovered over years of usage in production at Meta and other companies.
+The New Architecture is a name that we use to describe a complete refactoring of the internals of React Native. It is also used to solve limitations of the original React Native architecture discovered over years of usage in production at Meta and other companies.
 
 In this guide, we'll talk about how to use the New Architecture in Expo projects today.
 
@@ -31,9 +31,9 @@ To learn more about the ideas and motivations behind the New Architecture, we re
 
 ## Why invest in migrating to the New Architecture?
 
-The New Architecture is the future of React Native — yet, for many apps, there may not be many immediate benefits to migrating today. You may want to think of migrating to the New Architecture as an investment in the future of your app, rather than as a way to immediately improve your app.
+The New Architecture is the future of React Native &mdash; yet, for many apps, there may not be many immediate benefits to migrating today. You may want to think of migrating to the New Architecture as an investment in the future of your app, rather than as a way to immediately improve your app.
 
-The changes that come with the New Architecture address technical debt of the original implementation and unlock possibilities for solving long standing issues in React Native, such as interoperability with synchronous native APIs (eg: `UITableView`), and pave the way for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
+The changes that come with the New Architecture address the technical debt of the original implementation and unlock possibilities for solving long-standing issues in React Native, such as interoperability with synchronous native APIs (for example, `UITableView`), and pave the way for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
 
 ## Expo tools and the New Architecture
 
@@ -41,17 +41,17 @@ As of SDK 49, all `expo-*` packages in the [Expo SDK](/versions/latest/) support
 
 Additionally, all modules written using the [Expo Modules API](/modules/overview/) support the New Architecture by default! So if you have built your own native modules using this API, no additional work is needed to use them with the New Architecture.
 
-## Initializing a new project with the New Architecture
+## Initialize a new project with the New Architecture
 
 The easiest way to get started with the New Architecture is to use the `with-new-arch` template when creating a new project:
 
 <Terminal cmd={['$ npx create-expo-app@latest -e with-new-arch']} />
 
-## Enabling the New Architecture in an existing project
+## Enable the New Architecture in an existing project
 
-> Note: `expo-updates` does not yet support the New Architecture. If you use `expo-updates` in your project, you will need to remove it before continuing.
+> Note: `expo-updates` does not yet support the New Architecture. If you use it in your project, you will need to remove it before continuing.
 
-You can enable the New Architecture in your app using the [expo-build-properties](/versions/latest/sdk/build-properties/) config plugin:
+You can enable the New Architecture in your app using the [`expo-build-properties`](/versions/latest/sdk/build-properties/) config plugin:
 
 <Step label="1">
 
@@ -63,7 +63,7 @@ Install `expo-build-properties`:
 
 <Step label="2">
 
-Set `newArchEnabled` on target platforms
+Set `newArchEnabled` on target platforms:
 
 ```json
 {
@@ -89,15 +89,15 @@ Set `newArchEnabled` on target platforms
 
 <Step label="3">
 
-Run prebuild and compile your project.
+Run prebuild command and compile your project:
 
 <Terminal cmd={['$ npx expo prebuild --clean', '$ npx expo run:android # or ios', '$ eas build -p android # or ios']} />
 
 </Step>
 
-If the build succeeds, you'll now be running your app with the New Architecture! Depending on the native modules you use, your app may work properly immediately.
+If the build succeeds, you will now be running your app with the New Architecture! Depending on the native modules you use, your app may work properly immediately.
 
-Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the ["Using the compatibility layer"](#using-the-compatibility-layer) and [Troubleshooting](#troubleshooting) sections below for more information.
+Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the [Using the compatibility layer](#using-the-compatibility-layer) and [Troubleshooting](#troubleshooting) sections below for more information.
 
 <Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
 
@@ -111,7 +111,7 @@ TODO: write about the compatibility layer here
 
 ## Troubleshooting
 
-Meta and Expo are working towards making the New Architecture the default for all new apps and ensuring that it as easy as possible to migrate existing apps. However, the New Architecture isn't just a name — many of the internals of React Native have been re-architected and rebuilt from the ground up. As a result, you may encounter issues when enabling the New Architecture in your app. The following is some advice for troubleshooting these issues.
+Meta and Expo are working towards making the New Architecture the default for all new apps and ensuring it is as easy as possible to migrate existing apps. However, the New Architecture isn't just a name &mdash; many of the internals of React Native have been re-architected and rebuilt from the ground up. As a result, you may encounter issues when enabling the New Architecture in your app. The following is some advice for troubleshooting these issues.
 
 <Collapsible summary="My build failed after enabling the New Architecture">
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -105,9 +105,30 @@ Refer to the ["Prerequisites for Applications" section of the React Native docum
 
 </Collapsible>
 
-## Using the compatibility layer
+## Using the interop layer
 
-TODO: write about the compatibility layer here
+Not all libraries have been migrated to support the New Architecture yet. To use these libraries in your app, you can use the interop layer as described in the ["New Renderer Interop Layer" working group post](https://github.com/reactwg/react-native-new-architecture/discussions/135).
+
+To use the interop layer, you will need to add the following to your **react-native.config.js**:
+
+```js
+module.exports = {
+  project: {
+    android: {
+      unstable_reactLegacyComponentNames: ["NativeComponentName"]
+    },
+    ios: {
+      unstable_reactLegacyComponentNames: ["NativeComponentName"]
+    }
+  },
+};
+```
+
+Replace `"NativeComponentName"` with the name of the native component that you want to use. For example, the view component in [@react-native-segmented-control/segmented-control](https://github.com/react-native-segmented-control/segmented-control) is `RNCSegmentedControl`, so you would add `"RNCSegmentedControl"` to the list of `unstable_reactLegacyComponentNames`.
+
+You may need to look at the library source code to determine the name, it may be helpful to look for `requireNativeComponent` in the library to find the name ([example](https://github.com/react-native-segmented-control/segmented-control/blob/ca72237642499d9b06edd0d2adefb6bba7eaaea3/js/RNCSegmentedControlNativeComponent.js#L17-L19)).
+
+The interop layer is not perfect and may not work for all libraries. If you encounter issues, please file an issue with the library.
 
 ## Troubleshooting
 
@@ -115,13 +136,6 @@ Meta and Expo are working towards making the New Architecture the default for al
 
 <Collapsible summary="My build failed after enabling the New Architecture">
 
-TODO - any common problems we can address here?
+Create a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) and report the issue to the library author, if applicable, or to the React Native team.
 
 </Collapsible>
-
-<Collapsible summary="Still stuck? Ask for help!">
-
-TODO - instructions for submitting a good, actionable bug report or getting help (eg: on Discord?)
-
-</Collapsible>
-

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The New Architecture is a name that we use to describe a completely refactoring of the internals of React Native, to solve for limitations of the original React Native architecture that were discovered over years of usage in production at Meta and the community.
+The New Architecture is a name that we use to describe a complete refactoring of the internals of React Native, to solve limitations of the original React Native architecture that were discovered over years of usage in production at Meta and other companies.
 
 In this guide, we'll talk about how to use the New Architecture in Expo projects today.
 
@@ -33,13 +33,13 @@ To learn more about the ideas and motivations behind the New Architecture, we re
 
 The New Architecture is the future of React Native — yet, for many apps, there may not be many immediate benefits to migrating today. You may want to think of migrating to the New Architecture as an investment in the future of your app, rather than as a way to immediately improve your app.
 
-The changes that come with the New Architecture address technical debt of the original implementation and unlock possibilities for solving long standing issues in React Native, such as interoperability with synchronous native APIs (eg: `UITableView`), and pave the way for for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
+The changes that come with the New Architecture address technical debt of the original implementation and unlock possibilities for solving long standing issues in React Native, such as interoperability with synchronous native APIs (eg: `UITableView`), and pave the way for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
 
 ## Expo tools and the New Architecture
 
 As of SDK 49, all `expo-*` packages in the [Expo SDK](/versions/latest/) support the New Architecture, with the exception of `expo-updates`. We plan to add support for `expo-updates` in SDK 51.
 
-Additionally, all third-party modules written using the [Expo Modules API](/modules/overview/) support the New Architecture by default! So if you have built your own native modules using this API, no additional work is needed to use them with the New Architecture.
+Additionally, all modules written using the [Expo Modules API](/modules/overview/) support the New Architecture by default! So if you have built your own native modules using this API, no additional work is needed to use them with the New Architecture.
 
 ## Initializing a new project with the New Architecture
 
@@ -97,7 +97,7 @@ Run prebuild and compile your project.
 
 If the build succeeds, you'll now be running your app with the New Architecture! Depending on the native modules you use, your app may work properly immediately.
 
-Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the ["Using the compatibility layer"]() and [Troubleshooting](#troubleshooting) sections below for more information.
+Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the ["Using the compatibility layer"](#using-the-compatibility-layer) and [Troubleshooting](#troubleshooting) sections below for more information.
 
 <Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -97,7 +97,7 @@ Run prebuild command and compile your project:
 
 If the build succeeds, you will now be running your app with the New Architecture! Depending on the native modules you use, your app may work properly immediately.
 
-Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the [Using the compatibility layer](#using-the-compatibility-layer) and [Troubleshooting](#troubleshooting) sections below for more information.
+Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the [Using the interop layer](#using-the-interop-layer) and [Troubleshooting](#troubleshooting) sections below for more information.
 
 <Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -35,6 +35,12 @@ The New Architecture is the future of React Native — yet, for many apps, there
 
 The changes that come with the New Architecture address technical debt of the original implementation and unlock possibilities for solving long standing issues in React Native, such as interoperability with synchronous native APIs (eg: `UITableView`), and pave the way for for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
 
+## Expo tools and the New Architecture
+
+As of SDK 49, all `expo-*` packages in the [Expo SDK](/versions/latest/) support the New Architecture, with the exception of `expo-updates`. We plan to add support for `expo-updates` in SDK 51.
+
+Additionally, all third-party modules written using the [Expo Modules API](/modules/overview/) support the New Architecture by default! So if you have built your own native modules using this API, no additional work is needed to use them with the New Architecture.
+
 ## Initializing a new project with the New Architecture
 
 The easiest way to get started with the New Architecture is to use the `with-new-arch` template when creating a new project:

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -1,0 +1,121 @@
+---
+title: New Architecture
+description: Learn about React Native's "New Architecture" and how and why to migrate to it
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Step } from '~/ui/components/Step';
+import { Terminal } from '~/ui/components/Snippet';
+
+The New Architecture is a name that we use to describe a completely refactoring of the internals of React Native, to solve for limitations of the original React Native architecture that were discovered over years of usage in production at Meta and the community.
+
+In this guide, we'll talk about how to use the New Architecture in Expo projects today.
+
+To learn more about the ideas and motivations behind the New Architecture, we recommend the following resources:
+
+<BoxLink
+  title="Introduction to the New Architecture"
+  description="A starting point for exploring the various topics related to the New Architecture."
+  href="https://reactnative.dev/docs/the-new-architecture/landing-page"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Why a New Architecture"
+  description="A high level overview of the motivations behind the New Architecture."
+  href="https://reactnative.dev/docs/the-new-architecture/why"
+  Icon={BookOpen02Icon}
+/>
+
+## Why invest in migrating to the New Architecture?
+
+The New Architecture is the future of React Native — yet, for many apps, there may not be many immediate benefits to migrating today. You may want to think of migrating to the New Architecture as an investment in the future of your app, rather than as a way to immediately improve your app.
+
+The changes that come with the New Architecture address technical debt of the original implementation and unlock possibilities for solving long standing issues in React Native, such as interoperability with synchronous native APIs (eg: `UITableView`), and pave the way for for [concurrent React support](https://react.dev/blog/2022/03/29/react-v18#what-is-concurrent-react).
+
+## Initializing a new project with the New Architecture
+
+The easiest way to get started with the New Architecture is to use the `with-new-arch` template when creating a new project:
+
+<Terminal cmd={['$ npx create-expo-app@latest -e with-new-arch']} />
+
+## Enabling the New Architecture in an existing project
+
+> Note: `expo-updates` does not yet support the New Architecture. If you use `expo-updates` in your project, you will need to remove it before continuing.
+
+You can enable the New Architecture in your app using the [expo-build-properties](/versions/latest/sdk/build-properties/) config plugin:
+
+<Step label="1">
+
+Install `expo-build-properties`:
+
+<Terminal cmd={['$ npx expo install expo-build-properties']} />
+
+</Step>
+
+<Step label="2">
+
+Set `newArchEnabled` on target platforms
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "newArchEnabled": true
+          },
+          "android": {
+            "newArchEnabled": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Step>
+
+<Step label="3">
+
+Run prebuild and compile your project.
+
+<Terminal cmd={['$ npx expo prebuild --clean', '$ npx expo run:android # or ios', '$ eas build -p android # or ios']} />
+
+</Step>
+
+If the build succeeds, you'll now be running your app with the New Architecture! Depending on the native modules you use, your app may work properly immediately.
+
+Now you can tap around your app and test it out. For most non-trivial apps, you're likely to encounter some issues, such as missing native views that haven't been implemented for the New Architecture yet. Many of the issues you encounter are actionable and can be resolved with some configuration or code changes. We recommend reading the ["Using the compatibility layer"]() and [Troubleshooting](#troubleshooting) sections below for more information.
+
+<Collapsible summary="Are you enabling the New Architecture in a bare React Native app?">
+
+Refer to the ["Prerequisites for Applications" section of the React Native documentation](https://reactnative.dev/docs/new-architecture-app-intro) for instructions on how to enable the New Architecture in your project.
+
+</Collapsible>
+
+## Using the compatibility layer
+
+TODO: write about the compatibility layer here
+
+## Troubleshooting
+
+Meta and Expo are working towards making the New Architecture the default for all new apps and ensuring that it as easy as possible to migrate existing apps. However, the New Architecture isn't just a name — many of the internals of React Native have been re-architected and rebuilt from the ground up. As a result, you may encounter issues when enabling the New Architecture in your app. The following is some advice for troubleshooting these issues.
+
+<Collapsible summary="My build failed after enabling the New Architecture">
+
+TODO - any common problems we can address here?
+
+</Collapsible>
+
+<Collapsible summary="Still stuck? Ask for help!">
+
+TODO - instructions for submitting a good, actionable bug report or getting help (eg: on Discord?)
+
+</Collapsible>
+


### PR DESCRIPTION
# Why

Let's help people understand the state of Expo support for the New Architecture as we get closer to a point where we recommend that developers enable it in their apps. For now, it'll still be more for early adopters.