### PR TITLE
[home] Fix NavigationEvents component

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/f341423e-3518-4c6b-92bd-a8a7cde64c8c"
+  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/e3793176-0ddf-4b38-801f-99cf191d53cd"
 }

--- a/home/components/NavigationEvents.tsx
+++ b/home/components/NavigationEvents.tsx
@@ -1,19 +1,13 @@
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import * as React from 'react';
 
 export default function NavigationEvents(props: { children?: any; onDidFocus: () => void }) {
-  const navigation = useNavigation();
-
-  React.useEffect(() => {
-    const unsubscribe = navigation.addListener('focus', () => {
-      // The screen is focused
+  useFocusEffect(
+    React.useCallback(() => {
+      console.log('useFocusEffect');
       props.onDidFocus();
-    });
-    // Return the function to unsubscribe from the event so it gets removed on unmount
-    return () => {
-      unsubscribe();
-    };
-  }, [navigation]);
+    }, [props.onDidFocus])
+  );
 
   return props.children ?? null;
 }

--- a/home/components/NavigationEvents.tsx
+++ b/home/components/NavigationEvents.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 export default function NavigationEvents(props: { children?: any; onDidFocus: () => void }) {
   useFocusEffect(
     React.useCallback(() => {
-      console.log('useFocusEffect');
       props.onDidFocus();
     }, [props.onDidFocus])
   );


### PR DESCRIPTION
# Why
Closes ENG-10863

# How
The `NavigationEvents` component was preventing the map from rendering. Instead of using event listeners, switching to `useFocuEffect` fixes the issue. Unclear to me why it broke

# Test Plan
Unversioned expo go running local home
