### PR TITLE
feature(expo-module-scripts): add `expo-module script` command to execute package scripts

### DIFF
--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\",\"src/**/__integration_tests__/*\"",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && yarn run build",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck"

--- a/packages/@expo/config-types/package.json
+++ b/packages/@expo/config-types/package.json
@@ -9,7 +9,7 @@
     "clean": "expo-module clean",
     "generate": "ts-node ./scripts/generate.ts",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && expo-module tsc",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck",

--- a/packages/@expo/env/package.json
+++ b/packages/@expo/env/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && yarn run build",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck"

--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -8,7 +8,7 @@
     "build": "expo-module tsc",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && expo-module tsc",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "test:e2e": "yarn run prepare && expo-module test --config e2e/jest.config.js",

--- a/packages/@expo/json-file/package.json
+++ b/packages/@expo/json-file/package.json
@@ -7,7 +7,7 @@
     "build": "expo-module tsc",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && expo-module tsc",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck",

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && yarn run build",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck",

--- a/packages/@expo/package-manager/package.json
+++ b/packages/@expo/package-manager/package.json
@@ -8,7 +8,7 @@
     "build": "expo-module build",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && expo-module build",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck"

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --emitDeclarationOnly && babel src --out-dir build --extensions \".ts\" --source-maps --ignore \"src/**/__mocks__/*\",\"src/**/__tests__/*\"",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && yarn run build",
+    "prepare": "expo-module script clean && expo-module script build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "typecheck": "expo-module typecheck"

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add Node-specific Babel and Jest configurations. ([#25458](https://github.com/expo/expo/pull/25458) by [@byCedric](https://github.com/byCedric))
+- Add `expo-module script <name> [...flags]` command to execute package scripts. ([#25554](https://github.com/expo/expo/pull/25554) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-module-scripts/bin/expo-module-script
+++ b/packages/expo-module-scripts/bin/expo-module-script
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+'use strict';
+
+const { createForProject } = require('@expo/package-manager');
+const manager = createForProject(process.cwd());
+
+manager.runAsync(process.argv.slice(2));

--- a/packages/expo-module-scripts/bin/expo-module.js
+++ b/packages/expo-module-scripts/bin/expo-module.js
@@ -26,5 +26,6 @@ commander
   .command('eslint', `Runs ESLint with the given arguments`)
   .command('jest', `Runs Jest with the given arguments`)
   .command('tsc', `Runs tsc with the given arguments`)
+  .command('script', 'Runs a package script with the given arguments')
 
   .parse(process.argv);

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.12.12",
     "@expo/npm-proofread": "^1.0.1",
+    "@expo/package-manager": "^1.3.0",
     "@testing-library/react-hooks": "^7.0.1",
     "@tsconfig/node18": "^18.2.2",
     "@types/jest": "^29.2.1",


### PR DESCRIPTION
Follow-up of #25550

# Why

This uses `@expo/package-manager` under the hood to reuse the currently-used node package manager. We can replace the hardcoded `yarn run ...` in **package.json** scripts to improve Bun usage in E2E tests.

# Goal

When this works, we can also think of moving over some of the `expo-module-scripts` command to pure JS instead of bash. That tackles two things:
- Allow users to contribute on Windows (android code / JS packages only)
- Get rid of the hard-coded `yarn exec` and `npm exec` usage in `expo-module-scripts`, to pave the way for more Bun adoption.

# How

- Added `expo-module-script` that runs the script with the correct manager, and passes down the script name/flags.
- Replaced `yarn run ...` statements with `expo-module script ...`

# Test Plan

See if CI passes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
