### PR TITLE
[docs] Add Expo Orbit page

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -233,6 +233,7 @@ const general = [
     makePage('build/updates.mdx'),
     makePage('build/building-on-ci.mdx'),
     makePage('build/building-from-github.mdx'),
+    makePage('build/orbit.mdx'),
     makeGroup(
       'App Signing',
       [

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -7,28 +7,28 @@ description: Accelerate your development workflow with one-click build launches 
 import { Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 
-Expo Orbit for macOS makes it faster and easier to install and run builds from EAS or elsewhere, and to run Snack projects on simulators and physical devices.
+Expo Orbit for macOS makes it faster to install and run builds from EAS or run Snack projects, on simulators and physical devices.
 
 <Video file="orbit/basic-features.mp4" />
 
-The process for installing builds from EAS (Android device/emulator, iOS simulator/device) and running Snack projects on simulators used to be more manual than it needs to be. You could use `eas build:run` and select a build for Android devices/emulators or iOS simulators, or you could download the archive, extract it, and drag and drop it to the simulator/emulator. For Snack projects, additional steps include installing Expo Go in the simulator through the CLI, logging in, and selecting the Snack from a list. Orbit makes these steps as seamless as possible.
+Before Orbit, installing builds from EAS (Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible. 
 
 ## Highlights
 
-- List and launch simulators, including the ability to run Android emulators without audio
-- Install and launch builds from EAS to your simulators and real devices in one click
-- Launch Snack projects in your simulators in one click
-- Install and launch apps from local files using Finder or just drag and drop a file into the menu bar app. Orbit supports any Android APK, simulator compatible **.app**, or ad hoc signed apps
-- See pinned projects and quickly launch your latest builds
+- List and launch simulators, including running Android emulators without audio.
+- Install and launch builds from EAS to your simulators and real devices in one click.
+- Launch Snack projects in your simulators in one click.
+- Install and launch apps from local files using Finder or drag and drop a file into the menu bar app. Orbit supports any Android **.apk**, iOS simulator compatible **.app**, or ad hoc signed apps.
+- See pinned projects from your EAS dashboard and quickly launch your latest builds.
 
 ## Installation
 
-You can download Orbit via Homebrew or directly through [GitHub](https://github.com/expo/orbit/releases).
+You can download Orbit with Homebrew, or directly from the [GitHub releases](https://github.com/expo/orbit/releases).
 
 <Terminal cmd={['$ brew install expo-orbit']} />
 
-If you want Orbit to automatically start when you log in, click on the Orbit icon in the menu bar, then "Settings" and select the "Launch on Login" option.
+If you want Orbit to start when you log in automatically, click on the Orbit icon in the menu bar, then **Settings** and select the **Launch on Login** option.
 
-> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires having both Android Studio and Xcode set up.
+> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
 
-At this point in time, Orbit is compatible only with macOS but we have exciting plans to integrate it further into the Expo ecosystem and add even more features. Try out Expo Orbit now, explore its capabilities, and share your feedback.
+Right now, Orbit is compatible only with macOS. However, we have exciting plans to integrate it further into the Expo ecosystem and add even more features. Try out Expo Orbit now, explore its capabilities, and share your feedback.

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -1,0 +1,34 @@
+---
+title: Expo Orbit
+maxHeadingDepth: 4
+description: Accelerate your development workflow with one-click build launches and simulator management.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+import Video from '~/components/plugins/Video';
+
+Expo Orbit for macOS makes it faster and easier to install and run builds from EAS or elsewhere, and to run Snack projects on simulators and physical devices.
+
+<Video file="orbit/basic-features.mp4" />
+
+The process for installing builds from EAS (Android device/emulator, iOS simulator, iOS device) and running Snack projects on simulators used to be more manual than it needs to be. You could use `eas build:run` and select a build for Android devices/emulators or iOS simulators, or you could download the archive, extract it, and drag and drop it to the simulator/emulator. For Snack projects, additional steps include installing Expo Go in the simulator through the CLI, logging in, and selecting the Snack from a list. To improve this we released Orbit, making these steps as seamless as possible and aligning with the user-friendly experience that Expo offers
+
+## Highlights
+
+- List and launch simulators, including the ability to run Android emulators without audio
+- Install and launch builds from EAS to your simulators and real devices with just one click
+- Launch Snack projects in your simulators by clicking a button
+- Install and launch apps from local files using Finder or just drag and drop a file into the menu bar app. Orbit supports any Android apk, simulator compatible .app, or ad-hoc signed apps
+- See pinned projects and quickly launch your latest builds
+
+## Installation
+
+You can download Orbit via Homebrew or directly through [GitHub](https://github.com/expo/orbit/releases).
+
+<Terminal cmd={['$ brew install expo-orbit']} />
+
+If you want Orbit to automatically start when you log in, click on the Orbit icon in the menu bar, then "Settings" and select the "Launch on Login" option.
+
+> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires having both Android Studio and Xcode set up.
+
+At this point in time, Orbit is compatible only with macOS but we have exciting plans to integrate it further into the Expo ecosystem and add even more features. Try out Expo Orbit now, explore its capabilities, and share your feedback.

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -7,7 +7,7 @@ description: Accelerate your development workflow with one-click build launches 
 import { Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 
-Expo Orbit for macOS makes it faster to install and run builds from EAS or run Snack projects, on simulators and physical devices.
+Expo Orbit for macOS makes it faster to install and run builds from EAS, local files, or run Snack projects, on simulators and physical devices.
 
 <Video file="orbit/basic-features.mp4" />
 

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -11,14 +11,14 @@ Expo Orbit for macOS makes it faster and easier to install and run builds from E
 
 <Video file="orbit/basic-features.mp4" />
 
-The process for installing builds from EAS (Android device/emulator, iOS simulator, iOS device) and running Snack projects on simulators used to be more manual than it needs to be. You could use `eas build:run` and select a build for Android devices/emulators or iOS simulators, or you could download the archive, extract it, and drag and drop it to the simulator/emulator. For Snack projects, additional steps include installing Expo Go in the simulator through the CLI, logging in, and selecting the Snack from a list. To improve this we released Orbit, making these steps as seamless as possible and aligning with the user-friendly experience that Expo offers
+The process for installing builds from EAS (Android device/emulator, iOS simulator/device) and running Snack projects on simulators used to be more manual than it needs to be. You could use `eas build:run` and select a build for Android devices/emulators or iOS simulators, or you could download the archive, extract it, and drag and drop it to the simulator/emulator. For Snack projects, additional steps include installing Expo Go in the simulator through the CLI, logging in, and selecting the Snack from a list. Orbit makes these steps as seamless as possible.
 
 ## Highlights
 
 - List and launch simulators, including the ability to run Android emulators without audio
-- Install and launch builds from EAS to your simulators and real devices with just one click
-- Launch Snack projects in your simulators by clicking a button
-- Install and launch apps from local files using Finder or just drag and drop a file into the menu bar app. Orbit supports any Android apk, simulator compatible .app, or ad-hoc signed apps
+- Install and launch builds from EAS to your simulators and real devices in one click
+- Launch Snack projects in your simulators in one click
+- Install and launch apps from local files using Finder or just drag and drop a file into the menu bar app. Orbit supports any Android APK, simulator compatible **.app**, or ad hoc signed apps
 - See pinned projects and quickly launch your latest builds
 
 ## Installation


### PR DESCRIPTION
# Why

Closes ENG-10625

# How

Add Expo Orbit page to docs

# Test Plan

![image](https://github.com/expo/expo/assets/11707729/679c3c73-9c8d-4c28-bf3e-f064ddd0fd8c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
