### PR TITLE
refactor(native-component-list): drop `react-navigation@v4`

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -153,7 +153,6 @@
     "react-native-view-shot": "3.8.0",
     "react-native-web": "~0.19.6",
     "react-native-webview": "13.6.3",
-    "react-navigation": "^4.4.0",
     "regl": "^1.3.0",
     "three": "^0.137.4",
     "url": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,7 +3514,7 @@
     color "^4.2.3"
     warn-once "^0.1.0"
 
-"@react-navigation/core@6.4.0", "@react-navigation/core@^3.7.9", "@react-navigation/core@^6.4.10", "@react-navigation/core@^6.4.9":
+"@react-navigation/core@6.4.0", "@react-navigation/core@^6.4.10", "@react-navigation/core@^6.4.9":
   version "6.4.10"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.10.tgz#0c52621968b35e3a75e189e823d3b9e3bad77aff"
   integrity sha512-oYhqxETRHNHKsipm/BtGL0LI43Hs2VSFoWMbBdHK9OqgQPjTVUitslgLcPpo4zApCcmBWoOLX2qPxhsBda644A==
@@ -3564,7 +3564,7 @@
     "@react-navigation/elements" "^1.3.17"
     warn-once "^0.1.0"
 
-"@react-navigation/native@6.0.13", "@react-navigation/native@^3.8.4", "@react-navigation/native@^6.1.6", "@react-navigation/native@~6.0.13", "@react-navigation/native@~6.1.6":
+"@react-navigation/native@6.0.13", "@react-navigation/native@^6.1.6", "@react-navigation/native@~6.0.13", "@react-navigation/native@~6.1.6":
   version "6.1.9"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.1.9.tgz#8ef87095cd9c2ed094308c726157c7f6fc28796e"
   integrity sha512-AMuJDpwXE7UlfyhIXaUCCynXmv69Kb8NzKgKJO7v0k0L+u6xUTbt6xvshmJ79vsvaFyaEH9Jg5FMzek5/S5qNw==
@@ -16833,14 +16833,6 @@ react-native@0.73.0:
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
     yargs "^17.6.2"
-
-react-navigation@^4.4.0:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-4.4.4.tgz#8cda2219196311db440e54998bc724523359949f"
-  integrity sha512-08Nzy1aKEd73496CsuzN49vLFmxPKYF5WpKGgGvkQ10clB79IRM2BtAfVl6NgPKuUM8FXq1wCsrjo/c5ftl5og==
-  dependencies:
-    "@react-navigation/core" "^3.7.9"
-    "@react-navigation/native" "^3.8.4"
 
 react-query@^3.34.16:
   version "3.34.19"


### PR DESCRIPTION
# Why

I noticed that we resolve `@react-navigation/core@3.x.x` to `6.x.x`, which is far from correct 😄 

This is because `apps/native-component-list` has both `@react-navigation/*@6` and `react-navigation@4` packages installed. Since we only use v6, let's remove the v4 reference.

# How

- Dropped `"react-navigation": "^4.x.x"` reference from NCL's `package.json`

# Test Plan

See if CI passes, and start up NCL locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
