### PR TITLE
[docs] update web publishing docs

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -141,6 +141,7 @@ const general = [
         makePage('workflow/web.mdx'),
         makePage('guides/progressive-web-apps.mdx'),
         makePage('distribution/publishing-websites.mdx'),
+        makePage('distribution/publishing-websites-webpack.mdx'),
         makePage('guides/customizing-metro.mdx'),
         makePage('guides/customizing-webpack.mdx'),
         makePage('guides/web-performance.mdx'),

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -143,7 +143,7 @@ You will now see a URL that you can use to view your project online. Paste that 
 
 ### AWS Amplify Console
 
-The [AWS Amplify Console](https://console.amplify.aws) provides a Git-based workflow for continuously deploying and hosting full-stack serverless web apps. Amplify deploys your PWA from a repository instead of from your computer. In this guide, we'll use a GitHub repository. Before starting, [create a new repo on GitHub](https://github.com/new).
+The [AWS Amplify Console](https://console.amplify.aws) provides a Git-based workflow for continuously deploying and hosting full-stack serverless web apps. Amplify deploys your PWA from a repository instead of your computer, so you must use a GitHub repository. Before starting, [create a new repo on GitHub](https://github.com/new).
 
 <Step label="1">
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -7,7 +7,7 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { NoIcon } from '~/ui/components/DocIcons';
 
-> **warning** In SDK 50 and above, publishing with `webpack` is deprecated.
+> **warning** **Deprecation**: In SDK 50 and above, publishing with `webpack` is deprecated.
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -17,7 +17,7 @@ A web app created using Expo can be served locally for testing out the productio
 
 ## Create a web build
 
-Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you have to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
+Creating a web build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you have to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
 
 Run the webpack export command to compile the project for web:
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -110,8 +110,7 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
 
 </Step>
 <Step label="2">
-  Configure redirects for single-page applications.
-  Create a **vercel.json** file at the root of your app and add the following:
+  Configure redirects for single-page applications. Create a **vercel.json** file at the root of your app and add the following:
 
   ```json vercel.json
   {

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -15,7 +15,7 @@ A web app created using Expo can be served locally for testing out the productio
 | --------- | ----------- | ---------- | ------------------------------------------------------------------------------------------ |
 | `webpack` | <NoIcon />  | <NoIcon /> | Outputs a Single Page Application (SPA) with a single **index.html** in the output folder. |
 
-## Create a build
+## Create a web build
 
 Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you have to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -86,7 +86,7 @@ Deploy the web build folder by running the following command:
 
 <Terminal cmd={['$ netlify deploy --dir web-build']} />
 
-You'll see a URL that you can use to view your project online.
+You will see a URL that you can use to view your project online.
 
 </Step>
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -3,12 +3,9 @@ title: Publish websites with Webpack
 description: Different ways to publish the Expo web app with third-party services with webpack.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { Step } from '~/ui/components/Step';
-import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
-import { Table, TableHead, Row, HeaderCell } from '~/ui/components/Table';
 import { Terminal } from '~/ui/components/Snippet';
-import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
+import { NoIcon } from '~/ui/components/DocIcons';
 
 > **warning** In SDK 50 and above, publishing with `webpack` is deprecated.
 
@@ -30,13 +27,6 @@ The resulting project files are in the **web-build** directory. Any files inside
 
 If you make changes to your project, rebuild it for production. Do not edit the **web-build** directory directly.
 
-> **Tip:** If you want to serve your site in a subfolder, add its path to your **package.json** as shown below:
->
-> ```json package.json
-> {
->   "homepage": "/path/to/subfolder"
-> }
-> ```
 
 ## Serve locally
 
@@ -47,6 +37,16 @@ Run the following command to serve the single-page application:
 <Terminal cmd={['$ npx serve web-build --single']} />
 
 Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other things won't work.
+
+## Server a subfolder
+
+ If you want to serve your site in a subfolder, add its path to your **package.json** as shown below:
+
+ ```json package.json
+ {
+   "homepage": "/path/to/subfolder"
+ }
+ ```
 
 ## Hosting on third-party services
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -153,7 +153,7 @@ Add the [**amplify-explicit.yml**](https://github.com/expo/amplify-demo/blob/mas
 
 <Step label="2">
 
-Push your local Expo project to a GitHub repository. If you haven't pushed to GitHub yet, follow [GitHub's guide to add an existing project to GitHub](https://docs.github.com/en/get-started/importing-your-projects-to-github/importing-source-code-to-github/adding-locally-hosted-code-to-github).
+Push your local Expo project to a GitHub repository. If you have not pushed to GitHub yet, follow [GitHub's guide to add an existing project to GitHub](https://docs.github.com/en/get-started/importing-your-projects-to-github/importing-source-code-to-github/adding-locally-hosted-code-to-github).
 
 </Step>
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -137,7 +137,7 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
 
 <Terminal cmd={['$ vercel']} />
 
-You'll now see a URL that you can use to view your project online. Paste that URL into your browser when the build is complete, and you'll see your deployed app.
+You will now see a URL that you can use to view your project online. Paste that URL into your browser when the build is complete, and see your deployed app.
 
 </Step>
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -72,7 +72,7 @@ If your app implements any navigation, you'll need to configure Netlify to redir
 
 Navigate inside the **web-build** directory and run the following command to create **\_redirects** file with follwing rule:
 
-```sh web/_redirects
+```bash web/_redirects
 /*    /index.html   200
 ```
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -28,7 +28,7 @@ Run the webpack export command to compile the project for web:
 
 The resulting project files are in the **web-build** directory. Any files inside the **web** directory are also copied to the **web-build** directory.
 
-If you make changes to your project, you'll need to rebuild it for production. Don't edit the **web-build** directory directly.
+If you make changes to your project, rebuild it for production. Do not edit the **web-build** directory directly.
 
 > **Tip:** If you want to serve your site in a subfolder, add its path to your **package.json** as shown below:
 >

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -20,7 +20,7 @@ A web app created using Expo can be served locally for testing out the productio
 
 ## Create a build
 
-Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you'll need to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
+Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you have to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
 
 Run the webpack export command to compile the project for web:
 

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -1,5 +1,5 @@
 ---
-title: Publish websites with Metro
+title: Publish websites with Webpack
 description: Different ways to publish the Expo web app with third-party services.
 ---
 
@@ -10,101 +10,43 @@ import { Table, TableHead, Row, HeaderCell } from '~/ui/components/Table';
 import { Terminal } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
+> **warning** In SDK 50 and above, publishing with `webpack` is deprecated.
+
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 
-## Output targets
-
-The [`web.output`](/versions/latest/config/app/#output) target can be configured in the [app config](/workflow/configuration/) to set the export method for the web app:
-
-```json app.json
-{
-  "expo": {
-    "web": {
-      "output": "server",
-      "bundler": "metro"
-    }
-  }
-}
-```
-
-
-Expo Router supports three output targets for web apps.
-
-| Output             | Expo Router | API Routes  |  Description                                                                                                                   |
-| ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
-| `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA) with a single **index.html** in the output folder and has no statically indexable HTML. |
-| `server`           | <YesIcon /> | <YesIcon /> |  Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server.   |
-| `static`           | <YesIcon /> | <NoIcon />  |  Outputs separate HTML files for every route in the **app** directory.                                                             |
+| Bundler   | Expo Router | API Routes | Description                                                                                |
+| --------- | ----------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `webpack` | <NoIcon />  | <NoIcon /> | Outputs a Single Page Application (SPA) with a single **index.html** in the output folder. |
 
 ## Create a build
 
 Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or host it on a third-party service, you'll need to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:
 
-<TabsGroup>
+Run the webpack export command to compile the project for web:
 
-<Tabs>
+<Terminal cmd={['$ npx expo export:web']} />
 
-<Tab label={`single`}>
+The resulting project files are in the **web-build** directory. Any files inside the **web** directory are also copied to the **web-build** directory.
 
-Run the universal export command to compile the project for web:
+If you make changes to your project, you'll need to rebuild it for production. Don't edit the **web-build** directory directly.
 
-<Terminal cmd={['$ npx expo export -p web']} />
-
-The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
-
-</Tab>
-
-<Tab label={`server`}>
-
-Run the universal export command to compile the project for web:
-
-<Terminal cmd={['$ npx expo export -p web']} />
-
-The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
-
-</Tab>
-
-<Tab label={`static`}>
-
-Run the universal export command to compile the project for web:
-
-<Terminal cmd={['$ npx expo export -p web']} />
-
-The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
-
-</Tab>
-
-</Tabs>
+> **Tip:** If you want to serve your site in a subfolder, add its path to your **package.json** as shown below:
+>
+> ```json package.json
+> {
+>   "homepage": "/path/to/subfolder"
+> }
+> ```
 
 ## Serve locally
 
 Use [Serve CLI](https://www.npmjs.com/package/serve) to quickly test locally how your website will be hosted in production. Run the following command to serve the static bundle:
 
-<Tabs>
+Run the following command to serve the single-page application:
 
-<Tab label="single">
+<Terminal cmd={['$ npx serve web-build --single']} />
 
-<Terminal cmd={['$ npx serve dist --single']} />
-
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will not work.
-
-</Tab>
-
-<Tab label="static">
-
-<Terminal cmd={['$ npx serve dist']} />
-
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will work.
-
-</Tab>
-
-<Tab label="server">
-
-There is no prebuilt solution. You will need to create your own server to serve the static files and API routes.
-
-</Tab>
-
-</Tabs>
+Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other things won't work.
 
 ## Hosting on third-party services
 
@@ -126,15 +68,15 @@ Install the Netlify CLI by running the following command:
 
 Configure redirects for single-page applications.
 
-> If your app uses [static rendering](/router/reference/static-rendering), then you can skip this step.
+If your app implements any navigation, you'll need to configure Netlify to redirect requests to the single **web-build/index.html** file. This can be done in Netlify by creating a **./public/\_redirects** file and redirecting all requests to **/index.html**.
 
-`expo.web.output: 'single'` generates a single-page application. It means there's only one **dist/index.html** file to which all requests must be redirected. This can be done in Netlify by creating a **./public/\_redirects** file and redirecting all requests to **/index.html**.
+Navigate inside the **web-build** directory and run the following command to create **\_redirects** file with follwing rule:
 
-```sh public/_redirects
+```sh web/_redirects
 /*    /index.html   200
 ```
 
-If you modify this file, you must rebuild your project with `npx expo export -p web` to have it safely copied into the **dist** directory.
+If you modify this file, you must rebuild your project with `npx expo export:web` to have it safely copied into the **web-build** directory.
 
 </Step>
 
@@ -142,7 +84,7 @@ If you modify this file, you must rebuild your project with `npx expo export -p 
 
 Deploy the web build folder by running the following command:
 
-<Terminal cmd={['$ netlify deploy --dir dist']} />
+<Terminal cmd={['$ netlify deploy --dir web-build']} />
 
 You'll see a URL that you can use to view your project online.
 
@@ -169,13 +111,12 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
 </Step>
 <Step label="2">
   Configure redirects for single-page applications.
-
-  Create a **vercel.json** file at the root of your app and add the following configuration:
+  Create a **vercel.json** file at the root of your app and add the following:
 
   ```json vercel.json
   {
-    "buildCommand": "expo export -p web",
-    "outputDirectory": "dist",
+    "buildCommand": "expo export:web",
+    "outputDirectory": "web-build",
     "devCommand": "expo",
     "cleanUrls": true,
     "framework": null,
@@ -187,8 +128,6 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
     ]
   }
   ```
-
-  If your app uses [static rendering](/router/reference/static-rendering), then you may want to add additional [dynamic route configuration](/router/reference/static-rendering#dynamic-routes).
 
 </Step>
 
@@ -244,8 +183,6 @@ Follow the steps in the **Learn how to get the most out of Amplify Hosting** dro
 ### GitHub Pages
 
 [GitHub Pages](https://pages.github.com/) allows you to publish a website directly from a GitHub repository.
-
-> **warning** Expo Router websites do not support deployment to GitHub Pages yet.
 
 <Step label="1">
 
@@ -339,8 +276,7 @@ Then, initialize your firebase project to host by running the command:
 
 The settings will depend on how you built your Expo website:
 
-1. When asked about the public path, make sure to specify the **dist** directory.
-2. When prompted **Configure as a single-page app (rewrite all urls to /index.html)**, only select **Yes** if you used `web.output: "single"` (default). Otherwise, select **No**.
+When asked about the public path, make sure to specify the **web-build** directory. Also, when prompted **Configure as a single-page app (rewrite all urls to /index.html)**, select **Yes**.
 
 </Step>
 
@@ -352,7 +288,7 @@ In the existing `scripts` property of **package.json**, add `predeploy` and `dep
 ```json package.json
 "scripts": {
   /* @hide ... */ /* @end */
-  "predeploy": "expo export -p web",
+  "predeploy": "expo export:web",
   "deploy-hosting": "npm run predeploy && firebase deploy --only hosting",
 }
 ```
@@ -399,5 +335,3 @@ In case you want to change the header for hosting add the following config for `
 ```
 
 </Step>
-
-</TabsGroup>

--- a/docs/pages/distribution/publishing-websites-webpack.mdx
+++ b/docs/pages/distribution/publishing-websites-webpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Publish websites with Webpack
-description: Different ways to publish the Expo web app with third-party services.
+description: Different ways to publish the Expo web app with third-party services with webpack.
 ---
 
 import { APIBox } from '~/components/plugins/APIBox';

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -3,14 +3,15 @@ title: Publish websites with Metro
 description: Different ways to publish the Expo web app with third-party services.
 ---
 
-import { APIBox } from '~/components/plugins/APIBox';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
-import { Table, TableHead, Row, HeaderCell } from '~/ui/components/Table';
 import { Terminal } from '~/ui/components/Snippet';
-import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+
+> **warning** In SDK 50 and above, `metro` is the default bundler for web apps. The previous documentation for publishing with `webpack` is available [here](/distribution/publishing-websites-webpack/).
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
+
 
 ## Output targets
 
@@ -90,6 +91,12 @@ Open [`http://localhost:5000`](http://localhost:5000) to see your project in act
 
 </Tab>
 
+<Tab label="server">
+
+There is no prebuilt solution. You will need to create your own server to serve the static files and API routes.
+
+</Tab>
+
 <Tab label="static">
 
 <Terminal cmd={['$ npx serve dist']} />
@@ -98,11 +105,6 @@ Open [`http://localhost:5000`](http://localhost:5000) to see your project in act
 
 </Tab>
 
-<Tab label="server">
-
-There is no prebuilt solution. You will need to create your own server to serve the static files and API routes.
-
-</Tab>
 
 </Tabs>
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -33,7 +33,7 @@ Expo Router supports three output targets for web apps.
 
 | Output             | Expo Router | API Routes  |  Description                                                                                                                   |
 | ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
-| `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA), with a single index.html in the output folder, and has no statically indexable HTML. |
+| `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA) with a single **index.html** in the output folder and has no statically indexable HTML. |
 | `server`           | <YesIcon /> | <YesIcon /> |  Creates a client & server folder. Client files are outputed as seperate HTML files. API routes as seperate JavaScript files   |
 | `static`           | <YesIcon /> | <NoIcon />  |  Outputs seperate HTML files for every route in the app/ directory                                                             |
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -34,7 +34,7 @@ Expo Router supports three output targets for web apps.
 | Output             | Expo Router | API Routes  |  Description                                                                                                                   |
 | ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
 | `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA) with a single **index.html** in the output folder and has no statically indexable HTML. |
-| `server`           | <YesIcon /> | <YesIcon /> |  Creates a client & server folder. Client files are outputed as seperate HTML files. API routes as seperate JavaScript files   |
+| `server`           | <YesIcon /> | <YesIcon /> |  Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server.   |
 | `static`           | <YesIcon /> | <NoIcon />  |  Outputs seperate HTML files for every route in the app/ directory                                                             |
 
 > **warning** In SDK 50+, publishing with `webpack` is deprecated

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -27,7 +27,6 @@ The [`web.output`](/versions/latest/config/app/#output) target can be configured
 }
 ```
 
-> If you are using legacy Expo Webpack (deprecated), only `single` is supported.
 
 Expo Router supports three output targets for web apps.
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -124,7 +124,7 @@ Use [Serve CLI](https://www.npmjs.com/package/serve) to quickly test locally how
 
 <Terminal cmd={['$ npx serve dist --single']} />
 
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features won't work.
+Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will not work.
 
 </Tab>
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -3,11 +3,55 @@ title: Publish websites
 description: Different ways to publish the Expo web app with third-party services.
 ---
 
-import { Terminal } from '~/ui/components/Snippet';
+import { APIBox } from '~/components/plugins/APIBox';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
+import { Table, TableHead, Row, HeaderCell } from '~/ui/components/Table';
+import { Terminal } from '~/ui/components/Snippet';
+import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
+
+## Output targets
+
+Expo supports three output targets for web apps. The output target can be configured in the **app.json** file:
+
+```json app.json
+{
+  "expo": {
+    "web": {
+      "output": "server",
+      "bundler": "metro"
+    }
+  }
+}
+```
+
+> If you are using Expo Web without Expo Router, only `single` is supported
+
+| Output             | Expo Router | API Routes  |  Description                                                                                                                   |
+| ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
+| `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA), with a single index.html in the output folder, and has no statically indexable HTML. |
+| `server`           | <YesIcon /> | <YesIcon /> |  Creates a client & server folder. Client files are outputed as seperate HTML files. API routes as seperate JavaScript files   |
+| `static`           | <YesIcon /> | <NoIcon />  |  Outputs seperate HTML files for every route in the app/ directory                                                             |
+
+> **warning** In SDK 50+, publishing with `webpack` is deprecated
+
+Expo only supports the single output format when using `webpack`.
+
+```json app.json
+{
+  "expo": {
+    "web": {
+      "bundler": "webpack"
+    }
+  }
+}
+```
+
+| Bundler   | Expo Router | API Routes | Description                                                                             |
+| --------- | ----------- | ---------- | --------------------------------------------------------------------------------------- |
+| `webpack` | <NoIcon />  | <NoIcon /> | Outputs a Single Page Application (SPA), with a single index.html in the output folder. |
 
 ## Create a build
 
@@ -17,7 +61,27 @@ Creating a build of the project is the first step to publishing a web app. Wheth
 
 <Tabs>
 
-<Tab label="Expo Router">
+<Tab label={`single`}>
+
+Run the universal export command to compile the project for web:
+
+<Terminal cmd={['$ npx expo export -p web']} />
+
+The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
+
+</Tab>
+
+<Tab label={`server`}>
+
+Run the universal export command to compile the project for web:
+
+<Terminal cmd={['$ npx expo export -p web']} />
+
+The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
+
+</Tab>
+
+<Tab label={`static`}>
 
 Run the universal export command to compile the project for web:
 
@@ -55,17 +119,25 @@ Use [Serve CLI](https://www.npmjs.com/package/serve) to quickly test locally how
 
 <Tabs>
 
-<Tab label="Expo Router">
-
-If you're using [static rendering](/router/reference/static-rendering), then you can serve the static bundle with the following command:
-
-<Terminal cmd={['$ npx serve dist']} />
-
-Otherwise, use the `--single` flag to redirect all requests to the single **dist/index.html** file.
+<Tab label="single">
 
 <Terminal cmd={['$ npx serve dist --single']} />
 
 Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features won't work.
+
+</Tab>
+
+<Tab label="static">
+
+<Terminal cmd={['$ npx serve dist']} />
+
+Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features won't work.
+
+</Tab>
+
+<Tab label="server">
+
+There is no prebuilt solution. You will need to create your own server to serve the static files and API routes.
 
 </Tab>
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -52,7 +52,7 @@ Expo only supports the `single` output format using `webpack`.
 
 | Bundler   | Expo Router | API Routes | Description                                                                             |
 | --------- | ----------- | ---------- | --------------------------------------------------------------------------------------- |
-| `webpack` | <NoIcon />  | <NoIcon /> | Outputs a Single Page Application (SPA), with a single index.html in the output folder. |
+| `webpack` | <NoIcon />  | <NoIcon /> | Outputs a Single Page Application (SPA) with a single **index.html** in the output folder. |
 
 ## Create a build
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -14,7 +14,7 @@ A web app created using Expo can be served locally for testing out the productio
 
 ## Output targets
 
-Expo supports three output targets for web apps. The output target can be configured in the **app.json** file:
+Expo Router supports three output targets for web apps. The `web.output` target can be configured in the **app.json** file:
 
 ```json app.json
 {

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -35,7 +35,7 @@ Expo Router supports three output targets for web apps.
 | ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
 | `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA) with a single **index.html** in the output folder and has no statically indexable HTML. |
 | `server`           | <YesIcon /> | <YesIcon /> |  Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server.   |
-| `static`           | <YesIcon /> | <NoIcon />  |  Outputs seperate HTML files for every route in the app/ directory                                                             |
+| `static`           | <YesIcon /> | <NoIcon />  |  Outputs separate HTML files for every route in the **app** directory.                                                             |
 
 > **warning** In SDK 50 and above, publishing with `webpack` is deprecated. 
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -14,7 +14,7 @@ A web app created using Expo can be served locally for testing out the productio
 
 ## Output targets
 
-Expo Router supports three output targets for web apps. The `web.output` target can be configured in the **app.json** file:
+The [`web.output`](/versions/latest/config/app/#output) target can be configured in the [app config](/workflow/configuration/) to set the export method for the web app:
 
 ```json app.json
 {

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -132,7 +132,7 @@ Open [`http://localhost:5000`](http://localhost:5000) to see your project in act
 
 <Terminal cmd={['$ npx serve dist']} />
 
-Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features won't work.
+Open [`http://localhost:5000`](http://localhost:5000) to see your project in action. This method is **HTTP only**, so permissions, camera, location, and many other secure features will work.
 
 </Tab>
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -29,6 +29,8 @@ The [`web.output`](/versions/latest/config/app/#output) target can be configured
 
 > If you are using legacy Expo Webpack (deprecated), only `single` is supported.
 
+Expo Router supports three output targets for web apps.
+
 | Output             | Expo Router | API Routes  |  Description                                                                                                                   |
 | ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |
 | `single` (default) | <YesIcon /> | <NoIcon />  |  Outputs a Single Page Application (SPA), with a single index.html in the output folder, and has no statically indexable HTML. |

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -38,7 +38,7 @@ Expo Router supports three output targets for web apps.
 
 > **warning** In SDK 50 and above, publishing with `webpack` is deprecated. 
 
-Expo only supports the single output format when using `webpack`.
+Expo only supports the `single` output format using `webpack`.
 
 ```json app.json
 {

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -27,7 +27,7 @@ Expo supports three output targets for web apps. The output target can be config
 }
 ```
 
-> If you are using Expo Web without Expo Router, only `single` is supported
+> If you are using legacy Expo Webpack (deprecated), only `single` is supported.
 
 | Output             | Expo Router | API Routes  |  Description                                                                                                                   |
 | ------------------ | ----------- | ----------- |  ----------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -37,7 +37,7 @@ Expo Router supports three output targets for web apps.
 | `server`           | <YesIcon /> | <YesIcon /> |  Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server.   |
 | `static`           | <YesIcon /> | <NoIcon />  |  Outputs seperate HTML files for every route in the app/ directory                                                             |
 
-> **warning** In SDK 50+, publishing with `webpack` is deprecated
+> **warning** In SDK 50 and above, publishing with `webpack` is deprecated. 
 
 Expo only supports the single output format when using `webpack`.
 


### PR DESCRIPTION
# Why

Update the web publishing docs with more information around Expo Router's output modes.

We are also trying to shifted the tone away from "Metro vs webpack" and treat Expo Router as the best way to publish. So I've tried to focus more on Expo Router's output modes.

@amandeepmittal I don't like my layout, I think I'm using too many components back-to-back and it looks very blocky. Would love some feedback.

@kitten We should also work together to update the platforms section 
