### PR TITLE
Remove expo-application from dependencies of the expo package

### DIFF
--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Added dependency on `expo-application` as it's no longer a dependency of the `expo` package.
+- Added dependency on `expo-application` as it's no longer a dependency of the `expo` package. ([#25583](https://github.com/expo/expo/pull/25583) by [@tsapeta](https://github.com/tsapeta))
 
 ## 5.3.0 — 2023-11-14
 

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added dependency on `expo-application` as it's no longer a dependency of the `expo` package.
+
 ## 5.3.0 — 2023-11-14
 
 ### 💡 Others

--- a/packages/expo-auth-session/package.json
+++ b/packages/expo-auth-session/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/auth-session",
   "dependencies": {
+    "expo-application": "~5.7.0",
     "expo-constants": "~15.3.0",
     "expo-crypto": "~12.8.0",
     "expo-linking": "~6.2.0",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Removed the dependency on the `expo-application` package.
+
 ## 49.0.21 — 2023-11-24
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Removed the dependency on the `expo-application` package.
+- Removed the dependency on the `expo-application` package. ([#25583](https://github.com/expo/expo/pull/25583) by [@tsapeta](https://github.com/tsapeta))
 
 ## 49.0.21 — 2023-11-24
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -65,7 +65,6 @@
     "@expo/config-plugins": "7.7.0",
     "@expo/vector-icons": "^13.0.0",
     "babel-preset-expo": "~9.9.0",
-    "expo-application": "~5.7.0",
     "expo-asset": "~8.14.0",
     "expo-file-system": "~15.9.0",
     "expo-font": "~11.9.0",


### PR DESCRIPTION
# Why

Closes ENG-9187

We can just remove the dependency from the `expo` package, as `expo-application` is only used by `expo-auth-session` and `expo-notifications`.

# How

- Removed `expo-application` from dependencies of the `expo` package
- Added `expo-application` to dependencies in `expo-auth-session` (it's been missing, the package relied on the transitive dependency)
- Ensured it's added to `expo-notifications` dependencies

# Test Plan

CI checks are passing.