### PR TITLE
fix(templates): bump to `@types/react@~18.2.45`

### DIFF
--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.2.14",
+    "@types/react": "~18.2.45",
     "typescript": "^5.1.3"
   }
 }

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.45",
     "jest": "^29.2.1",
     "jest-expo": "~50.0.0",
     "react-test-renderer": "18.2.0",


### PR DESCRIPTION
# Why

We are using `react@18.2.x`, not `18.0.x`

# How

- Bumped template versions of `@types/react`

# Test Plan

🤷 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
