### PR TITLE
[docs] add a global settings menu to code blocks

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { mergeClasses, theme, Themes, typography } from '@expo/styleguide';
 import { borderRadius, spacing } from '@expo/styleguide-base';
 import { FileCode01Icon, LayoutAlt01Icon, Server03Icon } from '@expo/styleguide-icons';
 import { Language, Prism } from 'prism-react-renderer';
@@ -8,10 +8,12 @@ import tippy, { roundArrow } from 'tippy.js';
 
 import { installLanguages } from './languages';
 
+import { useCodeBlockSettingsContext } from '~/providers/CodeBlockSettingsProvider';
 import { Snippet } from '~/ui/components/Snippet/Snippet';
 import { SnippetContent } from '~/ui/components/Snippet/SnippetContent';
 import { SnippetHeader } from '~/ui/components/Snippet/SnippetHeader';
 import { CopyAction } from '~/ui/components/Snippet/actions/CopyAction';
+import { SettingsAction } from '~/ui/components/Snippet/actions/SettingsAction';
 import { CODE } from '~/ui/components/Text';
 
 // @ts-ignore Jest ESM issue https://github.com/facebook/jest/issues/9430
@@ -22,6 +24,163 @@ installLanguages(Prism);
 const attributes = {
   'data-text': true,
 };
