### PR TITLE
fix: [ios][expo-video-thumbnails] timeFrame > video duration will fail

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed an issue where `timeFrame` exceeding video duration failed to generate a thumbnail. Implemented clamping. ([#25681](https://github.com/expo/expo/pull/25681) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 - [iOS] Replace legacy `FileSystem` interfaces usage with core `FileSystemUtilities`. ([#25495](https://github.com/expo/expo/pull/25495) by [@alanhughes](https://github.com/alanjhughes))

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -27,8 +27,8 @@ public class VideoThumbnailsModule: Module {
 
     // `requestedTimeToleranceBefore` can only be set if `time` is less
     // than the video duration, otherwise it will fail to generate an image.
-    if(time < asset.duration) {
-      generator.requestedTimeToleranceBefore = CMTime.zero
+    if time < asset.duration {
+      generator.requestedTimeToleranceBefore = .zero
     }
 
     let imgRef = try generator.copyCGImage(at: time, actualTime: nil)

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -24,8 +24,8 @@ public class VideoThumbnailsModule: Module {
     generator.requestedTimeToleranceBefore = CMTime.zero
     generator.requestedTimeToleranceAfter = CMTime.zero
 
-    let time = CMTimeMake(value: options.time, timescale: 1000)
-    let imgRef = try generator.copyCGImage(at: time, actualTime: nil)
+    let requestedTime = clampTimeForThumbnail(asset: asset, time: options.time)
+    let imgRef = try generator.copyCGImage(at: requestedTime, actualTime: nil)
     let thumbnail = UIImage.init(cgImage: imgRef)
     let savedImageUrl = try saveImage(image: thumbnail, quality: options.quality)
 
@@ -62,4 +62,15 @@ public class VideoThumbnailsModule: Module {
 
     return fileUrl
   }
+}
+
+/**
+Adjusts the requested time for thumbnail generation to ensure it does not exceed the video's duration.
+*/
+private func clampTimeForThumbnail(asset: AVURLAsset, time: Int64) -> CMTime {
+  let duration = asset.duration
+  let requestedTime = CMTimeMake(value: time, timescale: 1000)
+  
+  // Check if the requested time exceeds the video's duration
+  return requestedTime > duration ? duration : requestedTime
 }

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -65,21 +65,15 @@ public class VideoThumbnailsModule: Module {
 }
 
 /**
-Adjusts the requested time for thumbnail generation to ensure it does not exceed the video's duration.
-*/
-/**
  Adjusts the requested time for thumbnail generation to ensure it does not exceed the video's duration.
  */
 private func clampTimeForThumbnail(asset: AVURLAsset, time: Int64) -> CMTime {
-  let originalDuration = asset.duration
+  let duration = asset.duration
   let requestedTime = CMTimeMake(value: time, timescale: 1000)
-    
-  // Rounding down to the nearest second or QuickLook might fail to generate
-  let roundingFactor = Int64(originalDuration.timescale)
-  let roundedValue = Int64(floor(Double(originalDuration.value) / Double(roundingFactor))) * roundingFactor
-  
-  let roundedDuration = CMTime(value: roundedValue, timescale: originalDuration.timescale, flags: originalDuration.flags, epoch: originalDuration.epoch)
+
+  // Some videos fail even when we pass the real duration (2/10). Subtracting 1000ms makes it work reliably.
+  let subtractedDuration = CMTime(value: duration.value - 1000, timescale: duration.timescale, flags: duration.flags, epoch: duration.epoch)
 
   // Check if the requested time exceeds the video's duration
-  return requestedTime > originalDuration ? roundedDuration : requestedTime
+  return requestedTime > subtractedDuration ? subtractedDuration : requestedTime
 }

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -69,4 +69,3 @@ public class VideoThumbnailsModule: Module {
     return fileUrl
   }
 }
-

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -67,10 +67,19 @@ public class VideoThumbnailsModule: Module {
 /**
 Adjusts the requested time for thumbnail generation to ensure it does not exceed the video's duration.
 */
+/**
+ Adjusts the requested time for thumbnail generation to ensure it does not exceed the video's duration.
+ */
 private func clampTimeForThumbnail(asset: AVURLAsset, time: Int64) -> CMTime {
-  let duration = asset.duration
+  let originalDuration = asset.duration
   let requestedTime = CMTimeMake(value: time, timescale: 1000)
+    
+  // Rounding down to the nearest second or QuickLook might fail to generate
+  let roundingFactor = Int64(originalDuration.timescale)
+  let roundedValue = Int64(floor(Double(originalDuration.value) / Double(roundingFactor))) * roundingFactor
   
+  let roundedDuration = CMTime(value: roundedValue, timescale: originalDuration.timescale, flags: originalDuration.flags, epoch: originalDuration.epoch)
+
   // Check if the requested time exceeds the video's duration
-  return requestedTime > duration ? duration : requestedTime
+  return requestedTime > originalDuration ? roundedDuration : requestedTime
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Expo Video Thumbnails will fail to generate a thumbnail with the error "Could not open" if the timeFrame exceeds the video duration.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Since AVFoundation provides access to the duration, I clamped the time by allowing requestedTimeToleranceBefore to be set on the generator only if the time is less than the duration. This was the only reliable way to prevent the generation from failing.

I haven't tested on Android. If Android also fails, I will address this issue in a separate pull request.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
