### PR TITLE
[Android][core] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
 - [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided. ([#25688](https://github.com/expo/expo/pull/25688) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
 - [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided. ([#25688](https://github.com/expo/expo/pull/25688) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted.
+- [Android] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted. ([#25732](https://github.com/expo/expo/pull/25732) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -136,6 +136,11 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
         addToAskedPermissionsCache(arrayOf(Manifest.permission.WRITE_SETTINGS))
         askForWriteSettingsPermissionFirst()
       } else {
+        // User only ask for `WRITE_SETTINGS`, we can already return response
+        if (permissionsToAsk.isEmpty()) {
+          newListener.onResult(mutableMapOf())
+          return
+        }
         askForManifestPermissions(permissionsToAsk, newListener)
       }
     } else {


### PR DESCRIPTION
# Why

Fixes requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted

# How

When users only asked for `WRITE_SETTINGS` and permission was already granted, the promise wasn't resolved correctly. 

# Test Plan

- test-suite - brightness screen ✅