### PR TITLE
[go] update react-native-reanimated to 3.6.0

### DIFF
--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
@@ -1,11 +1,8 @@
 #pragma once
 
+#include "JSLogger.h"
 #include "LayoutAnimationType.h"
 #include "Shareables.h"
-
-#ifndef NDEBUG
-#include "JSLogger.h"
-#endif
 
 #include <jsi/jsi.h>
 #include <stdio.h>
@@ -23,10 +20,8 @@ using namespace facebook;
 
 class LayoutAnimationsManager {
  public:
-#ifndef NDEBUG
   explicit LayoutAnimationsManager(const std::shared_ptr<JSLogger> &jsLogger)
       : jsLogger_(jsLogger) {}
-#endif
   void configureAnimation(
       int tag,
       LayoutAnimationType type,
@@ -54,8 +49,8 @@ class LayoutAnimationsManager {
   std::unordered_map<int, std::shared_ptr<Shareable>> &getConfigsForType(
       LayoutAnimationType type);
 
-#ifndef NDEBUG
   std::shared_ptr<JSLogger> jsLogger_;
+#ifndef NDEBUG
   // This set's function is to detect duplicate sharedTags on a single screen
   // it contains strings in form: "reactScreenTag:sharedTag"
   std::unordered_set<std::string> screenSharedTagSet_;

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -66,6 +66,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       jsi::Runtime &rt,
       const jsi::Value &name,
       const jsi::Value &initializer) override;
+  jsi::Value scheduleOnRuntime(
+      jsi::Runtime &rt,
+      const jsi::Value &workletRuntimeValue,
+      const jsi::Value &shareableWorkletValue) override;
 
   jsi::Value registerEventHandler(
       jsi::Runtime &rt,
@@ -112,6 +116,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       const int emitterReactTag,
       const jsi::Value &payload,
       double currentTime);
+
+  inline std::shared_ptr<JSLogger> getJSLogger() const {
+    return jsLogger_;
+  }
 
 #ifdef RCT_NEW_ARCH_ENABLED
   bool handleRawEvent(const RawEvent &rawEvent, double currentTime);
@@ -164,6 +172,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
 #ifdef RCT_NEW_ARCH_ENABLED
   bool isThereAnyLayoutProp(jsi::Runtime &rt, const jsi::Object &props);
+  jsi::Value filterNonAnimatableProps(
+      jsi::Runtime &rt,
+      const jsi::Value &props);
 #endif // RCT_NEW_ARCH_ENABLED
 
   const std::shared_ptr<MessageQueueThread> jsQueue_;
@@ -178,13 +189,15 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
   volatile bool renderRequested_{false};
   const std::function<void(const double)> onRenderCallback_;
   AnimatedSensorModule animatedSensorModule_;
+  const std::shared_ptr<JSLogger> jsLogger_;
   LayoutAnimationsManager layoutAnimationsManager_;
 
 #ifdef RCT_NEW_ARCH_ENABLED
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
 
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
-
+  std::unordered_set<std::string>
+      animatablePropNames_; // filled by configureProps
   std::shared_ptr<UIManager> uiManager_;
 
   // After app reload, surfaceId on iOS is still 1 but on Android it's 11.

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -68,6 +68,15 @@ static jsi::Value SPEC_PREFIX(createWorkletRuntime)(
       ->createWorkletRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
+static jsi::Value SPEC_PREFIX(scheduleOnRuntime)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->scheduleOnRuntime(rt, std::move(args[0]), std::move(args[1]));
+}
+
 static jsi::Value SPEC_PREFIX(registerEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -203,6 +212,8 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
   methodMap_["scheduleOnUI"] = MethodMetadata{1, SPEC_PREFIX(scheduleOnUI)};
   methodMap_["createWorkletRuntime"] =
       MethodMetadata{2, SPEC_PREFIX(createWorkletRuntime)};
+  methodMap_["scheduleOnRuntime"] =
+      MethodMetadata{2, SPEC_PREFIX(scheduleOnRuntime)};
 
   methodMap_["registerEventHandler"] =
       MethodMetadata{3, SPEC_PREFIX(registerEventHandler)};

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
@@ -48,6 +48,10 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &name,
       const jsi::Value &initializer) = 0;
+  virtual jsi::Value scheduleOnRuntime(
+      jsi::Runtime &rt,
+      const jsi::Value &workletRuntimeValue,
+      const jsi::Value &shareableWorkletValue) = 0;
 
   // events
   virtual jsi::Value registerEventHandler(

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/RNRuntimeDecorator.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/RNRuntimeDecorator.cpp
@@ -1,7 +1,5 @@
 #include "RNRuntimeDecorator.h"
-#ifndef NDEBUG
 #include "ReanimatedVersion.h"
-#endif // NDEBUG
 
 namespace reanimated {
 
@@ -32,7 +30,7 @@ void RNRuntimeDecorator::decorate(
   rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", isFabric);
 
 #ifndef NDEBUG
-  checkJSVersion(rnRuntime);
+  checkJSVersion(rnRuntime, nativeReanimatedModule->getJSLogger());
 #endif // NDEBUG
 
   rnRuntime.global().setProperty(

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.cpp
@@ -22,11 +22,13 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
+#if HERMES_ENABLE_DEBUGGER
 #if REACT_NATIVE_MINOR_VERSION >= 73
 using namespace facebook::hermes::inspector_modern;
 #else
 using namespace facebook::hermes::inspector;
 #endif
+#endif // HERMES_ENABLE_DEBUGGER
 
 #if HERMES_ENABLE_DEBUGGER
 

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
@@ -38,11 +38,13 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
+#if HERMES_ENABLE_DEBUGGER
 #if REACT_NATIVE_MINOR_VERSION >= 73
 using namespace facebook::hermes::inspector_modern;
 #else
 using namespace facebook::hermes::inspector;
 #endif
+#endif // HERMES_ENABLE_DEBUGGER
 
 // ReentrancyCheck is copied from React Native
 // from ReactCommon/hermes/executor/HermesExecutorFactory.cpp

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
@@ -62,4 +62,16 @@ std::shared_ptr<WorkletRuntime> extractWorkletRuntime(
   return value.getObject(rt).getHostObject<WorkletRuntime>(rt);
 }
 
+void scheduleOnRuntime(
+    jsi::Runtime &rt,
+    const jsi::Value &workletRuntimeValue,
+    const jsi::Value &shareableWorkletValue) {
+  auto workletRuntime = extractWorkletRuntime(rt, workletRuntimeValue);
+  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+      rt,
+      shareableWorkletValue,
+      "[Reanimated] Function passed to `_scheduleOnRuntime` is not a shareable worklet. Please make sure that `processNestedWorklets` option in Reanimated Babel plugin is enabled.");
+  workletRuntime->runAsyncGuarded(shareableWorklet);
+}
+
 } // namespace reanimated

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
@@ -3,6 +3,7 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <jsi/jsi.h>
 
+#include "AsyncQueue.h"
 #include "JSScheduler.h"
 #include "Shareables.h"
 
@@ -17,7 +18,8 @@ using namespace react;
 
 namespace reanimated {
 
-class WorkletRuntime : public jsi::HostObject {
+class WorkletRuntime : public jsi::HostObject,
+                       public std::enable_shared_from_this<WorkletRuntime> {
  public:
   explicit WorkletRuntime(
       jsi::Runtime &rnRuntime,
@@ -40,8 +42,17 @@ class WorkletRuntime : public jsi::HostObject {
         rt, shareableWorklet->getJSValue(rt), std::forward<Args>(args)...);
   }
 
+  void runAsyncGuarded(
+      const std::shared_ptr<ShareableWorklet> &shareableWorklet) {
+    if (queue_ == nullptr) {
+      queue_ = std::make_shared<AsyncQueue>(name_);
+    }
+    queue_->push(
+        [=, self = shared_from_this()] { self->runGuarded(shareableWorklet); });
+  }
+
   std::string toString() const {
-    return "<WorkletRuntime \"" + name_ + "\">";
+    return "[WorkletRuntime \"" + name_ + "\"]";
   }
 
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propName) override;
@@ -51,6 +62,7 @@ class WorkletRuntime : public jsi::HostObject {
  private:
   const std::shared_ptr<jsi::Runtime> runtime_;
   const std::string name_;
+  std::shared_ptr<AsyncQueue> queue_;
 };
 
 // This function needs to be non-inline to avoid problems with dynamic_cast on
@@ -58,5 +70,10 @@ class WorkletRuntime : public jsi::HostObject {
 std::shared_ptr<WorkletRuntime> extractWorkletRuntime(
     jsi::Runtime &rt,
     const jsi::Value &value);
+
+void scheduleOnRuntime(
+    jsi::Runtime &rt,
+    const jsi::Value &workletRuntimeValue,
+    const jsi::Value &shareableWorkletValue);
 
 } // namespace reanimated

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
@@ -2,6 +2,7 @@
 #include "JSISerializer.h"
 #include "ReanimatedJSIUtils.h"
 #include "Shareables.h"
+#include "WorkletRuntime.h"
 
 #ifdef ANDROID
 #include "Logger.h"
@@ -117,12 +118,29 @@ void WorkletRuntimeDecorator::decorate(
 
   jsi_utils::installJsiFunction(
       rt,
+      "_scheduleOnRuntime",
+      [](jsi::Runtime &rt,
+         const jsi::Value &workletRuntimeValue,
+         const jsi::Value &shareableWorkletValue) {
+        reanimated::scheduleOnRuntime(
+            rt, workletRuntimeValue, shareableWorkletValue);
+      });
+
+  jsi_utils::installJsiFunction(
+      rt,
       "_updateDataSynchronously",
       [](jsi::Runtime &rt,
          const jsi::Value &synchronizedDataHolderRef,
          const jsi::Value &newData) {
         return reanimated::updateDataSynchronously(
             rt, synchronizedDataHolderRef, newData);
+      });
+
+  jsi_utils::installJsiFunction(
+      rt,
+      "_getDataSynchronously",
+      [](jsi::Runtime &rt, const jsi::Value &synchronizedDataHolderRef) {
+        return reanimated::getDataSynchronously(rt, synchronizedDataHolderRef);
       });
 
   jsi::Object performance(rt);

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.cpp
@@ -119,6 +119,14 @@ void updateDataSynchronously(
   dataHolder->set(rt, newData);
 }
 
+jsi::Value getDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef) {
+  auto dataHolder = extractShareableOrThrow<ShareableSynchronizedDataHolder>(
+      rt, synchronizedDataHolderRef);
+  return dataHolder->get(rt);
+}
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.h
@@ -153,6 +153,10 @@ void updateDataSynchronously(
     const jsi::Value &synchronizedDataHolderRef,
     const jsi::Value &newData);
 
+jsi::Value getDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef);
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.cpp
@@ -1,0 +1,52 @@
+#include "AsyncQueue.h"
+
+#include <utility>
+
+namespace reanimated {
+
+AsyncQueue::AsyncQueue(std::string name)
+    : state_(std::make_shared<AsyncQueueState>()) {
+  auto thread = std::thread([name, state = state_] {
+#if __APPLE__
+    pthread_setname_np(name.c_str());
+#endif
+    while (state->running) {
+      std::unique_lock<std::mutex> lock(state->mutex);
+      state->cv.wait(
+          lock, [state] { return !state->queue.empty() || !state->running; });
+      if (!state->running) {
+        return;
+      }
+      if (state->queue.empty()) {
+        continue;
+      }
+      auto job = std::move(state->queue.front());
+      state->queue.pop();
+      lock.unlock();
+      job();
+    }
+  });
+#ifdef ANDROID
+  pthread_setname_np(thread.native_handle(), name.c_str());
+#endif
+  thread.detach();
+}
+
+AsyncQueue::~AsyncQueue() {
+  {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->running = false;
+    state_->queue = {};
+  }
+  state_->cv.notify_all();
+}
+
+void AsyncQueue::push(std::function<void()> &&job) {
+  {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->queue.emplace(job);
+  }
+  state_->cv.notify_one();
+}
+
+} // namespace reanimated

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <queue>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace reanimated {
+
+struct AsyncQueueState {
+  std::atomic_bool running{true};
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::queue<std::function<void()>> queue;
+};
+
+class AsyncQueue {
+ public:
+  explicit AsyncQueue(std::string name);
+
+  ~AsyncQueue();
+
+  void push(std::function<void()> &&job);
+
+ private:
+  const std::shared_ptr<AsyncQueueState> state_;
+};
+
+} // namespace reanimated

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.cpp
@@ -1,18 +1,16 @@
-#ifndef NDEBUG
-
 #include "JSLogger.h"
 #include <memory>
 
 namespace reanimated {
 
 void JSLogger::warnOnJS(const std::string &warning) const {
+#ifndef NDEBUG
   jsScheduler_->scheduleOnJS([warning](jsi::Runtime &rt) {
     auto console = rt.global().getPropertyAsObject(rt, "console");
     auto warn = console.getPropertyAsFunction(rt, "warn");
     warn.call(rt, jsi::String::createFromUtf8(rt, warning));
   });
+#endif // NDEBUG
 }
 
 } // namespace reanimated
-
-#endif // NDEBUG

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.h
@@ -1,5 +1,3 @@
-#ifndef NDEBUG
-
 #pragma once
 
 #include "JSScheduler.h"
@@ -20,5 +18,3 @@ class JSLogger {
 };
 
 } // namespace reanimated
-
-#endif // NDEBUG

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.cpp
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.cpp
@@ -1,6 +1,8 @@
 #include "ReanimatedVersion.h"
+#include <memory>
 #include <regex>
 #include <string>
+#include "JSLogger.h"
 
 #ifdef REANIMATED_VERSION
 #define STRINGIZE(x) #x
@@ -41,26 +43,30 @@ bool matchVersion(const std::string &version1, const std::string &version2) {
   }
 }
 
-void checkJSVersion(jsi::Runtime &rnRuntime) {
+void checkJSVersion(
+    jsi::Runtime &rnRuntime,
+    const std::shared_ptr<JSLogger> &jsLogger) {
   auto cppVersion = getReanimatedCppVersion();
 
   auto maybeJSVersion =
       rnRuntime.global().getProperty(rnRuntime, "_REANIMATED_VERSION_JS");
   if (maybeJSVersion.isUndefined()) {
-    throw std::runtime_error(
+    jsLogger->warnOnJS(
         std::string(
             "[Reanimated] C++ side failed to resolve JavaScript code version\n") +
         "See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#c-side-failed-to-resolve-javascript-code-version` for more details.");
+    return;
   }
 
   auto jsVersion = maybeJSVersion.asString(rnRuntime).utf8(rnRuntime);
 
   if (!matchVersion(cppVersion, jsVersion)) {
-    throw std::runtime_error(
+    jsLogger->warnOnJS(
         std::string(
             "[Reanimated] Mismatch between C++ code version and JavaScript code version (") +
         cppVersion + " vs. " + jsVersion + " respectively).\n" +
         "See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#mismatch-between-c-code-version-and-javascript-code-version` for more details.");
+    return;
   }
 
   rnRuntime.global().setProperty(

--- a/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.h
+++ b/android/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <memory>
 #include <string>
+#include "JSLogger.h"
 
 using namespace facebook;
 
@@ -9,9 +11,7 @@ namespace reanimated {
 
 std::string getReanimatedCppVersion();
 
-#ifndef NDEBUG
 bool matchVersion(const std::string &, const std::string &);
-void checkJSVersion(jsi::Runtime &);
-#endif // NDEBUG
+void checkJSVersion(jsi::Runtime &, const std::shared_ptr<JSLogger> &);
 
 }; // namespace reanimated

--- a/android/vendored/unversioned/react-native-reanimated/android/build.gradle
+++ b/android/vendored/unversioned/react-native-reanimated/android/build.gradle
@@ -85,7 +85,7 @@ def resolveReactNativeDirectory() {
     if (reactNativeFromProjectNodeModules.exists()) {
         return reactNativeFromProjectNodeModules
     }
-
+    
     def reactNativeFromNodeModulesWithReanimated = file("${projectDir}/../../react-native")
     if (reactNativeFromNodeModulesWithReanimated.exists()) {
         return reactNativeFromNodeModulesWithReanimated
@@ -137,7 +137,7 @@ file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { rea
 
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
-def REANIMATED_VERSION = "3.6.0-nightly-20231031-c56d44fd9"
+def REANIMATED_VERSION = "3.6.0"
 def REANIMATED_MAJOR_VERSION = 3
 def IS_NEW_ARCHITECTURE_ENABLED = isNewArchitectureEnabled()
 
@@ -282,7 +282,7 @@ android {
         buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
         buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
         buildConfigField("int", "REACT_NATIVE_MINOR_VERSION", REACT_NATIVE_MINOR_VERSION.toString())
-
+        
         consumerProguardFiles 'proguard-rules.pro'
     }
     externalNativeBuild {
@@ -373,11 +373,20 @@ android {
                 }
             }
 
-            // ReanimatedUIManager & ReanimatedUIImplementation
+            // ReanimatedUIManager & ReanimatedUIImplementation 
             if (REACT_NATIVE_MINOR_VERSION <= 70) {
                 srcDirs += "src/reactNativeVersionPatch/ReanimatedUIManager/70"
             } else {
                 srcDirs += "src/reactNativeVersionPatch/ReanimatedUIManager/latest"
+            }
+
+            // ReactFeatureFlags 
+            if (IS_NEW_ARCHITECTURE_ENABLED) {
+                if (REACT_NATIVE_MINOR_VERSION <= 72) {
+                    srcDirs += "src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/72"
+                } else {
+                    srcDirs += "src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/latest"
+                }
             }
         }
     }

--- a/android/vendored/unversioned/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
+++ b/android/vendored/unversioned/react-native-reanimated/android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java
@@ -1,7 +1,5 @@
 package com.swmansion.reanimated;
 
-import android.util.Log;
-
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -10,12 +8,10 @@ import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
-import com.swmansion.reanimated.layoutReanimation.AnimationsManager;
 import com.swmansion.reanimated.layoutReanimation.LayoutAnimations;
 import com.swmansion.reanimated.layoutReanimation.NativeMethodsHolder;
 import com.swmansion.reanimated.nativeProxy.NativeProxyCommon;
 
-import java.lang.ref.WeakReference;
 import java.util.HashMap;
 
 public class NativeProxy extends NativeProxyCommon {
@@ -25,7 +21,7 @@ public class NativeProxy extends NativeProxyCommon {
 
     public NativeProxy(ReactApplicationContext context) {
         super(context);
-
+        ReactFeatureFlagsWrapper.enableMountHooks();
         CallInvokerHolderImpl holder =
                 (CallInvokerHolderImpl) context.getCatalystInstance().getJSCallInvokerHolder();
 

--- a/android/vendored/unversioned/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
+++ b/android/vendored/unversioned/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/keyboardObserver/ReanimatedKeyboardEventListener.java
@@ -57,6 +57,17 @@ public class ReanimatedKeyboardEventListener {
     ViewCompat.setOnApplyWindowInsetsListener(
         rootView,
         (v, insets) -> {
+          if (state == KeyboardState.OPEN) {
+            int keyboardHeight =
+                (int)
+                    PixelUtil.toDIPFromPixel(
+                        Math.max(
+                            0,
+                            insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                                - insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom));
+
+            updateKeyboard(keyboardHeight);
+          }
           int paddingBottom = 0;
           if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
               && BuildConfig.REACT_NATIVE_MINOR_VERSION < 70) {

--- a/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/72/com/swmansion/reanimated/ReactFeatureFlagsWrapper.java
+++ b/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/72/com/swmansion/reanimated/ReactFeatureFlagsWrapper.java
@@ -1,0 +1,9 @@
+package com.swmansion.reanimated;
+
+public class ReactFeatureFlagsWrapper {
+
+  public static void enableMountHooks() {
+    // no-op
+  }
+
+}

--- a/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/latest/com/swmansion/reanimated/ReactFeatureFlagsWrapper.java
+++ b/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReactFeatureFlagsWrapper/latest/com/swmansion/reanimated/ReactFeatureFlagsWrapper.java
@@ -1,0 +1,11 @@
+package com.swmansion.reanimated;
+
+import com.facebook.react.config.ReactFeatureFlags;
+
+public class ReactFeatureFlagsWrapper {
+
+  public static void enableMountHooks() {
+    ReactFeatureFlags.enableMountHooks = true;
+  }
+
+}

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1401,37 +1401,15 @@ PODS:
     - React-Core
   - RNFlashList (1.6.3):
     - React-Core
-  - RNGestureHandler (2.12.0):
-    - React-Core
-  - RNReanimated (3.6.0-nightly-20231031-c56d44fd9):
-    - DoubleConversion
-    - FBLazyVector
+  - RNGestureHandler (2.14.0):
     - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTAppDelegate
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
+  - RNReanimated (3.6.0):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
     - ReactCommon/turbomodule/core
-    - Yoga
   - RNScreens (3.27.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1977,7 +1955,7 @@ SPEC CHECKSUMS:
   EXNotifications: 1cbda734d622205cd72a0523a90e01dda0470edc
   Expo: 97df3b68de6c485f894dbae821666bec8435e144
   expo-dev-client: 820f881c0dc8a0f1f4cd1e35a35469d1d0fbc798
-  expo-dev-launcher: ddd4c74d4192526603cf004baf47b445d5372410
+  expo-dev-launcher: 8f353ad1c0e24a449581da76141bff672c28c729
   expo-dev-menu: 9fc863259e3178e3c65ccdc2515bf3f6ba9e9512
   expo-dev-menu-interface: 05d08cc56649636de77253583b4bbb73adce7680
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
@@ -1993,7 +1971,7 @@ SPEC CHECKSUMS:
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: a1a38f72993a4f0622d0c918d520b4ff640ba1cb
   ExpoFileSystem: 1bc21c70ab0bf505cd6bef97c5b008618bfb72f2
-  ExpoGL: 6037e72282fce9746e973c129628cff7f2ee44a6
+  ExpoGL: e452774bffdc758a6fe2dbff589234fa4026a4c3
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
   ExpoImage: cfaa9c379a3467c7863a187a1059c220b27a0741
   ExpoImageManipulator: b9d5ddfe7f00932677b52b6d5bd667e41caf0b2d
@@ -2096,8 +2074,8 @@ SPEC CHECKSUMS:
   RNCPicker: 529d564911e93598cc399b56cc0769ce3675f8c8
   RNDateTimePicker: 8fb39263b721223e095248acaf6f406d5b7f6713
   RNFlashList: 4b4b6b093afc0df60ae08f9cbf6ccd4c836c667a
-  RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
-  RNReanimated: 44d8524115fc3a5e809609a302944055934e3611
+  RNGestureHandler: 61bfdfc05db9b79dd61f894dcd29d3dcc6db3c02
+  RNReanimated: 92958cd13e63c2c34c71bc50ee2c8d5561bc4e3f
   RNScreens: 5f4df9babb21d30723580377b5f52d9f9baf0005
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "react-native": "0.73.0-rc.5",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-pager-view": "6.2.2",
-    "react-native-reanimated": "3.6.0-nightly-20231031-c56d44fd9",
+    "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "13.9.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -146,7 +146,7 @@
     "react-native-maps": "1.8.0",
     "react-native-pager-view": "6.2.2",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "3.6.0-nightly-20231031-c56d44fd9",
+    "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "13.9.0",

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/b5143c8d-285a-44af-92b5-222c742eff75"
+  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/2263771a-33e6-4ea5-860d-432064e8a91b"
 }

--- a/home/package.json
+++ b/home/package.json
@@ -62,7 +62,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.8.0",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "3.6.0-nightly-20231031-c56d44fd9",
+    "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.27.0",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2217,7 +2217,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.14.0):
     - React-Core
-  - RNReanimated (3.6.0-nightly-20231031-c56d44fd9):
+  - RNReanimated (3.6.0):
     - DoubleConversion
     - FBLazyVector
     - glog
@@ -3279,7 +3279,7 @@ SPEC CHECKSUMS:
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: a1a38f72993a4f0622d0c918d520b4ff640ba1cb
   ExpoFileSystem: 1bc21c70ab0bf505cd6bef97c5b008618bfb72f2
-  ExpoGL: 6037e72282fce9746e973c129628cff7f2ee44a6
+  ExpoGL: e452774bffdc758a6fe2dbff589234fa4026a4c3
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
   ExpoHead: e4605573eea4e36b29ce35716d451e4218b21680
   ExpoImage: cfaa9c379a3467c7863a187a1059c220b27a0741
@@ -3403,7 +3403,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNFlashList: 4b4b6b093afc0df60ae08f9cbf6ccd4c836c667a
   RNGestureHandler: 4279931048471f17faf46d912b2e96e10f1da99b
-  RNReanimated: 8a00922e4aa2c11c325aac904e690b0d12a2a0c6
+  RNReanimated: c7706129cc5d41b737193456f549dca3a9b0a0ca
   RNScreens: 2b19e2471db8a581c83f381f4ea5d43071c9a3bf
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
@@ -3425,6 +3425,6 @@ SPEC CHECKSUMS:
   Yoga: 4604f93d2c5a12c7586666b03bed2a27e0324f33
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: b47270c5bb886bd7b10c355c587521e10ec38e2c
+PODFILE CHECKSUM: d21b959522ea734e5c316c7d6e3f09319baf866b
 
 COCOAPODS: 1.14.2

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/LayoutAnimations/LayoutAnimationsManager.h
@@ -1,11 +1,8 @@
 #pragma once
 
+#include "JSLogger.h"
 #include "LayoutAnimationType.h"
 #include "Shareables.h"
-
-#ifndef NDEBUG
-#include "JSLogger.h"
-#endif
 
 #include <jsi/jsi.h>
 #include <stdio.h>
@@ -23,10 +20,8 @@ using namespace facebook;
 
 class LayoutAnimationsManager {
  public:
-#ifndef NDEBUG
   explicit LayoutAnimationsManager(const std::shared_ptr<JSLogger> &jsLogger)
       : jsLogger_(jsLogger) {}
-#endif
   void configureAnimation(
       int tag,
       LayoutAnimationType type,
@@ -54,8 +49,8 @@ class LayoutAnimationsManager {
   std::unordered_map<int, std::shared_ptr<Shareable>> &getConfigsForType(
       LayoutAnimationType type);
 
-#ifndef NDEBUG
   std::shared_ptr<JSLogger> jsLogger_;
+#ifndef NDEBUG
   // This set's function is to detect duplicate sharedTags on a single screen
   // it contains strings in form: "reactScreenTag:sharedTag"
   std::unordered_set<std::string> screenSharedTagSet_;

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModule.h
@@ -66,6 +66,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       jsi::Runtime &rt,
       const jsi::Value &name,
       const jsi::Value &initializer) override;
+  jsi::Value scheduleOnRuntime(
+      jsi::Runtime &rt,
+      const jsi::Value &workletRuntimeValue,
+      const jsi::Value &shareableWorkletValue) override;
 
   jsi::Value registerEventHandler(
       jsi::Runtime &rt,
@@ -112,6 +116,10 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
       const int emitterReactTag,
       const jsi::Value &payload,
       double currentTime);
+
+  inline std::shared_ptr<JSLogger> getJSLogger() const {
+    return jsLogger_;
+  }
 
 #ifdef RCT_NEW_ARCH_ENABLED
   bool handleRawEvent(const RawEvent &rawEvent, double currentTime);
@@ -164,6 +172,9 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
 
 #ifdef RCT_NEW_ARCH_ENABLED
   bool isThereAnyLayoutProp(jsi::Runtime &rt, const jsi::Object &props);
+  jsi::Value filterNonAnimatableProps(
+      jsi::Runtime &rt,
+      const jsi::Value &props);
 #endif // RCT_NEW_ARCH_ENABLED
 
   const std::shared_ptr<MessageQueueThread> jsQueue_;
@@ -178,13 +189,15 @@ class NativeReanimatedModule : public NativeReanimatedModuleSpec {
   volatile bool renderRequested_{false};
   const std::function<void(const double)> onRenderCallback_;
   AnimatedSensorModule animatedSensorModule_;
+  const std::shared_ptr<JSLogger> jsLogger_;
   LayoutAnimationsManager layoutAnimationsManager_;
 
 #ifdef RCT_NEW_ARCH_ENABLED
   const SynchronouslyUpdateUIPropsFunction synchronouslyUpdateUIPropsFunction_;
 
   std::unordered_set<std::string> nativePropNames_; // filled by configureProps
-
+  std::unordered_set<std::string>
+      animatablePropNames_; // filled by configureProps
   std::shared_ptr<UIManager> uiManager_;
 
   // After app reload, surfaceId on iOS is still 1 but on Android it's 11.

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.cpp
@@ -68,6 +68,15 @@ static jsi::Value SPEC_PREFIX(createWorkletRuntime)(
       ->createWorkletRuntime(rt, std::move(args[0]), std::move(args[1]));
 }
 
+static jsi::Value SPEC_PREFIX(scheduleOnRuntime)(
+    jsi::Runtime &rt,
+    TurboModule &turboModule,
+    const jsi::Value *args,
+    size_t) {
+  return static_cast<NativeReanimatedModuleSpec *>(&turboModule)
+      ->scheduleOnRuntime(rt, std::move(args[0]), std::move(args[1]));
+}
+
 static jsi::Value SPEC_PREFIX(registerEventHandler)(
     jsi::Runtime &rt,
     TurboModule &turboModule,
@@ -203,6 +212,8 @@ NativeReanimatedModuleSpec::NativeReanimatedModuleSpec(
   methodMap_["scheduleOnUI"] = MethodMetadata{1, SPEC_PREFIX(scheduleOnUI)};
   methodMap_["createWorkletRuntime"] =
       MethodMetadata{2, SPEC_PREFIX(createWorkletRuntime)};
+  methodMap_["scheduleOnRuntime"] =
+      MethodMetadata{2, SPEC_PREFIX(scheduleOnRuntime)};
 
   methodMap_["registerEventHandler"] =
       MethodMetadata{3, SPEC_PREFIX(registerEventHandler)};

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/NativeModules/NativeReanimatedModuleSpec.h
@@ -48,6 +48,10 @@ class JSI_EXPORT NativeReanimatedModuleSpec : public TurboModule {
       jsi::Runtime &rt,
       const jsi::Value &name,
       const jsi::Value &initializer) = 0;
+  virtual jsi::Value scheduleOnRuntime(
+      jsi::Runtime &rt,
+      const jsi::Value &workletRuntimeValue,
+      const jsi::Value &shareableWorkletValue) = 0;
 
   // events
   virtual jsi::Value registerEventHandler(

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/RNRuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/RNRuntimeDecorator.cpp
@@ -1,7 +1,5 @@
 #include "RNRuntimeDecorator.h"
-#ifndef NDEBUG
 #include "ReanimatedVersion.h"
-#endif // NDEBUG
 
 namespace reanimated {
 
@@ -32,7 +30,7 @@ void RNRuntimeDecorator::decorate(
   rnRuntime.global().setProperty(rnRuntime, "_IS_FABRIC", isFabric);
 
 #ifndef NDEBUG
-  checkJSVersion(rnRuntime);
+  checkJSVersion(rnRuntime, nativeReanimatedModule->getJSLogger());
 #endif // NDEBUG
 
   rnRuntime.global().setProperty(

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.cpp
@@ -22,13 +22,13 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
-#if REACT_NATIVE_MINOR_VERSION >= 73
 #if HERMES_ENABLE_DEBUGGER
+#if REACT_NATIVE_MINOR_VERSION >= 73
 using namespace facebook::hermes::inspector_modern;
-#endif // HERMES_ENABLE_DEBUGGER
 #else
 using namespace facebook::hermes::inspector;
 #endif
+#endif // HERMES_ENABLE_DEBUGGER
 
 #if HERMES_ENABLE_DEBUGGER
 

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/ReanimatedHermesRuntime.h
@@ -38,13 +38,13 @@ namespace reanimated {
 
 using namespace facebook;
 using namespace react;
-#if REACT_NATIVE_MINOR_VERSION >= 73
 #if HERMES_ENABLE_DEBUGGER
+#if REACT_NATIVE_MINOR_VERSION >= 73
 using namespace facebook::hermes::inspector_modern;
-#endif // HERMES_ENABLE_DEBUGGER
 #else
 using namespace facebook::hermes::inspector;
 #endif
+#endif // HERMES_ENABLE_DEBUGGER
 
 // ReentrancyCheck is copied from React Native
 // from ReactCommon/hermes/executor/HermesExecutorFactory.cpp

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.cpp
@@ -62,4 +62,16 @@ std::shared_ptr<WorkletRuntime> extractWorkletRuntime(
   return value.getObject(rt).getHostObject<WorkletRuntime>(rt);
 }
 
+void scheduleOnRuntime(
+    jsi::Runtime &rt,
+    const jsi::Value &workletRuntimeValue,
+    const jsi::Value &shareableWorkletValue) {
+  auto workletRuntime = extractWorkletRuntime(rt, workletRuntimeValue);
+  auto shareableWorklet = extractShareableOrThrow<ShareableWorklet>(
+      rt,
+      shareableWorkletValue,
+      "[Reanimated] Function passed to `_scheduleOnRuntime` is not a shareable worklet. Please make sure that `processNestedWorklets` option in Reanimated Babel plugin is enabled.");
+  workletRuntime->runAsyncGuarded(shareableWorklet);
+}
+
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntime.h
@@ -3,6 +3,7 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <jsi/jsi.h>
 
+#include "AsyncQueue.h"
 #include "JSScheduler.h"
 #include "Shareables.h"
 
@@ -17,7 +18,8 @@ using namespace react;
 
 namespace reanimated {
 
-class WorkletRuntime : public jsi::HostObject {
+class WorkletRuntime : public jsi::HostObject,
+                       public std::enable_shared_from_this<WorkletRuntime> {
  public:
   explicit WorkletRuntime(
       jsi::Runtime &rnRuntime,
@@ -40,8 +42,17 @@ class WorkletRuntime : public jsi::HostObject {
         rt, shareableWorklet->getJSValue(rt), std::forward<Args>(args)...);
   }
 
+  void runAsyncGuarded(
+      const std::shared_ptr<ShareableWorklet> &shareableWorklet) {
+    if (queue_ == nullptr) {
+      queue_ = std::make_shared<AsyncQueue>(name_);
+    }
+    queue_->push(
+        [=, self = shared_from_this()] { self->runGuarded(shareableWorklet); });
+  }
+
   std::string toString() const {
-    return "<WorkletRuntime \"" + name_ + "\">";
+    return "[WorkletRuntime \"" + name_ + "\"]";
   }
 
   jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &propName) override;
@@ -51,6 +62,7 @@ class WorkletRuntime : public jsi::HostObject {
  private:
   const std::shared_ptr<jsi::Runtime> runtime_;
   const std::string name_;
+  std::shared_ptr<AsyncQueue> queue_;
 };
 
 // This function needs to be non-inline to avoid problems with dynamic_cast on
@@ -58,5 +70,10 @@ class WorkletRuntime : public jsi::HostObject {
 std::shared_ptr<WorkletRuntime> extractWorkletRuntime(
     jsi::Runtime &rt,
     const jsi::Value &value);
+
+void scheduleOnRuntime(
+    jsi::Runtime &rt,
+    const jsi::Value &workletRuntimeValue,
+    const jsi::Value &shareableWorkletValue);
 
 } // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/ReanimatedRuntime/WorkletRuntimeDecorator.cpp
@@ -2,6 +2,7 @@
 #include "JSISerializer.h"
 #include "ReanimatedJSIUtils.h"
 #include "Shareables.h"
+#include "WorkletRuntime.h"
 
 #ifdef ANDROID
 #include "Logger.h"
@@ -117,12 +118,29 @@ void WorkletRuntimeDecorator::decorate(
 
   jsi_utils::installJsiFunction(
       rt,
+      "_scheduleOnRuntime",
+      [](jsi::Runtime &rt,
+         const jsi::Value &workletRuntimeValue,
+         const jsi::Value &shareableWorkletValue) {
+        reanimated::scheduleOnRuntime(
+            rt, workletRuntimeValue, shareableWorkletValue);
+      });
+
+  jsi_utils::installJsiFunction(
+      rt,
       "_updateDataSynchronously",
       [](jsi::Runtime &rt,
          const jsi::Value &synchronizedDataHolderRef,
          const jsi::Value &newData) {
         return reanimated::updateDataSynchronously(
             rt, synchronizedDataHolderRef, newData);
+      });
+
+  jsi_utils::installJsiFunction(
+      rt,
+      "_getDataSynchronously",
+      [](jsi::Runtime &rt, const jsi::Value &synchronizedDataHolderRef) {
+        return reanimated::getDataSynchronously(rt, synchronizedDataHolderRef);
       });
 
   jsi::Object performance(rt);

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.cpp
@@ -119,6 +119,14 @@ void updateDataSynchronously(
   dataHolder->set(rt, newData);
 }
 
+jsi::Value getDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef) {
+  auto dataHolder = extractShareableOrThrow<ShareableSynchronizedDataHolder>(
+      rt, synchronizedDataHolderRef);
+  return dataHolder->get(rt);
+}
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/SharedItems/Shareables.h
@@ -153,6 +153,10 @@ void updateDataSynchronously(
     const jsi::Value &synchronizedDataHolderRef,
     const jsi::Value &newData);
 
+jsi::Value getDataSynchronously(
+    jsi::Runtime &rt,
+    const jsi::Value &synchronizedDataHolderRef);
+
 std::shared_ptr<Shareable> extractShareableOrThrow(
     jsi::Runtime &rt,
     const jsi::Value &maybeShareableValue,

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.cpp
@@ -1,0 +1,52 @@
+#include "AsyncQueue.h"
+
+#include <utility>
+
+namespace reanimated {
+
+AsyncQueue::AsyncQueue(std::string name)
+    : state_(std::make_shared<AsyncQueueState>()) {
+  auto thread = std::thread([name, state = state_] {
+#if __APPLE__
+    pthread_setname_np(name.c_str());
+#endif
+    while (state->running) {
+      std::unique_lock<std::mutex> lock(state->mutex);
+      state->cv.wait(
+          lock, [state] { return !state->queue.empty() || !state->running; });
+      if (!state->running) {
+        return;
+      }
+      if (state->queue.empty()) {
+        continue;
+      }
+      auto job = std::move(state->queue.front());
+      state->queue.pop();
+      lock.unlock();
+      job();
+    }
+  });
+#ifdef ANDROID
+  pthread_setname_np(thread.native_handle(), name.c_str());
+#endif
+  thread.detach();
+}
+
+AsyncQueue::~AsyncQueue() {
+  {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->running = false;
+    state_->queue = {};
+  }
+  state_->cv.notify_all();
+}
+
+void AsyncQueue::push(std::function<void()> &&job) {
+  {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->queue.emplace(job);
+  }
+  state_->cv.notify_one();
+}
+
+} // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/AsyncQueue.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <queue>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace reanimated {
+
+struct AsyncQueueState {
+  std::atomic_bool running{true};
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::queue<std::function<void()>> queue;
+};
+
+class AsyncQueue {
+ public:
+  explicit AsyncQueue(std::string name);
+
+  ~AsyncQueue();
+
+  void push(std::function<void()> &&job);
+
+ private:
+  const std::shared_ptr<AsyncQueueState> state_;
+};
+
+} // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.cpp
@@ -1,18 +1,16 @@
-#ifndef NDEBUG
-
 #include "JSLogger.h"
 #include <memory>
 
 namespace reanimated {
 
 void JSLogger::warnOnJS(const std::string &warning) const {
+#ifndef NDEBUG
   jsScheduler_->scheduleOnJS([warning](jsi::Runtime &rt) {
     auto console = rt.global().getPropertyAsObject(rt, "console");
     auto warn = console.getPropertyAsFunction(rt, "warn");
     warn.call(rt, jsi::String::createFromUtf8(rt, warning));
   });
+#endif // NDEBUG
 }
 
 } // namespace reanimated
-
-#endif // NDEBUG

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/JSLogger.h
@@ -1,5 +1,3 @@
-#ifndef NDEBUG
-
 #pragma once
 
 #include "JSScheduler.h"
@@ -20,5 +18,3 @@ class JSLogger {
 };
 
 } // namespace reanimated
-
-#endif // NDEBUG

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.cpp
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.cpp
@@ -1,6 +1,8 @@
 #include "ReanimatedVersion.h"
+#include <memory>
 #include <regex>
 #include <string>
+#include "JSLogger.h"
 
 #ifdef REANIMATED_VERSION
 #define STRINGIZE(x) #x
@@ -41,26 +43,30 @@ bool matchVersion(const std::string &version1, const std::string &version2) {
   }
 }
 
-void checkJSVersion(jsi::Runtime &rnRuntime) {
+void checkJSVersion(
+    jsi::Runtime &rnRuntime,
+    const std::shared_ptr<JSLogger> &jsLogger) {
   auto cppVersion = getReanimatedCppVersion();
 
   auto maybeJSVersion =
       rnRuntime.global().getProperty(rnRuntime, "_REANIMATED_VERSION_JS");
   if (maybeJSVersion.isUndefined()) {
-    throw std::runtime_error(
+    jsLogger->warnOnJS(
         std::string(
             "[Reanimated] C++ side failed to resolve JavaScript code version\n") +
         "See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#c-side-failed-to-resolve-javascript-code-version` for more details.");
+    return;
   }
 
   auto jsVersion = maybeJSVersion.asString(rnRuntime).utf8(rnRuntime);
 
   if (!matchVersion(cppVersion, jsVersion)) {
-    throw std::runtime_error(
+    jsLogger->warnOnJS(
         std::string(
             "[Reanimated] Mismatch between C++ code version and JavaScript code version (") +
         cppVersion + " vs. " + jsVersion + " respectively).\n" +
         "See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#mismatch-between-c-code-version-and-javascript-code-version` for more details.");
+    return;
   }
 
   rnRuntime.global().setProperty(

--- a/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.h
+++ b/ios/vendored/unversioned/react-native-reanimated/Common/cpp/Tools/ReanimatedVersion.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <memory>
 #include <string>
+#include "JSLogger.h"
 
 using namespace facebook;
 
@@ -9,9 +11,7 @@ namespace reanimated {
 
 std::string getReanimatedCppVersion();
 
-#ifndef NDEBUG
 bool matchVersion(const std::string &, const std::string &);
-void checkJSVersion(jsi::Runtime &);
-#endif // NDEBUG
+void checkJSVersion(jsi::Runtime &, const std::shared_ptr<JSLogger> &);
 
 }; // namespace reanimated

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "3.6.0-nightly-20231031-c56d44fd9",
+  "version": "3.6.0",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -9,13 +9,13 @@
     "author": "author@domain.cn"
   },
   "platforms": {
-    "ios": "10.0",
+    "ios": "13.4",
     "tvos": "9.0",
     "osx": "10.14"
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "3.6.0-nightly-20231031-c56d44fd9"
+    "tag": "3.6.0"
   },
   "source_files": [
     "apple/**/*.{mm,h,m}",
@@ -30,20 +30,21 @@
     "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_ROOT)/Headers/Private/Yoga\"",
     "FRAMEWORK_SEARCH_PATHS": "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\"",
     "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
-    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]": "$(inherited) HERMES_ENABLE_DEBUGGER=1"
+    "GCC_PREPROCESSOR_DEFINITIONS[config=Debug]": "$(inherited) HERMES_ENABLE_DEBUGGER=1",
+    "GCC_PREPROCESSOR_DEFINITIONS[config=Release]": "$(inherited) NDEBUG=1"
   },
   "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=73 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/Headers/Public/React-hermes\" \"$(PODS_ROOT)/Headers/Public/hermes-engine\" \"${PODS_ROOT}/../../react-native-lab/react-native/packages/react-native/ReactCommon\"",
-    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=73 -DREANIMATED_VERSION=3.6.0-nightly-20231031-c56d44fd9 "
+    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=73   -DREANIMATED_VERSION=3.6.0 "
   },
   "requires_arc": true,
   "dependencies": {
+    "ReactCommon/turbomodule/core": [],
     "React-Core": [],
     "RCT-Folly": [],
     "RCTRequired": [],
     "RCTTypeSafety": [],
-    "ReactCommon/turbomodule/core": [],
     "FBLazyVector": [],
     "React-CoreModules": [],
     "React-Core/DevSupport": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "setup:docs": "./scripts/download-dependencies.sh",
     "setup:native": "./scripts/download-dependencies.sh && ./scripts/setup-react-android.sh",
-    "postinstall": "yarn-deduplicate && expo-yarn-workspaces check-workspace-dependencies && ([ ! -f node_modules/react-native-reanimated/package.json.orig ] && patch -d node_modules -p2 -f --backup < patches/react-native-reanimated+3.6.0-nightly-20231031-c56d44fd9.patch || true) && yarn workspace @expo/cli prepare",
+    "postinstall": "yarn-deduplicate && expo-yarn-workspaces check-workspace-dependencies && yarn workspace @expo/cli prepare",
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -89,7 +89,7 @@
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.8.0",
   "react-native-pager-view": "6.2.2",
-  "react-native-reanimated": "3.6.0-nightly-20231031-c56d44fd9",
+  "react-native-reanimated": "~3.6.0",
   "react-native-screens": "~3.27.0",
   "react-native-safe-area-context": "4.6.3",
   "react-native-svg": "13.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16727,10 +16727,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@3.6.0-nightly-20231031-c56d44fd9:
-  version "3.6.0-nightly-20231031-c56d44fd9"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.0-nightly-20231031-c56d44fd9.tgz#86a10c0c1ef9ace0743371ebaf5579244990ed22"
-  integrity sha512-kmq/IBADwDfnyMBJngqcrmSU3OVPJzoAI9oPwZBxu0D1mRr9LBjdsTSRwKthkFmMmq92mYlCQaPbhKK56qcimg==
+react-native-reanimated@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.0.tgz#d2ca5f4c234f592af3d63bc749806e36d6e0a755"
+  integrity sha512-eDdhZTRYofrIqFB/Z5xLTWxcB7wDj4ifrNm+gZ2xHSZPjAQ747ukDdH9rglPyPmi+GcmDH7Wff411Xsw5fm45Q==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
# Why

Upgrade react-native-reanimated to 3.6.0 to remove the need for our patch 

# How 

`et uvm -m react-native-reanimated --commit 3.6.0`

# Test Plan

- [x] test using `bare-expo` Android + NCL  
- [x] test using `bare-expo` iOS + NCL  
- [x] test unversioned expo go ios + NCL  
- [x] test unversioned expo go android + NCL  

# Checklist
 
- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
