### PR TITLE
[docs] Embed EAS Update debug video

### DIFF
--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -6,6 +6,7 @@ description: Learn how to debug EAS Update.
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
+import Video from '~/components/plugins/Video';
 
 This guide shows how to verify our configuration so that we can find the source of problems like an app not showing a published update. It's important to tell the current state of our app at any given time, so EAS Update was built with this in mind. Once we know which updates are running on which builds, we can make changes so that our apps are in the state we expect.
 
@@ -142,3 +143,7 @@ To create and publish an update, we can run the following command:
 <Terminal cmd={['$ eas update']} />
 
 After publishing, the output will display the branch and the runtime version. This information can help us verify that we're creating an update with the configuration we expect.
+
+## Video walkthrough
+
+<Video url="https://www.youtube.com/embed/m9PLTr3t3S4" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10070

# How

<!--
How did you build this feature or fix this bug and why?
-->

Embed the video tutorial for debugging EAS Update in Debug EAS Update doc as a section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/eas-update/debug/#video-walkthrough

### Preview

![CleanShot 2023-11-27 at 21 12 37](https://github.com/expo/expo/assets/10234615/58d7c3d2-af6a-446a-8c55-1286f5725c41)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
