### PR TITLE
[core][Android] Fix functions scheduled on the main thread weren't being called as soon as possible

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
 - [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided. ([#25688](https://github.com/expo/expo/pull/25688) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted. ([#25732](https://github.com/expo/expo/pull/25732) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix functions that are scheduled on the main thread weren't being called as soon as possible.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [Android] Prevent the app from crashing during reloading when an unfinished promise tries to execute.
 - [Android] Fix `JavaScriptFunction` not working when the return type wasn't provided. ([#25688](https://github.com/expo/expo/pull/25688) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fix requesting only `WRITE_SETTINGS` rejecting promise even if the permission was granted. ([#25732](https://github.com/expo/expo/pull/25732) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fix functions that are scheduled on the main thread weren't being called as soon as possible.
+- [Android] Fix functions that are scheduled on the main thread weren't being called as soon as possible. ([#25757](https://github.com/expo/expo/pull/25757) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -50,7 +50,7 @@ abstract class AnyFunction(
   /**
    * A minimum number of arguments the functions needs which equals to `argumentsCount` reduced by the number of trailing optional arguments.
    */
-  internal val requiredArgumentsCount = run {
+  private val requiredArgumentsCount = run {
     val nonNullableArgIndex = desiredArgsTypes
       .reversed()
       .indexOfFirst { !it.kType.isMarkedNullable }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.functions
 
+import android.view.View
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.BuildConfig
 import expo.modules.kotlin.AppContext
@@ -85,24 +86,32 @@ abstract class AsyncFunction(
         }
       }
 
-      if (queue == Queues.MAIN) {
-        if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      dispatchOnQueue(appContext, functionBody)
+    }
+  }
+
+  private fun dispatchOnQueue(appContext: AppContext, block: () -> Unit) {
+    when (queue) {
+      Queues.DEFAULT -> {
+        appContext.modulesQueue.launch {
+          block()
+        }
+      }
+
+      Queues.MAIN -> {
+        if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && desiredArgsTypes.any { it.inheritFrom<View>() }) {
           // On certain occasions, invoking a function on a view could lead to an error
           // because of the asynchronous communication between the JavaScript and native components.
           // In such cases, the native view may not have been mounted yet,
           // but the JavaScript code has already received the future tag of the view.
           // To avoid this issue, we have decided to temporarily utilize
           // the UIManagerModule for dispatching functions on the main thread.
-          appContext.dispatchOnMainUsingUIManager(functionBody)
-          return@registerAsyncFunction
+          appContext.dispatchOnMainUsingUIManager(block)
+          return
         }
 
         appContext.mainQueue.launch {
-          functionBody()
-        }
-      } else {
-        appContext.modulesQueue.launch {
-          functionBody()
+          block()
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.types
 
+import android.view.View
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
 import kotlin.reflect.KClass
@@ -62,4 +63,11 @@ class AnyType(
   fun convert(value: Any?, appContext: AppContext? = null): Any? = converter.convert(value, appContext)
 
   fun getCppRequiredTypes(): ExpectedType = converter.getCppRequiredTypes()
+
+  internal inline fun <reified T> inheritFrom(): Boolean {
+    val kClass = kType.classifier as? KClass<*> ?: return false
+    val jClass = kClass.java
+
+    return View::class.java.isAssignableFrom(jClass)
+  }
 }


### PR DESCRIPTION
# Why

Fixes functions scheduled on the main thread weren't being called as soon as possible.

# How

When adding the UIBlock, the UI queue won't be flushed on each frame, but when the components update occurs. To mitigate waiting, we're only dispatching using the `UIManager` when view is expected as a parameter.

# Test Plan

- bare-expo ✅
- test-suite ✅
- unit tests ✅