### PR TITLE
[updates][e2e] Increase timeout

### DIFF
--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -32,7 +32,7 @@ jobs:
         platform: [ios, android]
         variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 80
     env:
       UPDATES_PORT: 4747
     steps:

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -32,7 +32,7 @@ jobs:
         platform: [ios, android]
         variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 80
     env:
       UPDATES_PORT: 4747
     steps:

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -58,7 +58,7 @@ jobs:
         platform: [ios, android]
         variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 80
     env:
       UPDATES_PORT: 4747
     steps:


### PR DESCRIPTION
# Why

This run https://github.com/expo/expo/actions/runs/7095925362 timed out due to not enough parallel builds on the EAS account.

# How

Increase timeout so that the lack of build parallelism doesn't affect CI green-ness.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
