### PR TITLE
feat(yarn-workspaces): reduce regex complexity

### DIFF
--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -31,9 +31,9 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
 
       // Ignore test files and JS files in the native Android and Xcode projects
       blockList: [
-        /\/__tests__\/.*/,
-        /.*\/android\/React(Android|Common)\/.*/,
-        /.*\/versioned-react-native\/.*/,
+        /\/__tests__\//,
+        /\/android\/React(Android|Common)\//,
+        /\/versioned-react-native\//,
       ],
     },
 


### PR DESCRIPTION
# Why

The regex matchers we inject for bundling within the expo monorepo are especially expensive:

### Before

<img width="688" alt="Screenshot 2023-12-01 at 7 09 16 PM" src="https://github.com/expo/expo/assets/9664363/bcf4f471-c921-477d-8d11-fe0e035d225e">

### After

<img width="599" alt="Screenshot 2023-12-01 at 7 08 58 PM" src="https://github.com/expo/expo/assets/9664363/1b2464dc-5d79-44d4-b83b-80a4e8fbbed6">


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
