### PR TITLE
[expo-updates][e2e] Add reloadAsync e2e test

### DIFF
--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -41,6 +41,8 @@ export default function App() {
   const [extraParamsString, setExtraParamsString] = React.useState('');
   const [nativeStateContextString, setNativeStateContextString] = React.useState('{}');
   const [isRollback, setIsRollback] = React.useState(false);
+  const [isReloading, setIsReloading] = React.useState(false);
+  const [startTime, setStartTime] = React.useState<number | null>(null);
   const [didCheckAndDownloadHappenInParallel, setDidCheckAndDownloadHappenInParallel] =
     React.useState(false);
 
@@ -54,6 +56,10 @@ export default function App() {
     isChecking,
     isDownloading,
   } = Updates.useUpdates();
+
+  React.useEffect(() => {
+    setStartTime(Date.now());
+  }, []);
 
   Updates.useUpdateEvents((event) => {
     setLastUpdateEventType(event.type);
@@ -120,6 +126,16 @@ export default function App() {
     await Updates.clearLogEntriesAsync();
   });
 
+  const handleReload = async () => {
+    setIsReloading(true);
+    try {
+      await Updates.reloadAsync();
+      setIsReloading(false);
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
   const handleCheckForUpdate = runBlockAsync(async () => {
     await Updates.checkForUpdateAsync();
   });
@@ -167,6 +183,8 @@ export default function App() {
       <TestValue testID="isEmbeddedLaunch" value={`${currentlyRunning.isEmbeddedLaunch}`} />
       <TestValue testID="availableUpdateID" value={`${availableUpdate?.updateId}`} />
       <TestValue testID="extraParamsString" value={`${extraParamsString}`} />
+      <TestValue testID="isReloading" value={`${isReloading}`} />
+      <TestValue testID="startTime" value={`${startTime}`} />
 
       <TestValue testID="state.isUpdateAvailable" value={`${isUpdateAvailable}`} />
       <TestValue testID="state.isUpdatePending" value={`${isUpdatePending}`} />
@@ -230,6 +248,7 @@ export default function App() {
             testID="triggerParallelFetchAndDownload"
             onPress={handleCheckAndDownloadAtSameTime}
           />
+          <TestButton testID="reload" onPress={handleReload} />
         </View>
       </View>
 

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -101,6 +101,30 @@ describe('Basic tests', () => {
     await device.terminateApp();
   });
 
+  it('reloads', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    Server.start(Update.serverPort, protocolVersion);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+
+    const isReloadingBefore = await testElementValueAsync('isReloading');
+    jestExpect(isReloadingBefore).toBe('false');
+    const startTimeBefore = parseInt(await testElementValueAsync('startTime'), 10);
+    jestExpect(startTimeBefore).toBeGreaterThan(0);
+
+    await pressTestButtonAsync('reload');
+
+    const isReloadingAfter = await testElementValueAsync('isReloading');
+    jestExpect(isReloadingAfter).toBe('false');
+    const startTimeAfter = parseInt(await testElementValueAsync('startTime'), 10);
+    jestExpect(startTimeAfter).toBeGreaterThan(startTimeBefore);
+
+    await device.terminateApp();
+  });
+
   it('initial request includes correct update-id headers', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(Update.serverPort);


### PR DESCRIPTION
# Why

This adds a test that calls `reloadAsync`. Note that this behavior differs between debug and release (the way react native is written), so to fully test this we'd need to have even more e2e tests: one for debug and one for release.

# How

Note that this is currently broken on android I believe. Works on iOS.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
