### PR TITLE
[babel-preset] Update reanimated test snapshots

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### 💡 Others
 
 - Replace `@expo/babel-preset-cli` with `expo-module-scripts`. ([#25425](https://github.com/expo/expo/pull/25425) by [@byCedric](https://github.com/byCedric))
-- Update reanimated test snapshots.
+- Update reanimated test snapshots. ([#25644](https://github.com/expo/expo/pull/25644) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 9.9.0 — 2023-11-14
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 💡 Others
 
 - Replace `@expo/babel-preset-cli` with `expo-module-scripts`. ([#25425](https://github.com/expo/expo/pull/25425) by [@byCedric](https://github.com/byCedric))
+- Update reanimated test snapshots.
 
 ## 9.9.0 — 2023-11-14
 

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -264,7 +264,7 @@ exports[`metro supports reanimated worklets 1`] = `
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__workletHash=549132292534;someWorklet.__stackDetails=_e;return someWorklet;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=549132292534;someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`metro transpiles non-standard exports 1`] = `"Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _default=_interopRequireWildcard(require("./Animated"));exports.default=_default;function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!=="function")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!=="object"&&typeof obj!=="function"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!=="default"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}"`;
@@ -293,7 +293,7 @@ exports[`metro+hermes supports reanimated worklets 1`] = `
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__workletHash=549132292534;someWorklet.__stackDetails=_e;return someWorklet;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=549132292534;someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`metro+hermes transpiles non-standard exports 1`] = `"Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _default=_interopRequireWildcard(require("./Animated"));exports.default=_default;function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!=="function")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!=="object"&&typeof obj!=="function"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!=="default"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}"`;
@@ -322,7 +322,7 @@ exports[`webpack supports reanimated worklets 1`] = `
 someWorklet=function(){var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__workletHash=549132292534;someWorklet.__stackDetails=_e;return someWorklet;}();"
+};someWorklet.__closure={};someWorklet.__workletHash=549132292534;someWorklet.__initData=_worklet_549132292534_init_data;someWorklet.__stackDetails=_e;return someWorklet;}();"
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `


### PR DESCRIPTION
# Why

After upgrading reanimated to 3.6.0 babel-preset-expo snapshots no longer work


# How

Run `yarn test -u` inside packages/babel-preset-expo

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
