### PR TITLE
[android] Fix loading SDK 49 projects

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -461,7 +461,11 @@ abstract class ReactNativeActivity :
     val devSettings =
       mReactInstanceManager.callRecursive("getDevSupportManager")!!.callRecursive("getDevSettings")
     if (devSettings != null) {
-      devSettings.call("setExponentActivityId", activityId)
+      if (sdkVersion.startsWith("49.")) {
+        devSettings.setField("exponentActivityId", activityId)
+      } else {
+        devSettings.call("setExponentActivityId", activityId)
+      }
       if (devSettings.call("isRemoteJSDebugEnabled") as Boolean) {
         if (manifest?.jsEngine == "hermes") {
           // Disable remote debugging when running on Hermes


### PR DESCRIPTION
# Why

Closes ENG-10852
As reported by Kudo, when using versioned Expo Go on Android the user is unable to load projects

# How

When upgrading react native I introduced new getters and setters for `exponentActivityId` due to the Meta's recent changes on dev internal interfaces. This `setExponentActivityId` method is only available on SDK 50 onwards, so for now we need to check which SDK we're running and call the appropriate method 

# Test Plan

Run Expo Go versioned on android loading a project using SDK 50 and another project using SDK49

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
