### PR TITLE
[core][android] Support asking PermissionService for an empty permissions list

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -63,9 +63,9 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   override fun getPermissionsWithPromise(promise: Promise, vararg permissions: String) {
     getPermissions(
       PermissionsResponseListener { permissionsMap: MutableMap<String, PermissionsResponse> ->
-        val areAllGranted = permissionsMap.all { (_, response) -> response.status == PermissionsStatus.GRANTED }
-        val areAllDenied = permissionsMap.all { (_, response) -> response.status == PermissionsStatus.DENIED }
-        val canAskAgain = permissionsMap.all { (_, response) -> response.canAskAgain }
+        val areAllGranted = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.status == PermissionsStatus.GRANTED }
+        val areAllDenied = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.status == PermissionsStatus.DENIED }
+        val canAskAgain = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.canAskAgain }
 
         promise.resolve(
           Bundle().apply {
@@ -113,6 +113,11 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
 
   @Throws(IllegalStateException::class)
   override fun askForPermissions(responseListener: PermissionsResponseListener, vararg permissions: String) {
+    if (permissions.isEmpty()) {
+      responseListener.onResult(mutableMapOf())
+      return
+    }
+
     if (permissions.contains(Manifest.permission.WRITE_SETTINGS)) {
       val permissionsToAsk = permissions.toMutableList().apply { remove(Manifest.permission.WRITE_SETTINGS) }.toTypedArray()
       val newListener = PermissionsResponseListener {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -63,9 +63,9 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   override fun getPermissionsWithPromise(promise: Promise, vararg permissions: String) {
     getPermissions(
       PermissionsResponseListener { permissionsMap: MutableMap<String, PermissionsResponse> ->
-        val areAllGranted = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.status == PermissionsStatus.GRANTED }
-        val areAllDenied = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.status == PermissionsStatus.DENIED }
-        val canAskAgain = permissionsMap.isEmpty() || permissionsMap.all { (_, response) -> response.canAskAgain }
+        val areAllGranted = permissionsMap.all { (_, response) -> response.status == PermissionsStatus.GRANTED }
+        val areAllDenied = permissionsMap.isNotEmpty() && permissionsMap.all { (_, response) -> response.status == PermissionsStatus.DENIED }
+        val canAskAgain = permissionsMap.all { (_, response) -> response.canAskAgain }
 
         promise.resolve(
           Bundle().apply {


### PR DESCRIPTION
# Why

In some cases Android requires permissions for functionalities only from a certain version up. In that case the permissions promise has to be resolved manually.  It'd be more convenient to ask the permissions manager for an empty permissions list, in that case it would always return granted status. Example:

```kotlin
   AsyncFunction("requestPermissionsAsync") { promise: Promise ->
      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
        Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.ACTIVITY_RECOGNITION)
      } else {
        // Permissions are not needed on Android versions below Q
        Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise)
      }
    }
 ```

# How

Handled a case of an empty permissions array in the PermissionsService. If the array is empty status: granted with expires: never and canAskAgain: true is returned.

# Test Plan

Tested in Bare Expo on Android 13

