### PR TITLE
[expo-updates][Android] Remove unnecessary throw on duplicate asset

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] overwrite duplicates when copying assets. ([#25898](https://github.com/expo/expo/pull/25898) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.24.1 — 2023-12-12

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -139,7 +139,10 @@ object UpdatesUtils {
       } catch (e: NoSuchFileException) {
         throw IOException("File download was successful, but temp file ${tmpFile.absolutePath} does not exist")
       } catch (e: FileAlreadyExistsException) {
-        throw IOException("File download was successful, but file already exists at ${destination.absolutePath}")
+        // ENG-10888: this will happen any time there are two assets with identical content
+        // (and therefore the same hash). Log this condition, but do not throw an exception.
+        // throw IOException("File download was successful, but file already exists at ${destination.absolutePath}")
+        Log.w(TAG, "File download was successful, but file already exists at ${destination.absolutePath}")
       } catch (e: Exception) {
         throw IOException("File download was successful, but an exception occurred: $e")
       } finally {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -131,7 +131,7 @@ object UpdatesUtils {
       // only rename after the hash has been verified
       // Since renameTo() does not expose detailed errors, and can fail if source and destination
       // are not on the same mount point, we do a copyTo followed by delete
-      // ENG-10888: if there are two assets with identical content, they will be written to the same file path,
+      // if there are two assets with identical content, they will be written to the same file path,
       // so we allow overwrites
       try {
         tmpFile.copyTo(destination, true)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -1,10 +1,8 @@
 package expo.modules.updates
 
 import android.content.Context
-import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
-import expo.modules.updates.db.entity.AssetEntity
-import android.os.AsyncTask
 import android.net.ConnectivityManager
+import android.os.AsyncTask
 import android.util.Base64
 import android.util.Log
 import com.facebook.react.ReactNativeHost
@@ -12,14 +10,14 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
+import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import org.apache.commons.io.FileUtils
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.*
-import java.lang.ClassCastException
-import java.lang.Exception
 import java.lang.ref.WeakReference
 import java.security.DigestInputStream
 import java.security.MessageDigest
@@ -130,19 +128,15 @@ object UpdatesUtils {
       if (expectedBase64URLEncodedHash != null && expectedBase64URLEncodedHash != hashBase64String) {
         throw IOException("File download was successful but base64url-encoded SHA-256 did not match expected; expected: $expectedBase64URLEncodedHash; actual: $hashBase64String")
       }
-
       // only rename after the hash has been verified
       // Since renameTo() does not expose detailed errors, and can fail if source and destination
       // are not on the same mount point, we do a copyTo followed by delete
+      // ENG-10888: if there are two assets with identical content, they will be written to the same file path,
+      // so we allow overwrites
       try {
-        tmpFile.copyTo(destination)
+        tmpFile.copyTo(destination, true)
       } catch (e: NoSuchFileException) {
         throw IOException("File download was successful, but temp file ${tmpFile.absolutePath} does not exist")
-      } catch (e: FileAlreadyExistsException) {
-        // ENG-10888: this will happen any time there are two assets with identical content
-        // (and therefore the same hash). Log this condition, but do not throw an exception.
-        // throw IOException("File download was successful, but file already exists at ${destination.absolutePath}")
-        Log.w(TAG, "File download was successful, but file already exists at ${destination.absolutePath}")
       } catch (e: Exception) {
         throw IOException("File download was successful, but an exception occurred: $e")
       } finally {

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -767,7 +767,7 @@ export async function setupManualTestAppAsync(projectRoot: string, repoRoot: str
     'com',
     'douglowderexpo',
     'MyUpdateableApp',
-    'MainApplication.java'
+    'MainApplication.kt'
   );
   const mainApplicationText = await fs.readFile(mainApplicationPath, { encoding: 'utf-8' });
   const mainApplicationTextModified = mainApplicationText.replace('BuildConfig.DEBUG', 'false');


### PR DESCRIPTION
# Why

A customer reports errors thrown by Android when two assets have exactly the same content (and therefore same hash). The error causes a download failure, saying that all assets were not downloaded successfully.

While this does not prevent the download from eventually succeeding, this condition should not cause an exception to be thrown.

# How

- Remove the throw and log a warning instead.
- Fix the updates E2E script that generates a manual test project to test this and other scenarios.
- 
# Test Plan

- Tested locally to verify the error is gone
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
