### PR TITLE
[cli] Speed up clean prebuild by preserving pods

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Ensure invalid production iOS builds fail more predictably. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 - Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 - Added support for React Native 0.73.0. ([#24971](https://github.com/expo/expo/pull/24971), [#25453](https://github.com/expo/expo/pull/25453) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Speed up clean prebuild by preserving pods. ([#25665](https://github.com/expo/expo/pull/25410) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -87,6 +87,7 @@ it('runs `npx expo prebuild --help`', async () => {
         --template <template>                    Project template to clone from. File path pointing to a local tar file or a github repo
         -p, --platform <all|android|ios>         Platforms to sync: ios, android, all. Default: all
         --skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)
+        --no-preserve-pods                       Delete the iOS Pods folder before regenerate the native files
         -h, --help                               Usage info
     "
   `);

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -61,11 +61,14 @@ export function copyTemplateFiles(
   {
     templateDirectory,
     platforms,
+    mergeExistingFiles,
   }: {
     /** File path to the template directory. */
     templateDirectory: string;
     /** List of platforms to copy against. */
     platforms: ModPlatform[];
+    /** Should merge existing local files with template files. */
+    mergeExistingFiles?: boolean;
   }
 ): CopyFilesResults {
   const copiedPaths: string[] = [];
@@ -73,7 +76,7 @@ export function copyTemplateFiles(
 
   platforms.forEach((copyFilePath) => {
     const projectPath = path.join(projectRoot, copyFilePath);
-    if (fs.existsSync(projectPath)) {
+    if (fs.existsSync(projectPath) && !mergeExistingFiles) {
       skippedPaths.push(copyFilePath);
     } else {
       copiedPaths.push(copyFilePath);

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -42,8 +42,8 @@ export const expoPrebuild: Command = async (argv) => {
         `--template <template>                    Project template to clone from. File path pointing to a local tar file or a github repo`,
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
+        `--no-preserve-pods                       Delete the iOS Pods folder before regenerate the native files`,
         `-h, --help                               Usage info`,
-        `--no-preserve-pods                             Delete the iOS Pods folder before regenerate the native files.`,
       ].join('\n')
     );
   }

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -15,6 +15,7 @@ export const expoPrebuild: Command = async (argv) => {
       '--yarn': Boolean,
       '--bun': Boolean,
       '--no-install': Boolean,
+      '--no-preserve-pods': Boolean,
       '--template': String,
       '--platform': String,
       '--skip-dependency-update': String,
@@ -42,6 +43,7 @@ export const expoPrebuild: Command = async (argv) => {
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
         `-h, --help                               Usage info`,
+        `--no-preserve-pods                             Delete the iOS Pods folder before regenerate the native files.`,
       ].join('\n')
     );
   }
@@ -64,7 +66,7 @@ export const expoPrebuild: Command = async (argv) => {
     return prebuildAsync(getProjectRoot(args), {
       // Parsed options
       clean: args['--clean'],
-
+      keepPods: !args['--no-preserve-pods'],
       packageManager: resolvePackageManagerOptions(args),
       install: !args['--no-install'],
       platforms: resolvePlatformOption(args['--platform']),

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -49,6 +49,8 @@ export async function prebuildAsync(
     platforms: ModPlatform[];
     /** Should delete the native folders before attempting to prebuild. */
     clean?: boolean;
+    /** Should keep the Pods folder even if using the `clean` option */
+    keepPods?: boolean;
     /** URL or file path to the prebuild template. */
     template?: string;
     /** Name of the node package manager to install with. */
@@ -71,8 +73,10 @@ export async function prebuildAsync(
     if (await maybeBailOnGitStatusAsync()) {
       return null;
     }
+
+    const ignorePaths = options.keepPods ? ['ios/Pods'] : [];
     // Clear the native folders before syncing
-    await clearNativeFolder(projectRoot, options.platforms);
+    await clearNativeFolder(projectRoot, options.platforms, ignorePaths);
   } else {
     // Check if the existing project folders are malformed.
     await promptToClearMalformedNativeProjectsAsync(projectRoot, options.platforms);
@@ -94,6 +98,7 @@ export async function prebuildAsync(
       template: options.template != null ? resolveTemplateOption(options.template) : undefined,
       platforms: options.platforms,
       skipDependencyUpdate: options.skipDependencyUpdate,
+      mergeExistingFiles: options.clean && options.keepPods,
     });
 
   // Install node modules

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -25,6 +25,7 @@ export async function updateFromTemplateAsync(
     templateDirectory,
     platforms,
     skipDependencyUpdate,
+    mergeExistingFiles,
   }: {
     /** Expo Config */
     exp: ExpoConfig;
@@ -38,6 +39,8 @@ export async function updateFromTemplateAsync(
     platforms: ModPlatform[];
     /** List of dependencies to skip updating. */
     skipDependencyUpdate?: string[];
+    /** Should merge existing local files with template files. */
+    mergeExistingFiles?: boolean;
   }
 ): Promise<
   {
@@ -58,6 +61,7 @@ export async function updateFromTemplateAsync(
     templateDirectory,
     exp,
     platforms,
+    mergeExistingFiles,
   });
 
   const depsResults = await profile(updatePackageJSONAsync)(projectRoot, {
@@ -85,12 +89,14 @@ async function cloneTemplateAndCopyToProjectAsync({
   template,
   exp,
   platforms: unknownPlatforms,
+  mergeExistingFiles,
 }: {
   projectRoot: string;
   templateDirectory: string;
   template?: string;
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
   platforms: ModPlatform[];
+  mergeExistingFiles?: boolean;
 }): Promise<string[]> {
   const platformDirectories = unknownPlatforms
     .map((platform) => `./${platform}`)
@@ -111,6 +117,7 @@ async function cloneTemplateAndCopyToProjectAsync({
     const results = copyTemplateFiles(projectRoot, {
       templateDirectory,
       platforms,
+      mergeExistingFiles,
     });
 
     ora.succeed(createCopyFilesSuccessMessage(platforms, results));


### PR DESCRIPTION
# Why

One of the main drawbacks of making prebuild clean native files by default (https://github.com/expo/expo/pull/25571) would be the long time necessary to install all pods every time the user ran this command, but by not deleting the `pods` folder when running `prebuild --clean` we can preserve the cache and speed things up significantly 

# How

- Introduced `--no-preserve-pods` flag (following the convention used in --no-install) to delete the pods folder when cleaning
- Did not update docs yet

# Test Plan

- ran prebuild with `--clean` and ensure pods files are not deleted 
- ran prebuild with `--clean --no-preserve-pods` and make sure pods files are deleted 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
