### PR TITLE
fix(expo-module-scripts): enable `universe/node` preset for root config files

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add Node-specific Babel and Jest configurations. ([#25458](https://github.com/expo/expo/pull/25458) by [@byCedric](https://github.com/byCedric))
+- Add Node override in ESLint config for root configuraiton files. ([#25767](https://github.com/expo/expo/pull/25767) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-module-scripts/eslintrc.base.js
+++ b/packages/expo-module-scripts/eslintrc.base.js
@@ -7,6 +7,10 @@ module.exports = {
       env: { node: true },
       globals: { __DEV__: true },
     },
+    {
+      files: ['./*.config.js', './.*rc.js'],
+      extends: ['universe/node'],
+    },
   ],
   rules: {
     'no-restricted-imports': [


### PR DESCRIPTION
# Why

This enables the Node environment in ESLint for root config files within each package. When using `__dirname` in `jest.config.js`, eslint currently warns that `__dirname` is unavailable.

Config files currently matching patterns are:
- `babel.config.js` (based on `./*.config.js`)
- `jest.config.js` (based on `./*.config.js`)
- `metro.config.js` (based on `./*.config.js`)
- `.eslintrc.js` (based on `./.*rc.js`)
- `.prettierrc.js` (based on `./.*rc.js`)

# How

- Added override to `eslintrc.base.js`

# Test Plan

- Open any package with `jest.config.js`
- Write `console.log(__dirname);`
- ESLint should not warn related to `__dirname`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
