### PR TITLE
[iOS] Fix unversioned QA issues in expo-file-system

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -112,7 +112,7 @@ export async function test({ describe, expect, it, ...t }) {
       } catch (e) {
         error = e;
       }
-      expect(error.message).toMatch(/could not be deleted because it could not be found/);
+      expect(error.message).toMatch(/could not be deleted/);
     });
 
     it('download(md5, uri) -> read -> delete -> !exists -> read[error]', async () => {
@@ -465,7 +465,7 @@ export async function test({ describe, expect, it, ...t }) {
         const localUri = FS.documentDirectory + 'doesnt/exists/download1.png';
         await FS.downloadAsync(remoteUrl, localUri);
       } catch (err) {
-        expect(err.message).toMatch(/exists before calling downloadAsync/);
+        expect(err.message).toMatch(/does not exist/);
       }
     }, 30000);
 

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -246,13 +246,6 @@
   return [EXVersions versionedString:string withPrefix:_versionSymbolPrefix];
 }
 
-- (NSString *)escapedResourceName:(NSString *)string
-{
-  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
-  NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
-  return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
-}
-
 - (BOOL)isReadyToLoad
 {
   if (_appRecord) {
@@ -703,18 +696,18 @@
 
 - (NSString *)scopedDocumentDirectory
 {
-  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
+  NSString *scopeKey = _appRecord.scopeKey;
   NSString *mainDocumentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentDocumentDirectory = [mainDocumentDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentDocumentDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
+  return [[exponentDocumentDirectory stringByAppendingPathComponent:scopeKey] stringByStandardizingPath];
 }
 
 - (NSString *)scopedCachesDirectory
 {
-  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
+  NSString *scopeKey = _appRecord.scopeKey;
   NSString *mainCachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentCachesDirectory = [mainCachesDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentCachesDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
+  return [[exponentCachesDirectory stringByAppendingPathComponent:scopeKey] stringByStandardizingPath];
 }
 
 - (void *)jsExecutorFactoryForBridge:(id)bridge

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - On `Android`, handle using files from `SAF` correctly. ([#25389](https://github.com/expo/expo/pull/25389) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed legacy `bundledAssets` constant that was used only in standalone apps. ([#25484](https://github.com/expo/expo/pull/25484) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added missing check for directory permissions in `deleteAsync` method. ([#25704](https://github.com/expo/expo/pull/25704) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -77,7 +77,7 @@ public final class FileSystemModule: Module {
       guard url.isFileURL else {
         throw InvalidFileUrlException(url)
       }
-      try ensurePathPermission(appContext, path: url.path.appending(".."), flag: .write)
+      try ensurePathPermission(appContext, path: url.appendingPathComponent("..").path, flag: .write)
       try removeFile(path: url.path, idempotent: options.idempotent)
     }
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -77,6 +77,7 @@ public final class FileSystemModule: Module {
       guard url.isFileURL else {
         throw InvalidFileUrlException(url)
       }
+      try ensurePathPermission(appContext, path: url.path.appending(".."), flag: .write)
       try removeFile(path: url.path, idempotent: options.idempotent)
     }
 


### PR DESCRIPTION
# Why

Fixes `expo-file-system` test failures in Expo Go

# How

- Adjusted some expectations for the error messages
- Fixed `deleteAsync` to check for permissions in the parent directory
- Removed additional escaping in scoped directories

# Test Plan

Tests are passing now