### PR TITLE
[docs] Add a section on how to read from environment variables

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -48,11 +48,13 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
 
 ### How to read from environment variables
 
+Once an environment variable is loaded into your app, it remains constant during an app's runtime. This means that the variable is a static property. It does not change unless a different value is set for the variable and the app is reloaded.
+
 - <YesIcon small /> **Every environment variable must be referenced as a static property for it to be
   inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.
 
 - <NoIcon small /> **Alternative versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
-  or `const {EXPO_PUBLIC_X} = process.env` are invalid and will not be inlined.
+  or `const {EXPO_PUBLIC_X} = process.env` is invalid and will not be inlined.
 
 ### Using multiple .env files to define separate environments
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -48,10 +48,7 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
 
 ### How to read from environment variables
 
-Once an environment variable is loaded into your app, it remains constant during that app's runtime. This means that the variable is a static property. It does not change unless a different value is set for the variable and the app is reloaded.
-
-- <YesIcon small /> **Every environment variable must be referenced as a static property for it to be
-  inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.
+- <YesIcon small /> **Every environment variable must be statically referenced as a property of `process.env` using JavaScript's dot notation for it to be inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.
 
 - <NoIcon small /> **Alternative versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
   or `const {EXPO_PUBLIC_X} = process.env` is invalid and will not be inlined.

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -48,7 +48,7 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
 
 ### How to read from environment variables
 
-Once an environment variable is loaded into your app, it remains constant during an app's runtime. This means that the variable is a static property. It does not change unless a different value is set for the variable and the app is reloaded.
+Once an environment variable is loaded into your app, it remains constant during that app's runtime. This means that the variable is a static property. It does not change unless a different value is set for the variable and the app is reloaded.
 
 - <YesIcon small /> **Every environment variable must be referenced as a static property for it to be
   inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -49,10 +49,9 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
 ### How to read from environment variables
 
 - <YesIcon small /> **Every environment variable must be referenced as a static property for it to be
-  inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` and `const EXPO_PUBLIC_KEY = process.env.EXPO_PUBLIC_KEY`
-  are valid and will be inlined.
+  inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.
 
-- <NoIcon small /> **Dynamic versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
+- <NoIcon small /> **Alternative versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
   or `const {EXPO_PUBLIC_X} = process.env` are invalid and will not be inlined.
 
 ### Using multiple .env files to define separate environments

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -53,7 +53,7 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
   are valid and will be inlined.
 
 - <NoIcon small /> **Dynamic versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
-  or `const {EXPO_PUBLIC_X} = process.env` will not be inlined.
+  or `const {EXPO_PUBLIC_X} = process.env` are invalid and will not be inlined.
 
 ### Using multiple .env files to define separate environments
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -5,6 +5,7 @@ description: Learn how to use environment variables in an Expo project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 Environment variables are key-value pairs configured outside your source code that allow your app to behave differently depending on the environment. For example, you can enable or disable certain features when building a test version of your app, or switch to a different API endpoint when building for production.
 
@@ -14,7 +15,7 @@ The Expo CLI will automatically load environment variables with an `EXPO_PUBLIC_
 
 ## Reading environment variables from .env files
 
-Create an **.env** file in the root of your project directory and add environment-specific variables on new lines in the form of `EXPO_PUBLIC_[NAME]=VALUE`:
+Create a **.env** file in the root of your project directory and add environment-specific variables on new lines in the form of `EXPO_PUBLIC_[NAME]=VALUE`:
 
 ```bash .env
 EXPO_PUBLIC_API_URL=https://staging.example.com
@@ -45,7 +46,14 @@ When you run `npx expo start`, `process.env.EXPO_PUBLIC_API_URL` will be replace
 
 Expo CLI loads **.env** files according to the [standard .env file resolution](https://github.com/bkeepers/dotenv/blob/c6e583a/README.md#what-other-env-files-can-i-use) and then replaces all references in your code to `process.env.EXPO_PUBLIC_[VARNAME]` with the corresponding value set in the **.env** files. Code inside **node_modules** is not affected for security purposes.
 
-Every variable must be referenced as a static property in order for it to be inlined. For example, the expression `process.env.EXPO_PUBLIC_KEY` will be rewritten, but `process.env['EXPO_PUBLIC_KEY']` will not.
+### How to read from environment variables
+
+- <YesIcon small /> **Every environment variable must be referenced as a static property for it to be
+  inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` and `const EXPO_PUBLIC_KEY = process.env.EXPO_PUBLIC_KEY`
+  are valid and will be inlined.
+
+- <NoIcon small /> **Dynamic versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
+  or `const {EXPO_PUBLIC_X} = process.env` will not be inlined.
 
 ### Using multiple .env files to define separate environments
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C5ERY0TAR/p1701748548030349) 
Closes ENG-10729

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a new section on how to read from environment variables and highlight by providing examples on which expressions are valid and will be inlined and which are invalid.
- Fix a minor typo.
- Update How variables are loaded section to remove reference of inlined variables.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/environment-variables/#how-to-read-from-environment-variables

### Preview

![CleanShot 2023-12-06 at 03 24 27@2x](https://github.com/expo/expo/assets/10234615/dea2dbbe-b4e4-48f5-974e-81a19a6ef792)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
