### PR TITLE
[core][Android] Add type information about module to module holder

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -15,7 +15,7 @@ import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
-class ModuleHolder(val module: Module) {
+class ModuleHolder<T : Module>(val module: T) {
   val definition = module.definition()
 
   val name get() = definition.name

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -17,7 +17,7 @@ import java.lang.ref.WeakReference
  * But because of that, we had to create a wrapper for EventEmitter.
  */
 class KModuleEventEmitterWrapper(
-  private val moduleHolder: ModuleHolder,
+  private val moduleHolder: ModuleHolder<*>,
   legacyEventEmitter: expo.modules.core.interfaces.services.EventEmitter,
   reactContextHolder: WeakReference<ReactApplicationContext>
 ) : KEventEmitterWrapper(legacyEventEmitter, reactContextHolder) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -22,7 +22,7 @@ abstract class AsyncFunction(
   desiredArgsTypes: Array<AnyType>
 ) : BaseAsyncFunctionComponent(name, desiredArgsTypes) {
 
-  override fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise) {
+  override fun call(holder: ModuleHolder<*>, args: ReadableArray, promise: Promise) {
     val queue = when (queue) {
       Queues.MAIN -> holder.module.appContext.mainQueue
       Queues.DEFAULT -> null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/BaseAsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/BaseAsyncFunctionComponent.kt
@@ -17,7 +17,7 @@ abstract class BaseAsyncFunctionComponent(
 
   protected var queue = Queues.DEFAULT
 
-  abstract fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise)
+  abstract fun call(holder: ModuleHolder<*>, args: ReadableArray, promise: Promise)
 
   fun runOnQueue(queue: Queues) = apply {
     this.queue = queue

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -22,7 +22,7 @@ class SuspendFunctionComponent(
   private val body: suspend CoroutineScope.(args: Array<out Any?>) -> Any?
 ) : BaseAsyncFunctionComponent(name, desiredArgsTypes) {
 
-  override fun call(holder: ModuleHolder, args: ReadableArray, promise: Promise) {
+  override fun call(holder: ModuleHolder<*>, args: ReadableArray, promise: Promise) {
     val appContext = holder.module.appContext
     val queue = when (queue) {
       Queues.MAIN -> appContext.mainQueue

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.logger
 
-class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
+class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder<*>) {
   private val definition: ViewManagerDefinition
     get() = requireNotNull(moduleHolder.definition.viewManagerDefinition)
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/SuspendFunctionComponentTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/SuspendFunctionComponentTest.kt
@@ -23,7 +23,7 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class SuspendFunctionComponentTest {
   private lateinit var testScope: TestScope
-  private lateinit var moduleHolderMock: ModuleHolder
+  private lateinit var moduleHolderMock: ModuleHolder<*>
 
   @Before
   fun setUp() {
@@ -32,7 +32,7 @@ class SuspendFunctionComponentTest {
       every { mainQueue } returns testScope
       every { modulesQueue } returns testScope
     }
-    moduleHolderMock = mockk<ModuleHolder>().apply {
+    moduleHolderMock = mockk<ModuleHolder<*>>().apply {
       every { name } returns "AsyncSuspendFunctionTestModule"
       every { module } returns mockk<Module>().apply {
         every { appContext } returns mockedAppContext

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleController.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleController.kt
@@ -11,7 +11,7 @@ interface ModuleController {
   fun onActivityDestroys()
 }
 
-class ModuleControllerImpl(private val holder: ModuleHolder) : ModuleController {
+class ModuleControllerImpl(private val holder: ModuleHolder<*>) : ModuleController {
   override fun onCreate() {
     holder.post(EventName.MODULE_CREATE)
   }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockInvocationHandler.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMockInvocationHandler.kt
@@ -43,7 +43,7 @@ class TestCodedException(
 class ModuleMockInvocationHandler<T : Any>(
   private val moduleTestInterface: KClass<T>,
   private val moduleController: ModuleController,
-  private val holder: ModuleHolder
+  private val holder: ModuleHolder<*>
 ) : InvocationHandler {
   override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
     if (!holder.definition.asyncFunctions.containsKey(method.name) &&


### PR DESCRIPTION
# Why

Add type information about the module to the module holder.

# How

Right now, the module holder stores the module objects. So if you want access to the module, you will cast it to the desired class. Sometimes, we can avoid it by making a module holder class a generic type. 

# Test Plan

- bare-expo ✅