### PR TITLE
[core][Android] Bump Kotlin version from `1.8.10` to `1.8.22`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Bump Kotlin version from `1.8.10` to `1.8.22`.
+
 ## 1.11.1 — 2023-12-12
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Bump Kotlin version from `1.8.10` to `1.8.22`.
+- [Android] Bump Kotlin version from `1.8.10` to `1.8.22`. ([#25945](https://github.com/expo/expo/pull/25945) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.11.1 — 2023-12-12
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -23,14 +23,15 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
           "1.6.21": "1.6.21-1.0.6",
           "1.7.22": "1.7.22-1.0.8",
           "1.8.0": "1.8.0-1.0.9",
-          "1.8.10": "1.8.10-1.0.9"
+          "1.8.10": "1.8.10-1.0.9",
+          "1.8.22": "1.8.22-1.0.11"
         ]
 
         project.rootProject.ext.has("kspVersion")
           ? project.rootProject.ext.get("kspVersion")
           : kspVersionsMap.containsKey(project.ext.kotlinVersion())
           ? kspVersionsMap.get(project.ext.kotlinVersion())
-          : "1.8.10-1.0.9"
+          : "1.8.22-1.0.11"
       }
     }
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -223,46 +223,34 @@ android {
   }
 }
 
-
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
-  implementation 'androidx.annotation:annotation:1.3.0'
+  implementation 'androidx.annotation:annotation:1.7.1'
 
   api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
-  api "androidx.core:core-ktx:1.6.0"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+  api "androidx.core:core-ktx:1.12.0"
   api project(':expo-modules-core$android-annotation')
 
-  /**
-   * ReactActivity (the base activity for every React Native application) is subclassing AndroidX classes.
-   * Unfortunately until https://github.com/facebook/react-native/pull/33072 is released React Native uses "androidx.appcompat:appcompat:1.0.2".
-   * Gradle is picking the highest version of the dependency so we enforce higher version here.
-   * see https://docs.gradle.org/current/userguide/dependency_resolution.html#sec:version-conflict
-   * We're enforcing the most up-to-date versions of the dependencies here that are used in subclassing chain for ReactActivity.
-   */
-  implementation "androidx.appcompat:appcompat:1.4.1"
-  implementation "androidx.activity:activity-ktx:1.7.1" // androidx.appcompat:appcompat:1.4.1 depends on version 1.2.3, so we enforce higher one here
-  implementation "androidx.fragment:fragment-ktx:1.5.7" // androidx.appcomapt:appcompat:1.4.1 depends on version 1.3.4, so we enforce higher one here
-
-  implementation("androidx.tracing:tracing-ktx:1.1.0")
+  implementation("androidx.tracing:tracing-ktx:1.2.0")
 
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
 
-  compileOnly 'com.facebook.fbjni:fbjni:0.3.0'
+  compileOnly 'com.facebook.fbjni:fbjni:0.5.1'
 
-  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation 'androidx.test:core:1.5.0'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'io.mockk:mockk:1.12.3'
+  testImplementation 'io.mockk:mockk:1.13.5'
   testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.11.1"
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
   testImplementation "org.json:json:20230227"
 
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:core:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
+  androidTestImplementation 'androidx.test:runner:1.5.2'
+  androidTestImplementation 'androidx.test:core:1.5.0'
+  androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation "io.mockk:mockk-android:1.12.3"
   androidTestImplementation "com.google.truth:truth:1.1.2"
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -156,9 +156,9 @@ dependencies { dependencyHandler ->
   implementation 'com.facebook.react:react-native:+'
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation 'androidx.test:core:1.5.0'
   testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation 'io.mockk:mockk:1.12.0'
+  testImplementation 'io.mockk:mockk:1.13.5'
 
   // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.
   // A collection of the dependencies depends on the options passed to `useExpoModules` in your project's `settings.gradle`.


### PR DESCRIPTION
# Why

Bumps Kotlin version from `1.8.10` to `1.8.22` and other native liberties. 

# How

I have updated the versions of the native libraries to match the newest ones or the recommended ones for use with react-native. In most cases, this will not change the library version we are currently using, as react-native already includes updated versions of these libraries.

# Test Plan

- bare-expo ✅
- tests ✅
- expo go ✅