+
+type Props = {
+  className?: string;
+};
+
+export function cleanCopyValue(value: string) {
+  return value
+    .replace(/\/\*\s?@(info[^*]+|end|hide[^*]+).?\*\//g, '')
+    .replace(/#\s?@(info[^#]+|end|hide[^#]+).?#/g, '')
+    .replace(/<!--\s?@(info[^<>]+|end|hide[^<>]+).?-->/g, '')
+    .replace(/^ +\r?\n|\n +\r?$/gm, '');
+}
+
+function escapeHtml(text: string) {
+  return text.replace(/"/g, '&quot;');
+}
+
+function replaceXmlCommentsWithAnnotations(value: string) {
+  return value
+    .replace(/<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g, (_, content) => {
+      return content
+        ? `<span class="code-annotation with-tooltip" data-tippy-content="${escapeHtml(content)}">`
+        : '<span class="code-annotation">';
+    })
+    .replace(/<span class="token comment">&lt;!-- @hide (.*?)--><\/span>\s*/g, (_, content) => {
+      return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${escapeHtml(
+        content
+      )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
+    })
+    .replace(/\s*<span class="token comment">&lt;!-- @end --><\/span>/g, '</span>');
+}
+
+function replaceHashCommentsWithAnnotations(value: string) {
+  return value
+    .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (_, content) => {
+      return content
+        ? `<span class="code-annotation with-tooltip" data-tippy-content="${escapeHtml(content)}">`
+        : '<span class="code-annotation">';
+    })
+    .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (_, content) => {
+      return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${escapeHtml(
+        content
+      )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
+    })
+    .replace(/\s*<span class="token comment"># @end #<\/span>/g, '</span>');
+}
+
+function replaceSlashCommentsWithAnnotations(value: string) {
+  return value
+    .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (_, content) => {
+      return content
+        ? `<span class="code-annotation with-tooltip" data-tippy-content="${escapeHtml(content)}">`
+        : '<span class="code-annotation">';
+    })
+    .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (_, content) => {
+      return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${escapeHtml(
+        content
+      )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
+    })
+    .replace(/\s*<span class="token comment">\/\* @end \*\/<\/span>/g, '</span>');
+}
+
+function parseValue(value: string) {
+  if (value.startsWith('@@@')) {
+    const valueChunks = value.split('@@@');
+    return {
+      title: valueChunks[1],
+      value: valueChunks[2],
+    };
+  }
+  return {
+    value,
+  };
+}
+
+export function Code({ className, children }: React.PropsWithChildren<Props>) {
+  const { preferredTheme, wordWrap } = useCodeBlockSettingsContext();
+
+  React.useEffect(() => {
+    const tippyFunc = testTippy || tippy;
+    tippyFunc('.code-annotation.with-tooltip', {
+      allowHTML: true,
+      theme: 'expo',
+      placement: 'top',
+      arrow: roundArrow,
+      interactive: true,
+      offset: [0, 20],
+      appendTo: document.body,
+    });
+  }, []);
+
+  // note(simek): MDX dropped `inlineCode` pseudo-tag, and we need to relay on `pre` and `code` now,
+  // which results in this nesting mess, we should fix it in the future
+  const rootProps =
+    className && className.startsWith('language')
+      ? { className, children }
+      : (React.Children.toArray(children)[0] as JSX.Element)?.props;
+
+  const value = parseValue(rootProps?.children?.toString() || '');
+  let html = value.value;
+
+  // mdx will add the class `language-foo` to codeblocks with the tag `foo`
+  // if this class is present, we want to slice out `language-`
+  let lang = rootProps.className && rootProps.className.slice(9).toLowerCase();
+
+  // Allow for code blocks without a language.
+  if (lang) {
+    // sh isn't supported, use sh to match js, and ts
+    if (lang in remapLanguages) {
+      lang = remapLanguages[lang];
+    }
+
+    const grammar = Prism.languages[lang as keyof typeof Prism.languages];
+    if (!grammar) {
+      throw new Error(`docs currently do not support language: ${lang}`);
+    }
+
+    html = Prism.highlight(html, grammar, lang as Language);
+    if (['properties', 'ruby', 'bash', 'yaml'].includes(lang)) {
+      html = replaceHashCommentsWithAnnotations(html);
+    } else if (['xml', 'html'].includes(lang)) {
+      html = replaceXmlCommentsWithAnnotations(html);
+    } else {
+      html = replaceSlashCommentsWithAnnotations(html);
+    }
+  }
+
+  return value?.title ? (
+    <Snippet>
+      <SnippetHeader title={value.title} Icon={getIconForFile(value.title)}>
+        <CopyAction text={cleanCopyValue(value.value)} />
+        <SettingsAction />
+      </SnippetHeader>
+      <SnippetContent className="p-0">
+        <pre
+          css={STYLES_CODE_CONTAINER}
+          className={mergeClasses(wordWrap && '!whitespace-pre-wrap !break-words')}
+          {...attributes}>
+          <code
+            css={STYLES_CODE_BLOCK}
+            dangerouslySetInnerHTML={{ __html: html.replace(/^@@@.+@@@/g, '') }}
+          />
+        </pre>
+      </SnippetContent>
+    </Snippet>
+  ) : (
+    <pre
+      css={[STYLES_CODE_CONTAINER, STYLES_CODE_CONTAINER_BLOCK]}
+      className={mergeClasses(
+        preferredTheme === Themes.DARK && 'dark-theme',
+        wordWrap && '!whitespace-pre-wrap !break-words'
+      )}
+      {...attributes}>
+      <code css={STYLES_CODE_BLOCK} dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  );
+}
 
 const STYLES_CODE_BLOCK = css`
   ${typography.body.code};
@@ -74,173 +233,6 @@ const STYLES_CODE_CONTAINER = css`
     margin-bottom: 0;
   }
 `;
-
-type Props = {
-  className?: string;
-};
-
-export function cleanCopyValue(value: string) {
-  return value
-    .replace(/\/\*\s?@(info[^*]+|end|hide[^*]+).?\*\//g, '')
-    .replace(/#\s?@(info[^#]+|end|hide[^#]+).?#/g, '')
-    .replace(/<!--\s?@(info[^<>]+|end|hide[^<>]+).?-->/g, '')
-    .replace(/^ +\r?\n|\n +\r?$/gm, '');
-}
-
-export class Code extends React.Component<React.PropsWithChildren<Props>> {
-  componentDidMount() {
-    this.runTippy();
-  }
-
-  componentDidUpdate() {
-    this.runTippy();
-  }
-
-  private runTippy() {
-    const tippyFunc = testTippy || tippy;
-    tippyFunc('.code-annotation.with-tooltip', {
-      allowHTML: true,
-      theme: 'expo',
-      placement: 'top',
-      arrow: roundArrow,
-      interactive: true,
-      offset: [0, 20],
-      appendTo: document.body,
-    });
-  }
-
-  private escapeHtml(text: string) {
-    return text.replace(/"/g, '&quot;');
-  }
-
-  private replaceXmlCommentsWithAnnotations(value: string) {
-    return value
-      .replace(
-        /<span class="token comment">&lt;!-- @info (.*?)--><\/span>\s*/g,
-        (match, content) => {
-          return content
-            ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
-                content
-              )}">`
-            : '<span class="code-annotation">';
-        }
-      )
-      .replace(
-        /<span class="token comment">&lt;!-- @hide (.*?)--><\/span>\s*/g,
-        (match, content) => {
-          return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
-            content
-          )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
-        }
-      )
-      .replace(/\s*<span class="token comment">&lt;!-- @end --><\/span>/g, '</span>');
-  }
-
-  private replaceHashCommentsWithAnnotations(value: string) {
-    return value
-      .replace(/<span class="token comment"># @info (.*?)#<\/span>\s*/g, (match, content) => {
-        return content
-          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
-              content
-            )}">`
-          : '<span class="code-annotation">';
-      })
-      .replace(/<span class="token comment"># @hide (.*?)#<\/span>\s*/g, (match, content) => {
-        return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
-          content
-        )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
-      })
-      .replace(/\s*<span class="token comment"># @end #<\/span>/g, '</span>');
-  }
-
-  private replaceSlashCommentsWithAnnotations(value: string) {
-    return value
-      .replace(/<span class="token comment">\/\* @info (.*?)\*\/<\/span>\s*/g, (match, content) => {
-        return content
-          ? `<span class="code-annotation with-tooltip" data-tippy-content="${this.escapeHtml(
-              content
-            )}">`
-          : '<span class="code-annotation">';
-      })
-      .replace(/<span class="token comment">\/\* @hide (.*?)\*\/<\/span>\s*/g, (match, content) => {
-        return `<span><span class="code-hidden">%%placeholder-start%%</span><span class="code-placeholder">${this.escapeHtml(
-          content
-        )}</span><span class="code-hidden">%%placeholder-end%%</span><span class="code-hidden">`;
-      })
-      .replace(/\s*<span class="token comment">\/\* @end \*\/<\/span>/g, '</span>');
-  }
-
-  private parseValue(value: string) {
-    if (value.startsWith('@@@')) {
-      const valueChunks = value.split('@@@');
-      return {
-        title: valueChunks[1],
-        value: valueChunks[2],
-      };
-    }
-    return {
-      value,
-    };
-  }
-
-  render() {
-    // note(simek): MDX dropped `inlineCode` pseudo-tag, and we need to relay on `pre` and `code` now,
-    // which results in this nesting mess, we should fix it in the future
-    const child =
-      this.props.className && this.props.className.startsWith('language')
-        ? this
-        : (React.Children.toArray(this.props.children)[0] as JSX.Element);
-
-    const value = this.parseValue(child?.props?.children?.toString() || '');
-    let html = value.value;
-
-    // mdx will add the class `language-foo` to codeblocks with the tag `foo`
-    // if this class is present, we want to slice out `language-`
-    let lang = child.props.className && child.props.className.slice(9).toLowerCase();
-
-    // Allow for code blocks without a language.
-    if (lang) {
-      // sh isn't supported, use sh to match js, and ts
-      if (lang in remapLanguages) {
-        lang = remapLanguages[lang];
-      }
-
-      const grammar = Prism.languages[lang as keyof typeof Prism.languages];
-      if (!grammar) {
-        throw new Error(`docs currently do not support language: ${lang}`);
-      }
-
-      html = Prism.highlight(html, grammar, lang as Language);
-      if (['properties', 'ruby', 'bash', 'yaml'].includes(lang)) {
-        html = this.replaceHashCommentsWithAnnotations(html);
-      } else if (['xml', 'html'].includes(lang)) {
-        html = this.replaceXmlCommentsWithAnnotations(html);
-      } else {
-        html = this.replaceSlashCommentsWithAnnotations(html);
-      }
-    }
-
-    return value?.title ? (
-      <Snippet>
-        <SnippetHeader title={value.title} Icon={getIconForFile(value.title)}>
-          <CopyAction text={cleanCopyValue(value.value)} />
-        </SnippetHeader>
-        <SnippetContent className="p-0">
-          <pre css={STYLES_CODE_CONTAINER} {...attributes}>
-            <code
-              css={STYLES_CODE_BLOCK}
-              dangerouslySetInnerHTML={{ __html: html.replace(/^@@@.+@@@/g, '') }}
-            />
-          </pre>
-        </SnippetContent>
-      </Snippet>
-    ) : (
-      <pre css={[STYLES_CODE_CONTAINER, STYLES_CODE_CONTAINER_BLOCK]} {...attributes}>
-        <code css={STYLES_CODE_BLOCK} dangerouslySetInnerHTML={{ __html: html }} />
-      </pre>
-    );
-  }
-}
 
 const remapLanguages: Record<string, string> = {
   'objective-c': 'objc',

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -7039,11 +7039,11 @@ This uses both
     </p>
     <pre>
       <pre
-        class="css-1tmj8fm"
+        class=" css-1r21cuo-Code"
         data-text="true"
       >
         <code
-          class="css-1r5zesl"
+          class="css-dpez7n-Code"
         >
           <span
             class="token keyword"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -75,11 +75,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </p>
   <pre>
     <pre
-      class="css-1tmj8fm"
+      class=" css-1r21cuo-Code"
       data-text="true"
     >
       <code
-        class="css-1r5zesl"
+        class="css-dpez7n-Code"
       >
         <span
           class="token keyword"

--- a/docs/global-styles/global.css
+++ b/docs/global-styles/global.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+input {
+  appearance: unset;
+}
+
+#__next[aria-hidden] {
+  filter: none !important;
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -63,6 +63,7 @@
     "@emotion/jest": "^11.11.0",
     "@ocular-d/vale-bin": "^2.29.6",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dropdown-menu": "^1.0.0",
     "@tailwindcss/typography": "^0.5.10",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.1.0",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -9,6 +9,7 @@ import { preprocessSentryError } from '~/common/sentry-utilities';
 import { useNProgress } from '~/common/use-nprogress';
 import DocumentationElements from '~/components/page-higher-order/DocumentationElements';
 import { AnalyticsProvider } from '~/providers/Analytics';
+import { CodeBlockSettingsProvider } from '~/providers/CodeBlockSettingsProvider';
 import { markdownComponents } from '~/ui/components/Markdown';
 
 import 'global-styles/global.css';
@@ -56,19 +57,21 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <AnalyticsProvider>
       <ThemeProvider>
-        <MDXProvider components={rootMarkdownComponents}>
-          <Global
-            styles={css({
-              'html, body, kbd, button, input, select': {
-                fontFamily: regularFont.style.fontFamily,
-              },
-              'code, pre, table.diff': {
-                fontFamily: monospaceFont.style.fontFamily,
-              },
-            })}
-          />
-          <Component {...pageProps} />
-        </MDXProvider>
+        <CodeBlockSettingsProvider>
+          <MDXProvider components={rootMarkdownComponents}>
+            <Global
+              styles={css({
+                'html, body, kbd, button, input, select': {
+                  fontFamily: regularFont.style.fontFamily,
+                },
+                'code, pre, table.diff': {
+                  fontFamily: monospaceFont.style.fontFamily,
+                },
+              })}
+            />
+            <Component {...pageProps} />
+          </MDXProvider>
+        </CodeBlockSettingsProvider>
       </ThemeProvider>
     </AnalyticsProvider>
   );

