### PR TITLE
Add `--no-wait` flag to CI execution examples

### DIFF
--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -59,7 +59,9 @@ npx eas-cli build --platform all --non-interactive --no-wait
 
 This will trigger a new build on EAS. A URL will be printed, linking to the build's progress in the EAS dashboard.
 
-> **info** The `--no-wait` flag will exit the step once the build has been triggered, meaning that you are not billed for CI execution time whilst EAS performs the build. If you need to add another CI step to run once the build has completed, you'll need to remove this flag.
+> **info** The `--no-wait` flag exits the step once the build has been triggered. You are not billed for CI execution time while EAS performs the build. However, your CI will report that the build job is passing only if triggering EAS Build is successful.
+>
+> If you need to add another CI step to run once the build is complete, remove this flag.
 
 <Collapsible summary="Travis CI">
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -54,10 +54,12 @@ Now that we're authenticated with Expo CLI, we can create the build step.
 To trigger new builds, we will add this script to our configuration:
 
 ```sh
-npx eas-cli build --platform all --non-interactive
+npx eas-cli build --platform all --non-interactive --no-wait
 ```
 
-This will trigger a new build on EAS and print the URLs for the built files after the build completes.
+This will trigger a new build on EAS. A URL will be printed, linking to the build's progress in the EAS dashboard.
+
+> **info** The `--no-wait` flag will exit the step once the build has been triggered, meaning that you are not billed for CI execution time whilst EAS performs the build. If you need to add another CI step to run once the build has completed, you'll need to remove this flag.
 
 <Collapsible summary="Travis CI">
 
@@ -81,7 +83,7 @@ jobs:
       node_js: lts/*
       script:
         - npm ci
-        - npx eas-cli build --platform all --non-interactive
+        - npx eas-cli build --platform all --non-interactive --no-wait
 ```
 
 </Collapsible>
@@ -112,7 +114,7 @@ eas-build:
   stage: build
   script:
     - apk add --no-cache bash
-    - npx eas-cli build --platform all --non-interactive
+    - npx eas-cli build --platform all --non-interactive --no-wait
 ```
 
 </Collapsible>
@@ -138,7 +140,7 @@ pipelines:
         script:
           - apk add --no-cache bash
           - npm ci
-          - npx eas-cli build --platform all --non-interactive
+          - npx eas-cli build --platform all --non-interactive --no-wait
 ```
 
 </Collapsible>
@@ -166,7 +168,7 @@ jobs:
           command: npm ci
       - run:
           name: Trigger build
-          command: npx eas-cli build --platform all --non-interactive
+          command: npx eas-cli build --platform all --non-interactive --no-wait
 
 workflows:
   build_app:
@@ -208,7 +210,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build on EAS
-        run: eas build --platform all --non-interactive
+        run: eas build --platform all --non-interactive --no-wait
 ```
 
 </Collapsible>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The current instructions for triggering EAS Builds from a CI environment will block the CI environment from finishing until EAS completes the build, wasting CI resources.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adding a suggestion to use the `--no-wait` flag will allow CI to finish as soon as the build is triggered, saving on CI execution time.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Triggering a build with CircleCI outputs the following in the Circle logs, ending as soon as the build is triggered. A URL is printed, which can be used to check on build progress in EAS.

```
#!/bin/bash -eo pipefail
npx eas-cli build --platform android --profile preview --non-interactive --no-wait

npm WARN exec The following package was not found and will be installed: eas-cli@5.9.1
The EAS build profile does not specify a Node.js version. Using the version specified in .nvmrc: v20 
Loaded "env" configuration for the "preview" profile: <redacted>. Learn more: https://docs.expo.dev/build-reference/variables/
✔ Using remote Android credentials (Expo server)
✔ Using Keystore from configuration: <redacted> (default)

Compressing project files and uploading to EAS Build. Learn more: https://expo.fyi/eas-build-archive
- Uploading to EAS Build (0 / 535 KB)
✔ Uploaded to EAS 

Build details: https://expo.dev/accounts/<redacted>/projects/<redacted>/builds/850da346-8acd-4a63-9eb0-bee073111430
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
