### PR TITLE
Add JS docs to `SQLTransactionErrorCallback`

### DIFF
--- a/packages/expo-sqlite/src/SQLite.types.ts
+++ b/packages/expo-sqlite/src/SQLite.types.ts
@@ -74,6 +74,8 @@ export interface SQLTransaction {
    * of the query.
    * @param errorCallback Called if an error occurred executing this particular query in the
    * transaction. Takes two parameters: the transaction itself, and the error object.
+   * Return boolean. If you return true, ends and rollback transaction. If you return false,
+   * continues executing the transaction.
    */
   executeSql(
     sqlStatement: string,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
When we use expo-sqlite, often use errorCallback, but there is no explanation of return value.
I thought it is needed for users who are not familiar with sqlite and good at developing mobile.

ref:
https://stackoverflow.com/questions/57089863/what-should-the-return-value-of-the-websql-sqlstatementerrorcallback-be
https://www.w3.org/TR/webdatabase/#sqlstatementerrorcallback

# How

<!--
How did you build this feature or fix this bug and why?
-->

none.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

none.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
