### PR TITLE
[native-component-list][android] Fix saving videos to gallery in CameraScreen

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -179,9 +179,11 @@ export default class CameraScreen extends React.Component<object, State> {
   takeVideo = async () => {
     const result = await this.recordVideo();
     if (result?.uri) {
+      const splitUri = result.uri.split('.');
+      const extension = splitUri[splitUri.length - 1];
       await FileSystem.moveAsync({
         from: result.uri,
-        to: `${FileSystem.documentDirectory}photos/${Date.now()}.${result.uri.split('.')[1]}`,
+        to: `${FileSystem.documentDirectory}photos/${Date.now()}.${extension}`,
       });
     }
   };


### PR DESCRIPTION
# Why

It wasn't possible to save videos to gallery when using `expo-camera` example in `ncl`

# How

The file was saved with incorrect extension.  Updated the code to use correct file type.

# Test Plan

- ✅ native-component-list in unversioned expo-go, android 13
- ✅ native-component-list in unversioned expo-go, iOS 17

