### PR TITLE
[updates][e2e] Run all variants on workflow dispatch

### DIFF
--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
-        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
+        variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
-        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
+        variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ios, android]
-        variant: ${{ github.event_name == 'schedule' && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
+        variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:


### PR DESCRIPTION
# Why

When one of the updates e2e workflows is dispatched manually, we should run all variants.

# How

Add condition.

# Test Plan

CI (to check valid syntax). Then, once landed, dispatch these manually to verify that it works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
