### PR TITLE
Fix JS Inspector by moving to devMiddleware

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -8,7 +8,6 @@ import type Metro from 'metro';
 import { Terminal } from 'metro-core';
 import semver from 'semver';
 import { URL } from 'url';
-import http from 'http';
 
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { MetroTerminalReporter } from './MetroTerminalReporter';


### PR DESCRIPTION
# Why

With @behenate we're seeing a crash when starting JS debugger on cli.

<img width="363" alt="image" src="https://github.com/expo/expo/assets/5597580/39d91ec5-9e9a-4d82-8d04-d7dbe101307b">

The /json/list was removed from metro in https://github.com/facebook/metro/commit/15c993f83eba3216c0d4d3d6cf7f0aff3bdc3d5b and moved to `devMiddleware`

How:

Used the devMiddleware instead

# Test Plan

Tested manually, now devtools open when pressing `J`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
