### PR TITLE
[go] Add User Review section to Home screen

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/BaseExperienceActivity.kt
@@ -12,6 +12,7 @@ import host.exp.exponent.kernel.*
 import host.exp.exponent.kernel.ExponentErrorMessage.Companion.developerErrorMessage
 import host.exp.exponent.utils.AsyncCondition
 import host.exp.exponent.utils.AsyncCondition.AsyncConditionListener
+import host.exp.exponent.storage.ExponentSharedPreferences
 import host.exp.expoview.Exponent
 import javax.inject.Inject
 
@@ -135,6 +136,7 @@ abstract class BaseExperienceActivity : MultipleVersionReactNativeActivity() {
       if (errorQueue.isEmpty()) {
         return@runOnUiThread
       }
+      kernel.exponentSharedPreferences.setLong(ExponentSharedPreferences.ExponentSharedPreferencesKey.LAST_FATAL_ERROR_DATE_KEY, System.currentTimeMillis())
       val (isFatal, errorMessage, errorHeader) = sendErrorsToErrorActivity()
       if (!shouldShowErrorScreen(errorMessage)) {
         return@runOnUiThread

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
@@ -60,6 +60,7 @@ class ErrorActivity() : FragmentActivity() {
   override fun onBackPressed() {
     if (pager.currentItem == 0) {
       kernel.killActivityStack(this)
+      kernel.dispatchForegroundHomeEvent()
     } else {
       pager.currentItem = pager.currentItem - 1
     }
@@ -68,6 +69,7 @@ class ErrorActivity() : FragmentActivity() {
   fun onClickHome() {
     clearErrorList()
 
+    kernel.dispatchForegroundHomeEvent()
     startActivity(Intent(this, LauncherActivity::class.java))
 
     // Mark as not visible so that any new errors go to a new activity.

--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -36,6 +36,7 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode
 import expo.modules.splashscreen.SplashScreenModule
 import expo.modules.splashscreen.SplashScreenPackage
 import expo.modules.splashscreen.singletons.SplashScreen
+import expo.modules.storereview.StoreReviewModule
 import expo.modules.taskManager.TaskManagerPackage
 import expo.modules.trackingtransparency.TrackingTransparencyModule
 import expo.modules.webbrowser.WebBrowserModule
@@ -174,6 +175,7 @@ open class HomeActivity : BaseExperienceActivity() {
         LinearGradientModule::class.java,
         SplashScreenModule::class.java,
         TrackingTransparencyModule::class.java,
+        StoreReviewModule::class.java,
         WebBrowserModule::class.java,
       )
     }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -742,6 +742,21 @@ class Kernel : KernelInterface() {
     killOrphanedLauncherActivities()
   }
 
+  fun dispatchForegroundHomeEvent() {
+    queueEvent(
+      "ExponentKernel.foregroundHome", Arguments.createMap(),
+      object : KernelEventCallback {
+        override fun onEventSuccess(result: ReadableMap) {
+          EXL.d(TAG, "Successfully called ExponentKernel.foregroundHome in kernel JS.")
+        }
+
+        override fun onEventFailure(errorMessage: String?) {
+          EXL.e(TAG, "Error calling ExponentKernel.foregroundHome in kernel JS: $errorMessage")
+        }
+      }
+    )
+  }
+
   /*
    *
    * Optimistic experiences

--- a/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
@@ -107,6 +107,17 @@ class ExponentKernelModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
+  fun getLastCrashDate(promise: Promise) {
+    try {
+      val lastCrashDate = exponentSharedPreferences.getLong(ExponentSharedPreferences.ExponentSharedPreferencesKey.LAST_FATAL_ERROR_DATE_KEY)
+      promise.resolve(lastCrashDate.toString())
+    } catch (e: Exception) {
+      promise.resolve(null)
+      EXL.e(TAG, e)
+    }
+  }
+
+  @ReactMethod
   fun goToHomeFromErrorScreen() {
     if (ErrorActivity.visibleActivity == null) {
       // shouldn't ever get here

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
@@ -43,6 +43,14 @@ class ExponentSharedPreferences constructor(val context: Context) {
     sharedPreferences.edit().putInt(key.preferenceKey, value).apply()
   }
 
+  fun getLong(key: ExponentSharedPreferencesKey): Long {
+    return sharedPreferences.getLong(key.preferenceKey, 0)
+  }
+
+  fun setLong(key: ExponentSharedPreferencesKey, value: Long) {
+    sharedPreferences.edit().putLong(key.preferenceKey, value).apply()
+  }
+
   fun getString(key: ExponentSharedPreferencesKey): String? {
     return getString(key, null)
   }
@@ -152,6 +160,7 @@ class ExponentSharedPreferences constructor(val context: Context) {
     REFERRER_KEY("referrer"),
     NUX_HAS_FINISHED_FIRST_RUN_KEY("nux_has_finished_first_run"),
     IS_ONBOARDING_FINISHED_KEY("is_onboarding_finished"),
+    LAST_FATAL_ERROR_DATE_KEY("last_fatal_error_date_key"),
     SHOULD_NOT_USE_KERNEL_CACHE("should_not_use_kernel_cache"),
     KERNEL_REVISION_ID("kernel_revision_id"),
     EXPO_AUTH_SESSION("expo_auth_session"),

--- a/home/components/UserReviewSection.tsx
+++ b/home/components/UserReviewSection.tsx
@@ -12,10 +12,11 @@ type Props = {
 };
 
 export default function UserReviewSection({ snacks, apps }: Props) {
-  const { shouldShowReviewSection, requestStoreReview, dismissReviewSection } = useUserReviewCheck({
-    apps,
-    snacks,
-  });
+  const { shouldShowReviewSection, requestStoreReview, dismissReviewSection, provideFeedback } =
+    useUserReviewCheck({
+      apps,
+      snacks,
+    });
   const theme = useExpoTheme();
 
   if (!shouldShowReviewSection) {
@@ -39,7 +40,7 @@ export default function UserReviewSection({ snacks, apps }: Props) {
           <Button.FadeOnPressContainer
             flex="1"
             bg="secondary"
-            onPress={dismissReviewSection}
+            onPress={provideFeedback}
             padding="tiny">
             <Button.Text
               align="center"

--- a/home/components/UserReviewSection.tsx
+++ b/home/components/UserReviewSection.tsx
@@ -1,0 +1,86 @@
+import { iconSize, XIcon, spacing, typography } from '@expo/styleguide-native';
+import { Row, Text, useExpoTheme, View, Button } from 'expo-dev-client-components';
+import { CommonAppDataFragment, CommonSnackDataFragment } from 'graphql/types';
+import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+
+import { useUserReviewCheck } from '../utils/useUserReviewCheck';
+
+type Props = {
+  apps?: CommonAppDataFragment[];
+  snacks?: CommonSnackDataFragment[];
+};
+
+export default function UserReviewSection({ snacks, apps }: Props) {
+  const { shouldShowReviewSection, requestStoreReview, dismissReviewSection } = useUserReviewCheck({
+    apps,
+    snacks,
+  });
+  const theme = useExpoTheme();
+
+  if (!shouldShowReviewSection) {
+    return null;
+  }
+
+  return (
+    <View bg="default" rounded="large" border="default" overflow="hidden">
+      <TouchableOpacity onPress={dismissReviewSection} style={styles.dismissButton}>
+        <XIcon size={iconSize.regular} color={theme.icon.default} />
+      </TouchableOpacity>
+      <View padding="medium">
+        <Text type="InterBold" size="small" style={styles.title}>
+          Enjoying Expo Go?
+        </Text>
+        <Text size="small" type="InterRegular" style={styles.subtitle}>
+          Whether you love us or feel we could be doing better, let us know, your feedback will help
+          us improve the app.
+        </Text>
+        <Row style={{ gap: 10 }}>
+          <Button.FadeOnPressContainer
+            flex="1"
+            bg="secondary"
+            onPress={dismissReviewSection}
+            padding="tiny">
+            <Button.Text
+              align="center"
+              size="medium"
+              color="secondary"
+              type="InterSemiBold"
+              style={typography.fontSizes[14]}>
+              Not really
+            </Button.Text>
+          </Button.FadeOnPressContainer>
+          <Button.FadeOnPressContainer
+            flex="1"
+            bg="primary"
+            onPress={requestStoreReview}
+            padding="tiny">
+            <Button.Text
+              align="center"
+              size="medium"
+              color="primary"
+              type="InterSemiBold"
+              style={typography.fontSizes[14]}>
+              Love it!
+            </Button.Text>
+          </Button.FadeOnPressContainer>
+        </Row>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dismissButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 1,
+  },
+  title: {
+    marginBottom: spacing[2],
+  },
+  subtitle: {
+    marginBottom: spacing[2],
+  },
+});

--- a/home/graphql.schema.json
+++ b/home/graphql.schema.json
@@ -1214,6 +1214,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isSSOEnabled",
+            "description": "Whether this account has SSO enabled. Can be queried by all members.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "args": [],
@@ -2557,18 +2573,6 @@
         "description": "Auth configuration data for an SSO account.",
         "fields": [
           {
-            "name": "authEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "authProtocol",
             "description": null,
             "args": [],
@@ -2649,18 +2653,6 @@
             "deprecationReason": null
           },
           {
-            "name": "endSessionEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "args": [],
@@ -2693,42 +2685,6 @@
             "deprecationReason": null
           },
           {
-            "name": "jwksEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "revokeEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tokenEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "updatedAt",
             "description": null,
             "args": [],
@@ -2740,18 +2696,6 @@
                 "name": "DateTime",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userInfoEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2768,18 +2712,6 @@
         "description": null,
         "fields": null,
         "inputFields": [
-          {
-            "name": "authEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "authProtocol",
             "description": null,
@@ -2845,18 +2777,6 @@
             "deprecationReason": null
           },
           {
-            "name": "endSessionEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "issuer",
             "description": null,
             "type": {
@@ -2867,54 +2787,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "jwksEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "revokeEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tokenEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userInfoEndpoint",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -3073,18 +2945,6 @@
         "description": "Public auth configuration data for an SSO account.",
         "fields": [
           {
-            "name": "authEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "authProtocol",
             "description": null,
             "args": [],
@@ -3117,7 +2977,7 @@
             "deprecationReason": null
           },
           {
-            "name": "clientIdentifier",
+            "name": "authorizationUrl",
             "description": null,
             "args": [],
             "type": {
@@ -3128,18 +2988,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endSessionEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3172,54 +3020,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "jwksEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "revokeEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tokenEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userInfoEndpoint",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3318,6 +3118,33 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "AccountUsageEASJobsMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "resourceClassDisplayName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "UNION",
         "name": "AccountUsageMetadata",
         "description": null,
@@ -3329,6 +3156,11 @@
           {
             "kind": "OBJECT",
             "name": "AccountUsageEASBuildMetadata",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AccountUsageEASJobsMetadata",
             "ofType": null
           }
         ]
@@ -3762,6 +3594,30 @@
             "deprecationReason": null
           },
           {
+            "name": "experiments",
+            "description": "Experiments associated with this actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActorExperiment",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureGates",
             "description": "Server feature gate values for this actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
             "args": [
@@ -3866,6 +3722,157 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ActorExperiment",
+        "description": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "enabled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "experiment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "Experiment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ActorExperimentMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createOrUpdateActorExperiment",
+            "description": "Create or update the value of a User Experiment",
+            "args": [
+              {
+                "name": "enabled",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "experiment",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "Experiment",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActorExperiment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ActorQuery",
         "description": null,
         "fields": [
@@ -3899,8 +3906,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public actor queries are no longer supported"
           }
         ],
         "inputFields": null,
@@ -5054,6 +5061,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "bun",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "env",
             "description": null,
             "type": {
@@ -5103,6 +5122,18 @@
           },
           {
             "name": "node",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pnpm",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -6318,22 +6349,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "type",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "AndroidKeystoreType",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -6500,6 +6515,18 @@
             "deprecationReason": null
           },
           {
+            "name": "rollout",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "track",
             "description": null,
             "args": [],
@@ -6593,6 +6620,18 @@
             "type": {
               "kind": "ENUM",
               "name": "SubmissionAndroidReleaseStatus",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rollout",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
               "ofType": null
             },
             "defaultValue": null,
@@ -6865,6 +6904,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BranchFilterInput",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -7375,6 +7426,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DeploymentFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "first",
                 "description": null,
                 "type": {
@@ -7483,6 +7546,30 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubBuildTriggers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubBuildTrigger",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -7612,6 +7699,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeleting",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -8027,6 +8130,71 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Legacy access tokens are deprecated"
+          },
+          {
+            "name": "runtimes",
+            "description": "Runtimes associated with this app",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RuntimesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "scopeKey",
@@ -11161,6 +11329,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "deviceClass",
             "description": null,
             "args": [],
@@ -11274,6 +11454,12 @@
           },
           {
             "name": "IPHONE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MAC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -13729,6 +13915,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "VOID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -13916,6 +14108,29 @@
         "description": "The `Boolean` scalar type represents `true` or `false`.",
         "fields": null,
         "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BranchFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "searchTerm",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -14123,12 +14338,36 @@
             "deprecationReason": null
           },
           {
+            "name": "customNodeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customWorkflowName",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "developmentClient",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "isDeprecated": false,
@@ -14314,6 +14553,22 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isWaived",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14515,6 +14770,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requiredPackageManager",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "resourceClass",
             "description": "The builder resource class requested by the developer",
             "args": [],
@@ -14608,6 +14875,18 @@
             "deprecationReason": null
           },
           {
+            "name": "selectedImage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],
@@ -14689,6 +14968,498 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BuildAnnotation",
+        "description": null,
+        "fields": [
+          {
+            "name": "authorUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildPhase",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exampleBuildLog",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalNotes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regexFlags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regexString",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildAnnotationDataInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildPhase",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exampleBuildLog",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalNotes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regexFlags",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regexString",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildAnnotationFiltersInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "buildPhases",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BuildAnnotationMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createBuildAnnotation",
+            "description": "Create a Build Annotation",
+            "args": [
+              {
+                "name": "buildAnnotationData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "BuildAnnotationDataInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildAnnotation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteBuildAnnotation",
+            "description": "Delete a Build Annotation",
+            "args": [
+              {
+                "name": "buildAnnotationId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteBuildAnnotationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateBuildAnnotation",
+            "description": "Update a Build Annotation",
+            "args": [
+              {
+                "name": "buildAnnotationData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "BuildAnnotationDataInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "buildAnnotationId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildAnnotation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BuildAnnotationsQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "all",
+            "description": "View build annotations",
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildAnnotationFiltersInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BuildAnnotation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byId",
+            "description": "Find a build annotation by ID",
+            "args": [
+              {
+                "name": "buildAnnotationId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildAnnotation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -14885,6 +15656,18 @@
         "name": "BuildError",
         "description": null,
         "fields": [
+          {
+            "name": "buildPhase",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildPhase",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "docsUrl",
             "description": null,
@@ -15091,6 +15874,38 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "developmentClient",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "distributions",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DistributionType",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -15638,6 +16453,80 @@
       },
       {
         "kind": "OBJECT",
+        "name": "BuildLimitThresholdExceededMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "thresholdsExceeded",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NotificationThresholdExceeded",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildLimitThresholdExceededMetadataType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOTAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "BuildLogs",
         "description": null,
         "fields": [
@@ -15726,18 +16615,6 @@
             "deprecationReason": null
           },
           {
-            "name": "buildMode",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "BuildMode",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "buildProfile",
             "description": null,
             "type": {
@@ -15786,11 +16663,35 @@
             "deprecationReason": null
           },
           {
+            "name": "customNodeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customWorkflowName",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "developmentClient",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -15894,6 +16795,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requiredPackageManager",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "runFromCI",
             "description": null,
             "type": {
@@ -15931,6 +16844,18 @@
           },
           {
             "name": "sdkVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "selectedImage",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -16604,6 +17529,332 @@
       },
       {
         "kind": "ENUM",
+        "name": "BuildPhase",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILDER_INFO",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CLEAN_UP_CREDENTIALS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMPLETE_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CONFIGURE_EXPO_UPDATES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CONFIGURE_XCODE_PROJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DOWNLOAD_APPLICATION_ARCHIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EAS_BUILD_INTERNAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FAIL_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIX_GRADLEW",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INSTALL_CUSTOM_TOOLS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INSTALL_DEPENDENCIES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INSTALL_PODS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ON_BUILD_CANCEL_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ON_BUILD_COMPLETE_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ON_BUILD_ERROR_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ON_BUILD_SUCCESS_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PARSE_CUSTOM_WORKFLOW_CONFIG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_INSTALL_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PREBUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PREPARE_ARTIFACTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PREPARE_CREDENTIALS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PREPARE_PROJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRE_INSTALL_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRE_UPLOAD_ARTIFACTS_HOOK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "QUEUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "READ_APP_CONFIG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "READ_PACKAGE_JSON",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESTORE_CACHE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RUN_EXPO_DOCTOR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RUN_FASTLANE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RUN_GRADLEW",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SAVE_CACHE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SET_UP_BUILD_ENVIRONMENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SPIN_UP_BUILDER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "START_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNKNOWN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPLOAD_APPLICATION_ARCHIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPLOAD_ARTIFACTS",
+            "description": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "UPLOAD_BUILD_ARTIFACTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BuildPlanCreditThresholdExceededMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildCreditUsage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "planLimit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "threshold",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "BuildPriority",
         "description": null,
         "fields": null,
@@ -17043,13 +18294,13 @@
             "name": "IOS_INTEL_LARGE",
             "description": null,
             "isDeprecated": true,
-            "deprecationReason": "Use IOS_INTEL_MEDIUM instead"
+            "deprecationReason": "No longer available. Use IOS_M_LARGE instead."
           },
           {
             "name": "IOS_INTEL_MEDIUM",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer available. Use IOS_M_MEDIUM instead."
           },
           {
             "name": "IOS_LARGE",
@@ -17066,8 +18317,8 @@
           {
             "name": "IOS_M1_MEDIUM",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use IOS_M_MEDIUM instead"
           },
           {
             "name": "IOS_MEDIUM",
@@ -17951,6 +19202,141 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CreateGitHubBuildTriggerInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "autoSubmit",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sourcePattern",
+            "description": "A branch or tag name, or a wildcard pattern where the code change originates from. For example, `main` or `release/*`.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetPattern",
+            "description": "A branch name or a wildcard pattern that the pull request targets. For example, `main` or `release/*`.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GitHubBuildTriggerType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateGitHubRepositoryInput",
         "description": null,
         "fields": null,
@@ -18471,6 +19857,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeleteBuildAnnotationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "buildAnnotationId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeleteDiscordUserResult",
         "description": null,
         "fields": [
@@ -18634,6 +20047,33 @@
       {
         "kind": "OBJECT",
         "name": "DeleteRobotResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteSSOUserResult",
         "description": null,
         "fields": [
           {
@@ -18896,16 +20336,77 @@
             "deprecationReason": null
           },
           {
-            "name": "latestUpdate",
-            "description": null,
+            "name": "insights",
+            "description": "Deployment query field",
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "Update",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeploymentInsights",
+                "ofType": null
+              }
             },
-            "isDeprecated": true,
-            "deprecationReason": "Not required for the new Deployment UI"
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "latestUpdatesPerBranch",
+            "description": "Ordered the same way as 'updateBranches' in UpdateChannel",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LatestUpdateOnBranch",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "runtime",
@@ -19054,6 +20555,208 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Deployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "DeploymentFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "embeddedUpdateTotalUniqueUsers",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdateUniqueUsersOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mostPopularUpdates",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Update",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUsersOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
                 "ofType": null
               }
             },
@@ -19445,6 +21148,12 @@
             "deprecationReason": null
           },
           {
+            "name": "JOBS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "UPDATES",
             "description": null,
             "isDeprecated": false,
@@ -19481,6 +21190,12 @@
           },
           {
             "name": "MANIFEST_REQUESTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RUN_TIME",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -20189,6 +21904,23 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "Experiment",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ORBIT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -21149,7 +22881,7 @@
           },
           {
             "name": "searchRepositories",
-            "description": null,
+            "description": "@deprecated",
             "args": [
               {
                 "name": "githubAppInstallationId",
@@ -21291,6 +23023,427 @@
       },
       {
         "kind": "OBJECT",
+        "name": "GitHubBuildTrigger",
+        "description": null,
+        "fields": [
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "autoSubmit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildProfile",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunBuild",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Build",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunErrorCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunErrorMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "GitHubBuildTriggerRunStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sourcePattern",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetPattern",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GitHubBuildTriggerType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubBuildTriggerMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createGitHubBuildTrigger",
+            "description": "Create GitHub build trigger for an App",
+            "args": [
+              {
+                "name": "githubBuildTriggerData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateGitHubBuildTriggerInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubBuildTrigger",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteGitHubBuildTrigger",
+            "description": "Delete GitHub build trigger by ID",
+            "args": [
+              {
+                "name": "githubBuildTriggerId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubBuildTrigger",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateGitHubBuildTrigger",
+            "description": "Update a GitHub build trigger by ID",
+            "args": [
+              {
+                "name": "githubBuildTriggerData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdateGitHubBuildTriggerInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "githubBuildTriggerId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubBuildTrigger",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GitHubBuildTriggerRunStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ERRORED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GitHubBuildTriggerType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PULL_REQUEST_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUSH_TO_BRANCH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TAG_UPDATED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "GitHubRepository",
         "description": null,
         "fields": [
@@ -21375,9 +23528,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "GitHubRepositoryMetadata",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubRepositoryMetadata",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -21509,18 +23666,6 @@
                 "name": "DateTime",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "openGraphImageUrl",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -22111,6 +24256,18 @@
                 "name": "DeleteGitHubUserResult",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "generateGitHubUserAccessToken",
+            "description": "Generate a GitHub User Access Token",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -23905,6 +26062,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "bun",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "bundler",
             "description": null,
             "type": {
@@ -23978,6 +26147,18 @@
           },
           {
             "name": "node",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pnpm",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -25074,6 +27255,45 @@
       },
       {
         "kind": "OBJECT",
+        "name": "LatestUpdateOnBranch",
+        "description": null,
+        "fields": [
+          {
+            "name": "branchId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Update",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "LeaveAccountResult",
         "description": null,
         "fields": [
@@ -25254,6 +27474,12 @@
           },
           {
             "name": "EAS_MASTER_LIST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NEWSLETTER_SIGNUP_LIST",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -25443,6 +27669,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DeleteAccountResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteSSOUser",
+            "description": "Delete a SSO user. Actor must be an owner on the SSO user's SSO account.",
+            "args": [
+              {
+                "name": "ssoUserId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteSSOUserResult",
                 "ofType": null
               }
             },
@@ -25996,6 +28255,157 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "Notification",
+        "description": null,
+        "fields": [
+          {
+            "name": "accountName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRead",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "NotificationMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "websiteMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "NotificationEvent",
         "description": null,
@@ -26005,6 +28415,12 @@
         "enumValues": [
           {
             "name": "BUILD_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BUILD_LIMIT_THRESHOLD_EXCEEDED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -26020,9 +28436,41 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "TEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "NotificationMetadata",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "BuildLimitThresholdExceededMetadata",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "BuildPlanCreditThresholdExceededMetadata",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "TestNotificationMetadata",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "OBJECT",
@@ -26305,6 +28753,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "NotificationThresholdExceeded",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "threshold",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BuildLimitThresholdExceededMetadataType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "NotificationType",
         "description": null,
@@ -26314,6 +28837,12 @@
         "enumValues": [
           {
             "name": "EMAIL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WEB",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -27677,6 +30206,30 @@
             "deprecationReason": null
           },
           {
+            "name": "experiments",
+            "description": "Experiments associated with this actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActorExperiment",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureGates",
             "description": "Server feature gate values for this actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
             "args": [
@@ -28086,6 +30639,22 @@
             "deprecationReason": null
           },
           {
+            "name": "actorExperiment",
+            "description": "Mutations for Actor experiments",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActorExperimentMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "androidAppBuildCredentials",
             "description": "Mutations that modify the build credentials for an Android app",
             "args": [],
@@ -28364,6 +30933,22 @@
             "deprecationReason": null
           },
           {
+            "name": "buildAnnotation",
+            "description": "Mutations that create, update, and delete Build Annotations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildAnnotationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJob",
             "description": "Mutations that modify an BuildJob",
             "args": [
@@ -28470,6 +31055,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "GitHubAppInstallationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubBuildTrigger",
+            "description": "Mutations for GitHub build triggers",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubBuildTriggerMutation",
                 "ofType": null
               }
             },
@@ -28733,6 +31334,22 @@
             "deprecationReason": null
           },
           {
+            "name": "userAppPins",
+            "description": "Mutations that create, update, and delete pinned apps",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserAppPinMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userInvitation",
             "description": "Mutations that create, delete, and accept UserInvitations",
             "args": [],
@@ -28758,6 +31375,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "WebhookMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "websiteNotifications",
+            "description": "Mutations that modify a websiteNotification",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebsiteNotificationMutation",
                 "ofType": null
               }
             },
@@ -28832,8 +31465,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public actor queries are no longer supported"
           },
           {
             "name": "allPublicApps",
@@ -29011,6 +31644,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "BackgroundJobReceiptQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildAnnotations",
+            "description": "Top-level query object for querying annotations.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuildAnnotationsQuery",
                 "ofType": null
               }
             },
@@ -29198,22 +31847,6 @@
             "deprecationReason": null
           },
           {
-            "name": "ssoUser",
-            "description": "Top-level query object for querying SSO Users.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SSOUserQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "statuspageService",
             "description": "Top-level query object for querying Expo status page services.",
             "args": [],
@@ -29299,8 +31932,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public user queries are no longer supported"
           },
           {
             "name": "userActor",
@@ -29312,6 +31945,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "UserActorQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Public user queries are no longer supported"
+          },
+          {
+            "name": "userActorPublicData",
+            "description": "Top-level query object for querying UserActorPublicData publicly.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserActorPublicDataQuery",
                 "ofType": null
               }
             },
@@ -29489,6 +32138,123 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RuntimeEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Runtime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "RuntimeFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branchId",
+            "description": "Only return runtimes shared with this branch",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RuntimesConnection",
+        "description": "Represents the connection over the runtime edge of an App",
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RuntimeEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
                 "ofType": null
               }
             },
@@ -29781,6 +32547,30 @@
             "deprecationReason": null
           },
           {
+            "name": "experiments",
+            "description": "Experiments associated with this actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActorExperiment",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureGates",
             "description": "Server feature gate values for this actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
             "args": [
@@ -29971,6 +32761,30 @@
             "deprecationReason": null
           },
           {
+            "name": "pinnedApps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "primaryAccount",
             "description": "Associated accounts",
             "args": [],
@@ -30086,6 +32900,71 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "websiteNotificationsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebsiteNotificationsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -30136,83 +33015,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SSOUserQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": "Query an SSOUser by ID",
-            "args": [
-              {
-                "name": "userId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SSOUser",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "byUsername",
-            "description": "Query an SSOUser by username",
-            "args": [
-              {
-                "name": "username",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SSOUser",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -31402,6 +34204,18 @@
           },
           {
             "name": "EAS_UPDATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GITHUB_API_REQUESTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GITHUB_WEBHOOKS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -32682,6 +35496,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "TestNotificationMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "TimelineActivityConnection",
         "description": null,
         "fields": [
@@ -33089,6 +35930,22 @@
             "deprecationReason": null
           },
           {
+            "name": "insights",
+            "description": "Update query field",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isGitWorkingTreeDirty",
             "description": null,
             "args": [],
@@ -33319,6 +36176,83 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimes",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RuntimeFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RuntimesConnection",
                 "ofType": null
               }
             },
@@ -34004,6 +36938,125 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "UpdateGitHubBuildTriggerInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "autoSubmit",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isActive",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sourcePattern",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "targetPattern",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GitHubBuildTriggerType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "UpdateGitHubRepositorySettingsInput",
         "description": null,
         "fields": null,
@@ -34073,6 +37126,66 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalUniqueUsers",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -34486,6 +37599,12 @@
             "deprecationReason": null
           },
           {
+            "name": "MINUTE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "REQUEST",
             "description": null,
             "isDeprecated": false,
@@ -34868,9 +37987,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -34886,6 +38009,30 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "experiments",
+            "description": "Experiments associated with this actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActorExperiment",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -35154,6 +38301,30 @@
             "deprecationReason": null
           },
           {
+            "name": "pinnedApps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "primaryAccount",
             "description": "Associated accounts",
             "args": [],
@@ -35288,6 +38459,71 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "websiteNotificationsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebsiteNotificationsConnection",
                 "ofType": null
               }
             },
@@ -35591,6 +38827,30 @@
             "deprecationReason": null
           },
           {
+            "name": "experiments",
+            "description": "Experiments associated with this actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActorExperiment",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureGates",
             "description": "Server feature gate values for this user actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
             "args": [
@@ -35781,6 +39041,30 @@
             "deprecationReason": null
           },
           {
+            "name": "pinnedApps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "primaryAccount",
             "description": "Associated accounts",
             "args": [],
@@ -35896,6 +39180,71 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "websiteNotificationsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WebsiteNotificationsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -35919,6 +39268,259 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserActorPublicData",
+        "description": "A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts.",
+        "fields": [
+          {
+            "name": "apps",
+            "description": "Apps this user has published",
+            "args": [
+              {
+                "name": "includeUnpublished",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "profilePhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snacks",
+            "description": "Snacks associated with this user's personal account",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Snack",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserActorPublicDataQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byUsername",
+            "description": "Get UserActorPublicData by username",
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserActorPublicData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
       },
       {
         "kind": "OBJECT",
@@ -35955,8 +39557,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public user actor queries are no longer supported"
           },
           {
             "name": "byUsername",
@@ -35987,6 +39589,79 @@
                 "name": "UserActor",
                 "ofType": null
               }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Public user actor queries are no longer supported"
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserAppPinMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "pinApp",
+            "description": null,
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unpinApp",
+            "description": null,
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -36785,8 +40460,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public user queries are no longer supported"
           },
           {
             "name": "byUsername",
@@ -36818,8 +40493,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Public user queries are no longer supported"
           }
         ],
         "inputFields": null,
@@ -36975,6 +40650,49 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WebNotificationUpdateReadStateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isRead",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -37374,6 +41092,160 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WebsiteNotificationEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Notification",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WebsiteNotificationMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "updateAllWebsiteNotificationReadStateAsRead",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateNotificationReadState",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WebNotificationUpdateReadStateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Notification",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WebsiteNotificationsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WebsiteNotificationEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/home/graphql/fragments/CurrentUserActorData.fragment.graphql
+++ b/home/graphql/fragments/CurrentUserActorData.fragment.graphql
@@ -5,6 +5,7 @@ fragment CurrentUserActorData on UserActor {
   firstName
   lastName
   profilePhoto
+  bestContactEmail
   accounts {
     id
     name

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -108,6 +108,8 @@ export type Account = {
   googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
   id: Scalars['ID'];
   isCurrent: Scalars['Boolean'];
+  /** Whether this account has SSO enabled. Can be queried by all members. */
+  isSSOEnabled: Scalars['Boolean'];
   name: Scalars['String'];
   /** Offers set on this account */
   offers?: Maybe<Array<Offer>>;
@@ -462,34 +464,22 @@ export type AccountQueryByNameArgs = {
 /** Auth configuration data for an SSO account. */
 export type AccountSsoConfiguration = {
   __typename?: 'AccountSSOConfiguration';
-  authEndpoint?: Maybe<Scalars['String']>;
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
   createdAt: Scalars['DateTime'];
-  endSessionEndpoint?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   issuer: Scalars['String'];
-  jwksEndpoint?: Maybe<Scalars['String']>;
-  revokeEndpoint?: Maybe<Scalars['String']>;
-  tokenEndpoint?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
-  userInfoEndpoint?: Maybe<Scalars['String']>;
 };
 
 export type AccountSsoConfigurationData = {
-  authEndpoint?: InputMaybe<Scalars['String']>;
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
-  endSessionEndpoint?: InputMaybe<Scalars['String']>;
   issuer: Scalars['String'];
-  jwksEndpoint?: InputMaybe<Scalars['String']>;
-  revokeEndpoint?: InputMaybe<Scalars['String']>;
-  tokenEndpoint?: InputMaybe<Scalars['String']>;
-  userInfoEndpoint?: InputMaybe<Scalars['String']>;
 };
 
 export type AccountSsoConfigurationMutation = {
@@ -522,17 +512,11 @@ export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
 /** Public auth configuration data for an SSO account. */
 export type AccountSsoConfigurationPublicData = {
   __typename?: 'AccountSSOConfigurationPublicData';
-  authEndpoint?: Maybe<Scalars['String']>;
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
-  clientIdentifier: Scalars['String'];
-  endSessionEndpoint?: Maybe<Scalars['String']>;
+  authorizationUrl: Scalars['String'];
   id: Scalars['ID'];
   issuer: Scalars['String'];
-  jwksEndpoint?: Maybe<Scalars['String']>;
-  revokeEndpoint?: Maybe<Scalars['String']>;
-  tokenEndpoint?: Maybe<Scalars['String']>;
-  userInfoEndpoint?: Maybe<Scalars['String']>;
 };
 
 export type AccountSsoConfigurationPublicDataQuery = {
@@ -552,7 +536,12 @@ export type AccountUsageEasBuildMetadata = {
   platform: AppPlatform;
 };
 
-export type AccountUsageMetadata = AccountUsageEasBuildMetadata;
+export type AccountUsageEasJobsMetadata = {
+  __typename?: 'AccountUsageEASJobsMetadata';
+  resourceClassDisplayName: Scalars['String'];
+};
+
+export type AccountUsageMetadata = AccountUsageEasBuildMetadata | AccountUsageEasJobsMetadata;
 
 export type AccountUsageMetric = {
   __typename?: 'AccountUsageMetric';
@@ -608,6 +597,8 @@ export type Actor = {
    * For example, when displaying a sentence indicating that actor X created a build or published an update.
    */
   displayName: Scalars['String'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
   /**
    * Server feature gate values for this actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -624,9 +615,33 @@ export type ActorFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type ActorExperiment = {
+  __typename?: 'ActorExperiment';
+  createdAt: Scalars['DateTime'];
+  enabled: Scalars['Boolean'];
+  experiment: Experiment;
+  id: Scalars['ID'];
+  updatedAt: Scalars['DateTime'];
+};
+
+export type ActorExperimentMutation = {
+  __typename?: 'ActorExperimentMutation';
+  /** Create or update the value of a User Experiment */
+  createOrUpdateActorExperiment: ActorExperiment;
+};
+
+
+export type ActorExperimentMutationCreateOrUpdateActorExperimentArgs = {
+  enabled: Scalars['Boolean'];
+  experiment: Experiment;
+};
+
 export type ActorQuery = {
   __typename?: 'ActorQuery';
-  /** Query an Actor by ID */
+  /**
+   * Query an Actor by ID
+   * @deprecated Public actor queries are no longer supported
+   */
   byId: Actor;
 };
 
@@ -795,11 +810,13 @@ export enum AndroidBuildType {
 }
 
 export type AndroidBuilderEnvironmentInput = {
+  bun?: InputMaybe<Scalars['String']>;
   env?: InputMaybe<Scalars['JSONObject']>;
   expoCli?: InputMaybe<Scalars['String']>;
   image?: InputMaybe<Scalars['String']>;
   ndk?: InputMaybe<Scalars['String']>;
   node?: InputMaybe<Scalars['String']>;
+  pnpm?: InputMaybe<Scalars['String']>;
   yarn?: InputMaybe<Scalars['String']>;
 };
 
@@ -933,7 +950,6 @@ export type AndroidKeystoreInput = {
   keyAlias: Scalars['String'];
   keyPassword?: InputMaybe<Scalars['String']>;
   keystorePassword: Scalars['String'];
-  type: AndroidKeystoreType;
 };
 
 export type AndroidKeystoreMutation = {
@@ -968,6 +984,7 @@ export type AndroidSubmissionConfig = {
   /** @deprecated archiveType is deprecated and will be null */
   archiveType?: Maybe<SubmissionAndroidArchiveType>;
   releaseStatus?: Maybe<SubmissionAndroidReleaseStatus>;
+  rollout?: Maybe<Scalars['Float']>;
   track: SubmissionAndroidTrack;
 };
 
@@ -978,6 +995,7 @@ export type AndroidSubmissionConfigInput = {
   googleServiceAccountKeyId?: InputMaybe<Scalars['String']>;
   googleServiceAccountKeyJson?: InputMaybe<Scalars['String']>;
   releaseStatus?: InputMaybe<SubmissionAndroidReleaseStatus>;
+  rollout?: InputMaybe<Scalars['Float']>;
   track: SubmissionAndroidTrack;
 };
 
@@ -1013,6 +1031,7 @@ export type App = Project & {
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
   fullName: Scalars['String'];
+  githubBuildTriggers: Array<GitHubBuildTrigger>;
   githubRepository?: Maybe<GitHubRepository>;
   githubRepositorySettings?: Maybe<GitHubRepositorySettings>;
   /** githubUrl field from most recent classic update manifest */
@@ -1026,6 +1045,7 @@ export type App = Project & {
   insights: AppInsights;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
+  isDeleting: Scalars['Boolean'];
   /** Whether the latest classic update publish is using a deprecated SDK version */
   isDeprecated: Scalars['Boolean'];
   /** @deprecated 'likes' have been deprecated. */
@@ -1060,6 +1080,8 @@ export type App = Project & {
   releaseChannels: Array<Scalars['String']>;
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
+  /** Runtimes associated with this app */
+  runtimes: RuntimesConnection;
   scopeKey: Scalars['String'];
   /** SDK version of the latest classic update publish, 0.0.0 otherwise */
   sdkVersion: Scalars['String'];
@@ -1116,6 +1138,7 @@ export type AppAndroidAppCredentialsArgs = {
 export type AppBranchesPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<BranchFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
@@ -1177,6 +1200,7 @@ export type AppDeploymentArgs = {
 export type AppDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<DeploymentFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
@@ -1212,6 +1236,15 @@ export type AppLatestReleaseForReleaseChannelArgs = {
 export type AppLikedByArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppRuntimesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1646,6 +1679,7 @@ export type AppleDevice = {
   __typename?: 'AppleDevice';
   account: Account;
   appleTeam: AppleTeam;
+  createdAt?: Maybe<Scalars['DateTime']>;
   deviceClass?: Maybe<AppleDeviceClass>;
   enabled?: Maybe<Scalars['Boolean']>;
   id: Scalars['ID'];
@@ -1657,7 +1691,8 @@ export type AppleDevice = {
 
 export enum AppleDeviceClass {
   Ipad = 'IPAD',
-  Iphone = 'IPHONE'
+  Iphone = 'IPHONE',
+  Mac = 'MAC'
 }
 
 export type AppleDeviceInput = {
@@ -2005,7 +2040,8 @@ export type BackgroundJobReceiptQueryByIdArgs = {
 };
 
 export enum BackgroundJobResultType {
-  GithubBuild = 'GITHUB_BUILD'
+  GithubBuild = 'GITHUB_BUILD',
+  Void = 'VOID'
 }
 
 export enum BackgroundJobState {
@@ -2033,6 +2069,10 @@ export type BillingPeriod = {
   start: Scalars['DateTime'];
 };
 
+export type BranchFilterInput = {
+  searchTerm?: InputMaybe<Scalars['String']>;
+};
+
 /** Represents an EAS Build */
 export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
@@ -2050,7 +2090,9 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   childBuild?: Maybe<Build>;
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
+  customNodeVersion?: Maybe<Scalars['String']>;
   customWorkflowName?: Maybe<Scalars['String']>;
+  developmentClient?: Maybe<Scalars['Boolean']>;
   distribution?: Maybe<DistributionType>;
   enqueuedAt?: Maybe<Scalars['DateTime']>;
   error?: Maybe<BuildError>;
@@ -2068,6 +2110,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   initiatingUser?: Maybe<User>;
   iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
   isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
+  isWaived: Scalars['Boolean'];
   logFiles: Array<Scalars['String']>;
   maxBuildTimeSeconds: Scalars['Int'];
   /** Retry time starts after completedAt */
@@ -2084,6 +2127,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   queuePosition?: Maybe<Scalars['Int']>;
   reactNativeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
+  requiredPackageManager?: Maybe<Scalars['String']>;
   /**
    * The builder resource class requested by the developer
    * @deprecated Use resourceClassDisplayName instead
@@ -2095,6 +2139,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   runFromCI?: Maybe<Scalars['Boolean']>;
   runtimeVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
+  selectedImage?: Maybe<Scalars['String']>;
   status: BuildStatus;
   submissions: Array<Submission>;
   updatedAt: Scalars['DateTime'];
@@ -2111,6 +2156,77 @@ export type BuildCanRetryArgs = {
 /** Represents an EAS Build */
 export type BuildRetryDisabledReasonArgs = {
   newMode?: InputMaybe<BuildMode>;
+};
+
+export type BuildAnnotation = {
+  __typename?: 'BuildAnnotation';
+  authorUsername?: Maybe<Scalars['String']>;
+  buildPhase: Scalars['String'];
+  exampleBuildLog?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  internalNotes?: Maybe<Scalars['String']>;
+  message: Scalars['String'];
+  regexFlags?: Maybe<Scalars['String']>;
+  regexString: Scalars['String'];
+  title: Scalars['String'];
+};
+
+export type BuildAnnotationDataInput = {
+  buildPhase: Scalars['String'];
+  exampleBuildLog?: InputMaybe<Scalars['String']>;
+  internalNotes?: InputMaybe<Scalars['String']>;
+  message: Scalars['String'];
+  regexFlags?: InputMaybe<Scalars['String']>;
+  regexString: Scalars['String'];
+  title: Scalars['String'];
+};
+
+export type BuildAnnotationFiltersInput = {
+  buildPhases: Array<Scalars['String']>;
+};
+
+export type BuildAnnotationMutation = {
+  __typename?: 'BuildAnnotationMutation';
+  /** Create a Build Annotation */
+  createBuildAnnotation: BuildAnnotation;
+  /** Delete a Build Annotation */
+  deleteBuildAnnotation: DeleteBuildAnnotationResult;
+  /** Update a Build Annotation */
+  updateBuildAnnotation: BuildAnnotation;
+};
+
+
+export type BuildAnnotationMutationCreateBuildAnnotationArgs = {
+  buildAnnotationData: BuildAnnotationDataInput;
+};
+
+
+export type BuildAnnotationMutationDeleteBuildAnnotationArgs = {
+  buildAnnotationId: Scalars['ID'];
+};
+
+
+export type BuildAnnotationMutationUpdateBuildAnnotationArgs = {
+  buildAnnotationData: BuildAnnotationDataInput;
+  buildAnnotationId: Scalars['ID'];
+};
+
+export type BuildAnnotationsQuery = {
+  __typename?: 'BuildAnnotationsQuery';
+  /** View build annotations */
+  all: Array<BuildAnnotation>;
+  /** Find a build annotation by ID */
+  byId: BuildAnnotation;
+};
+
+
+export type BuildAnnotationsQueryAllArgs = {
+  filters?: InputMaybe<BuildAnnotationFiltersInput>;
+};
+
+
+export type BuildAnnotationsQueryByIdArgs = {
+  buildAnnotationId: Scalars['ID'];
 };
 
 export type BuildArtifact = {
@@ -2141,6 +2257,7 @@ export enum BuildCredentialsSource {
 
 export type BuildError = {
   __typename?: 'BuildError';
+  buildPhase?: Maybe<BuildPhase>;
   docsUrl?: Maybe<Scalars['String']>;
   errorCode: Scalars['String'];
   message: Scalars['String'];
@@ -2162,6 +2279,8 @@ export type BuildFilter = {
 
 export type BuildFilterInput = {
   channel?: InputMaybe<Scalars['String']>;
+  developmentClient?: InputMaybe<Scalars['Boolean']>;
+  distributions?: InputMaybe<Array<DistributionType>>;
   platforms?: InputMaybe<Array<AppPlatform>>;
   releaseChannel?: InputMaybe<Scalars['String']>;
 };
@@ -2238,6 +2357,17 @@ export enum BuildJobStatus {
   Started = 'STARTED'
 }
 
+export type BuildLimitThresholdExceededMetadata = {
+  __typename?: 'BuildLimitThresholdExceededMetadata';
+  account: Account;
+  thresholdsExceeded: Array<NotificationThresholdExceeded>;
+};
+
+export enum BuildLimitThresholdExceededMetadataType {
+  Ios = 'IOS',
+  Total = 'TOTAL'
+}
+
 export type BuildLogs = {
   __typename?: 'BuildLogs';
   format?: Maybe<BuildJobLogsFormat>;
@@ -2249,12 +2379,13 @@ export type BuildMetadataInput = {
   appIdentifier?: InputMaybe<Scalars['String']>;
   appName?: InputMaybe<Scalars['String']>;
   appVersion?: InputMaybe<Scalars['String']>;
-  buildMode?: InputMaybe<BuildMode>;
   buildProfile?: InputMaybe<Scalars['String']>;
   channel?: InputMaybe<Scalars['String']>;
   cliVersion?: InputMaybe<Scalars['String']>;
   credentialsSource?: InputMaybe<BuildCredentialsSource>;
+  customNodeVersion?: InputMaybe<Scalars['String']>;
   customWorkflowName?: InputMaybe<Scalars['String']>;
+  developmentClient?: InputMaybe<Scalars['Boolean']>;
   distribution?: InputMaybe<DistributionType>;
   gitCommitHash?: InputMaybe<Scalars['String']>;
   gitCommitMessage?: InputMaybe<Scalars['String']>;
@@ -2263,10 +2394,12 @@ export type BuildMetadataInput = {
   message?: InputMaybe<Scalars['String']>;
   reactNativeVersion?: InputMaybe<Scalars['String']>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  requiredPackageManager?: InputMaybe<Scalars['String']>;
   runFromCI?: InputMaybe<Scalars['Boolean']>;
   runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']>;
   runtimeVersion?: InputMaybe<Scalars['String']>;
   sdkVersion?: InputMaybe<Scalars['String']>;
+  selectedImage?: InputMaybe<Scalars['String']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']>;
   username?: InputMaybe<Scalars['String']>;
   workflow?: InputMaybe<BuildWorkflow>;
@@ -2383,6 +2516,58 @@ export type BuildParamsInput = {
   sdkVersion?: InputMaybe<Scalars['String']>;
 };
 
+export enum BuildPhase {
+  BuilderInfo = 'BUILDER_INFO',
+  CleanUpCredentials = 'CLEAN_UP_CREDENTIALS',
+  CompleteBuild = 'COMPLETE_BUILD',
+  ConfigureExpoUpdates = 'CONFIGURE_EXPO_UPDATES',
+  ConfigureXcodeProject = 'CONFIGURE_XCODE_PROJECT',
+  Custom = 'CUSTOM',
+  DownloadApplicationArchive = 'DOWNLOAD_APPLICATION_ARCHIVE',
+  EasBuildInternal = 'EAS_BUILD_INTERNAL',
+  FailBuild = 'FAIL_BUILD',
+  FixGradlew = 'FIX_GRADLEW',
+  InstallCustomTools = 'INSTALL_CUSTOM_TOOLS',
+  InstallDependencies = 'INSTALL_DEPENDENCIES',
+  InstallPods = 'INSTALL_PODS',
+  OnBuildCancelHook = 'ON_BUILD_CANCEL_HOOK',
+  OnBuildCompleteHook = 'ON_BUILD_COMPLETE_HOOK',
+  OnBuildErrorHook = 'ON_BUILD_ERROR_HOOK',
+  OnBuildSuccessHook = 'ON_BUILD_SUCCESS_HOOK',
+  ParseCustomWorkflowConfig = 'PARSE_CUSTOM_WORKFLOW_CONFIG',
+  PostInstallHook = 'POST_INSTALL_HOOK',
+  Prebuild = 'PREBUILD',
+  PrepareArtifacts = 'PREPARE_ARTIFACTS',
+  PrepareCredentials = 'PREPARE_CREDENTIALS',
+  PrepareProject = 'PREPARE_PROJECT',
+  PreInstallHook = 'PRE_INSTALL_HOOK',
+  PreUploadArtifactsHook = 'PRE_UPLOAD_ARTIFACTS_HOOK',
+  Queue = 'QUEUE',
+  ReadAppConfig = 'READ_APP_CONFIG',
+  ReadPackageJson = 'READ_PACKAGE_JSON',
+  RestoreCache = 'RESTORE_CACHE',
+  RunExpoDoctor = 'RUN_EXPO_DOCTOR',
+  RunFastlane = 'RUN_FASTLANE',
+  RunGradlew = 'RUN_GRADLEW',
+  SaveCache = 'SAVE_CACHE',
+  SetUpBuildEnvironment = 'SET_UP_BUILD_ENVIRONMENT',
+  SpinUpBuilder = 'SPIN_UP_BUILDER',
+  StartBuild = 'START_BUILD',
+  Unknown = 'UNKNOWN',
+  UploadApplicationArchive = 'UPLOAD_APPLICATION_ARCHIVE',
+  /** @deprecated No longer supported */
+  UploadArtifacts = 'UPLOAD_ARTIFACTS',
+  UploadBuildArtifacts = 'UPLOAD_BUILD_ARTIFACTS'
+}
+
+export type BuildPlanCreditThresholdExceededMetadata = {
+  __typename?: 'BuildPlanCreditThresholdExceededMetadata';
+  account: Account;
+  buildCreditUsage: Scalars['Int'];
+  planLimit: Scalars['Int'];
+  threshold: Scalars['Int'];
+};
+
 export enum BuildPriority {
   High = 'HIGH',
   Normal = 'NORMAL',
@@ -2460,12 +2645,14 @@ export enum BuildResourceClass {
   AndroidLarge = 'ANDROID_LARGE',
   AndroidMedium = 'ANDROID_MEDIUM',
   IosDefault = 'IOS_DEFAULT',
-  /** @deprecated Use IOS_INTEL_MEDIUM instead */
+  /** @deprecated No longer available. Use IOS_M_LARGE instead. */
   IosIntelLarge = 'IOS_INTEL_LARGE',
+  /** @deprecated No longer available. Use IOS_M_MEDIUM instead. */
   IosIntelMedium = 'IOS_INTEL_MEDIUM',
   IosLarge = 'IOS_LARGE',
   /** @deprecated Use IOS_M_MEDIUM instead */
   IosM1Large = 'IOS_M1_LARGE',
+  /** @deprecated Use IOS_M_MEDIUM instead */
   IosM1Medium = 'IOS_M1_MEDIUM',
   IosMedium = 'IOS_MEDIUM',
   IosMLarge = 'IOS_M_LARGE',
@@ -2588,6 +2775,19 @@ export type CreateGitHubAppInstallationInput = {
   installationIdentifier: Scalars['Int'];
 };
 
+export type CreateGitHubBuildTriggerInput = {
+  appId: Scalars['ID'];
+  autoSubmit: Scalars['Boolean'];
+  buildProfile: Scalars['String'];
+  isActive: Scalars['Boolean'];
+  platform: AppPlatform;
+  /** A branch or tag name, or a wildcard pattern where the code change originates from. For example, `main` or `release/*`. */
+  sourcePattern: Scalars['String'];
+  /** A branch name or a wildcard pattern that the pull request targets. For example, `main` or `release/*`. */
+  targetPattern?: InputMaybe<Scalars['String']>;
+  type: GitHubBuildTriggerType;
+};
+
 export type CreateGitHubRepositoryInput = {
   appId: Scalars['ID'];
   githubAppInstallationId: Scalars['ID'];
@@ -2665,6 +2865,11 @@ export type DeleteAppleProvisioningProfileResult = {
   id: Scalars['ID'];
 };
 
+export type DeleteBuildAnnotationResult = {
+  __typename?: 'DeleteBuildAnnotationResult';
+  buildAnnotationId: Scalars['ID'];
+};
+
 export type DeleteDiscordUserResult = {
   __typename?: 'DeleteDiscordUserResult';
   id: Scalars['ID'];
@@ -2700,6 +2905,11 @@ export type DeleteRobotResult = {
   id: Scalars['ID'];
 };
 
+export type DeleteSsoUserResult = {
+  __typename?: 'DeleteSSOUserResult';
+  id: Scalars['ID'];
+};
+
 export type DeleteUpdateBranchResult = {
   __typename?: 'DeleteUpdateBranchResult';
   id: Scalars['ID'];
@@ -2731,8 +2941,10 @@ export type Deployment = {
   builds: DeploymentBuildsConnection;
   channel: UpdateChannel;
   id: Scalars['ID'];
-  /** @deprecated Not required for the new Deployment UI */
-  latestUpdate?: Maybe<Update>;
+  /** Deployment query field */
+  insights: DeploymentInsights;
+  /** Ordered the same way as 'updateBranches' in UpdateChannel */
+  latestUpdatesPerBranch: Array<LatestUpdateOnBranch>;
   runtime: Runtime;
 };
 
@@ -2743,6 +2955,13 @@ export type DeploymentBuildsArgs = {
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
+export type DeploymentLatestUpdatesPerBranchArgs = {
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
 };
 
 export type DeploymentBuildEdge = {
@@ -2762,6 +2981,40 @@ export type DeploymentEdge = {
   __typename?: 'DeploymentEdge';
   cursor: Scalars['String'];
   node: Deployment;
+};
+
+export type DeploymentFilterInput = {
+  channel?: InputMaybe<Scalars['String']>;
+  runtimeVersion?: InputMaybe<Scalars['String']>;
+};
+
+export type DeploymentInsights = {
+  __typename?: 'DeploymentInsights';
+  embeddedUpdateTotalUniqueUsers: Scalars['Int'];
+  embeddedUpdateUniqueUsersOverTime: UniqueUsersOverTimeData;
+  id: Scalars['ID'];
+  mostPopularUpdates: Array<Update>;
+  uniqueUsersOverTime: UniqueUsersOverTimeData;
+};
+
+
+export type DeploymentInsightsEmbeddedUpdateTotalUniqueUsersArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type DeploymentInsightsEmbeddedUpdateUniqueUsersOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type DeploymentInsightsMostPopularUpdatesArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type DeploymentInsightsUniqueUsersOverTimeArgs = {
+  timespan: InsightsTimespan;
 };
 
 /** Represents the connection over the deployments edge of an App */
@@ -2823,6 +3076,7 @@ export type EasBuildOrClassicBuildJob = Build | BuildJob;
 
 export enum EasService {
   Builds = 'BUILDS',
+  Jobs = 'JOBS',
   Updates = 'UPDATES'
 }
 
@@ -2831,6 +3085,7 @@ export enum EasServiceMetric {
   BandwidthUsage = 'BANDWIDTH_USAGE',
   Builds = 'BUILDS',
   ManifestRequests = 'MANIFEST_REQUESTS',
+  RunTime = 'RUN_TIME',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
   UniqueUsers = 'UNIQUE_USERS'
 }
@@ -2931,6 +3186,10 @@ export type EstimatedUsage = {
   serviceMetric: EasServiceMetric;
   value: Scalars['Float'];
 };
+
+export enum Experiment {
+  Orbit = 'ORBIT'
+}
 
 export type ExperimentationQuery = {
   __typename?: 'ExperimentationQuery';
@@ -3066,6 +3325,7 @@ export type GitHubAppQuery = {
   environment: GitHubAppEnvironment;
   installation: GitHubAppInstallation;
   name: Scalars['String'];
+  /** @deprecated */
   searchRepositories: GitHubRepositoryPaginationResult;
 };
 
@@ -3088,6 +3348,63 @@ export type GitHubBuildInput = {
   platform: AppPlatform;
 };
 
+export type GitHubBuildTrigger = {
+  __typename?: 'GitHubBuildTrigger';
+  app: App;
+  autoSubmit: Scalars['Boolean'];
+  buildProfile: Scalars['String'];
+  createdAt: Scalars['DateTime'];
+  id: Scalars['ID'];
+  isActive: Scalars['Boolean'];
+  lastRunAt?: Maybe<Scalars['DateTime']>;
+  lastRunBuild?: Maybe<Build>;
+  lastRunErrorCode?: Maybe<Scalars['String']>;
+  lastRunErrorMessage?: Maybe<Scalars['String']>;
+  lastRunStatus?: Maybe<GitHubBuildTriggerRunStatus>;
+  platform: AppPlatform;
+  sourcePattern: Scalars['String'];
+  targetPattern?: Maybe<Scalars['String']>;
+  type: GitHubBuildTriggerType;
+  updatedAt: Scalars['DateTime'];
+};
+
+export type GitHubBuildTriggerMutation = {
+  __typename?: 'GitHubBuildTriggerMutation';
+  /** Create GitHub build trigger for an App */
+  createGitHubBuildTrigger: GitHubBuildTrigger;
+  /** Delete GitHub build trigger by ID */
+  deleteGitHubBuildTrigger: GitHubBuildTrigger;
+  /** Update a GitHub build trigger by ID */
+  updateGitHubBuildTrigger: GitHubBuildTrigger;
+};
+
+
+export type GitHubBuildTriggerMutationCreateGitHubBuildTriggerArgs = {
+  githubBuildTriggerData: CreateGitHubBuildTriggerInput;
+};
+
+
+export type GitHubBuildTriggerMutationDeleteGitHubBuildTriggerArgs = {
+  githubBuildTriggerId: Scalars['ID'];
+};
+
+
+export type GitHubBuildTriggerMutationUpdateGitHubBuildTriggerArgs = {
+  githubBuildTriggerData: UpdateGitHubBuildTriggerInput;
+  githubBuildTriggerId: Scalars['ID'];
+};
+
+export enum GitHubBuildTriggerRunStatus {
+  Errored = 'ERRORED',
+  Success = 'SUCCESS'
+}
+
+export enum GitHubBuildTriggerType {
+  PullRequestUpdated = 'PULL_REQUEST_UPDATED',
+  PushToBranch = 'PUSH_TO_BRANCH',
+  TagUpdated = 'TAG_UPDATED'
+}
+
 export type GitHubRepository = {
   __typename?: 'GitHubRepository';
   app: App;
@@ -3095,7 +3412,7 @@ export type GitHubRepository = {
   githubRepositoryIdentifier: Scalars['Int'];
   githubRepositoryUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  metadata?: Maybe<GitHubRepositoryMetadata>;
+  metadata: GitHubRepositoryMetadata;
   nodeIdentifier: Scalars['String'];
 };
 
@@ -3108,7 +3425,6 @@ export type GitHubRepositoryMetadata = {
   githubRepoUrl: Scalars['String'];
   lastPushed: Scalars['DateTime'];
   lastUpdated: Scalars['DateTime'];
-  openGraphImageUrl?: Maybe<Scalars['String']>;
   private: Scalars['Boolean'];
 };
 
@@ -3197,6 +3513,8 @@ export type GitHubUserMutation = {
   __typename?: 'GitHubUserMutation';
   /** Delete a GitHub User by ID */
   deleteGitHubUser: DeleteGitHubUserResult;
+  /** Generate a GitHub User Access Token */
+  generateGitHubUserAccessToken?: Maybe<Scalars['String']>;
 };
 
 
@@ -3448,6 +3766,7 @@ export enum IosBuildType {
 }
 
 export type IosBuilderEnvironmentInput = {
+  bun?: InputMaybe<Scalars['String']>;
   bundler?: InputMaybe<Scalars['String']>;
   cocoapods?: InputMaybe<Scalars['String']>;
   env?: InputMaybe<Scalars['JSONObject']>;
@@ -3455,6 +3774,7 @@ export type IosBuilderEnvironmentInput = {
   fastlane?: InputMaybe<Scalars['String']>;
   image?: InputMaybe<Scalars['String']>;
   node?: InputMaybe<Scalars['String']>;
+  pnpm?: InputMaybe<Scalars['String']>;
   yarn?: InputMaybe<Scalars['String']>;
 };
 
@@ -3581,6 +3901,12 @@ export type KeystoreGenerationUrlMutation = {
   createKeystoreGenerationUrl: KeystoreGenerationUrl;
 };
 
+export type LatestUpdateOnBranch = {
+  __typename?: 'LatestUpdateOnBranch';
+  branchId: Scalars['String'];
+  update?: Maybe<Update>;
+};
+
 export type LeaveAccountResult = {
   __typename?: 'LeaveAccountResult';
   success: Scalars['Boolean'];
@@ -3605,7 +3931,8 @@ export enum MailchimpAudience {
 
 export enum MailchimpTag {
   DevClientUsers = 'DEV_CLIENT_USERS',
-  EasMasterList = 'EAS_MASTER_LIST'
+  EasMasterList = 'EAS_MASTER_LIST',
+  NewsletterSignupList = 'NEWSLETTER_SIGNUP_LIST'
 }
 
 export type MailchimpTagPayload = {
@@ -3624,6 +3951,8 @@ export type MeMutation = {
   createAccount: Account;
   /** Delete an Account created via createAccount */
   deleteAccount: DeleteAccountResult;
+  /** Delete a SSO user. Actor must be an owner on the SSO user's SSO account. */
+  deleteSSOUser: DeleteSsoUserResult;
   /** Delete a second factor device */
   deleteSecondFactorDevice: SecondFactorBooleanResult;
   /** Delete a Snack that the current user owns */
@@ -3673,6 +4002,11 @@ export type MeMutationCreateAccountArgs = {
 
 export type MeMutationDeleteAccountArgs = {
   accountId: Scalars['ID'];
+};
+
+
+export type MeMutationDeleteSsoUserArgs = {
+  ssoUserId: Scalars['ID'];
 };
 
 
@@ -3749,11 +4083,28 @@ export type MeteredBillingStatus = {
   EAS_UPDATE: Scalars['Boolean'];
 };
 
+export type Notification = {
+  __typename?: 'Notification';
+  accountName: Scalars['String'];
+  createdAt: Scalars['DateTime'];
+  event: NotificationEvent;
+  id: Scalars['ID'];
+  isRead: Scalars['Boolean'];
+  metadata?: Maybe<NotificationMetadata>;
+  type: NotificationType;
+  updatedAt: Scalars['DateTime'];
+  websiteMessage: Scalars['String'];
+};
+
 export enum NotificationEvent {
   BuildComplete = 'BUILD_COMPLETE',
+  BuildLimitThresholdExceeded = 'BUILD_LIMIT_THRESHOLD_EXCEEDED',
   BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
-  SubmissionComplete = 'SUBMISSION_COMPLETE'
+  SubmissionComplete = 'SUBMISSION_COMPLETE',
+  Test = 'TEST'
 }
+
+export type NotificationMetadata = BuildLimitThresholdExceededMetadata | BuildPlanCreditThresholdExceededMetadata | TestNotificationMetadata;
 
 export type NotificationSubscription = {
   __typename?: 'NotificationSubscription';
@@ -3795,8 +4146,17 @@ export type NotificationSubscriptionMutationUnsubscribeArgs = {
   id: Scalars['ID'];
 };
 
+export type NotificationThresholdExceeded = {
+  __typename?: 'NotificationThresholdExceeded';
+  count: Scalars['Int'];
+  limit: Scalars['Int'];
+  threshold: Scalars['Int'];
+  type: BuildLimitThresholdExceededMetadataType;
+};
+
 export enum NotificationType {
-  Email = 'EMAIL'
+  Email = 'EMAIL',
+  Web = 'WEB'
 }
 
 export type Offer = {
@@ -3966,6 +4326,8 @@ export type Robot = Actor & {
   accounts: Array<Account>;
   created: Scalars['DateTime'];
   displayName: Scalars['String'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
   /**
    * Server feature gate values for this actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -4037,6 +4399,8 @@ export type RootMutation = {
   account: AccountMutation;
   /** Mutations that create, update, and delete an AccountSSOConfiguration */
   accountSSOConfiguration: AccountSsoConfigurationMutation;
+  /** Mutations for Actor experiments */
+  actorExperiment: ActorExperimentMutation;
   /** Mutations that modify the build credentials for an Android app */
   androidAppBuildCredentials: AndroidAppBuildCredentialsMutation;
   /** Mutations that modify the credentials for an Android app */
@@ -4068,6 +4432,8 @@ export type RootMutation = {
   asset: AssetMutation;
   /** Mutations that modify an EAS Build */
   build: BuildMutation;
+  /** Mutations that create, update, and delete Build Annotations */
+  buildAnnotation: BuildAnnotationMutation;
   /** Mutations that modify an BuildJob */
   buildJob: BuildJobMutation;
   /** Mutations for Discord users */
@@ -4080,6 +4446,8 @@ export type RootMutation = {
   githubApp: GitHubAppMutation;
   /** Mutations for GitHub App installations */
   githubAppInstallation: GitHubAppInstallationMutation;
+  /** Mutations for GitHub build triggers */
+  githubBuildTrigger: GitHubBuildTriggerMutation;
   /** Mutations for GitHub repositories */
   githubRepository: GitHubRepositoryMutation;
   /** Mutations for GitHub repository settings */
@@ -4106,10 +4474,14 @@ export type RootMutation = {
   updateBranch: UpdateBranchMutation;
   updateChannel: UpdateChannelMutation;
   uploadSession: UploadSession;
+  /** Mutations that create, update, and delete pinned apps */
+  userAppPins: UserAppPinMutation;
   /** Mutations that create, delete, and accept UserInvitations */
   userInvitation: UserInvitationMutation;
   /** Mutations that create, delete, update Webhooks */
   webhook: WebhookMutation;
+  /** Mutations that modify a websiteNotification */
+  websiteNotifications: WebsiteNotificationMutation;
 };
 
 
@@ -4143,7 +4515,10 @@ export type RootQuery = {
   account: AccountQuery;
   /** Top-level query object for querying AccountSSOConfigurationPublicData */
   accountSSOConfigurationPublicData: AccountSsoConfigurationPublicDataQuery;
-  /** Top-level query object for querying Actors. */
+  /**
+   * Top-level query object for querying Actors.
+   * @deprecated Public actor queries are no longer supported
+   */
   actor: ActorQuery;
   /**
    * Public apps in the app directory
@@ -4162,6 +4537,8 @@ export type RootQuery = {
   appleTeam: AppleTeamQuery;
   asset: AssetQuery;
   backgroundJobReceipt: BackgroundJobReceiptQuery;
+  /** Top-level query object for querying annotations. */
+  buildAnnotations: BuildAnnotationsQuery;
   buildJobs: BuildJobQuery;
   buildOrBuildJob: BuildOrBuildJobQuery;
   /** Top-level query object for querying BuildPublicData publicly. */
@@ -4190,17 +4567,23 @@ export type RootQuery = {
   meUserActor?: Maybe<UserActor>;
   project: ProjectQuery;
   snack: SnackQuery;
-  /** Top-level query object for querying SSO Users. */
-  ssoUser: SsoUserQuery;
   /** Top-level query object for querying Expo status page services. */
   statuspageService: StatuspageServiceQuery;
   submissions: SubmissionQuery;
   /** fetch all updates in a group */
   updatesByGroup: Array<Update>;
-  /** Top-level query object for querying Users. */
+  /**
+   * Top-level query object for querying Users.
+   * @deprecated Public user queries are no longer supported
+   */
   user: UserQuery;
-  /** Top-level query object for querying UserActors. */
+  /**
+   * Top-level query object for querying UserActors.
+   * @deprecated Public user queries are no longer supported
+   */
   userActor: UserActorQuery;
+  /** Top-level query object for querying UserActorPublicData publicly. */
+  userActorPublicData: UserActorPublicDataQuery;
   /** @deprecated Use 'byId' field under 'user'. */
   userByUserId?: Maybe<User>;
   /** @deprecated Use 'byUsername' field under 'user'. */
@@ -4252,6 +4635,24 @@ export type Runtime = {
   version: Scalars['String'];
 };
 
+export type RuntimeEdge = {
+  __typename?: 'RuntimeEdge';
+  cursor: Scalars['String'];
+  node: Runtime;
+};
+
+export type RuntimeFilterInput = {
+  /** Only return runtimes shared with this branch */
+  branchId?: InputMaybe<Scalars['String']>;
+};
+
+/** Represents the connection over the runtime edge of an App */
+export type RuntimesConnection = {
+  __typename?: 'RuntimesConnection';
+  edges: Array<RuntimeEdge>;
+  pageInfo: PageInfo;
+};
+
 /** Represents a human SSO (not robot) actor. */
 export type SsoUser = Actor & UserActor & {
   __typename?: 'SSOUser';
@@ -4270,6 +4671,8 @@ export type SsoUser = Actor & UserActor & {
   /** Discord account linked to a user */
   discordUser?: Maybe<DiscordUser>;
   displayName: Scalars['String'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
   /**
    * Server feature gate values for this actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -4289,6 +4692,7 @@ export type SsoUser = Actor & UserActor & {
   /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
+  pinnedApps: Array<App>;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -4297,6 +4701,7 @@ export type SsoUser = Actor & UserActor & {
   /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
+  websiteNotificationsPaginated: WebsiteNotificationsConnection;
 };
 
 
@@ -4334,27 +4739,18 @@ export type SsoUserSnacksArgs = {
   offset: Scalars['Int'];
 };
 
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserWebsiteNotificationsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
 export type SsoUserDataInput = {
   firstName?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-};
-
-export type SsoUserQuery = {
-  __typename?: 'SSOUserQuery';
-  /** Query an SSOUser by ID */
-  byId: SsoUser;
-  /** Query an SSOUser by username */
-  byUsername: SsoUser;
-};
-
-
-export type SsoUserQueryByIdArgs = {
-  userId: Scalars['ID'];
-};
-
-
-export type SsoUserQueryByUsernameArgs = {
-  username: Scalars['String'];
 };
 
 export type SecondFactorBooleanResult = {
@@ -4546,7 +4942,9 @@ export type StatuspageService = {
 export enum StatuspageServiceName {
   EasBuild = 'EAS_BUILD',
   EasSubmit = 'EAS_SUBMIT',
-  EasUpdate = 'EAS_UPDATE'
+  EasUpdate = 'EAS_UPDATE',
+  GithubApiRequests = 'GITHUB_API_REQUESTS',
+  GithubWebhooks = 'GITHUB_WEBHOOKS'
 }
 
 export type StatuspageServiceQuery = {
@@ -4733,6 +5131,11 @@ export type SubscriptionDetailsPlanEnablementArgs = {
   serviceMetric: EasServiceMetric;
 };
 
+export type TestNotificationMetadata = {
+  __typename?: 'TestNotificationMetadata';
+  message: Scalars['String'];
+};
+
 export type TimelineActivityConnection = {
   __typename?: 'TimelineActivityConnection';
   edges: Array<TimelineActivityEdge>;
@@ -4775,6 +5178,8 @@ export type Update = ActivityTimelineProjectActivity & {
   gitCommitHash?: Maybe<Scalars['String']>;
   group: Scalars['String'];
   id: Scalars['ID'];
+  /** Update query field */
+  insights: UpdateInsights;
   isGitWorkingTreeDirty: Scalars['Boolean'];
   isRollBackToEmbedded: Scalars['Boolean'];
   manifestFragment: Scalars['String'];
@@ -4794,9 +5199,19 @@ export type UpdateBranch = {
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   name: Scalars['String'];
+  runtimes: RuntimesConnection;
   updateGroups: Array<Array<Update>>;
   updatedAt: Scalars['DateTime'];
   updates: Array<Update>;
+};
+
+
+export type UpdateBranchRuntimesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<RuntimeFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -4905,6 +5320,16 @@ export type UpdateChannelMutationEditUpdateChannelArgs = {
   channelId: Scalars['ID'];
 };
 
+export type UpdateGitHubBuildTriggerInput = {
+  autoSubmit: Scalars['Boolean'];
+  buildProfile: Scalars['String'];
+  isActive: Scalars['Boolean'];
+  platform: AppPlatform;
+  sourcePattern: Scalars['String'];
+  targetPattern?: InputMaybe<Scalars['String']>;
+  type: GitHubBuildTriggerType;
+};
+
 export type UpdateGitHubRepositorySettingsInput = {
   baseDirectory: Scalars['String'];
 };
@@ -4913,6 +5338,17 @@ export type UpdateInfoGroup = {
   android?: InputMaybe<PartialManifest>;
   ios?: InputMaybe<PartialManifest>;
   web?: InputMaybe<PartialManifest>;
+};
+
+export type UpdateInsights = {
+  __typename?: 'UpdateInsights';
+  id: Scalars['ID'];
+  totalUniqueUsers: Scalars['Int'];
+};
+
+
+export type UpdateInsightsTotalUniqueUsersArgs = {
+  timespan: InsightsTimespan;
 };
 
 export type UpdateMutation = {
@@ -4977,6 +5413,7 @@ export type UsageMetricTotal = {
 export enum UsageMetricType {
   Bandwidth = 'BANDWIDTH',
   Build = 'BUILD',
+  Minute = 'MINUTE',
   Request = 'REQUEST',
   Update = 'UPDATE',
   User = 'USER'
@@ -5012,8 +5449,10 @@ export type User = Actor & UserActor & {
   /** Discord account linked to a user */
   discordUser?: Maybe<DiscordUser>;
   displayName: Scalars['String'];
-  email?: Maybe<Scalars['String']>;
+  email: Scalars['String'];
   emailVerified: Scalars['Boolean'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
   /**
    * Server feature gate values for this actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -5040,6 +5479,7 @@ export type User = Actor & UserActor & {
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<UserInvitation>;
+  pinnedApps: Array<App>;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -5050,6 +5490,7 @@ export type User = Actor & UserActor & {
   /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
+  websiteNotificationsPaginated: WebsiteNotificationsConnection;
 };
 
 
@@ -5087,6 +5528,15 @@ export type UserSnacksArgs = {
   offset: Scalars['Int'];
 };
 
+
+/** Represents a human (not robot) actor. */
+export type UserWebsiteNotificationsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
 /** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
 export type UserActor = {
   /** Access Tokens belonging to this user actor */
@@ -5111,6 +5561,8 @@ export type UserActor = {
    * For example, when displaying a sentence indicating that actor X created a build or published an update.
    */
   displayName: Scalars['String'];
+  /** Experiments associated with this actor */
+  experiments: Array<ActorExperiment>;
   /**
    * Server feature gate values for this user actor, optionally filtering by desired gates.
    * Only resolves for the viewer.
@@ -5130,6 +5582,7 @@ export type UserActor = {
   /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
+  pinnedApps: Array<App>;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -5138,6 +5591,7 @@ export type UserActor = {
   /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
+  websiteNotificationsPaginated: WebsiteNotificationsConnection;
 };
 
 
@@ -5175,11 +5629,66 @@ export type UserActorSnacksArgs = {
   offset: Scalars['Int'];
 };
 
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorWebsiteNotificationsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorPublicData = {
+  __typename?: 'UserActorPublicData';
+  /** Apps this user has published */
+  apps: Array<App>;
+  firstName?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  lastName?: Maybe<Scalars['String']>;
+  profilePhoto: Scalars['String'];
+  /** Snacks associated with this user's personal account */
+  snacks: Array<Snack>;
+  username: Scalars['String'];
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorPublicDataAppsArgs = {
+  includeUnpublished?: InputMaybe<Scalars['Boolean']>;
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorPublicDataSnacksArgs = {
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+export type UserActorPublicDataQuery = {
+  __typename?: 'UserActorPublicDataQuery';
+  /** Get UserActorPublicData by username */
+  byUsername: UserActorPublicData;
+};
+
+
+export type UserActorPublicDataQueryByUsernameArgs = {
+  username: Scalars['String'];
+};
+
 export type UserActorQuery = {
   __typename?: 'UserActorQuery';
-  /** Query a UserActor by ID */
+  /**
+   * Query a UserActor by ID
+   * @deprecated Public user actor queries are no longer supported
+   */
   byId: UserActor;
-  /** Query a UserActor by username */
+  /**
+   * Query a UserActor by username
+   * @deprecated Public user actor queries are no longer supported
+   */
   byUsername: UserActor;
 };
 
@@ -5191,6 +5700,22 @@ export type UserActorQueryByIdArgs = {
 
 export type UserActorQueryByUsernameArgs = {
   username: Scalars['String'];
+};
+
+export type UserAppPinMutation = {
+  __typename?: 'UserAppPinMutation';
+  pinApp: Scalars['ID'];
+  unpinApp?: Maybe<Scalars['ID']>;
+};
+
+
+export type UserAppPinMutationPinAppArgs = {
+  appId: Scalars['ID'];
+};
+
+
+export type UserAppPinMutationUnpinAppArgs = {
+  appId: Scalars['ID'];
 };
 
 export type UserDataInput = {
@@ -5316,9 +5841,15 @@ export type UserPermission = {
 
 export type UserQuery = {
   __typename?: 'UserQuery';
-  /** Query a User by ID */
+  /**
+   * Query a User by ID
+   * @deprecated Public user queries are no longer supported
+   */
   byId: User;
-  /** Query a User by username */
+  /**
+   * Query a User by username
+   * @deprecated Public user queries are no longer supported
+   */
   byUsername: User;
 };
 
@@ -5344,6 +5875,11 @@ export type UserSecondFactorDevice = {
   smsPhoneNumber?: Maybe<Scalars['String']>;
   updatedAt: Scalars['DateTime'];
   user: User;
+};
+
+export type WebNotificationUpdateReadStateInput = {
+  id: Scalars['ID'];
+  isRead: Scalars['Boolean'];
 };
 
 export type Webhook = {
@@ -5408,6 +5944,29 @@ export enum WebhookType {
   Submit = 'SUBMIT'
 }
 
+export type WebsiteNotificationEdge = {
+  __typename?: 'WebsiteNotificationEdge';
+  cursor: Scalars['String'];
+  node: Notification;
+};
+
+export type WebsiteNotificationMutation = {
+  __typename?: 'WebsiteNotificationMutation';
+  updateAllWebsiteNotificationReadStateAsRead: Scalars['Boolean'];
+  updateNotificationReadState: Notification;
+};
+
+
+export type WebsiteNotificationMutationUpdateNotificationReadStateArgs = {
+  input: WebNotificationUpdateReadStateInput;
+};
+
+export type WebsiteNotificationsConnection = {
+  __typename?: 'WebsiteNotificationsConnection';
+  edges: Array<WebsiteNotificationEdge>;
+  pageInfo: PageInfo;
+};
+
 export type DeleteAndroidAppBuildCredentialsResult = {
   __typename?: 'deleteAndroidAppBuildCredentialsResult';
   id: Scalars['ID'];
@@ -5432,9 +5991,9 @@ export type CommonAppDataFragment = { __typename?: 'App', id: string, fullName: 
 
 export type CommonSnackDataFragment = { __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean };
 
-type CurrentUserActorData_SsoUser_Fragment = { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+type CurrentUserActorData_SsoUser_Fragment = { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
 
-type CurrentUserActorData_User_Fragment = { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+type CurrentUserActorData_User_Fragment = { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
 
 export type CurrentUserActorDataFragment = CurrentUserActorData_SsoUser_Fragment | CurrentUserActorData_User_Fragment;
 
@@ -5471,7 +6030,7 @@ export type BranchesForProjectQuery = { __typename?: 'RootQuery', app: { __typen
 export type Home_CurrentUserActorQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
+export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
 
 export type Home_ProfileData2QueryVariables = Exact<{
   appLimit: Scalars['Int'];
@@ -5548,14 +6107,14 @@ export type SendSmsotpToSecondFactorDeviceMutationVariables = Exact<{
 
 export type SendSmsotpToSecondFactorDeviceMutation = { __typename?: 'RootMutation', me: { __typename?: 'MeMutation', sendSMSOTPToSecondFactorDevice: { __typename?: 'SecondFactorBooleanResult', success: boolean } } };
 
-export type UserPermissionDataFragment = { __typename?: 'UserPermission', permissions: Array<Permission>, role: Role, user?: { __typename?: 'User', id: string, fullName?: string | null, profilePhoto: string, username: string, email?: string | null } | null };
+export type UserPermissionDataFragment = { __typename?: 'UserPermission', permissions: Array<Permission>, role: Role, user?: { __typename?: 'User', id: string, fullName?: string | null, profilePhoto: string, username: string, email: string } | null };
 
 export type HomeScreenDataQueryVariables = Exact<{
   accountName: Scalars['String'];
 }>;
 
 
-export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
+export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
 export const CommonAppDataFragmentDoc = gql`
     fragment CommonAppData on App {
@@ -5595,6 +6154,7 @@ export const CurrentUserActorDataFragmentDoc = gql`
   firstName
   lastName
   profilePhoto
+  bestContactEmail
   accounts {
     id
     name

--- a/home/kernel/Kernel.ts
+++ b/home/kernel/Kernel.ts
@@ -60,3 +60,7 @@ export function onEventSuccess(eventId: string, result: object): void {
 export function onEventFailure(eventId: string, message: string): void {
   NativeKernel.onEventFailure(eventId, message);
 }
+
+export async function getLastCrashDate(): Promise<number | null> {
+  return await NativeKernel.getLastCrashDate();
+}

--- a/home/kernel/Kernel.ts
+++ b/home/kernel/Kernel.ts
@@ -62,5 +62,5 @@ export function onEventFailure(eventId: string, message: string): void {
 }
 
 export async function getLastCrashDate(): Promise<number | null> {
-  return await NativeKernel.getLastCrashDate();
+  return Number(await NativeKernel.getLastCrashDate());
 }

--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -31,6 +31,7 @@ import {
 } from '../utils/PermissionUtils';
 
 import { DiagnosticsStackScreen } from '@/screens/DiagnosticsScreen';
+import { FeedbackFormScreen } from '@/screens/FeedbackFormScreen';
 
 // TODO(Bacon): Do we need to create a new one each time?
 const HomeStack = createStackNavigator<HomeStackRoutes>();
@@ -93,6 +94,13 @@ function HomeStackScreen() {
         component={BranchDetailsScreen}
         options={{
           title: 'Branch',
+        }}
+      />
+      <HomeStack.Screen
+        name="FeedbackForm"
+        component={FeedbackFormScreen}
+        options={{
+          title: 'Share your feedback',
         }}
       />
     </HomeStack.Navigator>

--- a/home/navigation/Navigation.types.ts
+++ b/home/navigation/Navigation.types.ts
@@ -12,6 +12,7 @@ export type HomeStackRoutes = {
   BranchDetails: { appId: string; branchName: string };
   Account: undefined;
   Project: { id: string };
+  FeedbackForm: undefined;
 };
 
 export type SettingsStackRoutes = {

--- a/home/package.json
+++ b/home/package.json
@@ -43,6 +43,7 @@
     "expo-device": "~5.9.0",
     "expo-font": "~11.9.0",
     "expo-linear-gradient": "~12.7.0",
+    "expo-linking": "^6.0.0",
     "expo-location": "~16.5.0",
     "expo-splash-screen": "~0.25.0",
     "expo-store-review": "~6.8.0",

--- a/home/package.json
+++ b/home/package.json
@@ -45,6 +45,7 @@
     "expo-linear-gradient": "~12.7.0",
     "expo-location": "~16.5.0",
     "expo-splash-screen": "~0.25.0",
+    "expo-store-review": "~6.8.0",
     "expo-task-manager": "~11.7.0",
     "expo-updates": "~0.23.0",
     "expo-web-browser": "~12.8.0",

--- a/home/screens/FeedbackFormScreen/index.tsx
+++ b/home/screens/FeedbackFormScreen/index.tsx
@@ -1,0 +1,122 @@
+import { CheckIcon, spacing } from '@expo/styleguide-native';
+import { APIV2Client } from 'api/APIV2Client';
+import {
+  Text,
+  View,
+  TextInput,
+  Button,
+  Heading,
+  Spacer,
+  useExpoTheme,
+} from 'expo-dev-client-components';
+import * as React from 'react';
+import { useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet } from 'react-native';
+
+export function FeedbackFormScreen() {
+  const theme = useExpoTheme();
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const [feedback, setFeedback] = useState('');
+  const [email, setEmail] = useState('');
+
+  async function onSubmit() {
+    setError(undefined);
+    setSubmitting(true);
+    try {
+      const api = new APIV2Client();
+      await api.sendOptionallyAuthenticatedApiV2Request('/feedback/expo-go-send', {
+        body: {
+          feedback,
+          email,
+        },
+      });
+      setSubmitted(true);
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <View flex="1" padding="medium" align="centered">
+        <CheckIcon color={theme.status.success} size={50} />
+        <Text type="InterBold">Thanks for sharing your feedback!</Text>
+        <Text size="small">Your feedback will help us make our app better.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View flex="1">
+      <ScrollView style={{ flexGrow: 0 }} alwaysBounceVertical={false}>
+        <View padding="medium" rounded="medium">
+          <Text color="secondary" size="small">
+            Add your feedback to help us improve this our app.
+          </Text>
+          <Heading size="small" style={{ marginVertical: spacing[1] }} type="InterSemiBold">
+            Email (optional)
+          </Heading>
+          <View bg="default" border="default" rounded="medium" padding="tiny">
+            <TextInput
+              px="2"
+              py="1"
+              onChangeText={setEmail}
+              editable={!submitting}
+              placeholder="your@email.com"
+            />
+          </View>
+          <Spacer.Vertical size="small" />
+          <Heading size="small" style={{ marginVertical: spacing[1] }} type="InterSemiBold">
+            Feedback
+          </Heading>
+          <View bg="default" border="default" rounded="medium">
+            <TextInput
+              multiline
+              editable={!submitting}
+              px="2"
+              py="1"
+              style={{ height: 200 }}
+              onChangeText={setFeedback}
+            />
+          </View>
+        </View>
+      </ScrollView>
+      <View px="medium">
+        {error ? (
+          <View mb="2">
+            <Text color="error" type="InterSemiBold" size="small">
+              Something went wrong. Please try again.
+            </Text>
+            <Text color="error" size="small">
+              {error}
+            </Text>
+          </View>
+        ) : null}
+        <Button.FadeOnPressContainer
+          padding="tiny"
+          onPress={onSubmit}
+          disabled={!feedback?.length || submitting}
+          bg={feedback?.length && !submitting ? 'primary' : 'disabled'}>
+          {submitting ? (
+            <ActivityIndicator style={styles.activityIndicator} color="white" />
+          ) : (
+            <Button.Text align="center" size="medium" color="primary" type="InterSemiBold">
+              Submit
+            </Button.Text>
+          )}
+        </Button.FadeOnPressContainer>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  activityIndicator: {
+    height: 26,
+  },
+});

--- a/home/screens/FeedbackFormScreen/index.tsx
+++ b/home/screens/FeedbackFormScreen/index.tsx
@@ -1,5 +1,4 @@
 import { CheckIcon, spacing } from '@expo/styleguide-native';
-import { APIV2Client } from 'api/APIV2Client';
 import {
   Text,
   View,
@@ -13,21 +12,26 @@ import * as React from 'react';
 import { useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet } from 'react-native';
 
+import { APIV2Client } from '../../api/APIV2Client';
+import { useInitialData } from '../../utils/InitialDataContext';
+
 export function FeedbackFormScreen() {
   const theme = useExpoTheme();
+  const { currentUserData } = useInitialData();
+
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string>();
 
   const [feedback, setFeedback] = useState('');
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState(currentUserData?.meUserActor?.bestContactEmail || '');
 
   async function onSubmit() {
     setError(undefined);
     setSubmitting(true);
     try {
       const api = new APIV2Client();
-      await api.sendOptionallyAuthenticatedApiV2Request('/feedback/expo-go-send', {
+      await api.sendUnauthenticatedApiV2Request('/feedback/expo-go-send', {
         body: {
           feedback,
           email,
@@ -68,6 +72,7 @@ export function FeedbackFormScreen() {
               onChangeText={setEmail}
               editable={!submitting}
               placeholder="your@email.com"
+              value={email}
             />
           </View>
           <Spacer.Vertical size="small" />

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -29,6 +29,7 @@ import Connectivity from '../../api/Connectivity';
 import ScrollView from '../../components/NavigationScrollView';
 import { SectionHeader } from '../../components/SectionHeader';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
+import UserReviewSection from '../../components/UserReviewSection';
 import {
   HomeScreenDataDocument,
   HomeScreenDataQuery,
@@ -113,6 +114,7 @@ export class HomeScreenView extends React.Component<Props, State> {
           key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
           style={styles.container}
           contentContainerStyle={[styles.contentContainer]}>
+          <UserReviewSection apps={data?.apps} snacks={data?.snacks} />
           <DevelopmentServersHeader onHelpPress={this._handlePressHelpProjects} />
           {projects?.length ? (
             <View bg="default" rounded="large" border="default" overflow="hidden">

--- a/home/utils/useUserReviewCheck.ts
+++ b/home/utils/useUserReviewCheck.ts
@@ -70,7 +70,7 @@ export const useUserReviewCheck = ({ apps, snacks }: UseUserReviewCheckParams) =
 
   function updateUserReviewInfo(info: Partial<UserReviewInfo>) {
     const newInfo: UserReviewInfo = { ...userReviewInfoDefaultValues, ...userReviewInfo, ...info };
-    AsyncStorage.setItem('userReviewInfo', JSON.stringify(userReviewInfo));
+    AsyncStorage.setItem('userReviewInfo', JSON.stringify(newInfo));
     setUserReviewInfo(newInfo);
   }
 

--- a/home/utils/useUserReviewCheck.ts
+++ b/home/utils/useUserReviewCheck.ts
@@ -1,0 +1,102 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as StoreReview from 'expo-store-review';
+import { CommonAppDataFragment, CommonSnackDataFragment } from 'graphql/types';
+import { useEffect, useState } from 'react';
+import { EventSubscription } from 'react-native';
+
+import addListenerWithNativeCallback from './addListenerWithNativeCallback';
+import * as Kernel from '../kernel/Kernel';
+
+export function listenForForegroundEvent(
+  listener: (event: any) => Promise<any>
+): EventSubscription {
+  return addListenerWithNativeCallback('ExponentKernel.foregroundHome', listener);
+}
+
+type UserReviewInfo = {
+  hasAskedForNativeReview: boolean;
+  lastDismissDate?: Date;
+  appOpenedCounter: number;
+};
+
+const userReviewInfoDefaultValues: UserReviewInfo = {
+  hasAskedForNativeReview: false,
+  lastDismissDate: undefined,
+  appOpenedCounter: 0,
+};
+
+type UseUserReviewCheckParams = {
+  apps?: CommonAppDataFragment[];
+  snacks?: CommonSnackDataFragment[];
+};
+
+export const useUserReviewCheck = ({ apps, snacks }: UseUserReviewCheckParams) => {
+  const [lastCrashDate, setLastCrashDate] = useState<Date>();
+  const [userReviewInfo, setUserReviewInfo] = useState<UserReviewInfo>();
+
+  const timeNow = new Date();
+  const noRecentCrashes = lastCrashDate
+    ? timeNow.getTime() - new Date(lastCrashDate).getTime() > 60 * 60 * 1000
+    : true;
+  const noRecentDismisses = userReviewInfo?.lastDismissDate
+    ? timeNow.getTime() - userReviewInfo?.lastDismissDate.getTime() > 15 * 24 * 60 * 60 * 1000
+    : true;
+
+  /**
+   * We should only prompt users to review the app if they seem to be
+   * having a good experience, to check that we verify if the user
+   * has not experienced any crashes in the last hour, and has at least
+   * 5 apps or 5 snacks or has opened the app at least 50 times.
+   * If the user dismisses the review section, we only show it again
+   * after 15 days.
+   */
+  const shouldShowReviewSection =
+    userReviewInfo &&
+    !userReviewInfo.hasAskedForNativeReview &&
+    noRecentCrashes &&
+    noRecentDismisses &&
+    (userReviewInfo.appOpenedCounter >= 50 ||
+      (apps?.length || 0) >= 5 ||
+      (snacks?.length || 0) >= 5);
+
+  function updateUserReviewInfo(info: Partial<UserReviewInfo>) {
+    const newInfo: UserReviewInfo = { ...userReviewInfoDefaultValues, ...userReviewInfo, ...info };
+    AsyncStorage.setItem('userReviewInfo', JSON.stringify(userReviewInfo));
+    setUserReviewInfo(newInfo);
+  }
+
+  useEffect(() => {
+    AsyncStorage.getItem('userReviewInfo').then((info) => {
+      const userReviewInfo: UserReviewInfo = info ? JSON.parse(info) : {};
+      userReviewInfo.appOpenedCounter = Number(userReviewInfo.appOpenedCounter || 0) + 1;
+      updateUserReviewInfo(userReviewInfo);
+    });
+  }, []);
+
+  useEffect(() => {
+    const getLastCrashDate = async () => {
+      const lastCrash = await Kernel.getLastCrashDate();
+      setLastCrashDate(lastCrash ? new Date(lastCrash) : undefined);
+    };
+    const listener = listenForForegroundEvent(getLastCrashDate);
+
+    getLastCrashDate();
+
+    return listener.remove;
+  }, []);
+
+  function requestStoreReview() {
+    updateUserReviewInfo({ hasAskedForNativeReview: true });
+    StoreReview.requestReview();
+  }
+
+  function dismissReviewSection() {
+    updateUserReviewInfo({ lastDismissDate: new Date() });
+  }
+
+  return {
+    shouldShowReviewSection,
+    dismissReviewSection,
+    requestStoreReview,
+  };
+};

--- a/ios/Client/EXHomeAppManager.h
+++ b/ios/Client/EXHomeAppManager.h
@@ -9,5 +9,6 @@
 - (void)addHistoryItemWithUrl:(NSURL *)manifestUrl manifest:(EXManifestsManifest *)manifest;
 - (void)getHistoryUrlForScopeKey:(NSString *)scopeKey completion:(void (^)(NSString *))completion;
 - (void)showQRReader;
+- (void)dispatchForegroundHomeEvent;
 
 @end

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -94,6 +94,11 @@ NSString * const kEXHomeLaunchUrlDefaultsKey = @"EXKernelLaunchUrlDefaultsKey";
   [self _dispatchHomeJSEvent:@"showQRReader" body:@{} onSuccess:nil onFailure:nil];
 }
 
+- (void)dispatchForegroundHomeEvent
+{
+  [self _dispatchHomeJSEvent:@"foregroundHome" body:@{} onSuccess:nil onFailure:nil];
+}
+
 #pragma mark - EXReactAppManager
 
 - (NSArray *)extraModulesForBridge:(RCTBridge *)bridge

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -112,6 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)moveHomeToVisible
 {
   [[EXDevMenuManager sharedInstance] close];
+  [[self _getHomeAppManager] dispatchForegroundHomeEvent];
   [self moveAppToVisible:[EXKernel sharedInstance].appRegistry.homeAppRecord];
 }
 

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.h
@@ -37,3 +37,5 @@
 - (void)requestToCloseDevMenu;
 
 @end
+
+extern NSString *const kEXLastFatalErrorDateDefaultsKey;

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -322,4 +322,16 @@ RCT_REMAP_METHOD(onEventFailure,
   }
 }
 
+RCT_EXPORT_METHOD(getLastCrashDate:(RCTPromiseResolveBlock)resolve
+                   rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSDate *retrievedTimestamp = [[NSUserDefaults standardUserDefaults] objectForKey:@"EXKernelLastFatalErrorDateDefaultsKey"];
+  if(!retrievedTimestamp) {
+    resolve(nil);
+    return;
+  }
+
+  resolve(@([retrievedTimestamp timeIntervalSince1970] * 1000));
+}
+
 @end

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -11,6 +11,8 @@
 
 #import <React/RCTEventDispatcher.h>
 
+NSString *const kEXLastFatalErrorDateDefaultsKey = @"EXKernelLastFatalErrorDateDefaultsKey";
+
 @interface EXHomeModule ()
 
 @property (nonatomic, assign) BOOL hasListeners;
@@ -325,7 +327,7 @@ RCT_REMAP_METHOD(onEventFailure,
 RCT_EXPORT_METHOD(getLastCrashDate:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSDate *retrievedTimestamp = [[NSUserDefaults standardUserDefaults] objectForKey:@"EXKernelLastFatalErrorDateDefaultsKey"];
+  NSDate *retrievedTimestamp = [[NSUserDefaults standardUserDefaults] objectForKey:kEXLastFatalErrorDateDefaultsKey];
   if(!retrievedTimestamp) {
     resolve(nil);
     return;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.h
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.h
@@ -40,3 +40,5 @@
 @property (nonatomic, strong) UIView *contentView;
 
 @end
+
+extern NSString *const kEXLastFatalErrorDateDefaultsKey;

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -10,6 +10,7 @@
 #import "EXManagedAppSplashScreenConfigurationBuilder.h"
 #import "EXManagedAppSplashScreenViewController.h"
 #import "EXHomeAppSplashScreenViewProvider.h"
+#import "EXHomeModule.h"
 #import "EXEnvironment.h"
 #import "EXErrorRecoveryManager.h"
 #import "EXErrorView.h"
@@ -46,8 +47,6 @@ const CGFloat kEXAutoReloadDebounceSeconds = 0.1;
 // (e.g. certain packager errors, such as an invalid bundle url)
 // and we want to make sure not to cover the error with a loading view or other chrome.
 const CGFloat kEXDevelopmentErrorCoolDownSeconds = 0.1;
-
-NSString *kEXLastFatalErrorDateDefaultsKey = @"EXKernelLastFatalErrorDateDefaultsKey";
 
 // copy of RNScreens protocol
 @protocol EXKernelRNSScreenWindowTraits

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -47,6 +47,8 @@ const CGFloat kEXAutoReloadDebounceSeconds = 0.1;
 // and we want to make sure not to cover the error with a loading view or other chrome.
 const CGFloat kEXDevelopmentErrorCoolDownSeconds = 0.1;
 
+NSString *kEXLastFatalErrorDateDefaultsKey = @"EXKernelLastFatalErrorDateDefaultsKey";
+
 // copy of RNScreens protocol
 @protocol EXKernelRNSScreenWindowTraits
 
@@ -725,12 +727,19 @@ NS_ASSUME_NONNULL_BEGIN
   return [[[UIApplication sharedApplication].windows firstObject].windowScene interfaceOrientation];
 }
 
+- (void)_storeLastFatalErrorDate:(NSDate *)date
+{
+  [[NSUserDefaults standardUserDefaults] setObject:date forKey:kEXLastFatalErrorDateDefaultsKey];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 #pragma mark - Internal
 
 - (void)_showErrorWithType:(EXFatalErrorType)type error:(nullable NSError *)error
 {
   EXAssertMainThread();
   _dtmLastFatalErrorShown = [NSDate date];
+  [self _storeLastFatalErrorDate:_dtmLastFatalErrorShown];
   if (_errorView && _contentView == _errorView) {
     // already showing, just update
     _errorView.type = type;

--- a/packages/expo-dev-client-components/CHANGELOG.md
+++ b/packages/expo-dev-client-components/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add flex prop to Button component. ([#25699](https://github.com/expo/expo/pull/25699) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-client-components/src/Button.tsx
+++ b/packages/expo-dev-client-components/src/Button.tsx
@@ -86,6 +86,11 @@ const Container = create(AnimatedPressable, {
       button: shadows.button,
     },
 
+    flex: {
+      '1': { flex: 1 },
+      '0': { flex: 0 },
+    },
+
     ...rounded,
     ...padding,
     ...margin,


### PR DESCRIPTION
# Why
 
Closes ENG-9492

# How

- Add User Review section to Home screen
- Add a new method to Kernel to keep track of the time of the last crash

# Test Plan
 
<table>
    <tr>
        <th>Android</th>
        <th>iOS</th>
    </tr>
    <tr>
        <td><img height="482" alt="image" src="https://github.com/expo/expo/assets/11707729/6cf996cc-bad8-45a4-bb2a-875bdb5ce547"></td> 
<td><img height="542" alt="image" src="https://github.com/expo/expo/assets/11707729/852f4a65-7c46-402b-a6ca-c370c0620ec1"></td>
    </tr> 
</table>


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
