### PR TITLE
[docs] Asset selection/exclusion for updates

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -312,6 +312,7 @@ const general = [
       makePage('eas-update/code-signing.mdx'),
       makePage('eas-update/rollouts.mdx'),
       makePage('eas-update/rollbacks.mdx'),
+      makePage('eas-update/asset-selection.mdx'),
     ]),
     makeGroup('Reference', [
       makePage('eas-update/migrate-from-classic-updates.mdx'),

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -8,9 +8,9 @@ import { GithubIcon } from '@expo/styleguide-icons';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update, and are uploaded to the update server. The new experimental asset selection feature in SDK 50 allows the developer to specify that only certain assets should be included in updates. This has the potential to greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS update server, or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1.mdx).
+In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update, and are uploaded to the update server. The new experimental asset selection feature in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
 
-To use this feature, a new property `extra.updates.assetPatternsToBeBundled` should be included in your Expo config. It should define one or more file matching patterns (regular expressions). For example, suppose your `app.json` file has the patterns defined this way:
+To use this feature, include the new property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file matching patterns (regular expressions). For example, suppose your **app.json** file has the patterns defined this way:
 
 ```json app.json
   "expo": {
@@ -25,15 +25,14 @@ To use this feature, a new property `extra.updates.assetPatternsToBeBundled` sho
   }
 ```
 
-In this case, all `.png` files in all subdirectories of `app/images` would be included in updates.
+In this case, all **.png** files in all subdirectories of **app/images** will be included in updates.
 
 Assets that do not match any of the file patterns will still resolve in the Metro bundler, but will not be uploaded to the updates server. If making use of this feature, a developer needs to be certain that assets not included in updates are built into the native build of the app.
 
-If this new property is not in your Expo config, all assets resolved by the bundler will be included in updates (SDK 49 and earlier behavior).
+If this new property is not in your app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
 
-We have created a [complete working demo](https://github.com/expo/UpdatesAPIDemo/blob/main/ASSETSELECTION.md) to allow developers to try out this feature.
 
-## More
+## Example
 
 <BoxLink
   title="Working example"

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -1,0 +1,44 @@
+---
+title: Asset selection and exclusion
+description: Select which assets should be included in updates.
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
+
+> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
+
+In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update, and are uploaded to the update server. The new experimental asset selection feature in SDK 50 allows the developer to specify that only certain assets should be included in updates. This has the potential to greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS update server, or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1.mdx).
+
+To use this feature, a new property `extra.updates.assetPatternsToBeBundled` should be included in your Expo config. It should define one or more file matching patterns (regular expressions). For example, suppose your `app.json` file has the patterns defined this way:
+
+```json app.json
+  "expo": {
+    /* @hide ... your existing configuration */ /* @end */
+    "extra": {
+      "updates": {
+        "assetPatternsToBeBundled": [
+          "app/images/**/*.png"
+        ]
+      }
+    }
+  }
+```
+
+In this case, all `.png` files in all subdirectories of `app/images` would be included in updates.
+
+Assets that do not match any of the file patterns will still resolve in the Metro bundler, but will not be uploaded to the updates server. If making use of this feature, a developer needs to be certain that assets not included in updates are built into the native build of the app.
+
+If this new property is not in your Expo config, all assets resolved by the bundler will be included in updates (SDK 49 and earlier behavior).
+
+We have created a [complete working demo](https://github.com/expo/UpdatesAPIDemo/blob/main/ASSETSELECTION.md) to allow developers to try out this feature.
+
+## More
+
+<BoxLink
+  title="Working example"
+  description="See a working example on using asset selection and other EAS update features."
+  Icon={GithubIcon}
+  href="https://github.com/expo/UpdatesAPIDemo"
+/>
+

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -7,7 +7,7 @@ description: Learn how EAS Update downloads assets and how to optimize them for 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** For SDK 50 and above, the new [asset selection feature](/eas-update/asset-selection.mdx) can greatly reduce the total number and size of downloaded assets.
+> **info** For SDK 50 and above, the new [asset selection feature](/eas-update/asset-selection) can greatly reduce the total number and size of downloaded assets.
 
 When an app finds a new update, it downloads a manifest and then downloads any new or updated assets so that it can run the update. The process is as follows:
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -7,6 +7,8 @@ description: Learn how EAS Update downloads assets and how to optimize them for 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
+> **info** For SDK 50 and above, the new [asset selection feature](/eas-update/asset-selection.mdx) can greatly reduce the total number and size of downloaded assets.
+
 When an app finds a new update, it downloads a manifest and then downloads any new or updated assets so that it can run the update. The process is as follows:
 
 <ImageSpotlight alt="Update download timeline" src="/static/images/eas-update/process.png" />


### PR DESCRIPTION
# Why

Documentation for the new asset selection/exclusion feature of updates.

# How

- New doc on the feature
- Link to demo
- Add reference from the existing asset optimization page

# Test Plan

- Tested with local docs dev server

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
