### PR TITLE
[core] add Data convertible on ios

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -541,6 +541,9 @@ Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are alre
 | `CGVector`              | `{ dx: number, dy: number }` or `number[]` with _dx_ and _dy_ vector differentials                                                                                                |
 | `CGRect`                | `{ x: number, y: number, width: number, height: number }` or `number[]` with _x_, _y_, _width_ and _height_ values                                                                |
 | `CGColor`<br/>`UIColor` | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
+| `Data`                  | `Uint8Array`                                                                                                                                                                      |
+
+> **Info** Data is available as of SDK 50.
 
 ---
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -6,7 +6,7 @@ sidebar_title: Module API
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { APIBox } from '~/components/plugins/APIBox';
-import { PlatformTags } from '~/ui/components/Tag';
+import { PlatformTags, StatusTag } from '~/ui/components/Tag';
 import { A, CALLOUT } from '~/ui/components/Text';
 import { APIMethod } from '~/components/plugins/api/APISectionMethods';
 import { FileTree } from '~/ui/components/FileTree';
@@ -541,9 +541,7 @@ Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are alre
 | `CGVector`              | `{ dx: number, dy: number }` or `number[]` with _dx_ and _dy_ vector differentials                                                                                                |
 | `CGRect`                | `{ x: number, y: number, width: number, height: number }` or `number[]` with _x_, _y_, _width_ and _height_ values                                                                |
 | `CGColor`<br/>`UIColor` | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
-| `Data`                  | `Uint8Array`                                                                                                                                                                      |
-
-> **Info** Data is available as of SDK 50.
+| `Data`                  | `Uint8Array` <StatusTag note="SDK 50+" />                                                                                                                                         |
 
 ---
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for React Native 0.73.0. ([#24971](https://github.com/expo/expo/pull/24971), [#25453](https://github.com/expo/expo/pull/25453) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added `Data <-> Uint8Array` convertible on iOS. ([#25726](https://github.com/expo/expo/pull/25726) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
@@ -33,6 +33,11 @@ extension Double: AnyArgument {}
 extension CGFloat: AnyArgument {}
 
 extension String: AnyArgument {}
+extension Data: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicFoundationDataType()
+  }
+}
 
 extension Optional: AnyArgument where Wrapped: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {

--- a/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
@@ -33,11 +33,16 @@ extension Double: AnyArgument {}
 extension CGFloat: AnyArgument {}
 
 extension String: AnyArgument {}
-extension Dictionary: AnyArgument {}
 
 extension Optional: AnyArgument where Wrapped: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {
     return DynamicOptionalType(wrappedType: ~Wrapped.self)
+  }
+}
+
+extension Dictionary: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicDictionaryType(valueType: ~Value.self)
   }
 }
 

--- a/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
@@ -33,11 +33,6 @@ extension Double: AnyArgument {}
 extension CGFloat: AnyArgument {}
 
 extension String: AnyArgument {}
-extension Data: AnyArgument {
-  public static func getDynamicType() -> AnyDynamicType {
-    return DynamicFoundationDataType()
-  }
-}
 
 extension Optional: AnyArgument where Wrapped: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {
@@ -45,7 +40,7 @@ extension Optional: AnyArgument where Wrapped: AnyArgument {
   }
 }
 
