### PR TITLE
feat(docs): add standard URL docs page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -27,7 +27,7 @@ const params = new URLSearchParams();
 
 Expo's build-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
 
-The only missing exception is that native platforms do not currently support [unicode characters](https://unicode.org/reports/tr46/) in the hostname. 
+The only missing exception is that native platforms do not currently support [non-ASCII characters](https://unicode.org/reports/tr46/) in the hostname. 
 
 Consider the following example:
 

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -32,11 +32,11 @@ The only missing exception is that native platforms do not currently support [un
 Consider the following example:
 
 ```js
-console.log(new URL('https://🥓.com/𝝠').toString())
+console.log(new URL('http://🥓').toString())
 ```
 
 This outputs the following:
-- Web, Node.js: `https://xn--pr9h.com/%F0%9D%9D%A0`
-- iOS, Android: `https://🥓.com/%F0%9D%9D%A0`
+- Web, Node.js: `http://xn--pr9h/`
+- iOS, Android: `http://🥓/`
 
 

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -13,7 +13,7 @@ The standard URL API is available on all Expo-supported platforms.
 
 ## Installation
 
-This API is part of the `expo` package. On native platforms, the build-in support for `URL` and `URLSearchParams` replaces the shim in `react-native`. Refer to the [browser and server runtime support](https://caniuse.com/url) for web and Node.js.
+This API is part of the `expo` package. On native platforms, built-in `URL` and `URLSearchParams` implementations replace the shims in `react-native`. Refer to the [browser and server runtime support](https://caniuse.com/url) for web and Node.js.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -1,18 +1,11 @@
 ---
 title: URL
-description: A library that allows programmatically controlling and responding to new updates made available to your app.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-updates'
-packageName: 'expo-updates'
-iconUrl: '/static/images/packages/expo-updates.png'
+description: Standard URL API available on all Expo-supported platforms. 
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo'
+packageName: 'expo'
 ---
 
-import APISection from '~/components/plugins/APISection';
-import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
-import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
-import { BoxLink } from '~/ui/components/BoxLink';
-import { GithubIcon } from '@expo/styleguide-icons';
 
 The standard URL API is available on all Expo-supported platforms.
 
@@ -20,7 +13,7 @@ The standard URL API is available on all Expo-supported platforms.
 
 ## Installation
 
-This API is part of the `expo` package.
+This API is part of the `expo` package. On native platforms, the build-in support for `URL` and `URLSearchParams` replaces the shim in `react-native`. Refer to the [browser and server runtime support](https://caniuse.com/url) for web and Node.js.
 
 ## Usage
 
@@ -33,3 +26,5 @@ const params = new URLSearchParams();
 ## Conformance
 
 Unicode characters are not supported on native platforms.
+
+See the standard [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) for more information.

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -25,6 +25,18 @@ const params = new URLSearchParams();
 
 ## Conformance
 
-Unicode characters are not supported on native platforms.
+Expo's build-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
 
-See the standard [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) for more information.
+The only missing exception is that native platforms do not currently support [unicode characters](https://unicode.org/reports/tr46/) in the hostname. 
+
+Consider the following example:
+
+```js
+console.log(new URL('https://🥓.com/𝝠').toString())
+```
+
+This outputs the following:
+- Web, Node.js: `https://xn--pr9h.com/%F0%9D%9D%A0`
+- iOS, Android: `https://🥓.com/%F0%9D%9D%A0`
+
+

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -1,0 +1,35 @@
+---
+title: URL
+description: A library that allows programmatically controlling and responding to new updates made available to your app.
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-updates'
+packageName: 'expo-updates'
+iconUrl: '/static/images/packages/expo-updates.png'
+---
+
+import APISection from '~/components/plugins/APISection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
+
+The standard URL API is available on all Expo-supported platforms.
+
+<PlatformsSection android emulator ios simulator web />
+
+## Installation
+
+This API is part of the `expo` package.
+
+## Usage
+
+```js
+const url = new URL('https://expo.dev');
+
+const params = new URLSearchParams();
+```
+
+## Conformance
+
+Unicode characters are not supported on native platforms.


### PR DESCRIPTION
# Why

Add docs for the new standard URL support.
