### PR TITLE
fix(cli): use proper `deviceName` when opening debugger for multiple devices

### DIFF
--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -102,8 +102,8 @@ export class DevServerManagerActions {
       app = apps[0];
     } else {
       const choices = apps.map((app) => ({
-        title: app.title,
-        value: app.deviceName ?? 'Unknown device',
+        title: app.deviceName ?? 'Unknown device',
+        value: app.id,
         app,
       }));
 


### PR DESCRIPTION
# Why

Correction of #25671

# How

- Use `app.deviceName` instead of `app.title`

# Test Plan

![image](https://github.com/expo/expo/assets/1203991/740ab535-3274-43fe-bd23-69fd0c725179)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
