### PR TITLE
fix(cli): add support for `webpack-dev-server@4`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add support for `webpack-dev-server@4`. ([#25863](https://github.com/expo/expo/pull/25863) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.10.16 — 2023-11-24


### PR DESCRIPTION
# Why

This patches SDK 49 with a fix to "support" `webpack-dev-server@v4`.

# How

- `sockWrite` was renamed to `sendMessage` in `webpack-dev-server@4.0.0-rc.0` ([PR](https://github.com/webpack/webpack-dev-server/pull/3381), [release](https://github.com/webpack/webpack-dev-server/compare/v4.0.0-beta.3...v4.0.0-rc.0#diff-b706bbadb3d2315d99678f05e1f4bfd78a4bb4a7a6c65f3e81f1386fee3c883aL111))
- Updated assertion and `broadcastMessage` in `WebpackBundlerDevServer`.

# Test Plan

- `$ bun create expo ./test-webpack --template blank@49
- `$ bun expo install react-native-web react-dom @expo/webpack-config`
- `$ bun expo start`
- Press `w` in terminal
- Press `r` in terminal
- This should render `No apps connected. Sending "reload" to all React Native apps failed.` (without crashing the CLI process with a `CommandError: ...`).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
