### PR TITLE
[sensors][android] Add pedometer permissions on Android

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix pedometer not working due to lack of permissions.
+- [Android] Fix pedometer not working due to lack of permissions. ([#25815](https://github.com/expo/expo/pull/25815) by [@omegascorp](https://github.com/omegascorp) and [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix pedometer not working due to lack of permissions.
+
 ### 💡 Others
 
 ## 12.8.0 — 2023-11-14

--- a/packages/expo-sensors/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sensors/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
 </manifest>

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/PedometerModule.kt
@@ -1,9 +1,13 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package expo.modules.sensors.modules
 
+import android.Manifest
 import android.hardware.Sensor
+import android.os.Build
 import android.os.Bundle
+import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.sensors.services.PedometerServiceInterface
+import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -37,6 +41,24 @@ class PedometerModule : Module() {
       EventName,
       listenerDecorator = { stepsAtTheBeginning = null }
     ) { sensorProxy }
+
+    AsyncFunction("getPermissionsAsync") { promise: Promise ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Permissions.getPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.ACTIVITY_RECOGNITION)
+      } else {
+        // Permissions don't need to be requested on Android versions below Q
+        Permissions.getPermissionsWithPermissionsManager(appContext.permissions, promise)
+      }
+    }
+
+    AsyncFunction("requestPermissionsAsync") { promise: Promise ->
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.ACTIVITY_RECOGNITION)
+      } else {
+        // Permissions don't need to be requested on Android versions below Q
+        Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise)
+      }
+    }
 
     AsyncFunction("getStepCountAsync") { _: Int, _: Int ->
       throw NotSupportedException("Getting step count for date range is not supported on Android yet")


### PR DESCRIPTION
# Why

Pedometer was not working on android due to missing permissions.

# How

Added appropriate permissions to AndroidManifest, added `getPermissionsAsync` and `requestPermissionsAsync` functions

# Test Plan

✅  BareExpo on Android 13
✅ `ncl` in unversioned Expo Go on Android 13

This PR needs changes from https://github.com/expo/expo/pull/25805 to work correctly on Android < Q
