### PR TITLE
[clipboard][android] Fix path traversal vulnerability in `getFileForUri` function

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix path traversal vulnerability in `getFileForUri` function.
+
 ### 💡 Others
 
 ## 4.8.0 — 2023-11-14

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix path traversal vulnerability in `getFileForUri` function.
+- [Android] Fix path traversal vulnerability in `getFileForUri` function. ([#25549](https://github.com/expo/expo/pull/25549) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardFileProvider.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardFileProvider.kt
@@ -348,7 +348,7 @@ class ClipboardFileProvider : ContentProvider() {
       } catch (e: IOException) {
         throw java.lang.IllegalArgumentException("Failed to resolve canonical path for $file")
       }
-      if (!file.path.startsWith(root.path)) {
+      if (!file.startsWith(root)) {
         throw SecurityException("Resolved path jumped beyond configured root")
       }
       return file


### PR DESCRIPTION
# Why

Fixes low severity vulnerability, which made it possible to  read from a wrong root directory.

ENG-10333

# How

Used `file.startsWith` instead of `file.path.startsWith`

# Test Plan

✅  Passes tests in BareExpo on Android 13