-extension Dictionary: AnyArgument {
+extension Dictionary: AnyArgument where Key: Hashable {
   public static func getDynamicType() -> AnyDynamicType {
     return DynamicDictionaryType(valueType: ~Value.self)
   }
@@ -54,5 +49,11 @@ extension Dictionary: AnyArgument {
 extension Array: AnyArgument {
   public static func getDynamicType() -> AnyDynamicType {
     return DynamicArrayType(elementType: ~Element.self)
+  }
+}
+
+extension Data: AnyArgument {
+  public static func getDynamicType() -> AnyDynamicType {
+    return DynamicDataType()
   }
 }

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicDataType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicDataType.swift
@@ -3,7 +3,7 @@
 /**
  A dynamic type representing Swift `Data` or Objective-C `NSData` type and backing by JavaScript `Uint8Array`.
  */
-internal struct DynamicFoundationDataType: AnyDynamicType {
+internal struct DynamicDataType: AnyDynamicType {
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return InnerType.self == Data.self
   }

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicDictionaryType.swift
@@ -1,0 +1,65 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ A dynamic type representing dictionary types. Requires the dictionary's value type
+ for the initialization as it delegates casting to that type for each element in the dictionary.
+ */
+internal struct DynamicDictionaryType: AnyDynamicType {
+  let valueType: AnyDynamicType
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    if let dictionaryType = InnerType.self as? AnyDictionary.Type {
+      return valueType.equals(dictionaryType.getValueDynamicType())
+    }
+    return false
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    if let dictionaryType = type as? Self {
+      return dictionaryType.valueType.equals(valueType)
+    }
+    return false
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    if let jsObject = try? jsValue.asObject() {
+      var result: [AnyHashable: Any] = [:]
+      for key in jsObject.getPropertyNames() {
+        result[key] = try valueType.cast(jsValue: jsObject.getProperty(key), appContext: appContext)
+      }
+      return result
+    }
+    throw Conversions.CastingException<JavaScriptObject>(jsValue)
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if let value = value as? [AnyHashable: Any] {
+      return try value.mapValues { try valueType.cast($0, appContext: appContext) }
+    }
+    throw Conversions.CastingException<[AnyHashable: Any]>(value)
+  }
+
+  var description: String {
+    "[AnyHashable: \(valueType.description)]"
+  }
+}
+
+/**
+ A type-erased protocol used to recognize if the generic type is a dictionary type.
+ `Dictionary` is a generic type, so it's impossible to check the inheritance directly.
+ */
+internal protocol AnyDictionary {
+  /**
+   Exposes the `Value` generic type wrapped by the dynamic type to preserve its metadata.
+   */
+  static func getValueDynamicType() -> AnyDynamicType
+}
+
+/**
+ Extends the `Dictionary` type to expose its generic `Value` as a dynamic type.
+ */
+extension Dictionary: AnyDictionary {
+  static func getValueDynamicType() -> AnyDynamicType {
+    return ~Value.self
+  }
+}

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicDictionaryType.swift
@@ -40,7 +40,7 @@ internal struct DynamicDictionaryType: AnyDynamicType {
   }
 
   var description: String {
-    "[AnyHashable: \(valueType.description)]"
+    "[Hashable: \(valueType.description)]"
   }
 }
 

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicFoundationDataType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicFoundationDataType.swift
@@ -1,0 +1,28 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+/**
+ A dynamic type representing Swift `Data` or Objective-C `NSData` type and backing by JavaScript `Uint8Array`.
+ */
+internal struct DynamicFoundationDataType: AnyDynamicType {
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return InnerType.self == Data.self
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    return type is Data.Type
+  }
+
+  /**
+   Converts JS typed array to its native representation.
+   */
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    guard let jsTypedArray = jsValue.getTypedArray(), jsTypedArray.kind == TypedArrayKind.Uint8Array else {
+      throw Conversions.CastingException<Uint8Array>(jsValue)
+    }
+    return Data(bytes: jsTypedArray.getUnsafeMutableRawPointer(), count: jsTypedArray.getProperty("byteLength").getInt())
+  }
+
+  var description: String {
+    return String(describing: Data.self)
+  }
+}

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
@@ -35,6 +35,9 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let TypedArrayType = T.self as? AnyTypedArray.Type {
     return DynamicTypedArrayType(innerType: TypedArrayType)
   }
+  if let DataType = T.self as? Data.Type {
+    return DynamicFoundationDataType()
+  }
   if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
     return DynamicJavaScriptType(innerType: JavaScriptValueType)
   }

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
@@ -14,6 +14,9 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let ArrayType = T.self as? AnyArray.Type {
     return DynamicArrayType(elementType: ArrayType.getElementDynamicType())
   }
+  if let DictionaryType = T.self as? AnyDictionary.Type {
+    return DynamicDictionaryType(valueType: DictionaryType.getValueDynamicType())
+  }
   if let OptionalType = T.self as? any AnyOptional.Type {
     return DynamicOptionalType(wrappedType: OptionalType.getWrappedDynamicType())
   }

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicType.swift
@@ -36,7 +36,7 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
     return DynamicTypedArrayType(innerType: TypedArrayType)
   }
   if let DataType = T.self as? Data.Type {
-    return DynamicFoundationDataType()
+    return DynamicDataType()
   }
   if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
     return DynamicJavaScriptType(innerType: JavaScriptValueType)

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -56,12 +56,13 @@ std::vector<jsi::Value> convertNSArrayToStdVector(jsi::Runtime &runtime, NSArray
 }
 
 jsi::Value createUint8Array(jsi::Runtime &runtime, NSData *data) {
-  auto arrayBufferCtor = runtime.global().getPropertyAsFunction(runtime, "ArrayBuffer");
+  auto global = runtime.global();
+  auto arrayBufferCtor = global.getPropertyAsFunction(runtime, "ArrayBuffer");
   auto arrayBufferObject = arrayBufferCtor.callAsConstructor(runtime, static_cast<int>(data.length)).getObject(runtime);
   auto arrayBuffer = arrayBufferObject.getArrayBuffer(runtime);
   memcpy(arrayBuffer.data(runtime), data.bytes, data.length);
 
-  auto uint8ArrayCtor = runtime.global().getPropertyAsFunction(runtime, "Uint8Array");
+  auto uint8ArrayCtor = global.getPropertyAsFunction(runtime, "Uint8Array");
   auto uint8Array = uint8ArrayCtor.callAsConstructor(runtime, arrayBufferObject).getObject(runtime);
   return uint8Array;
 }
@@ -84,12 +85,12 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
       return convertNSNumberToJSIBoolean(runtime, (NSNumber *)value);
     }
     return convertNSNumberToJSINumber(runtime, (NSNumber *)value);
