### PR TITLE
Fix `eas.json` in build-refrence

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -35,7 +35,7 @@ To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding on
     },
     "preview4": {
       "distribution": "internal"
-    }
+    },
     "production": {}
   }
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The `eas.json` in the docs for `Build APKs for Android Emulators and devices` was not having an expected comma at line 18.
# How

<!--
How did you build this feature or fix this bug and why?
-->

Added the comma in `eas.json` at line 18

Before
```json
{
  "build": {
    "preview": {
      "android": {
        "buildType": "apk"
      }
    },
    "preview2": {
      "android": {
        "gradleCommand": ":app:assembleRelease"
      }
    },
    "preview3": {
      "developmentClient": true
    },
    "preview4": {
      "distribution": "internal"
    }
    "production": {}
  }
}
```

After 

```json
{
  "build": {
    "preview": {
      "android": {
        "buildType": "apk"
      }
    },
    "preview2": {
      "android": {
        "gradleCommand": ":app:assembleRelease"
      }
    },
    "preview3": {
      "developmentClient": true
    },
    "preview4": {
      "distribution": "internal"
    }, // <-- added comma
    "production": {}
  }
}
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
