### PR TITLE
change the word "ad hoc" to "internal"

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -159,7 +159,7 @@ After the build is complete, copy the URL to the **.apk** from the build details
 
 > **warning** Apple Developer membership is required to create and install a development build on an iOS device.
 
-To register any iOS device you'd like to develop onto your [ad hoc provisioning profile](/build/internal-distribution/#22-configure-app-signing-credentials-for-ios), run the following command:
+To register any iOS device you'd like to develop onto your [internal provisioning profile](/build/internal-distribution/#22-configure-app-signing-credentials-for-ios), run the following command:
 
 <Terminal cmd={['$ eas device:create']} />
 


### PR DESCRIPTION


# Why

"ad hoc" is a confusing word, I though it meant "higher order component"  I asked github copilot, it said it is a Latin phrase that means "for this".  by reading through the context, I personally think "interal" is a better word. 



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
