### PR TITLE
[system-ui] fix RCTRootViewBackgroundColor setup from plugin

### DIFF
--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed custom `backgroundColor` is broken on iOS. ([#25946](https://github.com/expo/expo/pull/25946) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.9.0 — 2023-12-12

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -8,14 +8,14 @@ public class ExpoSystemUIModule: Module {
     Name("ExpoSystemUI")
 
     OnCreate {
-      // TODO: Maybe read from the app manifest instead of from Info.plist.
-      // Set / reset the initial color on reload and app start.
       let color = UserDefaults.standard.integer(forKey: Self.colorKey)
-
       if color > 0 {
         Self.setBackgroundColorAsync(color: color)
       } else {
-        Self.setBackgroundColorAsync(color: nil)
+        // TODO: Maybe read from the app manifest instead of from Info.plist.
+        // Set / reset the initial color on reload and app start.
+        let colorFromPlugin = Bundle.main.object(forInfoDictionaryKey: "RCTRootViewBackgroundColor") as? Int
+        Self.setBackgroundColorAsync(color: colorFromPlugin)
       }
     }
 


### PR DESCRIPTION
# Why

expo-system-ui config plugin will setup `RCTRootViewBackgroundColor` from app.json's `ios.backgroundColor` to info.plist. from #22773, we break this and expo-system-ui will always use system default color as the background color: https://github.com/expo/expo/blob/e281adb30e978c382220686ffb0cb1b665f8d3c5/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift#L44-L60

# How

if the color is not persisted yet, we should respect the color from `RCTRootViewBackgroundColor`

# Test Plan

```sh
$ yarn create expo -t blank@sdk-50 sdk50
$ cd sdk50
$ jq '.expo.ios.backgroundColor = "#0000ff"' app.json > app.json.tmp
$ mv app.json.tmp app.json
$ patch << EOF
--- a/App.js
+++ b/App.js
@@ -13,7 +13,7 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: 'transparent',
     alignItems: 'center',
     justifyContent: 'center',
   },
EOF
$ npx expo run:ios

# the view background should be blue color
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
