### PR TITLE
[sqlite] more sqlite next api fix

### DIFF
--- a/apps/test-suite/tests/SQLiteNext.ts
+++ b/apps/test-suite/tests/SQLiteNext.ts
@@ -82,6 +82,22 @@ CREATE TABLE IF NOT EXISTS SomeTable (id INTEGER PRIMARY KEY NOT NULL, name VARC
 
       await db.closeAsync();
     });
+
+    it('should support utf-8', async () => {
+      const db = await SQLite.openDatabaseAsync(':memory:');
+      await db.execAsync(
+        'CREATE TABLE translations (id INTEGER PRIMARY KEY NOT NULL, key TEXT, value TEXT);'
+      );
+      const statement = await db.prepareAsync(
+        'INSERT INTO translations (key, value) VALUES (?, ?)'
+      );
+      await statement.runAsync('hello', '哈囉');
+      await statement.finalizeAsync();
+
+      const result = await db.getAsync<any>('SELECT * FROM translations');
+      expect(result.key).toBe('hello');
+      expect(result.value).toBe('哈囉');
+    });
   });
 
   describe('File system tests', () => {

--- a/apps/test-suite/tests/SQLiteNext.ts
+++ b/apps/test-suite/tests/SQLiteNext.ts
@@ -296,7 +296,7 @@ DROP TABLE IF EXISTS Users;
 CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));
 `);
 
-      const statement = await db.prepareAsync('INSERT INTO Nulling (x, y) VALUES (?, ?)');
+      const statement = await db.prepareAsync('INSERT INTO Users (user_id, name) VALUES (?, ?)');
       await statement.finalizeAsync();
       let error = null;
       try {
@@ -304,7 +304,7 @@ CREATE TABLE IF NOT EXISTS Users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       } catch (e) {
         error = e;
       }
-      expect(error).not.toBeNull();
+      expect(error.toString()).toMatch(/Access to closed resource/);
     });
   });
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `expo-sqlite/next` crashes when access to finalized statements. ([#25623](https://github.com/expo/expo/pull/25623) by [@kudo](https://github.com/kudo))
+- Fixed `expo-sqlite/next` UTF-8 text issue and `:memory:` database issue. ([#25637](https://github.com/expo/expo/pull/25637) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
@@ -11,6 +11,8 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
 import java.io.IOException
 
+private const val MEMORY_DB_NAME = ":memory:"
+
 @Suppress("unused")
 class SQLiteModuleNext : Module() {
   private val cachedDatabases: MutableList<NativeDatabase> = mutableListOf()
@@ -179,6 +181,9 @@ class SQLiteModuleNext : Module() {
 
   @Throws(OpenDatabaseException::class)
   private fun pathForDatabaseName(name: String): String {
+    if (name == MEMORY_DB_NAME) {
+      return name
+    }
     try {
       val directory = File("${context.filesDir}${File.separator}SQLite")
       ensureDirExists(directory)
@@ -404,6 +409,9 @@ class SQLiteModuleNext : Module() {
       throw DeleteDatabaseException(dbName)
     }
 
+    if (dbName == MEMORY_DB_NAME) {
+      return
+    }
     val dbFile = File(pathForDatabaseName(dbName))
     if (!dbFile.exists()) {
       throw DatabaseNotFoundException(dbName)

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -499,7 +499,7 @@ public final class SQLiteModuleNext: Module {
     case let param as Double:
       sqlite3_bind_double(instance, index, param)
     case let param as String:
-      sqlite3_bind_text(instance, index, param, Int32(param.count), SQLITE_TRANSIENT)
+      sqlite3_bind_text(instance, index, param, -1, SQLITE_TRANSIENT)
     case let param as Data:
       _ = param.withUnsafeBytes {
         sqlite3_bind_blob(instance, index, $0.baseAddress, Int32(param.count), SQLITE_TRANSIENT)

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -6,6 +6,7 @@ import sqlite3
 private typealias ColumnNames = [String]
 private typealias ColumnValues = [Any]
 private let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+private let MEMORY_DB_NAME = ":memory:"
 
 public final class SQLiteModuleNext: Module {
   // Store unmanaged (SQLiteModuleNext, Database) pairs for sqlite callbacks,
@@ -179,6 +180,9 @@ public final class SQLiteModuleNext: Module {
   }
 
   private func pathForDatabaseName(name: String) -> URL? {
+    if name == MEMORY_DB_NAME {
+      return URL(string: name)
+    }
     guard let fileSystem = appContext?.fileSystem else {
       return nil
     }
@@ -391,6 +395,9 @@ public final class SQLiteModuleNext: Module {
       throw DeleteDatabaseException(dbName)
     }
 
+    if dbName == MEMORY_DB_NAME {
+      return
+    }
     guard let path = pathForDatabaseName(name: dbName) else {
       throw Exceptions.FileSystemModuleNotFound()
     }


### PR DESCRIPTION
# Why

fix some problems finding from dogfooding and #25618

# How

- fix the `:memory:` db being accidentally created as a file.
- fix utf8 issue on ios
- fix incorrect test case from #25623

# Test Plan

- check that `:memory:` file should not be created
- add a test case for utf8

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
