### PR TITLE
[status-bar] fix docs link in README file

### DIFF
--- a/packages/expo-status-bar/README.md
+++ b/packages/expo-status-bar/README.md
@@ -19,7 +19,7 @@ Provides the same interface as the React Native [StatusBar API](https://reactnat
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/status-bar/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 Please refer to the [React Native StatusBar API documentation](https://reactnative.dev/docs/statusbar).
 


### PR DESCRIPTION
# Why

Refs #25725

Port changes to `main`, did not spot that contributor selected SDK branch as base.

# How

Make sure that base file is up to date and included latest corrections.

# Test Plan

Status Bar README link works and leads to the correct docs.