### PR TITLE
[docs] Update pre-release info for alpha->canary and mention beta

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -54,17 +54,23 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
 
 New Expo SDK versions are released three times each year. Between these releases, we publish pre-release versions of the `expo` package and all of the Expo SDK packages. Pre-releases are not considered stable and should only be used if you are comfortable with the risk of encountering bugs or other issues.
 
-Pre-release versions of the `expo` package are versioned with an `-alpha` suffix, such as `50.0.0-alpha.1`. To install, for example, SDK 50 alpha, you can run the following command:
+### Canary releases
+
+Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `50.0.0-canary-20231205-250b31f`. To install the latest canary release:
 
 <Terminal
   cmd={[
     '# Install the alpha version of expo and its related packages',
-    '$ npm install expo@50.0.0-alpha && npx expo install --fix',
+    '$ npm install expo@canary && npx expo install --fix',
   ]}
-  cmdCopy="npm install expo@50.0.0-alpha && npx expo install --fix"
+  cmdCopy="npm install expo@canary && npx expo install --fix"
 />
 
-You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in alpha-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the alpha package and once you have verified that it works well for your use cases.
+You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in canary-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the canary package and once you have verified that it works well for your use cases.
+
+### Beta releases
+
+Prior to each Expo SDK release, we publish beta versions of the `expo` package and all of the Expo SDK packages. Beta releases are considered much more stable than canary releases, and we encourage developers to try them out on their apps and share their feedback. Beta releases use the `beta` tag on npm and follow the instructions in the related [changelog](https://expo.dev/changelog) post.
 
 ## Each Expo SDK version depends on a React Native version
 

--- a/docs/pages/versions/v49.0.0/index.mdx
+++ b/docs/pages/versions/v49.0.0/index.mdx
@@ -53,14 +53,23 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
 
 New Expo SDK versions are released three times each year. Between these releases, we publish pre-release versions of the `expo` package and all of the Expo SDK packages. Pre-releases are not considered stable and should only be used if you are comfortable with the risk of encountering bugs or other issues.
 
-Pre-release versions of the `expo` package are versioned with an `-alpha` suffix, such as `50.0.0-alpha.1`. To install, for example, SDK 50 alpha, you can run the following command:
+### Canary releases
+
+Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `50.0.0-canary-20231205-250b31f`. To install the latest canary release:
 
 <Terminal
-  cmd={['# Install the alpha version of expo and its related packages', '$ npm install expo@50.0.0-alpha && npx expo install --fix']}
-  cmdCopy="npm install expo@50.0.0-alpha && npx expo install --fix"
+  cmd={[
+    '# Install the alpha version of expo and its related packages',
+    '$ npm install expo@canary && npx expo install --fix',
+  ]}
+  cmdCopy="npm install expo@canary && npx expo install --fix"
 />
 
-You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in alpha-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the alpha package and once you have verified that it works well for your use cases.
+You can often use pre-release versions of individual packages with stable releases of the Expo SDK. There may occasionally be incompatibilities or other issues that arise in canary-quality releases. You may want to [silence dependency validation warnings](/more/expo-cli/#configuring-dependency-validation) if you opt in to the canary package and once you have verified that it works well for your use cases.
+
+### Beta releases
+
+Prior to each Expo SDK release, we publish beta versions of the `expo` package and all of the Expo SDK packages. Beta releases are considered much more stable than canary releases, and we encourage developers to try them out on their apps and share their feedback. Beta releases use the `beta` tag on npm and follow the instructions in the related [changelog](https://expo.dev/changelog) post.
 
 ## Each Expo SDK version depends on a React Native version
 


### PR DESCRIPTION
# Why

We're using "canary" releases rather than "alpha" releases

# How

<img width="1502" alt="image" src="https://github.com/expo/expo/assets/90494/0f3d561a-4679-40ce-b445-c01ecfbe4e54">
