### PR TITLE
[go] Remove background permissions requests

### DIFF
--- a/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
@@ -58,9 +58,8 @@ export default class GeofencingScreen extends React.Component<Props, State> {
 
   didFocus = async () => {
     const { status: foregroundStatus } = await Location.requestForegroundPermissionsAsync();
-    const { status: backgroundStatus } = await Location.requestBackgroundPermissionsAsync();
 
-    if (foregroundStatus !== 'granted' || backgroundStatus !== 'granted') {
+    if (foregroundStatus !== 'granted') {
       this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
       this.setState({
         error:

--- a/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
@@ -77,9 +77,8 @@ export default class LocationDiagnosticsScreen extends React.Component<Props, St
 
   didFocus = async () => {
     const { status: foregroundStatus } = await Location.requestForegroundPermissionsAsync();
-    const { status: backgroundStatus } = await Location.requestBackgroundPermissionsAsync();
 
-    if (foregroundStatus !== 'granted' || backgroundStatus !== 'granted') {
+    if (foregroundStatus !== 'granted') {
       this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
       this.setState({
         error:

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key> NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Allow Expo projects to use your location</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
# Why
We shouldn't be requesting background location permission on the `Geofencing` or `LocationDiagnostic` screens because EAS removes the required keys from the plist. Doing so prevents the map from rendering. 

# How
Removed the requests.

# Test Plan
Recreated the same build as what would be produced by EAS. Works correctly on versioned Expo Go