### PR TITLE
[docs] Add docs for rollbacks and update rollouts

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -311,6 +311,7 @@ const general = [
       makePage('eas-update/environment-variables.mdx'),
       makePage('eas-update/code-signing.mdx'),
       makePage('eas-update/rollouts.mdx'),
+      makePage('eas-update/rollbacks.mdx'),
     ]),
     makeGroup('Reference', [
       makePage('eas-update/migrate-from-classic-updates.mdx'),

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -1,0 +1,30 @@
+---
+title: Rollbacks
+description: Roll back a branch to a previous update or the embedded update.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+> **info** Available for SDK 50+ (`expo-updates` >= 0.23.0).
+
+There are two types of roll backs supported by EAS Update:
+- Roll back to a previously-published update.
+- Roll back to the update embedded in the build.
+
+To start a roll back, use `npx eas-cli@latest` or ensure you have `eas-cli` version `5.9.0` or above. Then, run the following command:
+
+<Terminal cmd={['npx eas-cli@latest update:rollback']} />
+
+In the terminal, an interactive guide will assist you in selecting the type of rollback and doing the rollback.
+
+## Rolling-back to a previously-published update
+
+This command re-publishes a previously-published update to functionally roll-back clients to that update.
+
+## Rolling back to the update embedded in the build
+
+This command instructs the client to run the update embedded in the build.
+
+## Publishing after the rollback
+
+Upon publishing again after a rollback, all clients will receive the new update.

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -5,7 +5,7 @@ description: Roll back a branch to a previous update or the embedded update.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available for SDK 50+ (`expo-updates` >= 0.23.0).
+> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
 There are two types of roll backs supported by EAS Update:
 - Roll back to a previously-published update.
@@ -17,13 +17,13 @@ To start a roll back, use `npx eas-cli@latest` or ensure you have `eas-cli` vers
 
 In the terminal, an interactive guide will assist you in selecting the type of rollback and doing the rollback.
 
-## Rolling-back to a previously-published update
+## Rolling back to a previously-published update
 
-This command re-publishes a previously-published update to functionally roll-back clients to that update.
+The above command re-publishes a previously-published update to functionally roll-back clients to that update.
 
 ## Rolling back to the update embedded in the build
 
-This command instructs the client to run the update embedded in the build.
+The above command instructs the client to run the update embedded in the build.
 
 ## Publishing after the rollback
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -5,7 +5,7 @@ description: Incrementally deploy updates on a new branch to a channel.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** This feature is in Developer Preview. It's not advised to use this feature in any production environment.
+> **info** Available for SDK 50+ (`expo-updates` >= 0.23.0).
 
 Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, you can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -5,7 +5,7 @@ description: Incrementally deploy updates on a new branch to a channel.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** Available for SDK 50+ (`expo-updates` >= 0.23.0).
+> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
 Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, you can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 


### PR DESCRIPTION
# Why

Closes ENG-10809.

These two features are launching with 50, so they need documentation.

# How

Add docs.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
