### PR TITLE
[tools] Fix prod home publish script

### DIFF
--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -129,7 +129,7 @@ async function fetchManifestAndBundleAsync(
   groupId: string,
   platform: 'ios' | 'android'
 ): Promise<void> {
-  const manifestUrl = `https://staging-u.expo.dev/${projectId}/group/${groupId}`;
+  const manifestUrl = `https://u.expo.dev/${projectId}/group/${groupId}`;
   const manifestResponse = await fetch(manifestUrl, {
     method: 'GET',
     headers: {


### PR DESCRIPTION
# Why

The `et publish-prod-home` script is broken. This fixes it.

# How

Update erroneous URL.

# Test Plan

Run command.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
