### PR TITLE
(expo-env-info): add expo-router

### DIFF
--- a/packages/expo-env-info/CHANGELOG.md
+++ b/packages/expo-env-info/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `expo-router` to list of packages.
+- Add `expo-router` to list of packages. ([#25896](https://github.com/expo/expo/pull/25896) by [@marklawlor](https://github.com/marklawlor))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-env-info/CHANGELOG.md
+++ b/packages/expo-env-info/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `expo-router` to list of packages.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-env-info/src/diagnosticsAsync.ts
+++ b/packages/expo-env-info/src/diagnosticsAsync.ts
@@ -16,6 +16,7 @@ function getEnvironmentInfoAsync(): Promise<string> {
       SDKs: ['iOS SDK', 'Android SDK'],
       npmPackages: [
         'expo',
+        'expo-router',
         'react',
         'react-dom',
         'react-native',


### PR DESCRIPTION
# Why

Expo Router uses a different versioning system to the SDK. With v3 being highly reliant on SDK 50, this wil help us easily identify if a user packages are not compatible.

- Added `expo-router` to the reported `npmPackages`

# How


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
