### PR TITLE
[home] Fix restoring user review date object from AsyncStorage

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/161e0c86-3257-4a50-a365-9826ea421c61"
+  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/543f55f2-fe80-42d1-b3e6-36f41ec02eaf"
 }

--- a/home/components/UserReviewSection.tsx
+++ b/home/components/UserReviewSection.tsx
@@ -20,7 +20,7 @@ export default function UserReviewSection({ snacks, apps }: Props) {
     });
   const theme = useExpoTheme();
 
-  if (!isDevice || !shouldShowReviewSection) {
+  if ((!isDevice && !__DEV__) || !shouldShowReviewSection) {
     return null;
   }
 

--- a/home/utils/useUserReviewCheck.ts
+++ b/home/utils/useUserReviewCheck.ts
@@ -95,7 +95,15 @@ export const useUserReviewCheck = ({ apps, snacks }: UseUserReviewCheckParams) =
   useEffect(() => {
     StoreReview.isAvailableAsync().then(setIsStoreReviewAvailable);
     AsyncStorage.getItem('userReviewInfo').then((info) => {
-      const userReviewInfo: UserReviewInfo = info ? JSON.parse(info) : {};
+      const userReviewInfo: UserReviewInfo = info
+        ? JSON.parse(info, (key, value) => {
+            // Convert string representations back to Date objects
+            if (key.endsWith('Date') && typeof value === 'string') {
+              return new Date(value);
+            }
+            return value;
+          })
+        : {};
       userReviewInfo.appOpenedCounter = Number(userReviewInfo.appOpenedCounter || 0) + 1;
       updateUserReviewInfo(userReviewInfo);
     });


### PR DESCRIPTION
# Why

Closes ENG-10891

# How
 
Fix JSON.parse to restore date objects when reading from AsyncStorage instead of treating them as strings 

# Test Plan

Then tap the X in the "Enjoying Expo Go?" box. Force quit, reopen

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
