### PR TITLE
[updates][e2e] Attempt to make startup tests more reliable

### DIFF
--- a/packages/expo-updates/e2e/fixtures/Updates-startup.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-startup.e2e.ts
@@ -77,7 +77,7 @@ describe('Basic tests', () => {
       projectRoot
     );
 
-    Server.start(Update.serverPort, protocolVersion, 5000);
+    Server.start(Update.serverPort, protocolVersion, 7000);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -467,7 +467,7 @@ export function transformAppJsonForE2EWithFallbackToCacheTimeout(
       ...transformedForE2E.expo,
       updates: {
         ...transformedForE2E.expo.updates,
-        fallbackToCacheTimeout: 3000,
+        fallbackToCacheTimeout: 5000,
       },
     },
   };


### PR DESCRIPTION
# Why

Saw this failure: https://github.com/expo/expo/actions/runs/7183977574/job/19563978383. It looks like maybe the server didn't respond quickly enough for the app's `fallbackToCacheTimeout`. 

# How

This changes it to the following:
- `downloads new update before launching` test: 1000ms artificial delay in serving update, 5000ms `fallbackToCacheTimeout`
- `does not download new update when it takes longer than timeout` test: 7000ms artificial delay in serving update, 5000ms `fallbackToCacheTimeout`

# Test Plan

Wait for CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
