### PR TITLE
[ios] Commit Gemfile.lock changes that result from running bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (2.0)
+    cocoapods-downloader (2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -279,4 +279,4 @@ DEPENDENCIES
   xcpretty (~> 0.3.0)
 
 BUNDLED WITH
-   2.4.17
+   2.4.22


### PR DESCRIPTION
# Why

I can't run `et pods` without running `bundle` first, which then changes the Gemfile.lock