### PR TITLE
feat(cli): prevent showing logs for source maps

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### 💡 Others
 
+- Prevent showing log events for source maps in development.
 - Remove unused Metro `extraNodeModules` augmentation for web resolution in favor of standard aliases. ([#25506](https://github.com/expo/expo/pull/25506) by [@EvanBacon](https://github.com/EvanBacon))
 - Consolidate logic for resolving Node.js built-in shims in browser environments. ([#25511](https://github.com/expo/expo/pull/25511) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### 💡 Others
 
-- Prevent showing log events for source maps in development.
+- Prevent showing log events for source maps in development. ([#25830](https://github.com/expo/expo/pull/25830) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused Metro `extraNodeModules` augmentation for web resolution in favor of standard aliases. ([#25506](https://github.com/expo/expo/pull/25506) by [@EvanBacon](https://github.com/EvanBacon))
 - Consolidate logic for resolving Node.js built-in shims in browser environments. ([#25511](https://github.com/expo/expo/pull/25511) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure we disable lazy bundling when exporting. ([#25436](https://github.com/expo/expo/pull/25436) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -3,7 +3,13 @@ import { Terminal } from 'metro-core';
 import path from 'path';
 
 import { logWarning, TerminalReporter } from './TerminalReporter';
-import { BuildPhase, BundleDetails, BundleProgress, SnippetError } from './TerminalReporter.types';
+import {
+  BuildPhase,
+  BundleDetails,
+  BundleProgress,
+  SnippetError,
+  TerminalReportableEvent,
+} from './TerminalReporter.types';
 import { NODE_STDLIB_MODULES } from './externals';
 import { learnMore } from '../../../utils/link';
 
@@ -83,6 +89,10 @@ export class MetroTerminalReporter extends TerminalReporter {
     data: unknown[];
   }): boolean {
     return isAppRegistryStartupMessage(event.data);
+  }
+
+  shouldFilterBundleEvent(event: TerminalReportableEvent): boolean {
+    return 'bundleDetails' in event && event.bundleDetails?.bundleType === 'map';
   }
 
   /** Print the cache clear message. */


### PR DESCRIPTION
# Why

<img width="904" alt="Screenshot 2023-12-08 at 8 18 34 PM" src="https://github.com/expo/expo/assets/9664363/af868d0b-6918-4bbc-b557-d2269ee935e0">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Detect if a bundling event is for a map, if so, hide it from the logger.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Start dev server.
- Add a bunch of modules.
- Comment them out / back in.
- Close/open inspector to trigger all the HMR sourcemaps being refetched.
- There shouldn't be any additional request logs in the terminal.