### PR TITLE
[fingerprint] Add an optional second parameter to CLI to diff

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add CLI parameter for diffing with an existing fingerprint file. ([#25565](https://github.com/expo/expo/pull/25565) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/fingerprint/README.md
+++ b/packages/@expo/fingerprint/README.md
@@ -115,7 +115,17 @@ console.log(result);
 
 ## CLI Usage
 
+### Generate a fingerprint for a given project
+
 `npx @expo/fingerprint /path/to/projectRoot`
+
+### Generate a fingerprint for a given project and write it to a file
+
+`npx @expo/fingerprint /path/to/projectRoot > fingerprint.json`
+
+### Compare a fingerprint with the current project state
+
+`npx @expo/fingerprint /path/to/projectRoot fingerprint.json`
 
 ## Limitations
 

--- a/packages/@expo/fingerprint/bin/cli.js
+++ b/packages/@expo/fingerprint/bin/cli.js
@@ -1,24 +1,45 @@
 #!/usr/bin/env node
 const path = require('path');
+const fs = require('fs');
 
 let Fingerprint;
 try {
   Fingerprint = require('@expo/fingerprint');
-} catch {}
+} catch { }
 if (!Fingerprint) {
   Fingerprint = require(path.join(__dirname, '..', 'build', 'index'));
 }
 
 (async () => {
-  if (process.argv.length !== 3) {
+  if (process.argv.length !== 3 && process.argv.length !== 4) {
     console.log(`Usage: ${path.basename(process.argv[1])} projectRoot`);
     process.exit(1);
   }
+
+  let comparatorFingerprint;
+  if (process.argv.length === 4) {
+    const comparator = process.argv[3];
+    try {
+      comparatorFingerprint = JSON.parse(fs.readFileSync(comparator));
+    } catch (e) {
+      console.log(`Unable to diff with fingerprint file ${comparator}: ${e.message}`);
+      process.exit(1);
+    }
+  }
+
   const projectRoot = process.argv[2];
 
   try {
-    const fingerprint = await Fingerprint.createFingerprintAsync(projectRoot);
-    console.log(JSON.stringify(fingerprint, null, 2));
+    if (comparatorFingerprint) {
+      const diff = await Fingerprint.diffFingerprintChangesAsync(
+        comparatorFingerprint,
+        projectRoot
+      );
+      console.log(JSON.stringify(diff, null, 2));
+    } else {
+      const fingerprint = await Fingerprint.createFingerprintAsync(projectRoot);
+      console.log(JSON.stringify(fingerprint, null, 2));
+    }
     // console.log(fingerprint.hash);
   } catch (e) {
     console.error('Uncaught Error', e);

--- a/packages/@expo/fingerprint/bin/cli.js
+++ b/packages/@expo/fingerprint/bin/cli.js
@@ -12,7 +12,7 @@ if (!Fingerprint) {
 
 (async () => {
   if (process.argv.length !== 3 && process.argv.length !== 4) {
-    console.log(`Usage: ${path.basename(process.argv[1])} projectRoot`);
+    console.log(`Usage: ${path.basename(process.argv[1])} projectRoot [fingerprintFileToDiff]`);
     process.exit(1);
   }
 


### PR DESCRIPTION
# Why

When reading over the the Fingerprint blog post that @Kudo is working on, I realized I wanted to have an easy way for to try (and for others to try) fingerprint diffing.

# How

I added support for an optional additional parameter: `npx @expo/fingerprint projectRoot [fingerprintFileToDiff]`

# Test Plan

I did the following in https://github.com/brentvatne/microfoam-app:

- `npx @expo/fingerprint apps/mobile/ > fp.json`
- Installed `expo-camera` in `apps/mobile` with `npx expo install expo-camera`
- `npx @expo/fingerprint apps/mobile/ fp.json`

(note: I didn't actually run `npx @expo/fingerprint` but rather an alias that points to the local cli.js file)

Output:

```
[
  {
    "type": "dir",
    "filePath": "../../node_modules/expo-camera/android",
    "reasons": [
      "expoAutolinkingAndroid"
    ],
    "hash": "7682b28ed4ef8356faa5d9ad5b71e76e53198375"
  },
  {
    "type": "dir",
    "filePath": "../../node_modules/expo-camera/ios",
    "reasons": [
      "expoAutolinkingIos"
    ],
    "hash": "a80c2b1abb73157b772a8d0a351920465894bb0d"
  },
  {
    "type": "contents",
    "id": "expoAutolinkingConfig:android",
    "contents": "--lots of stuff i removed for clarity--",
    "reasons": [
      "expoAutolinkingAndroid"
    ],
    "hash": "23c46a26c6072e5b80c114b738abf004cc4e50d9"
  },
  {
    "type": "contents",
    "id": "expoAutolinkingConfig:ios",
    "contents": "--lots of stuff i removed for clarity--",
    "reasons": [
      "expoAutolinkingIos"
    ],
    "hash": "0c50f8a3ca3c407ff12ba4883a715e0546f29de9"
  }
]
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
