### PR TITLE
[docs] build-in -> built-in

### DIFF
--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -25,7 +25,7 @@ const params = new URLSearchParams();
 
 ## Conformance
 
-Expo's build-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
+Expo's built-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
 
 The only missing exception is that native platforms do not currently support [non-ASCII characters](https://unicode.org/reports/tr46/) in the hostname. 
 

--- a/docs/pages/versions/v50.0.0/sdk/url.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/url.mdx
@@ -25,7 +25,7 @@ const params = new URLSearchParams();
 
 ## Conformance
 
-Expo's build-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
+Expo's built-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
 
 The only missing exception is that native platforms do not currently support [non-ASCII characters](https://unicode.org/reports/tr46/) in the hostname. 
 


### PR DESCRIPTION
Just a small typo fix.
