### PR TITLE
[docs] Fix diff in configuration for Android section

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -151,7 +151,7 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
          android:label="@string/app_name"
 ```
 
-If using the updates server URL shown above (a custom non-HTTPS update server running on the same machine), you will need to modify **android/app/src/main/AndroidManifest.xml** as follows:
+If using the updates server URL shown above (a custom non-HTTPS update server running on the same machine), you will need to modify **android/app/src/main/AndroidManifest.xml** as shown below:
 
 ```diff android/app/src/main/AndroidManifest.xml
  <application

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -153,16 +153,16 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
 
 If using the updates server URL shown above (a custom non-HTTPS update server running on the same machine), you will need to modify **android/app/src/main/AndroidManifest.xml** as follows:
 
-```
-<application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme"
-   ++ android:usesCleartextTraffic="true"
-      >
+```diff android/app/src/main/AndroidManifest.xml
+ <application
+  android:name=".MainApplication"
+  android:label="@string/app_name"
+  android:icon="@mipmap/ic_launcher"
+  android:roundIcon="@mipmap/ic_launcher_round"
+  android:allowBackup="false"
+  android:theme="@style/AppTheme"
++ android:usesCleartextTraffic="true"
+ >
 ```
 
 Add the Expo runtime version string key to **android/app/src/main/res/values/strings.xml**:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up PR for #25559 to fix the following diff block

![CleanShot 2023-12-07 at 19 07 24](https://github.com/expo/expo/assets/10234615/31bf090b-dfc4-403c-84ec-606a65073848)

# How

- Fix the diff block not appearing
- Update minor verbiage issue for concistency

## Preview

![CleanShot 2023-12-07 at 19 56 32](https://github.com/expo/expo/assets/10234615/a4e8965e-6423-4c81-b0fa-9f97c2c04c94)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/bare/installing-updates/#configuration-for-android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
