### PR TITLE
fix(cli): add back legacy js inspector middleware

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,7 +66,7 @@ android {
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
     versionCode 221
-    versionName '2.30.2'
+    versionName '2.30.3'
     // END VERSIONS
 
     multiDexEnabled true

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -248,7 +248,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     reactApplicationContext.runOnNativeModulesQueueThread {
       val devSupportManager = getDevSupportManager()
       devSupportManager?.devSettings?.packagerConnectionSettings?.inspectorServerHost?.let {
-        val url = "http://$it/inspector?applicationId=${reactApplicationContext.packageName}"
+        val url = "http://$it/_expo/inspector?applicationId=${reactApplicationContext.packageName}"
         val request = Request.Builder().url(url).put("".toRequestBody()).build()
         Exponent.instance.exponentNetwork.noCacheClient.newCall(request).execute()
       }

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -102,8 +102,8 @@ export class DevServerManagerActions {
       app = apps[0];
     } else {
       const choices = apps.map((app) => ({
-        title: app.title,
-        value: app.deviceName ?? 'Unknown device',
+        title: app.deviceName ?? 'Unknown device',
+        value: app.id,
         app,
       }));
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -21,6 +21,7 @@ import { createDebuggerTelemetryMiddleware } from '../../../utils/analytics/metr
 import { logEventAsync } from '../../../utils/analytics/rudderstackClient';
 import { env } from '../../../utils/env';
 import { getMetroServerRoot } from '../middleware/ManifestMiddleware';
+import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware, replaceMiddlewareWith } from '../middleware/mutations';
 import { remoteDevtoolsCorsMiddleware } from '../middleware/remoteDevtoolsCorsMiddleware';
 import { remoteDevtoolsSecurityHeadersMiddleware } from '../middleware/remoteDevtoolsSecurityHeadersMiddleware';
@@ -179,6 +180,7 @@ export async function instantiateMetroAsync(
   // Initialize all React Native debug features
   const { debugMiddleware, debugWebsocketEndpoints } = createDebugMiddleware(metroBundler);
   prependMiddleware(middleware, debugMiddleware);
+  middleware.use('/_expo/debugger', createJsInspectorMiddleware());
 
   const { server, metro } = await runServer(metroBundler, metroConfig, {
     // @ts-expect-error: Inconsistent `websocketEndpoints` type between metro and @react-native-community/cli-server-api

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
@@ -1,0 +1,134 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Socket } from 'net';
+import { URL } from 'url';
+
+import { METRO_INSPECTOR_RESPONSE_FIXTURE } from './fixtures/metroInspectorResponse';
+import * as JsInspector from '../JsInspector';
+import { createJsInspectorMiddleware } from '../createJsInspectorMiddleware';
+
+jest.mock('../JsInspector');
+
+describe('createJsInspectorMiddleware', () => {
+  it('should return specific app entity for GET request with given applicationId', async () => {
+    const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0];
+    const req = createRequest(`http://localhost:8081/inspector?applicationId=${app.description}`);
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(app));
+
+    const middlewareAsync = createJsInspectorMiddleware();
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 200, JSON.stringify(app));
+  });
+
+  it('should handle ipv6 address', async () => {
+    const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0];
+    const req = createRequest(
+      `http://[::ffff:127.0.0.1]/inspector?applicationId=${app.description}`
+    );
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(app));
+
+    const middlewareAsync = createJsInspectorMiddleware();
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 200, JSON.stringify(app));
+  });
+
+  it('should return 404 for GET request with nonexistent applicationId', async () => {
+    const req = createRequest('http://localhost:8081/inspector?applicationId=nonExistentApp');
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(null));
+
+    const middlewareAsync = createJsInspectorMiddleware();
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 404);
+  });
+
+  it('should return 400 for GET request without parameters', async () => {
+    const req = createRequest('http://localhost:8081/inspector');
+    const res = createMockedResponse();
+    const next = jest.fn();
+
+    const middlewareAsync = createJsInspectorMiddleware();
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 400);
+  });
+
+  it('should open browser for PUT request with given applicationId', async () => {
+    const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0];
+    const req = createRequest(
+      `http://localhost:8081/inspector?applicationId=${app.description}`,
+      'PUT'
+    );
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(app));
+
+    const middlewareAsync = createJsInspectorMiddleware();
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 200);
+    expect(JsInspector.openJsInspector).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createRequest(requestUrl: string, method?: 'GET' | 'POST' | 'PUT'): IncomingMessage {
+  const url = new URL(requestUrl);
+  const req: Partial<IncomingMessage> = {
+    method: method || 'GET',
+    headers: {
+      host: url.host,
+    },
+    socket: {
+      localAddress: url.hostname,
+      localPort: Number(url.port || 80),
+    } as Socket,
+    url: `${url.pathname}${url.search}`,
+  };
+  return req as IncomingMessage;
+}
+
+interface MockedResponse extends Partial<ServerResponse> {
+  end: jest.Mock;
+  writeHead: jest.Mock;
+  write: jest.Mock;
+}
+
+function createMockedResponse(): MockedResponse {
+  return {
+    end: jest.fn(),
+    writeHead: jest.fn().mockReturnThis(),
+    write: jest.fn().mockReturnThis(),
+  };
+}
+
+function expectMockedResponse(res: MockedResponse, status: number, body?: string) {
+  if (status !== 200) {
+    expect(res.writeHead.mock.calls[0][0]).toBe(status);
+  }
+  if (body) {
+    expect(res.end.mock.calls[0][0]).toBe(body);
+  }
+}

