### PR TITLE
[ENG-10916][tools] try to fix OpenSSL EAS Build credentials issues

### DIFF
--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -9,8 +9,8 @@ import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import os from 'os';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 import semver from 'semver';
+import { v4 as uuidv4 } from 'uuid';
 
 import { EXPO_DIR } from '../Constants';
 import Git from '../Git';

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -10,6 +10,7 @@ import fetch from 'node-fetch';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
+import semver from 'semver';
 
 import { EXPO_DIR } from '../Constants';
 import Git from '../Git';
@@ -181,12 +182,20 @@ async function iosBuildAndSubmitAsync() {
         stdio: isDebug ? 'inherit' : 'pipe',
       }
     );
+    const { stdout: opensslVersionCommandOutput } = await spawnAsync('openssl', ['--version'], {
+      stdio: isDebug ? 'inherit' : 'pipe',
+    });
+    const opensslVersionRegex = /OpenSSL\s(\d+\.\d+\.\d+)/;
+    const matches = opensslVersionCommandOutput.match(opensslVersionRegex);
+    assert(matches, 'Could not parse openssl version');
+    const opensslVersion = matches[1];
+    const isOpensslVersionAbove1 = semver.satisfies(opensslVersion, '>1');
     await spawnAsync(
       'openssl',
       [
         'pkcs12',
         '-export',
-        '-legacy',
+        ...(isOpensslVersionAbove1 ? ['-legacy'] : []),
         '-out',
         p12KeystorePath,
         '-inkey',

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -140,7 +140,6 @@ async function iosBuildAndSubmitAsync() {
   const credentialsDir = path.join(projectDir, 'credentials');
   const fastlaneMatchBucketCopyPath = path.join(credentialsDir, 'fastlane-match');
   const releaseSecretsPath = path.join(credentialsDir, 'secrets');
-  const isDarwin = os.platform() === 'darwin';
 
   logger.info('Preparing credentials');
   try {

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -187,7 +187,7 @@ async function iosBuildAndSubmitAsync() {
       [
         'pkcs12',
         '-export',
-        ...(isDarwin ? [] : ['-legacy']),
+        '-legacy',
         '-out',
         p12KeystorePath,
         '-inkey',


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/CNHBN8LNS/p1702086628447629

# How

I think that to make it work we need to use `OpenSSL` in `-legacy` mode on Mac too when preparing credentials. I believe this should fix the issues.

# Test Plan

1. Install openssl 3
2. try to run EAS iOS build requiring credentials on Mac using `et` script

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
