### PR TITLE
[docs] added bundle splitting section to SDK 50 metro

### DIFF
--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -546,13 +546,11 @@ Expo's Metro config injects build settings that can be used in the client bundle
 
 > This feature is web-only in SDK 50.
 
-Starting in SDK 50, Expo CLI will automatically split web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (default in Expo Router).
+In SDK 50, Expo CLI automatically splits web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (available by default in Expo Router).
 
-Shared dependencies of async bundles will be merged into a single chunk to reduce the number of requests. For example, if you have two async bundles that both import `lodash`, then `lodash` will be merged into a single initial chunk.
+Shared dependencies of async bundles are merged into a single chunk to reduce the number of requests. For example, if you have two async bundles that import `lodash`, then the library is merged into a single initial chunk.
 
-As of SDK 50, the chunk splitting heuristic cannot be customized.
-
-Example:
+As of SDK 50, the chunk splitting heuristic cannot be customized. For example:
 
 ```js
 import '@expo/metro-runtime';
@@ -563,7 +561,7 @@ import('./math').then(math => {
 });
 ```
 
-When you run `npx expo export -p web`, the bundles will be split into multiple files, and the entry bundle will be added to the main HTML file.
+When you run `npx expo export -p web`, the bundles are split into multiple files, and the entry bundle is added to the main HTML file.
 
 ## Bare workflow setup
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -542,6 +542,29 @@ Expo's Metro config injects build settings that can be used in the client bundle
 
 > These environment variables will not be defined in test environments!
 
+## Bundle splitting
+
+> This feature is web-only in SDK 50.
+
+Starting in SDK 50, Expo CLI will automatically split web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (default in Expo Router).
+
+Shared dependencies of async bundles will be merged into a single chunk to reduce the number of requests. For example, if you have two async bundles that both import `lodash`, then `lodash` will be merged into a single initial chunk.
+
+As of SDK 50, the chunk splitting heuristic cannot be customized.
+
+Example:
+
+```js
+import '@expo/metro-runtime';
+
+// This will be split into a separate chunk.
+import('./math').then(math => {
+  console.log(math.add(1, 2));
+});
+```
+
+When you run `npx expo export -p web`, the bundles will be split into multiple files, and the entry bundle will be added to the main HTML file.
+
 ## Bare workflow setup
 
 > This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/workflow/prebuild) for fully automated setup.


### PR DESCRIPTION
# Why

Add some simple mention for the new bundle splitting functionality in Metro web.

This isn't currently part of Expo Router yet so the mention is very simple.
