### PR TITLE
[doctor] Fix Doctor bin ("sh: expo-doctor: command not found")

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bin command. ([#25672](https://github.com/expo/expo/pull/25672) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.1.4 — 2023-11-30

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
-  "bin": "./bin/expo-doctor",
+  "bin": "./build/index.js",
   "files": [
     "build"
   ],


### PR DESCRIPTION
# Why
<img width="399" alt="image" src="https://github.com/expo/expo/assets/8053974/7072de28-0779-4906-8a87-a8de8c330448">

# How
This should basically match the old doctor bin before it was moved to Expo CLI

# Test Plan
I ... don't know how to test this :-/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
