### PR TITLE
[docs] update infra docs after Node 18 as default update

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -69,11 +69,13 @@ Android builders run on virtual machines in an isolated environment. Every build
 - Docker image: `ubuntu:jammy-20220531`
 - NDK 21.4.7075529
 - Node.js 18.18.0
-- Bun 1.0.2
-- Yarn 1.22.17
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 8.9.2
-- npm 8.19.2
+- npm 9.8.1
 - Java 17
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -83,12 +85,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:jammy-20220531`
 - NDK 21.4.7075529
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 8.7.5
-- npm 8.19.2
+- npm 9.8.1
 - Java 11
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -98,12 +102,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:jammy-20220531`
 - NDK 21.4.7075529
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - Java 8
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -113,12 +119,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:focal-20210921`
 - NDK 21.4.7075529
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - Java 11
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -128,12 +136,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:focal-20210921`
 - NDK 21.4.7075529
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - Java 8
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -143,12 +153,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:bionic-20210930`
 - NDK 19.2.5345600
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - Java 11
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -158,12 +170,14 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Docker image: `ubuntu:bionic-20210930`
 - NDK 19.2.5345600
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - Java 8
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -206,13 +220,15 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - macOS Ventura 13.6
 - Xcode 15.0 (15A240d)
 - Node.js 18.18.0
-- Bun 1.0.2
-- Yarn 1.22.17
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 8.7.6
-- npm 8.1.2
+- npm 9.8.1
 - fastlane 2.216.0
 - CocoaPods 1.13.0
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -222,14 +238,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Ventura 13.4
 - Xcode 14.3.1 (14E300c)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 8.6.5
-- npm 8.1.2
+- npm 9.8.1
 - fastlane 2.213.0
 - CocoaPods 1.12.1
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -239,14 +257,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Ventura 13.3
 - Xcode 14.3 (14E222b)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 8.2.0
-- npm 8.1.2
+- npm 9.8.1
 - fastlane 2.212.2
 - CocoaPods 1.12.0
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -256,14 +276,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.6
 - Xcode 14.2 (14C18)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.27.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.211.0
 - CocoaPods 1.11.3
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -273,14 +295,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.6
 - Xcode 14.1 (14B47b)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.15.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.210.1
 - CocoaPods 1.11.3
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -290,14 +314,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.6
 - Xcode 14.0 (14A309)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.11.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.210.0
 - CocoaPods 1.11.3
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -307,14 +333,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.4
 - Xcode 13.4 (13F17a)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -324,14 +352,16 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.3.1
 - Xcode 13.3.1 (13E500a)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>
 
@@ -341,13 +371,15 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 - macOS Monterey 12.1
 - Xcode 13.2.1 (13C100)
-- Node.js 16.18.1
-- Bun 1.0.2
-- Yarn 1.22.17
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
 - pnpm 7.0.0
-- npm 8.19.2
+- npm 9.8.1
 - fastlane 2.201.0
 - CocoaPods 1.11.2
 - Ruby 2.7
+- Python 3.12.0
+- node-gyp 10.0.1
 
 </Collapsible>

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -8,7 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **November 8, 2023**.
+> This document was last updated on **November 28, 2023**.
 
 ## Builder IP addresses
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -147,11 +147,11 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-18.04-jdk-11-ndk-r19c`
+#### `ubuntu-20.04-jdk-11-ndk-r19c`
 
 <Collapsible summary="Details">
 
-- Docker image: `ubuntu:bionic-20210930`
+- Docker image: `ubuntu:focal-20210921`
 - NDK 19.2.5345600
 - Node.js 18.18.0
 - Bun 1.0.14
@@ -164,11 +164,11 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-18.04-jdk-8-ndk-r19c`
+#### `ubuntu-20.04-jdk-8-ndk-r19c`
 
 <Collapsible summary="Details">
 
-- Docker image: `ubuntu:bionic-20210930`
+- Docker image: `ubuntu:focal-20210921`
 - NDK 19.2.5345600
 - Node.js 18.18.0
 - Bun 1.0.14


### PR DESCRIPTION
# Why

update infra docs after Node 18 as default update

# How

update infra docs after Node 18 as default update

# Deployment

Merge after node 18 as default is on prod

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
