### PR TITLE
chore: excluded typetests from the build

### DIFF
--- a/packages/@expo/cli/taskfile.js
+++ b/packages/@expo/cli/taskfile.js
@@ -11,7 +11,7 @@ export async function bin(task, opts) {
 export async function cli(task, opts) {
   await task
     .source('src/**/*.+(js|ts)', {
-      ignore: ['**/__tests__/**', '**/__mocks__/**'],
+      ignore: ['**/__mocks__/**', '**/__tests__/**', '**/__typetests__/**'],
     })
     .swc('cli', { dev: opts.dev })
     .target('build/src');


### PR DESCRIPTION
# Why

Currently the `__typetests__` directory is included in the build (source: https://www.npmjs.com/package/@expo/cli?activeTab=code):

<img width="775" alt="Screenshot 2023-11-23 at 14 56 52" src="https://github.com/expo/expo/assets/72159681/0a92de87-69d4-4430-b994-add997319c0e">

# How

I made a change in the `taskfile.js` file to exclude the `__typetests__` directory.

# Test Plan

Build the library and check the `build` directory. Before this change type tests are included, but that is not the case if this patch is applied.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
