### PR TITLE
[docs] Update latest SDK Expo Battery example to use hook and other updates

### DIFF
--- a/docs/pages/versions/unversioned/sdk/battery.mdx
+++ b/docs/pages/versions/unversioned/sdk/battery.mdx
@@ -24,35 +24,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Battery Usage' dependencies={['expo-battery']}>
 
 ```jsx
-import { useEffect, useState, useCallback } from "react";
-import * as Battery from "expo-battery";
-import { StyleSheet, Text, View } from "react-native";
+import { useBatteryLevel } from 'expo-battery';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
-  const [batteryLevel, setBatteryLevel] = useState(null);
-  const [subscription, setSubscription] = useState(null);
-
-  const _subscribe = async () => {
-    const batteryLevel = await Battery.getBatteryLevelAsync();
-    setBatteryLevel(batteryLevel);
-    
-    setSubscription(
-      Battery.addBatteryLevelListener(({ batteryLevel }) => {
-        setBatteryLevel(batteryLevel);
-        console.log("batteryLevel changed!", batteryLevel);
-      })
-    );
-  };
-
-  const _unsubscribe = useCallback(() => {
-    subscription && subscription.remove();
-    setSubscription(null);
-  }, [subscription]);
-
-  useEffect(() => {
-    _subscribe();
-    return () => _unsubscribe();
-  }, [_unsubscribe]);
+  const batteryLevel = useBatteryLevel();
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v46.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/battery.mdx
@@ -32,7 +32,7 @@ export default function App() {
   const [batteryLevel, setBatteryLevel] = useState(null);
   const [subscription, setSubscription] = useState(null);
 
-  const _subscribe = async () => {
+  const subscribe = async () => {
     const batteryLevel = await Battery.getBatteryLevelAsync();
     setBatteryLevel(batteryLevel);
 
@@ -44,15 +44,15 @@ export default function App() {
     );
   };
 
-  const _unsubscribe = useCallback(() => {
+  const unsubscribe = useCallback(() => {
     subscription && subscription.remove();
     setSubscription(null);
   }, [subscription]);
 
   useEffect(() => {
-    _subscribe();
-    return () => _unsubscribe();
-  }, [_unsubscribe]);
+    subscribe();
+    return () => unsubscribe();
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v47.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/battery.mdx
@@ -32,7 +32,7 @@ export default function App() {
   const [batteryLevel, setBatteryLevel] = useState(null);
   const [subscription, setSubscription] = useState(null);
 
-  const _subscribe = async () => {
+  const subscribe = async () => {
     const batteryLevel = await Battery.getBatteryLevelAsync();
     setBatteryLevel(batteryLevel);
 
@@ -50,9 +50,9 @@ export default function App() {
   }, [subscription]);
 
   useEffect(() => {
-    _subscribe();
-    return () => _unsubscribe();
-  }, [_unsubscribe]);
+    subscribe();
+    return () => unsubscribe();
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v48.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/battery.mdx
@@ -32,7 +32,7 @@ export default function App() {
   const [batteryLevel, setBatteryLevel] = useState(null);
   const [subscription, setSubscription] = useState(null);
 
-  const _subscribe = async () => {
+  const subscribe = async () => {
     const batteryLevel = await Battery.getBatteryLevelAsync();
     setBatteryLevel(batteryLevel);
 
@@ -50,9 +50,9 @@ export default function App() {
   }, [subscription]);
 
   useEffect(() => {
-    _subscribe();
-    return () => _unsubscribe();
-  }, [_unsubscribe]);
+    subscribe();
+    return () => unsubscribe();
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/v49.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/battery.mdx
@@ -24,35 +24,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Battery Usage' dependencies={['expo-battery']}>
 
 ```jsx
-import { useEffect, useState, useCallback } from 'react';
-import * as Battery from 'expo-battery';
+import { useBatteryLevel } from 'expo-battery';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
-  const [batteryLevel, setBatteryLevel] = useState(null);
-  const [subscription, setSubscription] = useState(null);
-
-  const _subscribe = async () => {
-    const batteryLevel = await Battery.getBatteryLevelAsync();
-    setBatteryLevel(batteryLevel);
-
-    setSubscription(
-      Battery.addBatteryLevelListener(({ batteryLevel }) => {
-        setBatteryLevel(batteryLevel);
-        console.log('batteryLevel changed!', batteryLevel);
-      })
-    );
-  };
-
-  const _unsubscribe = useCallback(() => {
-    subscription && subscription.remove();
-    setSubscription(null);
-  }, [subscription]);
-
-  useEffect(() => {
-    _subscribe();
-    return () => _unsubscribe();
-  }, [_unsubscribe]);
+  const batteryLevel = useBatteryLevel();
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #25095

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- Updates `unversioned` and SDK 49 example to use [`useBatteryLevel()`](https://docs.expo.dev/versions/latest/sdk/battery/#usebatterylevel) hook.
- In other SDK examples, remove `_unsubscribe` as dependency as it creates a stream of running `useEffect()` and also remove `_` from function handler names.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/battery/

## Preview

**unversioned and SDK 49**

![CleanShot 2023-12-04 at 22 12 25@2x](https://github.com/expo/expo/assets/10234615/ae1ce537-fb6e-4951-b3bd-e6191e2a5fb0)

**Older SDK versions**

![CleanShot 2023-12-04 at 22 13 00@2x](https://github.com/expo/expo/assets/10234615/7655eac6-1e57-4407-be14-61d1d76c66a1)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
