### PR TITLE
[docs] CodeBlockTable: fix regression after switching to TW

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -174,7 +174,8 @@ export function Code({ className, children }: React.PropsWithChildren<Props>) {
       css={[STYLES_CODE_CONTAINER, STYLES_CODE_CONTAINER_BLOCK]}
       className={mergeClasses(
         preferredTheme === Themes.DARK && 'dark-theme',
-        wordWrap && '!whitespace-pre-wrap !break-words'
+        wordWrap && '!whitespace-pre-wrap !break-words',
+        'last:mb-0'
       )}
       {...attributes}>
       <code css={STYLES_CODE_BLOCK} dangerouslySetInnerHTML={{ __html: html }} />

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
 import {
@@ -17,7 +18,9 @@ type APIBoxProps = PropsWithChildren<{
 
 export const APIBox = ({ header, platforms, children, className }: APIBoxProps) => {
   return (
-    <div css={[STYLES_APIBOX, STYLES_APIBOX_WRAPPER]} className={className}>
+    <div
+      css={[STYLES_APIBOX, STYLES_APIBOX_WRAPPER]}
+      className={mergeClasses(className, '!pb-4 last:[&>*]:!mb-1')}>
       {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
       {header && (
         <H3Code tags={platforms}>

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -40,7 +40,7 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
   return (
     <div css={[codeBlocksWrapperStyle, connected && codeBlockConnectedWrapperStyle]} {...rest}>
       {codeBlocks.map((codeBlock, index) => (
-        <Snippet key={index} css={snippetWrapperStyle}>
+        <Snippet key={index} className="last:mb-4 max-xl:!mb-0">
           <SnippetHeader title={tabNames[index]} Icon={FileCode01Icon}>
             <CopyAction text={cleanCopyValue(codeBlock.props.children.props.children)} />
           </SnippetHeader>
@@ -87,16 +87,6 @@ const codeBlockConnectedWrapperStyle = css({
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,
       },
-    },
-  },
-});
-
-const snippetWrapperStyle = css({
-  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
-    marginBottom: 0,
-
-    '&:last-of-type': {
-      marginBottom: spacing[4],
     },
   },
 });

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -7099,7 +7099,7 @@ This uses both
     </p>
     <pre>
       <pre
-        class=" css-1r21cuo-Code"
+        class="last:mb-0 css-1r21cuo-Code"
         data-text="true"
       >
         <code

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -143,7 +143,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </summary>
       <div
-        class="css-16wdqb0"
+        class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -156,7 +156,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     <div />
   </div>
   <div
-    class="css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -296,7 +296,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </summary>
       <div
-        class="css-16wdqb0"
+        class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -374,7 +374,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </summary>
       <div
-        class="css-16wdqb0"
+        class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -386,7 +386,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
     <div>
       <div
-        class="css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -535,7 +535,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </a>
           </summary>
           <div
-            class="css-16wdqb0"
+            class="last:[&>*]:!mb-1 css-qbaxbl"
           >
             <p
               class="mb-4 css-1kfqm4n-TextComponent"
@@ -547,7 +547,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </details>
         <div>
           <div
-            class="css-c2t1qw-AppConfigProperty"
+            class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
           >
             <p
               class="  css-1kfqm4n-TextComponent"
@@ -633,7 +633,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -733,7 +733,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -873,7 +873,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </a>
       </summary>
       <div
-        class="css-16wdqb0"
+        class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -927,7 +927,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </blockquote>
     <div>
       <div
-        class="css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -1011,7 +1011,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         <div />
       </div>
       <div
-        class="css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -1088,7 +1088,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
         <div>
           <div
-            class="css-c2t1qw-AppConfigProperty"
+            class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
           >
             <p
               class="  css-1kfqm4n-TextComponent"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -75,7 +75,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </p>
   <pre>
     <pre
-      class=" css-1r21cuo-Code"
+      class="last:mb-0 css-1r21cuo-Code"
       data-text="true"
     >
       <code

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -75,7 +75,9 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
             </span>
           </LinkBase>
         </summary>
-        <div css={contentStyle}>{children}</div>
+        <div css={contentStyle} className="last:[&>*]:!mb-1">
+          {children}
+        </div>
       </details>
     );
   }
@@ -147,7 +149,7 @@ const markerStyle = css({
 });
 
 const contentStyle = css({
-  padding: `${spacing[4]}px ${spacing[5]}px 0`,
+  padding: `${spacing[4]}px ${spacing[5]}px`,
 
   p: {
     marginLeft: 0,

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -59,7 +59,9 @@ const InnerTabs = ({
           </TabButton>
         ))}
       </TabList>
-      <TabPanels css={tabsPanelStyle}>{children}</TabPanels>
+      <TabPanels css={tabsPanelStyle} className="last:[&>*]:!mb-0">
+        {children}
+      </TabPanels>
     </ReachTabs>
   );
 };
@@ -72,7 +74,7 @@ const tabsWrapperStyle = css({
 });
 
 const tabsPanelStyle = css({
-  padding: `${spacing[4]}px ${spacing[5]}px ${spacing[1]}px`,
+  padding: `${spacing[4]}px ${spacing[5]}px`,
 
   'pre:first-child': {
     marginTop: spacing[1],


### PR DESCRIPTION
# Why

![image](https://github.com/expo/expo/assets/719641/d413001b-a7de-4d5c-a022-47990b521abe)

# How

Alter `CodeBlockTable` style overwrite to be compatible with Snipped switch to Tailwind.

# Test Plan

The changes have been reviewed locally. Lint checks and tests are passing.

# Preview

<img width="1031" alt="Screenshot 2023-12-01 at 14 44 11" src="https://github.com/expo/expo/assets/719641/6227188d-9ade-4691-b4db-b4608967e2e8">