### PR TITLE
[doctor] Allow skipping InstalledDependencyVersionCheck with env var

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Allow skipping dependency version check. ([#25822](https://github.com/expo/expo/pull/25822) by [@floatplane](https://github.com/floatplane))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/__tests__/doctor.test.ts
+++ b/packages/expo-doctor/src/__tests__/doctor.test.ts
@@ -25,6 +25,9 @@ const additionalProjectProps = {
     sdkVersion: '46.0.0',
   },
   pkg: {},
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
 };
 
 class MockSuccessfulCheck implements DoctorCheck {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -115,6 +115,25 @@ export async function runChecksAsync(
   );
 }
 
+export function getChecks() {
+  // add additional checks here
+  const checks = [
+    new GlobalPrereqsVersionCheck(),
+    new IllegalPackageCheck(),
+    new GlobalPackageInstalledCheck(),
+    new SupportPackageVersionCheck(),
+    new ExpoConfigSchemaCheck(),
+    new ExpoConfigCommonIssueCheck(),
+    new DirectPackageInstallCheck(),
+    new PackageJsonCheck(),
+    new ProjectSetupCheck(),
+  ];
+  if (!env.EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK) {
+    checks.push(new InstalledDependencyVersionCheck());
+  }
+  return checks;
+}
+
 export async function actionAsync(projectRoot: string) {
   await warnUponCmdExe();
 
@@ -133,19 +152,7 @@ export async function actionAsync(projectRoot: string) {
     return;
   }
 
-  // add additional checks here
-  const checks = [
-    new GlobalPrereqsVersionCheck(),
-    new IllegalPackageCheck(),
-    new GlobalPackageInstalledCheck(),
-    new SupportPackageVersionCheck(),
-    new InstalledDependencyVersionCheck(),
-    new ExpoConfigSchemaCheck(),
-    new ExpoConfigCommonIssueCheck(),
-    new DirectPackageInstallCheck(),
-    new PackageJsonCheck(),
-    new ProjectSetupCheck(),
-  ];
+  const checks = getChecks();
 
   const filteredChecks = checks.filter(
     (check) =>

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -15,6 +15,11 @@ class Env {
   get EXPO_STAGING() {
     return boolish('EXPO_STAGING', false);
   }
+
+  /** Allow disabling InstalledDependencyVersionCheck */
+  get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
+    return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

Adding ability to disable one particular check (`InstalledDependencyVersionCheck`). See https://github.com/expo/expo/discussions/25698 for background.

# How

Extract the list of checks into a method, make the addition of this particular check dynamic.

# Test Plan

Wrote tests for the new `getChecks` method. Also tested manually - sample output without the variable:
```
$  npx ../expo/packages/expo-doctor                                     
✔ Check Expo config for common issues
✔ Check package.json for common issues
✔ Check dependencies for packages that should not be installed directly
✔ Check for common project setup issues
✔ Check npm/ yarn versions
✔ Check Expo config (app.json/ app.config.js) schema
✖ Check that packages match versions required by installed Expo SDK
✔ Check for legacy global CLI installed locally
✔ Check that native modules do not use incompatible support packages
✔ Check that native modules use compatible support package versions for installed Expo SDK

Detailed check results:

Some dependencies are incompatible with the installed expo version:
  @sentry/react-native@5.5.0 - expected version: 5.10.0
  expo-file-system@15.4.4 - expected version: ~15.4.5
  sentry-expo@7.0.1 - expected version: ~7.1.0
Your project may not work correctly until you install the correct versions of the packages.
Fix with: npx expo install --fix
Found outdated dependencies
Advice: Use 'npx expo install --check' to review and upgrade your dependencies.

One or more checks failed, indicating possible issues with the project.
```

and sample output with:

```
$ EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx ../expo/packages/expo-doctor
✔ Check Expo config for common issues
✔ Check package.json for common issues
✔ Check dependencies for packages that should not be installed directly
✔ Check for common project setup issues
✔ Check npm/ yarn versions
✔ Check Expo config (app.json/ app.config.js) schema
✔ Check that native modules do not use incompatible support packages
✔ Check for legacy global CLI installed locally
✔ Check that native modules use compatible support package versions for installed Expo SDK

Didn't find any issues with the project!
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