--- a/docs/providers/CodeBlockSettingsProvider.tsx
+++ b/docs/providers/CodeBlockSettingsProvider.tsx
@@ -1,0 +1,45 @@
+import { Themes } from '@expo/styleguide';
+import { createContext, type Dispatch, type PropsWithChildren, useContext } from 'react';
+
+import { useLocalStorage } from '~/common/useLocalStorage';
+
+type CodeBlockSettingsContextType = {
+  preferredTheme: Themes;
+  setPreferredTheme: Dispatch<Themes>;
+  wordWrap: boolean;
+  setWordWrap: Dispatch<boolean>;
+};
+
+export const CodeBlockSettingsContext = createContext<CodeBlockSettingsContextType>({
+  preferredTheme: Themes.AUTO,
+  setPreferredTheme: (_: Themes) => {},
+  wordWrap: false,
+  setWordWrap: (_: boolean) => {},
+});
+
+export function CodeBlockSettingsProvider({ children }: PropsWithChildren) {
+  const [preferredTheme, setPreferredTheme] = useLocalStorage({
+    defaultValue: Themes.AUTO,
+    name: 'CODEBLOCK_THEME',
+  });
+  const [wordWrap, setWordWrap] = useLocalStorage({
+    defaultValue: false,
+    name: 'CODEBLOCK_WORDWRAP',
+  });
+
+  return (
+    <CodeBlockSettingsContext.Provider
+      value={{
+        preferredTheme,
+        setPreferredTheme,
+        wordWrap,
+        setWordWrap,
+      }}>
+      {children}
+    </CodeBlockSettingsContext.Provider>
+  );
+}
+
+export function useCodeBlockSettingsContext() {
+  return useContext(CodeBlockSettingsContext);
+}

