### PR TITLE
docs: improve app.config.ts documentation for importing .ts files

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -276,7 +276,7 @@ module.exports = config;
 **app.config.ts** is supported by default. However, it doesn't support external TypeScript modules, or **tsconfig.json** customization. You can use the following approach to get a more comprehensive TypeScript setup:
 
 ```ts app.config.ts
-import 'ts-node/register' // Add if you want to import TypeScript files
+import 'ts-node/register' // Add this to import TypeScript files
 import { ExpoConfig } from 'expo/config';
 
 // In SDK 46 and lower, use the following import instead:

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -275,12 +275,8 @@ module.exports = config;
 
 **app.config.ts** is supported by default. However, it doesn't support external TypeScript modules, or **tsconfig.json** customization. You can use the following approach to get a more comprehensive TypeScript setup:
 
-```js app.config.js
-require('ts-node/register');
-module.exports = require('./app.config.ts');
-```
-
 ```ts app.config.ts
+import 'ts-node/register' // Add if you want to import TypeScript files
 import { ExpoConfig } from 'expo/config';
 
 // In SDK 46 and lower, use the following import instead:


### PR DESCRIPTION
# Why

Clarify that `app.config.js` is not needed when trying to import `.ts` files into `app.config.ts`, you can simply add the `ts-node/register` import into the `.ts` file.

Fix: #25546
Close: #25721

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
