### PR TITLE
Remove "uuid" from the dependencies of several packages

### DIFF
--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -12,7 +12,6 @@
     "expo": "~50.0.0-alpha.0",
     "expo-clipboard": "~5.0.0",
     "react": "18.2.0",
-    "react-native": "0.73.0",
-    "uuid": "^3.4.0"
+    "react-native": "0.73.0"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -156,7 +156,6 @@
     "regl": "^1.3.0",
     "three": "^0.137.4",
     "url": "^0.11.0",
-    "uuid": "^8.3.0",
     "victory-native": "^36.3.1"
   },
   "devDependencies": {

--- a/apps/native-component-list/src/screens/RandomScreen.tsx
+++ b/apps/native-component-list/src/screens/RandomScreen.tsx
@@ -1,3 +1,4 @@
+import { uuid } from 'expo-modules-core';
 import { getRandomBytes, getRandomBytesAsync } from 'expo-random';
 import React from 'react';
 import { ScrollView } from 'react-native';
@@ -28,7 +29,7 @@ export default class RandomScreen extends React.Component<object, State> {
   readonly state: State = {
     random: getRandomBytes(10),
     randomAsync: null,
-    uuid: require('uuid').v4(),
+    uuid: uuid.v4(),
   };
 
   async componentDidMount() {

--- a/home/package.json
+++ b/home/package.json
@@ -89,7 +89,6 @@
     "@types/sha1": "^1.1.2",
     "expo-module-scripts": "^3.0.0",
     "jest-expo": "~50.0.0-alpha.0",
-    "react-native-bundle-visualizer": "^3.0.0",
-    "uuid": "^3.3.2"
+    "react-native-bundle-visualizer": "^3.0.0"
   }
 }

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -34,8 +34,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config": "~8.5.0",
-    "uuid": "^3.3.2"
+    "@expo/config": "~8.5.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^3.0.0"

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -33,11 +33,7 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "dependencies": {
-    "uuid": "^3.4.0"
-  },
   "devDependencies": {
-    "@types/uuid": "^3.4.7",
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -34,9 +34,6 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
-  "dependencies": {
-    "uuid": "^3.4.0"
-  },
   "devDependencies": {
     "expo-module-scripts": "^3.0.0",
     "jest-expo": "~50.0.0-alpha.0"

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -44,12 +44,10 @@
     "badgin": "^1.1.5",
     "expo-application": "~5.8.0",
     "expo-constants": "~15.4.0",
-    "fs-extra": "^9.1.0",
-    "uuid": "^3.4.0"
+    "fs-extra": "^9.1.0"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
-    "@types/uuid": "^3.4.7",
     "expo-module-scripts": "^3.0.0",
     "memfs": "^3.2.0",
     "node-fetch": "^2.6.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,23 @@
     tmp "^0.0.33"
     tslib "^1.10.0"
 
+"@expo/image-utils@0.3.23":
+  version "0.3.23"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.23.tgz#f14fd7e1f5ff6f8e4911a41e27dd274470665c3f"
+  integrity sha512-nhUVvW0TrRE4jtWzHQl8TR4ox7kcmrc2I0itaeJGjxF5A54uk7avgA0wRt7jP1rdvqQo1Ke1lXyLYREdhN9tPw==
+  dependencies:
+    "@expo/spawn-async" "1.5.0"
+    chalk "^4.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    jimp-compact "0.16.1"
+    mime "^2.4.4"
+    node-fetch "^2.6.0"
+    parse-png "^2.1.0"
+    resolve-from "^5.0.0"
+    semver "7.3.2"
+    tempy "0.3.0"
+
 "@expo/multipart-body-parser@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@expo/multipart-body-parser/-/multipart-body-parser-1.0.0.tgz#7227bab9cfe9d4baea925b748a3212e0239ba55d"
@@ -4764,11 +4781,6 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.1.tgz#4989c97f969464647a8586c7252d97b449cdc045"
   integrity sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==
-
-"@types/uuid@^3.4.7":
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.10.tgz#637d3c8431f112edf6728ac9bdfadfe029540f48"
-  integrity sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==
 
 "@types/victory@^31.0.14":
   version "31.0.22"
@@ -19914,7 +19926,7 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Why
---
We don't actually use the "uuid" package in several places but it was still referenced in package.json. Fully closes ENG-9174

How
---
Used `yarn` why to find packages (especially module packages) that still dependended on uuid. Grepped to make sure they didn't import uuid and were using the implementation from expo-modules-core instead.

Test Plan
---
I feel confident about the grepping and also started up NCL and browsed to several screens: Random, File system, Contacts.
