### PR TITLE
[ci] Add slack failure notification to expo-updates E2E tests

### DIFF
--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -17,6 +17,8 @@ on:
       - packages/expo-manifests/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
+  schedule:
+    - cron: '0 18 * * MON' # 18:00 UTC every Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -87,3 +89,14 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: updates_testing
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -17,6 +17,8 @@ on:
       - packages/expo-manifests/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
+  schedule:
+    - cron: '0 18 * * MON' # 18:00 UTC every Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -87,3 +89,14 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: updates_testing
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -43,6 +43,8 @@ on:
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
       - templates/expo-template-bare-minimum/**
+  schedule:
+    - cron: '0 18 * * MON' # 18:00 UTC every Monday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -113,3 +115,14 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           EAS_BUILD_PROFILE: updates_testing
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E


### PR DESCRIPTION
# Why

I'd like to run the less-frequently-run ones on a schedule and also find out about scheduled failures in slack.

# How

This runs all updates e2e tests every monday morning before our team meeting.

# Test Plan

Wait for CI to ensure valid syntax.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
