### PR TITLE
[home] Use relative imports instead of alias

### DIFF
--- a/home/navigation/Navigation.tsx
+++ b/home/navigation/Navigation.tsx
@@ -19,6 +19,8 @@ import { AccountModal } from '../screens/AccountModal';
 import { BranchDetailsScreen } from '../screens/BranchDetailsScreen';
 import { BranchListScreen } from '../screens/BranchListScreen';
 import { DeleteAccountScreen } from '../screens/DeleteAccountScreen';
+import { DiagnosticsStackScreen } from '../screens/DiagnosticsScreen';
+import { FeedbackFormScreen } from '../screens/FeedbackFormScreen';
 import { HomeScreen } from '../screens/HomeScreen';
 import { ProjectScreen } from '../screens/ProjectScreen';
 import { ProjectsListScreen } from '../screens/ProjectsListScreen';
@@ -29,9 +31,6 @@ import {
   alertWithCameraPermissionInstructions,
   requestCameraPermissionsAsync,
 } from '../utils/PermissionUtils';
-
-import { DiagnosticsStackScreen } from '@/screens/DiagnosticsScreen';
-import { FeedbackFormScreen } from '@/screens/FeedbackFormScreen';
 
 // TODO(Bacon): Do we need to create a new one each time?
 const HomeStack = createStackNavigator<HomeStackRoutes>();

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -5,12 +5,11 @@ import React from 'react';
 import { FlatList } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
+import { SectionHeader } from '../../components/SectionHeader';
 import { Home_CurrentUserActorQuery } from '../../graphql/types';
 import { useDispatch } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
-
-import { SectionHeader } from '@/components/SectionHeader';
 
 type Props = {
   accounts: Exclude<Home_CurrentUserActorQuery['meUserActor'], undefined | null>['accounts'];

--- a/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/GeofencingDiagnosticsScreen.tsx
@@ -15,8 +15,7 @@ import MapView, { Circle, MapPressEvent } from 'react-native-maps';
 
 import NavigationEvents from '../../components/NavigationEvents';
 import Button from '../../components/PrimaryButton';
-
-import { StyledText } from '@/components/Text';
+import { StyledText } from '../../components/Text';
 
 const GEOFENCING_TASK = 'geofencing';
 const REGION_RADIUSES = [30, 50, 75, 100, 150, 200];

--- a/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
+++ b/home/screens/DiagnosticsScreen/LocationDiagnosticsScreen.tsx
@@ -16,10 +16,10 @@ import {
 } from 'react-native';
 import MapView, { Polyline } from 'react-native-maps';
 
-import NavigationEvents from '@/components/NavigationEvents';
-import Button from '@/components/PrimaryButton';
-import { StyledText } from '@/components/Text';
-import Colors from '@/constants/Colors';
+import NavigationEvents from '../../components/NavigationEvents';
+import Button from '../../components/PrimaryButton';
+import { StyledText } from '../../components/Text';
+import Colors from '../../constants/Colors';
 
 const STORAGE_KEY = 'expo-home-locations';
 const LOCATION_UPDATES_TASK = 'location-updates';

--- a/home/screens/DiagnosticsScreen/index.tsx
+++ b/home/screens/DiagnosticsScreen/index.tsx
@@ -13,11 +13,10 @@ import { DiagnosticButton } from './DiagnosticsButton';
 import GeofencingScreen from './GeofencingDiagnosticsScreen';
 import LocationDiagnosticsScreen from './LocationDiagnosticsScreen';
 import ScrollView from '../../components/NavigationScrollView';
+import { ColorTheme } from '../../constants/Colors';
 import { DiagnosticsStackRoutes } from '../../navigation/Navigation.types';
+import defaultNavigationOptions from '../../navigation/defaultNavigationOptions';
 import Environment from '../../utils/Environment';
-
-import { ColorTheme } from '@/constants/Colors';
-import defaultNavigationOptions from '@/navigation/defaultNavigationOptions';
 
 function useThemeName() {
   const theme = useTheme();

--- a/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
+++ b/home/screens/HomeScreen/DevelopmentServersPlaceholder.tsx
@@ -6,9 +6,8 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import { DevelopmentServersOpenQR } from './DevelopmentServersOpenQR';
 import { DevelopmentServersOpenURL } from './DevelopmentServersOpenURL';
+import FeatureFlags from '../../FeatureFlags';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
-
-import FeatureFlags from '@/FeatureFlags';
 
 type Props = {
   isAuthenticated: boolean;

--- a/home/screens/SettingsScreen/index.tsx
+++ b/home/screens/SettingsScreen/index.tsx
@@ -9,8 +9,7 @@ import { DeleteAccountSection } from './DeleteAccountSection';
 import { DevMenuGestureSection } from './DevMenuGestureSection';
 import { ThemeSection } from './ThemeSection';
 import { TrackingSection } from './TrackingSection';
-
-import { useHome_CurrentUserActorQuery } from '@/graphql/types';
+import { useHome_CurrentUserActorQuery } from '../../graphql/types';
 
 export function SettingsScreen() {
   const { data } = useHome_CurrentUserActorQuery();

--- a/home/tsconfig.json
+++ b/home/tsconfig.json
@@ -7,10 +7,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitAny": true,
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "noImplicitAny": true
   },
   "exclude": ["**/__mocks__/*"]
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/25765 added this alias. While it works for tsc compilation, when compiled with the normal react-native bundling process it fails to find the alias. Rather than set up the alias for that process as well, I noticed that we already used relative imports almost everywhere, so this PR just makes it consistent.

The reason we're looking to use the normal react-native bundling process is for asset processing (https://linear.app/expo/issue/ENG-10861/embed-homes-assets-in-the-expo-go-app)

# How

Use relative imports.

# Test Plan

`yarn tsc`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
