### PR TITLE
Update installing-updates.mdx

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -151,7 +151,7 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
          android:label="@string/app_name"
 ```
 
-Add to **android/app/src/main/AndroidManifest.xml** so you can test it locally:
+If using the updates server URL shown above (a custom non-HTTPS update server running on the same machine), you will need to modify **android/app/src/main/AndroidManifest.xml** as follows:
 
 ```
 <application

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -151,6 +151,20 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
          android:label="@string/app_name"
 ```
 
+Add to **android/app/src/main/AndroidManifest.xml** so you can test ir locally:
+
+```
+<application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme"
+   ++ android:usesCleartextTraffic="true"
+      >
+```
+
 Add the Expo runtime version string key to **android/app/src/main/res/values/strings.xml**:
 
 <DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -151,7 +151,7 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
          android:label="@string/app_name"
 ```
 
-Add to **android/app/src/main/AndroidManifest.xml** so you can test ir locally:
+Add to **android/app/src/main/AndroidManifest.xml** so you can test it locally:
 
 ```
 <application


### PR DESCRIPTION
# Why
Missing step for installation and testing locally

# How
Adding this step to te android configuration

# Test Plan
Removing the tag and trying to update.

# Checklist
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
