### PR TITLE
[docs] Add icons for Development Process and Distribution sidebar groups

### DIFF
--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -11,7 +11,7 @@ import {
   PlanEnterpriseIcon,
   PaletteIcon,
   DataIcon,
-  Code01Icon,
+  CodeSquare01Icon,
   Phone01Icon,
 } from '@expo/styleguide-icons';
 
@@ -71,7 +71,7 @@ function getIconElement(iconName?: string) {
     case 'Deploy':
       return Rocket01Icon;
     case 'Development process':
-      return Code01Icon;
+      return CodeSquare01Icon;
     case 'EAS Build':
       return Cube01Icon;
     case 'EAS Submit':

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -11,6 +11,8 @@ import {
   PlanEnterpriseIcon,
   PaletteIcon,
   DataIcon,
+  Code01Icon,
+  Phone01Icon,
 } from '@expo/styleguide-icons';
 
 import { SidebarNodeProps } from './Sidebar';
@@ -68,6 +70,8 @@ function getIconElement(iconName?: string) {
       return TerminalBrowserIcon;
     case 'Deploy':
       return Rocket01Icon;
+    case 'Development process':
+      return Code01Icon;
     case 'EAS Build':
       return Cube01Icon;
     case 'EAS Submit':
@@ -84,6 +88,8 @@ function getIconElement(iconName?: string) {
       return RouterLogo;
     case 'Push notifications':
       return Bell03Icon;
+    case 'Distribution':
+      return Phone01Icon;
     case 'UI programming':
       return PaletteIcon;
     case 'EAS':


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the Development Process and Distribution sidebar groups are missing icons.

![CleanShot 2023-11-27 at 22 53 08](https://github.com/expo/expo/assets/10234615/4d4d5e72-149d-4eae-b5e5-2f1ff70c06a1)

![CleanShot 2023-12-06 at 00 18 57@2x](https://github.com/expo/expo/assets/10234615/7a33130a-1c3a-46b9-a281-e342d8902794)


# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding icons for the abovementioned sections

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

### Preview

![CleanShot 2023-11-27 at 22 55 10](https://github.com/expo/expo/assets/10234615/f49b0b2e-959c-4930-a649-0e9ffa27e6ad)

![CleanShot 2023-12-06 at 00 17 24](https://github.com/expo/expo/assets/10234615/0e5d1b4f-1119-43d3-b166-46b379971028)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
