### PR TITLE
Make detecting if expo modules is installed more reliable

### DIFF
--- a/packages/expo/react-native.config.js
+++ b/packages/expo/react-native.config.js
@@ -18,10 +18,7 @@ function isExpoModulesInstalledIos(projectRoot) {
     // Assumes true for managed apps
     return true;
   }
-  return isMatchedInFile(
-    podfilePath,
-    /^\s*require File.join\(File\.dirname\(`node --print "require\.resolve\('expo\/package\.json'\)"`\), "scripts\/autolinking"\)\s*$/m
-  );
+  return isMatchedInFile(podfilePath, /use_expo_modules!/);
 }
 
 /**
@@ -33,10 +30,7 @@ function isExpoModulesInstalledAndroid(projectRoot) {
     // Assumes true for managed apps
     return true;
   }
-  return isMatchedInFile(
-    gradlePath,
-    /^\s*apply from: (new File|file)\(\["node", "--print", "require\.resolve\('expo\/package.json'\)"\]\.execute\(null, rootDir\)\.text\.trim\(\), "\.\.\/scripts\/autolinking\.gradle"\);?\s*$/m
-  );
+  return isMatchedInFile(gradlePath, /useExpoModules/);
 }
 
 module.exports = {


### PR DESCRIPTION
# Why

I had some issues with autolinking on Android after formatting files with spotless. It results in this format for the autolinking script which breaks detection.

```
apply from: new File([
    "node",
    "--print",
    "require.resolve('expo/package.json')"
].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
```

I think it is safe to just check for the imported function `useExpoModules` / `use_expo_modules!` instead of the import.

# How

Use  `useExpoModules` / `use_expo_modules!` to detect if expo modules is installed.

# Test Plan

Tested in an app that expo modules are properly installed.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
