### PR TITLE
[docs] Update AuthContext example to have default values instead of possibly null

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -46,7 +46,17 @@ This provider uses a mock implementation. You can replace it with your own [auth
 import React from 'react';
 import { useStorageState } from './useStorageState';
 
-const AuthContext = React.createContext<{ signIn: () => void; signOut: () => void; session?: string | null, isLoading: boolean } | null>(null);
+const AuthContext = React.createContext<{ 
+  signIn: () => void; 
+  signOut: () => void;
+  session?: string | null,
+  isLoading: boolean
+}>({
+  signIn: () => null,
+  signOut: () => null,
+  session: null,
+  isLoading: false,
+});
 
 // This hook can be used to access the user info.
 export function useSession() {

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -49,8 +49,8 @@ import { useStorageState } from './useStorageState';
 const AuthContext = React.createContext<{ 
   signIn: () => void; 
   signOut: () => void;
-  session?: string | null,
-  isLoading: boolean
+  session?: string | null;
+  isLoading: boolean;
 }>({
   signIn: () => null,
   signOut: () => null,


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Having the AuthContext values as possibly null throws ts errors when destructuring the properties from the useSession hook.  `const {session, isLoading} = useSession()` will nag that `Property 'session' does not exist on type '{ signIn: () => void; signOut: () => void; session?: string | null | undefined; isLoading: boolean; } | null'.`.  Removing the null and adding default values allows users to follow the example usage of useSession without having to add some sort of null check.


# How

<!--
How did you build this feature or fix this bug and why?
-->

Removed  the null type and added default values
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
No more TS warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
