### PR TITLE
[go] add android sdk50 versioned code

### DIFF
--- a/android/versioned-react-native/settings.gradle
+++ b/android/versioned-react-native/settings.gradle
@@ -3,3 +3,11 @@ include ':packages:react-native:ReactAndroid'
 project(':packages:react-native:ReactAndroid').projectDir = new File(rootDir, 'packages/react-native/ReactAndroid')
 include ':packages:react-native:ReactAndroid:hermes-engine'
 project(':packages:react-native:ReactAndroid:hermes-engine').projectDir = new File(rootDir, 'packages/react-native/ReactAndroid/hermes-engine')
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files("./packages/react-native/gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/tools/src/versioning/android/libraries.ts
+++ b/tools/src/versioning/android/libraries.ts
@@ -26,7 +26,7 @@ export const JniLibNames = [
   'hermes',
   'hermes_executor',
   'hermes_executor_common',
-  'hermes_inspector',
+  'hermes_inspector_modern',
   'reanimated',
   'folly_futures',
   'folly_runtime',

--- a/tools/src/versioning/android/reactNativeTransforms.ts
+++ b/tools/src/versioning/android/reactNativeTransforms.ts
@@ -30,6 +30,27 @@ export function reactNativeTransforms(
         find: /(\bid\("com\.facebook\.react"\)$)/m,
         replaceWith: '// $1',
       },
+      // Fix classpath with an unknown version
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /(\alias\(libs\.plugins\.android\.library\)$)/m,
+        replaceWith: 'id("com.android.library")',
+      },
+      {
+        paths: './ReactAndroid/hermes-engine/build.gradle',
+        find: /(\alias\(libs\.plugins\.android\.library\)$)/m,
+        replaceWith: 'id("com.android.library")',
+      },
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /(\alias\(libs\.plugins\.download\)$)/m,
+        replaceWith: 'id("de.undercouch.download")',
+      },
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /(\alias\(libs\.plugins\.kotlin\.android\)$)/m,
+        replaceWith: 'id("org.jetbrains.kotlin.android")',
+      },
       {
         paths: './ReactAndroid/build.gradle',
         find: /(^react {[^]+?\n\})/m,
@@ -37,7 +58,22 @@ export function reactNativeTransforms(
       },
       {
         paths: './ReactAndroid/build.gradle',
-        find: /(\b(preBuild\.)?dependsOn\("generateCodegenArtifactsFromSchema"\))/g,
+        find: /(\b(preBuild\.)?dependsOn\("generateCodegenArtifactsFromSchema"\))/m,
+        replaceWith: '// $1',
+      },
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /\b(generateCodegenSchemaFromJavaScript.dependsOn\(buildCodegenCLITask\))/m,
+        replaceWith: '// $1',
+      },
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /\b(buildCodegenCLITask,)/g,
+        replaceWith: '// $1',
+      },
+      {
+        paths: './ReactAndroid/build.gradle',
+        find: /\b(generateCodegenArtifactsFromSchema,)/g,
         replaceWith: '// $1',
       },
       {
@@ -108,7 +144,7 @@ export function reactNativeTransforms(
       })),
       // add HERMES_ENABLE_DEBUGGER for libhermes-executor-release.so
       {
-        paths: './ReactAndroid/hermes-engine/build.gradle',
+        paths: ['./ReactAndroid/hermes-engine/build.gradle', './sdks/hermes/android/hermes/build.gradle'],
         find: /-DHERMES_ENABLE_DEBUGGER=False/,
         replaceWith: '-DHERMES_ENABLE_DEBUGGER=True',
       },
@@ -126,12 +162,20 @@ export function reactNativeTransforms(
         paths: [
           './ReactCommon/hermes/executor/CMakeLists.txt',
           './ReactCommon/hermes/inspector/CMakeLists.txt',
+          './ReactCommon/hermes/inspector-modern/CMakeLists.txt',
+          './ReactCommon/react/runtime/hermes/CMakeLists.txt'
         ],
         find: /if\(\${CMAKE_BUILD_TYPE} MATCHES Debug\)(\n\s*target_compile_options)/g,
         replaceWith: 'if(true)$1',
       },
       {
-        paths: './ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt',
+        paths: [
+          './ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt',
+          './ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt',
+          './ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt',
+          './ReactCommon/react/runtime/CMakeLists.txt',
+          '.sdks/hermes/CMakeLists.txt'
+        ],
         find: '$<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>',
         replaceWith: '-DHERMES_ENABLE_DEBUGGER=1',
       },
@@ -140,7 +184,7 @@ export function reactNativeTransforms(
         // originally, it's hermes_inspector -> hermes_executor_common -> hermes_executor
         paths: './ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt',
         find: /^(\s+hermes_executor_common.*)$/m,
-        replaceWith: `$1\n        hermes_inspector_${abiVersion}`,
+        replaceWith: `$1\n        hermes_inspector_modern_${abiVersion}`,
       },
     ],
   };

--- a/tools/src/versioning/android/versionReactNative.ts
+++ b/tools/src/versioning/android/versionReactNative.ts
@@ -73,12 +73,21 @@ async function versionHermesAsync(versionedReactNativeMonorepoRoot: string, abiV
     ),
     hermesTransforms(abiVersion)
   );
+  await transformFileAsync(
+    path.join(
+      versionedReactNativeMonorepoRoot,
+      'packages/react-native',
+      'sdks/hermes/API/hermes/inspector/CMakeLists.txt'
+    ),
+    hermesTransforms(abiVersion)
+  );
 }
 
 async function versionReactNativeAsync(versionedReactNativeRoot: string, abiVersion: string) {
   const files = await searchFilesAsync(REACT_NATIVE_SUBMODULE_DIR, [
     './ReactAndroid/**',
     './ReactCommon/**',
+    './gradle/**',
   ]);
   for (const file of files) {
     if ((file.match(/\/build\//) && !file.match(/src.*\/build\//)) || file.match(/\/\.cxx\//)) {


### PR DESCRIPTION
WIP - Currently stuck on `undefined symbol: facebook::hermes::inspector_modern::chrome::disableDebugging(int)`

# Why

For SDK 50

# How

- [go] add android sdk 50 versioned code
- [tools] minor fix for android versioning

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
