### PR TITLE
[expo-updates][android] Convert to coroutines

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoUpdatesModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoUpdatesModule.kt
@@ -45,13 +45,13 @@ class ExpoGoUpdatesModule(experienceProperties: Map<String, Any?>) : Module() {
         constants["channel"] = configuration.requestHeaders["expo-channel-name"] ?: ""
         constants["nativeDebug"] = BuildConfig.EX_UPDATES_NATIVE_DEBUG
 
-        val launchedUpdate = appLoaderLocal.launcher.launchedUpdate
+        val launchedUpdate = appLoaderLocal.launcherResult.launchedUpdate
         if (launchedUpdate != null) {
           constants["updateId"] = launchedUpdate.id.toString()
           constants["commitTime"] = launchedUpdate.commitTime.time
           constants["manifestString"] = launchedUpdate.manifest.toString()
         }
-        val localAssetFiles = appLoaderLocal.launcher.localAssetFiles
+        val localAssetFiles = appLoaderLocal.launcherResult.localAssetFiles
         if (localAssetFiles != null) {
           val localAssets = mutableMapOf<String, String>()
           for (asset in localAssetFiles.keys) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -6,7 +6,7 @@ import android.util.Log
 import com.facebook.react.ReactInstanceManager
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.UpdatesConfiguration.Companion.UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE
-import expo.modules.updates.launcher.Launcher
+import expo.modules.updates.launcher.LauncherResult
 import expo.modules.updates.launcher.NoDatabaseLauncher
 import expo.modules.updates.statemachine.UpdatesStateContext
 import java.io.File
@@ -24,7 +24,7 @@ class DisabledUpdatesController(
   private val isMissingRuntimeVersion: Boolean
 ) : IUpdatesController {
   private var isStarted = false
-  private var launcher: Launcher? = null
+  private var launcherResult: LauncherResult? = null
   private var isLoaderTaskFinished = false
   override var updatesDirectory: File? = null
 
@@ -41,11 +41,11 @@ class DisabledUpdatesController(
           Log.e(TAG, "Interrupted while waiting for launch asset file", e)
         }
       }
-      return launcher?.launchAssetFile
+      return launcherResult?.launchAssetFile
     }
 
   override val bundleAssetName: String?
-    get() = launcher?.bundleAssetName
+    get() = launcherResult?.bundleAssetName
 
   override fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {}
 
@@ -56,7 +56,7 @@ class DisabledUpdatesController(
     }
     isStarted = true
 
-    launcher = NoDatabaseLauncher(context, fatalException)
+    launcherResult = NoDatabaseLauncher(context, fatalException).launch()
     isEmergencyLaunch = fatalException != null
     notifyController()
     return
@@ -66,55 +66,50 @@ class DisabledUpdatesController(
 
   override fun getConstantsForModule(): IUpdatesController.UpdatesModuleConstants {
     return IUpdatesController.UpdatesModuleConstants(
-      launchedUpdate = launcher?.launchedUpdate,
+      launchedUpdate = launcherResult?.launchedUpdate,
       embeddedUpdate = null,
       isEmergencyLaunch = isEmergencyLaunch,
       isEnabled = false,
       releaseChannel = UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE,
-      isUsingEmbeddedAssets = launcher?.isUsingEmbeddedAssets ?: false,
+      isUsingEmbeddedAssets = launcherResult?.isUsingEmbeddedAssets ?: false,
       runtimeVersion = null,
       checkOnLaunch = UpdatesConfiguration.CheckAutomaticallyConfiguration.NEVER,
       requestHeaders = mapOf(),
-      localAssetFiles = launcher?.localAssetFiles,
+      localAssetFiles = launcherResult?.localAssetFiles,
       isMissingRuntimeVersion = isMissingRuntimeVersion,
     )
   }
 
-  override fun relaunchReactApplicationForModule(callback: IUpdatesController.ModuleCallback<Unit>) {
-    callback.onFailure(UpdatesDisabledException("You cannot reload when expo-updates is not enabled."))
+  override suspend fun relaunchReactApplicationForModule() {
+    throw UpdatesDisabledException("You cannot reload when expo-updates is not enabled.")
   }
 
   override fun getNativeStateMachineContext(callback: IUpdatesController.ModuleCallback<UpdatesStateContext>) {
     callback.onFailure(UpdatesDisabledException("You cannot check for updates when expo-updates is not enabled."))
   }
 
-  override fun checkForUpdate(
-    callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
-  ) {
-    callback.onFailure(UpdatesDisabledException("You cannot check for updates when expo-updates is not enabled."))
+  override suspend fun checkForUpdate(): IUpdatesController.CheckForUpdateResult {
+    throw UpdatesDisabledException("You cannot check for updates when expo-updates is not enabled.")
   }
 
-  override fun fetchUpdate(
-    callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
-  ) {
-    callback.onFailure(UpdatesDisabledException("You cannot fetch update when expo-updates is not enabled."))
+  override suspend fun fetchUpdate(): IUpdatesController.FetchUpdateResult {
+    throw UpdatesDisabledException("You cannot fetch update when expo-updates is not enabled.")
   }
 
-  override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled."))
+  override suspend fun getExtraParams(): Bundle {
+    throw UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled.")
   }
 
-  override fun setExtraParam(
+  override suspend fun setExtraParam(
     key: String,
     value: String?,
-    callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled."))
+    throw UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled.")
   }
 
   @Synchronized
   private fun notifyController() {
-    if (launcher == null) {
+    if (launcherResult == null) {
       throw AssertionError("UpdatesController.notifyController was called with a null launcher, which is an error. This method should only be called when an update is ready to launch.")
     }
     isLoaderTaskFinished = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -14,7 +14,6 @@ import expo.modules.kotlin.exception.toCodedException
 import expo.modules.updates.db.BuildData
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.UpdatesDatabase
-import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
@@ -29,6 +28,10 @@ import expo.modules.updates.statemachine.UpdatesStateChangeEventSender
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updates.statemachine.UpdatesStateEventType
 import expo.modules.updates.statemachine.UpdatesStateMachine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -74,12 +77,6 @@ class EnabledUpdatesController(
     selectionPolicy,
     logger,
     object : StartupProcedure.StartupProcedureCallback {
-      @Synchronized
-      override fun onFinished() {
-        isStartupFinished = true
-        (this as java.lang.Object).notify()
-      }
-
       override fun onLegacyJSEvent(event: StartupProcedure.StartupProcedureCallback.LegacyJSEvent) {
         when (event) {
           is StartupProcedure.StartupProcedureCallback.LegacyJSEvent.Error -> sendLegacyUpdateEventToJS(
@@ -98,8 +95,8 @@ class EnabledUpdatesController(
         }
       }
 
-      override fun onRequestRelaunch(shouldRunReaper: Boolean, callback: LauncherCallback) {
-        relaunchReactApplication(shouldRunReaper, callback)
+      override suspend fun onRequestRelaunch(shouldRunReaper: Boolean) {
+        relaunchReactApplication(shouldRunReaper)
       }
     }
   )
@@ -132,7 +129,6 @@ class EnabledUpdatesController(
     startupProcedure.onDidCreateReactInstanceManager(reactInstanceManager)
   }
 
-  @Synchronized
   override fun start() {
     if (isStarted) {
       return
@@ -144,10 +140,21 @@ class EnabledUpdatesController(
     BuildData.ensureBuildDataIsConsistent(updatesConfiguration, databaseHolder.database)
     databaseHolder.releaseDatabase()
 
-    stateMachine.queueExecution(startupProcedure)
+    CoroutineScope(Dispatchers.IO).launch {
+      val startupProcedureResult = stateMachine.queueExecution(startupProcedure)
+
+      if (startupProcedureResult.shouldPerformAdditionalBackgroundLoad) {
+        GlobalScope.launch {
+          fetchUpdate()
+        }
+      }
+
+      isStartupFinished = true
+      (this as java.lang.Object).notify()
+    }
   }
 
-  private fun relaunchReactApplication(shouldRunReaper: Boolean, callback: LauncherCallback) {
+  private suspend fun relaunchReactApplication(shouldRunReaper: Boolean) {
     val procedure = RelaunchProcedure(
       context,
       updatesConfiguration,
@@ -156,10 +163,9 @@ class EnabledUpdatesController(
       fileDownloader,
       selectionPolicy,
       reactNativeHost,
-      getCurrentLauncher = { startupProcedure.launcher!! },
-      setCurrentLauncher = { currentLauncher -> startupProcedure.setLauncher(currentLauncher) },
+      getCurrentLauncherResult = { startupProcedure.launcherResult!! },
+      setCurrentLauncherResult = { currentLauncherResult -> startupProcedure.setLauncherResult(currentLauncherResult) },
       shouldRunReaper = shouldRunReaper,
-      callback
     )
     stateMachine.queueExecution(procedure)
   }
@@ -192,85 +198,63 @@ class EnabledUpdatesController(
     )
   }
 
-  override fun relaunchReactApplicationForModule(callback: IUpdatesController.ModuleCallback<Unit>) {
+  override suspend fun relaunchReactApplicationForModule() {
     val canRelaunch = launchedUpdate != null
     if (!canRelaunch) {
-      callback.onFailure(object : CodedException("ERR_UPDATES_RELOAD", "Cannot relaunch without a launched update.", null) {})
-    } else {
-      relaunchReactApplication(
-        shouldRunReaper = true,
-        object : LauncherCallback {
-          override fun onFailure(e: Exception) {
-            callback.onFailure(e.toCodedException())
-          }
-
-          override fun onSuccess() {
-            callback.onSuccess(Unit)
-          }
-        }
-      )
+      throw CodedException("ERR_UPDATES_RELOAD", "Cannot relaunch without a launched update.", null)
     }
+    relaunchReactApplication(shouldRunReaper = true)
   }
 
   override fun getNativeStateMachineContext(callback: IUpdatesController.ModuleCallback<UpdatesStateContext>) {
     callback.onSuccess(stateMachine.context)
   }
 
-  override fun checkForUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>) {
-    val procedure = CheckForUpdateProcedure(context, updatesConfiguration, databaseHolder, logger, fileDownloader, selectionPolicy, launchedUpdate) {
-      callback.onSuccess(it)
-    }
-    stateMachine.queueExecution(procedure)
+  override suspend fun checkForUpdate(): IUpdatesController.CheckForUpdateResult {
+    val procedure = CheckForUpdateProcedure(context, updatesConfiguration, databaseHolder, logger, fileDownloader, selectionPolicy, launchedUpdate)
+    return stateMachine.queueExecution(procedure)
   }
 
-  override fun fetchUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>) {
-    val procedure = FetchUpdateProcedure(context, updatesConfiguration, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate) {
-      callback.onSuccess(it)
-    }
-    stateMachine.queueExecution(procedure)
+  override suspend fun fetchUpdate(): IUpdatesController.FetchUpdateResult {
+    val procedure = FetchUpdateProcedure(context, updatesConfiguration, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate)
+    return stateMachine.queueExecution(procedure)
   }
 
-  override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    AsyncTask.execute {
-      try {
-        val result = ManifestMetadata.getExtraParams(
-          databaseHolder.database,
-          updatesConfiguration,
-        )
-        databaseHolder.releaseDatabase()
-        val resultMap = when (result) {
-          null -> Bundle()
-          else -> {
-            Bundle().apply {
-              result.forEach {
-                putString(it.key, it.value)
-              }
+  override suspend fun getExtraParams(): Bundle {
+    try {
+      val result = ManifestMetadata.getExtraParams(
+        databaseHolder.database,
+        updatesConfiguration,
+      )
+      databaseHolder.releaseDatabase()
+      return when (result) {
+        null -> Bundle()
+        else -> {
+          Bundle().apply {
+            result.forEach {
+              putString(it.key, it.value)
             }
           }
         }
-        callback.onSuccess(resultMap)
-      } catch (e: Exception) {
-        databaseHolder.releaseDatabase()
-        callback.onFailure(e.toCodedException())
       }
+    } catch (e: Exception) {
+      databaseHolder.releaseDatabase()
+      throw e
     }
   }
 
-  override fun setExtraParam(key: String, value: String?, callback: IUpdatesController.ModuleCallback<Unit>) {
-    AsyncTask.execute {
-      try {
-        ManifestMetadata.setExtraParam(
-          databaseHolder.database,
-          updatesConfiguration,
-          key,
-          value
-        )
-        databaseHolder.releaseDatabase()
-        callback.onSuccess(Unit)
-      } catch (e: Exception) {
-        databaseHolder.releaseDatabase()
-        callback.onFailure(e.toCodedException())
-      }
+  override suspend fun setExtraParam(key: String, value: String?) {
+    try {
+      ManifestMetadata.setExtraParam(
+        databaseHolder.database,
+        updatesConfiguration,
+        key,
+        value
+      )
+      databaseHolder.releaseDatabase()
+    } catch (e: Exception) {
+      databaseHolder.releaseDatabase()
+      throw e
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -81,7 +81,7 @@ interface IUpdatesController {
   )
   fun getConstantsForModule(): UpdatesModuleConstants
 
-  fun relaunchReactApplicationForModule(callback: ModuleCallback<Unit>)
+  suspend fun relaunchReactApplicationForModule()
 
   fun getNativeStateMachineContext(callback: ModuleCallback<UpdatesStateContext>)
 
@@ -98,7 +98,7 @@ interface IUpdatesController {
     class RollBackToEmbedded(val commitTime: Date) : CheckForUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception, val message: String) : CheckForUpdateResult(Status.ERROR)
   }
-  fun checkForUpdate(callback: ModuleCallback<CheckForUpdateResult>)
+  suspend fun checkForUpdate(): CheckForUpdateResult
 
   sealed class FetchUpdateResult(private val status: Status) {
     private enum class Status {
@@ -113,9 +113,9 @@ interface IUpdatesController {
     class RollBackToEmbedded : FetchUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception) : FetchUpdateResult(Status.ERROR)
   }
-  fun fetchUpdate(callback: ModuleCallback<FetchUpdateResult>)
+  suspend fun fetchUpdate(): FetchUpdateResult
 
-  fun getExtraParams(callback: ModuleCallback<Bundle>)
+  suspend fun getExtraParams(): Bundle
 
-  fun setExtraParam(key: String, value: String?, callback: ModuleCallback<Unit>)
+  suspend fun setExtraParam(key: String, value: String?)
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecoveryDelegate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecoveryDelegate.kt
@@ -1,7 +1,6 @@
 package expo.modules.updates.errorrecovery
 
 import expo.modules.updates.UpdatesConfiguration
-import expo.modules.updates.launcher.Launcher
 
 /**
  * Interface for a delegate that will execute the actions prescribed by the error recovery
@@ -15,8 +14,8 @@ interface ErrorRecoveryDelegate {
     NEW_UPDATE_LOADED
   }
 
-  fun loadRemoteUpdate()
-  fun relaunch(callback: Launcher.LauncherCallback)
+  suspend fun loadRemoteUpdate()
+  suspend fun relaunch()
   fun throwException(exception: Exception)
 
   fun markFailedLaunchForLaunchedUpdate()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/Launcher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/Launcher.kt
@@ -3,40 +3,30 @@ package expo.modules.updates.launcher
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 
-/**
- * Provides an interface through which an update can be launched from disk. Classes that implement
- * this interface are responsible for selecting an eligible update to launch, ensuring all
- * required assets are present, and providing the fields here.
- */
-interface Launcher {
-  interface LauncherCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess()
-  }
-
-  val launchedUpdate: UpdateEntity?
+data class LauncherResult(
+  val launchedUpdate: UpdateEntity?,
 
   /**
    * Used by React Native to launch the app when the launch asset (JS bundle or HBC) is located on
    * the device's file system.
    */
-  val launchAssetFile: String?
+  val launchAssetFile: String?,
 
   /**
    * Used by React Native to launch the app when the launch asset (JS bundle or HBC) is embedded in
    * the application package.
    */
-  val bundleAssetName: String?
+  val bundleAssetName: String?,
 
   /**
    * Exported to JS through [UpdatesModule] for use by the expo-asset package. Used to map
    * references to `require`d assets to files on disk.
    */
-  val localAssetFiles: Map<AssetEntity, String>?
+  val localAssetFiles: Map<AssetEntity, String>?,
 
   /**
    * Exported to JS through [UpdatesModule] for use by the expo-asset package. Used to determine
    * whether to map references to `require`d assets to files embedded in the application package.
    */
-  val isUsingEmbeddedAssets: Boolean
-}
+  val isUsingEmbeddedAssets: Boolean,
+)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -18,12 +18,16 @@ import java.io.File
 class NoDatabaseLauncher @JvmOverloads constructor(
   context: Context,
   fatalException: Exception? = null
-) : Launcher {
-  override val bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
-  override val launchedUpdate = null
-  override val launchAssetFile = null
-  override val localAssetFiles = null
-  override val isUsingEmbeddedAssets = true
+) {
+  fun launch(): LauncherResult {
+    return LauncherResult(
+      bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME,
+      launchedUpdate = null,
+      launchAssetFile = null,
+      localAssetFiles = null,
+      isUsingEmbeddedAssets = true
+    )
+  }
 
   private fun writeErrorToLog(context: Context, fatalException: Exception) {
     try {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -8,12 +8,46 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.db.enums.UpdateStatus
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
-import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.UpdateManifest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import java.io.File
-import java.util.*
+import java.util.Date
+
+data class LoaderResult(val updateEntity: UpdateEntity?, val updateDirective: UpdateDirective?)
+
+data class OnUpdateResponseLoadedResult(val shouldDownloadManifestIfPresentInResponse: Boolean)
+
+interface LoaderStatusCallbacks {
+  /**
+   * Called when an asset has either been successfully downloaded or failed to download.
+   *
+   * @param asset Entity representing the asset that was either just downloaded or failed
+   * @param successfulAssetCount The number of assets that have so far been loaded successfully
+   * (including any that were found to already exist on disk)
+   * @param failedAssetCount The number of assets that have so far failed to load
+   * @param totalAssetCount The total number of assets that comprise the update
+   */
+  fun onAssetLoaded(
+    asset: AssetEntity,
+    successfulAssetCount: Int,
+    failedAssetCount: Int,
+    totalAssetCount: Int
+  )
+
+  /**
+   * Called when a response has been downloaded. The calling class should determine whether or not
+   * the RemoteLoader should continue to download the manifest in the manifest part of the update response,
+   * based on (for example) whether or not it already has the update downloaded locally.
+   *
+   * @param updateResponse Response downloaded by Loader
+   * @return true if Loader should download the manifest described in the manifest part of the update response,
+   * false if not.
+   */
+  fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult
+}
 
 /**
  * Abstract class responsible for loading an update, enumerating the assets required for
@@ -22,162 +56,61 @@ import java.util.*
  * There are two sources from which an update can be loaded - a remote server given a URL, and the
  * application package. These correspond to the two loader subclasses.
  */
-abstract class Loader protected constructor(
+abstract class Loader(
   private val context: Context,
   private val configuration: UpdatesConfiguration,
   private val database: UpdatesDatabase,
   private val updatesDirectory: File,
   private val loaderFiles: LoaderFiles
 ) {
-  private var updateResponse: UpdateResponse? = null
-  private var updateEntity: UpdateEntity? = null
-  private var callback: LoaderCallback? = null
-  private var assetTotal = 0
-  private var erroredAssetList = mutableListOf<AssetEntity>()
-  private var existingAssetList = mutableListOf<AssetEntity>()
-  private var finishedAssetList = mutableListOf<AssetEntity>()
-
-  data class LoaderResult(val updateEntity: UpdateEntity?, val updateDirective: UpdateDirective?)
-
-  data class OnUpdateResponseLoadedResult(val shouldDownloadManifestIfPresentInResponse: Boolean)
-
-  interface LoaderCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(loaderResult: LoaderResult)
-
-    /**
-     * Called when an asset has either been successfully downloaded or failed to download.
-     *
-     * @param asset Entity representing the asset that was either just downloaded or failed
-     * @param successfulAssetCount The number of assets that have so far been loaded successfully
-     * (including any that were found to already exist on disk)
-     * @param failedAssetCount The number of assets that have so far failed to load
-     * @param totalAssetCount The total number of assets that comprise the update
-     */
-    fun onAssetLoaded(
-      asset: AssetEntity,
-      successfulAssetCount: Int,
-      failedAssetCount: Int,
-      totalAssetCount: Int
-    )
-
-    /**
-     * Called when a response has been downloaded. The calling class should determine whether or not
-     * the RemoteLoader should continue to download the manifest in the manifest part of the update response,
-     * based on (for example) whether or not it already has the update downloaded locally.
-     *
-     * @param updateResponse Response downloaded by Loader
-     * @return true if Loader should download the manifest described in the manifest part of the update response,
-     * false if not.
-     */
-    fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult
-  }
-
-  protected abstract fun loadRemoteUpdate(
+  protected abstract suspend fun loadRemoteUpdate(
     context: Context,
     database: UpdatesDatabase,
     configuration: UpdatesConfiguration,
-    callback: RemoteUpdateDownloadCallback
-  )
+  ): UpdateResponse
 
-  protected abstract fun loadAsset(
+  protected abstract suspend fun loadAsset(
     context: Context,
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
-    callback: AssetDownloadCallback
-  )
+  ): FileDownloader.AssetDownloadResult
 
-  // lifecycle methods for class
-  fun start(callback: LoaderCallback) {
-    if (this.callback != null) {
-      callback.onFailure(Exception("RemoteLoader has already started. Create a new instance in order to load multiple URLs in parallel."))
-      return
+  suspend fun load(statusCallbacks: LoaderStatusCallbacks): LoaderResult {
+    val updateResponse = loadRemoteUpdate(context, database, configuration)
+
+    val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+    val onUpdateResponseLoadedResult = statusCallbacks.onUpdateResponseLoaded(updateResponse)
+    return if (updateManifest !== null && onUpdateResponseLoadedResult.shouldDownloadManifestIfPresentInResponse) {
+      // if onUpdateResponseLoaded returns true that is a sign that the delegate wants the update manifest
+      // to be processed/downloaded, and therefore the updateManifest needs to exist
+      val updateEntity = processUpdateManifest(updateManifest, statusCallbacks)
+      finishWithSuccess(updateEntity, updateResponse)
+    } else {
+      finishWithSuccess(null, updateResponse)
     }
-    this.callback = callback
-
-    loadRemoteUpdate(
-      context, database, configuration,
-      object : RemoteUpdateDownloadCallback {
-        override fun onFailure(message: String, e: Exception) {
-          finishWithError(message, e)
-        }
-
-        override fun onSuccess(updateResponse: UpdateResponse) {
-          this@Loader.updateResponse = updateResponse
-          val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
-          val onUpdateResponseLoadedResult = this@Loader.callback!!.onUpdateResponseLoaded(updateResponse)
-          if (updateManifest !== null && onUpdateResponseLoadedResult.shouldDownloadManifestIfPresentInResponse) {
-            // if onUpdateResponseLoaded returns true that is a sign that the delegate wants the update manifest
-            // to be processed/downloaded, and therefore the updateManifest needs to exist
-            processUpdateManifest(updateManifest)
-          } else {
-            updateEntity = null
-            finishWithSuccess()
-          }
-        }
-      }
-    )
   }
 
-  private fun reset() {
-    updateResponse = null
-    updateEntity = null
-    callback = null
-    assetTotal = 0
-    erroredAssetList = mutableListOf()
-    existingAssetList = mutableListOf()
-    finishedAssetList = mutableListOf()
-  }
-
-  private fun finishWithSuccess() {
-    if (callback == null) {
-      Log.e(
-        TAG,
-        this.javaClass.simpleName + " tried to finish but it already finished or was never initialized."
-      )
-      return
-    }
-
+  private fun finishWithSuccess(updateEntity: UpdateEntity?, updateResponse: UpdateResponse): LoaderResult {
     // store the header data even if only a message was included in the response
-    updateResponse!!.responseHeaderData?.let {
+    updateResponse.responseHeaderData?.let {
       ManifestMetadata.saveMetadata(it, database, configuration)
     }
-
-    val updateDirective = updateResponse!!.directiveUpdateResponsePart?.updateDirective
-
-    callback!!.onSuccess(
-      LoaderResult(
-        updateEntity = this.updateEntity,
-        updateDirective = updateDirective
-      )
+    val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+    return LoaderResult(
+      updateEntity = updateEntity,
+      updateDirective = updateDirective
     )
-    reset()
   }
 
-  private fun finishWithError(message: String, e: Exception) {
-    Log.e(TAG, message, e)
-    if (callback == null) {
-      Log.e(
-        TAG,
-        this.javaClass.simpleName + " tried to finish but it already finished or was never initialized."
-      )
-      return
-    }
-    callback!!.onFailure(e)
-    reset()
-  }
-
-  // private helper methods
-  private fun processUpdateManifest(updateManifest: UpdateManifest) {
+  private suspend fun processUpdateManifest(updateManifest: UpdateManifest, statusCallbacks: LoaderStatusCallbacks): UpdateEntity {
     if (updateManifest.isDevelopmentMode) {
       // insert into database but don't try to load any assets;
       // the RN runtime will take care of that and we don't want to cache anything
       val updateEntity = updateManifest.updateEntity
       database.updateDao().insertUpdate(updateEntity!!)
       database.updateDao().markUpdateFinished(updateEntity)
-      finishWithSuccess()
-      return
+      return updateEntity
     }
 
     val newUpdateEntity = updateManifest.updateEntity
@@ -196,21 +129,21 @@ abstract class Loader protected constructor(
       )
     }
 
-    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
+    return if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
       // hooray, we already have this update downloaded and ready to go!
-      updateEntity = existingUpdateEntity
-      finishWithSuccess()
+      existingUpdateEntity
     } else {
-      if (existingUpdateEntity == null) {
+      val updateEntity = if (existingUpdateEntity == null) {
         // no update already exists with this ID, so we need to insert it and download everything.
-        updateEntity = newUpdateEntity
-        database.updateDao().insertUpdate(updateEntity!!)
+        database.updateDao().insertUpdate(newUpdateEntity)
+        newUpdateEntity
       } else {
         // we've already partially downloaded the update, so we should use the existing entity.
         // however, it's not ready, so we should try to download all the assets again.
-        updateEntity = existingUpdateEntity
+        existingUpdateEntity
       }
-      downloadAllAssets(updateManifest.assetEntityList)
+      downloadAllAssets(updateEntity, updateManifest.assetEntityList, statusCallbacks)
+      return updateEntity
     }
   }
 
@@ -218,82 +151,84 @@ abstract class Loader protected constructor(
     FINISHED, ALREADY_EXISTS, ERRORED
   }
 
-  private fun downloadAllAssets(assetList: List<AssetEntity>) {
-    assetTotal = assetList.size
-    for (assetEntityCur in assetList) {
-      var assetEntity = assetEntityCur
+  private suspend fun downloadAllAssets(updateEntity: UpdateEntity, assetList: List<AssetEntity>, statusCallbacks: LoaderStatusCallbacks) {
+    coroutineScope {
+      val erroredAssetList = mutableListOf<AssetEntity>()
+      val existingAssetList = mutableListOf<AssetEntity>()
+      val finishedAssetList = mutableListOf<AssetEntity>()
+      val assetTotal = assetList.size
 
-      val matchingDbEntry = database.assetDao().loadAssetWithKey(assetEntity.key)
-      if (matchingDbEntry != null) {
-        // merge all fields not stored in the database onto matchingDbEntry,
-        // in case we need them later on in this class
-        database.assetDao().mergeAndUpdateAsset(matchingDbEntry, assetEntity)
-        assetEntity = matchingDbEntry
-      }
+      assetList.map { assetEntityCur ->
+        async {
+          var assetEntity = assetEntityCur
+          val matchingDbEntry = database.assetDao().loadAssetWithKey(assetEntity.key)
+          if (matchingDbEntry != null) {
+            // merge all fields not stored in the database onto matchingDbEntry,
+            // in case we need them later on in this class
+            database.assetDao().mergeAndUpdateAsset(matchingDbEntry, assetEntity)
+            assetEntity = matchingDbEntry
+          }
 
-      // if we already have a local copy of this asset, don't try to download it again!
-      if (assetEntity.relativePath != null && loaderFiles.fileExists(
-          File(
-              updatesDirectory,
-              assetEntity.relativePath
+          // if we already have a local copy of this asset, don't try to download it again!
+          if (assetEntity.relativePath != null && loaderFiles.fileExists(
+              File(updatesDirectory, assetEntity.relativePath)
             )
-        )
-      ) {
-        handleAssetDownloadCompleted(assetEntity, AssetLoadResult.ALREADY_EXISTS)
-        continue
-      }
+          ) {
+            existingAssetList.add(assetEntity)
+            statusCallbacks.onAssetLoaded(
+              assetEntity,
+              finishedAssetList.size + existingAssetList.size,
+              erroredAssetList.size,
+              assetTotal
+            )
+            return@async Pair(assetEntity, Loader.AssetLoadResult.ALREADY_EXISTS)
+          }
 
-      loadAsset(
-        context, assetEntity, updatesDirectory, configuration,
-        object : AssetDownloadCallback {
-          override fun onFailure(e: Exception, assetEntity: AssetEntity) {
+          val assetDownloadResult = try {
+            loadAsset(context, assetEntity, updatesDirectory, configuration)
+          } catch (e: Exception) {
             val identifier = if (assetEntity.hash != null) "hash " + UpdatesUtils.bytesToHex(
               assetEntity.hash!!
             ) else "key " + assetEntity.key
             Log.e(TAG, "Failed to download asset with $identifier", e)
-            handleAssetDownloadCompleted(assetEntity, AssetLoadResult.ERRORED)
-          }
-
-          override fun onSuccess(assetEntity: AssetEntity, isNew: Boolean) {
-            handleAssetDownloadCompleted(
+            existingAssetList.add(assetEntity)
+            statusCallbacks.onAssetLoaded(
               assetEntity,
-              if (isNew) AssetLoadResult.FINISHED else AssetLoadResult.ALREADY_EXISTS
+              finishedAssetList.size + existingAssetList.size,
+              erroredAssetList.size,
+              assetTotal
             )
+            return@async Pair(assetEntity, Loader.AssetLoadResult.ERRORED)
           }
+
+          if (assetDownloadResult.isNew) {
+            finishedAssetList.add(assetEntity)
+          } else {
+            existingAssetList.add(assetEntity)
+          }
+          statusCallbacks.onAssetLoaded(
+            assetEntity,
+            finishedAssetList.size + existingAssetList.size,
+            erroredAssetList.size,
+            assetTotal
+          )
+          return@async Pair(assetEntity, if (assetDownloadResult.isNew) Loader.AssetLoadResult.FINISHED else Loader.AssetLoadResult.ALREADY_EXISTS)
         }
-      )
-    }
-  }
+      }.awaitAll()
 
-  @Synchronized
-  private fun handleAssetDownloadCompleted(assetEntity: AssetEntity, result: AssetLoadResult) {
-    when (result) {
-      AssetLoadResult.FINISHED -> finishedAssetList.add(assetEntity)
-      AssetLoadResult.ALREADY_EXISTS -> existingAssetList.add(assetEntity)
-      AssetLoadResult.ERRORED -> erroredAssetList.add(assetEntity)
-      else -> throw AssertionError("Missing implementation for AssetLoadResult value")
-    }
+      assert(finishedAssetList.size + erroredAssetList.size + existingAssetList.size == assetTotal) { "incorrect asset count" }
 
-    callback!!.onAssetLoaded(
-      assetEntity,
-      finishedAssetList.size + existingAssetList.size,
-      erroredAssetList.size,
-      assetTotal
-    )
-
-    if (finishedAssetList.size + erroredAssetList.size + existingAssetList.size == assetTotal) {
       try {
         for (asset in existingAssetList) {
-          val existingAssetFound = database.assetDao()
-            .addExistingAssetToUpdate(updateEntity!!, asset, asset.isLaunchAsset)
+          val existingAssetFound = database.assetDao().addExistingAssetToUpdate(updateEntity, asset, asset.isLaunchAsset)
           if (!existingAssetFound) {
             // the database and filesystem have gotten out of sync
             // do our best to create a new entry for this file even though it already existed on disk
             // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-            var hash: ByteArray? = null
-            try {
-              hash = UpdatesUtils.sha256(File(updatesDirectory, asset.relativePath))
+            val hash = try {
+              UpdatesUtils.sha256(File(updatesDirectory, asset.relativePath))
             } catch (e: Exception) {
+              null
             }
             asset.downloadTime = Date()
             asset.hash = hash
@@ -301,20 +236,17 @@ abstract class Loader protected constructor(
           }
         }
 
-        database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
+        database.assetDao().insertAssets(finishedAssetList, updateEntity)
 
         if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!)
+          database.updateDao().markUpdateFinished(updateEntity)
         }
       } catch (e: Exception) {
-        finishWithError("Error while adding new update to database", e)
-        return
+        throw Exception("Error while adding new update to database", e)
       }
 
       if (erroredAssetList.size > 0) {
-        finishWithError("Failed to load all assets", Exception("Failed to load all assets"))
-      } else {
-        finishWithSuccess()
+        throw Exception("Failed to load all assets")
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -1,7 +1,6 @@
 package expo.modules.updates.procedures
 
 import android.content.Context
-import android.os.AsyncTask
 import expo.modules.updates.IUpdatesController
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
@@ -9,7 +8,6 @@ import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.loader.UpdateDirective
-import expo.modules.updates.loader.UpdateResponse
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifest
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -23,159 +21,116 @@ class CheckForUpdateProcedure(
   private val fileDownloader: FileDownloader,
   private val selectionPolicy: SelectionPolicy,
   private val launchedUpdate: UpdateEntity?,
-  private val callback: (IUpdatesController.CheckForUpdateResult) -> Unit
-) : StateMachineProcedure() {
-  override fun run(procedureContext: ProcedureContext) {
+) : StateMachineProcedure<IUpdatesController.CheckForUpdateResult>() {
+  override suspend fun run(procedureContext: ProcedureContext): IUpdatesController.CheckForUpdateResult {
     procedureContext.processStateEvent(UpdatesStateEvent.Check())
 
-    AsyncTask.execute {
-      val embeddedUpdate = EmbeddedManifest.get(context, updatesConfiguration)?.updateEntity
-      val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(
-        databaseHolder.database,
-        updatesConfiguration,
-        launchedUpdate,
-        embeddedUpdate
-      )
-      databaseHolder.releaseDatabase()
+    val embeddedUpdate = EmbeddedManifest.get(context, updatesConfiguration)?.updateEntity
+    val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(
+      databaseHolder.database,
+      updatesConfiguration,
+      launchedUpdate,
+      embeddedUpdate
+    )
+    databaseHolder.releaseDatabase()
+    val updateResponse = try {
       fileDownloader.downloadRemoteUpdate(
         updatesConfiguration,
         extraHeaders,
         context,
-        object : FileDownloader.RemoteUpdateDownloadCallback {
-          override fun onFailure(message: String, e: Exception) {
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckError(message))
-            callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e, message))
-            procedureContext.onComplete()
-          }
-
-          override fun onSuccess(updateResponse: UpdateResponse) {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
-
-            if (updateDirective != null) {
-              when (updateDirective) {
-                is UpdateDirective.NoUpdateAvailableUpdateDirective -> {
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
-                    )
-                  )
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  procedureContext.onComplete()
-                  return
-                }
-                is UpdateDirective.RollBackToEmbeddedUpdateDirective -> {
-                  if (!updatesConfiguration.hasEmbeddedUpdate) {
-                    callback(
-                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
-                      )
-                    )
-                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                    procedureContext.onComplete()
-                    return
-                  }
-
-                  if (embeddedUpdate == null) {
-                    callback(
-                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
-                      )
-                    )
-                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                    procedureContext.onComplete()
-                    return
-                  }
-
-                  if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
-                      updateDirective,
-                      embeddedUpdate,
-                      launchedUpdate,
-                      updateResponse.responseHeaderData?.manifestFilters
-                    )
-                  ) {
-                    callback(
-                      IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                        LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
-                      )
-                    )
-                    procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                    procedureContext.onComplete()
-                    return
-                  }
-
-                  callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
-                  procedureContext.onComplete()
-                  return
-                }
-              }
-            }
-
-            if (updateManifest == null) {
-              callback(
-                IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                  LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
-                )
-              )
-              procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-              procedureContext.onComplete()
-              return
-            }
-
-            if (launchedUpdate == null) {
-              // this shouldn't ever happen, but if we don't have anything to compare
-              // the new manifest to, let the user know an update is available
-              callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
-              procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
-              procedureContext.onComplete()
-              return
-            }
-
-            var shouldLaunch = false
-            var failedPreviously = false
-            if (selectionPolicy.shouldLoadNewUpdate(
-                updateManifest.updateEntity,
-                launchedUpdate,
-                updateResponse.responseHeaderData?.manifestFilters
-              )
-            ) {
-              // If "update" has failed to launch previously, then
-              // "launchedUpdate" will be an earlier update, and the test above
-              // will return true (incorrectly).
-              // We check to see if the new update is already in the DB, and if so,
-              // only allow the update if it has had no launch failures.
-              shouldLaunch = true
-              updateManifest.updateEntity?.let { updateEntity ->
-                val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
-                  updateEntity.id
-                )
-                databaseHolder.releaseDatabase()
-                storedUpdateEntity?.let {
-                  shouldLaunch = it.failedLaunchCount == 0
-                  updatesLogger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
-                  failedPreviously = !shouldLaunch
-                }
-              }
-            }
-            if (shouldLaunch) {
-              callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest))
-              procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
-              procedureContext.onComplete()
-              return
-            } else {
-              val reason = when (failedPreviously) {
-                true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
-                else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
-              }
-              callback(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason))
-              procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-              procedureContext.onComplete()
-              return
-            }
-          }
-        }
       )
+    } catch (e: Exception) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.message ?: ""))
+      return IUpdatesController.CheckForUpdateResult.ErrorResult(e, e.message ?: "")
+    }
+
+    val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+    val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+
+    if (updateDirective != null) {
+      if (updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
+        if (!updatesConfiguration.hasEmbeddedUpdate) {
+          procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+          return IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+            LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+          )
+        }
+
+        if (embeddedUpdate == null) {
+          procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+          return IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+            LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+          )
+        }
+
+        if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+            updateDirective,
+            embeddedUpdate,
+            launchedUpdate,
+            updateResponse.responseHeaderData?.manifestFilters
+          )
+        ) {
+          procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+          return IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+            LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
+          )
+        }
+
+        procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
+        return IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime)
+      }
+    }
+
+    if (updateManifest == null) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+      return IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+        LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
+      )
+    }
+
+    if (launchedUpdate == null) {
+      // this shouldn't ever happen, but if we don't have anything to compare
+      // the new manifest to, let the user know an update is available
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
+      return IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest)
+    }
+
+    var shouldLaunch = false
+    var failedPreviously = false
+    if (selectionPolicy.shouldLoadNewUpdate(
+        updateManifest.updateEntity,
+        launchedUpdate,
+        updateResponse.responseHeaderData?.manifestFilters
+      )
+    ) {
+      // If "update" has failed to launch previously, then
+      // "launchedUpdate" will be an earlier update, and the test above
+      // will return true (incorrectly).
+      // We check to see if the new update is already in the DB, and if so,
+      // only allow the update if it has had no launch failures.
+      shouldLaunch = true
+      updateManifest.updateEntity?.let { updateEntity ->
+        val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
+          updateEntity.id
+        )
+        databaseHolder.releaseDatabase()
+        storedUpdateEntity?.let {
+          shouldLaunch = it.failedLaunchCount == 0
+          updatesLogger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
+          failedPreviously = !shouldLaunch
+        }
+      }
+    }
+    if (shouldLaunch) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(updateManifest.manifest.getRawJson()))
+      return IUpdatesController.CheckForUpdateResult.UpdateAvailable(updateManifest)
+    } else {
+      val reason = when (failedPreviously) {
+        true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
+        else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
+      }
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+      return IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason)
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -1,14 +1,14 @@
 package expo.modules.updates.procedures
 
 import android.content.Context
-import android.os.AsyncTask
 import expo.modules.updates.IUpdatesController
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.Loader
+import expo.modules.updates.loader.LoaderStatusCallbacks
+import expo.modules.updates.loader.OnUpdateResponseLoadedResult
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
@@ -24,13 +24,12 @@ class FetchUpdateProcedure(
   private val fileDownloader: FileDownloader,
   private val selectionPolicy: SelectionPolicy,
   private val launchedUpdate: UpdateEntity?,
-  private val callback: (IUpdatesController.FetchUpdateResult) -> Unit
-) : StateMachineProcedure() {
-  override fun run(procedureContext: ProcedureContext) {
+) : StateMachineProcedure<IUpdatesController.FetchUpdateResult>() {
+  override suspend fun run(procedureContext: ProcedureContext): IUpdatesController.FetchUpdateResult {
     procedureContext.processStateEvent(UpdatesStateEvent.Download())
 
-    AsyncTask.execute {
-      val database = databaseHolder.database
+    val database = databaseHolder.database
+    val loaderResult = try {
       RemoteLoader(
         context,
         updatesConfiguration,
@@ -38,80 +37,75 @@ class FetchUpdateProcedure(
         fileDownloader,
         updatesDirectory,
         launchedUpdate
-      )
-        .start(
-          object : Loader.LoaderCallback {
-            override fun onFailure(e: Exception) {
-              databaseHolder.releaseDatabase()
-              callback(IUpdatesController.FetchUpdateResult.ErrorResult(e))
-              procedureContext.processStateEvent(
-                UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
-              )
-              procedureContext.onComplete()
-            }
+      ).load(object : LoaderStatusCallbacks {
+        override fun onAssetLoaded(
+          asset: AssetEntity,
+          successfulAssetCount: Int,
+          failedAssetCount: Int,
+          totalAssetCount: Int
+        ) {
+        }
 
-            override fun onAssetLoaded(
-              asset: AssetEntity,
-              successfulAssetCount: Int,
-              failedAssetCount: Int,
-              totalAssetCount: Int
-            ) {
-            }
-
-            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-              if (updateDirective != null) {
-                return Loader.OnUpdateResponseLoadedResult(
-                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                  }
-                )
+        override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult {
+          val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+          if (updateDirective != null) {
+            return OnUpdateResponseLoadedResult(
+              shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
               }
-
-              val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
-                ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
-                  updateManifest.updateEntity,
-                  launchedUpdate,
-                  updateResponse.responseHeaderData?.manifestFilters
-                )
-              )
-            }
-
-            override fun onSuccess(loaderResult: Loader.LoaderResult) {
-              RemoteLoader.processSuccessLoaderResult(
-                context,
-                updatesConfiguration,
-                database,
-                selectionPolicy,
-                updatesDirectory,
-                launchedUpdate,
-                loaderResult
-              ) { availableUpdate, didRollBackToEmbedded ->
-                databaseHolder.releaseDatabase()
-
-                if (didRollBackToEmbedded) {
-                  callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
-                  procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
-                  procedureContext.onComplete()
-                } else {
-                  if (availableUpdate == null) {
-                    callback(IUpdatesController.FetchUpdateResult.Failure())
-                    procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
-                    procedureContext.onComplete()
-                  } else {
-                    callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
-                    procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
-                    procedureContext.onComplete()
-                  }
-                }
-              }
-            }
+            )
           }
+
+          val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+            ?: return OnUpdateResponseLoadedResult(
+              shouldDownloadManifestIfPresentInResponse = false
+            )
+
+          return OnUpdateResponseLoadedResult(
+            shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
+              updateManifest.updateEntity,
+              launchedUpdate,
+              updateResponse.responseHeaderData?.manifestFilters
+            )
+          )
+        }
+      })
+    } catch (e: Exception) {
+      databaseHolder.releaseDatabase()
+      procedureContext.processStateEvent(
+        UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
+      )
+      return IUpdatesController.FetchUpdateResult.ErrorResult(e)
+    }
+
+    val processSuccessLoaderResultResult = RemoteLoader.processSuccessLoaderResult(
+      context,
+      updatesConfiguration,
+      database,
+      selectionPolicy,
+      updatesDirectory,
+      launchedUpdate,
+      loaderResult
+    )
+
+    databaseHolder.releaseDatabase()
+
+    if (processSuccessLoaderResultResult.didRollBackToEmbedded) {
+      procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
+      return IUpdatesController.FetchUpdateResult.RollBackToEmbedded()
+    } else {
+      return if (processSuccessLoaderResultResult.availableUpdate == null) {
+        procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+        IUpdatesController.FetchUpdateResult.Failure()
+      } else {
+        procedureContext.processStateEvent(
+          UpdatesStateEvent.DownloadCompleteWithUpdate(
+            processSuccessLoaderResultResult.availableUpdate.manifest
+          )
         )
+        IUpdatesController.FetchUpdateResult.Success(processSuccessLoaderResultResult.availableUpdate)
+      }
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -10,11 +10,12 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.errorrecovery.ErrorRecovery
 import expo.modules.updates.errorrecovery.ErrorRecoveryDelegate
-import expo.modules.updates.launcher.Launcher
+import expo.modules.updates.launcher.LauncherResult
 import expo.modules.updates.launcher.NoDatabaseLauncher
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.Loader
+import expo.modules.updates.loader.LoaderStatusCallbacks
 import expo.modules.updates.loader.LoaderTask
+import expo.modules.updates.loader.OnUpdateResponseLoadedResult
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
@@ -27,6 +28,8 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import org.json.JSONObject
 import java.io.File
 
+data class StartupProcedureResult(val launcherResult: LauncherResult, val shouldPerformAdditionalBackgroundLoad: Boolean)
+
 class StartupProcedure(
   private val context: Context,
   private val updatesConfiguration: UpdatesConfiguration,
@@ -36,10 +39,8 @@ class StartupProcedure(
   private val selectionPolicy: SelectionPolicy,
   private val logger: UpdatesLogger,
   private val callback: StartupProcedureCallback
-) : StateMachineProcedure() {
+) : StateMachineProcedure<StartupProcedureResult>() {
   interface StartupProcedureCallback {
-    fun onFinished()
-
     sealed class LegacyJSEvent(private val type: Type) {
       private enum class Type {
         ERROR,
@@ -53,27 +54,27 @@ class StartupProcedure(
     }
     fun onLegacyJSEvent(event: LegacyJSEvent)
 
-    fun onRequestRelaunch(shouldRunReaper: Boolean, callback: Launcher.LauncherCallback)
+    suspend fun onRequestRelaunch(shouldRunReaper: Boolean)
   }
 
   private lateinit var procedureContext: ProcedureContext
 
-  var launcher: Launcher? = null
+  var launcherResult: LauncherResult? = null
     private set
-  fun setLauncher(launcher: Launcher) {
-    this.launcher = launcher
+  fun setLauncherResult(launcherResult: LauncherResult) {
+    this.launcherResult = launcherResult
   }
 
   val launchAssetFile
-    get() = launcher?.launchAssetFile
+    get() = launcherResult?.launchAssetFile
   val bundleAssetName: String?
-    get() = launcher?.bundleAssetName
+    get() = launcherResult?.bundleAssetName
   val localAssetFiles: Map<AssetEntity, String>?
-    get() = launcher?.localAssetFiles
+    get() = launcherResult?.localAssetFiles
   val isUsingEmbeddedAssets: Boolean
-    get() = launcher?.isUsingEmbeddedAssets ?: false
+    get() = launcherResult?.isUsingEmbeddedAssets ?: false
   val launchedUpdate: UpdateEntity?
-    get() = launcher?.launchedUpdate
+    get() = launcherResult?.launchedUpdate
 
   var isEmergencyLaunch = false
     private set
@@ -91,149 +92,135 @@ class StartupProcedure(
   }
 
   private val loaderTask = LoaderTask(
+    context,
     updatesConfiguration,
     databaseHolder,
     updatesDirectory,
     fileDownloader,
     selectionPolicy,
-    object : LoaderTask.LoaderTaskCallback {
-      override fun onFailure(e: Exception) {
-        logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
-        launcher = NoDatabaseLauncher(context, e)
-        isEmergencyLaunch = true
-        notifyController()
-      }
-
-      override fun onSuccess(launcher: Launcher, isUpToDate: Boolean) {
-        if (remoteLoadStatus == ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING && isUpToDate) {
-          remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-        }
-        this@StartupProcedure.launcher = launcher
-        notifyController()
-      }
-
-      override fun onFinishedAllLoading() {
-        procedureContext.onComplete()
-      }
-
-      override fun onCachedUpdateLoaded(update: UpdateEntity): Boolean {
-        return true
-      }
-
-      override fun onRemoteCheckForUpdateStarted() {
-        procedureContext.processStateEvent(UpdatesStateEvent.Check())
-      }
-
-      override fun onRemoteCheckForUpdateFinished(result: LoaderTask.RemoteCheckResult) {
-        val event = when (result) {
-          is LoaderTask.RemoteCheckResult.NoUpdateAvailable -> UpdatesStateEvent.CheckCompleteUnavailable()
-          is LoaderTask.RemoteCheckResult.UpdateAvailable -> UpdatesStateEvent.CheckCompleteWithUpdate(result.manifest)
-          is LoaderTask.RemoteCheckResult.RollBackToEmbedded -> UpdatesStateEvent.CheckCompleteWithRollback(result.commitTime)
-        }
-        procedureContext.processStateEvent(event)
-      }
-
-      override fun onRemoteUpdateManifestResponseManifestLoaded(updateManifest: UpdateManifest) {
-        remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
-      }
-
-      override fun onRemoteUpdateLoadStarted() {
-        procedureContext.processStateEvent(UpdatesStateEvent.Download())
-      }
-
-      override fun onRemoteUpdateAssetLoaded(
-        asset: AssetEntity,
-        successfulAssetCount: Int,
-        failedAssetCount: Int,
-        totalAssetCount: Int
-      ) {
-        val body = mapOf(
-          "assetInfo" to mapOf(
-            "name" to asset.embeddedAssetFilename,
-            "successfulAssetCount" to successfulAssetCount,
-            "failedAssetCount" to failedAssetCount,
-            "totalAssetCount" to totalAssetCount
-          )
-        )
-        logger.info("AppController appLoaderTask didLoadAsset: $body", UpdatesErrorCode.None, null, asset.expectedHash)
-      }
-
-      override fun onRemoteUpdateFinished(
-        status: LoaderTask.RemoteUpdateStatus,
-        update: UpdateEntity?,
-        exception: Exception?
-      ) {
-        when (status) {
-          LoaderTask.RemoteUpdateStatus.ERROR -> {
-            if (exception == null) {
-              throw AssertionError("Background update with error status must have a nonnull exception object")
-            }
-            logger.error("UpdatesController onBackgroundUpdateFinished: Error: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
-            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.Error(exception))
-
-            // Since errors can happen through a number of paths, we do these checks
-            // to make sure the state machine is valid
-            when (procedureContext.getCurrentState()) {
-              UpdatesStateValue.Idle -> {
-                procedureContext.processStateEvent(UpdatesStateEvent.Download())
-                procedureContext.processStateEvent(
-                  UpdatesStateEvent.DownloadError(exception.message ?: "")
-                )
-              }
-              UpdatesStateValue.Checking -> {
-                procedureContext.processStateEvent(
-                  UpdatesStateEvent.CheckError(exception.message ?: "")
-                )
-              }
-              else -> {
-                // .downloading
-                procedureContext.processStateEvent(
-                  UpdatesStateEvent.DownloadError(exception.message ?: "")
-                )
-              }
-            }
-          }
-          LoaderTask.RemoteUpdateStatus.UPDATE_AVAILABLE -> {
-            if (update == null) {
-              throw AssertionError("Background update with error status must have a nonnull update object")
-            }
-            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
-            logger.info("UpdatesController onBackgroundUpdateFinished: Update available", UpdatesErrorCode.None)
-            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.UpdateAvailable(update.manifest))
-            procedureContext.processStateEvent(
-              UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
-            )
-          }
-          LoaderTask.RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {
-            remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-            logger.error("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
-            callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.NoUpdateAvailable())
-            // TODO: handle rollbacks properly, but this works for now
-            if (procedureContext.getCurrentState() == UpdatesStateValue.Downloading) {
-              procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
-            }
-          }
-        }
-        errorRecovery.notifyNewRemoteLoadStatus(remoteLoadStatus)
-      }
-    }
   )
 
-  override fun run(procedureContext: ProcedureContext) {
+  override suspend fun run(procedureContext: ProcedureContext): StartupProcedureResult {
     this.procedureContext = procedureContext
     initializeDatabaseHandler()
     initializeErrorRecovery()
-    loaderTask.start(context)
-  }
 
-  @Synchronized
-  private fun notifyController() {
-    if (launcher == null) {
-      throw AssertionError("UpdatesController.notifyController was called with a null launcher, which is an error. This method should only be called when an update is ready to launch.")
+    val loaderTaskResult = try {
+      loaderTask.load(object : LoaderTask.LoaderTaskCallbacks {
+        override fun onCachedUpdateLoaded(update: UpdateEntity): Boolean {
+          return true
+        }
+
+        override fun onRemoteUpdateManifestResponseManifestLoaded(updateManifest: UpdateManifest) {
+          remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
+        }
+
+        override fun onRemoteCheckForUpdateStarted() {
+          procedureContext.processStateEvent(UpdatesStateEvent.Check())
+        }
+
+        override fun onRemoteCheckForUpdateFinished(result: LoaderTask.RemoteCheckResult) {
+          val event = when (result) {
+            is LoaderTask.RemoteCheckResult.NoUpdateAvailable -> UpdatesStateEvent.CheckCompleteUnavailable()
+            is LoaderTask.RemoteCheckResult.UpdateAvailable -> UpdatesStateEvent.CheckCompleteWithUpdate(result.manifest)
+            is LoaderTask.RemoteCheckResult.RollBackToEmbedded -> UpdatesStateEvent.CheckCompleteWithRollback(result.commitTime)
+          }
+          procedureContext.processStateEvent(event)
+        }
+
+        override fun onRemoteUpdateLoadStarted() {
+          procedureContext.processStateEvent(UpdatesStateEvent.Download())
+        }
+
+        override fun onRemoteUpdateAssetLoaded(
+          asset: AssetEntity,
+          successfulAssetCount: Int,
+          failedAssetCount: Int,
+          totalAssetCount: Int
+        ) {
+          val body = mapOf(
+            "assetInfo" to mapOf(
+              "name" to asset.embeddedAssetFilename,
+              "successfulAssetCount" to successfulAssetCount,
+              "failedAssetCount" to failedAssetCount,
+              "totalAssetCount" to totalAssetCount
+            )
+          )
+          logger.info("AppController appLoaderTask didLoadAsset: $body", UpdatesErrorCode.None, null, asset.expectedHash)
+        }
+
+        override fun onRemoteUpdateFinished(
+          status: LoaderTask.RemoteUpdateStatus,
+          update: UpdateEntity?,
+          exception: Exception?
+        ) {
+          when (status) {
+            LoaderTask.RemoteUpdateStatus.ERROR -> {
+              if (exception == null) {
+                throw AssertionError("Background update with error status must have a nonnull exception object")
+              }
+              logger.error("UpdatesController onBackgroundUpdateFinished: Error: ${exception.localizedMessage}", UpdatesErrorCode.Unknown, exception)
+              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+              callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.Error(exception))
+
+              // Since errors can happen through a number of paths, we do these checks
+              // to make sure the state machine is valid
+              when (procedureContext.getCurrentState()) {
+                UpdatesStateValue.Idle -> {
+                  procedureContext.processStateEvent(UpdatesStateEvent.Download())
+                  procedureContext.processStateEvent(
+                    UpdatesStateEvent.DownloadError(exception.message ?: "")
+                  )
+                }
+                UpdatesStateValue.Checking -> {
+                  procedureContext.processStateEvent(
+                    UpdatesStateEvent.CheckError(exception.message ?: "")
+                  )
+                }
+                else -> {
+                  // .downloading
+                  procedureContext.processStateEvent(
+                    UpdatesStateEvent.DownloadError(exception.message ?: "")
+                  )
+                }
+              }
+            }
+            LoaderTask.RemoteUpdateStatus.UPDATE_AVAILABLE -> {
+              if (update == null) {
+                throw AssertionError("Background update with error status must have a nonnull update object")
+              }
+              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
+              logger.info("UpdatesController onBackgroundUpdateFinished: Update available", UpdatesErrorCode.None)
+              callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.UpdateAvailable(update.manifest))
+              procedureContext.processStateEvent(
+                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
+              )
+            }
+            LoaderTask.RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {
+              remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+              logger.error("UpdatesController onBackgroundUpdateFinished: No update available", UpdatesErrorCode.NoUpdatesAvailable)
+              callback.onLegacyJSEvent(StartupProcedureCallback.LegacyJSEvent.NoUpdateAvailable())
+              // TODO: handle rollbacks properly, but this works for now
+              if (procedureContext.getCurrentState() == UpdatesStateValue.Downloading) {
+                procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+              }
+            }
+          }
+          errorRecovery.notifyNewRemoteLoadStatus(remoteLoadStatus)
+        }
+      })
+    } catch (e: Exception) {
+      logger.error("UpdatesController loaderTask onFailure: ${e.localizedMessage}", UpdatesErrorCode.None)
+      launcherResult = NoDatabaseLauncher(context, e).launch()
+      isEmergencyLaunch = true
+      return StartupProcedureResult(launcherResult!!, shouldPerformAdditionalBackgroundLoad = false)
     }
 
-    callback.onFinished()
+    if (remoteLoadStatus == ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING && loaderTaskResult.isUpToDate) {
+      remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+    }
+    launcherResult = loaderTaskResult.launcherResult
+    return StartupProcedureResult(launcherResult!!, shouldPerformAdditionalBackgroundLoad = loaderTaskResult.shouldPerformAdditionalBackgroundLoad)
   }
 
   fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
@@ -250,47 +237,51 @@ class StartupProcedure(
 
   private fun initializeErrorRecovery() {
     errorRecovery.initialize(object : ErrorRecoveryDelegate {
-      override fun loadRemoteUpdate() {
-        if (loaderTask.isRunning) {
+      override suspend fun loadRemoteUpdate() {
+        if (launcherResult === null) {
           return
         }
         remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
         val remoteLoader = RemoteLoader(context, updatesConfiguration, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
-        remoteLoader.start(object : Loader.LoaderCallback {
-          override fun onFailure(e: Exception) {
-            logger.error("UpdatesController loadRemoteUpdate onFailure: ${e.localizedMessage}", UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
-            setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
-            databaseHolder.releaseDatabase()
-          }
+        val loaderResult = try {
+          remoteLoader.load(object : LoaderStatusCallbacks {
+            override fun onAssetLoaded(
+              asset: AssetEntity,
+              successfulAssetCount: Int,
+              failedAssetCount: Int,
+              totalAssetCount: Int
+            ) {}
 
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
-            setRemoteLoadStatus(
-              if (loaderResult.updateEntity != null || loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
-              else ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
-            )
-            databaseHolder.releaseDatabase()
-          }
+            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult {
+              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+              if (updateDirective != null) {
+                return OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+                  }
+                )
+              }
 
-          override fun onAssetLoaded(asset: AssetEntity, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) { }
-
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            if (updateDirective != null) {
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                }
-              )
+              val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+              return OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(updateManifest.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
             }
+          })
+        } catch (e: Exception) {
+          logger.error("UpdatesController loadRemoteUpdate onFailure: ${e.localizedMessage}", UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
+          setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
+          databaseHolder.releaseDatabase()
+          return
+        }
 
-            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(updateManifest.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
-          }
-        })
+        setRemoteLoadStatus(
+          if (loaderResult.updateEntity != null || loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
+          else ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
+        )
+        databaseHolder.releaseDatabase()
       }
 
-      override fun relaunch(callback: Launcher.LauncherCallback) { this@StartupProcedure.callback.onRequestRelaunch(shouldRunReaper = false, callback) }
+      override suspend fun relaunch() { this@StartupProcedure.callback.onRequestRelaunch(shouldRunReaper = false) }
       override fun throwException(exception: Exception) { throw exception }
 
       override fun markFailedLaunchForLaunchedUpdate() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineProcedure.kt
@@ -8,7 +8,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
  * State machine state may only be mutated in subclasses of this class to ensure serial
  * (well-defined) ordering of state transitions.
  */
-abstract class StateMachineProcedure {
+abstract class StateMachineProcedure<T> {
   interface StateMachineProcedureContext {
     /**
      * Transition the state machine forward to a new state.
@@ -28,12 +28,7 @@ abstract class StateMachineProcedure {
   }
 
   interface ProcedureContext : StateMachineProcedureContext {
-    /**
-     * Must be called when the StateMachineProcedure is done updating the state machine. Usually
-     * at the end of work in the run method.
-     */
-    fun onComplete()
   }
 
-  abstract fun run(procedureContext: ProcedureContext)
+  abstract suspend fun run(procedureContext: ProcedureContext): T
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.procedures.StateMachineProcedure
 import expo.modules.updates.procedures.StateMachineSerialExecutorQueue
+import kotlinx.coroutines.CoroutineScope
 import java.util.Date
 
 /**
@@ -31,8 +32,8 @@ class UpdatesStateMachine(
   /**
    * Queue a StateMachineProcedure procedure for serial execution.
    */
-  fun queueExecution(stateMachineProcedure: StateMachineProcedure) {
-    serialExecutorQueue.queueExecution(stateMachineProcedure)
+  suspend fun <T>queueExecution(stateMachineProcedure: StateMachineProcedure<T>): T {
+    return serialExecutorQueue.queueExecution(stateMachineProcedure)
   }
 
   private val logger = UpdatesLogger(androidContext)


### PR DESCRIPTION
# Why

This is a first attempt at converting file downloading in expo-update to coroutines, and propagating the coroutine suspend chain outwards, almost all the way to the package.

# How

Lots of stuff. Will detail more soon.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
