### PR TITLE
[ci] Improve Android instrumentation test reliability

### DIFF
--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -162,7 +162,7 @@ export async function androidNativeUnitTests({
 
     console.log(chalk.green('Finished android unit tests successfully.'));
   } finally {
-    restoreBareExpoPackageJson(packageJsonOriginalText);
+    await restoreBareExpoPackageJson(packageJsonOriginalText);
   }
 }
 


### PR DESCRIPTION
# Why

Sometimes Android instrumentation test reruns fail due to bare-expo's package.json being an empty file 

e.g. 

<img width="891" alt="image" src="https://github.com/expo/expo/assets/11707729/38abba07-84ed-47b0-829f-1645306b58b0">


# How

Add an `await` to the `restoreBareExpoPackageJson` function call ensuring that we wait for the package.json file to be restored before finalizing the process 

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
