### PR TITLE
[kernel] Fix deep links in expo go ios

### DIFF
--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.h
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.h
@@ -6,7 +6,7 @@
 #import "EXReactAppManager.h"
 #import "EXUtil.h"
 
-@interface EXKernelLinkingManager : NSObject <EXLinkingManagerScopedModuleDelegate>
+@interface EXKernelLinkingManager : NSObject <EXLinkingManagerScopedModuleDelegate, UIApplicationDelegate>
 
 /**
  *  Either opens the url on an existing bridge, or sends it to the kernel
@@ -44,6 +44,10 @@
 + (NSString *)releaseChannelWithUrlComponents:(NSURLComponents *)urlComponents;
 
 # pragma mark - app-wide linking handlers
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)URL
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options;
 
 + (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)URL

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -10,6 +10,7 @@
 #import <CocoaLumberjack/CocoaLumberjack.h>
 #import <React/RCTBridge+Private.h>
 #import <React/RCTUtils.h>
+#import <ExpoModulesCore/EXModuleRegistryProvider.h>
 
 NSString *kEXExpoDeepLinkSeparator = @"--/";
 NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
@@ -17,10 +18,13 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
 @interface EXKernelLinkingManager ()
 
 @property (nonatomic, weak) EXReactAppManager *appManagerToRefresh;
-
+@property int priority;
 @end
 
+
 @implementation EXKernelLinkingManager
+
+EX_REGISTER_SINGLETON_MODULE(KernelLinkingManager);
 
 - (void)openUrl:(NSString *)urlString isUniversalLink:(BOOL)isUniversalLink
 {
@@ -251,6 +255,14 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
 }
 
 #pragma mark - UIApplication hooks
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)URL
+            options:options
+{
+  [[EXKernel sharedInstance].serviceRegistry.linkingManager openUrl:URL.absoluteString isUniversalLink:NO];
+  return YES;
+}
 
 + (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)URL


### PR DESCRIPTION
# Why

Deep links are broken in Expo Go iOS.

Before:

https://github.com/expo/expo/assets/5597580/6eae3951-306c-492d-bf08-77325fa8f8e1

After:

https://github.com/expo/expo/assets/5597580/07eedd29-0de1-4ce0-8734-03bea699acde

# How

I made the ExKernelLinkingManager register as a singleton module and added an instance method to handle the links.

Note:
This might not be the way this worked before – I'm struggling in finding where it broke and how it was connected before – I don't think this implementation breaks scoping but I'm not a 100% sure.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