--- a/docs/ui/components/Dropdown/Item.tsx
+++ b/docs/ui/components/Dropdown/Item.tsx
@@ -1,0 +1,95 @@
+import { mergeClasses } from '@expo/styleguide';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { ComponentType, HTMLAttributes, ReactNode } from 'react';
+
+import { A, CALLOUT, FOOTNOTE } from '../Text';
+
+type Props = Omit<DropdownMenu.DropdownMenuItemProps, 'onClick'> & {
+  label: string;
+  description?: React.ReactNode;
+  href?: string;
+  Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
+  rightSlot?: ReactNode;
+  disabled?: boolean;
+  destructive?: boolean;
+  openInNewTab?: boolean;
+  preventAutoClose?: boolean;
+};
+
+export function Item({
+  label,
+  description,
+  Icon,
+  rightSlot,
+  href,
+  openInNewTab,
+  disabled,
+  destructive,
+  onSelect,
+  preventAutoClose,
+  ...rest
+}: Props) {
+  const textItem = (
+    <DropdownMenu.Item
+      aria-disabled={disabled}
+      className={mergeClasses(
+        'relative z-40 flex cursor-pointer select-none items-center justify-between rounded-sm px-2 py-1',
+        'hocus:bg-hover hover:outline-0',
+        disabled && 'cursor-default opacity-60 hocus:bg-default'
+      )}
+      onSelect={event => {
+        // prevent default behavior of closing the menu without using pointer-events-none on the
+        // whole item
+        if (disabled) {
+          event.preventDefault();
+          return;
+        }
+
+        if (preventAutoClose) {
+          event.preventDefault();
+        } else {
+          // note(simek): workaround for Radix primitives interaction blocking styles desync,
+          // when clicking Dropdown option spawns another Radix primitive utilizing Portal, i.e. Dialog
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        }
+        onSelect?.(event);
+      }}
+      {...rest}>
+      <div className="flex flex-1 flex-col gap-0.5">
+        <div
+          className={mergeClasses(
+            'flex items-center justify-between',
+            disabled && 'pointer-events-none'
+          )}>
+          <div className="flex items-center gap-2">
+            {Icon && (
+              <Icon className={mergeClasses('icon-sm', destructive && 'text-icon-danger')} />
+            )}
+            <CALLOUT theme={destructive ? 'danger' : 'default'}>{label}</CALLOUT>
+          </div>
+          {typeof rightSlot === 'string' ? (
+            <FOOTNOTE theme="secondary">{rightSlot}</FOOTNOTE>
+          ) : (
+            rightSlot
+          )}
+        </div>
+        {description && typeof description === 'string' ? (
+          <FOOTNOTE theme="tertiary" className="!leading-[18px]">
+            {description}
+          </FOOTNOTE>
+        ) : null}
+        {description && typeof description !== 'string' ? description : null}
+      </div>
+    </DropdownMenu.Item>
+  );
+
+  if (href) {
+    return (
+      <A href={href} openInNewTab={openInNewTab}>
+        {textItem}
+      </A>
+    );
+  } else {
+    return textItem;
+  }
+}

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -1,8 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
-import DropdownMenu from '@radix-ui/react-dropdown-menu';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type { ReactNode } from 'react';
 
 import { Item } from '~/ui/components/Dropdown/Item';
