### PR TITLE
refactor: drop `expo-yarn-workspaces`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "setup:docs": "./scripts/download-dependencies.sh",
     "setup:native": "./scripts/download-dependencies.sh && ./scripts/setup-react-android.sh",
-    "postinstall": "yarn-deduplicate && yarn workspace @expo/cli prepare",
+    "postinstall": "yarn-deduplicate && yarn workspace @expo/cli prepare && et validate-workspace-dependencies",
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "setup:docs": "./scripts/download-dependencies.sh",
     "setup:native": "./scripts/download-dependencies.sh && ./scripts/setup-react-android.sh",
-    "postinstall": "yarn-deduplicate && expo-yarn-workspaces check-workspace-dependencies && yarn workspace @expo/cli prepare",
+    "postinstall": "yarn-deduplicate && yarn workspace @expo/cli prepare",
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "eslint": "^8.45.0",
-    "expo-yarn-workspaces": "*",
     "jsc-android": "^250231.0.0",
     "node-gyp": "^10.0.1",
     "prettier": "^3.0.0",


### PR DESCRIPTION
# Why

This PR drops `expo-yarn-workspace` usage within this monorepo.

> ~~⚠️ This includes a test where `expo-yarn-workspaces` is fully deleted from the monorepo, see last commit.~~


> ℹ️ CI test was successful and the commit where this was deleted has been removed. If we want to deprecate `expo-yarn-workspaces`, we need to pull it into a different repository and archive it from there.
> → See stacked PR #26063

# How

- Dropped `expo-yarn-workspaces` from root `package.json`

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
