### PR TITLE
[ci] Add release variant to expo-updates e2e

### DIFF
--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -84,7 +84,7 @@ jobs:
         id: build_eas
         with:
           platform: ${{ env.EAS_PLATFORM }}
-          profile: 'updates_testing'
+          profile: 'updates_testing_debug'
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
@@ -95,4 +95,4 @@ jobs:
         working-directory: './updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: updates_testing
+          EAS_BUILD_PROFILE: updates_testing_debug

--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -30,6 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
+        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -77,7 +78,7 @@ jobs:
         id: build_eas
         with:
           platform: ${{ env.EAS_PLATFORM }}
-          profile: 'updates_testing'
+          profile: ${{ matrix.variant }}
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
@@ -88,7 +89,7 @@ jobs:
         working-directory: './updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: updates_testing
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -30,6 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
+        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
@@ -77,7 +78,7 @@ jobs:
         id: build_eas
         with:
           platform: ${{ env.EAS_PLATFORM }}
-          profile: 'updates_testing'
+          profile: ${{ matrix.variant }}
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
@@ -88,7 +89,7 @@ jobs:
         working-directory: './updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: updates_testing
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -56,11 +56,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
+        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       UPDATES_PORT: 4747
     steps:
+
       - name: 👀 Checkout
         uses: actions/checkout@v3
       - name: ⬢ Setup Node
@@ -103,7 +105,7 @@ jobs:
         id: build_eas
         with:
           platform: ${{ env.EAS_PLATFORM }}
-          profile: 'updates_testing'
+          profile: ${{ matrix.variant }}
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           noWait: ${{ github.event.schedule }}
@@ -114,7 +116,7 @@ jobs:
         working-directory: './updates-e2e'
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: updates_testing
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -62,7 +62,7 @@ Edit `app.json` and remove the `extra` section with the EAS project ID, then exe
 
 ```bash
 eas init
-eas build --profile=updates_testing --platform=<android|ios>
+eas build --profile=updates_testing_debug --platform=<android|ios>
 ```
 
 - Testing the EAS build locally:
@@ -74,7 +74,7 @@ eas build --profile=updates_testing --platform=<android|ios>
 --- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
 +++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
 @@ -15,7 +15,8 @@
-     "updates_testing": {
+     "updates_testing_debug": {
        "env": {
          "EX_UPDATES_NATIVE_DEBUG": "1",
 -        "NO_FLIPPER": "1"
@@ -105,7 +105,7 @@ rm -rf $EAS_LOCAL_BUILD_WORKINGDIR
 
 ```bash
 eas init
-eas build --profile=updates_testing --platform=<android|ios> --local
+eas build --profile=updates_testing_debug --platform=<android|ios> --local
 ```
 
 ## Updates API test project:

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -128,12 +128,15 @@ export default function App() {
 
   const handleReload = async () => {
     setIsReloading(true);
-    try {
-      await Updates.reloadAsync();
-      setIsReloading(false);
-    } catch (e) {
-      console.warn(e);
-    }
+    // this is done after a timeout so that the button press finishes for detox
+    setTimeout(async () => {
+      try {
+        await Updates.reloadAsync();
+        setIsReloading(false);
+      } catch (e) {
+        console.warn(e);
+      }
+    }, 1000);
   };
 
   const handleCheckForUpdate = runBlockAsync(async () => {

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -14,7 +14,7 @@ set -eox pipefail
 # If this script exits, trap it first and clean up the emulator
 trap cleanup EXIT
 
-if [[ "$EAS_BUILD_PROFILE" != "updates_testing" ]]; then
+if [[ "$EAS_BUILD_PROFILE" != "updates_testing_debug" && "$EAS_BUILD_PROFILE" != "updates_testing_release" ]]; then
   exit 0
 fi
 
@@ -67,10 +67,18 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   adb reverse tcp:4747 tcp:4747
 
   # Execute Android tests
-  detox test --configuration android.debug 2>&1 | tee ./logs/detox-tests.log
+  if [[ "$EAS_BUILD_PROFILE" == "updates_testing_debug" ]]; then
+    detox test --configuration android.debug 2>&1 | tee ./logs/detox-tests.log
+  else
+    detox test --configuration android.release 2>&1 | tee ./logs/detox-tests.log
+  fi
 else
   # Execute iOS tests
-  detox test --configuration ios.debug 2>&1 | tee ./logs/detox-tests.log
+  if [[ "$EAS_BUILD_PROFILE" == "updates_testing_debug" ]]; then
+    detox test --configuration ios.debug 2>&1 | tee ./logs/detox-tests.log
+  else
+    detox test --configuration ios.release 2>&1 | tee ./logs/detox-tests.log
+  fi
 fi
 
 

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
@@ -6,7 +6,7 @@ if [[ "$LOCAL_TESTING" == "1" ]]; then
   exit 0
 fi
 
-if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "updates_testing" ]]; then
+if [[ "$EAS_BUILD_RUNNER" == "eas-build" && ("$EAS_BUILD_PROFILE" == "updates_testing_debug" || "$EAS_BUILD_PROFILE" == "updates_testing_release") ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     sudo apt-get --quiet update --yes
 

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -16,7 +16,7 @@
         "buildConfiguration": "Debug"
       }
     },
-    "updates_testing": {
+    "updates_testing_debug": {
       "extends": "base",
       "env": {
         "EX_UPDATES_NATIVE_DEBUG": "1",
@@ -33,6 +33,30 @@
         "resourceClass": "m-medium",
         "image": "macos-ventura-13.3-xcode-14.3",
         "buildConfiguration": "Debug",
+        "cache": {
+          "cacheDefaultPaths": false
+        }
+      },
+      "distribution": "internal",
+      "buildArtifactPaths": ["logs/*.log"]
+    },
+    "updates_testing_release": {
+      "extends": "base",
+      "env": {
+        "EX_UPDATES_NATIVE_DEBUG": "1",
+        "NO_FLIPPER": "1"
+      },
+      "android": {
+        "image": "ubuntu-22.04-jdk-17-ndk-r21e",
+        "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
+        "withoutCredentials": true,
+        "resourceClass": "large"
+      },
+      "ios": {
+        "simulator": true,
+        "resourceClass": "m-medium",
+        "image": "macos-ventura-13.3-xcode-14.3",
+        "buildConfiguration": "Release",
         "cache": {
           "cacheDefaultPaths": false
         }

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -177,10 +177,17 @@ async function copyCommonFixturesToProject(
       ...easJson,
       build: {
         ...easJson.build,
-        updates_testing: {
-          ...easJson.build.updates_testing,
+        updates_testing_debug: {
+          ...easJson.build.updates_testing_debug,
           env: {
-            ...easJson.build.updates_testing.env,
+            ...easJson.build.updates_testing_debug.env,
+            TEST_TV_BUILD: '1',
+          },
+        },
+        updates_testing_release: {
+          ...easJson.build.updates_testing_release,
+          env: {
+            ...easJson.build.updates_testing_release.env,
             TEST_TV_BUILD: '1',
           },
         },


### PR DESCRIPTION
# Why

Release and debug variant behavior differ significantly within react native itself, so we need to test both for expo-updates since it makes use of the differences significantly (reloading, for example).

We only want to run tests for the release variant on the schedule added in https://github.com/expo/expo/pull/25718.

# How

Add new matrix value.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
