### PR TITLE
[ios][sensors] Prevent asking for permission on reload

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix pedometer not working due to lack of permissions. ([#25815](https://github.com/expo/expo/pull/25815) by [@omegascorp](https://github.com/omegascorp) and [@behenate](https://github.com/behenate))
+- On iOS, fix an issue where permissions were requested on reload. ([#25827](https://github.com/expo/expo/pull/25827) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -39,9 +39,8 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
-        permissionsManager,
-        withRequester: EXMotionPermissionRequester.self,
+      appContext?.permissions?.getPermissionUsingRequesterClass(
+        EXMotionPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
       )
@@ -51,9 +50,8 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      EXPermissionsMethodsDelegate.askForPermission(
-        withPermissionsManager: permissionsManager,
-        withRequester: EXMotionPermissionRequester.self,
+      appContext?.permissions?.askForPermission(
+        usingRequesterClass: EXMotionPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
       )
@@ -63,7 +61,7 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      EXPermissionsMethodsDelegate.register([EXMotionPermissionRequester()], withPermissionsManager: permissionsManager)
+      appContext?.permissions?.register([EXMotionPermissionRequester()])
     }
 
     OnStartObserving {
@@ -98,15 +96,20 @@ public final class PedometerModule: Module {
     }
 
     OnDestroy {
-      pedometer.stopUpdates()
+      stopUpdates()
     }
   }
 
   private func stopUpdates() {
-    if watchHandler != nil {
-      pedometer.stopUpdates()
-      watchStartDate = nil
-      watchHandler = nil
+    guard let permissions = appContext?.permissions else {
+      return
+    }
+    if permissions.hasGrantedPermission(usingRequesterClass: EXMotionPermissionRequester.self) {
+      if watchHandler != nil {
+        pedometer.stopUpdates()
+        watchStartDate = nil
+        watchHandler = nil
+      }
     }
   }
 }


### PR DESCRIPTION
# Why
Fixes an issue where permissions would be requested on reload.

# How
Use the `stopUpdates` function instead of accessing the pedometer directly.

# Test Plan
bare-expo on a physical device
