### PR TITLE
[expo-updates][android] Fix wait notify bug in launch asset when enabled

### DIFF
--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -1,10 +1,10 @@
-name: Updates e2e (disabled) EAS
+name: Updates e2e (startup) EAS
 
 on:
   workflow_dispatch: {}
   pull_request:
     paths:
-      - .github/workflows/updates-e2e-disabled.yml
+      - .github/workflows/updates-e2e-startup.yml
       - packages/expo-asset/**
       - packages/expo-manifests/**
       - packages/expo-updates-interface/**
@@ -12,7 +12,7 @@ on:
   push:
     branches: [main, 'sdk-*']
     paths:
-      - .github/workflows/updates-e2e-disabled.yml
+      - .github/workflows/updates-e2e-startup.yml
       - packages/expo-asset/**
       - packages/expo-manifests/**
       - packages/expo-updates-interface/**
@@ -68,8 +68,8 @@ jobs:
         run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
         run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
-      - name: 📦 Setup test project for updates E2E disabled tests
-        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
+      - name: 📦 Setup test project for updates E2E startup tests
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
       - name: 🚀 Build with EAS for ${{ matrix.platform }}
         uses: ./.github/actions/eas-build
         id: build_eas

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix interaction between reload JS API and ErrorRecovery. ([#25651](https://github.com/expo/expo/pull/25651) by [@wschurman](https://github.com/wschurman))
+- [Android] Fix wait notify bug in launch asset when enabled. ([#25676](https://github.com/expo/expo/pull/25676) by [@wschurman](https://github.com/wschurman))
 
 
 ### 💡 Others

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -65,6 +65,12 @@ class EnabledUpdatesController(
 
   private var isStartupFinished = false
 
+  @Synchronized
+  private fun onStartupProcedureFinished() {
+    isStartupFinished = true
+    (this@EnabledUpdatesController as java.lang.Object).notify()
+  }
+
   private val startupProcedure = StartupProcedure(
     context,
     updatesConfiguration,
@@ -74,10 +80,8 @@ class EnabledUpdatesController(
     selectionPolicy,
     logger,
     object : StartupProcedure.StartupProcedureCallback {
-      @Synchronized
       override fun onFinished() {
-        isStartupFinished = true
-        (this as java.lang.Object).notify()
+        onStartupProcedureFinished()
       }
 
       override fun onLegacyJSEvent(event: StartupProcedure.StartupProcedureCallback.LegacyJSEvent) {

--- a/packages/expo-updates/e2e/fixtures/Updates-startup.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-startup.e2e.ts
@@ -1,0 +1,92 @@
+import { by, device, element, waitFor } from 'detox';
+import jestExpect from 'expect';
+
+import Server from './utils/server';
+import Update from './utils/update';
+
+const projectRoot = process.env.PROJECT_ROOT || process.cwd();
+const platform = device.getPlatform();
+const protocolVersion = 1;
+const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
+
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
+  return attributes?.text || '';
+};
+
+const waitForAppToBecomeVisible = async () => {
+  await waitFor(element(by.id('updateString')))
+    .toBeVisible()
+    .withTimeout(2000);
+};
+
+describe('Basic tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+    Server.stop();
+  });
+
+  it('downloads new update before launching', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      [],
+      projectRoot
+    );
+
+    Server.start(Update.serverPort, protocolVersion, 1000);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+    jestExpect(message).toBe('test-update-1');
+
+    await device.terminateApp();
+  });
+
+  it('does not download new update when it takes longer than timeout', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      [],
+      projectRoot
+    );
+
+    Server.start(Update.serverPort, protocolVersion, 5000);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+    jestExpect(message).toBe('test');
+
+    await device.terminateApp();
+  });
+});

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
@@ -4,6 +4,7 @@ import FormData from 'form-data';
 import * as fs from 'fs';
 import * as path from 'path';
 import { serializeDictionary } from 'structured-headers';
+import { setTimeout as setTimeoutNormal } from 'timers';
 import { setTimeout } from 'timers/promises';
 
 const app = express();
@@ -22,11 +23,13 @@ let multipartResponseToServe: any = null;
 let requestedStaticFiles: string[] = [];
 
 let protocolVersion: number = 1;
+let artificialDelay: number = 0;
 
-function start(port: any, protocol: number = 1) {
+function start(port: any, protocol: number = 1, artificialDelayMs: number = 0) {
   if (!server) {
     server = app.listen(port);
     protocolVersion = protocol;
+    artificialDelay = artificialDelayMs;
   }
 }
 
@@ -123,13 +126,23 @@ app.get('/update', (req: any, res: any) => {
       });
     }
 
-    res.statusCode = 200;
-    res.setHeader('expo-protocol-version', 1);
-    res.setHeader('expo-sfv-version', 0);
-    res.setHeader('cache-control', 'private, max-age=0');
-    res.setHeader('content-type', `multipart/mixed; boundary=${form.getBoundary()}`);
-    res.write(form.getBuffer());
-    res.end();
+    const sendResponse = () => {
+      res.statusCode = 200;
+      res.setHeader('expo-protocol-version', 1);
+      res.setHeader('expo-sfv-version', 0);
+      res.setHeader('cache-control', 'private, max-age=0');
+      res.setHeader('content-type', `multipart/mixed; boundary=${form.getBoundary()}`);
+      res.write(form.getBuffer());
+      res.end();
+    };
+
+    if (artificialDelay > 0) {
+      setTimeoutNormal(() => {
+        sendResponse();
+      }, artificialDelay);
+    } else {
+      sendResponse();
+    }
   } else {
     // Protocol 0
     if (manifestToServe) {

--- a/packages/expo-updates/e2e/setup/create-startup-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-startup-eas-project.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import {
+  initAsync,
+  setupUpdatesStartupE2EAppAsync,
+  transformAppJsonForE2EWithFallbackToCacheTimeout,
+} from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: true,
+    transformAppJson: transformAppJsonForE2EWithFallbackToCacheTimeout,
+  });
+
+  await setupUpdatesStartupE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();


### PR DESCRIPTION
# Why

There's a bug in the wait/notify pattern synchronization (synchronized on the wrong object) where a fallbackToCacheTimeout causes the app not to launch.

This wasn't caught by e2e since e2e doesn't use `fallbackToCacheTimeout`, and when it is not used the race of startup procedure and calling for launch asset is won by startup procedure, so wait/notify isn't even used.

Closes ENG-10774.

# How

1. Add `fallbackToCacheTimeout` e2e tests.
2. Run e2e, verify that they fail.
3. Apply fix.
4. Run e2e, verify that they are fixed.

# Test Plan

e2e tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
