### PR TITLE
[docs] Update npx eas-cli@latest command references

### DIFF
--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -52,7 +52,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`. Remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -19,7 +19,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`. Remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -75,7 +75,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`. Remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -17,7 +17,7 @@ EAS CLI is the command line app you will use to interact with EAS services from 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`; remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`. Remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -1,25 +1,28 @@
 ---
 title: Rollbacks
-description: Roll back a branch to a previous update or the embedded update.
+description: Rollback a branch to a previous update or the embedded update.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-There are two types of roll backs supported by EAS Update:
+There are two types of rollbacks supported by EAS Update:
+
 - Roll back to a previously-published update.
 - Roll back to the update embedded in the build.
 
-To start a roll back, use `npx eas-cli@latest` or ensure you have `eas-cli` version `5.9.0` or above. Then, run the following command:
+## Start a rollback
 
-<Terminal cmd={['npx eas-cli@latest update:rollback']} />
+To start a rollback, ensure you have EAS CLI version `5.9.0` or above installed. Then, run the following command:
+
+<Terminal cmd={['eas update:rollback']} />
 
 In the terminal, an interactive guide will assist you in selecting the type of rollback and doing the rollback.
 
 ## Rolling back to a previously-published update
 
-The above command re-publishes a previously-published update to functionally roll-back clients to that update.
+The above command re-publishes a previously-published update to functionally roll back clients to that update.
 
 ## Rolling back to the update embedded in the build
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -11,9 +11,9 @@ Rollouts incrementally deploy updates on a new branch to a specific channel. Wit
 
 ## Start a rollout
 
-To start a rollout, use `npx eas-cli@latest` or ensure you have `eas-cli` version `4.0.0` or above. Then, run the following command:
+To start a rollout, ensure you have EAS CLI version `4.0.0` or above installed. Then, run the following command:
 
-<Terminal cmd={['npx eas-cli@latest channel:rollout']} />
+<Terminal cmd={['eas channel:rollout']} />
 
 In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [slack](https://exponent-internal.slack.com/archives/C013ZK4SA12/p1702336058926329)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update `npx eas-cli@latest` command references in Rollout and Rollback guides to use `eas ...` command.
- In Rollback guide, added a section title for starting a rollback
- Also checked for other places to use this references but did not find any
- In some callouts related to EAS Update docs, split the sentence for clarity.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/eas-update/rollbacks/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
