### PR TITLE
[expo] add missing fbemitter

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fixed `concurrentRoot` is missing from intialProps when running on New Architecture mode. ([#25415](https://github.com/expo/expo/pull/25415) by [@kudo](https://github.com/kudo))
 - Use explicit `@expo/metro-config` dependendecy to avoid unexpected versions in monorepos. ([#25804](https://github.com/expo/expo/pull/25804) by [@byCedric](https://github.com/byCedric))
+- Fixed `Unable to resolve "fbemitter"` issue when using DevTools Plugins. ([#25856](https://github.com/expo/expo/pull/25856) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -72,6 +72,7 @@
     "expo-keep-awake": "~12.8.0",
     "expo-modules-autolinking": "1.8.0",
     "expo-modules-core": "1.10.0",
+    "fbemitter": "^3.0.0",
     "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

dogfooding devtools plugins from a new app and having `fbemitter` not found issue

# How

`fbemitter` is used inside devtools plugins https://github.com/expo/expo/blob/79392551477b5a88e4c178b19314ef461063c9c3/packages/expo/src/devtools/DevToolsPluginClient.ts#L1
i didn't notice the fbemitter was removed from #18596. this pr tries to add fbemitter back

# Test Plan

on a new sdk 50 tabs project and add `@dev-plugins/react-navigation`. start the project will see the bundler error

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
