### PR TITLE
[expo-updates][e2e] Fix reload test on android

### DIFF
--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -136,7 +136,7 @@ export default function App() {
       } catch (e) {
         console.warn(e);
       }
-    }, 1000);
+    }, 2000);
   };
 
   const handleCheckForUpdate = runBlockAsync(async () => {

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -101,7 +101,7 @@ describe('Basic tests', () => {
     await device.terminateApp();
   });
 
-  xit('reloads', async () => {
+  it('reloads', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(Update.serverPort, protocolVersion);
     await device.installApp();
@@ -116,6 +116,22 @@ describe('Basic tests', () => {
     jestExpect(startTimeBefore).toBeGreaterThan(0);
 
     await pressTestButtonAsync('reload');
+
+    // wait 3 seconds for reload to complete
+    // it's delayed 2 seconds after the button press in the client so the button press finish registers in detox
+    await setTimeout(3000);
+
+    // on android, the react context must be reacquired by detox.
+    // there's no detox public API to tell it that react native
+    // has been reloaded by the client application and that it should
+    // reacquire the react context. Instead, we use the detox reload
+    // API to do a second reload which reacquires the context. This
+    // detox reload method does the same thing that expo-updates reload does
+    // under the hood, so this is ok and is the best we can do. It should
+    // do the job of catching issues in react native either way.
+    if (device.getPlatform() === 'android') {
+      await device.reloadReactNative();
+    }
 
     const isReloadingAfter = await testElementValueAsync('isReloading');
     jestExpect(isReloadingAfter).toBe('false');


### PR DESCRIPTION
# Why

Reloading of react native in detox on android is less reliable than on iOS: https://github.com/wix/Detox/issues/1685

This PR updates the reload test on android to make it still test the functionality in a way that should raise issues if there are any in the underlying code, but does so in a hacky way.

# How

See inline comments.

# Test Plan

Run the tests locally in both debug and release variant on android and iOS.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
