### PR TITLE
[docs] FeedbackForm: autofocus textarea, tweak focus outline

### DIFF
--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -91,7 +91,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                   event.preventDefault();
                   sendFeedback();
                 }}>
-                <div className="px-6 py-5 ">
+                <div className="px-6 py-5">
                   <div className="flex justify-between">
                     <RawH2 className="!my-0">Share your feedback</RawH2>
                     <Dialog.Close asChild>
@@ -105,6 +105,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     <div>
                       <LABEL>Feedback</LABEL>
                       <Textarea
+                        autoFocus
                         className="h-[180px] resize-none"
                         characterLimit={1000}
                         value={feedback}

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -61,16 +61,16 @@ export const EditPageLink = ({ pathname }: { pathname: string }) => (
 
 export const ShareFeedbackLink = ({ pathname }: { pathname?: string }) => {
   return (
-    <Dialog.Root>
-      <Dialog.Trigger>
-        <LI>
+    <LI>
+      <Dialog.Root>
+        <Dialog.Trigger className="h-[22px] focus-visible:outline-offset-4">
           <A isStyled className={LINK_CLASSES}>
             <MessageTextSquare02Icon className={ICON_CLASSES} />
             <CALLOUT theme="secondary">Share your feedback</CALLOUT>
           </A>
-        </LI>
-      </Dialog.Trigger>
-      <FeedbackDialog pathname={pathname} />
-    </Dialog.Root>
+        </Dialog.Trigger>
+        <FeedbackDialog pathname={pathname} />
+      </Dialog.Root>
+    </LI>
   );
 };


### PR DESCRIPTION
# Why

Small UX and a11y tweaks for the FeedbackForm components.

# How

Autofocus `textarea` on dialog open, adjust the size and position of focus outline.

# Test Plan

The changes have been reviewed locally. Lint checks and tests are passing.

# Preview

<img width="539" alt="Screenshot 2023-12-01 at 21 30 54" src="https://github.com/expo/expo/assets/719641/2448dfa0-db74-4183-aa30-e601129298b5">
<img width="437" alt="Screenshot 2023-12-01 at 21 30 19" src="https://github.com/expo/expo/assets/719641/b378618a-8140-4b23-b350-54c6aee82ece">
