### PR TITLE
[expo-sensors] Add requestPermissionsAsync and getPermissionsAsync to pedometer

### DIFF
--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.kt
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package expo.modules.sensors.modules
 
+import android.Manifest
 import android.hardware.Sensor
 import android.os.Bundle
 import expo.modules.interfaces.sensors.services.PedometerServiceInterface
@@ -9,6 +10,9 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.sensors.UseSensorProxy
 import expo.modules.sensors.createSensorProxy
+import expo.modules.interfaces.permissions.Permissions
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.Promise
 
 private const val EventName = "Exponent.pedometerUpdate"
 
@@ -16,6 +20,9 @@ class NotSupportedException(message: String) : CodedException(message)
 
 class PedometerModule : Module() {
   private var stepsAtTheBeginning: Int? = null
+
+  private val permissionsManager: Permissions
+    get() = appContext.permissions ?: throw Exceptions.PermissionsModuleNotFound()
 
   private val sensorProxy by lazy {
     createSensorProxy<PedometerServiceInterface>(EventName) { sensorEvent ->
@@ -41,6 +48,22 @@ class PedometerModule : Module() {
     AsyncFunction("getStepCountAsync") { _: Int, _: Int ->
       throw NotSupportedException("Getting step count for date range is not supported on Android yet")
       Unit
+    }
+
+    AsyncFunction("requestPermissionsAsync") { promise: Promise ->
+      Permissions.getPermissionsWithPermissionsManager(
+        permissionsManager,
+        promise,
+        Manifest.permission.ACTIVITY_RECOGNITION
+      )
+    }
+
+    AsyncFunction("getPermissionsAsync") { promise: Promise ->
+      Permissions.getPermissionsWithPermissionsManager(
+        permissionsManager,
+        promise,
+        Manifest.permission.ACTIVITY_RECOGNITION
+      )
     }
   }
 }


### PR DESCRIPTION
# Why

Currently requestPermissionsAsync and getPermissionsAsync return `{"canAskAgain": true, "expires": "never", "granted": true, "status": "granted"}` even when the app does not have permission to read `ACTIVITY_RECOGNITION`.

There was an issue regarding this: https://github.com/expo/expo/issues/16920 which was resolved by using `PermissionsAndroid.request()` in bare workflow.

# How

The PR requests ACTIVITY_RECOGNITION permission when requestPermissionsAsync and getPermissionsAsync. This might not prompt the user to give the permission, but at least will notify the app that permission is not granted.

# Test Plan

For testing, I've published the package with the alternative name `expo-sensors-2` and built the project locally. I did a local build and received the following `{"canAskAgain": true, "expires": "never", "granted": false, "status": "undetermined"}` when the permission was not granted by user `{"canAskAgain": true, "expires": "never", "granted": true, "status": "granted"}` when permission was granted. Android never promoted to confirm the permission.

Testing device: Samsung S23+, Android 14

# Checklist

Updated endpoints were already documented
