### PR TITLE
[docs] Fix minor formatting and verbiage issues across multiple docs

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -261,6 +261,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/development/tools/expo-dev-client/':
     '/develop/development-builds/introduction/#what-is-expo-dev-client',
   '/develop/user-interface/custom-fonts/': '/develop/user-interface/fonts/#use-a-custom-font',
+  '/accounts/teams-and-accounts/': '/accounts/account-types/',
+  '/push-notifications/fcm/': '/push-notifications/sending-notifications-custom/',
+  '/troubleshooting/clear-cache-mac/': '/troubleshooting/clear-cache-macos-linux/',
 
   // Renaming a submit section
   '/submit/submit-ios': '/submit/ios/',
@@ -382,6 +385,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/v45.0.0/sdk/google-sign-in': '/guides/google-authentication/',
   '/versions/v44.0.0/sdk/google/': '/guides/google-authentication/',
   '/versions/latest/sdk/error-recovery/': '/versions/latest/',
+  '/guides/using-preact/': '/guides/overview/',
+  '/versions/latest/sdk/shared-element/': '/versions/latest/',
+  '/workflow/hermes/': '/guides/using-hermes/',
 
   // Push notifications
   '/config/app/': '/workflow/configuration/',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -312,6 +312,12 @@ redirects[eas/submit]=submit/introduction/
 redirects[development/tools/expo-dev-client/]=develop/development-builds/introduction/
 redirects[develop/user-interface/custom-fonts/]=develop/user-interface/fonts/
 redirects[workflow/snack/]=/more/glossary-of-terms/
+redirects[accounts/teams-and-accounts/]=accounts/account-types/
+redirects[push-notifications/fcm/]=push-notifications/sending-notifications-custom/
+redirects[troubleshooting/clear-cache-mac/]=troubleshooting/clear-cache-macos-linux/
+redirects[guides/using-preact/]=guides/overview/
+redirects[versions/latest/sdk/shared-element/]=versions/latest/
+redirects[workflow/hermes/]=guides/using-hermes/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys

--- a/docs/pages/eas-update/deployment-patterns.mdx
+++ b/docs/pages/eas-update/deployment-patterns.mdx
@@ -1,17 +1,16 @@
 ---
 title: Deployment patterns
-description: Learn how about different deployment patterns for your project when using EAS Update.
+description: Learn about different deployment patterns for your project when using EAS Update.
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Diagram } from '~/ui/components/Diagram';
 
-Once we've created features and fixed bugs in our app, we want to deliver those features and bug fixes out to our users as quickly and safely as we can. Often "safe" and "fast" are opposing forces when delivering code to our users.
-We could push our code directly to production, which would be fast yet less safe since we never tested our code. On the other hand, we could make test builds, share them with a QA team, and release periodically, which would be safer but slower to deliver changes to our users.
+Once we've created features and fixed bugs in our app, we want to deliver those features and bug fixes to our users as quickly and safely as we can. Often "safe" and "fast" are opposing forces when delivering code to our users.
+We could push our code directly to production, which would be fast yet less safe since we never tested our code. On the other hand, we could make test builds, share them with a QA team, and release them periodically, which would be safer but slower to deliver changes to our users.
 
 Depending on your project, you'll have some tolerance for how "fast" and how "safe" you'll need to be when delivering updates to your users.
 
-There are three parts to consider when designing a EAS Update deployment process:
+There are three parts to consider when designing the EAS Update deployment process:
 
 1. **Creating builds**
    - (a) We can create builds for production use only.
@@ -52,7 +51,7 @@ This flow is the simplest and fastest flow, with the fewest amount of safety che
 ### Explanation of flow
 
 1. Develop a project locally and test changes in a development build or in Expo Go.
-2. Run `eas build` to create builds, then submit them to app stores. These builds are for public use, and should be submitted/reviewed, and released on the app stores.
+2. Run `eas build` to create builds, then submit them to app stores. These builds are for public use and should be submitted/reviewed, and released on the app stores.
 3. When we have updates we'd like to deliver, run `eas update --branch production` to deliver updates to our users immediately.
 
 #### Advantages of this flow

--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -69,11 +69,13 @@ See [Upgrading Expo SDK guide](/workflow/upgrading-expo-sdk-walkthrough) for ins
 
 <Collapsible summary="How can I install an older version of Expo Go to run my project?">
 
-If you can't upgrade your project to a newer SDK version, you can still run it using an older version of Expo Go. However, this method will not work for physical iOS devices because it is impossible to install apps directly (sideload). If you need to run your project on a physical iOS device, consider creating a [development build](/develop/development-builds/introduction).
+If you cannot upgrade your project to a newer SDK version, you can still run it using an older version of Expo Go. However, this method will not work for physical iOS devices because it is impossible to install apps directly (sideload). If you need to run your project on a physical iOS device, consider creating a [development build](/develop/development-builds/introduction).
 
