### PR TITLE
fix(cli): resolve proper versions with `install expo@canary --fix`

### DIFF
--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -44,17 +44,19 @@ export async function installAsync(
     log: Log.log,
   });
 
-  const expoVersionRequested = packageHasVersion(findPackageByName(packages, 'expo'));
-  // Abort if a specific verion of `expo` is requested and `--check` is passed
-  if (expoVersionRequested && options.check) {
+  const expoVersion = findPackageByName(packages, 'expo');
+  const otherPackages = packages.filter((pkg) => pkg !== expoVersion);
+
+  // Abort early when installing `expo@<version>` and other packages with `--fix/--check`
+  if (packageHasVersion(expoVersion) && otherPackages.length && (options.check || options.fix)) {
     throw new CommandError(
       'BAD_ARGS',
-      'Cannot use --check with `expo@<version>`, --check only validates currently installed version'
+      `Cannot install other packages with ${expoVersion} and --fix or --check`
     );
   }
 
   // Only check/fix packages if `expo@<version>` is not requested
-  if (!expoVersionRequested && (options.check || options.fix)) {
+  if (!packageHasVersion(expoVersion) && (options.check || options.fix)) {
     return await checkPackagesAsync(projectRoot, {
       packages,
       options,

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -8,6 +8,7 @@ import { installExpoPackageAsync } from './installExpoPackage';
 import { Options } from './resolveOptions';
 import * as Log from '../log';
 import { getVersionedPackagesAsync } from '../start/doctor/dependencies/getVersionedPackages';
+import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { learnMore } from '../utils/link';
 import { setNodeEnv } from '../utils/nodeEnv';
@@ -43,7 +44,17 @@ export async function installAsync(
     log: Log.log,
   });
 
-  if (options.check || options.fix) {
+  const expoVersionRequested = packageHasVersion(findPackageByName(packages, 'expo'));
+  // Abort if a specific verion of `expo` is requested and `--check` is passed
+  if (expoVersionRequested && options.check) {
+    throw new CommandError(
+      'BAD_ARGS',
+      'Cannot use --check with `expo@<version>`, --check only validates currently installed version'
+    );
+  }
+
+  // Only check/fix packages if `expo@<version>` is not requested
+  if (!expoVersionRequested && (options.check || options.fix)) {
     return await checkPackagesAsync(projectRoot, {
       packages,
       options,
@@ -61,6 +72,7 @@ export async function installAsync(
 
   // Resolve the versioned packages, then install them.
   return installPackagesAsync(projectRoot, {
+    ...options,
     packageManager,
     packages,
     packageManagerArguments,
@@ -76,7 +88,9 @@ export async function installPackagesAsync(
     packageManager,
     sdkVersion,
     packageManagerArguments,
-  }: {
+    fix,
+    check,
+  }: Options & {
     /**
      * List of packages to version, grouped by the type of dependency.
      * @example ['uuid', 'react-native-reanimated@latest']
@@ -157,22 +171,35 @@ export async function installPackagesAsync(
     }
   }
 
-  // if updating expo package, install this first, then re-run the command minus expo to install everything else
-  if (packages.find((pkg) => pkg === 'expo')) {
-    const packagesMinusExpo = packages.filter((pkg) => pkg !== 'expo');
+  // `expo` needs to be installed before installing other packages
+  const expoPackage = findPackageByName(packages, 'expo');
+  if (expoPackage) {
+    const postInstallCommand = packages.filter((pkg) => pkg !== expoPackage);
 
-    await installExpoPackageAsync(projectRoot, {
+    // Pipe options to the next command
+    if (fix) postInstallCommand.push('--fix');
+    if (check) postInstallCommand.push('--check');
+
+    // Abort after installing `expo`, follow up command is spawn in a new process
+    return await installExpoPackageAsync(projectRoot, {
       packageManager,
       packageManagerArguments,
       expoPackageToInstall: versioning.packages.find((pkg) => pkg.startsWith('expo@'))!,
-      followUpCommandArgs: packagesMinusExpo,
+      followUpCommandArgs: postInstallCommand,
     });
-
-    // follow-up commands will be spawned in a detached process, so return immediately
-    return;
   }
 
   await packageManager.addAsync([...packageManagerArguments, ...versioning.packages]);
 
   await applyPluginsAsync(projectRoot, versioning.packages);
+}
+
+/** Find a package, by name, in the requested packages list (`expo` -> `expo`/`expo@<version>`) */
+function findPackageByName(packages: string[], name: string) {
+  return packages.find((pkg) => pkg === name || pkg.startsWith(`${name}@`));
+}
+
+/** Determine if a specific version is requested for a package */
+function packageHasVersion(name = '') {
+  return name.includes('@');
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/getVersionedPackages-test.ts
@@ -7,6 +7,7 @@ import {
   getRemoteVersionsForSdkAsync,
   getVersionedPackagesAsync,
 } from '../getVersionedPackages';
+import { hasExpoCanaryAsync } from '../resolvePackages';
 
 jest.mock('../../../../log');
 
@@ -16,6 +17,10 @@ jest.mock('../../../../api/getVersions', () => ({
 
 jest.mock('../bundledNativeModules', () => ({
   getVersionedNativeModulesAsync: jest.fn(),
+}));
+
+jest.mock('../resolvePackages', () => ({
+  hasExpoCanaryAsync: jest.fn().mockResolvedValue(false),
 }));
 
 describe(getCombinedKnownVersionsAsync, () => {
@@ -45,7 +50,8 @@ describe(getCombinedKnownVersionsAsync, () => {
     });
   });
 
-  it(`skips fetching remote versions when requested`, async () => {
+  it(`skips remote versions for canary releases`, async () => {
+    jest.mocked(hasExpoCanaryAsync).mockResolvedValueOnce(true);
     jest.mocked(getVersionedNativeModulesAsync).mockResolvedValue({
       shared: 'bundled',
     });
@@ -57,7 +63,6 @@ describe(getCombinedKnownVersionsAsync, () => {
       await getCombinedKnownVersionsAsync({
         projectRoot: '/',
         sdkVersion: '1.0.0',
-        skipRemoteVersions: true,
       })
     ).toEqual({
       shared: 'bundled',

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/resolvePackages.test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/resolvePackages.test.ts
@@ -1,0 +1,88 @@
+import { vol } from 'memfs';
+import resolveFrom from 'resolve-from';
+
+import { resolvePackageVersionAsync, resolveAllPackageVersionsAsync } from '../resolvePackages';
+
+afterEach(() => {
+  vol.reset();
+});
+
+const projectRoot = '/fake/project';
+
+describe(resolvePackageVersionAsync, () => {
+  it('resolves installed package', async () => {
+    vol.fromJSON(
+      { [`node_modules/expo/package.json`]: JSON.stringify({ version: '1.0.0' }) },
+      projectRoot
+    );
+
+    await expect(resolvePackageVersionAsync(projectRoot, 'expo')).resolves.toBe('1.0.0');
+  });
+
+  it('resolves installed package using `exports` without `package.json`', async () => {
+    // Mock the Node error when not exporting `package.json` from `exports`.
+    jest.mocked(resolveFrom).mockImplementationOnce(() => {
+      const error: any = new Error(
+        `Package subpath './package.json' is not defined by "exports" in ${projectRoot}/node_modules/expo/package.json`
+      );
+      error.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
+      throw error;
+    });
+
+    vol.fromJSON(
+      {
+        [`node_modules/expo/package.json`]: JSON.stringify({
+          version: '2.0.0',
+          exports: {
+            '.': {
+              require: './index.js',
+            },
+          },
+        }),
+      },
+      projectRoot
+    );
+
+    await expect(resolvePackageVersionAsync(projectRoot, 'expo')).resolves.toBe('2.0.0');
+  });
+
+  it('throws when package is not installed', async () => {
+    vol.fromJSON({}, projectRoot);
+
+    await expect(resolvePackageVersionAsync(projectRoot, 'expo')).rejects.toThrowError(
+      `"expo" is added as a dependency in your project's package.json but it doesn't seem to be installed`
+    );
+  });
+});
+
+describe(resolveAllPackageVersionsAsync, () => {
+  it('resolves installed packages', async () => {
+    vol.fromJSON(
+      {
+        [`node_modules/expo/package.json`]: JSON.stringify({ version: '1.0.0' }),
+        [`node_modules/react/package.json`]: JSON.stringify({ version: '2.0.0' }),
+      },
+      projectRoot
+    );
+
+    await expect(
+      resolveAllPackageVersionsAsync(projectRoot, ['expo', 'react'])
+    ).resolves.toMatchObject({
+      expo: '1.0.0',
+      react: '2.0.0',
+    });
+  });
+
+  it('throws when package is not installed', async () => {
+    vol.fromJSON(
+      {
+        [`node_modules/expo/package.json`]: JSON.stringify({ version: '1.0.0' }),
+      },
+      projectRoot
+    );
+
+    await expect(resolveAllPackageVersionsAsync(projectRoot, ['expo', 'react'])).rejects.toThrow(
+      `"react" is added as a dependency in your project's package.json but it doesn't seem to be installed`
+    );
+  });
+});

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import * as Log from '../../../../log';
-import { getCombinedKnownVersionsAsync } from '../getVersionedPackages';
 import {
   logIncorrectDependencies,
   validateDependenciesVersionsAsync,

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts
@@ -233,39 +233,6 @@ describe(validateDependenciesVersionsAsync, () => {
     );
   });
 
-  it('only uses local bundled module versions when using canary versions', async () => {
-    vol.fromJSON(
-      {
-        'node_modules/expo/package.json': JSON.stringify({
-          version: '50.0.0-canary-20231125-d600e44',
-        }),
-        'node_modules/react-native/package.json': JSON.stringify({
-          version: '0.73.0-rc.5',
-        }),
-      },
-      projectRoot
-    );
-    jest.mocked(getCombinedKnownVersionsAsync).mockResolvedValue({
-      'react-native': '0.73.0-rc.5',
-    });
-
-    const exp = { sdkVersion: '50.0.0' };
-    const pkg = { dependencies: { 'react-native': '0.73.0-rc.5' } };
-
-    // This should pass validation without any problems
-    await expect(validateDependenciesVersionsAsync(projectRoot, exp as any, pkg)).resolves.toBe(
-      true
-    );
-    // This should be called with `skipRemoteVersions: true` because of a `canary` Expo SDK version
-    expect(getCombinedKnownVersionsAsync).toBeCalledWith(
-      expect.objectContaining({
-        projectRoot,
-        sdkVersion: exp.sdkVersion,
-        skipRemoteVersions: true,
-      })
-    );
-  });
-
   it('skips validating dependencies when running in offline mode', async () => {
     jest.resetModules();
 

--- a/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
@@ -2,6 +2,7 @@ import { PackageJSONConfig } from '@expo/config';
 import npmPackageArg from 'npm-package-arg';
 
 import { getVersionedNativeModulesAsync } from './bundledNativeModules';
+import { hasExpoCanaryAsync } from './resolvePackages';
 import { getVersionsAsync, SDKVersion } from '../../../api/getVersions';
 import { Log } from '../../../log';
 import { env } from '../../../utils/env';
@@ -43,14 +44,16 @@ export async function getCombinedKnownVersionsAsync({
   projectRoot,
   sdkVersion,
   skipCache,
-  skipRemoteVersions = false,
 }: {
   projectRoot: string;
   sdkVersion?: string;
   skipCache?: boolean;
-  /** Do not fetch version information from the API, e.g. when using a `canary` SDK version */
-  skipRemoteVersions?: boolean;
 }) {
+  const skipRemoteVersions = await hasExpoCanaryAsync(projectRoot);
+  if (skipRemoteVersions) {
+    Log.warn('Dependency validation might be unreliable when using canary SDK versions');
+  }
+
   const bundledNativeModules = sdkVersion
     ? await getVersionedNativeModulesAsync(projectRoot, sdkVersion, { skipRemoteVersions })
     : {};

--- a/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
@@ -27,18 +27,13 @@ export async function resolvePackageVersionAsync(
   return packageJson.version;
 }
 
-export async function resolveAllPackageVersionsAsync(
-  projectRoot: string,
-  packages: string[]
-): Promise<Record<string, string>> {
-  const packageVersionsFromPackageJSON = await Promise.all(
-    packages.map((packageName) => resolvePackageVersionAsync(projectRoot, packageName))
+export async function resolveAllPackageVersionsAsync(projectRoot: string, packages: string[]) {
+  const resolvedPackages = await Promise.all(
+    packages.map(async (packageName) => [
+      packageName,
+      await resolvePackageVersionAsync(projectRoot, packageName),
+    ])
   );
-  return packages.reduce(
-    (acc, packageName, idx) => {
-      acc[packageName] = packageVersionsFromPackageJSON[idx];
-      return acc;
-    },
-    {} as Record<string, string>
-  );
+
+  return Object.fromEntries(resolvedPackages);
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
@@ -1,0 +1,44 @@
+import JsonFile from '@expo/json-file';
+import resolveFrom from 'resolve-from';
+
+import { CommandError } from '../../../utils/errors';
+
+export async function resolvePackageVersionAsync(
+  projectRoot: string,
+  packageName: string
+): Promise<string> {
+  let packageJsonPath: string | undefined;
+  try {
+    packageJsonPath = resolveFrom(projectRoot, `${packageName}/package.json`);
+  } catch (error: any) {
+    // This is a workaround for packages using `exports`. If this doesn't
+    // include `package.json`, we have to use the error message to get the location.
+    if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      packageJsonPath = error.message.match(/("exports"|defined) in (.*)$/i)?.[2];
+    }
+  }
+  if (!packageJsonPath) {
+    throw new CommandError(
+      'PACKAGE_NOT_FOUND',
+      `"${packageName}" is added as a dependency in your project's package.json but it doesn't seem to be installed. Please run "yarn" or "npm install" to fix this issue.`
+    );
+  }
+  const packageJson = await JsonFile.readAsync<{ version: string }>(packageJsonPath);
+  return packageJson.version;
+}
+
+export async function resolveAllPackageVersionsAsync(
+  projectRoot: string,
+  packages: string[]
+): Promise<Record<string, string>> {
+  const packageVersionsFromPackageJSON = await Promise.all(
+    packages.map((packageName) => resolvePackageVersionAsync(projectRoot, packageName))
+  );
+  return packages.reduce(
+    (acc, packageName, idx) => {
+      acc[packageName] = packageVersionsFromPackageJSON[idx];
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}

--- a/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
@@ -43,6 +43,7 @@ export async function resolveAllPackageVersionsAsync(projectRoot: string, packag
  * Determine if the project has a `expo@canary` version installed.
  * This means that an unsable version is used, without the API knowing the exact packages.
  * Since this may be called during, or before, packages are installed, we also need to test on `package.json`.
+ * Note, this returns `false` for beta releases.
  */
 export async function hasExpoCanaryAsync(projectRoot: string) {
   let expoVersion = '';
@@ -62,5 +63,10 @@ export async function hasExpoCanaryAsync(projectRoot: string) {
     expoVersion = packageJson.dependencies?.expo ?? '';
   }
 
-  return expoVersion === 'canary' || !!semver.prerelease(expoVersion);
+  if (expoVersion === 'canary') {
+    return true;
+  }
+
+  const prerelease = semver.prerelease(expoVersion) || [];
+  return !!prerelease.some((segment) => typeof segment === 'string' && segment.includes('canary'));
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/resolvePackages.ts
@@ -1,5 +1,6 @@
 import JsonFile from '@expo/json-file';
 import resolveFrom from 'resolve-from';
+import semver from 'semver';
 
 import { CommandError } from '../../../utils/errors';
 
@@ -36,4 +37,30 @@ export async function resolveAllPackageVersionsAsync(projectRoot: string, packag
   );
 
   return Object.fromEntries(resolvedPackages);
+}
+
+/**
+ * Determine if the project has a `expo@canary` version installed.
+ * This means that an unsable version is used, without the API knowing the exact packages.
+ * Since this may be called during, or before, packages are installed, we also need to test on `package.json`.
+ */
+export async function hasExpoCanaryAsync(projectRoot: string) {
+  let expoVersion = '';
+
+  try {
+    // Resolve installed `expo` version first
+    expoVersion = await resolvePackageVersionAsync(projectRoot, 'expo');
+  } catch (error: any) {
+    if (error.code !== 'PACKAGE_NOT_FOUND') {
+      throw error;
+    }
+
+    // Resolve through project `package.json`
+    const packageJson = await JsonFile.readAsync<{ dependencies?: Record<string, string> }>(
+      resolveFrom(projectRoot, './package.json')
+    );
+    expoVersion = packageJson.dependencies?.expo ?? '';
+  }
+
+  return expoVersion === 'canary' || !!semver.prerelease(expoVersion);
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -92,16 +92,10 @@ export async function getVersionedDependenciesAsync(
   // the CLI is versioned in the `expo` package.
   assert(exp.sdkVersion, 'SDK Version is missing');
 
-  const isCanaryRelease = await isExpoPreReleaseAsync(projectRoot);
-  if (isCanaryRelease) {
-    Log.warn('Dependency validation might be unreliable when using canary SDK versions');
-  }
-
   // Get from both endpoints and combine the known package versions.
   const combinedKnownPackages = await getCombinedKnownVersionsAsync({
     projectRoot,
     sdkVersion: exp.sdkVersion,
-    skipRemoteVersions: isCanaryRelease,
   });
   // debug(`Known dependencies: %O`, combinedKnownPackages);
 
@@ -257,9 +251,4 @@ function findDependencyType(
   }
 
   return 'dependencies';
-}
-
-/** Check if the currently installed `expo` version is a pre-released (canary) version */
-async function isExpoPreReleaseAsync(projectRoot: string) {
-  return !!semver.prerelease(await getPackageVersionAsync(projectRoot, 'expo'));
 }


### PR DESCRIPTION
# Why

This is a follow-up of #25600

# How

This PR addresses a couple of things:

- `expo install <package> --fix` should only fix that package. But, `expo` affects all other packages, and should be handled properly when executing `expo install expo@canary --fix`.
- Some package managers might use `"canary"` (dist tag) when installing through `expo install expo@canary`, meaning the canary detection from #25600 was not good enough.
- Move the canary detection into `getCombinedKnownVersionsAsync` to include this in `expo install --fix` _**and**_ `expo install <package>`.

# Test Plan

- `$ bun create expo ./test-canary --template blank`
- `$ bun expo install expo@canary --fix`
  - _should result in: `expo@canary` (or exact version), `expo-status-bar@0.0.x-canary-...`_
- `$ bun expo install expo-dev-client`
  - _should result in: `expo-dev-client@0.0.x-canary-...`_
- `$ bun expo install --check` -> _should show no errors_

There were edge cases, because this is a new concept and I can't really test this properly (it invokes the canary CLI, not CLI from source). Because of that, this is now not allowed:

- `$ bun expo install expo@canary expo-dev-client --fix`

The command above not only changes `expo@canary,` but it also invokes `expo install expo-dev-client --fix,` which throws because it's not yet installed. 

To avoid some confusion, this combination is aborted early without installing anything.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
