### PR TITLE
[cli] asMock -> jest.mocked

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Consolidate logic for resolving Node.js built-in shims in browser environments. ([#25511](https://github.com/expo/expo/pull/25511) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))
 - Split web server output into `server/` and `client/` subfolders when exporting. ([#25640](https://github.com/expo/expo/pull/25640) by [@kitten](https://github.com/kitten))
+- asMock -> jest.mocked. ([#25685](https://github.com/expo/expo/pull/25685) by [@wschurman](https://github.com/wschurman))
 
 ## 0.10.16 — 2023-11-24
 

--- a/packages/@expo/cli/src/__tests__/asMock.ts
+++ b/packages/@expo/cli/src/__tests__/asMock.ts
@@ -1,3 +1,0 @@
-// TODO: replace with jest.mocked when jest 27+ is upgraded to
-export const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -3,7 +3,6 @@ import nock from 'nock';
 import { FetchError } from 'node-fetch';
 import { URLSearchParams } from 'url';
 
-import { asMock } from '../../../__tests__/asMock';
 import { getExpoApiBaseUrl } from '../../endpoint';
 import UserSettings from '../../user/UserSettings';
 import { ApiV2Error, fetchAsync } from '../client';
@@ -113,7 +112,7 @@ it('makes a request using an absolute URL', async () => {
 });
 
 it('makes an authenticated request with access token', async () => {
-  asMock(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
+  jest.mocked(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
 
   nock(getExpoApiBaseUrl())
     .matchHeader('authorization', (val) => val.length === 1 && val[0] === 'Bearer my-access-token')
@@ -126,13 +125,13 @@ it('makes an authenticated request with access token', async () => {
 });
 
 it('makes an authenticated request with session secret', async () => {
-  asMock(UserSettings.getSession).mockClear().mockReturnValue({
+  jest.mocked(UserSettings.getSession).mockClear().mockReturnValue({
     sessionSecret: 'my-secret-token',
     userId: '',
     username: '',
     currentConnection: 'Username-Password-Authentication',
   });
-  asMock(UserSettings.getAccessToken).mockReturnValue(null);
+  jest.mocked(UserSettings.getAccessToken).mockReturnValue(null);
 
   nock(getExpoApiBaseUrl())
     .matchHeader('expo-session', (val) => val.length === 1 && val[0] === 'my-secret-token')
@@ -145,8 +144,8 @@ it('makes an authenticated request with session secret', async () => {
 });
 
 it('only uses access token when both authentication methods are available', async () => {
-  asMock(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
-  asMock(UserSettings.getSession).mockClear().mockReturnValue({
+  jest.mocked(UserSettings.getAccessToken).mockClear().mockReturnValue('my-access-token');
+  jest.mocked(UserSettings.getSession).mockClear().mockReturnValue({
     sessionSecret: 'my-secret-token',
     userId: '',
     username: '',

--- a/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import { Stream } from 'stream';
 import { promisify } from 'util';
 
-import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { wrapFetchWithProgress } from '../wrapFetchWithProgress';
 
@@ -15,7 +14,7 @@ jest.mock(`../../../log`);
 
 describe(wrapFetchWithProgress, () => {
   beforeEach(() => {
-    asMock(Log.warn).mockClear();
+    jest.mocked(Log.warn).mockClear();
   });
   it('should call the progress callback', async () => {
     const url = 'https://example.com';

--- a/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../__tests__/asMock';
 import { promptAsync } from '../../../utils/prompts';
 import { ApiV2Error } from '../../rest/client';
 import { showLoginPromptAsync } from '../actions';
@@ -17,24 +16,26 @@ jest.mock('../otp');
 jest.mock('../user');
 
 beforeEach(() => {
-  asMock(promptAsync).mockClear();
-  asMock(promptAsync).mockImplementation(() => {
+  jest.mocked(promptAsync).mockClear();
+  jest.mocked(promptAsync).mockImplementation(() => {
     throw new Error('Should not be called');
   });
 
-  asMock(loginAsync).mockClear();
-  asMock(ssoLoginAsync).mockClear();
+  jest.mocked(loginAsync).mockClear();
+  jest.mocked(ssoLoginAsync).mockClear();
 });
 
 describe(showLoginPromptAsync, () => {
   it('prompts for OTP when 2FA is enabled', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ username: 'hello', password: 'world' }))
       .mockImplementationOnce(async () => ({ otp: '123456' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
-    asMock(loginAsync)
+    jest
+      .mocked(loginAsync)
       .mockImplementationOnce(async () => {
         throw new ApiV2Error({
           message: 'An OTP is required',
@@ -70,16 +71,16 @@ describe(showLoginPromptAsync, () => {
   });
 
   it('does not prompt if all required credentials are provided', async () => {
-    asMock(promptAsync).mockImplementation(() => {
+    jest.mocked(promptAsync).mockImplementation(() => {
       throw new Error("shouldn't happen");
     });
-    asMock(loginAsync).mockImplementation(async () => {});
+    jest.mocked(loginAsync).mockImplementation(async () => {});
 
     await showLoginPromptAsync({ username: 'hello', password: 'world' });
   });
 
   it('calls regular login if the sso flag is false', async () => {
-    asMock(promptAsync).mockImplementationOnce(async () => ({
+    jest.mocked(promptAsync).mockImplementationOnce(async () => ({
       username: 'USERNAME',
       password: 'PASSWORD',
     }));
@@ -90,7 +91,8 @@ describe(showLoginPromptAsync, () => {
   });
 
   it('calls regular login if the sso flag is undefined', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
@@ -102,7 +104,7 @@ describe(showLoginPromptAsync, () => {
   });
 
   it('calls SSO login if the sso flag is true', async () => {
-    asMock(promptAsync);
+    jest.mocked(promptAsync);
     await showLoginPromptAsync({ username: 'hello', password: 'world', sso: true });
 
     expect(ssoLoginAsync).toHaveBeenCalledTimes(1);

--- a/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/otp-test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock';
 
-import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { promptAsync, selectAsync } from '../../../utils/prompts';
 import { getExpoApiBaseUrl } from '../../endpoint';
@@ -12,19 +11,20 @@ jest.mock('../user');
 jest.mock('../../../log');
 
 beforeEach(() => {
-  asMock(promptAsync).mockImplementation(() => {
+  jest.mocked(promptAsync).mockImplementation(() => {
     throw new Error('Should not be called');
   });
 
-  asMock(selectAsync).mockClear();
-  asMock(selectAsync).mockImplementation(() => {
+  jest.mocked(selectAsync).mockClear();
+  jest.mocked(selectAsync).mockImplementation(() => {
     throw new Error('Should not be called');
   });
 });
 
 describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: 'hello' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
@@ -50,7 +50,8 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('shows authenticator OTP prompt when authenticator is primary', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: 'hello' }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
@@ -73,14 +74,16 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('shows menu when user bails on primary', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
-    asMock(selectAsync)
+    jest
+      .mocked(selectAsync)
       .mockImplementationOnce(async () => -1)
       .mockImplementation(async () => {
         throw new Error("shouldn't happen");
@@ -109,7 +112,8 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('shows a warning when when user bails on primary and does not have any secondary set up', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
@@ -133,14 +137,16 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
-    asMock(selectAsync)
+    jest
+      .mocked(selectAsync)
       .mockImplementationOnce(async () => -1)
       .mockImplementation(async () => {
         throw new Error("shouldn't happen");
@@ -168,14 +174,16 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('requests SMS OTP and prompts for SMS OTP when user selects SMS secondary', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
-    asMock(selectAsync)
+    jest
+      .mocked(selectAsync)
       .mockImplementationOnce(async () => 0)
       .mockImplementation(async () => {
         throw new Error("shouldn't happen");
@@ -212,13 +220,15 @@ describe(retryUsernamePasswordAuthWithOTPAsync, () => {
   });
 
   it('exits when user bails on primary and backup', async () => {
-    asMock(promptAsync)
+    jest
+      .mocked(promptAsync)
       .mockImplementationOnce(async () => ({ otp: null }))
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
       });
 
-    asMock(selectAsync)
+    jest
+      .mocked(selectAsync)
       .mockImplementationOnce(async () => -2)
       .mockImplementation(async () => {
         throw new Error("shouldn't happen");

--- a/packages/@expo/cli/src/customize/__tests__/generate-test.ts
+++ b/packages/@expo/cli/src/customize/__tests__/generate-test.ts
@@ -5,9 +5,6 @@ import { copyAsync } from '../../utils/dir';
 import { queryAndGenerateAsync, selectAndGenerateAsync } from '../generate';
 import { selectTemplatesAsync } from '../templates';
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 jest.mock('../../log');
 jest.mock('../templates', () => {
   const templates = jest.requireActual('../templates');
@@ -67,7 +64,7 @@ describe(selectAndGenerateAsync, () => {
   });
 
   it(`exits when no items are selected`, async () => {
-    asMock(selectTemplatesAsync).mockResolvedValue([]);
+    jest.mocked(selectTemplatesAsync).mockResolvedValue([]);
 
     await expect(
       selectAndGenerateAsync('/', {
@@ -90,7 +87,7 @@ describe(selectAndGenerateAsync, () => {
       '/'
     );
 
-    asMock(selectTemplatesAsync).mockResolvedValue([1]);
+    jest.mocked(selectTemplatesAsync).mockResolvedValue([1]);
 
     await selectAndGenerateAsync('/', {
       props: {
@@ -110,7 +107,7 @@ describe(selectAndGenerateAsync, () => {
   it(`selects a file from installed, and generates`, async () => {
     vol.fromJSON({}, '/');
 
-    asMock(selectTemplatesAsync).mockResolvedValue([1]);
+    jest.mocked(selectTemplatesAsync).mockResolvedValue([1]);
 
     await selectAndGenerateAsync('/', {
       props: {

--- a/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { vol } from 'memfs';
 
-import { asMock } from '../../__tests__/asMock';
 import { exportAppAsync } from '../exportApp';
 import { unstable_exportStaticAsync } from '../exportStaticAsync';
 import { ExportAssetMap } from '../saveAssets';
@@ -122,7 +121,7 @@ describe(exportAppAsync, () => {
   });
 
   it(`exports an app for web in SPA mode`, async () => {
-    asMock(getConfig).mockReturnValue({
+    jest.mocked(getConfig).mockReturnValue({
       // @ts-expect-error
       exp: { web: { bundler: 'metro' } },
     });
@@ -166,7 +165,7 @@ describe(exportAppAsync, () => {
   });
 
   it(`exports an app for web in server mode`, async () => {
-    asMock(getConfig).mockReturnValue({
+    jest.mocked(getConfig).mockReturnValue({
       // @ts-expect-error
       exp: { web: { bundler: 'metro', output: 'server' } },
     });

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@expo/config';
 
-import { asMock } from '../../__tests__/asMock';
 import { resolveOptionsAsync } from '../resolveOptions';
 
 jest.mock('@expo/config', () => ({
@@ -87,7 +86,7 @@ describe(resolveOptionsAsync, () => {
     });
   });
   it(`parses default options with web enabled`, async () => {
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       // @ts-expect-error
       exp: { web: { bundler: 'metro' } },
     });

--- a/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@expo/config';
 
-import { asMock } from '../../__tests__/asMock';
 import { Log } from '../../log';
 import {
   getVersionedDependenciesAsync,
@@ -37,8 +36,8 @@ jest.mock('@expo/config', () => ({
 
 describe(checkPackagesAsync, () => {
   it(`checks packages and exits when packages are invalid`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(false);
-    asMock(getVersionedDependenciesAsync).mockResolvedValueOnce([
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce([
       {
         packageName: 'react-native',
         packageType: 'dependencies',
@@ -66,9 +65,9 @@ describe(checkPackagesAsync, () => {
   });
 
   it(`notifies when dependencies are on exclude list`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
     // @ts-expect-error
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       pkg: {
         expo: {
           install: {
@@ -82,7 +81,7 @@ describe(checkPackagesAsync, () => {
         slug: 'my-app',
       },
     });
-    asMock(getVersionedDependenciesAsync).mockResolvedValueOnce([
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce([
       {
         packageName: 'expo-av',
         packageType: 'dependencies',
@@ -104,8 +103,8 @@ describe(checkPackagesAsync, () => {
   });
 
   it(`checks packages and exits with zero if all are valid`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(false);
-    asMock(getVersionedDependenciesAsync).mockResolvedValueOnce([]);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce([]);
     await expect(
       checkPackagesAsync('/', {
         packages: ['react-native'],
@@ -141,7 +140,7 @@ describe(checkPackagesAsync, () => {
       },
     ];
 
-    asMock(getVersionedDependenciesAsync).mockResolvedValueOnce(issues);
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce(issues);
 
     await checkPackagesAsync('/', {
       packages: ['react-native', 'expo'],

--- a/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
@@ -1,7 +1,6 @@
 import * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 
-import { asMock } from '../../__tests__/asMock';
 import { Log } from '../../log';
 import { installExpoPackageAsync } from '../installExpoPackage';
 
@@ -57,7 +56,7 @@ describe(installExpoPackageAsync, () => {
 
   it(`Does not run follow-up command if first command fails`, async () => {
     const packageManager = PackageManager.createForProject('/path/to/project');
-    asMock(packageManager.addAsync).mockRejectedValueOnce(new Error('Something went wrong'));
+    jest.mocked(packageManager.addAsync).mockRejectedValueOnce(new Error('Something went wrong'));
 
     try {
       await installExpoPackageAsync('/path/to/project', {

--- a/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
+++ b/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
@@ -3,9 +3,6 @@ import { vol } from 'memfs';
 import { resolvePortAsync } from '../../utils/port';
 import { resolveBundlerPropsAsync } from '../resolveBundlerProps';
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 jest.mock('../../utils/port');
 
 describe(resolveBundlerPropsAsync, () => {
@@ -17,7 +14,7 @@ describe(resolveBundlerPropsAsync, () => {
     ).rejects.toThrowError(/mutually exclusive arguments/);
   });
   it(`skips bundling if the port is busy`, async () => {
-    asMock(resolvePortAsync).mockResolvedValueOnce(null);
+    jest.mocked(resolvePortAsync).mockResolvedValueOnce(null);
 
     expect(await resolveBundlerPropsAsync('/', {})).toEqual({
       port: 8081,
@@ -35,7 +32,7 @@ describe(resolveBundlerPropsAsync, () => {
     });
   });
   it(`resolves default port`, async () => {
-    asMock(resolvePortAsync).mockResolvedValueOnce(19006);
+    jest.mocked(resolvePortAsync).mockResolvedValueOnce(19006);
 
     expect(
       await resolveBundlerPropsAsync('/', {

--- a/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveInstallApkName-test.ts
@@ -1,6 +1,5 @@
 import { vol } from 'memfs';
 
-import { asMock } from '../../../__tests__/asMock';
 import { DeviceABI, getDeviceABIsAsync } from '../../../start/platforms/android/adb';
 import { resolveInstallApkNameAsync } from '../resolveInstallApkName';
 
@@ -31,7 +30,7 @@ describe(resolveInstallApkNameAsync, () => {
       },
       '/'
     );
-    asMock(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64, DeviceABI.x86]);
+    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64, DeviceABI.x86]);
     await expect(runCheck()).resolves.toBe('app-debug.apk');
   });
   it(`resolves an APK using universal cpu name`, async () => {
@@ -42,7 +41,7 @@ describe(resolveInstallApkNameAsync, () => {
       },
       '/'
     );
-    asMock(getDeviceABIsAsync).mockResolvedValueOnce([]);
+    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([]);
     await expect(runCheck()).resolves.toBe('app-universal-debug.apk');
   });
   it(`resolves an APK using custom cpu name`, async () => {
@@ -54,7 +53,7 @@ describe(resolveInstallApkNameAsync, () => {
       },
       '/'
     );
-    asMock(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
+    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64]);
     await expect(runCheck()).resolves.toBe('app-arm64-debug.apk');
   });
 });

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -12,12 +12,9 @@ jest.mock('../codeSigning/configureCodeSigning');
 
 const fs = jest.requireActual('fs') as typeof import('fs');
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 describe(getXcodeBuildArgsAsync, () => {
   it(`returns fully qualified arguments for a build`, async () => {
-    asMock(ensureDeviceIsCodeSignedForDeploymentAsync).mockResolvedValueOnce('my-dev-team');
+    jest.mocked(ensureDeviceIsCodeSignedForDeploymentAsync).mockResolvedValueOnce('my-dev-team');
     await expect(
       getXcodeBuildArgsAsync({
         projectRoot: '/path/to/project',

--- a/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
@@ -56,9 +56,6 @@ jest.mock('../launchApp', () => ({
   launchAppAsync: jest.fn(async () => {}),
 }));
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 const mockPlatform = (value: typeof process.platform) =>
   Object.defineProperty(process, 'platform', {
     value,
@@ -108,14 +105,15 @@ describe(resolveOptionsAsync, () => {
   });
 
   it(`runs ios on device`, async () => {
-    asMock(resolveDeviceAsync).mockResolvedValueOnce({
+    jest.mocked(resolveDeviceAsync).mockResolvedValueOnce({
       name: "Evan's phone",
       model: 'iPhone13,4',
       osVersion: '15.4.1',
       deviceType: 'device',
       udid: '00008101-001964A22629003A',
+      connectionType: 'USB',
     });
-    asMock(isSimulatorDevice).mockReturnValueOnce(false);
+    jest.mocked(isSimulatorDevice).mockReturnValueOnce(false);
     mockPlatform('darwin');
     vol.fromJSON(rnFixture, '/');
 
@@ -130,6 +128,7 @@ describe(resolveOptionsAsync, () => {
         name: "Evan's phone",
         osVersion: '15.4.1',
         udid: '00008101-001964A22629003A',
+        connectionType: 'USB',
       },
       isSimulator: false,
       port: 8081,
@@ -147,6 +146,7 @@ describe(resolveOptionsAsync, () => {
         name: "Evan's phone",
         osVersion: '15.4.1',
         udid: '00008101-001964A22629003A',
+        connectionType: 'USB',
       },
       isSimulator: false,
       shouldStartBundler: true,

--- a/packages/@expo/cli/src/run/ios/appleDevice/__tests__/installOnDeviceAsync-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/__tests__/installOnDeviceAsync-test.ts
@@ -13,9 +13,6 @@ jest.mock('../../../../utils/interactive', () => ({
   isInteractive: jest.fn(() => true),
 }));
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 describe(installOnDeviceAsync, () => {
   it(`resolves when the app is installed`, async () => {
     await installOnDeviceAsync({
@@ -29,10 +26,10 @@ describe(installOnDeviceAsync, () => {
     expect(confirmAsync).not.toBeCalled();
   });
   it(`prompts to retry when the device is locked`, async () => {
-    asMock(runOnDevice).mockImplementationOnce(() => {
+    jest.mocked(runOnDevice).mockImplementationOnce(() => {
       throw new CommandError('APPLE_DEVICE_LOCKED', 'device locked');
     });
-    asMock(confirmAsync).mockImplementationOnce(async () => true);
+    jest.mocked(confirmAsync).mockImplementationOnce(async () => true);
 
     await installOnDeviceAsync({
       bundle: 'foo',
@@ -45,10 +42,10 @@ describe(installOnDeviceAsync, () => {
     expect(confirmAsync).toBeCalledTimes(1);
   });
   it(`prompts to retry and throws on false`, async () => {
-    asMock(runOnDevice).mockImplementationOnce(() => {
+    jest.mocked(runOnDevice).mockImplementationOnce(() => {
       throw new CommandError('APPLE_DEVICE_LOCKED', 'device locked');
     });
-    asMock(confirmAsync).mockImplementationOnce(async () => false);
+    jest.mocked(confirmAsync).mockImplementationOnce(async () => false);
 
     await expect(
       installOnDeviceAsync({
@@ -63,7 +60,7 @@ describe(installOnDeviceAsync, () => {
     expect(confirmAsync).toBeCalledTimes(1);
   });
   it(`surfaces rejections`, async () => {
-    asMock(runOnDevice).mockImplementationOnce(() => {
+    jest.mocked(runOnDevice).mockImplementationOnce(() => {
       throw new Error('unknown');
     });
 

--- a/packages/@expo/cli/src/run/ios/codeSigning/__tests__/Security-test.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/__tests__/Security-test.ts
@@ -8,9 +8,6 @@ import {
   getSecurityPemAsync,
 } from '../Security';
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 jest.mock('../../../../start/doctor/SecurityBinPrerequisite', () => ({
   SecurityBinPrerequisite: {
     instance: {
@@ -21,7 +18,7 @@ jest.mock('../../../../start/doctor/SecurityBinPrerequisite', () => ({
 
 describe(getSecurityPemAsync, () => {
   it(`asserts that the pem could not be found`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: '',
     } as any);
 
@@ -31,7 +28,7 @@ describe(getSecurityPemAsync, () => {
 
 describe(findIdentitiesAsync, () => {
   it(`return identities`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: [
         'Returns a string like:',
         '1) 12222234253761286351826735HGKDHAJGF45283 "Apple Development: Evan Bacon (AA00AABB0A)" (CSSMERR_TP_CERT_REVOKED)',

--- a/packages/@expo/cli/src/run/ios/codeSigning/__tests__/resolveCertificateSigningIdentity-test.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/__tests__/resolveCertificateSigningIdentity-test.ts
@@ -11,8 +11,6 @@ import * as Settings from '../settings';
 
 jest.mock('../../../../log');
 jest.mock('../../../../utils/prompts');
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
 
 jest.mock('../../../../utils/interactive', () => ({
   isInteractive: jest.fn(() => true),
@@ -70,8 +68,8 @@ describe(resolveCertificateSigningIdentityAsync, () => {
   });
 
   it(`prompts when there are more than one signing identities`, async () => {
-    asMock(Settings.getLastDeveloperCodeSigningIdAsync).mockResolvedValue('YYY');
-    asMock(Security.resolveIdentitiesAsync).mockResolvedValueOnce([
+    jest.mocked(Settings.getLastDeveloperCodeSigningIdAsync).mockResolvedValue('YYY');
+    jest.mocked(Security.resolveIdentitiesAsync).mockResolvedValueOnce([
       {
         signingCertificateId: 'XXX',
         codeSigningInfo: 'Apple Development: Evan Bacon (XXX)',
@@ -85,7 +83,7 @@ describe(resolveCertificateSigningIdentityAsync, () => {
       },
     ]);
 
-    asMock(selectAsync).mockResolvedValueOnce(0);
+    jest.mocked(selectAsync).mockResolvedValueOnce(0);
 
     await expect(resolveCertificateSigningIdentityAsync(['YYY', 'XXX'])).resolves.toEqual({
       appleTeamId: expect.any(String),
@@ -107,7 +105,7 @@ describe(resolveCertificateSigningIdentityAsync, () => {
   });
 
   it(`auto selects the first ID when there is only one`, async () => {
-    asMock(Security.resolveCertificateSigningInfoAsync).mockResolvedValue({
+    jest.mocked(Security.resolveCertificateSigningInfoAsync).mockResolvedValue({
       signingCertificateId: 'XXX',
     });
 

--- a/packages/@expo/cli/src/run/ios/codeSigning/__tests__/simulatorCodeSigning.test.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/__tests__/simulatorCodeSigning.test.ts
@@ -2,7 +2,6 @@ import { IOSConfig } from '@expo/config-plugins';
 import plist from '@expo/plist';
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { simulatorBuildRequiresCodeSigning } from '../simulatorCodeSigning';
 
 jest.mock('fs');
@@ -20,7 +19,7 @@ describe(simulatorBuildRequiresCodeSigning, () => {
   afterEach(() => vol.reset());
 
   it(`returns false if the entitlements file cannot be found`, () => {
-    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue(null);
+    jest.mocked(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue(null);
     expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(false);
   });
   it(`returns false if the entitlements file contains values which don't need to be signed`, () => {
@@ -33,7 +32,7 @@ describe(simulatorBuildRequiresCodeSigning, () => {
       projectRoot
     );
 
-    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
+    jest.mocked(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
     expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(false);
   });
   it(`returns true if the entitlements file contains values which require signing`, () => {
@@ -46,7 +45,7 @@ describe(simulatorBuildRequiresCodeSigning, () => {
       projectRoot
     );
 
-    asMock(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
+    jest.mocked(IOSConfig.Entitlements.getEntitlementsPath).mockReturnValue('/entitlements.xml');
     expect(simulatorBuildRequiresCodeSigning(projectRoot)).toBe(true);
   });
 });

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveNativeScheme-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveNativeScheme-test.ts
@@ -3,9 +3,6 @@ import { IOSConfig } from '@expo/config-plugins';
 import { selectAsync } from '../../../../utils/prompts';
 import { promptOrQueryNativeSchemeAsync, getDefaultNativeScheme } from '../resolveNativeScheme';
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 jest.mock('../../../../utils/prompts');
 jest.mock('@expo/config-plugins', () => {
   return {
@@ -20,7 +17,7 @@ jest.mock('@expo/config-plugins', () => {
 
 describe(getDefaultNativeScheme, () => {
   it(`defaults to application scheme regardless of position in array`, () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
+    jest.mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
       // Ensure the wrong one is first...
       { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
       { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
@@ -42,9 +39,11 @@ describe(getDefaultNativeScheme, () => {
     });
   });
   it(`uses only scheme if available even if no application scheme is available`, () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
-      { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
-    ]);
+    jest
+      .mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj)
+      .mockReturnValueOnce([
+        { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
+      ]);
     expect(
       getDefaultNativeScheme(
         '/',
@@ -65,9 +64,11 @@ describe(getDefaultNativeScheme, () => {
 
 describe(promptOrQueryNativeSchemeAsync, () => {
   it(`resolves xcworkspace with higher priority than xcodeproj`, async () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
-      { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
-    ]);
+    jest
+      .mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj)
+      .mockReturnValueOnce([
+        { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
+      ]);
 
     expect(await promptOrQueryNativeSchemeAsync('/', { scheme: 'foobar' })).toEqual({
       name: 'foobar',
@@ -76,19 +77,19 @@ describe(promptOrQueryNativeSchemeAsync, () => {
     });
   });
   it(`asserts no schemes`, async () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([]);
+    jest.mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([]);
 
     await expect(promptOrQueryNativeSchemeAsync('/', { scheme: 'foobar' })).rejects.toThrowError(
       /No native iOS build schemes found/
     );
   });
   it(`prompts to select a scheme`, async () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
+    jest.mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
       { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
       { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
     ]);
 
-    asMock(selectAsync).mockResolvedValueOnce('foobar2');
+    jest.mocked(selectAsync).mockResolvedValueOnce('foobar2');
 
     expect(await promptOrQueryNativeSchemeAsync('/', { scheme: true })).toEqual({
       name: 'foobar2',
@@ -97,12 +98,12 @@ describe(promptOrQueryNativeSchemeAsync, () => {
     });
   });
   it(`returns null if no matching scheme can be found`, async () => {
-    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
+    jest.mocked(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
       { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
       { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
     ]);
 
-    asMock(selectAsync).mockResolvedValueOnce('bacon');
+    jest.mocked(selectAsync).mockResolvedValueOnce('bacon');
     expect(await promptOrQueryNativeSchemeAsync('/', { scheme: true })).toEqual(null);
   });
 });

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
@@ -4,9 +4,6 @@ import rnFixture from '../../../../prebuild/__tests__/fixtures/react-native-proj
 import { isSimulatorDevice } from '../resolveDevice';
 import { resolveOptionsAsync } from '../resolveOptions';
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 jest.mock('../../../../utils/port');
 
 jest.mock('../resolveDevice', () => ({
@@ -39,7 +36,7 @@ describe(resolveOptionsAsync, () => {
   it(`resolves complex options`, async () => {
     vol.fromJSON(rnFixture, '/');
 
-    asMock(isSimulatorDevice).mockImplementationOnce(() => false);
+    jest.mocked(isSimulatorDevice).mockImplementationOnce(() => false);
 
     expect(
       await resolveOptionsAsync('/', {

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../__tests__/asMock';
 import { hasDirectDevClientDependency } from '../../utils/analytics/getDevClientProperties';
 import { resolvePortAsync } from '../../utils/port';
 import { resolveHostType, resolveOptionsAsync, resolvePortsAsync } from '../resolveOptions';
@@ -81,14 +80,16 @@ describe(resolveHostType, () => {
 
 describe(resolvePortsAsync, () => {
   beforeEach(() => {
-    asMock(resolvePortAsync).mockImplementation(async (root, { defaultPort, fallbackPort }) => {
-      if (typeof defaultPort === 'string' && defaultPort) {
-        return parseInt(defaultPort, 10);
-      } else if (typeof defaultPort === 'number' && defaultPort) {
-        return defaultPort;
-      }
-      return fallbackPort;
-    });
+    jest
+      .mocked(resolvePortAsync)
+      .mockImplementation(async (root, { defaultPort, fallbackPort }) => {
+        if (typeof defaultPort === 'string' && defaultPort) {
+          return parseInt(defaultPort, 10);
+        } else if (typeof defaultPort === 'number' && defaultPort) {
+          return defaultPort;
+        }
+        return fallbackPort;
+      });
   });
   it(`resolves default port for metro`, async () => {
     await expect(resolvePortsAsync('/noop', {}, { webOnly: false })).resolves.toStrictEqual({

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/SimulatorAppPrerequisite-test.ts
@@ -1,17 +1,18 @@
 import { execAsync } from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { SimulatorAppPrerequisite } from '../SimulatorAppPrerequisite';
 
 jest.mock(`../../../../log`);
 
 it(`detects that Simulator.app is installed`, async () => {
   // Mock Simulator.app installed for CI
-  asMock(execAsync)
+  jest
+    .mocked(execAsync)
     .mockReset()
     .mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
-  asMock(spawnAsync)
+  jest
+    .mocked(spawnAsync)
     .mockReset()
     .mockResolvedValueOnce({} as any);
 
@@ -23,8 +24,8 @@ it(`detects that Simulator.app is installed`, async () => {
 
 it(`asserts that Simulator.app is installed with invalid Simulator.app`, async () => {
   // Mock Simulator.app installed with invalid binary
-  asMock(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.bacon`);
-  asMock(spawnAsync).mockReset();
+  jest.mocked(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.bacon`);
+  jest.mocked(spawnAsync).mockReset();
 
   await expect(SimulatorAppPrerequisite.instance.assertImplementation()).rejects.toThrow(/\.bacon/);
   expect(spawnAsync).not.toBeCalled();
@@ -32,8 +33,8 @@ it(`asserts that Simulator.app is installed with invalid Simulator.app`, async (
 
 it(`asserts that Simulator.app is installed but simctl doesn't work`, async () => {
   // Mock Simulator.app installed for CI
-  asMock(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
-  asMock(spawnAsync).mockImplementationOnce(() => {
+  jest.mocked(execAsync).mockResolvedValueOnce(`com.apple.CoreSimulator.SimulatorTrampoline`);
+  jest.mocked(spawnAsync).mockImplementationOnce(() => {
     throw new Error('foobar');
   });
 

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { confirmAsync } from '../../../../utils/prompts';
 import { getXcodeVersionAsync, XcodePrerequisite } from '../XcodePrerequisite';
@@ -9,27 +8,27 @@ jest.mock(`../../../../log`);
 jest.mock('../../../../utils/prompts');
 
 function mockXcodeInstalled() {
-  return asMock(execSync).mockReturnValue(`Xcode 14.3
+  return jest.mocked(execSync).mockReturnValue(`Xcode 14.3
 Build version 14E222b`);
 }
 
 describe(getXcodeVersionAsync, () => {
   beforeEach(() => {
-    asMock(Log.error).mockReset();
+    jest.mocked(Log.error).mockReset();
   });
   it(`returns the xcode version`, () => {
     mockXcodeInstalled();
     expect(getXcodeVersionAsync()).toEqual('14.3.0');
   });
   it(`logs an error when the xcode cli format is invalid`, () => {
-    asMock(execSync).mockReturnValue(`foobar`);
+    jest.mocked(execSync).mockReturnValue(`foobar`);
     expect(getXcodeVersionAsync()).toEqual(null);
     expect(Log.error).toHaveBeenLastCalledWith(
       expect.stringMatching(/Unable to check Xcode version/)
     );
   });
   it(`returns null when the xcode command fails (not installed)`, () => {
-    asMock(execSync).mockImplementationOnce(() => {
+    jest.mocked(execSync).mockImplementationOnce(() => {
       throw new Error('foobar');
     });
     expect(getXcodeVersionAsync()).toEqual(null);
@@ -53,7 +52,8 @@ it(`validates that Xcode is installed and is valid`, async () => {
   mockXcodeInstalled();
 
   // Ensure the confirmation is never called.
-  asMock(confirmAsync)
+  jest
+    .mocked(confirmAsync)
     .mockReset()
     .mockImplementation(() => {
       throw new Error("shouldn't happen");
@@ -78,7 +78,8 @@ for (const platform of ['darwin', 'win32']) {
     ]) {
       it(`opens the app store when: ${condition}`, async () => {
         mockPlatform(platform);
-        asMock(execSync)
+        jest
+          .mocked(execSync)
           // Mock xcode is not installed.
           .mockImplementationOnce(() => {
             return `Xcode ${xcodeVersion}
@@ -87,7 +88,8 @@ Build version 13A1030d`;
           // Skip actually opening the app store.
           .mockImplementationOnce((cmd) => '');
 
-        asMock(confirmAsync)
+        jest
+          .mocked(confirmAsync)
           .mockReset()
           // Ensure the confirmation is selected.
           .mockImplementationOnce(async () => true)

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import { execSync } from 'child_process';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { confirmAsync } from '../../../../utils/prompts';
 import { XcrunPrerequisite } from '../XcrunPrerequisite';
 
@@ -10,10 +9,11 @@ jest.mock('../../../../utils/prompts');
 
 it(`detects that xcrun is installed and is valid`, async () => {
   // Mock xcrun installed for CI
-  asMock(execSync).mockReset().mockReturnValueOnce(`xcrun version 64.`);
+  jest.mocked(execSync).mockReset().mockReturnValueOnce(`xcrun version 64.`);
 
   // Ensure the confirmation is never called.
-  asMock(confirmAsync)
+  jest
+    .mocked(confirmAsync)
     .mockReset()
     .mockImplementation(() => {
       throw new Error("shouldn't happen");
@@ -23,16 +23,18 @@ it(`detects that xcrun is installed and is valid`, async () => {
 });
 
 it(`asserts that xcrun is not installed and installs it successfully`, async () => {
-  asMock(spawnAsync).mockReset();
+  jest.mocked(spawnAsync).mockReset();
   // Mock xcrun installed for CI
-  asMock(execSync)
+  jest
+    .mocked(execSync)
     .mockReset()
     .mockImplementationOnce(() => {
       throw new Error('foobar');
     })
     .mockReturnValueOnce(`xcrun version 64.`);
 
-  asMock(confirmAsync)
+  jest
+    .mocked(confirmAsync)
     .mockReset()
     // Invoke the confirmation
     .mockResolvedValueOnce(true)
@@ -46,16 +48,18 @@ it(`asserts that xcrun is not installed and installs it successfully`, async () 
 });
 
 it(`asserts that xcrun is not installed and the user cancels`, async () => {
-  asMock(spawnAsync).mockReset();
+  jest.mocked(spawnAsync).mockReset();
   // Mock xcrun installed for CI
-  asMock(execSync)
+  jest
+    .mocked(execSync)
     .mockReset()
     .mockImplementationOnce(() => {
       throw new Error('foobar');
     })
     .mockReturnValueOnce(`xcrun version 64.`);
 
-  asMock(confirmAsync)
+  jest
+    .mocked(confirmAsync)
     .mockReset()
     // Invoke the confirmation
     .mockResolvedValueOnce(false)

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getMissingPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getMissingPackages-test.ts
@@ -1,6 +1,5 @@
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import {
   collectMissingPackages,
   getMissingPackagesAsync,
@@ -53,7 +52,7 @@ describe(getMissingPackagesAsync, () => {
 
   it('gets missing packages', async () => {
     const projectRoot = '/test-project';
-    asMock(getCombinedKnownVersionsAsync).mockResolvedValue({
+    jest.mocked(getCombinedKnownVersionsAsync).mockResolvedValue({
       'react-native': '1.0.0',
       'react-dom': '420.0.0',
       react: '420.0.0',

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import { getVersionsAsync } from '../../../../api/getVersions';
 import { Log } from '../../../../log';
 import { getVersionedNativeModulesAsync } from '../bundledNativeModules';
@@ -22,7 +21,7 @@ jest.mock('../bundledNativeModules', () => ({
 describe(getCombinedKnownVersionsAsync, () => {
   it(`should prioritize remote versions over bundled versions`, async () => {
     // Remote versions
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -34,7 +33,7 @@ describe(getCombinedKnownVersionsAsync, () => {
     } as any);
 
     // Bundled versions
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({
       shared: 'bundled',
       'local-only': 'xxx',
     });
@@ -47,7 +46,7 @@ describe(getCombinedKnownVersionsAsync, () => {
   });
 
   it(`skips fetching remote versions when requested`, async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValue({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValue({
       shared: 'bundled',
     });
 
@@ -68,8 +67,8 @@ describe(getCombinedKnownVersionsAsync, () => {
 
 describe(getVersionedPackagesAsync, () => {
   it('should return an SDK compatible version of a package if one is available', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -92,8 +91,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should ignore SDK compatible version if package@version is passed in', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -116,8 +115,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should return an SDK compatible version of react if one is available', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -140,8 +139,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should return the SDK incompatible version of react when react@version is passed in', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -164,8 +163,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should ignore SDK compatible version if package@version is passed in', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -188,8 +187,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should return versioned packages', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -231,8 +230,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should not specify versions for excluded packages', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -273,8 +272,8 @@ describe(getVersionedPackagesAsync, () => {
   });
 
   it('should not list packages in expo.install.exclude that do not have a bundledNativeVersion', async () => {
-    asMock(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionedNativeModulesAsync).mockResolvedValueOnce({});
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {
@@ -354,7 +353,7 @@ describe(getRemoteVersionsForSdkAsync, () => {
     expect(getVersionsAsync).not.toBeCalled();
   });
   it('returns an empty object when the SDK version is not supported', async () => {
-    asMock(getVersionsAsync).mockResolvedValueOnce({ sdkVersions: {} } as any);
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({ sdkVersions: {} } as any);
 
     expect(await getRemoteVersionsForSdkAsync({ sdkVersion: '1.0.0', skipCache: true })).toEqual(
       {}
@@ -362,7 +361,7 @@ describe(getRemoteVersionsForSdkAsync, () => {
   });
 
   it('returns versions for SDK with Facebook overrides', async () => {
-    asMock(getVersionsAsync).mockResolvedValueOnce({
+    jest.mocked(getVersionsAsync).mockResolvedValueOnce({
       sdkVersions: {
         '1.0.0': {
           relatedPackages: {

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -2,7 +2,6 @@ import { vol } from 'memfs';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { getCombinedKnownVersionsAsync } from '../getVersionedPackages';
 import {
@@ -29,7 +28,7 @@ jest.mock('../getVersionedPackages', () => ({
 
 describe(logIncorrectDependencies, () => {
   it(`logs incorrect dependencies`, () => {
-    asMock(Log.warn).mockImplementation(console.log);
+    jest.mocked(Log.warn).mockImplementation(console.log);
 
     logIncorrectDependencies([
       {
@@ -126,7 +125,7 @@ describe(validateDependenciesVersionsAsync, () => {
   });
 
   it('resolves to false when the installed packages do not match bundled native modules', async () => {
-    asMock(Log.warn).mockReset();
+    jest.mocked(Log.warn).mockReset();
     vol.fromJSON(
       {
         'node_modules/expo/package.json': JSON.stringify({
@@ -160,7 +159,7 @@ describe(validateDependenciesVersionsAsync, () => {
   });
 
   it('skips packages do not match bundled native modules but are in package.json expo.install.exclude', async () => {
-    asMock(Log.warn).mockReset();
+    jest.mocked(Log.warn).mockReset();
     vol.fromJSON(
       {
         'node_modules/expo/package.json': JSON.stringify({
@@ -215,7 +214,7 @@ describe(validateDependenciesVersionsAsync, () => {
     // Manually trigger the Node import error for "exports".
     // This isn't triggered by memfs, or our mock, that's why we need to do it manually.
     // see: https://github.com/expo/expo-cli/pull/3878
-    asMock(resolveFrom).mockImplementationOnce(() => {
+    jest.mocked(resolveFrom).mockImplementationOnce(() => {
       const message = `Package subpath './package.json' is not defined by "exports" in ${packageJsonPath}`;
       const error: any = new Error(message);
       error.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
@@ -246,7 +245,7 @@ describe(validateDependenciesVersionsAsync, () => {
       },
       projectRoot
     );
-    asMock(getCombinedKnownVersionsAsync).mockResolvedValue({
+    jest.mocked(getCombinedKnownVersionsAsync).mockResolvedValue({
       'react-native': '0.73.0-rc.5',
     });
 

--- a/packages/@expo/cli/src/start/doctor/ngrok/__tests__/ExternalModule-test.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/__tests__/ExternalModule-test.ts
@@ -1,6 +1,5 @@
 import * as PackageManager from '@expo/package-manager';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { delayAsync } from '../../../../utils/delay';
 import { confirmAsync } from '../../../../utils/prompts';
 import { ExternalModule, ExternalModuleVersionError } from '../ExternalModule';
@@ -36,7 +35,7 @@ function createExternalModuleResolver() {
 describe('get', () => {
   it(`returns null when the version is incorrect.`, () => {
     const { externalModule } = createExternalModuleResolver();
-    asMock(externalModule._require).mockReturnValue({
+    jest.mocked(externalModule._require).mockReturnValue({
       version: '1.0.0',
     });
 
@@ -48,10 +47,11 @@ describe('get', () => {
 describe('_resolveModule', () => {
   it(`asserts when the required package exports a nullish value.`, () => {
     const { externalModule } = createExternalModuleResolver();
-    asMock(externalModule._require)
+    jest
+      .mocked(externalModule._require)
       .mockReturnValueOnce({ version: '4.1.0' })
       .mockReturnValueOnce(null);
-    asMock(externalModule._resolveLocal).mockReturnValue('/');
+    jest.mocked(externalModule._resolveLocal).mockReturnValue('/');
 
     expect(() => externalModule._resolveModule(true)).toThrowError(/exports a nullish value/);
   });
@@ -60,7 +60,8 @@ describe('_resolveModule', () => {
 describe('getVersioned', () => {
   it('resolves the local instance of a package', () => {
     const { externalModule } = createExternalModuleResolver();
-    asMock(externalModule._require)
+    jest
+      .mocked(externalModule._require)
       .mockReturnValueOnce({
         version: '4.1.0',
       })
@@ -76,7 +77,8 @@ describe('getVersioned', () => {
 
   it('resolves the global instance of a package', () => {
     const { externalModule } = createExternalModuleResolver();
-    asMock(externalModule._require)
+    jest
+      .mocked(externalModule._require)
       .mockReturnValueOnce(null)
       .mockReturnValueOnce({
         version: '4.1.0',
@@ -112,7 +114,7 @@ describe('resolveAsync', () => {
   });
   it('upgrades non-compliant local package', async () => {
     const { externalModule } = createExternalModuleResolver();
-    asMock(externalModule._require).mockReturnValueOnce({
+    jest.mocked(externalModule._require).mockReturnValueOnce({
       version: '3.0.0',
     });
 
@@ -128,7 +130,8 @@ describe('resolveAsync', () => {
   it('upgrades non-compliant global package', async () => {
     const { externalModule } = createExternalModuleResolver();
 
-    asMock(externalModule._require)
+    jest
+      .mocked(externalModule._require)
       .mockReturnValueOnce(
         // Return the local package as null to imply that it doesn't exist.
         null
@@ -151,11 +154,12 @@ describe('installAsync', () => {
   it(`installs the missing package to project dev dependencies`, async () => {
     const { externalModule } = createExternalModuleResolver();
 
-    asMock(externalModule.getVersioned).mockReturnValueOnce(
+    jest.mocked(externalModule.getVersioned).mockReturnValueOnce(
       // Return the global package as null to imply that it doesn't exist.
       'foobar'
     );
-    asMock(confirmAsync)
+    jest
+      .mocked(confirmAsync)
       .mockResolvedValueOnce(true)
       .mockImplementation(() => {
         throw new Error("shouldn't happen");
@@ -163,7 +167,7 @@ describe('installAsync', () => {
 
     const addDevAsync = jest.fn();
 
-    asMock(PackageManager.createForProject).mockReturnValueOnce({
+    jest.mocked(PackageManager.createForProject).mockReturnValueOnce({
       addDevAsync,
     } as any);
 
@@ -184,14 +188,14 @@ describe('installAsync', () => {
   it(`installs the missing package globally with npm`, async () => {
     const { externalModule } = createExternalModuleResolver();
 
-    asMock(externalModule.getVersioned).mockReturnValueOnce(
+    jest.mocked(externalModule.getVersioned).mockReturnValueOnce(
       // Return the global package as null to imply that it doesn't exist.
       'foobar'
     );
 
     const addGlobalAsync = jest.fn();
 
-    asMock(PackageManager.NpmPackageManager as any).mockReturnValueOnce({
+    jest.mocked(PackageManager.NpmPackageManager as any).mockReturnValueOnce({
       addGlobalAsync,
     } as any);
 
@@ -209,15 +213,15 @@ describe('installAsync', () => {
   it(`throws an error when the package cannot be found after install`, async () => {
     const { externalModule } = createExternalModuleResolver();
 
-    asMock(externalModule.getVersioned).mockReturnValue(
+    jest.mocked(externalModule.getVersioned).mockReturnValue(
       // Return the local package as null to imply that it doesn't exist.
       null
     );
-    asMock(confirmAsync).mockImplementation(() => {
+    jest.mocked(confirmAsync).mockImplementation(() => {
       throw new Error("shouldn't happen");
     });
 
-    asMock(PackageManager.createForProject).mockReturnValueOnce({
+    jest.mocked(PackageManager.createForProject).mockReturnValueOnce({
       addDevAsync: jest.fn(),
     } as any);
 
@@ -232,15 +236,15 @@ describe('installAsync', () => {
   it(`asserts on missing`, async () => {
     const { externalModule } = createExternalModuleResolver();
 
-    asMock(externalModule.getVersioned).mockReturnValue(
+    jest.mocked(externalModule.getVersioned).mockReturnValue(
       // Return the local package as null to imply that it doesn't exist.
       null
     );
-    asMock(confirmAsync).mockImplementation(() => {
+    jest.mocked(confirmAsync).mockImplementation(() => {
       throw new Error("shouldn't happen");
     });
 
-    asMock(PackageManager.createForProject).mockReturnValueOnce({
+    jest.mocked(PackageManager.createForProject).mockReturnValueOnce({
       addDevAsync: jest.fn(),
     } as any);
 

--- a/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
@@ -1,6 +1,5 @@
 import { getConfig, getProjectConfigDescriptionWithPaths, ProjectConfig } from '@expo/config';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { stripAnsi } from '../../../../utils/ansi';
 import {
@@ -74,8 +73,8 @@ describe('_shouldSetupWebSupportAsync', () => {
   const projectRoot = '/test-project';
 
   it('skips setup due to platform exclusion', async () => {
-    asMock(getProjectConfigDescriptionWithPaths).mockReturnValueOnce('app.json');
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getProjectConfigDescriptionWithPaths).mockReturnValueOnce('app.json');
+    jest.mocked(getConfig).mockReturnValueOnce({
       pkg: {},
       rootConfig: {
         expo: {
@@ -92,8 +91,8 @@ describe('_shouldSetupWebSupportAsync', () => {
   });
 
   it('should setup web support', async () => {
-    asMock(getProjectConfigDescriptionWithPaths).mockReturnValueOnce('app.json');
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getProjectConfigDescriptionWithPaths).mockReturnValueOnce('app.json');
+    jest.mocked(getConfig).mockReturnValueOnce({
       pkg: {},
       rootConfig: {
         expo: {},

--- a/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@expo/config';
 
-import { asMock } from '../../../__tests__/asMock';
 import { AppIdResolver } from '../AppIdResolver';
 
 jest.mock('@expo/config', () => ({
@@ -44,7 +43,7 @@ describe('getAppIdAsync', () => {
     resolver.hasNativeProjectAsync = jest.fn(async () => false);
     resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
 
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       exp: {
         foo: {
           bar: 'dev.bacon.myapp',
@@ -59,7 +58,7 @@ describe('getAppIdAsync', () => {
     const resolver = createAppIdResolver();
     resolver.hasNativeProjectAsync = jest.fn(async () => false);
     resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       exp: {},
     } as any);
     await expect(resolver.getAppIdAsync()).rejects.toThrowError(/foo\.bar.*app\.json/);

--- a/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../__tests__/asMock';
 import { getVersionsAsync, SDKVersion, Versions } from '../../../api/getVersions';
 import { downloadExpoGoAsync } from '../../../utils/downloadExpoGoAsync';
 import { confirmAsync } from '../../../utils/prompts';
@@ -21,7 +20,7 @@ function createInstaller(platform: 'ios' | 'android') {
 }
 
 function mockVersionsOnce(versions: Partial<Versions>) {
-  asMock(getVersionsAsync).mockResolvedValueOnce(asVersions(versions));
+  jest.mocked(getVersionsAsync).mockResolvedValueOnce(asVersions(versions));
 }
 
 function asVersions(versions: Partial<Versions>): Versions {
@@ -122,10 +121,10 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
     } as any;
   }
   beforeEach(() => {
-    asMock(confirmAsync).mockReset();
+    jest.mocked(confirmAsync).mockReset();
   });
   it(`returns true when the user uninstalls the outdated app`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(true);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(true);
     const installer = createInstaller('android');
     installer.isClientOutdatedAsync = jest.fn(async () => true);
     const deviceManager = createDeviceManager();
@@ -136,7 +135,7 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
   });
 
   it(`prevents checking the same device twice`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(true);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(true);
     const installer = createInstaller('android');
     installer.isClientOutdatedAsync = jest.fn(async () => true);
     const deviceManager = createDeviceManager();
@@ -149,7 +148,7 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
   });
 
   it(`returns false when the user uninstalls the outdated app`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
     const installer = createInstaller('android');
     installer.isClientOutdatedAsync = jest.fn(async () => true);
     const deviceManager = createDeviceManager();
@@ -159,7 +158,7 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
   });
 
   it(`does not actually uninstall the outdated app on iOS`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(true);
+    jest.mocked(confirmAsync).mockResolvedValueOnce(true);
     const installer = createInstaller('ios');
     installer.isClientOutdatedAsync = jest.fn(async () => true);
     const deviceManager = createDeviceManager();
@@ -169,7 +168,7 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
     expect(deviceManager.uninstallAppAsync).not.toBeCalled();
   });
   it(`does not prompt if the app is not up to date`, async () => {
-    asMock(confirmAsync).mockImplementationOnce(() => {
+    jest.mocked(confirmAsync).mockImplementationOnce(() => {
       throw new Error('Should not be called');
     });
     const installer = createInstaller('ios');

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
@@ -2,7 +2,6 @@ import spawnAsync from '@expo/spawn-async';
 import { execFileSync } from 'child_process';
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { AbortCommandError } from '../../../../utils/errors';
 import { installExitHooks } from '../../../../utils/exit';
@@ -70,7 +69,7 @@ describe('resolveAdbPromise', () => {
 
 describe('startAsync', () => {
   it(`starts the ADB server`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stderr: '* daemon started successfully',
     } as any);
     const server = new ADBServer();
@@ -90,7 +89,7 @@ describe('startAsync', () => {
 });
 describe('runAsync', () => {
   it(`runs an ADB command`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       output: ['did thing'],
       stderr: 'did thing',
     } as any);
@@ -108,7 +107,7 @@ describe('runAsync', () => {
 });
 describe('getFileOutputAsync', () => {
   it(`returns file output from ADB`, async () => {
-    asMock(execFileSync).mockReturnValueOnce('foobar');
+    jest.mocked(execFileSync).mockReturnValueOnce('foobar');
     const server = new ADBServer();
     server.startAsync = jest.fn();
     server.resolveAdbPromise = jest.fn(server.resolveAdbPromise);
@@ -126,7 +125,7 @@ describe('getFileOutputAsync', () => {
 });
 describe('stopAsync', () => {
   it(`stops the ADB server when running`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
+    jest.mocked(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
     const server = new ADBServer();
     server.isRunning = true;
     await expect(server.stopAsync()).resolves.toBe(true);
@@ -134,7 +133,7 @@ describe('stopAsync', () => {
     expect(spawnAsync).toBeCalledTimes(1);
   });
   it(`stops the ADB server when not running`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
+    jest.mocked(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
     const server = new ADBServer();
     server.isRunning = false;
     await expect(server.stopAsync()).resolves.toBe(false);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidAppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidAppIdResolver-test.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { AndroidConfig } from '@expo/config-plugins';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { AndroidAppIdResolver } from '../AndroidAppIdResolver';
 
 jest.mock('@expo/config-plugins', () => ({
@@ -32,7 +31,9 @@ describe('getAppIdAsync', () => {
     const resolver = new AndroidAppIdResolver('/');
     resolver.hasNativeProjectAsync = jest.fn(resolver.hasNativeProjectAsync);
     resolver.getAppIdFromNativeAsync = jest.fn(resolver.getAppIdFromNativeAsync);
-    asMock(AndroidConfig.Package.getApplicationIdAsync).mockResolvedValueOnce('dev.bacon.myapp');
+    jest
+      .mocked(AndroidConfig.Package.getApplicationIdAsync)
+      .mockResolvedValueOnce('dev.bacon.myapp');
     expect(await resolver.getAppIdAsync()).toBe('dev.bacon.myapp');
     expect(resolver.getAppIdFromNativeAsync).toBeCalledTimes(1);
     expect(resolver.hasNativeProjectAsync).toBeCalledTimes(1);
@@ -43,7 +44,7 @@ describe('getAppIdAsync', () => {
     resolver.hasNativeProjectAsync = jest.fn(async () => false);
     resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
 
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       exp: {
         android: {
           package: 'dev.bacon.myapp',

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -1,5 +1,4 @@
 import { shellDumpsysPackage } from './fixtures/adb-output';
-import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { AndroidDeviceManager } from '../AndroidDeviceManager';
 import {
@@ -29,12 +28,12 @@ function createDevice() {
 describe('getAppVersionAsync', () => {
   it(`gets the version from an installed app`, async () => {
     const device = createDevice();
-    asMock(getPackageInfoAsync).mockResolvedValueOnce(shellDumpsysPackage);
+    jest.mocked(getPackageInfoAsync).mockResolvedValueOnce(shellDumpsysPackage);
     await expect(device.getAppVersionAsync('foobar')).resolves.toBe('2.23.2');
   });
   it(`returns null when the app is not installed`, async () => {
     const device = createDevice();
-    asMock(getPackageInfoAsync).mockResolvedValueOnce('');
+    jest.mocked(getPackageInfoAsync).mockResolvedValueOnce('');
     await expect(device.getAppVersionAsync('foobar')).resolves.toBe(null);
   });
 });
@@ -42,14 +41,14 @@ describe('getAppVersionAsync', () => {
 describe('launchActivityAsync', () => {
   it(`asserts that the app is not installed`, async () => {
     const device = createDevice();
-    asMock(launchActivityAsync).mockImplementationOnce(() => {
+    jest.mocked(launchActivityAsync).mockImplementationOnce(() => {
       throw new CommandError('APP_NOT_INSTALLED', '...');
     });
     await expect(device.launchActivityAsync).rejects.toThrow(/run:android/);
   });
   it(`asserts that an unexpected error occurred`, async () => {
     const device = createDevice();
-    asMock(launchActivityAsync).mockImplementationOnce(() => {
+    jest.mocked(launchActivityAsync).mockImplementationOnce(() => {
       throw new Error('...');
     });
     await expect(device.launchActivityAsync).rejects.toThrow(/\.\.\./);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/activateWindow-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/activateWindow-test.ts
@@ -2,7 +2,6 @@
 import { execAsync } from '@expo/osascript';
 import { execFileSync } from 'child_process';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { activateWindowAsync } from '../activateWindow';
 
 const platform = process.platform;
@@ -31,7 +30,7 @@ it(`skips for devices`, async () => {
 
 it(`brings window to the front`, async () => {
   mockPlatform('darwin');
-  asMock(execFileSync).mockReturnValueOnce('36420' as any);
+  jest.mocked(execFileSync).mockReturnValueOnce('36420' as any);
   await activateWindowAsync({ type: 'emulator', pid: 'emulator-5554' });
   expect(execFileSync).toBeCalledTimes(1);
   expect(execAsync).toBeCalledTimes(1);
@@ -40,7 +39,7 @@ it(`brings window to the front`, async () => {
 
 it(`skips if the pid cannot be found`, async () => {
   mockPlatform('darwin');
-  asMock(execFileSync).mockReturnValueOnce('' as any);
+  jest.mocked(execFileSync).mockReturnValueOnce('' as any);
   await activateWindowAsync({ type: 'emulator', pid: 'emulator-5554' });
   expect(execFileSync).toBeCalledTimes(1);
   expect(execAsync).toBeCalledTimes(0);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import {
   Device,
@@ -47,9 +46,9 @@ describe(openUrlAsync, () => {
 
 describe(launchActivityAsync, () => {
   it(`asserts that the launch activity does not exist`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce(
-      'Error: Activity class dev.bacon.app/.MainActivity does not exist.'
-    );
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce('Error: Activity class dev.bacon.app/.MainActivity does not exist.');
     await expect(
       launchActivityAsync(device, {
         launchActivity: 'dev.bacon.app/.MainActivity',
@@ -57,7 +56,7 @@ describe(launchActivityAsync, () => {
     ).rejects.toThrow(CommandError);
   });
   it(`runs`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce('...');
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
     await launchActivityAsync(device, {
       launchActivity: 'dev.bacon.app/.MainActivity',
     });
@@ -77,13 +76,15 @@ describe(launchActivityAsync, () => {
 
 describe(isPackageInstalledAsync, () => {
   it(`returns true when a package is installed`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce(
-      [
-        'package:com.google.android.networkstack.tethering',
-        'package:com.android.cts.priv.ctsshim',
-        'package:com.google.android.youtube',
-      ].join('\n')
-    );
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce(
+        [
+          'package:com.google.android.networkstack.tethering',
+          'package:com.android.cts.priv.ctsshim',
+          'package:com.google.android.youtube',
+        ].join('\n')
+      );
     expect(await isPackageInstalledAsync(device, 'com.google.android.youtube')).toBe(true);
     expect(getServer().runAsync).toBeCalledWith([
       '-s',
@@ -96,16 +97,16 @@ describe(isPackageInstalledAsync, () => {
     ]);
   });
   it(`returns false when a package is not isntalled`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce('');
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
     expect(await isPackageInstalledAsync(device, 'com.google.android.youtube')).toBe(false);
   });
 });
 
 describe(openAppIdAsync, () => {
   it(`asserts that the app does not exist`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce(
-      'Error: Activity not started, unable to resolve Intent'
-    );
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce('Error: Activity not started, unable to resolve Intent');
     await expect(
       openAppIdAsync(device, {
         applicationId: 'dev.bacon.app',
@@ -116,16 +117,16 @@ describe(openAppIdAsync, () => {
 
 describe(getAdbNameForDeviceIdAsync, () => {
   it(`returns a device name`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
     expect(await getAdbNameForDeviceIdAsync(asDevice({ pid: 'emulator-5554' }))).toBe(
       'Pixel_4_XL_API_30'
     );
   });
   it(`asserts when a device is not found`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce(
-      'error: could not connect to TCP port 55534: Connection refused'
-    );
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce('error: could not connect to TCP port 55534: Connection refused');
 
     await expect(
       getAdbNameForDeviceIdAsync(asDevice({ pid: 'emulator-5554' }))
@@ -135,7 +136,8 @@ describe(getAdbNameForDeviceIdAsync, () => {
 
 describe(isDeviceBootedAsync, () => {
   it(`returns a device when booted`, async () => {
-    asMock(getServer().runAsync)
+    jest
+      .mocked(getServer().runAsync)
       .mockResolvedValueOnce(
         [
           'List of devices attached',
@@ -158,14 +160,15 @@ describe(isDeviceBootedAsync, () => {
   });
 
   it(`returns null when the device is not booted`, async () => {
-    asMock(getServer().runAsync).mockResolvedValueOnce('');
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
     expect(await isDeviceBootedAsync(device)).toBe(null);
   });
 });
 
 describe(getAttachedDevicesAsync, () => {
   it(`gets devices`, async () => {
-    asMock(getServer().runAsync)
+    jest
+      .mocked(getServer().runAsync)
       .mockResolvedValueOnce(
         [
           'List of devices attached',
@@ -214,20 +217,20 @@ describe(getAttachedDevicesAsync, () => {
 
 describe(isBootAnimationCompleteAsync, () => {
   it(`returns true if the boot animation is complete for a device`, async () => {
-    asMock(getServer().getFileOutputAsync).mockResolvedValueOnce(
-      ['[init.svc.bootanim]: [stopped]'].join('\n')
-    );
+    jest
+      .mocked(getServer().getFileOutputAsync)
+      .mockResolvedValueOnce(['[init.svc.bootanim]: [stopped]'].join('\n'));
 
     await expect(isBootAnimationCompleteAsync()).resolves.toBe(true);
   });
   it(`returns false if the boot animation is not complete`, async () => {
-    asMock(getServer().getFileOutputAsync).mockResolvedValueOnce(
-      ['[init.svc.bootanim]: [running]'].join('\n')
-    );
+    jest
+      .mocked(getServer().getFileOutputAsync)
+      .mockResolvedValueOnce(['[init.svc.bootanim]: [running]'].join('\n'));
     await expect(isBootAnimationCompleteAsync()).resolves.toBe(false);
   });
   it(`returns false if the properties cannot be read`, async () => {
-    asMock(getServer().getFileOutputAsync).mockImplementationOnce(() => {
+    jest.mocked(getServer().getFileOutputAsync).mockImplementationOnce(() => {
       throw new Error('File not found');
     });
 
@@ -237,7 +240,7 @@ describe(isBootAnimationCompleteAsync, () => {
 
 describe(getPropertyDataForDeviceAsync, () => {
   it(`returns parsed property data`, async () => {
-    asMock(getServer().getFileOutputAsync).mockResolvedValueOnce(
+    jest.mocked(getServer().getFileOutputAsync).mockResolvedValueOnce(
       [
         '[wifi.direct.interface]: [p2p-dev-wlan0]',
         '[init.svc.bootanim]: [stopped]',
@@ -257,9 +260,9 @@ describe(getPropertyDataForDeviceAsync, () => {
 
 describe(getDeviceABIsAsync, () => {
   it(`returns a list of device ABIs`, async () => {
-    asMock(getServer().getFileOutputAsync).mockResolvedValueOnce(
-      ['x86,armeabi-v7a,armeabi', ''].join('\n')
-    );
+    jest
+      .mocked(getServer().getFileOutputAsync)
+      .mockResolvedValueOnce(['x86,armeabi-v7a,armeabi', ''].join('\n'));
     await expect(isBootAnimationCompleteAsync()).resolves.toBe(false);
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { getAttachedDevicesAsync, getServer } from '../adb';
 import { startAdbReverseAsync, stopAdbReverseAsync } from '../adbReverse';
@@ -21,7 +20,7 @@ jest.mock('../../../../utils/exit', () => ({
 
 describe(startAdbReverseAsync, () => {
   it(`reverses devices`, async () => {
-    asMock(getAttachedDevicesAsync).mockResolvedValueOnce([
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
         isAuthorized: true,
         isBooted: true,
@@ -49,7 +48,7 @@ describe(startAdbReverseAsync, () => {
     ]);
   });
   it(`reverses multiple ports`, async () => {
-    asMock(getAttachedDevicesAsync).mockResolvedValueOnce([
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
         isAuthorized: true,
         isBooted: true,
@@ -71,7 +70,7 @@ describe(startAdbReverseAsync, () => {
   });
 
   it(`returns false when reversing a device that is unauthorized`, async () => {
-    asMock(getAttachedDevicesAsync).mockResolvedValueOnce([
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
         isAuthorized: false,
         isBooted: true,
@@ -86,7 +85,7 @@ describe(startAdbReverseAsync, () => {
   });
 
   it(`returns false when reversing a device fails`, async () => {
-    asMock(getAttachedDevicesAsync).mockResolvedValueOnce([
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
         isAuthorized: true,
         isBooted: true,
@@ -95,7 +94,7 @@ describe(startAdbReverseAsync, () => {
         type: 'device',
       },
     ]);
-    asMock(getServer().runAsync).mockRejectedValueOnce(new Error('test'));
+    jest.mocked(getServer().runAsync).mockRejectedValueOnce(new Error('test'));
     await expect(startAdbReverseAsync([3000])).resolves.toBe(false);
     expect(getServer().runAsync).toBeCalledTimes(1);
     expect(Log.warn).toBeCalledTimes(1);
@@ -104,7 +103,7 @@ describe(startAdbReverseAsync, () => {
 
 describe(stopAdbReverseAsync, () => {
   it(`stops reverse`, async () => {
-    asMock(getAttachedDevicesAsync).mockResolvedValueOnce([
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
         isAuthorized: true,
         isBooted: true,

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import { spawn } from 'child_process';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as ADB from '../adb';
 import { listAvdsAsync, startDeviceAsync } from '../emulator';
 
@@ -16,7 +15,7 @@ jest.mock('../adb', () => ({
 
 describe(listAvdsAsync, () => {
   it(`returns list of avds`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: ['avd1', 'avd2'].join(jest.requireActual('os').EOL),
     } as any);
 
@@ -26,7 +25,7 @@ describe(listAvdsAsync, () => {
     ]);
   });
   it(`returns an empty list when emulator fails`, async () => {
-    asMock(spawnAsync).mockRejectedValueOnce({
+    jest.mocked(spawnAsync).mockRejectedValueOnce({
       stderr: 'err',
     } as any);
 
@@ -36,10 +35,10 @@ describe(listAvdsAsync, () => {
 
 describe(startDeviceAsync, () => {
   it(`times out waiting for an emulator to start`, async () => {
-    asMock(ADB.getAttachedDevicesAsync).mockResolvedValue([]);
+    jest.mocked(ADB.getAttachedDevicesAsync).mockResolvedValue([]);
 
     // @ts-expect-error
-    asMock(spawn).mockReturnValueOnce({
+    jest.mocked(spawn).mockReturnValueOnce({
       unref: jest.fn(),
       on: jest.fn(),
     });
@@ -49,7 +48,8 @@ describe(startDeviceAsync, () => {
     );
   });
   it(`starts an emulator`, async () => {
-    asMock(ADB.getAttachedDevicesAsync)
+    jest
+      .mocked(ADB.getAttachedDevicesAsync)
       .mockResolvedValueOnce([])
       .mockResolvedValue([
         // @ts-expect-error
@@ -57,10 +57,10 @@ describe(startDeviceAsync, () => {
           name: 'foo',
         },
       ]);
-    asMock(ADB.isBootAnimationCompleteAsync).mockResolvedValueOnce(true);
+    jest.mocked(ADB.isBootAnimationCompleteAsync).mockResolvedValueOnce(true);
 
     // @ts-expect-error
-    asMock(spawn).mockReturnValueOnce({
+    jest.mocked(spawn).mockReturnValueOnce({
       unref: jest.fn(),
       on: jest.fn(),
     });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { getAttachedDevicesAsync } from '../adb';
 import { listAvdsAsync } from '../emulator';
@@ -12,8 +11,8 @@ jest.mock('../emulator', () => ({
 }));
 
 it(`asserts no devices are available`, async () => {
-  asMock(getAttachedDevicesAsync).mockResolvedValueOnce([]);
-  asMock(listAvdsAsync).mockResolvedValueOnce([]);
+  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
+  jest.mocked(listAvdsAsync).mockResolvedValueOnce([]);
   await expect(getDevicesAsync()).rejects.toThrowError(CommandError);
   expect(getAttachedDevicesAsync).toBeCalled();
   expect(listAvdsAsync).toBeCalled();

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
@@ -1,6 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { AbortCommandError } from '../../../../utils/errors';
 import { assembleAsync, formatGradleArguments, installAsync, spawnGradleAsync } from '../gradle';
 
@@ -118,7 +117,7 @@ describe(spawnGradleAsync, () => {
 
   it(`throws a controlled abort error for ctrl+c`, async () => {
     mockPlatform('darwin');
-    asMock(spawnAsync).mockRejectedValueOnce({ status: 130 });
+    jest.mocked(spawnAsync).mockRejectedValueOnce({ status: 130 });
 
     await expect(
       spawnGradleAsync('/', {

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleAppIdResolver-test.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { IOSConfig } from '@expo/config-plugins';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { AppleAppIdResolver } from '../AppleAppIdResolver';
 
 jest.mock('@expo/config-plugins', () => ({
@@ -30,12 +29,12 @@ jest.mock('@expo/config', () => ({
 
 describe('hasNativeProjectAsync', () => {
   it(`returns true when the AppDelegate file exists`, async () => {
-    asMock(IOSConfig.Paths.getAllPBXProjectPaths).mockReturnValueOnce(['/path/to/file']);
+    jest.mocked(IOSConfig.Paths.getAllPBXProjectPaths).mockReturnValueOnce(['/path/to/file']);
     const resolver = new AppleAppIdResolver('/');
     expect(await resolver.hasNativeProjectAsync()).toBe(true);
   });
   it(`returns false when the AppDelegate getter throws`, async () => {
-    asMock(IOSConfig.Paths.getAllPBXProjectPaths).mockImplementationOnce(() => {
+    jest.mocked(IOSConfig.Paths.getAllPBXProjectPaths).mockImplementationOnce(() => {
       throw new Error('file missing');
     });
     const resolver = new AppleAppIdResolver('/');
@@ -48,9 +47,9 @@ describe('getAppIdAsync', () => {
     const resolver = new AppleAppIdResolver('/');
     resolver.hasNativeProjectAsync = jest.fn(async () => true);
     resolver.getAppIdFromNativeAsync = jest.fn(resolver.getAppIdFromNativeAsync);
-    asMock(IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj).mockReturnValueOnce(
-      'dev.bacon.myapp'
-    );
+    jest
+      .mocked(IOSConfig.BundleIdentifier.getBundleIdentifierFromPbxproj)
+      .mockReturnValueOnce('dev.bacon.myapp');
     expect(await resolver.getAppIdAsync()).toBe('dev.bacon.myapp');
     expect(resolver.getAppIdFromNativeAsync).toBeCalledTimes(1);
     expect(resolver.hasNativeProjectAsync).toBeCalledTimes(1);
@@ -60,7 +59,7 @@ describe('getAppIdAsync', () => {
     const resolver = new AppleAppIdResolver('/');
     resolver.hasNativeProjectAsync = jest.fn(async () => false);
     resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
-    asMock(getConfig).mockReturnValueOnce({
+    jest.mocked(getConfig).mockReturnValueOnce({
       exp: {
         ios: {
           bundleIdentifier: 'dev.bacon.myapp',

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import { CommandError } from '../../../../utils/errors';
 import { AppleDeviceManager } from '../AppleDeviceManager';
 import { Device, getInfoPlistValueAsync, openAppIdAsync, openUrlAsync } from '../simctl';
@@ -18,7 +17,7 @@ function createDevice() {
 describe('getAppVersionAsync', () => {
   it(`gets the version from an installed app`, async () => {
     const device = createDevice();
-    asMock(getInfoPlistValueAsync).mockResolvedValueOnce('2.23.2');
+    jest.mocked(getInfoPlistValueAsync).mockResolvedValueOnce('2.23.2');
     await expect(device.getAppVersionAsync('host.exp.Exponent')).resolves.toBe('2.23.2');
     expect(getInfoPlistValueAsync).toHaveBeenCalledWith(expect.anything(), {
       appId: 'host.exp.Exponent',
@@ -27,7 +26,7 @@ describe('getAppVersionAsync', () => {
   });
   it(`returns null when the app is not installed`, async () => {
     const device = createDevice();
-    asMock(getInfoPlistValueAsync).mockResolvedValueOnce(null);
+    jest.mocked(getInfoPlistValueAsync).mockResolvedValueOnce(null);
     await expect(device.getAppVersionAsync('host.exp.Exponent')).resolves.toBe(null);
   });
 });
@@ -35,14 +34,14 @@ describe('getAppVersionAsync', () => {
 describe('launchApplicationIdAsync', () => {
   it(`asserts that the app is not installed`, async () => {
     const device = createDevice();
-    asMock(openAppIdAsync).mockImplementationOnce(() => {
+    jest.mocked(openAppIdAsync).mockImplementationOnce(() => {
       throw new CommandError('APP_NOT_INSTALLED', '...');
     });
     await expect(device.launchApplicationIdAsync('host.exp.foobar')).rejects.toThrow(/run:ios/);
   });
   it(`asserts that the Expo Go app is not installed`, async () => {
     const device = createDevice();
-    asMock(openAppIdAsync).mockImplementationOnce(() => {
+    jest.mocked(openAppIdAsync).mockImplementationOnce(() => {
       throw new CommandError('APP_NOT_INSTALLED', '...');
     });
     await expect(device.launchApplicationIdAsync('host.exp.Exponent')).rejects.toThrow(
@@ -51,7 +50,7 @@ describe('launchApplicationIdAsync', () => {
   });
   it(`asserts unknown error`, async () => {
     const device = createDevice();
-    asMock(openAppIdAsync).mockResolvedValueOnce({ status: 1 } as any);
+    jest.mocked(openAppIdAsync).mockResolvedValueOnce({ status: 1 } as any);
     await expect(device.launchApplicationIdAsync('host.exp.Exponent')).rejects.toThrow(
       /Couldn't open iOS app with ID/
     );
@@ -59,13 +58,13 @@ describe('launchApplicationIdAsync', () => {
   it(`opens the app by ID and activates the window.`, async () => {
     const device = createDevice();
     device.activateWindowAsync = jest.fn();
-    asMock(openAppIdAsync).mockResolvedValueOnce({ status: 0 } as any);
+    jest.mocked(openAppIdAsync).mockResolvedValueOnce({ status: 0 } as any);
     await device.launchApplicationIdAsync('host.exp.Exponent');
     expect(device.activateWindowAsync).toBeCalled();
   });
   it(`asserts that an unexpected error occurred`, async () => {
     const device = createDevice();
-    asMock(openAppIdAsync).mockImplementationOnce(() => {
+    jest.mocked(openAppIdAsync).mockImplementationOnce(() => {
       throw new Error('...');
     });
     await expect(device.launchApplicationIdAsync).rejects.toThrow(/\.\.\./);

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/ensureSimulatorAppRunning-test.ts
@@ -6,10 +6,8 @@ import { ensureSimulatorAppRunningAsync } from '../ensureSimulatorAppRunning';
 
 jest.mock(`../../../../log`);
 
-const asMock = (fn: any): jest.Mock => fn;
-
 it('should do nothing when the Simulator.app is running', async () => {
-  asMock(execAsync).mockResolvedValueOnce('1');
+  jest.mocked(execAsync).mockResolvedValueOnce('1');
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 
@@ -18,7 +16,7 @@ it('should do nothing when the Simulator.app is running', async () => {
 });
 
 it('should activate the window when Simulator.app is not running', async () => {
-  asMock(execAsync).mockResolvedValueOnce('0').mockResolvedValueOnce('1');
+  jest.mocked(execAsync).mockResolvedValueOnce('0').mockResolvedValueOnce('1');
 
   await ensureSimulatorAppRunningAsync({ udid: '123' });
 
@@ -33,13 +31,13 @@ it('should activate the window when Simulator.app is not running', async () => {
 });
 
 it('should throw a timeout warning when Simulator.app takes too long to start', async () => {
-  asMock(execAsync).mockRejectedValue(new Error('Application isn’t running'));
+  jest.mocked(execAsync).mockRejectedValue(new Error('Application isn’t running'));
 
   await expect(
     ensureSimulatorAppRunningAsync({ udid: '123' }, { maxWaitTime: 100 })
   ).rejects.toThrow(/Simulator app did not open fast enough/);
 
   // initial call (1) + interval / timeout (2)
-  expect(asMock(execAsync).mock.calls.length).toBeGreaterThanOrEqual(3);
+  expect(jest.mocked(execAsync).mock.calls.length).toBeGreaterThanOrEqual(3);
   expect(spawnAsync).toBeCalledTimes(1);
 });

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/getBestSimulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/getBestSimulator-test.ts
@@ -1,23 +1,22 @@
 import spawnAsync from '@expo/spawn-async';
 import { execSync } from 'child_process';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { getBestUnbootedSimulatorAsync } from '../getBestSimulator';
 
 beforeEach(() => {
-  asMock(spawnAsync).mockResolvedValueOnce({
+  jest.mocked(spawnAsync).mockResolvedValueOnce({
     stdout: JSON.stringify(require('./fixtures/xcrun-simctl-list-devices.json')),
   } as any);
 });
 
 describe(getBestUnbootedSimulatorAsync, () => {
   it(`returns the default simulator`, async () => {
-    asMock(execSync).mockReturnValueOnce(`foobar`);
+    jest.mocked(execSync).mockReturnValueOnce(`foobar`);
     await expect(getBestUnbootedSimulatorAsync()).resolves.toBe('foobar');
   });
 
   it(`returns the first simulator when osType is provided and doesn't match default`, async () => {
-    asMock(execSync).mockReturnValueOnce(`foobar`);
+    jest.mocked(execSync).mockReturnValueOnce(`foobar`);
     await expect(getBestUnbootedSimulatorAsync({ osType: 'watchOS' })).resolves.toBe(
       // This is a watch.
       'BE99E61A-37C2-4DE2-91DB-D5508C8FD1C8'
@@ -26,12 +25,12 @@ describe(getBestUnbootedSimulatorAsync, () => {
 
   it(`returns the default simulator when osType is provided`, async () => {
     const defaultUdid = `E3F2EAAD-5A58-4003-A029-5C642E00C9F4`;
-    asMock(execSync).mockReturnValueOnce(defaultUdid);
+    jest.mocked(execSync).mockReturnValueOnce(defaultUdid);
     await expect(getBestUnbootedSimulatorAsync({ osType: 'iOS' })).resolves.toBe(defaultUdid);
   });
 
   it(`returns the first simulator when no preferences are available`, async () => {
-    asMock(execSync).mockReturnValueOnce('');
+    jest.mocked(execSync).mockReturnValueOnce('');
     await expect(getBestUnbootedSimulatorAsync()).resolves.toBe(
       // First udid.
       `0288B8DC-5EC9-43EB-A8E9-A3E3AA43352E`

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/promptAppleDevice-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/promptAppleDevice-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../../__tests__/asMock';
 import { getBestSimulatorAsync } from '../getBestSimulator';
 import { sortDefaultDeviceToBeginningAsync } from '../promptAppleDevice';
 
@@ -6,7 +5,7 @@ jest.mock('../getBestSimulator');
 
 describe(sortDefaultDeviceToBeginningAsync, () => {
   it(`sorts default to the beginning`, async () => {
-    asMock(getBestSimulatorAsync).mockResolvedValueOnce('should-be-first');
+    jest.mocked(getBestSimulatorAsync).mockResolvedValueOnce('should-be-first');
 
     const devices = await sortDefaultDeviceToBeginningAsync([
       { udid: 'abc' },
@@ -18,7 +17,7 @@ describe(sortDefaultDeviceToBeginningAsync, () => {
   });
 
   it(`does not change order when there is no default`, async () => {
-    asMock(getBestSimulatorAsync).mockResolvedValueOnce(null);
+    jest.mocked(getBestSimulatorAsync).mockResolvedValueOnce(null);
     const devices = await sortDefaultDeviceToBeginningAsync([
       { udid: 'abc' },
       { udid: 'def' },

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/simctl-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/simctl-test.ts
@@ -10,9 +10,6 @@ import {
 
 jest.mock(`../../../../log`);
 
-const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
-  fn as jest.MockedFunction<T>;
-
 describe(isOSType, () => {
   it(`returns true for iOS`, () => {
     expect(isOSType('iOS')).toBe(true);
@@ -28,7 +25,7 @@ describe(isOSType, () => {
 
 describe(getDevicesAsync, () => {
   it(`returns a list of malformed devices`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: 'foobar',
     } as any);
 
@@ -38,7 +35,7 @@ describe(getDevicesAsync, () => {
   });
 
   it(`returns a list of devices`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: JSON.stringify(require('./fixtures/xcrun-simctl-list-devices.json')),
     } as any);
 
@@ -55,7 +52,8 @@ describe(getDevicesAsync, () => {
 
 describe(getInfoPlistValueAsync, () => {
   it(`fetches a value from the Info.plist of an app`, async () => {
-    asMock(spawnAsync)
+    jest
+      .mocked(spawnAsync)
       .mockResolvedValueOnce({
         // Like: '/Users/evanbacon/Library/Developer/CoreSimulator/Devices/EFEEA6EF-E3F5-4EDE-9B72-29EAFA7514AE/data/Containers/Bundle/Application/FA43A0C6-C2AD-442D-B8B1-EAF3E88CF3BF/Exponent-2.23.2.tar.app'
         stdout: '  /path/to/my-app.app ',
@@ -79,7 +77,7 @@ describe(getInfoPlistValueAsync, () => {
 
 describe(getContainerPathAsync, () => {
   it(`returns container path`, async () => {
-    asMock(spawnAsync).mockResolvedValueOnce({
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: '  /path/to/my-app.app ',
     } as any);
 
@@ -94,7 +92,7 @@ describe(getContainerPathAsync, () => {
     );
   });
   it(`returns null when the requested app isn't installed`, async () => {
-    asMock(spawnAsync).mockRejectedValueOnce({
+    jest.mocked(spawnAsync).mockRejectedValueOnce({
       stderr: 'No such file or directory',
     } as any);
 

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/xcrun-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/xcrun-test.ts
@@ -1,11 +1,10 @@
 import spawnAsync from '@expo/spawn-async';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { xcrunAsync } from '../xcrun';
 
 it(`throws on invalid license`, async () => {
   // Mock Simulator.app installed for CI
-  asMock(spawnAsync).mockImplementationOnce(() => {
+  jest.mocked(spawnAsync).mockImplementationOnce(() => {
     // eslint-disable-next-line no-throw-literal
     throw {
       stderr: 'Xcode license is foobar',
@@ -20,7 +19,7 @@ it(`throws on invalid license`, async () => {
 
 it(`throws on invalid setup`, async () => {
   // Mock Simulator.app installed for CI
-  asMock(spawnAsync).mockImplementationOnce(() => {
+  jest.mocked(spawnAsync).mockImplementationOnce(() => {
     // eslint-disable-next-line no-throw-literal
     throw {
       stderr: 'not a developer tool or in PATH',

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
@@ -1,6 +1,5 @@
 import { vol } from 'memfs';
 
-import { asMock } from '../../../__tests__/asMock';
 import { NgrokInstance, NgrokResolver } from '../../doctor/ngrok/NgrokResolver';
 import { hasAdbReverseAsync, startAdbReverseAsync } from '../../platforms/android/adbReverse';
 import { AsyncNgrok } from '../AsyncNgrok';
@@ -67,7 +66,7 @@ describe('getActiveUrl', () => {
 describe('startAsync', () => {
   it(`skips adb reverse if Android cannot be found`, async () => {
     const { ngrok } = createNgrokInstance();
-    asMock(hasAdbReverseAsync).mockReturnValueOnce(false);
+    jest.mocked(hasAdbReverseAsync).mockReturnValueOnce(false);
 
     await ngrok.startAsync();
     expect(startAdbReverseAsync).not.toBeCalled();
@@ -77,7 +76,7 @@ describe('startAsync', () => {
   });
   it(`fails if adb reverse doesn't work`, async () => {
     const { ngrok } = createNgrokInstance();
-    asMock(startAdbReverseAsync).mockResolvedValueOnce(false);
+    jest.mocked(startAdbReverseAsync).mockResolvedValueOnce(false);
 
     await expect(ngrok.startAsync()).rejects.toThrow(/adb/);
   });

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -4,8 +4,6 @@ import { getExpoApiBaseUrl } from '../../../api/endpoint';
 import * as ProjectDevices from '../../project/devices';
 import { DevelopmentSession } from '../DevelopmentSession';
 
-const asMock = (fn: any): jest.Mock => fn as jest.Mock;
-
 jest.mock('../../project/devices', () => ({
   getDevicesInfoAsync: jest.fn(),
 }));
@@ -19,7 +17,7 @@ describe(`startAsync`, () => {
     const err = jest.fn();
     const session = new DevelopmentSession('/', 'http://localhost:19001/', err);
 
-    asMock(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
+    jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
       devices: [{ installationId: '123' }, { installationId: '456' }],
     });
 
@@ -54,7 +52,9 @@ describe(`startAsync`, () => {
     const err = jest.fn();
     const session = new DevelopmentSession('/', 'http://localhost:19001/', err);
 
-    asMock(ProjectDevices.getDevicesInfoAsync).mockRejectedValueOnce(new Error('predefined error'));
+    jest
+      .mocked(ProjectDevices.getDevicesInfoAsync)
+      .mockRejectedValueOnce(new Error('predefined error'));
 
     const exp = {
       name: 'my-app',
@@ -80,7 +80,7 @@ describe(`startAsync`, () => {
     const err = jest.fn();
     const session = new DevelopmentSession('/', 'http://localhost:19001/', err);
 
-    asMock(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
+    jest.mocked(ProjectDevices.getDevicesInfoAsync).mockResolvedValue({
       devices: [{ installationId: '123' }, { installationId: '456' }],
     });
 

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../__tests__/asMock';
 import * as Log from '../../../log';
 import { UrlCreator } from '../UrlCreator';
 
@@ -118,7 +117,7 @@ describe('constructUrl', () => {
     ).toMatchInlineSnapshot(`"newer://100.100.1.100:8081"`);
   });
   it(`warns when tunnel isn't available`, () => {
-    asMock(Log.warn).mockClear();
+    jest.mocked(Log.warn).mockClear();
     expect(
       new UrlCreator({}, { port: 8081, getTunnelUrl: () => null }).constructUrl({
         hostType: 'tunnel',

--- a/packages/@expo/cli/src/start/server/__tests__/openPlatforms-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/openPlatforms-test.ts
@@ -1,4 +1,3 @@
-import { asMock } from '../../../__tests__/asMock';
 import { AbortCommandError } from '../../../utils/errors';
 import { DevServerManager } from '../DevServerManager';
 import { openPlatformsAsync } from '../openPlatforms';
@@ -49,7 +48,7 @@ it(`opens web only`, async () => {
 
 it(`rethrows assertions`, async () => {
   const manager = createDevServerManager();
-  asMock(manager.getDefaultDevServer).mockImplementationOnce(
+  jest.mocked(manager.getDefaultDevServer).mockImplementationOnce(
     () =>
       ({
         async openPlatformAsync() {
@@ -71,7 +70,8 @@ it(`rethrows assertions`, async () => {
 
 it(`surfaces aborting`, async () => {
   const manager = createDevServerManager();
-  asMock(manager.getDefaultDevServer)
+  jest
+    .mocked(manager.getDefaultDevServer)
     .mockReturnValueOnce({
       async openPlatformAsync() {},
     } as any)

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -8,7 +8,6 @@ import { GraphQLError } from 'graphql';
 import { vol } from 'memfs';
 import nullthrows from 'nullthrows';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { AppQuery } from '../../../../api/graphql/queries/AppQuery';
 import { getUserAsync } from '../../../../api/user/user';
 import {
@@ -188,7 +187,7 @@ describe('getParsedHeaders', () => {
 describe('_getManifestResponseAsync', () => {
   beforeEach(() => {
     delete process.env.EXPO_OFFLINE;
-    asMock(getUserAsync).mockImplementation(async () => ({
+    jest.mocked(getUserAsync).mockImplementation(async () => ({
       __typename: 'User',
       id: 'userwat',
       username: 'wat',

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
@@ -2,7 +2,6 @@ import { getConfig, getNameFromConfig } from '@expo/config';
 import { getRuntimeVersionNullableAsync } from '@expo/config-plugins/build/utils/Updates';
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import { InterstitialPageMiddleware } from '../InterstitialPageMiddleware';
 import { ServerRequest, ServerResponse } from '../server.types';
 
@@ -58,8 +57,8 @@ describe('shouldHandleRequest', () => {
 
 describe('_getProjectOptionsAsync', () => {
   it('returns the project settings from the config', async () => {
-    asMock(getNameFromConfig).mockReturnValueOnce({ appName: 'my-app' });
-    asMock(getRuntimeVersionNullableAsync).mockResolvedValueOnce('123');
+    jest.mocked(getNameFromConfig).mockReturnValueOnce({ appName: 'my-app' });
+    jest.mocked(getRuntimeVersionNullableAsync).mockResolvedValueOnce('123');
 
     const middleware = new InterstitialPageMiddleware('/');
 
@@ -78,8 +77,8 @@ describe('_getProjectOptionsAsync', () => {
     );
   });
   it('returns the project settings from the config with SDK version', async () => {
-    asMock(getNameFromConfig).mockReturnValueOnce({ appName: 'my-app' });
-    asMock(getRuntimeVersionNullableAsync).mockResolvedValueOnce(null);
+    jest.mocked(getNameFromConfig).mockReturnValueOnce({ appName: 'my-app' });
+    jest.mocked(getRuntimeVersionNullableAsync).mockResolvedValueOnce(null);
 
     const middleware = new InterstitialPageMiddleware('/');
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -1,7 +1,6 @@
 import { getConfig } from '@expo/config';
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import * as ProjectDevices from '../../../project/devices';
 import { getPlatformBundlers } from '../../platformBundlers';
@@ -64,7 +63,7 @@ describe('checkBrowserRequestAsync', () => {
     jest.fn(({ scheme, hostname }) => `${scheme}://${hostname ?? 'localhost'}:8080`);
 
   it('handles browser requests when the web bundler is "metro" and no platform is specified', async () => {
-    asMock(getPlatformBundlers).mockReturnValueOnce({
+    jest.mocked(getPlatformBundlers).mockReturnValueOnce({
       web: 'metro',
       ios: 'metro',
       android: 'metro',
@@ -101,7 +100,7 @@ describe('checkBrowserRequestAsync', () => {
   });
 
   it('skips handling browser requests when the web bundler is "webpack"', async () => {
-    asMock(getPlatformBundlers).mockReturnValueOnce({
+    jest.mocked(getPlatformBundlers).mockReturnValueOnce({
       web: 'webpack',
       ios: 'metro',
       android: 'metro',
@@ -202,7 +201,7 @@ describe('_resolveProjectSettingsAsync', () => {
       mode: 'development',
     });
 
-    asMock(getConfig).mockClear();
+    jest.mocked(getConfig).mockClear();
 
     middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
 
@@ -233,7 +232,7 @@ describe('_resolveProjectSettingsAsync', () => {
       mode: 'production',
     });
 
-    asMock(getConfig).mockClear();
+    jest.mocked(getConfig).mockClear();
 
     middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
 

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/tls-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/tls-test.ts
@@ -1,7 +1,6 @@
 import { certificateFor } from '@expo/devcert';
 import { vol } from 'memfs';
 
-import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { ensureEnvironmentSupportsTLSAsync, getTLSCertAsync } from '../tls';
 
@@ -41,7 +40,7 @@ describe(ensureEnvironmentSupportsTLSAsync, () => {
 
 describe(getTLSCertAsync, () => {
   it(`creates an TLS cert for the computer`, async () => {
-    asMock(Log.log).mockReset();
+    jest.mocked(Log.log).mockReset();
     await expect(getTLSCertAsync('/')).resolves.toEqual({
       certPath: '/.expo/tls/cert-localhost.pem',
       keyPath: '/.expo/tls/key-localhost.pem',

--- a/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/FileNotifier-test.ts
@@ -1,6 +1,5 @@
 import { fs, vol } from 'memfs';
 
-import { asMock } from '../../__tests__/asMock';
 import * as Log from '../../log';
 import { FileNotifier } from '../FileNotifier';
 
@@ -29,7 +28,8 @@ it('returns null when no files can be found', () => {
 });
 
 it('observes the first existing file', () => {
-  asMock(fs.watchFile)
+  jest
+    .mocked(fs.watchFile)
     // @ts-expect-error
     .mockImplementationOnce((_, callback) => {
       // @ts-expect-error: polymorphism

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -1,7 +1,6 @@
 import { vol } from 'memfs';
 
 import { mockExpoRootChain, mockSelfSigned } from './fixtures/certificates';
-import { asMock } from '../../__tests__/asMock';
 import { getProjectDevelopmentCertificateAsync } from '../../api/getProjectDevelopmentCertificate';
 import { getUserAsync } from '../../api/user/user';
 import { getCodeSigningInfoAsync, signManifestString } from '../codesigning';
@@ -46,7 +45,7 @@ jest.mock('../../api/getExpoGoIntermediateCertificate', () => ({
 beforeEach(() => {
   vol.reset();
 
-  asMock(getUserAsync).mockImplementation(async () => ({
+  jest.mocked(getUserAsync).mockImplementation(async () => ({
     __typename: 'User',
     id: 'userwat',
     username: 'wat',
@@ -109,11 +108,11 @@ describe(getCodeSigningInfoAsync, () => {
           undefined
         );
 
-        asMock(getProjectDevelopmentCertificateAsync).mockImplementationOnce(
-          async (): Promise<string> => {
+        jest
+          .mocked(getProjectDevelopmentCertificateAsync)
+          .mockImplementationOnce(async (): Promise<string> => {
             throw Error('wat');
-          }
-        );
+          });
 
         const result2 = await getCodeSigningInfoAsync(
           { extra: { eas: { projectId: 'testprojectid' } } } as any,
@@ -124,11 +123,11 @@ describe(getCodeSigningInfoAsync, () => {
       });
 
       it('throws when it tried to falls back to cached when there is a network error but no cached value exists', async () => {
-        asMock(getProjectDevelopmentCertificateAsync).mockImplementationOnce(
-          async (): Promise<string> => {
+        jest
+          .mocked(getProjectDevelopmentCertificateAsync)
+          .mockImplementationOnce(async (): Promise<string> => {
             throw Error('wat');
-          }
-        );
+          });
 
         await expect(
           getCodeSigningInfoAsync(

--- a/packages/@expo/cli/src/utils/__tests__/downloadExpoGoAsync-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/downloadExpoGoAsync-test.ts
@@ -6,8 +6,6 @@ import { downloadAppAsync } from '../downloadAppAsync';
 import { downloadExpoGoAsync, getExpoGoVersionEntryAsync } from '../downloadExpoGoAsync';
 import { extractAsync } from '../tar';
 
-const asMock = (fn: any): jest.Mock => fn;
-
 jest.mock('../../log');
 
 jest.mock(`../downloadAppAsync`, () => ({
@@ -58,10 +56,10 @@ describe(getExpoGoVersionEntryAsync, () => {
 
 describe(downloadExpoGoAsync, () => {
   beforeEach(() => {
-    asMock(extractAsync).mockImplementationOnce(jest.fn());
-    asMock(downloadAppAsync).mockImplementationOnce(
-      jest.fn(jest.requireActual('../downloadAppAsync').downloadAppAsync)
-    );
+    jest.mocked(extractAsync).mockImplementationOnce(jest.fn());
+    jest
+      .mocked(downloadAppAsync)
+      .mockImplementationOnce(jest.fn(jest.requireActual('../downloadAppAsync').downloadAppAsync));
     vol.reset();
   });
   it('downloads the Expo Go app on iOS', async () => {

--- a/packages/@expo/cli/src/utils/__tests__/editor-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/editor-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import editors from 'env-editor';
 
-import { asMock } from '../../__tests__/asMock';
 import { guessEditor, openInEditorAsync } from '../editor';
 
 jest.mock('../../log');
@@ -25,7 +24,7 @@ describe(guessEditor, () => {
   });
 
   it(`defaults to vscode if the default editor cannot be guessed`, () => {
-    asMock(editors.defaultEditor).mockImplementationOnce(() => {
+    jest.mocked(editors.defaultEditor).mockImplementationOnce(() => {
       throw new Error('Could not guess default editor');
     });
     guessEditor();
@@ -35,12 +34,12 @@ describe(guessEditor, () => {
 
 describe(openInEditorAsync, () => {
   it(`fails to open in a given editor that does not exist`, async () => {
-    asMock(editors.defaultEditor).mockReturnValueOnce({
+    jest.mocked(editors.defaultEditor).mockReturnValueOnce({
       name: 'my-editor',
       binary: 'my-editor-binary',
       id: 'my-editor-id',
     } as any);
-    asMock(spawnAsync).mockImplementationOnce(() => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() => {
       throw new Error('failed');
     });
 

--- a/packages/@expo/cli/src/utils/__tests__/getRunningProcess-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/getRunningProcess-test.ts
@@ -2,11 +2,9 @@ import { execFileSync, execSync } from 'child_process';
 
 import { getDirectoryOfProcessById, getPID } from '../getRunningProcess';
 
-const asMock = (fn: any): jest.Mock => fn;
-
 describe(getPID, () => {
   it(`should return the pid value for a running port`, () => {
-    asMock(execFileSync).mockImplementationOnce(() => '63828');
+    jest.mocked(execFileSync).mockImplementationOnce(() => '63828');
     const pid = getPID(63828);
     expect(pid).toBe(63828);
   });
@@ -14,7 +12,7 @@ describe(getPID, () => {
 
 describe(getDirectoryOfProcessById, () => {
   it(`should return the directory of a pid`, () => {
-    asMock(execSync).mockImplementationOnce(() => 'cwd');
+    jest.mocked(execSync).mockImplementationOnce(() => 'cwd');
     const directory = getDirectoryOfProcessById(63828);
     expect(directory).toBe('cwd');
   });

--- a/packages/@expo/cli/src/utils/__tests__/scheme-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/scheme-test.ts
@@ -10,15 +10,12 @@ jest.mock('@expo/config-plugins');
 jest.mock('@expo/config-plugins/build/ios/utils/getInfoPlistPath');
 
 // TODO: replace with `jest.mocked`, when updating Jest
-const asMock = (fn: any): jest.Mock => fn;
 
 describe(getSchemesForAndroidAsync, () => {
   it('resolves longest scheme without known expo schemes', async () => {
-    asMock(AndroidConfig.Scheme.getSchemesFromManifest).mockResolvedValue([
-      'com.expo.test',
-      'com.expo.longertest',
-      'com.expo.longesttest',
-    ]);
+    jest
+      .mocked(AndroidConfig.Scheme.getSchemesFromManifest)
+      .mockResolvedValue(['com.expo.test', 'com.expo.longertest', 'com.expo.longesttest']);
 
     await expect(getSchemesForAndroidAsync('/fake-project')).resolves.toEqual([
       'com.expo.longesttest',
@@ -28,10 +25,9 @@ describe(getSchemesForAndroidAsync, () => {
   });
 
   it('resolves known expo schemes before longest schemes', async () => {
-    asMock(AndroidConfig.Scheme.getSchemesFromManifest).mockResolvedValue([
-      'com.expo.longesttest',
-      'exp+com.expo.test',
-    ]);
+    jest
+      .mocked(AndroidConfig.Scheme.getSchemesFromManifest)
+      .mockResolvedValue(['com.expo.longesttest', 'exp+com.expo.test']);
 
     await expect(getSchemesForAndroidAsync('/fake-project')).resolves.toEqual([
       'exp+com.expo.test',
@@ -62,12 +58,10 @@ describe(getSchemesForIosAsync, () => {
   });
 
   it('resolves longest scheme without known expo schemes', async () => {
-    asMock(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
-    asMock(IOSConfig.Scheme.getSchemesFromPlist).mockReturnValue([
-      'com.expo.test',
-      'com.expo.longertest',
-      'com.expo.longesttest',
-    ]);
+    jest.mocked(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
+    jest
+      .mocked(IOSConfig.Scheme.getSchemesFromPlist)
+      .mockReturnValue(['com.expo.test', 'com.expo.longertest', 'com.expo.longesttest']);
 
     await expect(getSchemesForIosAsync('fake-project')).resolves.toEqual([
       'com.expo.longesttest',
@@ -77,11 +71,10 @@ describe(getSchemesForIosAsync, () => {
   });
 
   it('resolves known expo schemes before longest schemes', async () => {
-    asMock(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
-    asMock(IOSConfig.Scheme.getSchemesFromPlist).mockReturnValue([
-      'com.expo.longesttest',
-      'exp+com.expo.test',
-    ]);
+    jest.mocked(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
+    jest
+      .mocked(IOSConfig.Scheme.getSchemesFromPlist)
+      .mockReturnValue(['com.expo.longesttest', 'exp+com.expo.test']);
 
     await expect(getSchemesForIosAsync('fake-project')).resolves.toEqual(['exp+com.expo.test']);
   });

--- a/packages/@expo/cli/src/utils/__tests__/tar-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/tar-test.ts
@@ -4,8 +4,6 @@ import tar from 'tar';
 import * as Log from '../../log';
 import { extractAsync } from '../tar';
 
-const asMock = (fn: any): jest.Mock => fn;
-
 jest.mock(`../../log`);
 
 function mockPlatform(value: typeof process.platform) {
@@ -18,9 +16,9 @@ describe(extractAsync, () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
-    asMock(spawnAsync).mockClear();
-    asMock(tar.extract).mockClear();
-    asMock(Log.warn).mockClear();
+    jest.mocked(spawnAsync).mockClear();
+    jest.mocked(tar.extract).mockClear();
+    jest.mocked(Log.warn).mockClear();
   });
 
   afterAll(() => {
@@ -30,7 +28,7 @@ describe(extractAsync, () => {
   it('extracts a tar file using node module when native fails', async () => {
     // set to mac in order to test native tools.
     mockPlatform('darwin');
-    asMock(spawnAsync).mockImplementationOnce(() => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() => {
       throw new Error('mock failure');
     });
 


### PR DESCRIPTION
# Why

This can be replaced now since we're on jest 27+. 

# How

Find/replace, lint fix, run all tests.

# Test Plan

Run all tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
