### PR TITLE
[splash-screen][android] Remove 'The current activity is no longer available' warning

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Removed 'The current activity is no longer available' warning on Android. ([#25608](https://github.com/expo/expo/pull/25608) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.25.0 — 2023-11-14
 
 ### 🛠 Breaking changes

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.splashscreen
 
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.splashscreen.exceptions.HideAsyncException
@@ -24,7 +23,7 @@ class SplashScreenModule : Module() {
           { hasEffect -> promise.resolve(hasEffect) },
           { m -> promise.reject(PreventAutoHideException(m)) }
         )
-      }?: run {
+      } ?: run {
         promise.resolve(false)
       }
     }
@@ -36,7 +35,7 @@ class SplashScreenModule : Module() {
           { hasEffect -> promise.resolve(hasEffect) },
           { m -> promise.reject(HideAsyncException(m)) }
         )
-      }?: run {
+      } ?: run {
         promise.resolve(false)
       }
     }

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -18,25 +18,27 @@ class SplashScreenModule : Module() {
     Name("ExpoSplashScreen")
 
     AsyncFunction("preventAutoHideAsync") { promise: Promise ->
-      val currentActivity =
-        appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
-      SplashScreen.preventAutoHide(
-        currentActivity,
-        { hasEffect -> promise.resolve(hasEffect) },
-        { m -> promise.reject(PreventAutoHideException(m)) }
-      )
+      appContext.currentActivity?.let {
+        SplashScreen.preventAutoHide(
+          it,
+          { hasEffect -> promise.resolve(hasEffect) },
+          { m -> promise.reject(PreventAutoHideException(m)) }
+        )
+      }?: run {
+        promise.resolve(false)
+      }
     }
 
     AsyncFunction("hideAsync") { promise: Promise ->
-      val currentActivity =
-        appContext.currentActivity ?: throw Exceptions.MissingActivity()
-
-      SplashScreen.hide(
-        currentActivity,
-        { hasEffect -> promise.resolve(hasEffect) },
-        { m -> promise.reject(HideAsyncException(m)) }
-      )
+      appContext.currentActivity?.let {
+        SplashScreen.hide(
+          it,
+          { hasEffect -> promise.resolve(hasEffect) },
+          { m -> promise.reject(HideAsyncException(m)) }
+        )
+      }?: run {
+        promise.resolve(false)
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Closes ENG-10433

Historically these warnings have raised many questions/reports from the community. The warning itself is not very useful and people constantly ask about it, because of that we should just get rid of it as we did in https://github.com/expo/expo/pull/24210

# How

Update `preventAutoHideAsync` and `hideAsync` on android to, instead of throwing a MissingActivity error on android just resolve the promise return false 

# Test Plan

Test through bare-expo on Android  

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
