### PR TITLE
[core][Android] Call `onCreate` when the `react` is ready

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `OnCrete` was called before the `React` instance was ready.
+
 ### 💡 Others
 
 ## 1.11.0 — 2023-12-12

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `OnCrete` was called before the `React` instance was ready.
+- [Android] Fixed `OnCreate` was called before the `React` instance was ready. ([#25866](https://github.com/expo/expo/pull/25866) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -97,7 +97,10 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     }
 
     mModuleRegistry.ensureIsInitialized();
-    getKotlinInteropModuleRegistry().installJSIInterop();
+
+    KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
+    kotlinModuleRegistry.emitOnCreate();
+    kotlinModuleRegistry.installJSIInterop();
 
     Collection<ExportedModule> exportedModules = mModuleRegistry.getAllExportedModules();
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -121,7 +121,7 @@ class AppContext(
       addActivityEventListener(reactLifecycleDelegate)
 
       // Registering modules has to happen at the very end of `AppContext` creation. Some modules need to access
-      // `AppContext` during their initialisation (or during `OnCreate` method), so we need to ensure all `AppContext`'s
+      // `AppContext` during their initialisation, so we need to ensure all `AppContext`'s
       // properties are initialized first. Not having that would trigger NPE.
       registry.register(ErrorManagerModule())
       registry.register(NativeModulesProxyModule())
@@ -129,6 +129,10 @@ class AppContext(
 
       logger.info("✅ AppContext was initialized")
     }
+  }
+
+  fun onCreate() = trace("AppContext.onCreate") {
+    registry.post(EventName.MODULE_CREATE)
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -132,7 +132,9 @@ class AppContext(
   }
 
   fun onCreate() = trace("AppContext.onCreate") {
+    registry.readyForPostingEvents()
     registry.post(EventName.MODULE_CREATE)
+    registry.flushTheEventQueue()
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -128,6 +128,10 @@ class KotlinInteropModuleRegistry(
     appContext.installJSIInterop()
   }
 
+  fun emitOnCreate() {
+    appContext.onCreate()
+  }
+
   fun setLegacyModulesProxy(proxyModule: NativeModulesProxy) {
     appContext.legacyModulesProxyHolder = WeakReference(proxyModule)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -16,6 +16,10 @@ class ModuleRegistry(
   @PublishedApi
   internal val registry = mutableMapOf<String, ModuleHolder<*>>()
 
+  private val postponedEvents = mutableListOf<PostponedEvent>()
+
+  private var onCreateEventWasEmitted = false
+
   fun <T : Module> register(module: T) = trace("ModuleRegistry.register(${module.javaClass})") {
     module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
 
@@ -30,7 +34,6 @@ class ModuleRegistry(
     }
 
     holder.apply {
-      post(EventName.MODULE_CREATE)
       registerContracts()
     }
 
@@ -73,20 +76,30 @@ class ModuleRegistry(
   }
 
   fun post(eventName: EventName) {
+    if (postponeEvent(eventName)) {
+      return
+    }
+
     forEach {
       it.post(eventName)
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
   fun <Sender> post(eventName: EventName, sender: Sender) {
+    if (postponeEvent(eventName)) {
+      return
+    }
+
     forEach {
       it.post(eventName, sender)
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
   fun <Sender, Payload> post(eventName: EventName, sender: Sender, payload: Payload) {
+    if (postponeEvent(eventName)) {
+      return
+    }
+
     forEach {
       it.post(eventName, sender, payload)
     }
@@ -97,5 +110,61 @@ class ModuleRegistry(
   fun cleanUp() {
     registry.clear()
     logger.info("✅ ModuleRegistry was destroyed")
+  }
+
+  /**
+   * It’s important that the [EventName.MODULE_CREATE] event is emitted first by the registry.
+   * However, some events like [EventName.ACTIVITY_ENTERS_FOREGROUND] are automatically emitted when the catalyst instance is created.
+   * To ensure the correct order of events, we capture all events that are emitted
+   * during the initialization phase and send them back to the modules later.
+   * This way, we can ensure that the order of events is correct.
+   */
+  private fun postponeEvent(
+    eventName: EventName,
+    sender: Any? = null,
+    payload: Any? = null
+  ): Boolean = synchronized(this) {
+    if (onCreateEventWasEmitted) {
+      return false
+    }
+
+    if (eventName == EventName.MODULE_CREATE) {
+      onCreateEventWasEmitted = true
+      val onCrete = PostponedEvent(eventName, sender, payload)
+      forEach {
+        onCrete.post(it)
+      }
+
+      postponedEvents.forEach { event ->
+        forEach {
+          event.post(it)
+        }
+      }
+
+      return true
+    }
+
+    postponedEvents.add(PostponedEvent(eventName, sender, payload))
+    return true
+  }
+
+  data class PostponedEvent(
+    val eventName: EventName,
+    val sender: Any? = null,
+    val payload: Any? = null
+  ) {
+    fun post(moduleHolder: ModuleHolder<*>) {
+      if (sender != null && payload != null) {
+        moduleHolder.post(eventName, sender, payload)
+        return
+      }
+
+      if (sender != null) {
+        moduleHolder.post(eventName, sender)
+        return
+      }
+
+      moduleHolder.post(eventName)
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -141,6 +141,8 @@ class ModuleRegistry(
         }
       }
 
+      postponedEvents.clear()
+
       return true
     }
 


### PR DESCRIPTION
# Why

Closes ENG-10874

# How

Call `OnCreate` when the react instance is ready - not when the module was added to the registry.

# Test Plan

- bare-expo ✅
- expo go ✅

