### PR TITLE
[tracking-transparency][android] Add tracking-transparency to Expo Go and Home

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -37,6 +37,7 @@ import expo.modules.splashscreen.SplashScreenModule
 import expo.modules.splashscreen.SplashScreenPackage
 import expo.modules.splashscreen.singletons.SplashScreen
 import expo.modules.taskManager.TaskManagerPackage
+import expo.modules.trackingtransparency.TrackingTransparencyModule
 import expo.modules.webbrowser.WebBrowserModule
 import host.exp.exponent.Constants
 import host.exp.exponent.ExponentManifest
@@ -172,6 +173,7 @@ open class HomeActivity : BaseExperienceActivity() {
         KeepAwakeModule::class.java,
         LinearGradientModule::class.java,
         SplashScreenModule::class.java,
+        TrackingTransparencyModule::class.java,
         WebBrowserModule::class.java,
       )
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -80,6 +80,7 @@ import expo.modules.systemui.SystemUIModule
 import expo.modules.systemui.SystemUIPackage
 import expo.modules.taskManager.TaskManagerModule
 import expo.modules.taskManager.TaskManagerPackage
+import expo.modules.trackingtransparency.TrackingTransparencyModule
 import expo.modules.updates.UpdatesPackage
 import expo.modules.videothumbnails.VideoThumbnailsModule
 import expo.modules.webbrowser.WebBrowserModule
@@ -185,6 +186,7 @@ object ExperiencePackagePicker : ModulesProvider {
     SQLiteModuleNext::class.java,
     SystemUIModule::class.java,
     TaskManagerModule::class.java,
+    TrackingTransparencyModule::class.java,
     VideoThumbnailsModule::class.java,
     VideoViewModule::class.java,
     WebBrowserModule::class.java,


### PR DESCRIPTION
# Why
ENG-10813

Attempting to use TrackingTransparency in Expo Go or Home on Android would lead to a failed import.

# How
Added tracking-transparency to `ExperiencePackagePicker.kt` and `HomeActivity.kt`

# Test Plan

Tested in ncl in Expo Go and in Home on Android 13

