### PR TITLE
[core][Android] Fix `JavaScriptFunction` not working when return type wasn't provided

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
-- [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided.
+- [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided. ([#25688](https://github.com/expo/expo/pull/25688) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
+- [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -6,7 +6,6 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.types.TypeConverterProviderImpl
-import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -27,11 +26,13 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
       .toTypedArray()
 
     val converter = TypeConverterProviderImpl
-      .obtainTypeConverter(returnType ?: LazyKType(
-        classifier = Unit::class,
-        isMarkedNullable = false,
-        kTypeProvider = { typeOf<Unit>() }
-      ))
+      .obtainTypeConverter(
+        returnType ?: LazyKType(
+          classifier = Unit::class,
+          isMarkedNullable = false,
+          kTypeProvider = { typeOf<Unit>() }
+        )
+      )
 
     val expectedReturnType = converter.getCppRequiredTypes()
     val result = invoke(convertedArgs, expectedReturnType)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -4,7 +4,9 @@ import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.types.JSTypeConverter
+import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.types.TypeConverterProviderImpl
+import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -25,7 +27,11 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
       .toTypedArray()
 
     val converter = TypeConverterProviderImpl
-      .obtainTypeConverter(returnType ?: typeOf<Unit>())
+      .obtainTypeConverter(returnType ?: LazyKType(
+        classifier = Unit::class,
+        isMarkedNullable = false,
+        kTypeProvider = { typeOf<Unit>() }
+      ))
 
     val expectedReturnType = converter.getCppRequiredTypes()
     val result = invoke(convertedArgs, expectedReturnType)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -288,6 +288,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       Any::class to AnyTypeConverter(isOptional),
 
+      Unit::class to UnitTypeConverter(isOptional),
+
       ReadableArguments::class to ReadableArgumentsTypeConverter(isOptional),
     )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
@@ -1,0 +1,15 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+
+class UnitTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): Any {
+    return Unit
+  }
+
+  override fun convertFromAny(value: Any): Any = Unit
+
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
+}


### PR DESCRIPTION
# Why

Fixed `JavaScriptFunction` not working when the return type wasn't provided 

# How

The `JavaScriptFunction` returns `Unit` by default, but we're missing the unit type converter. So it didn't work correctly. 

# Test Plan

- bare-expo ✅