### PR TITLE
[docs] APISectionEnums: remove nesting, streamline appearance

### DIFF
--- a/docs/common/headingManager.ts
+++ b/docs/common/headingManager.ts
@@ -42,6 +42,7 @@ export type AdditionalProps = {
   sidebarType?: HeadingType;
   tags?: string[];
   style?: React.CSSProperties;
+  className?: string;
 };
 
 type Metadata = Partial<PageMetadata> & { headings: (RemarkHeading & { _processed?: boolean })[] };

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -92,7 +92,10 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(
     );
 
     return (
-      <PermalinkBase component={component} style={props.additionalProps?.style}>
+      <PermalinkBase
+        component={component}
+        style={props.additionalProps?.style}
+        className={props.additionalProps?.className}>
         <LinkBase css={STYLES_PERMALINK_LINK} href={'#' + heading.slug} ref={heading.ref}>
           <span css={STYLES_PERMALINK_TARGET} id={heading.slug} />
           <span css={STYLED_PERMALINK_CONTENT}>{children}</span>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4268,80 +4268,90 @@ OAuth 2.0 protocol
     </a>
   </h2>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
+    <div
+      class="px-5 pt-4"
     >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationbuttonstyle"
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
       >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationbuttonstyle"
-        />
-        <span
-          class="css-6n7j50"
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationbuttonstyle"
+        >
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationbuttonstyle"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationButtonStyle
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        An enum whose values control which pre-defined color scheme to use when rendering an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationappleauthenticationbutton"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="css-1a6y07t-TextComponent"
             data-text="true"
           >
-            AppleAuthenticationButtonStyle
+            AppleAuthenticationButton
           </code>
-        </span>
-        <span
-          class="css-13330di"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      An enum whose values control which pre-defined color scheme to use when rendering an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationappleauthenticationbutton"
+        </a>
+        .
+      </p>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
       >
-        <code
-          class="css-1a6y07t-TextComponent"
-          data-text="true"
-        >
-          AppleAuthenticationButton
-        </code>
-      </a>
-      .
-    </p>
+        AppleAuthenticationButtonStyle Values
+      </p>
+    </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -4409,7 +4419,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -4477,7 +4487,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -4546,80 +4556,90 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
+    <div
+      class="px-5 pt-4"
     >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationbuttontype"
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
       >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationbuttontype"
-        />
-        <span
-          class="css-6n7j50"
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationbuttontype"
+        >
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationbuttontype"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationButtonType
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        An enum whose values control which pre-defined text to use when rendering an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationappleauthenticationbutton"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="css-1a6y07t-TextComponent"
             data-text="true"
           >
-            AppleAuthenticationButtonType
+            AppleAuthenticationButton
           </code>
-        </span>
-        <span
-          class="css-13330di"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      An enum whose values control which pre-defined text to use when rendering an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationappleauthenticationbutton"
+        </a>
+        .
+      </p>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
       >
-        <code
-          class="css-1a6y07t-TextComponent"
-          data-text="true"
-        >
-          AppleAuthenticationButton
-        </code>
-      </a>
-      .
-    </p>
+        AppleAuthenticationButtonType Values
+      </p>
+    </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -4687,7 +4707,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -4755,7 +4775,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <strong
         class="css-bvflvn-TextComponent"
@@ -4857,133 +4877,143 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
+    <div
+      class="px-5 pt-4"
     >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationcredentialstate"
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
       >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationcredentialstate"
-        />
-        <span
-          class="css-6n7j50"
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationcredentialstate"
+        >
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationcredentialstate"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationCredentialState
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        An enum whose values specify state of the credential when checked with 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="css-1a6y07t-TextComponent"
             data-text="true"
           >
-            AppleAuthenticationCredentialState
+            AppleAuthentication.getCredentialStateAsync()
           </code>
-        </span>
-        <span
-          class="css-13330di"
+        </a>
+        .
+      </p>
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
         >
           <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
             viewBox="0 0 24 24"
-            width="24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
+            <g
+              id="info-circle"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
           </svg>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      An enum whose values specify state of the credential when checked with 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationgetcredentialstateasyncuser"
-      >
-        <code
-          class="css-1a6y07t-TextComponent"
-          data-text="true"
+        </div>
+        <div
+          class="css-1m74yfi-Callout"
         >
-          AppleAuthentication.getCredentialStateAsync()
-        </code>
-      </a>
-      .
-    </p>
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            id="info-circle"
+          <p
+            class="mb-4 css-1kfqm4n-TextComponent"
+            data-text="true"
           >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1m74yfi-Callout"
-      >
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          <strong
-            class="css-bvflvn-TextComponent"
-          >
-            See:
-          </strong>
-           
-          <a
-            class="css-1na8e0o-A"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Apple
+            <strong
+              class="css-bvflvn-TextComponent"
+            >
+              See:
+            </strong>
+             
+            <a
+              class="css-1na8e0o-A"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        AppleAuthenticationCredentialState Values
+      </p>
+    </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5045,7 +5075,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5107,7 +5137,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5169,7 +5199,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5232,62 +5262,72 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
-    >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationoperation"
-      >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationoperation"
-        />
-        <span
-          class="css-6n7j50"
-        >
-          <code
-            class="css-yd3r23-TextComponent"
-            data-text="true"
-          >
-            AppleAuthenticationOperation
-          </code>
-        </span>
-        <span
-          class="css-13330di"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </h3>
     <div
-      class="css-11xr3cd"
+      class="px-5 pt-4"
+    >
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationoperation"
+        >
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationoperation"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationOperation
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        AppleAuthenticationOperation Values
+      </p>
+    </div>
+    <div
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5355,7 +5395,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5417,7 +5457,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5479,7 +5519,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5542,177 +5582,187 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
+    <div
+      class="px-5 pt-4"
     >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationscope"
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
       >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationscope"
-        />
-        <span
-          class="css-6n7j50"
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationscope"
+        >
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationscope"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationScope
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        An enum whose values specify scopes you can request when calling 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="css-yd3r23-TextComponent"
+            class="css-1a6y07t-TextComponent"
             data-text="true"
           >
-            AppleAuthenticationScope
+            AppleAuthentication.signInAsync()
           </code>
-        </span>
-        <span
-          class="css-13330di"
+        </a>
+        .
+      </p>
+      
+
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
         >
           <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
             viewBox="0 0 24 24"
-            width="24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
+            <g
+              id="info-circle"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
           </svg>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      An enum whose values specify scopes you can request when calling 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationsigninasyncoptions"
-      >
-        <code
-          class="css-1a6y07t-TextComponent"
-          data-text="true"
+        </div>
+        <div
+          class="css-1m74yfi-Callout"
         >
-          AppleAuthentication.signInAsync()
-        </code>
-      </a>
-      .
-    </p>
-    
-
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            id="info-circle"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1m74yfi-Callout"
-      >
-        
-
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          Note that it is possible that you will not be granted all of the scopes which you request.
-You will still need to handle null values for any fields you request.
-        </p>
-        
-
-      </div>
-    </blockquote>
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            id="info-circle"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1m74yfi-Callout"
-      >
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          <strong
-            class="css-bvflvn-TextComponent"
-          >
-            See:
-          </strong>
-           
-          <a
-            class="css-1na8e0o-A"
-            href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Apple
-Documentation
-          </a>
           
+
+          <p
+            class="mb-4 css-1kfqm4n-TextComponent"
+            data-text="true"
+          >
+            Note that it is possible that you will not be granted all of the scopes which you request.
+You will still need to handle null values for any fields you request.
+          </p>
+          
+
+        </div>
+      </blockquote>
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
+        >
+          <svg
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              id="info-circle"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="css-1m74yfi-Callout"
+        >
+          <p
+            class="mb-4 css-1kfqm4n-TextComponent"
+            data-text="true"
+          >
+            <strong
+              class="css-bvflvn-TextComponent"
+            >
+              See:
+            </strong>
+             
+            <a
+              class="css-1na8e0o-A"
+              href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
+Documentation
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        AppleAuthenticationScope Values
+      </p>
+    </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5774,7 +5824,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -5837,121 +5887,131 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
+    <div
+      class="px-5 pt-4"
     >
-      <a
-        class="css-1yk6eqh"
-        href="#appleauthenticationuserdetectionstatus"
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
       >
-        <span
-          class="css-s3qkfm"
-          id="appleauthenticationuserdetectionstatus"
-        />
-        <span
-          class="css-6n7j50"
+        <a
+          class="css-1yk6eqh"
+          href="#appleauthenticationuserdetectionstatus"
         >
-          <code
-            class="css-yd3r23-TextComponent"
-            data-text="true"
+          <span
+            class="css-s3qkfm"
+            id="appleauthenticationuserdetectionstatus"
+          />
+          <span
+            class="css-6n7j50"
           >
-            AppleAuthenticationUserDetectionStatus
-          </code>
-        </span>
-        <span
-          class="css-13330di"
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              AppleAuthenticationUserDetectionStatus
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        An enum whose values specify the system's best guess for how likely the current user is a real person.
+      </p>
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
         >
           <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
             viewBox="0 0 24 24"
-            width="24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
+            <g
+              id="info-circle"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
           </svg>
-        </span>
-      </a>
-    </h3>
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      An enum whose values specify the system's best guess for how likely the current user is a real person.
-    </p>
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        </div>
+        <div
+          class="css-1m74yfi-Callout"
         >
-          <g
-            id="info-circle"
+          <p
+            class="mb-4 css-1kfqm4n-TextComponent"
+            data-text="true"
           >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1m74yfi-Callout"
-      >
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          <strong
-            class="css-bvflvn-TextComponent"
-          >
-            See:
-          </strong>
-           
-          <a
-            class="css-1na8e0o-A"
-            href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Apple
+            <strong
+              class="css-bvflvn-TextComponent"
+            >
+              See:
+            </strong>
+             
+            <a
+              class="css-1na8e0o-A"
+              href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Apple
 Documentation
-          </a>
-          
+            </a>
+            
 for more details.
-        </p>
-      </div>
-    </blockquote>
+          </p>
+        </div>
+      </blockquote>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        AppleAuthenticationUserDetectionStatus Values
+      </p>
+    </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -6019,7 +6079,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -6087,7 +6147,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -9468,62 +9528,72 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
-    >
-      <a
-        class="css-1yk6eqh"
-        href="#permissionstatus"
-      >
-        <span
-          class="css-s3qkfm"
-          id="permissionstatus"
-        />
-        <span
-          class="css-6n7j50"
-        >
-          <code
-            class="css-yd3r23-TextComponent"
-            data-text="true"
-          >
-            PermissionStatus
-          </code>
-        </span>
-        <span
-          class="css-13330di"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </h3>
     <div
-      class="css-11xr3cd"
+      class="px-5 pt-4"
+    >
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#permissionstatus"
+        >
+          <span
+            class="css-s3qkfm"
+            id="permissionstatus"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              PermissionStatus
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        PermissionStatus Values
+      </p>
+    </div>
+    <div
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -9591,7 +9661,7 @@ you don't get this value.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -9659,7 +9729,7 @@ you don't get this value.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -11565,62 +11635,72 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1gsbrid"
+    class="!p-0 css-1fultt1"
   >
-    <h3
-      class="  css-wbzzgj-TextComponent"
-      data-heading="true"
-    >
-      <a
-        class="css-1yk6eqh"
-        href="#permissionstatus"
-      >
-        <span
-          class="css-s3qkfm"
-          id="permissionstatus"
-        />
-        <span
-          class="css-6n7j50"
-        >
-          <code
-            class="css-yd3r23-TextComponent"
-            data-text="true"
-          >
-            PermissionStatus
-          </code>
-        </span>
-        <span
-          class="css-13330di"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </h3>
     <div
-      class="css-11xr3cd"
+      class="px-5 pt-4"
+    >
+      <h3
+        class="  css-wbzzgj-TextComponent"
+        data-heading="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#permissionstatus"
+        >
+          <span
+            class="css-s3qkfm"
+            id="permissionstatus"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-yd3r23-TextComponent"
+              data-text="true"
+            >
+              PermissionStatus
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </h3>
+      <p
+        class="!mb-0 !border-b-0 css-1eksndl-BoxSectionHeader"
+        data-text="true"
+      >
+        PermissionStatus Values
+      </p>
+    </div>
+    <div
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -11688,7 +11768,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"
@@ -11756,7 +11836,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-11xr3cd"
+      class="border-t border-t-secondary p-5 pb-0 pt-4"
     >
       <h4
         class="  css-1y1xevk-TextComponent"

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-
 import { EnumDefinitionData, EnumValueData } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
@@ -7,8 +5,8 @@ import {
   CommentTextBlock,
   getTagNamesList,
   STYLES_APIBOX,
-  STYLES_APIBOX_NESTED,
   H3Code,
+  BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
 import { H2, H4, CODE, MONOSPACE } from '~/ui/components/Text';
 
@@ -30,18 +28,21 @@ const sortByValue = (a: EnumValueData, b: EnumValueData) => {
 const renderEnumValue = (value: any) => (typeof value === 'string' ? `"${value}"` : value);
 
 const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Element => (
-  <div key={`enum-definition-${name}`} css={[STYLES_APIBOX, enumContentStyles]}>
-    <APISectionDeprecationNote comment={comment} />
-    <APISectionPlatformTags comment={comment} prefix="Only for:" />
-    <H3Code tags={getTagNamesList(comment)}>
-      <MONOSPACE weight="medium">{name}</MONOSPACE>
-    </H3Code>
-    <CommentTextBlock comment={comment} includePlatforms={false} />
+  <div key={`enum-definition-${name}`} css={STYLES_APIBOX} className="!p-0">
+    <div className="px-5 pt-4">
+      <APISectionDeprecationNote comment={comment} />
+      <APISectionPlatformTags comment={comment} prefix="Only for:" />
+      <H3Code tags={getTagNamesList(comment)}>
+        <MONOSPACE weight="medium">{name}</MONOSPACE>
+      </H3Code>
+      <CommentTextBlock comment={comment} includePlatforms={false} />
+      <BoxSectionHeader text={`${name} Values`} className="!mb-0 !border-b-0" />
+    </div>
     {children.sort(sortByValue).map((enumValue: EnumValueData) => (
-      <div css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]} key={enumValue.name}>
+      <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
         <APISectionDeprecationNote comment={enumValue.comment} />
         <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" />
-        <H4 css={enumValueNameStyle}>
+        <H4 className="!mt-0">
           <CODE>{enumValue.name}</CODE>
         </H4>
         <CODE theme="secondary" className="mb-4">
@@ -60,15 +61,5 @@ const APISectionEnums = ({ data }: APISectionEnumsProps) =>
       {data.map(renderEnum)}
     </>
   ) : null;
-
-const enumValueNameStyle = css({
-  h4: {
-    marginTop: 0,
-  },
-});
-
-const enumContentStyles = css({
-  paddingBottom: 0,
-});
 
 export default APISectionEnums;

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -432,15 +432,21 @@ function createInheritPermalink(baseNestingLevel: number) {
 export const BoxSectionHeader = ({
   text,
   exposeInSidebar,
+  className,
   baseNestingLevel = DEFAULT_BASE_NESTING_LEVEL,
 }: {
   text: string;
   exposeInSidebar?: boolean;
+  className?: string;
   baseNestingLevel?: number;
 }) => {
   const TextWrapper = exposeInSidebar ? createInheritPermalink(baseNestingLevel) : Fragment;
   return (
-    <CALLOUT theme="secondary" weight="medium" css={STYLES_NESTED_SECTION_HEADER}>
+    <CALLOUT
+      theme="secondary"
+      weight="medium"
+      css={STYLES_NESTED_SECTION_HEADER}
+      className={className}>
       <TextWrapper>{text}</TextWrapper>
     </CALLOUT>
   );

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -28,7 +28,7 @@ export const createPermalinkedComponent = (
   }
 ) => {
   const { baseNestingLevel, sidebarType = HeadingType.Text } = options || {};
-  return ({ children, level, id, ...props }: PermalinkedComponentProps) => {
+  return ({ children, level, id, className, ...props }: PermalinkedComponentProps) => {
     const cleanChildren = React.Children.map(children, child => {
       if (React.isValidElement(child) && child?.props?.href) {
         isDev &&


### PR DESCRIPTION
# Why

We are moving off nested boxes in our design patterns. Let's start altering the API reference components, so they follow the latest design direction.

# How

Remove nested boxes with enum values, replace them with box sections, add values section header, tweaks.

# Test Plan

The changes have been tested locally. All lint checks and tests are passing.

# Preview

<img width="981" alt="Screenshot 2023-11-29 at 15 24 09" src="https://github.com/expo/expo/assets/719641/a9b4f9df-6ac4-4bc2-bd5a-1f950ac792ab">
<img width="981" alt="Screenshot 2023-11-29 at 15 22 59" src="https://github.com/expo/expo/assets/719641/fbcf0b94-25c0-41f7-8343-549d48783041">
<img width="981" alt="Screenshot 2023-11-29 at 15 23 26" src="https://github.com/expo/expo/assets/719641/d70ec4b2-5b57-47f5-a6eb-4cb28c736bd9">
