### PR TITLE
[expo-go][ios] Always run ios-generate-dynamic-macros build step

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -2296,6 +2296,7 @@
 		};
 		78CEE2F21ACDF25E0095B124 /* Generate Dynamic Macros */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
# Why

Ever since https://github.com/expo/expo/pull/24216, we need to generate the manifest and asset HMACs as close to build & run time as possible so that the asset downloads work (the HMACs in eas-update expire after a certain amount of time).

This was causing issues in iOS builds when the build pipeline would decide that the ios-generate-dynamic-macros build step was up-to-date and didn't need to be run, when in fact the HMACs may have expired.

Closes ENG-10761.

# How

Always run the ios-generate-dynamic-macros build step.

# Test Plan

Build and run.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
