### PR TITLE
[docs] Prevent selecting line numbers on diffs

### DIFF
--- a/docs/global-styles/diff.ts
+++ b/docs/global-styles/diff.ts
@@ -37,6 +37,7 @@ export const globalDiff = css`
     ${typography.fontSizes[12]};
     text-align: right;
     padding: 0 ${spacing[2]}px;
+    user-select: none;
   }
 
   .diff-gutter-normal {


### PR DESCRIPTION
# Why
<img width="1092" alt="image" src="https://github.com/expo/expo/assets/8053974/5dae5a41-fcd8-42aa-909d-b3bff076dc9b">

# How
Added `user-select: none;`

# Test Plan
- [ ] Copying from diff no longer copies line numbers
 