### PR TITLE
[ci] fix pr-labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   test-suite-fingerprint:
     runs-on: ubuntu-22.04
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
     # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:


### PR DESCRIPTION
# Why

fix regression from #25103 that pr-labeler is now skipped always when merging back to main

# How

we need to update fingerprint database when merging back to main. this pr adds the push event integration

# Test Plan

check whether the pr-labeler workflow being skipped after merge
