### PR TITLE
[sqlite] fix crash when access to finalize statements

### DIFF
--- a/apps/test-suite/tests/SQLiteNext.ts
+++ b/apps/test-suite/tests/SQLiteNext.ts
@@ -272,6 +272,24 @@ CREATE TABLE IF NOT EXISTS Posts (post_id INTEGER PRIMARY KEY NOT NULL, content 
       await db.runAsync('PRAGMA foreign_keys = OFF');
       await db.closeAsync();
     });
+
+    it('should throw when accessing a finalized statement', async () => {
+      const db = await SQLite.openDatabaseAsync(':memory:');
+      await db.execAsync(`
+DROP TABLE IF EXISTS Users;
+CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));
+`);
+
+      const statement = await db.prepareAsync('INSERT INTO Nulling (x, y) VALUES (?, ?)');
+      await statement.finalizeAsync();
+      let error = null;
+      try {
+        await statement.runAsync(null, null);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.toBeNull();
+    });
   });
 
   describe('Statement parameters bindings', () => {

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `expo-sqlite/next` crashes when access to finalized statements. ([#25623](https://github.com/expo/expo/pull/25623) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - [iOS] Replace legacy `FileSystem` interfaces usage with core `FileSystemUtilities`. ([#25495](https://github.com/expo/expo/pull/25495) by [@alanhughes](https://github.com/alanjhughes))

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -5,6 +5,8 @@ package expo.modules.sqlite
 import expo.modules.kotlin.sharedobjects.SharedRef
 
 internal class NativeDatabase(val dbName: String, val openOptions: OpenDatabaseOptions) : SharedRef<NativeDatabaseBinding>(NativeDatabaseBinding()) {
+  var isClosed = false
+
   override fun equals(other: Any?): Boolean {
     return other is NativeDatabase && this.ref == other.ref
   }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
@@ -5,6 +5,8 @@ package expo.modules.sqlite
 import expo.modules.kotlin.sharedobjects.SharedRef
 
 internal class NativeStatement : SharedRef<NativeStatementBinding>(NativeStatementBinding()) {
+  var isFinalized = false
+
   override fun equals(other: Any?): Boolean {
     return other is NativeStatement && this.ref == other.ref
   }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLExceptions.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLExceptions.kt
@@ -24,3 +24,6 @@ internal class SQLiteErrorException(message: String) :
 @DoNotStrip
 internal class InvalidConvertibleException(message: String) :
   CodedException(message)
+
+internal class AccessClosedResourceException :
+  CodedException("Access to closed resource")

--- a/packages/expo-sqlite/ios/Exceptions.swift
+++ b/packages/expo-sqlite/ios/Exceptions.swift
@@ -52,6 +52,12 @@ internal class InvalidArgumentsException: Exception {
   }
 }
 
+internal class AccessClosedResourceException: Exception {
+  override var reason: String {
+    "Access to closed resource"
+  }
+}
+
 internal class SQLiteErrorException: GenericException<String> {
   override var code: String {
     "ERR_INTERNAL_SQLITE_ERROR"

--- a/packages/expo-sqlite/ios/NativeDatabase.swift
+++ b/packages/expo-sqlite/ios/NativeDatabase.swift
@@ -5,6 +5,7 @@ import ExpoModulesCore
 final class NativeDatabase: SharedRef<OpaquePointer?>, Equatable, Hashable {
   let dbName: String
   let openOptions: OpenDatabaseOptions
+  var isClosed = false
 
   init(_ pointer: OpaquePointer?, dbName: String, openOptions: OpenDatabaseOptions) {
     self.dbName = dbName

--- a/packages/expo-sqlite/ios/NativeStatement.swift
+++ b/packages/expo-sqlite/ios/NativeStatement.swift
@@ -4,6 +4,7 @@ import ExpoModulesCore
 
 final class NativeStatement: SharedObject, Equatable {
   var pointer: OpaquePointer?
+  var isFinalized = false
 
   // MARK: - Equatable
 


### PR DESCRIPTION
# Why

originally, calling methods to a finalized statement will cause app crash, because it accesses to a dangling pointer. it's the developer's responsibility for not accessing a finalized statement. but i think we can throw errors rather than hard crash.

# How

add a flag to check the database and statement status.

# Test Plan

add a test suite test case

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