-If you are trying to use this method on a physical Android device, connect it to your computer and enable the **USB Debugging** option. To learn more, see [Android emulators](/workflow/android-studio-emulator) and [iOS simulators](/workflow/ios-simulator)
+If you are trying to use this method on a physical Android device, connect it to your computer and enable the **USB Debugging** option.
 
-<Step label="1">If installed, remove Expo Go from your device/simulator.</Step>
+To run it on an emulator or a simulator, see [Android emulators](/workflow/android-studio-emulator) and [iOS simulators](/workflow/ios-simulator).
+
+<Step label="1">If installed, remove Expo Go from your device or simulator.</Step>
 <Step label="2">
   Start the development server:
   <Terminal cmd={['npx expo start']} />
@@ -83,7 +85,7 @@ If you are trying to use this method on a physical Android device, connect it to
   install the compatible Expo Go on your device/simulator and open your project in the client.
 </Step>
 
-A compatible version of Expo Go will be automatically installed on your device/simulator, and your project will open.
+A compatible version of Expo Go will be automatically installed on your device or simulator, and your project will open.
 
 </Collapsible>
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -86,7 +86,7 @@ Remove all fields that are outside of the top-level `expo` object as these will 
 
 **metro.config.js**
 
-See: [Customizing Metro](/guides/customizing-metro.mdx)
+See[Customizing Metro](/guides/customizing-metro/).
 
 **package.json**
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -5,7 +5,7 @@ description: Learn how to adopt Expo Prebuild in a project that was bootstrapped
 
 import { Terminal } from '~/ui/components/Snippet';
 
-There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation.mdx). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx react-native init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects &mdash; on a brand new project, this may take a minute or two, and on a large project it could be much longer.
+There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx react-native init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
 
 Adopting prebuild will automatically add support for developing modules with the [Expo native module API][expo-modules-core] by linking `expo-modules-core` natively. You can also use any command from [Expo CLI][cli] in your project.
 
@@ -34,13 +34,13 @@ import App from './App';
 + registerRootComponent(App);
 ```
 
-> Learn more about [`registerRootComponent`](/versions/latest/sdk/register-root-component#registerrootcomponentcomponent).
+> Learn more about [`registerRootComponent`](/versions/latest/sdk/register-root-component/#registerrootcomponentcomponent).
 
 ## Prebuild
 
 > **warning** Make sure you have committed your changes in case you want to revert, the command will warn you about this too!
 
-If you're migrating an existing project, then you may want to refer to [**migrating native customizations**](#migrating-native-customizations) first.
+If you're migrating an existing project, then you may want to refer to [**migrating native customizations**](#migrate-native-customizations) first.
 
 Run the following command to regenerate the **android** and **ios** directories based on the app config (**app.json/app.config.js**) configuration:
 
@@ -68,7 +68,7 @@ The following changes are optional but recommended.
 
 You can add **.expo** to your **.gitignore** to prevent generated values from Expo CLI from being committed. These [values are unique to your project](/more/expo-cli/#expo-directory) on your local computer.
 
-You can also add **android** and **ios** to the **.gitignore** if you want to ensure they aren't committed between prebuilds.
+You can also add **android** and **ios** to the **.gitignore** if you want to ensure they are not committed between prebuilds.
 
 **app.json**
 
@@ -104,16 +104,16 @@ You may want to change the scripts to use the [Expo CLI](/more/expo-cli/#compili
 
 These commands have better logging, auto code signing, better simulator handling, and they ensure you run `npx expo start` to serve files.
 
-## Migrating native customizations
+## Migrate native customizations
 
 If your project has any native modifications (changes to the **android** or **ios** directories, such as app icon configuration or splash screen) then you'll need to configure your app config (**app.json**) to reflect those native changes.
 
 - Check to see if your changes overlap with the built-in [app config fields](/versions/latest/config/app/). For example, if you have an app icon, be sure to define it as `expo.icon` in the **app.json** then re-run `npx expo prebuild`.
-- Look up if any of the packages you're using require an [Expo config plugin][config-plugins]. If a package in your project requires additional changes inside of the **android** or **ios** directories, then you will probably need a Config Plugin. Some plugins can be automatically added by running `npx expo install` with all of the packages in your `package.json` `dependencies`. If a package requires a plugin but doesn't supply one, then you can try checking the community plugins at [`expo/config-plugins`](https://github.com/expo/config-plugins) to see if one already exists.
-- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>, type "Expo: Preview Modifier", and select the native file you wish to introspect.
+- Look up if any of the packages you are using require an [Expo config plugin][config-plugins]. If a package in your project requires additional changes inside of the **android** or **ios** directories, then you will probably need a Config Plugin. Some plugins can be automatically added by running `npx expo install` with all of the packages in your **package.json** dependencies. If a package requires a plugin but doesn't supply one, then you can try checking the community plugins at [`expo/config-plugins`](https://github.com/expo/config-plugins) to see if one already exists.
+- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd>, type "Expo: Preview Modifier", and select the native file you wish to introspect.
 - Additionally, you can develop local config plugins to fit your needs. [Learn more](/config-plugins/development-and-debugging/#develop-a-plugin).
 
-## Adding more features
+## Add more features
 
 Prebuild is the tip of the automation iceberg, here are some features you can adopt next:
 

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -417,7 +417,7 @@ This is the easiest way to set up deep links in your app because it requires a m
 
 The main problem is that if the user does not have your app installed and follows a link to your app with its custom scheme, their operating system will indicate that the page couldn't be opened but not give much more information. This is not a great experience. There is no way to work around this in the browser.
 
-Additionally, many messaging apps do not autolink URLs with custom schemes -- for example, `exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]` might just show up as plain text in your browser rather than as a link ([exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]](#)).
+Additionally, many messaging apps do not autolink URLs with custom schemes. For example, `exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]` might just show up as plain text in your browser rather than as a link ([exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]](#)).
 
 An example of this is Gmail which strips the `href` property from the links of most apps, a trick to use is to link to a regular HTTPS URL instead of your app's custom scheme, this will open the user's web browser. Browsers do not usually strip the `href` property so you can host a file online that redirects the user to your app's custom schemes.
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -127,9 +127,9 @@ After updating your Babel config file, be sure to clear your cache with `npx exp
 
 ### From direnv
 
