### PR TITLE
fix(cli): load `@react-native/dev-middleware` from project

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Exclude `+not-found` and `*+api` routes from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
 - Fix Expo Router typed routes error with external URLs ([#25591](https://github.com/expo/expo/pull/25591) by [@marklawlor](https://github.com/marklawlor))
 - Fix permission issue when user doesn't have permission to view app. ([#25650](https://github.com/expo/expo/pull/25650) by [@wschurman](https://github.com/wschurman))
+- Load `@react-native/dev-middleware` from the user's project. ([#25799](https://github.com/expo/expo/pull/25799) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 import { createInspectorDeviceClass } from './InspectorDevice';
 import { createInspectorProxyClass } from './InspectorProxy';
+import { importDevMiddlewareFromProject } from './importFromProject';
 import { Log } from '../../../../log';
 import { type MetroBundlerDevServer } from '../MetroBundlerDevServer';
 
@@ -9,7 +10,7 @@ export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
   // Load the React Native debugging tools from project
   // TODO: check if this works with isolated modules
   const { createDevMiddleware, unstable_Device, unstable_InspectorProxy } =
-    require('@react-native/dev-middleware') as typeof import('@react-native/dev-middleware');
+    importDevMiddlewareFromProject(metroBundler.projectRoot);
 
   // Create the extended inspector proxy, using our own device class
   const ExpoInspectorProxy = createInspectorProxyClass(

--- a/packages/@expo/cli/src/start/server/metro/debugging/importFromProject.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/importFromProject.ts
@@ -1,0 +1,11 @@
+import resolveFrom from 'resolve-from';
+
+export function importDevMiddlewareFromProject(
+  projectRoot: string
+): typeof import('@react-native/dev-middleware') {
+  const devMiddleware = resolveFrom.silent(projectRoot, '@react-native/dev-middleware');
+  if (!devMiddleware) {
+    throw new Error(`Missing package "@react-native/dev-middleware" in the project.`);
+  }
+  return require(devMiddleware);
+}


### PR DESCRIPTION
# Why

We need to load `@react-native/dev-middleware` from the user's project, as opposed to load it from within the CLI.

# How

- Added `importDevMiddlewareFromProject` that fails when not found

# Test Plan

- `$ bun create expo ./test-network --template blank`
- `$ bun expo install expo@canary`
- `$ bun expo install --fix`
- `$ bun expo install expo-dev-middleware`
- `$ EXPO_USE_UNSTABLE_DEBUGGER=true bun expo run:ios`

This should start everything, but use the locally installed `@react-native/dev-middleware`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
