### PR TITLE
[docs] Add a known issue for component ordering when using `BlurView`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -17,6 +17,17 @@ A React component that blurs everything underneath the view. Common usage of thi
 
 <PlatformsSection emulator android ios simulator web />
 
+#### Known issues
+
+The blur effect does not update when `BlurView` is rendered before dynamic content is rendered using, for example, `FlatList`. To fix this, make sure that `BlurView` is rendered after the dynamic content component. For example:
+
+```jsx
+<View>
+  <FlatList />
+  <BlurView />
+</View>
+```
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -10,7 +10,6 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
-import { PlatformTags } from '~/ui/components/Tag';
 
 A React component that blurs everything underneath the view. Common usage of this is for navigation bars, tab bars, and modals.
 
@@ -35,7 +34,7 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.background}>
-        {[...Array(20).keys()].map((i) => (
+        {[...Array(20).keys()].map(i => (
           <View
             key={`box-${i}`}
             style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}

--- a/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
@@ -15,6 +15,17 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection ios simulator web />
 
+#### Known issues
+
+The blur effect does not update when `BlurView` is rendered before dynamic content is rendered using, for example, `FlatList`. To fix this, make sure that `BlurView` is rendered after the dynamic content component. For example:
+
+```jsx
+<View>
+  <FlatList />
+  <BlurView />
+</View>
+```
+
 ## Installation
 
 <APIInstallSection />
@@ -32,7 +43,7 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.background}>
-        {[...Array(20).keys()].map((i) => (
+        {[...Array(20).keys()].map(i => (
           <View
             key={`box-${i}`}
             style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}

--- a/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
@@ -15,6 +15,17 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection ios simulator web />
 
+#### Known issues
+
+The blur effect does not update when `BlurView` is rendered before dynamic content is rendered using, for example, `FlatList`. To fix this, make sure that `BlurView` is rendered after the dynamic content component. For example:
+
+```jsx
+<View>
+  <FlatList />
+  <BlurView />
+</View>
+```
+
 ## Installation
 
 <APIInstallSection />
@@ -32,7 +43,7 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.background}>
-        {[...Array(20).keys()].map((i) => (
+        {[...Array(20).keys()].map(i => (
           <View
             key={`box-${i}`}
             style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -18,9 +18,22 @@ A React component that blurs everything underneath the view. Common usage of thi
 
 <PlatformsSection emulator android ios simulator web />
 
-#### Known issues&ensp;<PlatformTags platforms={['android']} />
+#### Known issues
 
-`BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
+##### Incorrect rendering during screen transitions&nbsp;<PlatformTags platforms={['android']} />
+
+On Android, `BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
+
+##### Component render re-order in case of dynamic list
+
+The blur effect does not update when `BlurView` is rendered before dynamic content is rendered using, for example, `FlatList`. To fix this, make sure that `BlurView` is rendered after the dynamic content component. For example:
+
+```jsx
+<View>
+  <FlatList />
+  <BlurView />
+</View>
+```
 
 ## Installation
 
@@ -39,7 +52,7 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.background}>
-        {[...Array(20).keys()].map((i) => (
+        {[...Array(20).keys()].map(i => (
           <View
             key={`box-${i}`}
             style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C05R8KJK1PC/p1697170418830699)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Since this is a known issue in https://github.com/expo/expo/issues/6613, this PR documents it:

- Adds a known issue section for `unversioned`, SDK 48 and 47 API references
- Updates the known issue section in SDK 49 to add this as a section
- Remove unused import statement from `unversioned` reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/blur-view/#known-issues

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
