### PR TITLE
fix(cli): fix Expo Router types route errors with external urls

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Prevent log-spew when running prebuild in debug mode. ([#25434](https://github.com/expo/expo/pull/25434) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix @react-native/dev-middleware types for react-native 0.73. ([#25513](https://github.com/expo/expo/pull/25513) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Only use `bundledNativeModules.json` for dependencies validation when using canary versions. ([#25600](https://github.com/expo/expo/pull/25600) by [@byCedric](https://github.com/byCedric))
+- Fix Expo Router typed routes error with external URLs
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix @react-native/dev-middleware types for react-native 0.73. ([#25513](https://github.com/expo/expo/pull/25513) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Only use `bundledNativeModules.json` for dependencies validation when using canary versions. ([#25600](https://github.com/expo/expo/pull/25600) by [@byCedric](https://github.com/byCedric))
 - Fix Expo Router typed routes error with external URLs
+- Fix Expo Router typed routes error with external URLs ([#25591](https://github.com/expo/expo/pull/25591) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -15,7 +15,8 @@ type DynamicRouteTemplate = `/colors/[color]` | `/animals/[...animal]` | `/mix/[
 
 type RelativePathString = `./${string}` | `../${string}` | '..';
 type AbsoluteRoute = DynamicRouteTemplate | StaticRoutes;
-type ExternalPathString = `http${string}`;
+type ExternalPathString = `${string}:${string}`;
+
 type ExpoRouterRoutes = DynamicRouteTemplate | StaticRoutes | RelativePathString;
 type AllRoutes = ExpoRouterRoutes | ExternalPathString;
 

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/route.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/route.test.ts
@@ -52,10 +52,6 @@ describe('router.push()', () => {
       expectError(router.push('/mix/apple'));
       expectError(router.push('/mix/apple/cat'));
     });
-
-    it('can accept any external url', () => {
-      expectType<void>(router.push('http://expo.dev'));
-    });
   });
 
   describe('HrefObject', () => {
@@ -192,5 +188,19 @@ describe('useSegments', () => {
 
   it('only accepts valid possible segments', () => {
     expectError(useSegments<['invalid segment']>());
+  });
+});
+
+describe('external routes', () => {
+  it('can accept any external url', () => {
+    expectType<void>(router.push('http://expo.dev'));
+  });
+
+  it('can accept any schema url', () => {
+    expectType<void>(router.push('custom-schema://expo.dev'));
+  });
+
+  it('can accept mailto url', () => {
+    expectType<void>(router.push('mailto:test@test.com'));
   });
 });

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -312,7 +312,8 @@ declare module "expo-router" {
 
   type RelativePathString = \`./\${string}\` | \`../\${string}\` | '..';
   type AbsoluteRoute = DynamicRouteTemplate | StaticRoutes;
-  type ExternalPathString = \`http\${string}\`;
+  type ExternalPathString = \`\${string}:\${string}\`;
+
   type ExpoRouterRoutes = DynamicRouteTemplate | StaticRoutes | RelativePathString;
   type AllRoutes = ExpoRouterRoutes | ExternalPathString;
 


### PR DESCRIPTION
# Why

Update the `ExternalPathString` type generation to accept any scheme. I tried making this a bit fancier to match the regex but I saw a performance drop inside VS Code.

There is no real standard on how schema work eg `:` vs `://` so I just kept it simple.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
