### PR TITLE
[expo-updates] better schedule for updates E2E CI

### DIFF
--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -18,7 +18,7 @@ on:
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
   schedule:
-    - cron: '0 18 * * MON' # 18:00 UTC every Monday
+    - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -18,7 +18,7 @@ on:
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
   schedule:
-    - cron: '0 18 * * MON' # 18:00 UTC every Monday
+    - cron: '0 20 * * SUN' # 20:00 UTC every Sunday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -44,7 +44,7 @@ on:
       - packages/expo-updates/**
       - templates/expo-template-bare-minimum/**
   schedule:
-    - cron: '0 18 * * MON' # 18:00 UTC every Monday
+    - cron: '0 22 * * SUN' # 22:00 UTC every Sunday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -62,7 +62,6 @@ jobs:
     env:
       UPDATES_PORT: 4747
     steps:
-
       - name: 👀 Checkout
         uses: actions/checkout@v3
       - name: ⬢ Setup Node


### PR DESCRIPTION
Move scheduled updates E2E CI to Sunday, and stagger start times.
