### PR TITLE
[docs] Add newsletter back in the sidebar footer

### DIFF
--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -1,5 +1,5 @@
 import { SnackLogo } from '@expo/styleguide';
-import { ChangelogIcon, DiscordIcon } from '@expo/styleguide-icons';
+import { ChangelogIcon, DiscordIcon, Mail01Icon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { SidebarSingleEntry } from './SidebarSingleEntry';
@@ -37,6 +37,13 @@ export const SidebarFooter = ({ isMobileMenuVisible }: SideBarFooterProps) => {
         Icon={DiscordIcon}
         isExternal
         shouldLeakReferrer
+      />
+      <SidebarSingleEntry
+        secondary
+        href="https://expo.dev/mailing-list/signup"
+        title="Newsletter"
+        Icon={Mail01Icon}
+        isExternal
       />
       {isMobileMenuVisible && (
         <SidebarSingleEntry


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1701454013893709)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adds newsletter link back in the sidebar footer.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit http://localhost:3002, and see the sidebar footer

## Preview

![CleanShot 2023-12-04 at 17 18 13@2x](https://github.com/expo/expo/assets/10234615/45729a95-a233-4e92-a0cc-d13560ac7504)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
