### PR TITLE
 [home] Fix path imports

### DIFF
--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -8,7 +8,6 @@ import {
 import { createStackNavigator, TransitionPresets } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, StyleSheet, Linking } from 'react-native';
-import { DiagnosticsStackScreen } from 'screens/DiagnosticsScreen';
 
 import BottomTab, { getNavigatorProps } from './BottomTabNavigator';
 import { HomeStackRoutes, SettingsStackRoutes, ModalStackRoutes } from './Navigation.types';
@@ -30,6 +29,8 @@ import {
   alertWithCameraPermissionInstructions,
   requestCameraPermissionsAsync,
 } from '../utils/PermissionUtils';
+
+import { DiagnosticsStackScreen } from '@/screens/DiagnosticsScreen';
 
 // TODO(Bacon): Do we need to create a new one each time?
 const HomeStack = createStackNavigator<HomeStackRoutes>();

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -1,6 +1,5 @@
 import { borderRadius, CheckIcon, iconSize, spacing, UsersIcon } from '@expo/styleguide-native';
 import { useNavigation } from '@react-navigation/native';
-import { SectionHeader } from 'components/SectionHeader';
 import { Text, View, Image, useExpoTheme, Row, Spacer, Divider } from 'expo-dev-client-components';
 import React from 'react';
 import { FlatList } from 'react-native';
@@ -10,6 +9,8 @@ import { Home_CurrentUserActorQuery } from '../../graphql/types';
 import { useDispatch } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
+
+import { SectionHeader } from '@/components/SectionHeader';
 
 type Props = {
   accounts: Exclude<Home_CurrentUserActorQuery['meUserActor'], undefined | null>['accounts'];

--- a/home/screens/DiagnosticsScreen/index.tsx
+++ b/home/screens/DiagnosticsScreen/index.tsx
@@ -5,9 +5,7 @@ import {
   StackNavigationProp,
   StackScreenProps,
 } from '@react-navigation/stack';
-import { ColorTheme } from 'constants/Colors';
 import { Spacer } from 'expo-dev-client-components';
-import defaultNavigationOptions from 'navigation/defaultNavigationOptions';
 import * as React from 'react';
 
 import AudioDiagnosticsScreen from './AudioDiagnosticsScreen';
@@ -17,6 +15,9 @@ import LocationDiagnosticsScreen from './LocationDiagnosticsScreen';
 import ScrollView from '../../components/NavigationScrollView';
 import { DiagnosticsStackRoutes } from '../../navigation/Navigation.types';
 import Environment from '../../utils/Environment';
+
+import { ColorTheme } from '@/constants/Colors';
+import defaultNavigationOptions from '@/navigation/defaultNavigationOptions';
 
 function useThemeName() {
   const theme = useTheme();

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -1,6 +1,5 @@
 import { spacing } from '@expo/styleguide-native';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import FeatureFlags from 'FeatureFlags';
 import { Text, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
@@ -8,6 +7,8 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { DevelopmentServersOpenQR } from './DevelopmentServersOpenQR';
 import { DevelopmentServersOpenURL } from './DevelopmentServersOpenURL';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
+
+import FeatureFlags from '@/FeatureFlags';
 
 type Props = {
   isAuthenticated: boolean;

--- a/home/screens/SettingsScreen/index.tsx
+++ b/home/screens/SettingsScreen/index.tsx
@@ -1,6 +1,5 @@
 import { Spacer, View } from 'expo-dev-client-components';
 import * as Tracking from 'expo-tracking-transparency';
-import { useHome_CurrentUserActorQuery } from 'graphql/types';
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
@@ -10,6 +9,8 @@ import { DeleteAccountSection } from './DeleteAccountSection';
 import { DevMenuGestureSection } from './DevMenuGestureSection';
 import { ThemeSection } from './ThemeSection';
 import { TrackingSection } from './TrackingSection';
+
+import { useHome_CurrentUserActorQuery } from '@/graphql/types';
 
 export function SettingsScreen() {
   const { data } = useHome_CurrentUserActorQuery();

--- a/home/tsconfig.json
+++ b/home/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "noImplicitAny": true,
     "paths": {
-      "*": ["./*"]
+      "@/*": ["./*"]
     }
   },
   "exclude": ["**/__mocks__/*"]

--- a/home/tsconfig.json
+++ b/home/tsconfig.json
@@ -7,7 +7,10 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "paths": {
+      "*": ["./*"]
+    }
   },
   "exclude": ["**/__mocks__/*"]
 }


### PR DESCRIPTION
# Why

After merging https://github.com/expo/expo/pull/25510 imports like `import X from 'screens/DiagnosticsScreen';` stopped working on /home

# How

Add `paths` key to `tsconfig.json`

# Test Plan

Run expo go with DEV_KERNEL_SOURCE LOCAL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
