### PR TITLE
[docs] Step: fix incorrect content appearance in dark mode

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -71,7 +71,7 @@ const Home = () => {
                 <RawH2>
                   <QuickStartIcon /> Quick Start
                 </RawH2>
-                <Terminal includeMargin={false} cmd={['$ npx create-expo-app my-app']} />
+                <Terminal cmd={['$ npx create-expo-app my-app']} />
               </div>
             </GridCell>
             <GridCell

--- a/docs/ui/components/Snippet/Snippet.tsx
+++ b/docs/ui/components/Snippet/Snippet.tsx
@@ -1,12 +1,10 @@
 import { mergeClasses } from '@expo/styleguide';
 import type { HTMLAttributes } from 'react';
 
-type SnippetProps = HTMLAttributes<HTMLDivElement> & {
-  includeMargin?: boolean;
-};
+type SnippetProps = HTMLAttributes<HTMLDivElement>;
 
-export const Snippet = ({ children, className, includeMargin = true, ...rest }: SnippetProps) => (
-  <div className={mergeClasses('flex flex-col', includeMargin && 'mb-4', className)} {...rest}>
+export const Snippet = ({ children, className, ...rest }: SnippetProps) => (
+  <div className={mergeClasses('flex flex-col mb-4 last:mb-0', className)} {...rest}>
     {children}
   </div>
 );

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -13,18 +13,11 @@ type TerminalProps = {
   cmd: string[];
   cmdCopy?: string;
   hideOverflow?: boolean;
-  includeMargin?: boolean;
   title?: string;
 };
 
-export const Terminal = ({
-  cmd,
-  cmdCopy,
-  hideOverflow,
-  includeMargin = true,
-  title = 'Terminal',
-}: TerminalProps) => (
-  <Snippet css={wrapperStyle} includeMargin={includeMargin}>
+export const Terminal = ({ cmd, cmdCopy, hideOverflow, title = 'Terminal' }: TerminalProps) => (
+  <Snippet css={wrapperStyle}>
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { HEADLINE } from '~/ui/components/Text';
+import { HEADLINE, P } from '~/ui/components/Text';
 
 type Props = PropsWithChildren<{
   label: string;
@@ -13,7 +13,7 @@ export const Step = ({ children, label }: Props) => {
         {label}
       </HEADLINE>
       <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
-        {children}
+        {typeof children === 'string' ? <P>{children}</P> : children}
       </div>
     </div>
   );


### PR DESCRIPTION
# Why

<img width="981" alt="Screenshot 2023-11-29 at 14 37 29" src="https://github.com/expo/expo/assets/719641/91341c33-5e0f-4b0a-8f5c-21a7b9b24596">

# How

This PR fixes the Step appearance when a bare string has been provided as content.

I have also removed the Terminal `includeMargin` prop, and replaced it with TW class which should ensure that if terminal is a last child in wrapper it will drop margin automatically.

# Test Plan

The changes have been tested locally.

# Preview

<img width="981" alt="Screenshot 2023-11-29 at 14 37 06" src="https://github.com/expo/expo/assets/719641/8f942934-c319-4ebb-b64e-d9e30407e3cf">