-  } else if ([value isKindOfClass:[NSData class]]) {
-    return createUint8Array(runtime, (NSData *)value);
   } else if ([value isKindOfClass:[NSDictionary class]]) {
     return convertNSDictionaryToJSIObject(runtime, (NSDictionary *)value);
   } else if ([value isKindOfClass:[NSArray class]]) {
     return convertNSArrayToJSIArray(runtime, (NSArray *)value);
+  } else if ([value isKindOfClass:[NSData class]]) {
+    return createUint8Array(runtime, (NSData *)value);
   } else if (value == (id)kCFNull) {
     return jsi::Value::null();
   }

--- a/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
@@ -1,0 +1,98 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class DataUint8ArrayConvertiblesSpec: ExpoSpec {
+  override class func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    beforeSuite {
+      appContext.moduleRegistry.register(moduleType: BlobModule.self)
+    }
+
+    it("should support sync function") {
+      let isUint8Array = try runtime
+        .eval([
+          "result = expo.modules.BlobModule.echoSync(new Uint8Array([0x00, 0xff]))",
+          "result instanceof Uint8Array"
+        ])
+        .asBool()
+      expect(isUint8Array) == true
+
+      let array = try runtime.eval("Array.from(result)").asArray()
+      expect(array[0]?.getInt()) == 0x00
+      expect(array[1]?.getInt()) == 0xff
+    }
+
+    it("should support sync function for dict") {
+      let isUint8Array = try runtime
+        .eval([
+          "result = expo.modules.BlobModule.echoMapSync({ key: new Uint8Array([0x00, 0xff]) })",
+          "result.key instanceof Uint8Array"
+        ])
+        .asBool()
+      expect(isUint8Array) == true
+
+      let array = try runtime.eval("Array.from(result.key)").asArray()
+      expect(array[0]?.getInt()) == 0x00
+      expect(array[1]?.getInt()) == 0xff
+    }
+
+    it("should support async function") {
+      try runtime
+        .eval(
+          "expo.modules.BlobModule.echoAsync(new Uint8Array([0x00, 0xff])).then((result) => { globalThis.result = result; })"
+        )
+      expect(try runtime.eval("globalThis.result !== undefined").getBool()).toEventually(beTrue())
+      let isUint8Array = try runtime.eval("globalThis.result instanceof Uint8Array").asBool()
+      expect(isUint8Array) == true
+      let array = try runtime.eval("Array.from(globalThis.result)").asArray()
+      expect(array[0]?.getInt()) == 0x00
+      expect(array[1]?.getInt()) == 0xff
+    }
+
+    it("should support async function for dict") {
+      try runtime
+        .eval(
+          "expo.modules.BlobModule.echoMapAsync({ key: new Uint8Array([0x00, 0xff]) }).then((result) => { globalThis.result = result; })"
+        )
+      expect(try runtime.eval("globalThis.result !== undefined").getBool()).toEventually(beTrue())
+      let isUint8Array = try runtime.eval("globalThis.result.key instanceof Uint8Array").asBool()
+      expect(isUint8Array) == true
+      let array = try runtime.eval("Array.from(globalThis.result.key)").asArray()
+      expect(array[0]?.getInt()) == 0x00
+      expect(array[1]?.getInt()) == 0xff
+    }
+  }
+}
+
+private class BlobModule: Module {
+  public func definition() -> ModuleDefinition {
+    Function("echoSync") { (data: Data) -> Data in
+      expect(data[0]) == 0x00
+      expect(data[1]) == 0xff
+      return data
+    }
+
+    AsyncFunction("echoAsync") { (data: Data) -> Data in
+      expect(data[0]) == 0x00
+      expect(data[1]) == 0xff
+      return data
+    }
+
+    Function("echoMapSync") { (map: [String: Data]) -> [String: Data] in
+      expect(map["key"]?[0]) == 0x00
+      expect(map["key"]?[1]) == 0xff
+      return map
+    }
+
+    AsyncFunction("echoMapAsync") { (map: [String: Data]) -> [String: Data] in
+      expect(map["key"]?[0]) == 0x00
+      expect(map["key"]?[1]) == 0xff
+      return map
+    }
+  }
+}


### PR DESCRIPTION
# Why

to support Blob data type for expo-sqlite/next. This pr adds `Data <-> Uint8Array` convertible on ios

# How

- fix dict values does not convert correctly
- add Data <-> Uint8Array convertible
  - why not using TypedArray?
    since hermes requires accessing everything in the js thread, i think our current TypedArray implementation may violate the hermes restriction on AsyncFunction. the current `DynamicDictionaryType` will convert UintArray to Data in js thread because jumping to async function queue thread.
- it's best to align the conversion between function input and output. adding Data -> Uint8Array conversion in `convertObjCObjectToJSIValue`
- adding call invoker for async js unit test. the code is referenced from the expo-modules-core.

# Test Plan

- add `BlobConvertiblesSpec` unit test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
