### PR TITLE
[install-expo-modules] add sdk 50 and react-native 0.73 support

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added Expo SDK 50 and React Native 0.73 support. ([#25907](https://github.com/expo/expo/pull/25907) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073-updated.kt
@@ -1,0 +1,23 @@
+package com.helloworld
+import expo.modules.ReactActivityDelegateWrapper
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "HelloWorld"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+      ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainActivity-rn073.kt
@@ -1,0 +1,22 @@
+package com.helloworld
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "HelloWorld"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn073-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn073-updated.kt
@@ -1,0 +1,54 @@
+package com.helloworld
+import android.content.res.Configuration
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ReactNativeHostWrapper
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.flipper.ReactNativeFlipper
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost =
+      ReactNativeHostWrapper(this, object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return PackageList(this).packages
+        }
+
+        override fun getJSMainModuleName(): String = "index"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      })
+
+  override val reactHost: ReactHost
+    get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+    ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn073.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn073.kt
@@ -1,0 +1,45 @@
+package com.helloworld
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.flipper.ReactNativeFlipper
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost =
+      object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // packages.add(new MyReactNativePackage());
+          return PackageList(this).packages
+        }
+
+        override fun getJSMainModuleName(): String = "index"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      }
+
+  override val reactHost: ReactHost
+    get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+    ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainActivity-test.ts
@@ -35,6 +35,19 @@ describe(setModulesMainActivity, () => {
     expect(nextContents).toEqual(expectContents);
   });
 
+  it(`should be able to update from react-native@>=0.73.0 kotlin template`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn073.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn073-updated.kt'), 'utf8'),
+    ]);
+
+    const contents = setModulesMainActivity(rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainActivity(contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it(`should add ReactActivityDelegateWrapper for react-native@>=0.71.0 - java`, async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainActivity-rn071.java'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -6,6 +6,19 @@ import { setModulesMainApplication } from '../withAndroidModulesMainApplication'
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(setModulesMainApplication, () => {
+  it('should able to update from react-native@>=0.73.0 kotlin template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn073.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn073-updated.kt'), 'utf8'),
+    ]);
+
+    const contents = setModulesMainApplication(rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainApplication(contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should able to update from react-native@>=0.71.0 template', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn071.java'), 'utf8'),

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -12,6 +12,12 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '50.0.0',
+    iosDeploymentTarget: '13.4',
+    reactNativeVersionRange: '>= 0.73.0',
+    supportCliIntegration: true,
+  },
+  {
     expoSdkVersion: '49.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.72.0',


### PR DESCRIPTION
# Why

add react-native 0.73 migration support from install-expo-modules

# How

although 0.73 migrates the MainApplication and MainActivity to kotlin, thank to previous effort, install-expo-modules works seamless without any further necessary changes. just to update the `expoVersionMapping`

# Test Plan

- added 0.73 MainApplication and MainActivity test cases
- test the migration from `npx react-native@latest init RN073 --version 0.73` project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
