### PR TITLE
[test-suite] Update SecureStore tests

### DIFF
--- a/apps/test-suite/tests/SecureStore.js
+++ b/apps/test-suite/tests/SecureStore.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import * as SecureStore from 'expo-secure-store';
-import { Platform } from 'react-native';
 
 export const name = 'SecureStore';
 
@@ -96,22 +95,10 @@ export function test(t) {
         const result = await SecureStore.setItemAsync(key, value, optionsServiceA);
         t.expect(result).toBe(undefined);
       });
-      if (Platform.OS === 'ios') {
-        t.it('Fetch value with keychainServiceB, expect null', async () => {
-          const result = await SecureStore.getItemAsync(key, optionsServiceB);
-          t.expect(result).toBe(null);
-        });
-      } else if (Platform.OS === 'android') {
-        t.it('Fetch value with keychainServiceB, expect decoding error', async () => {
-          try {
-            const result = await SecureStore.getItemAsync(key, optionsServiceB);
-            t.fail(result);
-          } catch (e) {
-            t.expect(e).toBeTruthy();
-            t.expect(e.message).toMatch(`Could not encrypt/decrypt the value for SecureStore`);
-          }
-        });
-      }
+      t.it('Fetch value with keychainServiceB, expect null', async () => {
+        const result = await SecureStore.getItemAsync(key, optionsServiceB);
+        t.expect(result).toBe(null);
+      });
     });
     t.describe('store long value, fetch long value -> Success:', () => {
       t.it('Set long value', async () => {


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/23804 I modified the behaviour of SecureStore to be consistent with iOS. 
This introduced a change, where trying to get a value from a keychain service in which it isn't registered will return null instead of throwing an exception. (I would prefer to do it the other way around - throwing an exception in that case seems to make more sense - it was not possible to do on iOS)

This causes one of the tests to fail in `test-suite`

# How

Removed OS type check from the failing test

# Test Plan

✅  `native-component-list` in unversioned Expo Go


