### PR TITLE
[ios][image-manipulator] fix threading issue

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix an issue where the image is manipulated on a background thread.
+
 ### 💡 Others
 
 - [iOS] Replace legacy `FileSystem` interfaces usage with core `FileSystemUtilities`. ([#25495](https://github.com/expo/expo/pull/25495) by [@alanhughes](https://github.com/alanjhughes))

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix an issue where the image is manipulated on a background thread.
+- [iOS] Fix an issue where the image is manipulated on a background thread. ([#25756](https://github.com/expo/expo/pull/25756) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -13,27 +13,28 @@ public class ImageManipulatorModule: Module {
     Name("ExpoImageManipulator")
 
     AsyncFunction("manipulateAsync", manipulateImage)
-      .runOnQueue(.main)
   }
 
   internal func manipulateImage(url: URL, actions: [ManipulateAction], options: ManipulateOptions, promise: Promise) {
     loadImage(atUrl: url) { result in
       switch result {
       case .failure(let error):
-        return promise.reject(error)
+        promise.reject(error)
       case .success(let image):
-        do {
-          let newImage = try manipulate(image: image, actions: actions)
-          let saveResult = try self.saveImage(newImage, options: options)
-
-          promise.resolve([
-            "uri": saveResult.url.absoluteString,
-            "width": newImage.cgImage?.width ?? 0,
-            "height": newImage.cgImage?.height ?? 0,
-            "base64": options.base64 ? saveResult.data.base64EncodedString() : nil
-          ])
-        } catch {
-          promise.reject(error)
+        DispatchQueue.main.async {
+          do {
+            let newImage = try manipulate(image: image, actions: actions)
+            let saveResult = try self.saveImage(newImage, options: options)
+            
+            promise.resolve([
+              "uri": saveResult.url.absoluteString,
+              "width": newImage.cgImage?.width ?? 0,
+              "height": newImage.cgImage?.height ?? 0,
+              "base64": options.base64 ? saveResult.data.base64EncodedString() : nil
+            ])
+          } catch {
+            promise.reject(error)
+          }
         }
       }
     }

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -25,7 +25,7 @@ public class ImageManipulatorModule: Module {
           do {
             let newImage = try manipulate(image: image, actions: actions)
             let saveResult = try self.saveImage(newImage, options: options)
-            
+
             promise.resolve([
               "uri": saveResult.url.absoluteString,
               "width": newImage.cgImage?.width ?? 0,


### PR DESCRIPTION
# Why
Fixes an issue found in unversioned QA where image manipulator would cause a crash

# How
The reason for the crash is manipulating a UIView on a background thread. Even though the `AsyncFunction` was marked as using the `main` queue, this is not what we want. What we need is only the success callback to run on the `main` queue, everything else can and should happen on a background thread

# Test Plan
Unversioned expo go
Bare expo