### PR TITLE
Add ios option to disable notification entitlement

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -473,6 +473,10 @@ export interface IOS {
     runtimeVersion?: string | {
         policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprintExperimental';
     };
+    /**
+     * Disable ios notifications entitlement
+     */
+    disableNotifications?: boolean;
 }
 /**
  * Configuration that is specific to the Android platform.

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -477,6 +477,10 @@ export interface IOS {
   runtimeVersion?:
     | string
     | { policy: 'nativeVersion' | 'sdkVersion' | 'appVersion' | 'fingerprintExperimental' };
+  /**
+   * Disable ios notifications entitlement
+   */
+  disableNotifications?: boolean;
 }
 /**
  * Configuration that is specific to the Android platform.

--- a/packages/expo-notifications/plugin/build/withNotificationsIOS.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsIOS.js
@@ -7,7 +7,12 @@ const path_1 = require("path");
 const ERROR_MSG_PREFIX = 'An error occurred while configuring iOS notifications. ';
 const withNotificationsIOS = (config, { mode = 'development', sounds = [] }) => {
     config = (0, config_plugins_1.withEntitlementsPlist)(config, (config) => {
-        config.modResults['aps-environment'] = mode;
+        if (config.ios?.disableNotifications) {
+            config.modResults['aps-environment'] = undefined;
+        }
+        else {
+            config.modResults['aps-environment'] = mode;
+        }
         return config;
     });
     config = (0, exports.withNotificationSounds)(config, { sounds });

--- a/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsIOS.ts
@@ -17,7 +17,11 @@ export const withNotificationsIOS: ConfigPlugin<NotificationsPluginProps> = (
   { mode = 'development', sounds = [] }
 ) => {
   config = withEntitlementsPlist(config, (config) => {
-    config.modResults['aps-environment'] = mode;
+    if (config.ios?.disableNotifications) {
+      config.modResults['aps-environment'] = undefined;
+    } else {
+      config.modResults['aps-environment'] = mode;
+    }
     return config;
   });
   config = withNotificationSounds(config, { sounds });


### PR DESCRIPTION
# Why

Adding the `aps-environment` iOS entitlement is unnecessary when your app doesn't have push notifications

- fixes https://github.com/expo/expo/issues/18951
- fixes https://github.com/expo/eas-cli/issues/987

# How

Use a new config field `ios.disableNotifications` to remove the `aps-environment` generation. Setting it to `undefined` causes the value to be removed.

If you just don't set it, it will leave any existing value in your `App.entitlements` file so setting to `undefined` as I think the desired behaviour would be to remove the value when `disableNotifications=true`

- An alternative would be using something like `notifications.disableIosNotifications: true`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested by changes the config and running `npx expo prebuild`

1. Set `ios.disableNotifications` to `true` and see that the `aps-environment` key is removed (or not added)
2. Set `ios.disableNotifications` to `false` or omit and see that it is set to `aps-environment:development` as before

*Changes to `App.entitlements` when setting to `true`:*
<img width="342" alt="image" src="https://github.com/expo/expo/assets/5689874/ce83ce12-1907-4134-97e7-fd94c2319989">

The default behaviour - i.e. when there is no value set is the same as before so this won't cause any breaking changes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
