### PR TITLE
[cli] Fix permission issue when user doesn't have permission to view app

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Remove the 404 route from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
 - Exclude `+not-found` and `*+api` routes from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
 - Fix Expo Router typed routes error with external URLs ([#25591](https://github.com/expo/expo/pull/25591) by [@marklawlor](https://github.com/marklawlor))
+- Fix permission issue when user doesn't have permission to view app. ([#25650](https://github.com/expo/expo/pull/25650) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -39,8 +39,8 @@ export async function showLoginPromptAsync({
 
   Log.log(
     hasCredentials
-      ? `Logging in to EAS with email or username (exit and run 'eas login' for other options)`
-      : `Log in to EAS with email or username (exit and run 'eas login' for other options)`
+      ? `Logging in to EAS with email or username (exit and run 'npx expo login' for other options)`
+      : `Log in to EAS with email or username (exit and run 'npx expo login' for other options)`
   );
 
   let username = options.username;

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -4,10 +4,12 @@ import {
   parseMultipartMixedResponseAsync,
   MultipartPart,
 } from '@expo/multipart-body-parser';
+import { GraphQLError } from 'graphql';
 import { vol } from 'memfs';
 import nullthrows from 'nullthrows';
 
 import { asMock } from '../../../../__tests__/asMock';
+import { AppQuery } from '../../../../api/graphql/queries/AppQuery';
 import { getUserAsync } from '../../../../api/user/user';
 import {
   mockExpoRootChain,
@@ -24,13 +26,7 @@ jest.mock('../../../../api/user/user');
 jest.mock('../../../../log');
 jest.mock('../../../../api/graphql/queries/AppQuery', () => ({
   AppQuery: {
-    byIdAsync: jest.fn(async () => ({
-      id: 'blah',
-      scopeKey: 'scope-key',
-      ownerAccount: {
-        id: 'blah-account',
-      },
-    })),
+    byIdAsync: jest.fn(),
   },
 }));
 jest.mock('@expo/code-signing-certificates', () => ({
@@ -199,6 +195,14 @@ describe('_getManifestResponseAsync', () => {
       primaryAccount: { id: 'blah-account' },
       accounts: [],
     }));
+
+    jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => ({
+      id: 'blah',
+      scopeKey: 'scope-key',
+      ownerAccount: {
+        id: 'blah-account',
+      },
+    }));
   });
 
   function createMiddleware(
@@ -251,6 +255,110 @@ describe('_getManifestResponseAsync', () => {
     );
 
     const { body } = nullthrows(await getMultipartPartAsync('manifest', results));
+    expect(JSON.parse(body)).toEqual({
+      id: expect.any(String),
+      createdAt: expect.any(String),
+      runtimeVersion: '45.0.0',
+      launchAsset: {
+        key: 'bundle',
+        contentType: 'application/javascript',
+        url: 'https://localhost:8081/bundle.js',
+      },
+      assets: [],
+      metadata: {},
+      extra: {
+        eas: {
+          projectId: 'projectId',
+        },
+        expoClient: {
+          extra: {
+            eas: {
+              projectId: 'projectId',
+            },
+          },
+          hostUri: 'https://localhost:8081',
+          slug: 'slug',
+        },
+        expoGo: {},
+        scopeKey: expect.stringMatching(/@anonymous\/.*/),
+      },
+    });
+  });
+
+  it('returns an anon manifest when viewer does not have permission to view app', async () => {
+    jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => {
+      throw new GraphQLError('test');
+    });
+
+    const middleware = createMiddleware();
+
+    const results = await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.MULTIPART_MIXED,
+      platform: 'android',
+      expectSignature: 'sig, keyid="expo-root", alg="rsa-v1_5-sha256"',
+      hostname: 'localhost',
+    });
+    expect(results.version).toBe('45.0.0');
+
+    const { body, headers: manifestPartHeaders } = nullthrows(
+      await getMultipartPartAsync('manifest', results)
+    );
+    expect(manifestPartHeaders.get('expo-signature')).toBe(undefined);
+
+    expect(JSON.parse(body)).toEqual({
+      id: expect.any(String),
+      createdAt: expect.any(String),
+      runtimeVersion: '45.0.0',
+      launchAsset: {
+        key: 'bundle',
+        contentType: 'application/javascript',
+        url: 'https://localhost:8081/bundle.js',
+      },
+      assets: [],
+      metadata: {},
+      extra: {
+        eas: {
+          projectId: 'projectId',
+        },
+        expoClient: {
+          extra: {
+            eas: {
+              projectId: 'projectId',
+            },
+          },
+          hostUri: 'https://localhost:8081',
+          slug: 'slug',
+        },
+        expoGo: {},
+        scopeKey: expect.stringMatching(/@anonymous\/.*/),
+      },
+    });
+  });
+
+  it('returns an anon manifest when viewer can view app but does not have permission to view account', async () => {
+    jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => ({
+      id: 'blah',
+      scopeKey: 'scope-key',
+      ownerAccount: {
+        id: 'blah-other-account',
+      },
+    }));
+
+    const middleware = createMiddleware();
+
+    const results = await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.MULTIPART_MIXED,
+      platform: 'android',
+      expectSignature: 'sig, keyid="expo-root", alg="rsa-v1_5-sha256"',
+      hostname: 'localhost',
+    });
+    expect(results.version).toBe('45.0.0');
+
+    const { body, headers: manifestPartHeaders } = nullthrows(
+      await getMultipartPartAsync('manifest', results)
+    );
+    expect(manifestPartHeaders.get('expo-signature')).toBe(undefined);
+
     expect(JSON.parse(body)).toEqual({
       id: expect.any(String),
       createdAt: expect.any(String),


### PR DESCRIPTION
# Why

When https://github.com/expo/expo/pull/21989 was written, it forgot to account for cases where the app isn't visible to the viewer (happens when app privacy is set to private). It had incorrectly assumed that all app privacy delegated to the viewer's permissions on the owning account.

Closes ENG-10719.

# How

The fix is to treat errors thrown when trying to query an app as permission errors and return null for `fetchAndCacheNewDevelopmentCodeSigningInfoAsync`. Note that this does mask network errors, I think this is ignored when offline anyways.

# Test Plan

Run new tests.

Manual test plan:
1. Log in to account that doesn't have permission on NCL
2. Build Expo Go locally
3. Build CLI locally
4. `nexpo start`
5. Load NCL before change, see error about Account entity not being visible.
6. Load NCL after change, see it works and is unsigned.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
