### PR TITLE
[docs] Add a step to clear bundler cache in Expo Router installation guide

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Expo Router
-description: Learn how to quickly get started by creating a new project with Expo Router or add the library to an existing project.
+description: Learn how to quickly get started by creating a new project with Expo Router or adding the library to an existing project.
 sidebar_title: Installation
 ---
 
@@ -149,12 +149,22 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    /* @info Add it in the plugins list as the last plugin.*/
+    /* @info Add it to the plugins list as the last plugin.*/
     plugins: ['expo-router/babel'],
     /* @end */
   };
 };
 ```
+
+</Step>
+
+<Step label="6">
+
+### Clear bundler cache
+
+After updating the Babel config file, run the following command to clear the bundler cache:
+
+<Terminal cmd={['$ npx expo start -c']} />
 
 </Step>
 


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Following manual steps from the Expo Router installation guide, it is missing the last step to clear the bundler cache after updating the Babel config file. This was brought up in the last Expo Router sync.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- Adds a "Clear bundler cache" step to make sure developers do not run into caching issues.
- Fix grammatic typo in the doc's `description`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/installation/#clear-bundler-cache

### Preview

![CleanShot 2023-12-01 at 01 51 08](https://github.com/expo/expo/assets/10234615/f29ab976-fef3-4e34-b662-9f7bd275268e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