--- a/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
@@ -1,0 +1,69 @@
+import chalk from 'chalk';
+import type { NextHandleFunction } from 'connect';
+import type { IncomingMessage, ServerResponse } from 'http';
+import net from 'net';
+import { TLSSocket } from 'tls';
+import { URL } from 'url';
+
+import { openJsInspector, queryInspectorAppAsync } from './JsInspector';
+
+/**
+ * Create a middleware that handles new requests to open the debugger from the dev menu.
+ * @todo(cedric): delete this middleware once we fully swap over to the new React Native JS Inspector.
+ */
+export function createJsInspectorMiddleware(): NextHandleFunction {
+  return async function (req: IncomingMessage, res: ServerResponse, next: (err?: Error) => void) {
+    const { origin, searchParams } = new URL(req.url ?? '/', getServerBase(req));
+    const appId = searchParams.get('appId') || searchParams.get('applicationId');
+    if (!appId) {
+      res.writeHead(400).end('Missing application identifier ("?appId=...")');
+      return;
+    }
+
+    const app = await queryInspectorAppAsync(origin, appId);
+    if (!app) {
+      res.writeHead(404).end('Unable to find inspector target from @react-native/dev-middleware');
+      console.warn(
+        chalk.yellow(
+          'No compatible apps connected. JavaScript Debugging can only be used with the Hermes engine.'
+        )
+      );
+      return;
+    }
+
+    if (req.method === 'GET') {
+      const data = JSON.stringify(app);
+      res.writeHead(200, {
+        'Content-Type': 'application/json; charset=UTF-8',
+        'Cache-Control': 'no-cache',
+        'Content-Length': data.length.toString(),
+      });
+      res.end(data);
+    } else if (req.method === 'POST' || req.method === 'PUT') {
+      try {
+        await openJsInspector(origin, app);
+      } catch (error: any) {
+        // abort(Error: Command failed: osascript -e POSIX path of (path to application "google chrome")
+        // 15:50: execution error: Google Chrome got an error: Application isn’t running. (-600)
+
+        console.error(
+          chalk.red('Error launching JS inspector: ' + (error?.message ?? 'Unknown error occurred'))
+        );
+        res.writeHead(500);
+        res.end();
+        return;
+      }
+      res.end();
+    } else {
+      res.writeHead(405);
+    }
+  };
+}
+
+function getServerBase(req: IncomingMessage): string {
+  const scheme =
+    req.socket instanceof TLSSocket && req.socket.encrypted === true ? 'https' : 'http';
+  const { localAddress, localPort } = req.socket;
+  const address = localAddress && net.isIPv6(localAddress) ? `[${localAddress}]` : localAddress;
+  return `${scheme}:${address}:${localPort}`;
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/api/DevMenuMetroClient.kt
@@ -10,7 +10,7 @@ class DevMenuMetroClient {
   private val httpClient = OkHttpClient()
 
   suspend fun openJSInspector(metroHost: String, applicationId: String) {
-    val url = Uri.parse("$metroHost/inspector")
+    val url = Uri.parse("$metroHost/_expo/inspector")
       .buildUpon()
       .appendQueryParameter("applicationId", applicationId)
       .build()

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -39,7 +39,7 @@ class DevMenuDevOptionsDelegate {
     }
     let port = bundleURL.port ?? Int(RCT_METRO_PORT)
     let host = bundleURL.host ?? "localhost"
-    let openURL = "http://\(host):\(port)/inspector?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
+    let openURL = "http://\(host):\(port)/_expo/inspector?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
     guard let url = URL(string: openURL) else {
       NSLog("[DevMenu] Invalid openJSInspector URL: $@", openURL)
       return


### PR DESCRIPTION
# Why

Stacked on top of #25881

This was in place for the dev menu, and I deleted it a bit too early in https://github.com/expo/expo/pull/25671.

We can only delete this once we fully swapped over to `@react-native/dev-middleware`, which is currently only used for the inspector proxy infrastructure.

# How

- Added back `createJsInspectorMiddleware` from #25671

# Test Plan

- `$ bun create expo ./test-devmenu-debugger --template blank@50`
- `$ cd ./test-devmenu-debugger`
- `$ bun expo install expo-dev-client
- `$ bun expo start`
- Press `m` in terminal
- Press "Inspect JS" in the menu within the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
