### PR TITLE
[ci] Use Node 20.10.0+ for check-packages

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -32,12 +32,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches


### PR DESCRIPTION
Reviewers: this PR has an extra commit to force CI to check all packages. This commit will be reverted before landing.

Why
---
Node 20.10.0 includes a memory leak fix in V8's compilation cache. This matters for Jest test suites, which repeatedly discard and reload the environment. See https://github.com/jestjs/jest/issues/11956.

With a sample size of one, the check-packages step ran in [27m46s](https://github.com/expo/expo/actions/runs/7067532822/job/19241013344?pr=25709) with Node 20.10.0 and [31m27s](https://github.com/expo/expo/actions/runs/7067530553/job/19241009110?pr=25711) with Node 18.18.2.

How
---
Used setup-node to explicitly install Node 20. Getting the latest version will include the V8 fix. Also upgraded the checkout action (breaking change is that it uses Node 20 itself internally).

If this works well, we could consider using setup-node's own Yarn node_modules caching instead of our own but that is out of the scope of this PR.

Test Plan
---
Make sure this passes in CI.