### PR TITLE
fix(cli): Invalidate API Route cache whenever any file in the repo changes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Invalidate API Route cache whenever any file in the repo changes.
+- Invalidate API Route cache whenever any file in the repo changes. ([#25936](https://github.com/expo/expo/pull/25936) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Invalidate API Route cache whenever any file in the repo changes.
+
 ### 💡 Others
 
 ## 0.16.2 — 2023-12-14

--- a/packages/@expo/cli/src/start/server/metro/bundleApiRoutes.ts
+++ b/packages/@expo/cli/src/start/server/metro/bundleApiRoutes.ts
@@ -65,11 +65,6 @@ export async function bundleApiRoute(
   return route;
 }
 
-export async function rebundleApiRoute(
-  projectRoot: string,
-  filepath: string,
-  options: ApiRouteOptions
-) {
-  pendingRouteOperations.delete(filepath);
-  return bundleApiRoute(projectRoot, filepath, options);
+export async function invalidateApiRouteCache() {
+  pendingRouteOperations.clear();
 }

--- a/packages/@expo/cli/src/start/server/metro/router.ts
+++ b/packages/@expo/cli/src/start/server/metro/router.ts
@@ -62,10 +62,6 @@ export function getRouterDirectory(projectRoot: string): string {
   return 'app';
 }
 
-export function isApiRouteConvention(name: string): boolean {
-  return /\+api\.[tj]sx?$/.test(name);
-}
-
 export function getApiRoutesForDirectory(cwd: string) {
   return globSync('**/*+api.@(ts|tsx|js|jsx)', {
     cwd,

--- a/packages/@expo/cli/src/start/server/metro/waitForMetroToObserveTypeScriptFile.ts
+++ b/packages/@expo/cli/src/start/server/metro/waitForMetroToObserveTypeScriptFile.ts
@@ -8,55 +8,6 @@ const debug = require('debug')('expo:start:server:metro:waitForTypescript') as t
  * Use the native file watcher / Metro ruleset to detect if a
  * TypeScript file is added to the project during development.
  */
-export function observeApiRouteChanges(
-  appDir: string,
-  runner: {
-    metro: import('metro').Server;
-    server: ServerLike;
-  },
-  callback: (filepath: string, operation: string) => Promise<void>
-): () => void {
-  const watcher = runner.metro.getBundler().getBundler().getWatcher();
-
-  const listener = ({
-    eventsQueue,
-  }: {
-    eventsQueue: {
-      filePath: string;
-      metadata?: {
-        type: 'f' | 'd' | 'l'; // Regular file / Directory / Symlink
-      } | null;
-      type: string;
-    }[];
-  }) => {
-    for (const event of eventsQueue) {
-      if (
-        // event.type === 'add' &&
-        // event.metadata?.type !== 'd' &&
-        // We need to ignore node_modules because Metro will add all of the files in node_modules to the watcher.
-        !/node_modules/.test(event.filePath) &&
-        event.filePath.startsWith(appDir)
-      ) {
-        const { filePath } = event;
-        callback(filePath, event.type);
-      }
-    }
-  };
-
-  watcher.addListener('change', listener);
-
-  const off = () => {
-    watcher.removeListener('change', listener);
-  };
-
-  runner.server.addListener?.('close', off);
-  return off;
-}
-
-/**
- * Use the native file watcher / Metro ruleset to detect if a
- * TypeScript file is added to the project during development.
- */
 export function waitForMetroToObserveTypeScriptFile(
   projectRoot: string,
   runner: {
@@ -155,6 +106,39 @@ export function observeFileChanges(
   };
 
   debug('Watching file changes:', files);
+  watcher.addListener('change', listener);
+
+  const off = () => {
+    watcher.removeListener('change', listener);
+  };
+
+  runner.server.addListener?.('close', off);
+  return off;
+}
+
+export function observeAnyFileChanges(
+  runner: {
+    metro: import('metro').Server;
+    server: ServerLike;
+  },
+  callback: () => void | Promise<void>
+): () => void {
+  const watcher = runner.metro.getBundler().getBundler().getWatcher();
+
+  const listener = ({
+    eventsQueue,
+  }: {
+    eventsQueue: {
+      filePath: string;
+      metadata?: {
+        type: 'f' | 'd' | 'l'; // Regular file / Directory / Symlink
+      } | null;
+      type: string;
+    }[];
+  }) => {
+    callback();
+  };
+
   watcher.addListener('change', listener);
 
   const off = () => {


### PR DESCRIPTION

# Why

We aren't sure what files the API routes are using so we'll just invalidate aggressively to ensure we always have the latest. The only caching we really get here is for cases where the user is making subsequent requests to the same API route without changing anything.
This is useful for testing but pretty suboptimal. Luckily our caching is pretty aggressive so it makes up for a lot of the overhead.

# How

Tap the Metro file watcher and invalidate the API routes cache so they get rebundled on the next request.

# Test Plan

- Have an API route, make a number of subsequent requests and logs wont show rebundling.
- Modify any file in the repo, and reload, it should rebundle the file quickly due to Metro caching. 

