### PR TITLE
[updates] disable broken test

### DIFF
--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -101,7 +101,7 @@ describe('Basic tests', () => {
     await device.terminateApp();
   });
 
-  it('reloads', async () => {
+  xit('reloads', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(Update.serverPort, protocolVersion);
     await device.installApp();


### PR DESCRIPTION
# Why

fix broken test https://github.com/expo/expo/actions/runs/7041771709/job/19164843271 coming from react-native 0.73 regression

# How

the fix was already picked for next react-native release. will re-enable the test case after upgrade

# Test Plan

updates e2e ci passed