+
+// note(simek): Radix Jest ESM issue workaround: https://github.com/radix-ui/primitives/issues/1848
+let sanitizedRadixDropdownMenu = { default: undefined, ...DropdownMenu };
+sanitizedRadixDropdownMenu = sanitizedRadixDropdownMenu.default ?? sanitizedRadixDropdownMenu;
+const { Trigger, Root, Portal, Content, Arrow } = sanitizedRadixDropdownMenu;
 
 type Props = DropdownMenu.DropdownMenuContentProps & {
   trigger: ReactNode;
@@ -18,10 +23,10 @@ export function Dropdown({
   ...rest
 }: Props) {
   return (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
-      <DropdownMenu.Portal className="bg-danger">
-        <DropdownMenu.Content
+    <Root>
+      <Trigger asChild>{trigger}</Trigger>
+      <Portal className="bg-danger">
+        <Content
           className={mergeClasses(
             'flex min-w-[180px] flex-col gap-0.5 rounded-md border border-default bg-default p-1 shadow-md',
             'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
@@ -31,13 +36,13 @@ export function Dropdown({
           sideOffset={sideOffset}
           collisionPadding={collisionPadding}
           {...rest}>
-          <DropdownMenu.Arrow asChild>
+          <Arrow asChild>
             <div className="relative -top-1 h-2.5 w-2.5 rotate-45 border-b border-r border-default bg-default" />
-          </DropdownMenu.Arrow>
+          </Arrow>
           {children}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+        </Content>
+      </Portal>
+    </Root>
   );
 }
 

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -1,0 +1,44 @@
+import { mergeClasses } from '@expo/styleguide';
+import DropdownMenu from '@radix-ui/react-dropdown-menu';
+import type { ReactNode } from 'react';
+
+import { Item } from '~/ui/components/Dropdown/Item';
+
+type Props = DropdownMenu.DropdownMenuContentProps & {
+  trigger: ReactNode;
+};
+
+export function Dropdown({
+  children,
+  trigger,
+  className,
+  sideOffset = 0,
+  collisionPadding = { left: 16, right: 16 },
+  side = 'bottom',
+  ...rest
+}: Props) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
+      <DropdownMenu.Portal className="bg-danger">
+        <DropdownMenu.Content
+          className={mergeClasses(
+            'flex min-w-[180px] flex-col gap-0.5 rounded-md border border-default bg-default p-1 shadow-md',
+            'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
+            className
+          )}
+          side={side}
+          sideOffset={sideOffset}
+          collisionPadding={collisionPadding}
+          {...rest}>
+          <DropdownMenu.Arrow asChild>
+            <div className="relative -top-1 h-2.5 w-2.5 rotate-45 border-b border-r border-default bg-default" />
+          </DropdownMenu.Arrow>
+          {children}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+export { Item };

--- a/docs/ui/components/Form/Checkbox.tsx
+++ b/docs/ui/components/Form/Checkbox.tsx
@@ -1,0 +1,46 @@
+import { mergeClasses } from '@expo/styleguide';
+import { CheckIcon } from '@expo/styleguide-icons';
+import { forwardRef, Ref, InputHTMLAttributes, ReactNode } from 'react';
+
+import { P } from '../Text';
+
+type Props = InputHTMLAttributes<HTMLInputElement> & {
+  label?: ReactNode;
+};
+
+export const Checkbox = forwardRef(function Checkbox(
+  { className, label, id, disabled, checked, ...rest }: Props,
+  ref?: Ref<HTMLInputElement>
+) {
+  return (
+    <div className={mergeClasses('flex items-center gap-2 relative', className)}>
+      {checked && (
+        <CheckIcon className="absolute w-4 px-0.5 text-palette-white [&_path]:!stroke-[3px]" />
+      )}
+      <input
+        type="checkbox"
+        id={id}
+        ref={ref}
+        checked={checked}
+        data-label={label}
+        disabled={disabled}
+        className={mergeClasses(
+          'rounded-sm border-palette-gray8 bg-default transition-colors border w-4 h-4',
+          !disabled &&
+            'focus-within:ring-palette-blue10 hocus:cursor-pointer hocus:border-palette-blue10 hocus:bg-palette-blue3',
+          !disabled && 'dark:focus:ring-palette-blue8 dark:hocus:border-palette-blue8',
+          'checked:bg-palette-blue10 checked:border-palette-blue10 checked:hocus:bg-palette-blue10',
+          'dark:checked:bg-palette-blue8 dark:checked:hocus:bg-palette-blue8'
+        )}
+        {...rest}
+      />
+      {label && (
+        <label
+          htmlFor={id}
+          className={mergeClasses('select-none text-default', !disabled && 'hocus:cursor-pointer')}>
+          {typeof label === 'string' ? <P>{label}</P> : label}
+        </label>
+      )}
+    </div>
+  );
+});

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -6,9 +6,14 @@ export type SnippetActionProps = ButtonProps & {
   alwaysDark?: boolean;
 };
 
-export const SnippetAction = (props: SnippetActionProps) => {
-  const { children, leftSlot, rightSlot, alwaysDark = false, ...rest } = props;
-
+export const SnippetAction = ({
+  children,
+  leftSlot,
+  rightSlot,
+  className,
+  alwaysDark = false,
+  ...rest
+}: SnippetActionProps) => {
   return (
     <Button
       size="xs"
@@ -20,10 +25,15 @@ export const SnippetAction = (props: SnippetActionProps) => {
         alwaysDark &&
           'dark-theme border-transparent bg-[transparent] hocus:shadow-xs hocus:border-palette-gray9 hocus:bg-palette-gray5',
         !alwaysDark &&
-          'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4 hocus:bg-subtle hocus:shadow-none'
+          'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4 hocus:bg-subtle hocus:shadow-none',
+        className
       )}
       {...rest}>
-      <FOOTNOTE className={mergeClasses(alwaysDark && '!text-palette-white')}>{children}</FOOTNOTE>
+      {children && (
+        <FOOTNOTE className={mergeClasses(alwaysDark && '!text-palette-white')}>
+          {children}
+        </FOOTNOTE>
+      )}
     </Button>
   );
 };

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -1,5 +1,7 @@
-import { mergeClasses } from '@expo/styleguide';
+import { mergeClasses, Themes } from '@expo/styleguide';
 import { forwardRef, PropsWithChildren } from 'react';
+
+import { useCodeBlockSettingsContext } from '~/providers/CodeBlockSettingsProvider';
 
 export type SnippetContentProps = PropsWithChildren<{
   alwaysDark?: boolean;
@@ -8,17 +10,23 @@ export type SnippetContentProps = PropsWithChildren<{
 }>;
 
 export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
-  ({ children, className, alwaysDark = false, hideOverflow = false }: SnippetContentProps, ref) => (
-    <div
-      ref={ref}
-      className={mergeClasses(
-        'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
-        'prose-code:!px-0',
-        alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
-        hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
-        className
-      )}>
-      {children}
-    </div>
-  )
+  ({ children, className, alwaysDark = false, hideOverflow = false }: SnippetContentProps, ref) => {
+    const { preferredTheme, wordWrap } = useCodeBlockSettingsContext();
+
+    return (
+      <div
+        ref={ref}
+        className={mergeClasses(
+          preferredTheme === Themes.DARK && 'dark-theme',
+          wordWrap && '!whitespace-pre-wrap !break-words',
+          'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
+          'prose-code:!px-0',
+          alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
+          hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
+          className
+        )}>
+        {children}
+      </div>
+    );
+  }
 );

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -36,7 +36,7 @@ export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
       }>
       <Dropdown.Item
         preventAutoClose
-        label="Force dark theme"
+        label="Use dark theme"
         onSelect={onThemeChange}
         rightSlot={
           <Checkbox

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -1,0 +1,57 @@
+import { Themes } from '@expo/styleguide';
+import { DotsVerticalIcon } from '@expo/styleguide-icons';
+
+import { Checkbox } from '../../Form/Checkbox';
+import { SnippetAction, SnippetActionProps } from '../SnippetAction';
+
+import { useCodeBlockSettingsContext } from '~/providers/CodeBlockSettingsProvider';
+import * as Dropdown from '~/ui/components/Dropdown';
+
+export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
+  const { preferredTheme, setPreferredTheme, wordWrap, setWordWrap } =
+    useCodeBlockSettingsContext();
+
+  const onThemeChange = () => {
+    if (preferredTheme === Themes.AUTO) {
+      setPreferredTheme(Themes.DARK);
+    } else if (preferredTheme === Themes.DARK) {
+      setPreferredTheme(Themes.AUTO);
+    }
+  };
+
+  const onWordWrapChange = () => {
+    setWordWrap(!wordWrap);
+  };
+
+  return (
+    <Dropdown.Dropdown
+      trigger={
+        <div>
+          <SnippetAction
+            className="px-3 min-w-[44px]"
+            leftSlot={<DotsVerticalIcon className="shrink-0 icon-md text-icon-secondary" />}
+            {...rest}
+          />
+        </div>
+      }>
+      <Dropdown.Item
+        preventAutoClose
+        label="Force dark theme"
+        onSelect={onThemeChange}
+        rightSlot={
+          <Checkbox
+            checked={preferredTheme === Themes.DARK}
+            readOnly
+            className="pointer-events-none"
+          />
+        }
+      />
+      <Dropdown.Item
+        preventAutoClose
+        label="Wrap long lines"
+        onSelect={onWordWrapChange}
+        rightSlot={<Checkbox checked={wordWrap} readOnly className="pointer-events-none" />}
+      />
+    </Dropdown.Dropdown>
+  );
+};

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -6,6 +6,8 @@ import { Snippet } from '../Snippet';
 import { SnippetContent } from '../SnippetContent';
 import { SnippetHeader } from '../SnippetHeader';
 
+import { SettingsAction } from '~/ui/components/Snippet/actions/SettingsAction';
+
 const randomCommitHash = () => Math.random().toString(36).slice(2, 9);
 
 // These types come from `react-diff-view` library
@@ -49,7 +51,9 @@ export const DiffBlock = ({ source, raw }: Props) => {
     newPath,
   }: RenderLine) => (
     <Snippet key={oldRevision + '-' + newRevision}>
-      <SnippetHeader title={newPath} Icon={Copy07Icon} />
+      <SnippetHeader title={newPath} Icon={Copy07Icon}>
+        <SettingsAction />
+      </SnippetHeader>
       <SnippetContent className="p-0" hideOverflow>
         <Diff viewType="unified" diffType={type} hunks={hunks}>
           {(hunks: any[]) => hunks.map(hunk => <Hunk key={hunk.content} hunk={hunk} />)}

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -12,6 +12,7 @@ import { cleanCopyValue } from '~/components/base/code';
 import { PageApiVersionContextType, usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { CopyAction } from '~/ui/components/Snippet/actions/CopyAction';
+import { SettingsAction } from '~/ui/components/Snippet/actions/SettingsAction';
 
 const DEFAULT_PLATFORM = 'android';
 const { LATEST_VERSION } = versions;
@@ -105,6 +106,7 @@ export const SnackInline = ({
             type="submit">
             {buttonTitle || 'Open in Snack'}
           </SnippetAction>
+          <SettingsAction />
         </form>
       </SnippetHeader>
       <SnippetContent ref={contentRef} className={mergeClasses('p-0', contentHidden && 'hidden')}>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -503,6 +503,26 @@
     "@expo/styleguide-base" "^1.0.1"
     tailwind-merge "^1.13.2"
 
+"@floating-ui/core@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
+  integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
+
+"@floating-ui/dom@^0.5.3":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
+  integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
+  dependencies:
+    "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/react-dom@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-0.7.2.tgz#0bf4ceccb777a140fc535c87eb5d6241c8e89864"
+  integrity sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==
+  dependencies:
+    "@floating-ui/dom" "^0.5.3"
+    use-isomorphic-layout-effect "^1.1.1"
+
 "@gitbeaker/core@^35.8.1":
   version "35.8.1"
   resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-35.8.1.tgz#b4ce2d08d344ff50e76c38ff81b800bec6dfe851"
@@ -1128,6 +1148,25 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-arrow@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.0.tgz#c461f4c2cab3317e3d42a1ae62910a4cbb0192a1"
+  integrity sha512-1MUuv24HCdepi41+qfv125EwMuxgQ+U+h0A9K3BjCO/J8nVRREKHHpkD9clwfnjEDk9hgGzCnff4aUKCPiRepw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.0"
+
+"@radix-ui/react-collection@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.0.tgz#0ec4c72fabd35a03b5787075ac799e3b17ca5710"
+  integrity sha512-8i1pf5dKjnq90Z8udnnXKzdCEV3/FYrfw0n/b6NvB6piXEn3fO1bOh7HBcpG8XrnIXzxlYu2oCcR38QpyLS/mg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+
 "@radix-ui/react-compose-refs@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
@@ -1198,6 +1237,13 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.5"
 
+"@radix-ui/react-direction@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.0.tgz#a2e0b552352459ecf96342c79949dd833c1e6e45"
+  integrity sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/react-dismissable-layer@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz#35b7826fa262fd84370faef310e627161dffa76b"
@@ -1221,6 +1267,20 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-dropdown-menu@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-1.0.0.tgz#687959e1bcdd5e8eb0de406484aff28d0974c593"
+  integrity sha512-Ptben3TxPWrZLbInO7zjAK73kmjYuStsxfg6ujgt+EywJyREoibhZYnsSNqC+UiOtl4PdW/MOHhxVDtew5fouQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-menu" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
 
 "@radix-ui/react-focus-guards@1.0.0":
   version "1.0.0"
@@ -1272,6 +1332,47 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
 
+"@radix-ui/react-menu@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-1.0.0.tgz#f1e07778c0011aa0c5be260fee88491d3aadf261"
+  integrity sha512-icW4C64T6nHh3Z4Q1fxO1RlSShouFF4UpUmPV8FLaJZfphDljannKErDuALDx4ClRLihAPZ9i+PrLNPoWS2DMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.0"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-popper" "1.0.0"
+    "@radix-ui/react-portal" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-roving-focus" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.4"
+
+"@radix-ui/react-popper@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.0.0.tgz#fb4f937864bf39c48f27f55beee61fa9f2bef93c"
+  integrity sha512-k2dDd+1Wl0XWAMs9ZvAxxYsB9sOsEhrFQV4CINd7IUZf0wfdye4OHen9siwxvZImbzhgVeKTJi68OQmPRvVdMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "0.7.2"
+    "@radix-ui/react-arrow" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-use-rect" "1.0.0"
+    "@radix-ui/react-use-size" "1.0.0"
+    "@radix-ui/rect" "1.0.0"
+
 "@radix-ui/react-portal@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.0.tgz#7220b66743394fabb50c55cb32381395cc4a276b"
@@ -1321,6 +1422,22 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-roving-focus@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.0.tgz#aadeb65d5dbcdbdd037078156ae1f57c2ff754ee"
+  integrity sha512-lHvO4MhvoWpeNbiJAoyDsEtbKqP2jkkdwsMVJ3kfqbkC71J/aXE6Th6gkZA1xHEqSku+t+UgoDjvE7Z3gsBpcg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
 
 "@radix-ui/react-slot@1.0.0":
   version "1.0.0"
@@ -1395,6 +1512,29 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
   integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz#b040cc88a4906b78696cd3a32b075ed5b1423b3e"
+  integrity sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.0"
+
+"@radix-ui/react-use-size@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz#a0b455ac826749419f6354dc733e2ca465054771"
+  integrity sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/rect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.0.tgz#0dc8e6a829ea2828d53cbc94b81793ba6383bf3c"
+  integrity sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -9511,6 +9651,11 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# Why

Add global settings menu to the code blocks and Snippets, allowing degree of personalisation, i.e force dark theme (even in light mode) and wrap lines display. 

We plan to improve the capabilities in time, if you have anything in your mind, let us know!

Stacked on #25604 (since I wanted to reuse local storage helper added in this PR)

# How

This PR adds global code block settings menu which provides an ability to alter code block display and appearance for users. The data is preserved in local storage and changes applies immediately to all elements on the pages. The menu should be fully accessible.

I had also to refactor one of the code block instances to the function component to be able to utilize introduced hook.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

https://github.com/expo/expo/assets/719641/d189cb06-2870-4e48-b5e3-c9edb944b1d0
