### PR TITLE
[go] fix launch crash on android release build

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -152,3 +152,9 @@
 
 ##### svg #####
 -keep public class com.horcrux.svg.** { *; }
+
+##### DI #####
+-keep @javax.inject.Inject class *
+-keepclassmembers class * {
+  @javax.inject.Inject *;
+}

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -220,7 +220,7 @@ class Kernel : KernelInterface() {
   private fun kernelBundleListener(): BundleListener {
     return object : BundleListener {
       override fun onBundleLoaded(localBundlePath: String) {
-        if (!ExpoViewBuildConfig.DEBUG) {
+        if (!exponentSharedPreferences.shouldUseEmbeddedKernel() && !ExpoViewBuildConfig.DEBUG) {
           exponentSharedPreferences.setString(
             ExponentSharedPreferences.ExponentSharedPreferencesKey.KERNEL_REVISION_ID,
             kernelRevisionId


### PR DESCRIPTION
# Why

close ENG-10864

# How

1. our DI requires the `@Inject` annotation. since AGP 8 full R8 mode, the annotations are stripped. this pr keeps `@Inject`.
2. after kernel eas update migration, the [`getRevisionId`](https://github.com/expo/expo/blob/8f632c1f8a253aed85cca706660bbdc18ac71054/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt#L68-L69) will crash because new manifest does not have the `revisionId`. expo-go on release build should use the embedded kernel as always, this pr fix the call flow to skip the unnecessary `getRevisionId` call from release build.  

# Test Plan

versioned android expo-go release build + sdk 50 NCL

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
