### PR TITLE
feat(export): Split server and client code in web server output

### DIFF
--- a/apps/router-e2e/__e2e__/server/express.js
+++ b/apps/router-e2e/__e2e__/server/express.js
@@ -7,7 +7,8 @@ const express = require('express');
 const compression = require('compression');
 const morgan = require('morgan');
 
-const BUILD_DIR = path.join(__dirname, '../../dist-server');
+const CLIENT_BUILD_DIR = path.join(__dirname, '../../dist-server/client');
+const SERVER_BUILD_DIR = path.join(__dirname, '../../dist-server/server');
 
 const app = express();
 
@@ -19,10 +20,7 @@ app.disable('x-powered-by');
 process.env.NODE_ENV = 'production';
 
 app.use(
-  // Prevent access to expo functions as these may
-  // contain sensitive information.
-  [/^\/_expo\/functions($|\/)/, '/'],
-  express.static(BUILD_DIR, {
+  express.static(CLIENT_BUILD_DIR, {
     maxAge: '1h',
     extensions: ['html'],
   })
@@ -33,7 +31,7 @@ app.use(morgan('tiny'));
 app.all(
   '*',
   createRequestHandler({
-    build: BUILD_DIR,
+    build: SERVER_BUILD_DIR,
   })
 );
 const port = process.env.PORT || 3000;

--- a/docs/pages/preview/api-routes.mdx
+++ b/docs/pages/preview/api-routes.mdx
@@ -295,7 +295,7 @@ const { createRequestHandler } = require('@expo/server/adapter/netlify');
 
 const handler = createRequestHandler({
   /* @info Points to the root `dist/` (output) folder */
-  build: require('path').join(__dirname, '../../dist'),
+  build: require('path').join(__dirname, '../../dist/server'),
   /* @end */
   mode: process.env.NODE_ENV,
 });
@@ -313,7 +313,7 @@ Create a Netlify configuration file at the root of your project to redirect all 
 [build]
   command = "expo export -p web"
   functions = "netlify/functions"
-  publish = "dist"
+  publish = "dist/client"
 
 [[redirects]]
   from = "/*"
@@ -322,10 +322,10 @@ Create a Netlify configuration file at the root of your project to redirect all 
 
 [functions]
   # Include everything to ensure dynamic routes can be used.
-  included_files = ["dist/**/*.html", "dist/_expo/functions/**/*", "dist/_expo/routes.json"]
+  included_files = ["dist/server/**/*"]
 
 [[headers]]
-  for = "/dist/_expo/functions/*"
+  for = "/dist/server/_expo/functions/*"
   [headers.values]
     # Set to 60 seconds as an example.
     "Cache-Control" = "public, max-age=60, s-maxage=60"
@@ -377,7 +377,7 @@ const { createRequestHandler } = require('@expo/server/adapter/vercel');
 
 module.exports = createRequestHandler({
   /* @info Points to the root `dist/` (output) folder */
-  build: require('path').join(__dirname, '../../dist'),
+  build: require('path').join(__dirname, '../dist/server'),
   /* @end */
   mode: process.env.NODE_ENV,
 });
@@ -401,23 +401,18 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "dist/client"
       }
     },
     {
       "src": "api/index.js",
       "use": "@vercel/node",
       "config": {
-        "includeFiles": ["dist/**"]
+        "includeFiles": ["dist/server/**"]
       }
     }
   ],
   "routes": [
-    {
-      "src": "/_expo/functions/.*",
-      "dest": "/404",
-      "status": 404
-    },
     {
       "handle": "filesystem"
     },
@@ -429,31 +424,21 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
 }
 ```
 
-The **legacy** version of the **vercel.json** needs a `@vercel/static-build` runtime to serve your assets from the **dist** output directory.
+The **legacy** version of the **vercel.json** needs a `@vercel/static-build` runtime to serve your assets from the **dist/client** output directory.
 
 </Tab>
 <Tab label="vercel.json v3">
 
-{/* prettier-ignore */}
-> **warning** When used as is, this **vercel.json** configuration makes server code in **/dist/_expo/functions/&#42;** publicly accessible.
-
 ```json vercel.json
 {
   "buildCommand": "expo export -p web",
-  "outputDirectory": "dist",
+  "outputDirectory": "dist/client",
   "functions": {
     "api/index.js": {
       "runtime": "@vercel/node@3.0.11",
-      "includeFiles": "dist/**"
+      "includeFiles": "dist/server/**"
     }
   },
-  "redirects": [
-    {
-      "source": "/_expo/functions/(.*)",
-      "destination": "/404",
-      "statusCode": 404
-    }
-  ],
   "rewrites": [
     {
       "source": "/(.*)",
@@ -463,7 +448,7 @@ The **legacy** version of the **vercel.json** needs a `@vercel/static-build` run
 }
 ```
 
-The newer version of the **vercel.json** does not use `routes` and `builds` configuration options anymore, and serves your public assets from the **dist** output directory automatically.
+The newer version of the **vercel.json** does not use `routes` and `builds` configuration options anymore, and serves your public assets from the **dist/client** output directory automatically.
 
 </Tab>
 </Tabs>

--- a/docs/pages/preview/api-routes.mdx
+++ b/docs/pages/preview/api-routes.mdx
@@ -236,7 +236,8 @@ const express = require('express');
 const compression = require('compression');
 const morgan = require('morgan');
 
-const BUILD_DIR = path.join(process.cwd(), 'dist');
+const CLIENT_BUILD_DIR = path.join(process.cwd(), 'dist/client');
+const SERVER_BUILD_DIR = path.join(process.cwd(), 'dist/server');
 
 const app = express();
 
@@ -248,10 +249,7 @@ app.disable('x-powered-by');
 process.env.NODE_ENV = 'production';
 
 app.use(
-  // Prevent access to expo functions as these may
-  // contain sensitive information.
-  [/^\/_expo\/functions($|\/)/, '/'],
-  express.static(BUILD_DIR, {
+  express.static(CLIENT_BUILD_DIR, {
     maxAge: '1h',
     extensions: ['html'],
   })
@@ -262,7 +260,7 @@ app.use(morgan('tiny'));
 app.all(
   '*',
   createRequestHandler({
-    build: BUILD_DIR,
+    build: SERVER_BUILD_DIR,
   })
 );
 const port = process.env.PORT || 3000;

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Remove unused Metro `extraNodeModules` augmentation for web resolution in favor of standard aliases. ([#25506](https://github.com/expo/expo/pull/25506) by [@EvanBacon](https://github.com/EvanBacon))
 - Consolidate logic for resolving Node.js built-in shims in browser environments. ([#25511](https://github.com/expo/expo/pull/25511) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))
+- Split web server output into `server/` and `client/` subfolders when exporting. ([#25640](https://github.com/expo/expo/pull/25640) by [@kitten](https://github.com/kitten))
 
 ## 0.10.16 — 2023-11-24
 

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -240,31 +240,31 @@ describe('server-output', () => {
         .filter(Boolean);
 
       // The wrapper should not be included as a route.
-      expect(files).not.toContain('+html.html');
-      expect(files).not.toContain('_layout.html');
+      expect(files).not.toContain('server/+html.html');
+      expect(files).not.toContain('server/_layout.html');
 
       // Has routes.json
-      expect(files).toContain('_expo/routes.json');
+      expect(files).toContain('server/_expo/routes.json');
 
       // Has functions
-      expect(files).toContain('_expo/functions/methods+api.js');
-      expect(files).toContain('_expo/functions/api/[dynamic]+api.js');
-      expect(files).toContain('_expo/functions/api/externals+api.js');
+      expect(files).toContain('server/_expo/functions/methods+api.js');
+      expect(files).toContain('server/_expo/functions/api/[dynamic]+api.js');
+      expect(files).toContain('server/_expo/functions/api/externals+api.js');
 
       // TODO: We shouldn't export this
-      expect(files).toContain('_expo/functions/api/empty+api.js');
+      expect(files).toContain('server/_expo/functions/api/empty+api.js');
 
       // Has single variation of group file
-      expect(files).toContain('(alpha)/beta.html');
-      expect(files).not.toContain('beta.html');
+      expect(files).toContain('server/(alpha)/beta.html');
+      expect(files).not.toContain('server/beta.html');
 
       // Injected by framework
-      expect(files).toContain('_sitemap.html');
-      expect(files).toContain('+not-found.html');
+      expect(files).toContain('server/_sitemap.html');
+      expect(files).toContain('server/+not-found.html');
 
       // Normal routes
-      expect(files).toContain('index.html');
-      expect(files).toContain('blog/[post].html');
+      expect(files).toContain('server/index.html');
+      expect(files).toContain('server/blog/[post].html');
     },
     5 * 1000
   );

--- a/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
@@ -1,10 +1,29 @@
+import { getConfig } from '@expo/config';
 import { vol } from 'memfs';
 
+import { asMock } from '../../__tests__/asMock';
 import { exportAppAsync } from '../exportApp';
+import { unstable_exportStaticAsync } from '../exportStaticAsync';
+import { ExportAssetMap } from '../saveAssets';
 
 jest.mock('../../log');
 
+jest.mock('../exportStaticAsync', () => ({
+  unstable_exportStaticAsync: jest.fn(
+    async (_root: string, { files }: { files: ExportAssetMap }) => {
+      files.set('output-test.txt', {
+        contents: 'test',
+        targetDomain: 'server',
+      });
+    }
+  ),
+}));
+
 jest.mock('@expo/config', () => ({
+  getNameFromConfig: () => ({
+    appName: 'my-app',
+    webName: 'my-app',
+  }),
   getConfig: jest.fn(() => ({
     pkg: {},
     exp: {
@@ -17,7 +36,7 @@ jest.mock('@expo/config', () => ({
 
 jest.mock('../fork-bundleAsync', () => ({
   createBundlesAsync: jest.fn(
-    async (projectRoot, projectConfig, { platforms }: { platforms: string[] }) =>
+    async (_projectRoot, _projectConfig, { platforms }: { platforms: string[] }) =>
       platforms.reduce(
         (prev, platform) => ({
           ...prev,
@@ -25,6 +44,7 @@ jest.mock('../fork-bundleAsync', () => ({
             artifacts: [
               {
                 type: 'js',
+                metadata: { isAsync: false },
                 originFilename: 'index.js',
                 filename: `_expo/static/js/${platform}/index-xxx.js`,
                 source:
@@ -51,6 +71,7 @@ jest.mock('../fork-bundleAsync', () => ({
                 name: 'icon',
                 type: 'png',
                 fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
+                scales: [],
               },
             ],
           },
@@ -61,11 +82,11 @@ jest.mock('../fork-bundleAsync', () => ({
 }));
 
 describe(exportAppAsync, () => {
-  afterAll(() => {
+  afterEach(() => {
     vol.reset();
   });
 
-  it(`exports an app`, async () => {
+  it(`exports an app for iOS`, async () => {
     const outputDir = '/dist/';
 
     vol.fromJSON(
@@ -98,5 +119,89 @@ describe(exportAppAsync, () => {
       '/icon.png': 'icon',
       '/package.json': expect.any(String),
     });
+  });
+
+  it(`exports an app for web in SPA mode`, async () => {
+    asMock(getConfig).mockReturnValue({
+      // @ts-expect-error
+      exp: { web: { bundler: 'metro' } },
+    });
+
+    const outputDir = '/dist/';
+
+    vol.fromJSON(
+      {
+        'icon.png': 'icon',
+        'package.json': JSON.stringify({ dependencies: { expo: '49.0.0' } }),
+        'public/index.html': '<!DOCTYPE html>\n<html>\n<head></head>\n<body></body>\n</html>\n',
+      },
+      '/'
+    );
+
+    await exportAppAsync('/', {
+      outputDir,
+      minify: true,
+      platforms: ['web'],
+      dev: false,
+      dumpAssetmap: true,
+      sourceMaps: true,
+      clear: false,
+    });
+
+    expect(vol.toJSON()).toStrictEqual({
+      '/dist/_expo/static/css/bc6aa0a69dcebf8e8cac1faa76705756.css': expect.stringMatching(/cyan/),
+      '/dist/_expo/static/js/web/index-xxx.js': expect.stringMatching(/sourceMappingURL/),
+      '/dist/_expo/static/js/web/index-xxx.js.map': 'web_map',
+      '/dist/debug.html': expect.stringMatching(/<script/),
+      '/dist/index.html': expect.stringMatching(/html/),
+      '/dist/assetmap.json': expect.any(String),
+      '/dist/metadata.json': expect.stringContaining('"fileMetadata"'),
+
+      '/icon.png': 'icon',
+      '/package.json': expect.any(String),
+      '/public/index.html': expect.any(String),
+    });
+
+    expect(unstable_exportStaticAsync).not.toHaveBeenCalled();
+  });
+
+  it(`exports an app for web in server mode`, async () => {
+    asMock(getConfig).mockReturnValue({
+      // @ts-expect-error
+      exp: { web: { bundler: 'metro', output: 'server' } },
+    });
+
+    const outputDir = '/dist/';
+
+    vol.fromJSON(
+      {
+        'icon.png': 'icon',
+        'package.json': JSON.stringify({ dependencies: { expo: '49.0.0' } }),
+        'public/index.html': '<!DOCTYPE html>\n<html>\n<head></head>\n<body></body>\n</html>\n',
+      },
+      '/'
+    );
+
+    await exportAppAsync('/', {
+      outputDir,
+      minify: true,
+      platforms: ['web'],
+      dev: false,
+      dumpAssetmap: true,
+      sourceMaps: true,
+      clear: false,
+    });
+
+    expect(vol.toJSON()).toStrictEqual({
+      '/dist/server/output-test.txt': 'test',
+      '/dist/client/index.html': expect.stringMatching(/html/),
+      '/dist/index.html': expect.stringMatching(/html/),
+
+      '/icon.png': 'icon',
+      '/package.json': expect.any(String),
+      '/public/index.html': expect.any(String),
+    });
+
+    expect(unstable_exportStaticAsync).toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -214,33 +214,31 @@ describe(getHtmlFiles, () => {
 describe(getFilesToExportFromServerAsync, () => {
   it(`should export from server async`, async () => {
     const renderAsync = jest.fn(async () => '');
-    expect([
-      // @ts-expect-error: downlevel iteration
-      ...(
-        await getFilesToExportFromServerAsync('/', {
-          includeGroupVariations: true,
-          manifest: {
-            initialRouteName: undefined,
-            screens: {
-              alpha: {
-                path: 'alpha',
-                screens: { index: '', second: 'second' },
-                initialRouteName: 'index',
-              },
-              '(app)': {
-                path: '(app)',
-                screens: { compose: 'compose', index: '', 'note/[note]': 'note/:note' },
-                initialRouteName: 'index',
-              },
-              '(auth)/sign-in': '(auth)/sign-in',
-              _sitemap: '_sitemap',
-              '[...404]': '*404',
-            },
+
+    const files = await getFilesToExportFromServerAsync('/', {
+      includeGroupVariations: true,
+      manifest: {
+        initialRouteName: undefined,
+        screens: {
+          alpha: {
+            path: 'alpha',
+            screens: { index: '', second: 'second' },
+            initialRouteName: 'index',
           },
-          renderAsync,
-        })
-      ).keys(),
-    ]).toEqual([
+          '(app)': {
+            path: '(app)',
+            screens: { compose: 'compose', index: '', 'note/[note]': 'note/:note' },
+            initialRouteName: 'index',
+          },
+          '(auth)/sign-in': '(auth)/sign-in',
+          _sitemap: '_sitemap',
+          '[...404]': '*404',
+        },
+      },
+      renderAsync,
+    });
+
+    expect([...files.keys()]).toEqual([
       'alpha/index.html',
       'alpha/second.html',
       '(app)/compose.html',
@@ -254,5 +252,7 @@ describe(getFilesToExportFromServerAsync, () => {
       '_sitemap.html',
       '[...404].html',
     ]);
+
+    expect([...files.values()].every((file) => file.webTarget === 'client')).toBeTruthy();
   });
 });

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -253,6 +253,6 @@ describe(getFilesToExportFromServerAsync, () => {
       '[...404].html',
     ]);
 
-    expect([...files.values()].every((file) => file.webTarget === 'client')).toBeTruthy();
+    expect([...files.values()].every((file) => file.targetDomain === 'client')).toBeTruthy();
   });
 });

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -174,7 +174,10 @@ export async function exportAppAsync(
 
       // Generate SPA-styled HTML file.
       // If web exists, then write the template HTML file.
-      files.set('index.html', { contents: html });
+      files.set('index.html', {
+        contents: html,
+        webTargetDomain: 'client',
+      });
     }
   }
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -135,8 +135,13 @@ export async function exportAppAsync(
 
   if (platforms.includes('web')) {
     if (useServerRendering) {
-      // TODO: Remove when this is abstracted into the files map
-      await copyPublicFolderAsync(publicPath, path.resolve(outputPath, 'client'));
+      // @ts-expect-error: server not on type yet
+      const exportServer = exp.web?.output === 'server';
+
+      if (exportServer) {
+        // TODO: Remove when this is abstracted into the files map
+        await copyPublicFolderAsync(publicPath, path.resolve(outputPath, 'client'));
+      }
 
       await unstable_exportStaticAsync(projectRoot, {
         files,
@@ -145,9 +150,8 @@ export async function exportAppAsync(
         minify,
         baseUrl,
         includeSourceMaps: sourceMaps,
-        // @ts-expect-error: server not on type yet
-        exportServer: exp.web?.output === 'server',
         routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
+        exportServer,
       });
     } else {
       // TODO: Unify with exportStaticAsync

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -17,7 +17,6 @@ import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/ro
 import { serializeHtmlWithAssets } from '../start/server/metro/serializeHtml';
 import { getBaseUrlFromExpoConfig } from '../start/server/middleware/metroOptions';
 import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTemplate';
-import { ensureDirectoryAsync } from '../utils/dir';
 import { env } from '../utils/env';
 import { setNodeEnv } from '../utils/nodeEnv';
 
@@ -61,11 +60,7 @@ export async function exportAppAsync(
   }
 
   const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
-
   const outputPath = path.resolve(projectRoot, outputDir);
-  const assetsPath = path.join(outputPath, 'assets');
-
-  await Promise.all([assetsPath].map(ensureDirectoryAsync));
 
   await copyPublicFolderAsync(publicPath, outputPath);
 
@@ -93,6 +88,7 @@ export async function exportAppAsync(
   // Can be empty during web-only SSG.
   if (bundleEntries.length) {
     // TODO: Use same asset system across platforms again.
+    // NOTE(kitten): Re. above, this is now using `files` except for iOS catalog output, which isn't used here
     const { assets, embeddedHashSet } = await exportAssetsAsync(projectRoot, {
       files,
       exp,

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -171,7 +171,7 @@ export async function exportAppAsync(
       // If web exists, then write the template HTML file.
       files.set('index.html', {
         contents: html,
-        webTarget: 'client',
+        targetDomain: 'client',
       });
     }
   }

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -88,7 +88,6 @@ export async function exportAppAsync(
   // Can be empty during web-only SSG.
   if (bundleEntries.length) {
     // TODO: Use same asset system across platforms again.
-    // NOTE(kitten): Re. above, this is now using `files` except for iOS catalog output, which isn't used here
     const { assets, embeddedHashSet } = await exportAssetsAsync(projectRoot, {
       files,
       exp,
@@ -172,7 +171,7 @@ export async function exportAppAsync(
       // If web exists, then write the template HTML file.
       files.set('index.html', {
         contents: html,
-        webTargetDomain: 'client',
+        webTarget: 'client',
       });
     }
   }

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -62,10 +62,9 @@ export async function exportAppAsync(
   const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
   const outputPath = path.resolve(projectRoot, outputDir);
 
-  // TODO: Remove when this is abstracted into the files map
-  if (!platforms.includes('web') || !useServerRendering) {
-    await copyPublicFolderAsync(publicPath, outputPath);
-  }
+  // NOTE(kitten): The public folder is currently always copied, regardless of targetDomain
+  // split. Hence, there's another separate `copyPublicFolderAsync` call below for `web`
+  await copyPublicFolderAsync(publicPath, outputPath);
 
   // Run metro bundler and create the JS bundles/source maps.
   const bundles = await createBundlesAsync(projectRoot, projectConfig, {

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -62,7 +62,10 @@ export async function exportAppAsync(
   const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
   const outputPath = path.resolve(projectRoot, outputDir);
 
-  await copyPublicFolderAsync(publicPath, outputPath);
+  // TODO: Remove when this is abstracted into the files map
+  if (!platforms.includes('web') || !useServerRendering) {
+    await copyPublicFolderAsync(publicPath, outputPath);
+  }
 
   // Run metro bundler and create the JS bundles/source maps.
   const bundles = await createBundlesAsync(projectRoot, projectConfig, {
@@ -133,6 +136,9 @@ export async function exportAppAsync(
 
   if (platforms.includes('web')) {
     if (useServerRendering) {
+      // TODO: Remove when this is abstracted into the files map
+      await copyPublicFolderAsync(publicPath, path.resolve(outputPath, 'client'));
+
       await unstable_exportStaticAsync(projectRoot, {
         files,
         clear: !!clear,

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -139,6 +139,7 @@ export async function exportAssetsAsync(
     // Save assets like a typical bundler, preserving the file paths on web.
     // TODO: Update React Native Web to support loading files from asset hashes.
     await persistMetroAssetsAsync(web.assets, {
+      files,
       platform: 'web',
       outputDirectory: outputDir,
       baseUrl,

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -197,6 +197,7 @@ async function exportFromServerAsync(
     // TODO: Collect files without writing to disk.
     // TODO: Account for `webTargetDomain` split
     await persistMetroAssetsAsync(resources.assets, {
+      files,
       platform: 'web',
       outputDirectory: outputDir,
       baseUrl,

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -6,7 +6,6 @@
  */
 import assert from 'assert';
 import chalk from 'chalk';
-import fs from 'fs';
 import path from 'path';
 import { inspect } from 'util';
 
@@ -100,7 +99,7 @@ export async function getFilesToExportFromServerAsync(
       try {
         files.set(outputPath, {
           contents: '',
-          webTarget: 'server',
+          targetDomain: 'server',
         });
 
         const data = await renderAsync(pathname);
@@ -108,7 +107,7 @@ export async function getFilesToExportFromServerAsync(
         files.set(outputPath, {
           contents: data,
           routeId: pathname,
-          webTarget: includeGroupVariations ? 'client' : 'server',
+          targetDomain: includeGroupVariations ? 'client' : 'server',
         });
       } catch (e: any) {
         await logMetroErrorAsync({ error: e, projectRoot });
@@ -351,7 +350,7 @@ async function exportApiRoutesAsync({
 
   files.set('_expo/routes.json', {
     contents: JSON.stringify(manifest, null, 2),
-    webTarget: 'server',
+    targetDomain: 'server',
   });
 
   return files;

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -108,7 +108,7 @@ export async function getFilesToExportFromServerAsync(
         files.set(outputPath, {
           contents: data,
           routeId: pathname,
-          webTargetDomain: 'server',
+          webTargetDomain: includeGroupVariations ? 'client' : 'server',
         });
       } catch (e: any) {
         await logMetroErrorAsync({ error: e, projectRoot });

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -100,7 +100,7 @@ export async function getFilesToExportFromServerAsync(
       try {
         files.set(outputPath, {
           contents: '',
-          webTargetDomain: 'server',
+          webTarget: 'server',
         });
 
         const data = await renderAsync(pathname);
@@ -108,7 +108,7 @@ export async function getFilesToExportFromServerAsync(
         files.set(outputPath, {
           contents: data,
           routeId: pathname,
-          webTargetDomain: includeGroupVariations ? 'client' : 'server',
+          webTarget: includeGroupVariations ? 'client' : 'server',
         });
       } catch (e: any) {
         await logMetroErrorAsync({ error: e, projectRoot });
@@ -195,7 +195,7 @@ async function exportFromServerAsync(
 
   if (resources.assets) {
     // TODO: Collect files without writing to disk.
-    // TODO: Account for `webTargetDomain` split
+    // NOTE(kitten): Re. above, this is now using `files` except for iOS catalog output, which isn't used here
     await persistMetroAssetsAsync(resources.assets, {
       files,
       platform: 'web',
@@ -351,7 +351,7 @@ async function exportApiRoutesAsync({
 
   files.set('_expo/routes.json', {
     contents: JSON.stringify(manifest, null, 2),
-    webTargetDomain: 'server',
+    webTarget: 'server',
   });
 
   return files;

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -34,7 +34,10 @@ export async function getVirtualFaviconAssetsAsync(
       const assetPath = path.join(outputDir, asset.path);
       if (files) {
         debug('Storing asset for persisting: ' + assetPath);
-        files?.set(asset.path, { contents: asset.source });
+        files?.set(asset.path, {
+          contents: asset.source,
+          webTargetDomain: 'client',
+        });
       } else {
         debug('Writing asset to disk: ' + assetPath);
         await fs.promises.writeFile(assetPath, asset.source);

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -36,7 +36,7 @@ export async function getVirtualFaviconAssetsAsync(
         debug('Storing asset for persisting: ' + assetPath);
         files?.set(asset.path, {
           contents: asset.source,
-          webTarget: 'client',
+          targetDomain: 'client',
         });
       } else {
         debug('Writing asset to disk: ' + assetPath);

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -36,7 +36,7 @@ export async function getVirtualFaviconAssetsAsync(
         debug('Storing asset for persisting: ' + assetPath);
         files?.set(asset.path, {
           contents: asset.source,
-          webTargetDomain: 'client',
+          webTarget: 'client',
         });
       } else {
         debug('Writing asset to disk: ' + assetPath);

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -174,7 +174,6 @@ export function copyInBatchesAsync(filesToCopy: Record<string, string>) {
         // queue.length === 0 is checked in previous branch, so this is string
         const src = queue.shift() as string;
         const dest = filesToCopy[src];
-        console.log('copy', src, dest);
         copy(src, dest, copyNext);
       } else {
         resolve();

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -84,7 +84,7 @@ export async function persistMetroAssetsAsync(
       const data = await fs.promises.readFile(src);
       files.set(dest, {
         contents: data,
-        webTargetDomain: platform === 'web' ? 'client' : undefined,
+        webTarget: platform === 'web' ? 'client' : undefined,
       });
     } else {
       batches[src] = path.join(outputDirectory, dest);

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -84,7 +84,7 @@ export async function persistMetroAssetsAsync(
       const data = await fs.promises.readFile(src);
       files.set(dest, {
         contents: data,
-        webTarget: platform === 'web' ? 'client' : undefined,
+        targetDomain: platform === 'web' ? 'client' : undefined,
       });
     } else {
       batches[src] = path.join(outputDirectory, dest);

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -13,6 +13,7 @@ import type { AssetData } from 'metro';
 import path from 'path';
 
 import { getAssetLocalPath } from './metroAssetLocalPath';
+import { ExportAssetMap } from './saveAssets';
 import { Log } from '../log';
 
 function cleanAssetCatalog(catalogDir: string): void {
@@ -22,18 +23,20 @@ function cleanAssetCatalog(catalogDir: string): void {
   }
 }
 
-export function persistMetroAssetsAsync(
+export async function persistMetroAssetsAsync(
   assets: readonly AssetData[],
   {
     platform,
     outputDirectory,
     baseUrl,
     iosAssetCatalogDirectory,
+    files,
   }: {
     platform: string;
     outputDirectory: string;
     baseUrl?: string;
     iosAssetCatalogDirectory?: string;
+    files?: ExportAssetMap;
   }
 ) {
   if (outputDirectory == null) {
@@ -43,6 +46,7 @@ export function persistMetroAssetsAsync(
 
   let assetsToCopy: AssetData[] = [];
 
+  // TODO: Use `files` as below to defer writing files
   if (platform === 'ios' && iosAssetCatalogDirectory != null) {
     // Use iOS Asset Catalog for images. This will allow Apple app thinning to
     // remove unused scales from the optimized bundle.
@@ -73,24 +77,33 @@ export function persistMetroAssetsAsync(
     assetsToCopy = [...assets];
   }
 
-  const files = assetsToCopy.reduce<Record<string, string>>((acc, asset) => {
+  const batches: Record<string, string> = {};
+
+  async function write(src: string, dest: string) {
+    if (files) {
+      const data = await fs.promises.readFile(src);
+      files.set(dest, {
+        contents: data,
+        webTargetDomain: platform === 'web' ? 'client' : undefined,
+      });
+    } else {
+      batches[src] = path.join(outputDirectory, dest);
+    }
+  }
+
+  for (const asset of assetsToCopy) {
     const validScales = new Set(filterPlatformAssetScales(platform, asset.scales));
-
-    asset.scales.forEach((scale, idx) => {
-      if (!validScales.has(scale)) {
-        return;
+    for (let idx = 0; idx < asset.scales.length; idx++) {
+      const scale = asset.scales[idx];
+      if (validScales.has(scale)) {
+        await write(asset.files[idx], getAssetLocalPath(asset, { platform, scale, baseUrl }));
       }
-      const src = asset.files[idx];
-      const dest = path.join(
-        outputDirectory,
-        getAssetLocalPath(asset, { platform, scale, baseUrl })
-      );
-      acc[src] = dest;
-    });
-    return acc;
-  }, {});
+    }
+  }
 
-  return copyInBatchesAsync(files);
+  if (!files) {
+    await copyInBatchesAsync(batches);
+  }
 }
 
 function writeImageSet(imageSet: ImageSet): void {
@@ -161,6 +174,7 @@ export function copyInBatchesAsync(filesToCopy: Record<string, string>) {
         // queue.length === 0 is checked in previous branch, so this is string
         const src = queue.shift() as string;
         const dest = filesToCopy[src];
+        console.log('copy', src, dest);
         copy(src, dest, copyNext);
       } else {
         resolve();

--- a/packages/@expo/cli/src/export/saveAssets.ts
+++ b/packages/@expo/cli/src/export/saveAssets.ts
@@ -24,8 +24,8 @@ export type ExportAssetDescriptor = {
   assetId?: string;
   /** Expo Router route path for formatting the HTML output. */
   routeId?: string;
-  /** A key for grouping together web output files by server- or client-side. */
-  webTarget?: 'server' | 'client';
+  /** A key for grouping together output files by server- or client-side. */
+  targetDomain?: 'server' | 'client';
 };
 
 export type ExportAssetMap = Map<string, ExportAssetDescriptor>;
@@ -49,7 +49,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   let hasServerOutput = false;
   for (const asset of files.entries()) {
-    hasServerOutput = hasServerOutput || asset[1].webTarget === 'server';
+    hasServerOutput = hasServerOutput || asset[1].targetDomain === 'server';
     if (asset[1].assetId) assetEntries.push(asset);
     else if (asset[1].routeId != null) routeEntries.push(asset);
     else remainingEntries.push(asset);
@@ -159,9 +159,9 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
   await Promise.all(
     [...files.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(async ([file, { contents, webTarget }]) => {
-        // NOTE: Only use `webTarget` if we have at least one server asset
-        const domain = (hasServerOutput && webTarget) || '';
+      .map(async ([file, { contents, targetDomain }]) => {
+        // NOTE: Only use `targetDomain` if we have at least one server asset
+        const domain = (hasServerOutput && targetDomain) || '';
         const outputPath = path.join(outputDir, domain, file);
         await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
         await fs.promises.writeFile(outputPath, contents);
@@ -199,7 +199,7 @@ export function getFilesFromSerialAssets(
     files.set(resource.filename, {
       contents: resource.source,
       originFilename: resource.originFilename,
-      webTarget: platform === 'web' ? 'client' : undefined,
+      targetDomain: platform === 'web' ? 'client' : undefined,
     });
   });
 

--- a/packages/@expo/cli/src/export/saveAssets.ts
+++ b/packages/@expo/cli/src/export/saveAssets.ts
@@ -25,7 +25,7 @@ export type ExportAssetDescriptor = {
   /** Expo Router route path for formatting the HTML output. */
   routeId?: string;
   /** A key for grouping together web output files by server- or client-side. */
-  webTargetDomain?: 'server' | 'client';
+  webTarget?: 'server' | 'client';
 };
 
 export type ExportAssetMap = Map<string, ExportAssetDescriptor>;
@@ -49,7 +49,7 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
 
   let hasServerOutput = false;
   for (const asset of files.entries()) {
-    hasServerOutput = hasServerOutput || asset[1].webTargetDomain === 'server';
+    hasServerOutput = hasServerOutput || asset[1].webTarget === 'server';
     if (asset[1].assetId) assetEntries.push(asset);
     else if (asset[1].routeId != null) routeEntries.push(asset);
     else remainingEntries.push(asset);
@@ -159,9 +159,9 @@ export async function persistMetroFilesAsync(files: ExportAssetMap, outputDir: s
   await Promise.all(
     [...files.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(async ([file, { contents, webTargetDomain }]) => {
-        // NOTE: Only use `webTargetDomain` if we have at least one server asset
-        const domain = (hasServerOutput && webTargetDomain) || '';
+      .map(async ([file, { contents, webTarget }]) => {
+        // NOTE: Only use `webTarget` if we have at least one server asset
+        const domain = (hasServerOutput && webTarget) || '';
         const outputPath = path.join(outputDir, domain, file);
         await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
         await fs.promises.writeFile(outputPath, contents);
@@ -199,7 +199,7 @@ export function getFilesFromSerialAssets(
     files.set(resource.filename, {
       contents: resource.source,
       originFilename: resource.originFilename,
-      webTargetDomain: platform === 'web' ? 'client' : undefined,
+      webTarget: platform === 'web' ? 'client' : undefined,
     });
   });
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -123,7 +123,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       if (contents) {
         files.set(artifactFilename, {
           contents,
-          webTarget: 'server',
+          targetDomain: 'server',
         });
       }
       // Remap the manifest files to represent the output files.

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -121,7 +121,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         path.relative(appDir, filepath.replace(/\.[tj]sx?$/, '.js'))
       );
       if (contents) {
-        files.set(artifactFilename, { contents });
+        files.set(artifactFilename, {
+          contents,
+          webTargetDomain: 'server',
+        });
       }
       // Remap the manifest files to represent the output files.
       route.file = artifactFilename;

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -123,7 +123,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       if (contents) {
         files.set(artifactFilename, {
           contents,
-          webTargetDomain: 'server',
+          webTarget: 'server',
         });
       }
       // Remap the manifest files to represent the output files.


### PR DESCRIPTION
# Why

We need a crude first attempt at separating export outputs by multiple targets.
In the case of Web Server exports for API routes, this already becomes necessary as we've got files that should only be accessible on the server-side and files that are served publicly.

Both Vercel and Netlify (as per the experimental adapters) treat publicly served files and server function files differently and if they're mixed, there's no good mechanism to mark server-function files (such as API route exports) as private, except for having an allow list.

Hence, we want to output to `dist/server/` and `dist/client/` when exporting Web sever outputs to separate our function code and assets from our client-side assets.

# How

We already have a new mechanism to delay writing outputs to the disk, `ExportAssetMap` i.e. `Map<string, ExportAssetDescriptor>`. While this isn't used everywhere yet, it was already used in most of the Web export execution path, with the exception of `persistMetroAssetsAsync`.

The `ExportAssetDescriptor` now contains a new optional property of `targetDomain?: 'server' | 'client'`. This is used to separate output files by either the `client` or `server` domain, which is then used in `persistMetroFilesAsync` to separate these files into two output subfolders.

If no asset is marked as `server`, we ignore `targetDomain` entirely, and dump all files into the `outputDir` directly to prevent us from changing the structure of output files for any other platform or target.

If an asset isn't marked with `targetDomain`, we currently default it to `client`, if necessary. Currently, there's luckily no overlap in web export output assets and files. No assets can be shared, as far as I know, between API routes and client-side code, HTML files are only output for the web platform, and no client-side JS bundle chunks are used in the API route.
Hence, the output format for other platforms and cases isn't affected as we have no concept of shared files, except for the public folder.

The public folder currently doesn't use the `ExportAssetMap` and is copied to `dist/server/` manually, and duplicated when iOS/Android code is exported to `dist/` as well.

<details><summary>

Example output of `expo export -p web` in a server output format

</summary>

```
dist
├── client
│   ├── _expo
│   │   └── static
│   │       └── js
│   │           └── web
│   │               └── entry-4d6d5b1085cf3cb1c8a27eb963c94cf6.js
│   ├── assets
│   │   ├── assets
│   │   │   └── fonts
│   │   │       └── SpaceMono-Regular.ttf
│   │   └── node_modules
│   │       ├── @expo
│   │       │   └── vector-icons
│   │       │       └── build
│   │       │           └── vendor
│   │       │               └── react-native-vector-icons
│   │       │                   └── Fonts
│   │       │                       └── FontAwesome.ttf
│   │       ├── @react-navigation
│   │       │   └── elements
│   │       │       └── lib
│   │       │           └── module
│   │       │               └── assets
│   │       │                   ├── back-icon-mask.png
│   │       │                   └── back-icon.png
│   │       └── expo-router
│   │           └── assets
│   │               ├── error.png
│   │               ├── file.png
│   │               ├── forward.png
│   │               └── pkg.png
│   └── favicon.ico
└── server
    ├── (tabs)
    │   ├── index.html
    │   └── two.html
    ├── +not-found.html
    ├── _expo
    │   ├── functions
    │   │   └── about+api.js
    │   └── routes.json
    ├── _sitemap.html
    └── modal.html
```

</details>

# Test Plan

- Tested against `expo export -p web` output with Express, Netlify, and Vercel
- Updated E2E test for server output to target `dist/server` and `dist/client`
- Checked other output to be unaffected

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
