### PR TITLE
[dev-menu][ios] Fix `Unable to find module for ExpoModulesCore.ViewModuleWrapper`

### DIFF
--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -42,7 +42,15 @@
 
 - (NSArray<Class> *)filterModuleList:(NSArray<Class> *)modules
 {
-  NSArray<NSString *> *allowedModules = @[@"RCT", @"DevMenu", @"ExpoBridgeModule", @"EXNativeModulesProxy", @"ViewManagerAdapter_", @"EXReactNativeEventEmitter"];
+  NSArray<NSString *> *allowedModules = @[
+    @"RCT",
+    @"DevMenu",
+    @"ExpoBridgeModule",
+    @"EXNativeModulesProxy",
+    @"ViewManagerAdapter_",
+    @"ExpoModulesCore"
+    @"EXReactNativeEventEmitter"
+  ];
   NSArray<Class> *filteredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
     if ([clazz conformsToProtocol:@protocol(DevMenuExtensionProtocol)]) {
       return true;

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `Unable to find module for ExpoModulesCore.ViewModuleWrapper`.
+
 ### 💡 Others
 
 - Bump C++ compiler setting to C++20. ([#25548](https://github.com/expo/expo/pull/25548) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `Unable to find module for ExpoModulesCore.ViewModuleWrapper`.
+- [iOS] Fix `Unable to find module for ExpoModulesCore.ViewModuleWrapper`. ([#25813](https://github.com/expo/expo/pull/25813) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.mm
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.mm
@@ -70,7 +70,14 @@
 
 - (NSArray<Class> *)filterModuleList:(NSArray<Class> *)modules
 {
-  NSArray<NSString *> *allowedModules = @[@"RCT", @"ExpoBridgeModule", @"EXNativeModulesProxy", @"EXReactNativeEventEmitter"];
+  NSArray<NSString *> *allowedModules = @[
+    @"RCT",
+    @"ExpoBridgeModule",
+    @"EXNativeModulesProxy",
+    @"EXReactNativeEventEmitter",
+    @"ExpoModulesCore",
+    @"ViewManagerAdapter_"
+  ];
   NSArray<Class> *filteredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {
     NSString* clazzName = NSStringFromClass(clazz);
 


### PR DESCRIPTION
# Why

Fixes ENG-10769.
Fixes `Unable to find a module for ExpoModulesCore.ViewModuleWrapper`

# How

We have the modules filter that reduces the number of native classes that we use with `dev-menu` and `dev-launcher`. We didn't add the `ViewModuleWrapper` to that list. We don't use expo views inside of the dev-menu UI, but the rn seems to add a check if all base view managers are present during initialization. To satisfy that, I've just changed the class filter to allow the `ExpoModuelsCore` prefix for both the launcher and menu. 

# Test Plan

- new expo project ✅