### PR TITLE
[docs] API: support displaying enum to string union conversions

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -64,6 +64,8 @@ export type TypeDefinitionData = {
     value: string;
   };
   qualifiedName?: string;
+  head?: string;
+  tail?: (TypeDefinitionData | string)[][];
 };
 
 export type MethodParamData = {

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -253,6 +253,28 @@ const renderType = ({
         </P>
       </div>
     );
+  } else if (type.type === 'templateLiteral' && type.tail) {
+    const possibleData = [type.head ?? '', ...type.tail.flat()].filter(
+      entry => typeof entry !== 'string'
+    );
+
+    if (possibleData.length === 0 || typeof possibleData[0] === 'string') {
+      return undefined;
+    }
+
+    return (
+      <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
+        <APISectionDeprecationNote comment={comment} />
+        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium">{name}</MONOSPACE>
+        </H3Code>
+        <CommentTextBlock comment={comment} includePlatforms={false} />
+        <P>
+          String union of <CODE>{resolveTypeName(possibleData[0])}</CODE> values.
+        </P>
+      </div>
+    );
   }
   return undefined;
 };


### PR DESCRIPTION
# Why

Fixes #25033

# How

Add support to `APISectionTypes` for displaying enum to string union conversions when assigned directly to type.

# Test Plan

Reviewed locally that after the changes type is visible in package Reference and contains correct data.

# Preview

<img width="1622" alt="Screenshot 2023-12-01 at 21 00 54" src="https://github.com/expo/expo/assets/719641/648428f5-eba2-46ce-b375-dbc4c8919e4b">


