### PR TITLE
[expo-go] Revert deep linking ExpoKitAppDelegate removals

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		A1C33FE42667F6E70091644A /* EXSplashScreenHUDButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A1C33FDB2667F6E70091644A /* EXSplashScreenHUDButton.m */; };
 		A1C33FE52667F6E70091644A /* EXSplashScreenHUDButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A1C33FDB2667F6E70091644A /* EXSplashScreenHUDButton.m */; };
 		B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */; };
+		B21355FC2B1FA9D80016AAB5 /* ExpoKitAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B21355F82B1FA8D90016AAB5 /* ExpoKitAppDelegate.m */; };
+		B21355FD2B1FA9D80016AAB5 /* ExpoKitAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B21355F82B1FA8D90016AAB5 /* ExpoKitAppDelegate.m */; };
 		B216039C2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */; };
 		B216039D2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */; };
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
@@ -704,6 +706,8 @@
 		A60CC11587F645D0BF1C832F /* RNCPicker.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; path = RNCPicker.m; sourceTree = "<group>"; };
 		B21115F6246C1B47005BA616 /* EXScopedNotificationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationBuilder.h; sourceTree = "<group>"; };
 		B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationBuilder.m; sourceTree = "<group>"; };
+		B21355F72B1FA8D90016AAB5 /* ExpoKitAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpoKitAppDelegate.h; sourceTree = "<group>"; };
+		B21355F82B1FA8D90016AAB5 /* ExpoKitAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExpoKitAppDelegate.m; sourceTree = "<group>"; };
 		B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXExpoGoLauncherSelectionPolicyFilterAware.swift; sourceTree = "<group>"; };
 		B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedErrorRecoveryModule.m; sourceTree = "<group>"; };
 		B22BB0332366F3F400EE04EC /* EXScopedErrorRecoveryModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedErrorRecoveryModule.h; sourceTree = "<group>"; };
@@ -1274,6 +1278,8 @@
 		B526B5031E6A543500606CAB /* ExpoKit */ = {
 			isa = PBXGroup;
 			children = (
+				B21355F72B1FA8D90016AAB5 /* ExpoKitAppDelegate.h */,
+				B21355F82B1FA8D90016AAB5 /* ExpoKitAppDelegate.m */,
 				B526B5041E6A543500606CAB /* ExpoKit.h */,
 				B526B5051E6A543500606CAB /* ExpoKit.m */,
 				B5D0D65A204F152D00DDFC99 /* EXViewController.h */,
@@ -2690,6 +2696,7 @@
 				31AD99EB2285B51100F19090 /* AIRGoogleMapMarker.m in Sources */,
 				F108698B2448B11D00B7DC04 /* EXDevMenuMotionInterceptor.m in Sources */,
 				B2E2CCD02AA7DF9C00E2260C /* HomeAppLoaderTask.swift in Sources */,
+				B21355FC2B1FA9D80016AAB5 /* ExpoKitAppDelegate.m in Sources */,
 				F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */,
 				F138E0D32A5F1AE9002E15BC /* EXVersionUtils.mm in Sources */,
 				31AD99DC2285B51100F19090 /* AIRGoogleMapPolygon.m in Sources */,
@@ -2944,6 +2951,7 @@
 				F1421901262CB68600BB97E6 /* EXScopedNotificationsHandlerModule.m in Sources */,
 				837259A9280671D200E204C1 /* AIRMapUrlTileCachedOverlay.m in Sources */,
 				19762DC50FD4D897EDAF61A5 /* ExpoModulesProvider.swift in Sources */,
+				B21355FD2B1FA9D80016AAB5 /* ExpoKitAppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Exponent/ExpoKit/ExpoKit.h
+++ b/ios/Exponent/ExpoKit/ExpoKit.h
@@ -4,6 +4,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXPORT NSString * const EXAppDidRegisterForRemoteNotificationsNotification;
+FOUNDATION_EXPORT NSString * const EXAppDidRegisterUserNotificationSettingsNotification;
+
 @class EXViewController;
 
 @interface ExpoKit : NSObject
@@ -40,6 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSDictionary *launchOptions;
 
 @property (nonatomic, weak) Class moduleRegistryDelegateClass;
+
+#pragma mark - remote JS loading hooks
+
+/**
+ *  If specified, use this url instead of the one configured in `EXShell.plist`.
+ *  Must be set prior to loading the RN application.
+ */
+@property (nonatomic, strong, nullable) NSString *publishedManifestUrlOverride;
+
+#pragma mark - deep linking hooks
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler;
 
 @end
 

--- a/ios/Exponent/ExpoKit/ExpoKitAppDelegate.h
+++ b/ios/Exponent/ExpoKit/ExpoKitAppDelegate.h
@@ -1,0 +1,13 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ExpoKitAppDelegate : EXSingletonModule <UIApplicationDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
+++ b/ios/Exponent/ExpoKit/ExpoKitAppDelegate.m
@@ -1,0 +1,33 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXModuleRegistryProvider.h>
+
+#import "ExpoKitAppDelegate.h"
+#import "ExpoKit.h"
+#import "EXViewController.h"
+
+@implementation ExpoKitAppDelegate
+
+EX_REGISTER_SINGLETON_MODULE(ExpoKitAppDelegate)
+
+- (const NSInteger)priority
+{
+  return -1;
+}
+
+#pragma mark - Handling URLs
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
+  NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
+  
+  return [[ExpoKit sharedInstance] application:app openURL:url sourceApplication:sourceApplication annotation:annotation];
+}
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+  return [[ExpoKit sharedInstance] application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+}
+
+@end


### PR DESCRIPTION
# Why

It was noticed that removing `ExpoKitAppDelegate` broke deep linking (fixed in https://github.com/expo/expo/pull/25759).

This PR is for posterity only as it shows a revert that also would fix deep linking if we needed it.

I also checked that the other deletions in `ExpoKitAppDelegate` (notifications) are unaffected by the deletion by creating an app with push notifications and sending a push (on main branch).

Closes ENG-10821.

# How

partial revert

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
