### PR TITLE
[ios] Fix loading fonts

### DIFF
--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -246,6 +246,13 @@
   return [EXVersions versionedString:string withPrefix:_versionSymbolPrefix];
 }
 
+- (NSString *)escapedResourceName:(NSString *)string
+{
+  NSString *charactersToEscape = @"!*'();:@&=+$,/?%#[]";
+  NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:charactersToEscape] invertedSet];
+  return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+}
+
 - (BOOL)isReadyToLoad
 {
   if (_appRecord) {
@@ -696,18 +703,18 @@
 
 - (NSString *)scopedDocumentDirectory
 {
-  NSString *scopeKey = _appRecord.scopeKey;
+  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
   NSString *mainDocumentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentDocumentDirectory = [mainDocumentDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentDocumentDirectory stringByAppendingPathComponent:scopeKey] stringByStandardizingPath];
+  return [[exponentDocumentDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
 }
 
 - (NSString *)scopedCachesDirectory
 {
-  NSString *scopeKey = _appRecord.scopeKey;
+  NSString *escapedScopeKey = [self escapedResourceName:_appRecord.scopeKey];
   NSString *mainCachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
   NSString *exponentCachesDirectory = [mainCachesDirectory stringByAppendingPathComponent:@"ExponentExperienceData"];
-  return [[exponentCachesDirectory stringByAppendingPathComponent:scopeKey] stringByStandardizingPath];
+  return [[exponentCachesDirectory stringByAppendingPathComponent:escapedScopeKey] stringByStandardizingPath];
 }
 
 - (void *)jsExecutorFactoryForBridge:(id)bridge


### PR DESCRIPTION
# Why

Loading Ionicons font on Expo Go is no longer working since https://github.com/expo/expo/pull/25704

# How

I'm still doing a deeper investigation into why this change broke this but for now I've just added back the `escapedResourceName` function to EXReactAppManager.mm

# Test Plan

Run Expo Go loading home from a local bundle 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
