### PR TITLE
[install-expo-modules] fix strange error when running on a managed project

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the unclear `ENOENT: no such file or directory` error when running on a CNG project. ([#25913](https://github.com/expo/expo/pull/25913) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.7.0 — 2023-12-12

--- a/packages/install-expo-modules/src/utils/projectRoot.ts
+++ b/packages/install-expo-modules/src/utils/projectRoot.ts
@@ -1,6 +1,20 @@
 import assert from 'assert';
 import findUp from 'find-up';
+import fs from 'fs/promises';
 import path from 'path';
+
+export async function normalizeProjectRootAsync(
+  projectRoot?: string
+): Promise<{ projectRoot: string; platformAndroid: boolean; platformIos: boolean }> {
+  const root = path.dirname(findUpPackageJson(projectRoot ?? process.cwd()));
+  const platformAndroid = await pathExistsAsync(path.join(root, 'android'));
+  const platformIos = await pathExistsAsync(path.join(root, 'ios'));
+  return {
+    projectRoot: root,
+    platformAndroid,
+    platformIos,
+  };
+}
 
 function findUpPackageJson(root: string): string {
   const packageJson = findUp.sync('package.json', { cwd: root });
@@ -8,6 +22,11 @@ function findUpPackageJson(root: string): string {
   return packageJson;
 }
 
-export function normalizeProjectRoot(projectRoot?: string): string {
-  return path.dirname(findUpPackageJson(projectRoot ?? process.cwd()));
+async function pathExistsAsync(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/issues/21768#issuecomment-1480241909 that running install-expo-modules on a CNG project would show the error
```
Uncaught Error [Error: ENOENT: no such file or directory, open '/workspaces/Test/Example/android/build.gradle'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/workspaces/Test/Example/android/build.gradle'
}
```
close ENG-8136

# How

detect whether **android** and **ios** exist and pass the correct platform to config-plugins compiler

# Test Plan

test on a managed project created by `yarn create expo -t blank@sdk-50 sdk50` and run install-expo-modules, it should not show error and even not touching any files.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
