### PR TITLE
[expo-updates][android] Fix interaction between reload JS API and ErrorRecovery

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix interaction between reload JS API and ErrorRecovery. ([#25651](https://github.com/expo/expo/pull/25651) by [@wschurman](https://github.com/wschurman))
+
+
 ### 💡 Others
 
 - Update E2E tests to use local copies of `@expo/metro-config`, `@expo/env`, `@expo/config`. ([#25430](https://github.com/expo/expo/pull/25430) by [@EvanBacon](https://github.com/EvanBacon))


### PR DESCRIPTION
# Why

While debugging reload issues, I noticed this warning being thrown. Essentially, we never removed the content appeared listener, so a reload via the JS API would trigger another call to this listener. Usually by the time this occurred the handler thread would have been stopped, so the post to the thread would fail.

Closes ENG-10750.

# How

Remove listener when content appears. This matches the behavior on iOS.

# Test Plan

1. Create e2e test suite locally
2. Run in android studio and click reload a bunch of times, no longer see error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
