### PR TITLE
[asset] Fix asset source uri tests

### DIFF
--- a/home/__mocks__/react-native.js
+++ b/home/__mocks__/react-native.js
@@ -1,0 +1,11 @@
+const RN = jest.requireActual('react-native');
+Object.defineProperty(RN.NativeModules, 'ExponentKernel', {
+  configurable: true,
+  enumerable: true,
+  get: () => ({
+    getSessionAsync: jest.fn(),
+    setSessionAsync: jest.fn(),
+  }),
+});
+
+module.exports = RN;

--- a/home/__mocks__/react-native.js
+++ b/home/__mocks__/react-native.js
@@ -3,8 +3,8 @@ Object.defineProperty(RN.NativeModules, 'ExponentKernel', {
   configurable: true,
   enumerable: true,
   get: () => ({
-    getSessionAsync: jest.fn(),
-    setSessionAsync: jest.fn(),
+    getSessionAsync: jest.fn(async () => {}),
+    setSessionAsync: jest.fn(async () => {}),
   }),
 });
 

--- a/packages/expo-asset/src/__tests__/AssetSources-test.ts
+++ b/packages/expo-asset/src/__tests__/AssetSources-test.ts
@@ -32,6 +32,7 @@ describe('selectAssetSource', () => {
   });
 
   it(`returns an asset source object with an invalid dummy remote URL if the asset metadata does not specify an absolute URL in production`, () => {
+    _mockNativeModulesWithoutExponentKernel();
     const AssetSources = require('../AssetSources');
     expect(AssetSources.selectAssetSource(mockFontMetadata)).toEqual({
       hash: 'cafecafecafecafecafecafecafecafe',
@@ -271,5 +272,14 @@ function _mockConstants(constants: { [key: string]: any }): void {
       ...constants,
       manifest: { ...Constants.manifest, ...constants.manifest },
     };
+  });
+}
+
+function _mockNativeModulesWithoutExponentKernel(): void {
+  jest.doMock('react-native', () => {
+    const RN = jest.requireActual('react-native');
+
+    delete RN.NativeModules.ExponentKernel;
+    return RN;
   });
 }

--- a/packages/expo-asset/src/__tests__/AssetSources-test.ts
+++ b/packages/expo-asset/src/__tests__/AssetSources-test.ts
@@ -32,7 +32,6 @@ describe('selectAssetSource', () => {
   });
 
   it(`returns an asset source object with an invalid dummy remote URL if the asset metadata does not specify an absolute URL in production`, () => {
-    _mockNativeModulesWithoutExponentKernel();
     const AssetSources = require('../AssetSources');
     expect(AssetSources.selectAssetSource(mockFontMetadata)).toEqual({
       hash: 'cafecafecafecafecafecafecafecafe',
@@ -272,14 +271,5 @@ function _mockConstants(constants: { [key: string]: any }): void {
       ...constants,
       manifest: { ...Constants.manifest, ...constants.manifest },
     };
-  });
-}
-
-function _mockNativeModulesWithoutExponentKernel(): void {
-  jest.doMock('react-native', () => {
-    const RN = jest.requireActual('react-native');
-
-    delete RN.NativeModules.ExponentKernel;
-    return RN;
   });
 }

--- a/packages/jest-expo/src/preset/internalExpoModules.js
+++ b/packages/jest-expo/src/preset/internalExpoModules.js
@@ -1,9 +1,4 @@
 module.exports = {
-  ExponentKernel: {
-    getSessionAsync: { type: 'function', functionType: 'async' },
-    removeSessionAsync: { type: 'function', functionType: 'async' },
-    setSessionAsync: { type: 'function', functionType: 'async' },
-  },
   DevLoadingView: {
     getConstants: { type: 'function' },
     addListener: { type: 'function', functionType: 'async' },


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/1d8cdf42a01f2c4e9cb4c182d5f3ed5798e751e8 broke expo-asset unit tests

# How

Mock native modules and Remove `ExponentKernel` from AssetSources tests


# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
