### PR TITLE
[docs] remove race condition from expo auth example

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -145,9 +145,8 @@ export function useStorageState(key: string): UseStateHook<string> {
   // Set
   const setValue = React.useCallback(
     (value: string | null) => {
-      setStorageItemAsync(key, value).then(() => {
-        setState(value);
-      });
+      setState(value);
+      setStorageItemAsync(key, value);
     },
     [key]
   );


### PR DESCRIPTION
# Why

When you copy past the [Expo Router auth](https://docs.expo.dev/router/reference/authentication/) example exactly, you'll encounter a race condition: "sign in" has to be pressed twice before it actually signs you in.


https://github.com/expo/expo/assets/6534400/a25cca0f-7e47-4bec-818c-258a90b0bc2f



It's caused by this function in `useStorageState` (setState is called in a callback):

```
  const setValue = React.useCallback(
    (value: string | null) => {
      setStorageItemAsync(key, value).then(() => {
        setState(value);
      });
    },
    [key]
  );
```

Context from [Discord](https://discord.com/channels/695411232856997968/695411232856997971/1182787482635481129)

# How

Make it synchronous.

# Test Plan

- `npx create-expo-app -t`
- choose with router
- delete `/app` and copy-paste all the files from the auth example
- `yarn start`

-> with this code change, you only have to press "sign in" once

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
