### PR TITLE
[ci] fix client build be skipped from push events

### DIFF
--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Why

client-ios-eas and client-android-eas does not trigger on main

# How

should not skip the workflow from push event

# Test Plan

- try if the workflow runs from manual dispatch (https://github.com/expo/expo/actions/runs/7009650377/job/19068559214)
- check whether the workflow is triggered after merge