### PR TITLE
[metro-config] pass in custom serializer to expo default config 

### DIFF
--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -18,7 +18,7 @@ import { getModulesPaths, getServerRoot } from './getModulesPaths';
 import { getWatchFolders } from './getWatchFolders';
 import { getRewriteRequestUrl } from './rewriteRequestUrl';
 import { JSModule } from './serializer/getCssDeps';
-import { withExpoSerializers } from './serializer/withExpoSerializers';
+import { Serializer, withExpoSerializers } from './serializer/withExpoSerializers';
 import { getPostcssConfigHash } from './transform-worker/postcss';
 import { importMetroConfig } from './traveling/metro-config';
 const debug = require('debug')('expo:metro:config') as typeof console.log;
@@ -41,6 +41,7 @@ export interface DefaultConfigOptions {
    * is subject to change, and native support for CSS Modules may be added in the future during a non-major SDK release.
    */
   isCSSEnabled?: boolean;
+  customSerializer?: Serializer;
 }
 
 function getAssetPlugins(projectRoot: string): string[] {
@@ -91,7 +92,7 @@ function patchMetroGraphToSupportUncachedModules() {
 
 export function getDefaultConfig(
   projectRoot: string,
-  { mode, isCSSEnabled = true }: DefaultConfigOptions = {}
+  { mode, isCSSEnabled = true, customSerializer }: DefaultConfigOptions = {}
 ): InputConfigT {
   const { getDefaultConfig: getDefaultMetroConfig, mergeConfig } = importMetroConfig(projectRoot);
 
@@ -255,7 +256,7 @@ export function getDefaultConfig(
     },
   });
 
-  return withExpoSerializers(metroConfig);
+  return withExpoSerializers(metroConfig, { customSerializer });
 }
 
 export async function loadAsync(

--- a/packages/@expo/metro-config/src/serializer/fork/baseJSBundle.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/baseJSBundle.ts
@@ -95,17 +95,18 @@ export function baseJSBundle(
   });
 }
 
+export type BaseJsBundleOptions = ExpoSerializerOptions & {
+  platform: string;
+  baseUrl: string;
+  splitChunks: boolean;
+  skipWrapping: boolean;
+  computedAsyncModulePaths: Record<string, string> | null;
+};
 export function baseJSBundleWithDependencies(
   entryPoint: string,
   preModules: readonly Module[],
   dependencies: Module<MixedOutput>[],
-  options: ExpoSerializerOptions & {
-    platform: string;
-    baseUrl: string;
-    splitChunks: boolean;
-    skipWrapping: boolean;
-    computedAsyncModulePaths: Record<string, string> | null;
-  }
+  options: BaseJsBundleOptions
 ): Bundle {
   for (const module of dependencies) {
     options.createModuleId(module.path);

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -52,6 +52,7 @@ export async function graphToSerialAssetsAsync(
   ...props: SerializerParameters
 ): Promise<{ artifacts: SerialAsset[] | null; assets: AssetData[] }> {
   const [entryFile, preModules, graph, options] = props;
+  // TODO: maybe call the default serializer around here?
 
   const cssDeps = getCssSerialAssets<MixedOutput>(graph.dependencies, {
     projectRoot: options.projectRoot,
@@ -406,11 +407,15 @@ class Chunk {
       if (hermesBundleOutput.hbc) {
         // TODO: Unclear if we should add multiple assets, link the assets, or mutate the first asset.
         // jsAsset.metadata.hbc = hermesBundleOutput.hbc;
+        // DEBUG Push the js bundle for debugging purposes
+        assets.push({ ...assets[0] });
         // @ts-expect-error: TODO
         jsAsset.source = hermesBundleOutput.hbc;
         jsAsset.filename = jsAsset.filename.replace(/\.js$/, '.hbc');
       }
       if (assets[1] && hermesBundleOutput.sourcemap) {
+        // DEBUG Push the js source map for debugging purposes
+        assets.push({ ...assets[1] });
         assets[1].source = hermesBundleOutput.sourcemap;
         assets[1].filename = assets[1].filename.replace(/\.js\.map$/, '.hbc.map');
       }

--- a/packages/@expo/metro-config/src/serializer/withExpoSerializers.ts
+++ b/packages/@expo/metro-config/src/serializer/withExpoSerializers.ts
@@ -27,27 +27,35 @@ export type SerializerParameters = [
   ExpoSerializerOptions,
 ];
 
+type SerializerOptions = {
+  customSerializer?: Serializer;
+};
+
 // A serializer that processes the input and returns a modified version.
 // Unlike a serializer, these can be chained together.
 export type SerializerPlugin = (...props: SerializerParameters) => SerializerParameters;
 
-export function withExpoSerializers(config: InputConfigT): InputConfigT {
+export function withExpoSerializers(
+  config: InputConfigT,
+  options: SerializerOptions = {}
+): InputConfigT {
   const processors: SerializerPlugin[] = [];
   processors.push(serverPreludeSerializerPlugin);
   if (!env.EXPO_NO_CLIENT_ENV_VARS) {
     processors.push(environmentVariableSerializerPlugin);
   }
 
-  return withSerializerPlugins(config, processors);
+  return withSerializerPlugins(config, processors, options);
 }
 
 // There can only be one custom serializer as the input doesn't match the output.
 // Here we simply run
 export function withSerializerPlugins(
   config: InputConfigT,
-  processors: SerializerPlugin[]
+  processors: SerializerPlugin[],
+  options: SerializerOptions = {}
 ): InputConfigT {
-  const originalSerializer = config.serializer?.customSerializer;
+  const originalSerializer = options.customSerializer ?? config.serializer?.customSerializer;
 
   return {
     ...config,

--- a/packages/@expo/metro-config/src/serializer/withExpoSerializers.ts
+++ b/packages/@expo/metro-config/src/serializer/withExpoSerializers.ts
@@ -116,6 +116,7 @@ function getDefaultSerializer(
       return null;
     })();
 
+    // TODO(quin): how can i get the default serializer to run?
     if (serializerOptions?.outputMode !== 'static') {
       return defaultSerializer(...props);
     }


### PR DESCRIPTION
# Why

I want my `metro.configs.js` to use the sentry custom serializer. It will look something like this:

```
const {
  getDefaultConfig,
} = require("/Users/quin/Documents/expo/packages/@expo/metro-config/build/ExpoMetroConfig");
const {
  createChunkSerializer,
} = require("/Users/quin/Documents/expo/packages/@expo/metro-config/build/serializer/serializeChunks");
const { mergeConfig } = require("metro");
const {
  createSentryMetroSerializer,
} = require("@sentry/react-native/dist/js/tools/sentryMetroSerializer");

const config = getDefaultConfig(__dirname, {
  customSerializer: createSentryMetroSerializer(createChunkSerializer()),
});

module.exports = config;

``` 

# How you can help 

I noticed that the passed in serializer is only called when the output is not static. However, I want this seriaIizer to be called in the static case. I noticed we split the modules up into chunks and then serialize the chunks . When we serialize each chunk to code, I'm thinking we can use the passed in serializer there. Any guidance someone can give me would be much appreciated!

# Test Plan

Ran `expo-dev export --output-dir dist --dump-sourcemap` on my test app to verify that it works

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
