### PR TITLE
[store-review][ios] Update isAvailableAsync to check if app is from TestFlight

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- `StoreReview.isAvailableAsync()` on iOS now resolves to `false` for apps distributed through TestFlight. ([#25900](https://github.com/expo/expo/pull/25900) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -27,7 +27,13 @@ public class StoreReviewModule: Module {
     return false
     #endif
 
-    return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" && !hasEmbeddedMobileProvision()
+    // For apps distributed through TestFlight or intalled from Xcode the receipt file is named "StoreKit/sandboxReceipt"
+    // instead of "StoreKit/receipt"
+    let isSandboxEnv = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+
+    // Apps distributed through TestFlight or the App Store will not have an embedded provisioning profile
+    // Source: https://developer.apple.com/documentation/technotes/tn3125-inside-code-signing-provisioning-profiles#Profile-location
+    return isSandboxEnv && !hasEmbeddedMobileProvision()
   }
 
   private func hasEmbeddedMobileProvision() -> Bool {

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -2,11 +2,13 @@ import ExpoModulesCore
 import StoreKit
 
 public class StoreReviewModule: Module {
+  let plist = StoreReviewModule.readProvisioningProfilePlist()
+
   public func definition() -> ModuleDefinition {
     Name("ExpoStoreReview")
 
     AsyncFunction("isAvailableAsync") { () -> Bool in
-      return true
+      return !isRunningFromTestFlight()
     }
 
     AsyncFunction("requestReview") {
@@ -20,5 +22,55 @@ public class StoreReviewModule: Module {
         SKStoreReviewController.requestReview()
       }
     }.runOnQueue(DispatchQueue.main)
+  }
+
+  private func isRunningFromTestFlight() -> Bool {
+    let isSandbox = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+
+    if Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") == nil {
+      #if targetEnvironment(simulator)
+      return false
+      #else
+      return isSandbox
+      #endif
+    }
+
+    guard let mobileProvision = plist else {
+      return false
+    }
+
+    if let provisionsAllDevices = mobileProvision["ProvisionsAllDevices"] as? Bool, provisionsAllDevices {
+      return false
+    }
+
+    if let provisionedDevices = mobileProvision["ProvisionedDevices"] as? [String], !provisionedDevices.isEmpty {
+      return false
+    }
+
+    return isSandbox
+  }
+
+  private static func readProvisioningProfilePlist() -> [String: Any]? {
+    guard let profilePath = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") else {
+      return nil
+    }
+
+    do {
+      let profileString = try String(contentsOfFile: profilePath, encoding: .ascii)
+      guard let plistStart = profileString.range(of: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
+        let plistEnd = profileString.range(of: "</plist>") else {
+        return nil
+      }
+
+      let plistString = String(profileString[plistStart.lowerBound..<plistEnd.upperBound])
+      if let plistData = plistString.data(using: .utf8) {
+        return try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any]
+      }
+      log.error("Failed to convert plistString to UTF-8 encoded data object.")
+      return nil
+    } catch {
+      log.error("Error reading provisioning profile: \(error.localizedDescription)")
+      return nil
+    }
   }
 }

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -2,8 +2,6 @@ import ExpoModulesCore
 import StoreKit
 
 public class StoreReviewModule: Module {
-  let plist = StoreReviewModule.readProvisioningProfilePlist()
-
   public func definition() -> ModuleDefinition {
     Name("ExpoStoreReview")
 
@@ -25,52 +23,14 @@ public class StoreReviewModule: Module {
   }
 
   private func isRunningFromTestFlight() -> Bool {
-    let isSandbox = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    #if targetEnvironment(simulator)
+    return false
+    #endif
 
-    if Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") == nil {
-      #if targetEnvironment(simulator)
-      return false
-      #else
-      return isSandbox
-      #endif
-    }
-
-    guard let mobileProvision = plist else {
-      return false
-    }
-
-    if let provisionsAllDevices = mobileProvision["ProvisionsAllDevices"] as? Bool, provisionsAllDevices {
-      return false
-    }
-
-    if let provisionedDevices = mobileProvision["ProvisionedDevices"] as? [String], !provisionedDevices.isEmpty {
-      return false
-    }
-
-    return isSandbox
+    return Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" && !hasEmbeddedMobileProvision()
   }
 
-  private static func readProvisioningProfilePlist() -> [String: Any]? {
-    guard let profilePath = Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") else {
-      return nil
-    }
-
-    do {
-      let profileString = try String(contentsOfFile: profilePath, encoding: .ascii)
-      guard let plistStart = profileString.range(of: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
-        let plistEnd = profileString.range(of: "</plist>") else {
-        return nil
-      }
-
-      let plistString = String(profileString[plistStart.lowerBound..<plistEnd.upperBound])
-      if let plistData = plistString.data(using: .utf8) {
-        return try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any]
-      }
-      log.error("Failed to convert plistString to UTF-8 encoded data object.")
-      return nil
-    } catch {
-      log.error("Error reading provisioning profile: \(error.localizedDescription)")
-      return nil
-    }
+  private func hasEmbeddedMobileProvision() -> Bool {
+    return (Bundle.main.path(forResource: "embedded", ofType: "mobileprovision") != nil)
   }
 }


### PR DESCRIPTION
# Why

According to [Apple's documentation](https://developer.apple.com/documentation/foundation/nsbundle/1407276-appstorereceipturl), using `SKStoreReviewController.requestReview` has no effect when using an app distributed through TestFlight

> When you call this method while your app is in development mode, a rating and review request view is always displayed so you can test the user interface and experience. However, this method has no effect when you call it in an app that you distribute using TestFlight.

Given that `requestReview` is "not available" when using TestFlight we should change `isAvailableAsync` to check for this scenario 

# How

Update `isAvailableAsync` to return false when using an app distributed through TestFlight
 

# Test Plan

Run BareExpo on simulator and real device

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
