### PR TITLE
chore: add `.vscode/launch.json` to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log
 .*.swn
 .*.swm
 
+# VS Code
+.vscode/launch.json
+
 # Sublime Text
 *.sublime-project
 *.sublime-workspace


### PR DESCRIPTION
# Why

I keep accidentally pushing my launch config, to debug things in the CLI.

![image](https://github.com/expo/expo/assets/1203991/f14af244-e886-4c88-a459-f79728309cdf)


# How

- Added to the git ignore

# Test Plan

- `$ cp ./.vscode/launch.json.example ./.vscode/launch.json`
- `$ git status` -> should not include the new launch config
- `$ touch ./.vscode/somethingelse.json`
- `$ git status` -> should include this file

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