-Move any environment variables used in your JavaScript from their **.envrc** file to an **.env** file and prefix it with `EXPO_PUBLIC_`.
+Move any environment variables used in your JavaScript from their **.envrc** file to a **.env** file and prefix it with `EXPO_PUBLIC_`.
 
-Previously with direnv, you would need to use a [dynamic app config](/versions/latest/config/app/#app-config) that reads from [`process.env`](https://nodejs.org/dist/latest/docs/api/process.html#process_process_env) to set environment variables on the `extra` field so they can be used in your JavaScript code via [expo-constants](/versions/latest/sdk/constants). Move those references directly into your code, adding the `EXPO_PUBLIC_` prefix:
+Previously with `direnv`, you would need to use a [dynamic app config](/versions/latest/config/app/#app-config) that reads from [`process.env`](https://nodejs.org/dist/latest/docs/api/process.html#process_process_env) to set environment variables on the `extra` field so they can be used in your JavaScript code via [`expo-constants`](/versions/latest/sdk/constants). Move those references directly into your code, adding the `EXPO_PUBLIC_` prefix:
 
 ```diff
 - import Constants from 'expo-constants';
@@ -138,7 +138,7 @@ Previously with direnv, you would need to use a [dynamic app config](/versions/l
 + const apiUrl = process.env.EXPO_PUBLIC_API_URL;
 ```
 
-> [direnv](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory, meaning it can affect the environment for any process running in that directly, not just the Expo CLI. You will likely want to continue using direnv for other environment variables that are not used in your JavaScript code.
+> [`direnv`](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory, meaning it can affect the environment for any process running in that directly, not just the Expo CLI. You will likely want to continue using `direnv` for other environment variables that are not used in your JavaScript code.
 
 ## Security considerations
 
@@ -146,4 +146,4 @@ Never store sensitive secrets in environment variables that are prefixed with `E
 
 ## Environment variables in SDK 48 and lower
 
-Due to its ability to automatically load and unload environment variables in your shell depending on your current directory, we highly recommend [direnv](https://direnv.net/) for the highest level of compatibility with all Expo and EAS CLI tooling for SDK versions that do not support Expo environment variables. Since variables loaded with direnv are available in Node processes but not your application code itself, you can load it into the `extra` field of your [dynamic Expo config](/versions/latest/config/app/#app-config) and then access it in your JavaScript code via [expo-constants](/versions/latest/sdk/constants).
+Due to its ability to automatically load and unload environment variables in your shell depending on your current directory, we recommend [`direnv`](https://direnv.net/) for the highest level of compatibility with all Expo and EAS CLI tooling for SDK versions that do not support Expo environment variables. Since variables loaded with `direnv` are available in Node processes but not your application code itself, you can load it into the `extra` field of your [dynamic Expo config](/versions/latest/config/app/#app-config) and then access it in your JavaScript code via [`expo-constants`](/versions/latest/sdk/constants).

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -182,8 +182,7 @@ See an example of **app.json** that enables audio playback in background:
 ### Notes on web usage
 
 - A MediaRecorder issue on Chrome produces WebM files missing the duration metadata. [See the open Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=642012).
-- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder).
-  or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
+- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder) or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
 - Web browsers require sites to be served securely for them to listen to a mic. See [MediaDevices `getUserMedia()` security](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#security) for more details.
 
 ## API
@@ -196,4 +195,4 @@ import { Audio } from 'expo-av';
 
 ## Unified API
 
-The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref` - see the [AV documentation](av/#playback) for further information.
+The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref`. See the [AV documentation](av/#playback) for more information.

--- a/docs/pages/versions/v46.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/audio.mdx
@@ -175,8 +175,7 @@ See an example of **app.json** that enables audio playback in background:
 ### Notes on web usage
 
 - A MediaRecorder issue on Chrome produces WebM files missing the duration metadata. [See the open Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=642012).
-- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder).
-  or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
+- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder) or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
 - Web browsers require sites to be served securely for them to listen to a mic. See [MediaDevices `getUserMedia()` security](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#security) for more details.
 
 ## API
@@ -189,4 +188,4 @@ import { Audio } from 'expo-av';
 
 ## Unified API
 
-The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref` - see the [AV documentation](av/#playback) for further information.
+The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref`. See the [AV documentation](av/#playback) for more information.

--- a/docs/pages/versions/v47.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/audio.mdx
@@ -180,8 +180,7 @@ See an example of **app.json** that enables audio playback in background:
 ### Notes on web usage
 
 - A MediaRecorder issue on Chrome produces WebM files missing the duration metadata. [See the open Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=642012).
-- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder).
-  or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
+- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder) or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
 - Web browsers require sites to be served securely for them to listen to a mic. See [MediaDevices `getUserMedia()` security](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#security) for more details.
 
 ## API
@@ -194,4 +193,4 @@ import { Audio } from 'expo-av';
 
 ## Unified API
 
-The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref` - see the [AV documentation](av/#playback) for further information.
+The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref`. See the [AV documentation](av/#playback) for more information.

--- a/docs/pages/versions/v48.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/audio.mdx
@@ -182,8 +182,7 @@ See an example of **app.json** that enables audio playback in background:
 ### Notes on web usage
 
 - A MediaRecorder issue on Chrome produces WebM files missing the duration metadata. [See the open Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=642012).
-- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder).
-  or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
+- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder) or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
 - Web browsers require sites to be served securely for them to listen to a mic. See [MediaDevices `getUserMedia()` security](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#security) for more details.
 
 ## API
@@ -196,4 +195,4 @@ import { Audio } from 'expo-av';
 
 ## Unified API
 
-The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref` - see the [AV documentation](av/#playback) for further information.
+The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref`. See the [AV documentation](av/#playback) for more information.

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -182,8 +182,7 @@ See an example of **app.json** that enables audio playback in background:
 ### Notes on web usage
 
 - A MediaRecorder issue on Chrome produces WebM files missing the duration metadata. [See the open Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=642012).
-- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder).
-  or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
+- MediaRecorder encoding options and other configurations are inconsistent across browsers, utilizing a Polyfill such as [kbumsik/opus-media-recorder](https://github.com/kbumsik/opus-media-recorder) or [ai/audio-recorder-polyfill](https://github.com/ai/audio-recorder-polyfill) in your application will improve your experience. Any options passed to `prepareToRecordAsync` will be passed directly to the MediaRecorder API and as such the polyfill.
 - Web browsers require sites to be served securely for them to listen to a mic. See [MediaDevices `getUserMedia()` security](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#security) for more details.
 
 ## API
@@ -196,4 +195,4 @@ import { Audio } from 'expo-av';
 
 ## Unified API
 
-The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref` - see the [AV documentation](av/#playback) for further information.
+The rest of the API on the `Sound.Audio` is the same as the API for `Video` component `ref`. See the [AV documentation](av/#playback) for more information.

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -144,9 +144,9 @@ If your project does not support [Expo Prebuild](/workflow/prebuild) then you wo
 If the module is not supported in [Expo Go][expo-go], you can create a [development build](/develop/development-builds/introduction/):
 
 <BoxLink
-  title="Adding custom native code"
-  description="Learn how to create a development build."
-  href="/workflow/customizing"
+  title="Add custom native code"
+  description="Learn how to add custom native code to your Expo project."
+  href="/workflow/customizing/"
 />
 
 [expo-cli]: /more/expo-cli/


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Over the week, I found multiple minor formatting and verbiage issues across multiple docs. This PR fixes those issues. Also, updated client and server side redirects based on the weekly Sentry report.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
