### PR TITLE
[test-core][Android] Move current implementation to legacy package

### DIFF
--- a/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
+++ b/packages/expo-clipboard/android/src/test/java/expo/modules/clipboard/ClipboardModuleTest.kt
@@ -9,9 +9,9 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.errorCodeOf
-import expo.modules.test.core.ModuleMock
-import expo.modules.test.core.ModuleMockHolder
-import expo.modules.test.core.assertCodedException
+import expo.modules.test.core.legacy.ModuleMock
+import expo.modules.test.core.legacy.ModuleMockHolder
+import expo.modules.test.core.legacy.assertCodedException
 import io.mockk.confirmVerified
 import io.mockk.verify
 import org.junit.Assert.assertEquals

--- a/packages/expo-crypto/android/src/test/java/expo/modules/crypto/CryptoModuleTest.kt
+++ b/packages/expo-crypto/android/src/test/java/expo/modules/crypto/CryptoModuleTest.kt
@@ -1,8 +1,8 @@
 package expo.modules.crypto
 
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.test.core.ModuleMock
-import expo.modules.test.core.ModuleMockHolder
+import expo.modules.test.core.legacy.ModuleMock
+import expo.modules.test.core.legacy.ModuleMockHolder
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
@@ -9,9 +9,9 @@ import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.PromiseMock
-import expo.modules.test.core.assertRejectedWithCode
-import expo.modules.test.core.promiseResolved
+import expo.modules.test.core.legacy.PromiseMock
+import expo.modules.test.core.legacy.assertRejectedWithCode
+import expo.modules.test.core.legacy.promiseResolved
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkStatic

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
@@ -10,11 +10,11 @@ import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.PromiseMock
-import expo.modules.test.core.assertRejected
-import expo.modules.test.core.assertRejectedWithCode
-import expo.modules.test.core.promiseResolved
-import expo.modules.test.core.promiseResolvedWithType
+import expo.modules.test.core.legacy.PromiseMock
+import expo.modules.test.core.legacy.assertRejected
+import expo.modules.test.core.legacy.assertRejectedWithCode
+import expo.modules.test.core.legacy.promiseResolved
+import expo.modules.test.core.legacy.promiseResolvedWithType
 import io.mockk.justRun
 import io.mockk.mockkStatic
 import io.mockk.slot

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
@@ -10,9 +10,9 @@ import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.PromiseMock
-import expo.modules.test.core.assertRejectedWithCode
-import expo.modules.test.core.promiseResolvedWithType
+import expo.modules.test.core.legacy.PromiseMock
+import expo.modules.test.core.legacy.assertRejectedWithCode
+import expo.modules.test.core.legacy.promiseResolvedWithType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Before

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -11,9 +11,9 @@ import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.PromiseMock
-import expo.modules.test.core.assertRejectedWithCode
-import expo.modules.test.core.promiseResolvedWithType
+import expo.modules.test.core.legacy.PromiseMock
+import expo.modules.test.core.legacy.assertRejectedWithCode
+import expo.modules.test.core.legacy.promiseResolvedWithType
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -9,9 +9,9 @@ import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.PromiseMock
-import expo.modules.test.core.assertRejectedWithCode
-import expo.modules.test.core.promiseResolved
+import expo.modules.test.core.legacy.PromiseMock
+import expo.modules.test.core.legacy.assertRejectedWithCode
+import expo.modules.test.core.legacy.promiseResolved
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
@@ -11,7 +11,7 @@ interface ModuleController {
   fun onActivityDestroys()
 }
 
-class ModuleControllerImpl(private val holder: ModuleHolder) : ModuleController {
+class ModuleControllerImpl(private val holder: ModuleHolder<*>) : ModuleController {
   override fun onCreate() {
     holder.post(EventName.MODULE_CREATE)
   }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.events.EventName

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleController.kt
@@ -11,7 +11,7 @@ interface ModuleController {
   fun onActivityDestroys()
 }
 
-class ModuleControllerImpl(private val holder: ModuleHolder<*>) : ModuleController {
+class ModuleControllerImpl(private val holder: ModuleHolder) : ModuleController {
   override fun onCreate() {
     holder.post(EventName.MODULE_CREATE)
   }

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMock.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import android.content.Context
 import android.os.Bundle
@@ -12,7 +12,6 @@ import io.mockk.MockK
 import io.mockk.MockKGateway
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
 import java.lang.ref.WeakReference
 import java.lang.reflect.Proxy
 import kotlin.reflect.KClass

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockHolder.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockHolder.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.kotlin.AppContext

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.ModuleHolder

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
@@ -43,7 +43,7 @@ class TestCodedException(
 class ModuleMockInvocationHandler<T : Any>(
   private val moduleTestInterface: KClass<T>,
   private val moduleController: ModuleController,
-  private val holder: ModuleHolder<*>
+  private val holder: ModuleHolder
 ) : InvocationHandler {
   override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
     if (!holder.definition.asyncFunctions.containsKey(method.name) &&

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/ModuleMockInvocationHandler.kt
@@ -43,7 +43,7 @@ class TestCodedException(
 class ModuleMockInvocationHandler<T : Any>(
   private val moduleTestInterface: KClass<T>,
   private val moduleController: ModuleController,
-  private val holder: ModuleHolder
+  private val holder: ModuleHolder<*>
 ) : InvocationHandler {
   override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
     if (!holder.definition.asyncFunctions.containsKey(method.name) &&

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/PromiseMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/PromiseMock.kt
@@ -1,5 +1,5 @@
 // copied from expo-modules-core
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import expo.modules.kotlin.Promise
 

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/TestJSContainerProvider.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/TestJSContainerProvider.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/TestUtils.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/legacy/TestUtils.kt
@@ -1,4 +1,4 @@
-package expo.modules.test.core
+package expo.modules.test.core.legacy
 
 import android.os.Bundle
 import expo.modules.kotlin.exception.CodedException

--- a/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
+++ b/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
@@ -5,9 +5,9 @@ import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.errorCodeOf
-import expo.modules.test.core.ModuleMock
-import expo.modules.test.core.ModuleMockHolder
-import expo.modules.test.core.assertCodedException
+import expo.modules.test.core.legacy.ModuleMock
+import expo.modules.test.core.legacy.ModuleMockHolder
+import expo.modules.test.core.legacy.assertCodedException
 import io.mockk.every
 import io.mockk.slot
 import io.mockk.verify


### PR DESCRIPTION
# Why

Move the current implementation of the native test setup to the legacy package.
