### PR TITLE
[home] Fix home not updating modal user state on login

### DIFF
--- a/home/screens/AccountModal/index.tsx
+++ b/home/screens/AccountModal/index.tsx
@@ -13,7 +13,9 @@ import { useHome_CurrentUserActorQuery } from '../../graphql/types';
 export function AccountModal() {
   const theme = useExpoTheme();
 
-  const { data, loading, error, refetch } = useHome_CurrentUserActorQuery();
+  const { data, loading, error, refetch } = useHome_CurrentUserActorQuery({
+    fetchPolicy: 'cache-and-network',
+  });
 
   if (loading) {
     return (


### PR DESCRIPTION
# Why

Old error where the account modal in home did not update after login.

Before

https://github.com/expo/expo/assets/5597580/53250e42-20f0-44aa-8a57-9cbb429f384f

After

https://github.com/expo/expo/assets/5597580/526fcab0-19f6-4bd4-ba9d-57d18a67f166


# How

Tried evicting or gcing the fragment, but the easiest was to set a fetchPolicy on the query.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
