### PR TITLE
[go] Add plist key for location permissions

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -6,9 +6,9 @@ PODS:
   - EASClient/Tests (0.11.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXApplication (5.7.0):
+  - EXApplication (5.8.0):
     - ExpoModulesCore
-  - EXAV (13.9.0):
+  - EXAV (13.10.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - EXBarCodeScanner (12.9.0):
@@ -18,11 +18,11 @@ PODS:
     - ZXingObjC/PDF417
   - EXCalendar (12.2.0):
     - ExpoModulesCore
-  - EXConstants (15.3.0):
+  - EXConstants (15.4.0):
     - ExpoModulesCore
-  - EXContacts (12.7.0):
+  - EXContacts (12.8.0):
     - ExpoModulesCore
-  - EXFont (11.9.0):
+  - EXFont (11.10.0):
     - ExpoModulesCore
   - EXImageLoader (4.6.0):
     - ExpoModulesCore
@@ -31,29 +31,29 @@ PODS:
   - EXJSONUtils/Tests (0.12.0)
   - EXLocation (16.5.0):
     - ExpoModulesCore
-  - EXManifests (0.12.0):
+  - EXManifests (0.13.0):
     - ExpoModulesCore
-  - EXManifests/Tests (0.12.0):
+  - EXManifests/Tests (0.13.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXMediaLibrary (15.8.0):
+  - EXMediaLibrary (15.9.0):
     - ExpoModulesCore
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - EXNotifications (0.26.0):
+  - EXNotifications (0.27.0):
     - ExpoModulesCore
-  - Expo (50.0.0-alpha.7):
+  - Expo (50.0.0-preview.0):
     - ExpoModulesCore
-  - expo-dev-client (3.3.0):
+  - expo-dev-client (3.3.1):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (3.4.0):
+  - expo-dev-launcher (3.5.0):
     - EXManifests
-    - expo-dev-launcher/Main (= 3.4.0)
+    - expo-dev-launcher/Main (= 3.5.0)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -62,7 +62,7 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Main (3.4.0):
+  - expo-dev-launcher/Main (3.5.0):
     - EXManifests
     - expo-dev-launcher/Unsafe
     - expo-dev-menu
@@ -73,7 +73,7 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Tests (3.4.0):
+  - expo-dev-launcher/Tests (3.5.0):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -88,7 +88,7 @@ PODS:
     - React-Core
     - React-CoreModules
     - React-RCTAppDelegate
-  - expo-dev-launcher/Unsafe (3.4.0):
+  - expo-dev-launcher/Unsafe (3.5.0):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -98,17 +98,17 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-menu (4.4.0):
-    - expo-dev-menu/Main (= 4.4.0)
-    - expo-dev-menu/ReactNativeCompatibles (= 4.4.0)
+  - expo-dev-menu (4.5.0):
+    - expo-dev-menu/Main (= 4.5.0)
+    - expo-dev-menu/ReactNativeCompatibles (= 4.5.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - expo-dev-menu-interface (1.6.0)
-  - expo-dev-menu-interface/Tests (1.6.0):
+  - expo-dev-menu-interface (1.7.0)
+  - expo-dev-menu-interface/Tests (1.7.0):
     - Nimble
     - Quick
-  - expo-dev-menu/Main (4.4.0):
+  - expo-dev-menu/Main (4.5.0):
     - EXManifests
     - expo-dev-menu-interface
     - expo-dev-menu/Vendored
@@ -116,16 +116,16 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - expo-dev-menu/ReactNativeCompatibles (4.4.0):
+  - expo-dev-menu/ReactNativeCompatibles (4.5.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - expo-dev-menu/SafeAreaView (4.4.0):
+  - expo-dev-menu/SafeAreaView (4.5.0):
     - ExpoModulesCore
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - expo-dev-menu/Tests (4.4.0):
+  - expo-dev-menu/Tests (4.5.0):
     - ExpoModulesTestCore
     - glog
     - Nimble
@@ -133,13 +133,13 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-CoreModules
-  - expo-dev-menu/UITests (4.4.0):
+  - expo-dev-menu/UITests (4.5.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React
     - React-Core
     - React-CoreModules
-  - expo-dev-menu/Vendored (4.4.0):
+  - expo-dev-menu/Vendored (4.5.0):
     - expo-dev-menu/SafeAreaView
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -148,46 +148,46 @@ PODS:
     - ExpoModulesCore
   - ExpoBackgroundFetch (11.8.0):
     - ExpoModulesCore
-  - ExpoBattery (7.7.0):
+  - ExpoBattery (7.7.1):
     - ExpoModulesCore
   - ExpoBlur (12.9.0):
     - ExpoModulesCore
   - ExpoBrightness (11.8.0):
     - ExpoModulesCore
-  - ExpoCamera (13.9.0):
+  - ExpoCamera (14.0.0):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
   - ExpoCellular (5.7.0):
     - ExpoModulesCore
-  - ExpoClipboard (4.8.0):
+  - ExpoClipboard (5.0.0):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (4.8.0):
+  - ExpoClipboard/Tests (5.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - ExpoCrypto (12.8.0):
     - ExpoModulesCore
   - ExpoDevice (5.9.0):
     - ExpoModulesCore
-  - ExpoDocumentPicker (11.9.0):
+  - ExpoDocumentPicker (11.10.0):
     - ExpoModulesCore
-  - ExpoFileSystem (15.9.0):
+  - ExpoFileSystem (16.0.0):
     - ExpoModulesCore
-  - ExpoFileSystem/Tests (15.9.0):
+  - ExpoFileSystem/Tests (16.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoGL (13.5.0):
+  - ExpoGL (13.6.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - ExpoHaptics (12.8.0):
     - ExpoModulesCore
-  - ExpoImage (1.9.0):
+  - ExpoImage (1.10.0):
     - ExpoModulesCore
     - SDWebImage (~> 5.17.0)
     - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.13.0)
-  - ExpoImageManipulator (11.7.0):
+  - ExpoImageManipulator (11.8.0):
     - EXImageLoader
     - ExpoModulesCore
   - ExpoImagePicker (14.7.0):
@@ -201,7 +201,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (13.8.0):
     - ExpoModulesCore
-  - ExpoLocalization (14.7.0):
+  - ExpoLocalization (14.8.0):
     - ExpoModulesCore
   - ExpoMailComposer (12.7.0):
     - ExpoModulesCore
@@ -209,14 +209,14 @@ PODS:
     - ExpoModulesCore
     - GoogleMaps (= 7.3.0)
     - GooglePlaces (= 7.3.0)
-  - ExpoModulesCore (1.10.0):
+  - ExpoModulesCore (1.11.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesCore/Tests (1.10.0):
+  - ExpoModulesCore/Tests (1.11.0):
     - ExpoModulesTestCore
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -224,7 +224,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesTestCore (0.16.0):
+  - ExpoModulesTestCore (0.17.0):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
     - Quick (~> 7.3.0)
@@ -240,34 +240,34 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - ExpoSecureStore (12.7.0):
+  - ExpoSecureStore (12.8.0):
     - ExpoModulesCore
-  - ExpoSensors (12.8.0):
+  - ExpoSensors (12.9.0):
     - ExpoModulesCore
-  - ExpoSharing (11.9.0):
+  - ExpoSharing (11.10.0):
     - ExpoModulesCore
   - ExpoSMS (11.7.0):
     - ExpoModulesCore
   - ExpoSpeech (11.7.0):
     - ExpoModulesCore
-  - ExpoSQLite (12.2.1):
+  - ExpoSQLite (13.0.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.8.0):
     - ExpoModulesCore
-  - ExpoSystemUI (2.8.0):
+  - ExpoSystemUI (2.9.0):
     - ExpoModulesCore
   - ExpoTrackingTransparency (3.3.0):
     - ExpoModulesCore
-  - ExpoVideo (0.2.0):
+  - ExpoVideo (0.3.0):
     - ExpoModulesCore
-  - ExpoVideoThumbnails (7.8.0):
+  - ExpoVideoThumbnails (7.9.0):
     - ExpoModulesCore
   - ExpoWebBrowser (12.8.0):
     - ExpoModulesCore
   - EXScreenCapture (5.7.0):
     - ExpoModulesCore
-  - EXSplashScreen (0.25.0):
+  - EXSplashScreen (0.26.0):
     - ExpoModulesCore
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1936,68 +1936,68 @@ SPEC CHECKSUMS:
   boost: 26fad476bfa736552bbfa698a06cc530475c1505
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   EASClient: b550a8d3d3d9d1211ba71eabf789cb46c7e92b3c
-  EXApplication: 196861d13bdaeb7f74e222f1907b8c677de489c3
-  EXAV: 4ddc18b96735a71cfeaebabeaacf77dc9fd2cb52
+  EXApplication: 7d3063cc3cbd14a0d3c6e1c73854f4a71901ac67
+  EXAV: 69adaa7433e7123a7dc9df9841fd80e954916d2d
   EXBarCodeScanner: 2c2fee40a33902612792b2f0de4e9da40f080613
   EXCalendar: 3c6e6c545f617c89835a10fe251093cf36914b31
-  EXConstants: adcf913f005bb3a6eba1f89c34090bed5a0b89f7
-  EXContacts: 1cf97b2518b2e687b184cf0cb153346cf67fd3aa
-  EXFont: 0a688bc37845f2665376c8c93a822fe5483dae37
+  EXConstants: 72036156769fff0ec37d0385ce9cd47e0042e7a0
+  EXContacts: a9e39b5a7176e421d70c9396dfc6d1399bfe3945
+  EXFont: 9ae7e8e2e4825cef04a45dca74512a3f711e2fe9
   EXImageLoader: 55080616b2fe9da19ef8c7f706afd9814e279b6b
   EXJSONUtils: d138005ee11b84fc4e3bf7119a160034db5d5e20
   EXLocation: 4cdbc108ff5bd944d981b7d0c0cf98630104a84a
-  EXManifests: 17fbf8ed7e987cdbc6b93064f427a1bca4732088
-  EXMediaLibrary: 944823444f1be749f3fbe0c33afbacdf691fa159
-  EXNotifications: 1cbda734d622205cd72a0523a90e01dda0470edc
-  Expo: 97df3b68de6c485f894dbae821666bec8435e144
-  expo-dev-client: 820f881c0dc8a0f1f4cd1e35a35469d1d0fbc798
-  expo-dev-launcher: 8f353ad1c0e24a449581da76141bff672c28c729
-  expo-dev-menu: 9fc863259e3178e3c65ccdc2515bf3f6ba9e9512
-  expo-dev-menu-interface: 05d08cc56649636de77253583b4bbb73adce7680
+  EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
+  EXMediaLibrary: 9ca30a11319813904316ac3910bc4beef6af5b8a
+  EXNotifications: 4c22233f3be3bdcc2e935adccd961cf20053952f
+  Expo: 848e319eaa72f1e2b16e3ab070fe49df8cb5ebe4
+  expo-dev-client: a63c93ade434e7a381f516bcc03803843341cd7f
+  expo-dev-launcher: 7c1eb84c208aa585855683abe35b2646a9639574
+  expo-dev-menu: f751ca704ad23480ef79f8af460aff084b2dd036
+  expo-dev-menu-interface: 3c36b4d5032397e022958a2041afe91a130ea74c
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
-  ExpoBattery: af4f5e348dc1e1506d6d813e06c172c22bc8d36d
+  ExpoBattery: c75a7c094d64d89d96d3e3f419627b152da94f29
   ExpoBlur: 6c4602d729a492663b0916e5862b334a23157f0a
   ExpoBrightness: 6d160de5877289d11674aea61aacdb37422774cf
-  ExpoCamera: c13580cc0964c9e462f76579a0de9f468a9c6e73
+  ExpoCamera: a3f3681963815533c24f698a22c239e68724fb99
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
-  ExpoClipboard: b8f76767b0dbaefb3be7adbf85049fd85861d527
+  ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
   ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
-  ExpoDocumentPicker: a1a38f72993a4f0622d0c918d520b4ff640ba1cb
-  ExpoFileSystem: 1bc21c70ab0bf505cd6bef97c5b008618bfb72f2
-  ExpoGL: e452774bffdc758a6fe2dbff589234fa4026a4c3
+  ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
+  ExpoFileSystem: afa26ca687713c020c51b9cb880d74a82083f79f
+  ExpoGL: 085542f97b13f2428ac2edb077c9a90f4566944d
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
-  ExpoImage: cfaa9c379a3467c7863a187a1059c220b27a0741
-  ExpoImageManipulator: b9d5ddfe7f00932677b52b6d5bd667e41caf0b2d
+  ExpoImage: 5ba424cbd89ba94103f21817cc310c26a009d967
+  ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
   ExpoImagePicker: 247fc7d2c13426a835525b67d5fb221864b79612
   ExpoInsights: 28a5bab3d75d32c6266b00c5166668561a0bf756
   ExpoKeepAwake: ed71bfe0e6ecd38e337586ba6e1ba27a56eb373b
   ExpoLinearGradient: 6ff7b35f824f18f77d9c3ad3ee09fe0b4229e669
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
-  ExpoLocalization: 80da146f602b14cc42077b93305ccd1c20fb9d55
+  ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042
   ExpoMailComposer: 1f980bbdd0647500178625f453e509cef1282d43
   ExpoMaps: e9e83d84c3af7c25fc4a139917239881e319e08a
-  ExpoModulesCore: 9f8a0e08e339ba3e380417aebbdbbe63a209d953
-  ExpoModulesTestCore: dc4fb42e754da2127b7b4d37513788a70e3bfcc4
+  ExpoModulesCore: 0fcf4d6d8c18a013de78ea4ab96e4f339e050f23
+  ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
   ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7
   ExpoRandom: f0cd58e154e463d913462f3b445870b12d1c2f12
   ExpoScreenOrientation: b536311828c68fbe8ce5d5c46dadf14933a37812
-  ExpoSecureStore: 4c908afd15fc011dd7cbfcd73f7c2c54fb255f34
-  ExpoSensors: bbe19829983c1f676368441fb720a60b58398f3b
-  ExpoSharing: 5cf14269b25e6d5b7f9e8bd069ff2b273378a6b4
+  ExpoSecureStore: 684e61c2fb2d5e61fee11b3bbd2c67610cd808b8
+  ExpoSensors: 773adb32167d5d3c28280697ceee342b88f606ab
+  ExpoSharing: 752ad6ae2b693de9cd4e7fddb78297bdc658b815
   ExpoSMS: aca5b62dbfef73670cb35d0ebd9a2017899bbb2d
   ExpoSpeech: 5e108798facd5e77e0ff040bdae6907aebeed6c5
-  ExpoSQLite: cc81d9cd1fd0d0751a709e83f373728c0d93e3bb
+  ExpoSQLite: faef97b8091da7d0e23f4e7efee86696bd274093
   ExpoStoreReview: 32f07e415ae739d2db51693c3befa1d6c0151562
-  ExpoSystemUI: 3b64029a3a3dbaf74d843acdbe68c157a982f06d
+  ExpoSystemUI: 7bf1f529a4c3d2dfc6b681d770a7babf68c11a7e
   ExpoTrackingTransparency: bbae3e495bc58c79b9430cfbc217a56c2ddc9354
-  ExpoVideo: 90a408fa68eddf5ea0e3e7b0762332f36eaaa7a6
-  ExpoVideoThumbnails: abe119b4605428b02291e9f06f0edabc27c1fc8a
+  ExpoVideo: 47be0f06e040977ff550071c832dc2ef55142bfd
+  ExpoVideoThumbnails: 9b6c0dada0b3240dd3527e0dc688711e17842c88
   ExpoWebBrowser: 2b660d423b818c4c45b6b3d22a3c0652153fb176
   EXScreenCapture: b5be31ba5b35aed400d325b85b335da6a2e547ac
-  EXSplashScreen: 0e99f595cb18dc8b8a6ed775001dcfa3320fd765
+  EXSplashScreen: d6d7ea9582e4ed7655cf893b32dca13ef0712279
   EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
   EXTaskManager: 81b2dfaaba6d9f9a4bc3e3e2a786a98004eb9e98
   EXUpdatesInterface: 4f787eeabc62c258f978ea4865c67adfb6b2f19f

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/ff953626-b775-43f8-b11c-db43d02c0ecc"
+  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/d9948414-de97-44da-b195-55d9a725801d"
 }

--- a/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
@@ -9,13 +9,14 @@ import {
   NativeEventSubscription,
   Platform,
   StyleSheet,
-  Text,
   View,
 } from 'react-native';
 import MapView, { Circle, MapPressEvent } from 'react-native-maps';
 
 import NavigationEvents from '../../components/NavigationEvents';
 import Button from '../../components/PrimaryButton';
+
+import { StyledText } from '@/components/Text';
 
 const GEOFENCING_TASK = 'geofencing';
 const REGION_RADIUSES = [30, 50, 75, 100, 150, 200];
@@ -199,7 +200,7 @@ export default class GeofencingScreen extends React.Component<Props, State> {
 
   render() {
     if (this.state.error) {
-      return <Text style={styles.errorText}>{this.state.error}</Text>;
+      return <StyledText style={styles.errorText}>{this.state.error}</StyledText>;
     }
 
     if (!this.state.initialRegion) {

--- a/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
@@ -16,9 +16,10 @@ import {
 } from 'react-native';
 import MapView, { Polyline } from 'react-native-maps';
 
-import NavigationEvents from '../../components/NavigationEvents';
-import Button from '../../components/PrimaryButton';
-import Colors from '../../constants/Colors';
+import NavigationEvents from '@/components/NavigationEvents';
+import Button from '@/components/PrimaryButton';
+import { StyledText } from '@/components/Text';
+import Colors from '@/constants/Colors';
 
 const STORAGE_KEY = 'expo-home-locations';
 const LOCATION_UPDATES_TASK = 'location-updates';
@@ -82,11 +83,9 @@ export default class LocationDiagnosticsScreen extends React.Component<Props, St
       this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
       this.setState({
         error:
-          'Location permissions are required in order to use this feature. You can manually enable them at any time in the "Location Services" section of the Settings app.',
+          'Location access is required to be set to `Always` in order to use this feature. You can manually enable them at any time in the "Location Services" section of the Settings app.',
       });
       return;
-    } else {
-      this.setState({ error: null });
     }
 
     const { coords } = await Location.getCurrentPositionAsync();
@@ -114,6 +113,7 @@ export default class LocationDiagnosticsScreen extends React.Component<Props, St
         latitudeDelta: 0.004,
         longitudeDelta: 0.002,
       },
+      error: null,
     }));
   };
 
@@ -231,7 +231,7 @@ export default class LocationDiagnosticsScreen extends React.Component<Props, St
 
   render() {
     if (this.state.error) {
-      return <Text style={styles.errorText}>{this.state.error}</Text>;
+      return <StyledText style={styles.errorText}>{this.state.error}</StyledText>;
     }
 
     if (!this.state.initialRegion) {
@@ -348,7 +348,6 @@ const styles = StyleSheet.create({
   },
   errorText: {
     fontSize: 15,
-    color: 'rgba(0,0,0,0.7)',
     margin: 20,
   },
 });

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key> NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allow Expo projects to use your location</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -801,9 +801,9 @@ PODS:
   - EASClient/Tests (0.11.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXApplication (5.7.0):
+  - EXApplication (5.8.0):
     - ExpoModulesCore
-  - EXAV (13.9.0):
+  - EXAV (13.10.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - EXBarCodeScanner (12.9.0):
@@ -813,11 +813,11 @@ PODS:
     - ZXingObjC/PDF417
   - EXCalendar (12.2.0):
     - ExpoModulesCore
-  - EXConstants (15.3.0):
+  - EXConstants (15.4.0):
     - ExpoModulesCore
-  - EXContacts (12.7.0):
+  - EXContacts (12.8.0):
     - ExpoModulesCore
-  - EXFont (11.9.0):
+  - EXFont (11.10.0):
     - ExpoModulesCore
   - EXImageLoader (4.6.0):
     - ExpoModulesCore
@@ -826,65 +826,65 @@ PODS:
   - EXJSONUtils/Tests (0.12.0)
   - EXLocation (16.5.0):
     - ExpoModulesCore
-  - EXManifests (0.12.0):
+  - EXManifests (0.13.0):
     - ExpoModulesCore
-  - EXManifests/Tests (0.12.0):
+  - EXManifests/Tests (0.13.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXMediaLibrary (15.8.0):
+  - EXMediaLibrary (15.9.0):
     - ExpoModulesCore
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - EXNotifications (0.26.0):
+  - EXNotifications (0.27.0):
     - ExpoModulesCore
-  - Expo (50.0.0-alpha.7):
+  - Expo (50.0.0-preview.0):
     - ExpoModulesCore
   - ExpoAppleAuthentication (6.3.0):
     - ExpoModulesCore
   - ExpoBackgroundFetch (11.8.0):
     - ExpoModulesCore
-  - ExpoBattery (7.7.0):
+  - ExpoBattery (7.7.1):
     - ExpoModulesCore
   - ExpoBlur (12.9.0):
     - ExpoModulesCore
   - ExpoBrightness (11.8.0):
     - ExpoModulesCore
-  - ExpoCamera (13.9.0):
+  - ExpoCamera (14.0.0):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
   - ExpoCellular (5.7.0):
     - ExpoModulesCore
-  - ExpoClipboard (4.8.0):
+  - ExpoClipboard (5.0.0):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (4.8.0):
+  - ExpoClipboard/Tests (5.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - ExpoCrypto (12.8.0):
     - ExpoModulesCore
   - ExpoDevice (5.9.0):
     - ExpoModulesCore
-  - ExpoDocumentPicker (11.9.0):
+  - ExpoDocumentPicker (11.10.0):
     - ExpoModulesCore
-  - ExpoFileSystem (15.9.0):
+  - ExpoFileSystem (16.0.0):
     - ExpoModulesCore
-  - ExpoFileSystem/Tests (15.9.0):
+  - ExpoFileSystem/Tests (16.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoGL (13.5.0):
+  - ExpoGL (13.6.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - ExpoHaptics (12.8.0):
     - ExpoModulesCore
-  - ExpoHead (3.2.0):
+  - ExpoHead (3.3.0):
     - ExpoModulesCore
-  - ExpoImage (1.9.0):
+  - ExpoImage (1.10.0):
     - ExpoModulesCore
     - SDWebImage (~> 5.17.0)
     - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.13.0)
-  - ExpoImageManipulator (11.7.0):
+  - ExpoImageManipulator (11.8.0):
     - EXImageLoader
     - ExpoModulesCore
   - ExpoImagePicker (14.7.0):
@@ -895,24 +895,24 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (13.8.0):
     - ExpoModulesCore
-  - ExpoLocalization (14.7.0):
+  - ExpoLocalization (14.8.0):
     - ExpoModulesCore
   - ExpoMailComposer (12.7.0):
     - ExpoModulesCore
-  - ExpoModulesCore (1.10.0):
+  - ExpoModulesCore (1.11.0):
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesCore/Tests (1.10.0):
+  - ExpoModulesCore/Tests (1.11.0):
     - ExpoModulesTestCore
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesTestCore (0.16.0):
+  - ExpoModulesTestCore (0.17.0):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
     - Quick (~> 7.3.0)
@@ -927,34 +927,34 @@ PODS:
     - ExpoModulesCore
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - ExpoSecureStore (12.7.0):
+  - ExpoSecureStore (12.8.0):
     - ExpoModulesCore
-  - ExpoSensors (12.8.0):
+  - ExpoSensors (12.9.0):
     - ExpoModulesCore
-  - ExpoSharing (11.9.0):
+  - ExpoSharing (11.10.0):
     - ExpoModulesCore
   - ExpoSMS (11.7.0):
     - ExpoModulesCore
   - ExpoSpeech (11.7.0):
     - ExpoModulesCore
-  - ExpoSQLite (12.2.1):
+  - ExpoSQLite (13.0.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.8.0):
     - ExpoModulesCore
-  - ExpoSystemUI (2.8.0):
+  - ExpoSystemUI (2.9.0):
     - ExpoModulesCore
   - ExpoTrackingTransparency (3.3.0):
     - ExpoModulesCore
-  - ExpoVideo (0.2.0):
+  - ExpoVideo (0.3.0):
     - ExpoModulesCore
-  - ExpoVideoThumbnails (7.8.0):
+  - ExpoVideoThumbnails (7.9.0):
     - ExpoModulesCore
   - ExpoWebBrowser (12.8.0):
     - ExpoModulesCore
   - EXScreenCapture (5.7.0):
     - ExpoModulesCore
-  - EXSplashScreen (0.25.0):
+  - EXSplashScreen (0.26.0):
     - ExpoModulesCore
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -963,7 +963,7 @@ PODS:
   - EXTaskManager (11.7.0):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.23.0):
+  - EXUpdates (0.24.0):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -973,7 +973,7 @@ PODS:
     - ReachabilitySwift
     - React-Core
     - sqlite3 (~> 3.42.0)
-  - EXUpdates/Tests (0.23.0):
+  - EXUpdates/Tests (0.24.0):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -3249,66 +3249,66 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EASClient: b550a8d3d3d9d1211ba71eabf789cb46c7e92b3c
-  EXApplication: 196861d13bdaeb7f74e222f1907b8c677de489c3
-  EXAV: 4ddc18b96735a71cfeaebabeaacf77dc9fd2cb52
+  EXApplication: 7d3063cc3cbd14a0d3c6e1c73854f4a71901ac67
+  EXAV: 69adaa7433e7123a7dc9df9841fd80e954916d2d
   EXBarCodeScanner: 2c2fee40a33902612792b2f0de4e9da40f080613
   EXCalendar: 3c6e6c545f617c89835a10fe251093cf36914b31
-  EXConstants: adcf913f005bb3a6eba1f89c34090bed5a0b89f7
-  EXContacts: 1cf97b2518b2e687b184cf0cb153346cf67fd3aa
-  EXFont: 0a688bc37845f2665376c8c93a822fe5483dae37
+  EXConstants: 72036156769fff0ec37d0385ce9cd47e0042e7a0
+  EXContacts: a9e39b5a7176e421d70c9396dfc6d1399bfe3945
+  EXFont: 9ae7e8e2e4825cef04a45dca74512a3f711e2fe9
   EXImageLoader: 55080616b2fe9da19ef8c7f706afd9814e279b6b
   EXJSONUtils: d138005ee11b84fc4e3bf7119a160034db5d5e20
   EXLocation: 4cdbc108ff5bd944d981b7d0c0cf98630104a84a
-  EXManifests: 17fbf8ed7e987cdbc6b93064f427a1bca4732088
-  EXMediaLibrary: 47f8b7d3ab5e4f0f3a6284025697aab421df0756
-  EXNotifications: 1cbda734d622205cd72a0523a90e01dda0470edc
-  Expo: 97df3b68de6c485f894dbae821666bec8435e144
+  EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
+  EXMediaLibrary: abe485eada37ee162a7f486f3ffe3e7847e0b509
+  EXNotifications: 4c22233f3be3bdcc2e935adccd961cf20053952f
+  Expo: 848e319eaa72f1e2b16e3ab070fe49df8cb5ebe4
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
-  ExpoBattery: af4f5e348dc1e1506d6d813e06c172c22bc8d36d
+  ExpoBattery: c75a7c094d64d89d96d3e3f419627b152da94f29
   ExpoBlur: 6c4602d729a492663b0916e5862b334a23157f0a
   ExpoBrightness: 6d160de5877289d11674aea61aacdb37422774cf
-  ExpoCamera: c13580cc0964c9e462f76579a0de9f468a9c6e73
+  ExpoCamera: a3f3681963815533c24f698a22c239e68724fb99
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
-  ExpoClipboard: b8f76767b0dbaefb3be7adbf85049fd85861d527
+  ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
   ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
-  ExpoDocumentPicker: a1a38f72993a4f0622d0c918d520b4ff640ba1cb
-  ExpoFileSystem: 1bc21c70ab0bf505cd6bef97c5b008618bfb72f2
-  ExpoGL: e452774bffdc758a6fe2dbff589234fa4026a4c3
+  ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
+  ExpoFileSystem: afa26ca687713c020c51b9cb880d74a82083f79f
+  ExpoGL: 085542f97b13f2428ac2edb077c9a90f4566944d
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
-  ExpoHead: e4605573eea4e36b29ce35716d451e4218b21680
-  ExpoImage: cfaa9c379a3467c7863a187a1059c220b27a0741
-  ExpoImageManipulator: b9d5ddfe7f00932677b52b6d5bd667e41caf0b2d
+  ExpoHead: d45bf5e3190d792c89cc049cef9cf9ce3dc7485b
+  ExpoImage: 5ba424cbd89ba94103f21817cc310c26a009d967
+  ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
   ExpoImagePicker: 247fc7d2c13426a835525b67d5fb221864b79612
   ExpoKeepAwake: ed71bfe0e6ecd38e337586ba6e1ba27a56eb373b
   ExpoLinearGradient: 6ff7b35f824f18f77d9c3ad3ee09fe0b4229e669
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
-  ExpoLocalization: 80da146f602b14cc42077b93305ccd1c20fb9d55
+  ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042
   ExpoMailComposer: 1f980bbdd0647500178625f453e509cef1282d43
-  ExpoModulesCore: 0fe70281431a0eb3b60fc6ae7a40bc36bd2bafc9
-  ExpoModulesTestCore: dc4fb42e754da2127b7b4d37513788a70e3bfcc4
+  ExpoModulesCore: 140655292447fada8b754b8220d004251cd5d773
+  ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
   ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7
   ExpoRandom: f0cd58e154e463d913462f3b445870b12d1c2f12
   ExpoScreenOrientation: 0c5bd98532cc4ee077a86da6f41ce2df0f31c029
-  ExpoSecureStore: 4c908afd15fc011dd7cbfcd73f7c2c54fb255f34
-  ExpoSensors: bbe19829983c1f676368441fb720a60b58398f3b
-  ExpoSharing: 5cf14269b25e6d5b7f9e8bd069ff2b273378a6b4
+  ExpoSecureStore: 684e61c2fb2d5e61fee11b3bbd2c67610cd808b8
+  ExpoSensors: 773adb32167d5d3c28280697ceee342b88f606ab
+  ExpoSharing: 752ad6ae2b693de9cd4e7fddb78297bdc658b815
   ExpoSMS: aca5b62dbfef73670cb35d0ebd9a2017899bbb2d
   ExpoSpeech: 5e108798facd5e77e0ff040bdae6907aebeed6c5
-  ExpoSQLite: cc81d9cd1fd0d0751a709e83f373728c0d93e3bb
+  ExpoSQLite: faef97b8091da7d0e23f4e7efee86696bd274093
   ExpoStoreReview: 32f07e415ae739d2db51693c3befa1d6c0151562
-  ExpoSystemUI: 3b64029a3a3dbaf74d843acdbe68c157a982f06d
+  ExpoSystemUI: 7bf1f529a4c3d2dfc6b681d770a7babf68c11a7e
   ExpoTrackingTransparency: bbae3e495bc58c79b9430cfbc217a56c2ddc9354
-  ExpoVideo: 90a408fa68eddf5ea0e3e7b0762332f36eaaa7a6
-  ExpoVideoThumbnails: abe119b4605428b02291e9f06f0edabc27c1fc8a
+  ExpoVideo: 47be0f06e040977ff550071c832dc2ef55142bfd
+  ExpoVideoThumbnails: 9b6c0dada0b3240dd3527e0dc688711e17842c88
   ExpoWebBrowser: 2b660d423b818c4c45b6b3d22a3c0652153fb176
   EXScreenCapture: b5be31ba5b35aed400d325b85b335da6a2e547ac
-  EXSplashScreen: 1c589accb47d99cd7c6e20590b34b489bd2b6594
+  EXSplashScreen: 03bd63f9217e0849d5131dfb80c16e096879280e
   EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
   EXTaskManager: 81b2dfaaba6d9f9a4bc3e3e2a786a98004eb9e98
-  EXUpdates: e9f30b5fde2bbeabaf340081ecae3eca3a3312c2
+  EXUpdates: c8584972e1fc5856084689b4f526a78bc62e6d87
   EXUpdatesInterface: 4f787eeabc62c258f978ea4865c67adfb6b2f19f
   FBAEMKit: 4763aa27b8f69eb9d2c274189e91388de1dbd88a
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06


### PR DESCRIPTION
# Why
Closes ENG-10863
Try to fix location diagnostics screen issue in Expo go. Adds `NSLocationAlwaysAndWhenInUseUsageDescription` to Expo gos plist. We require location permissions to be set to `Always`. Without this key, on devices running iOS 11 and above we cannot request it, and it isn't even an option when you try to add it manually through the settings app. Podfile changes are related to a recent publish.  

# How
Added the key to the plist also fixed the error text on the diagnostic screens so they will be visible when running in dark mode.

# Test Plan
Versioned expo go in release mode.

