### PR TITLE
[docs] Add CNG reminder to native upgrade helper

### DIFF
--- a/docs/pages/bare/upgrade.mdx
+++ b/docs/pages/bare/upgrade.mdx
@@ -9,7 +9,7 @@ If you manage your native projects (previously known as bare workflow), to [upgr
 
 The following guide provides diffs to compare native project files between your project's current SDK version and the target SDK version you want to upgrade. You can use them to make changes to your project depending on the `expo` package version your project uses. The tools on this page are similar to [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/). However, they are oriented around projects that use Expo modules and related tooling.
 
-> Interested in avoiding upgrading native code altogether? Check out [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) to learn how Expo Prebuild can generate your native projects just prior to build.
+> Interested in avoiding upgrading native code altogether? See [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) to learn how Expo Prebuild can generate your native projects before a build.
 
 ## Upgrade native project files
 

--- a/docs/pages/bare/upgrade.mdx
+++ b/docs/pages/bare/upgrade.mdx
@@ -9,6 +9,8 @@ If you manage your native projects (previously known as bare workflow), to [upgr
 
 The following guide provides diffs to compare native project files between your project's current SDK version and the target SDK version you want to upgrade. You can use them to make changes to your project depending on the `expo` package version your project uses. The tools on this page are similar to [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/). However, they are oriented around projects that use Expo modules and related tooling.
 
+> Interested in avoiding upgrading native code altogether? Check out [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) to learn how Expo Prebuild can generate your native projects just prior to build.
+
 ## Upgrade native project files
 
 Once you have [upgraded your Expo SDK version and related dependencies](/workflow//upgrading-expo-sdk-walkthrough/#how-to-upgrade-to-the-latest-sdk-version), use the diff tool below to learn about changes you need to make to your native project and bring them up to date with the current Expo SDK version.

--- a/tools/src/commands/GenerateBareDiffs.ts
+++ b/tools/src/commands/GenerateBareDiffs.ts
@@ -146,6 +146,9 @@ async function action({ check = false }: ActionOptions) {
         logger.log(
           `expo-template-bare-minimum has changed. Run 'et generate-bare-diffs' to regenerate them.`
         );
+        logger.log(
+          'If this check is failing in CI but the diffs have not changed, check that your version of git matches the version used in CI.'
+        );
         process.exit(1);
       }
 


### PR DESCRIPTION
# Why
There was a suggestion to add a note about CNG to the native project upgrade helper.

# How
Added the note.
<img width="893" alt="image" src="https://github.com/expo/expo/assets/8053974/7c4ec2a3-43b5-4228-bfdb-e8e6389d8d21">

Also added a console log to the `generate-bare-diffs` ExpoTool to help others whose CI fails due to the template bare minimum diff check avoid wasting the couple of hours I did when I couldn't get my tests to pass 😅 

# Test Plan
Try it out.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
