### PR TITLE
[ENG-10922][docs] add docs for the new Xcode 15.1 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -224,7 +224,7 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.0` (`default`)
+#### `macos-ventura-13.6-xcode-15.0`
 
 <Collapsible summary="Details">
 
@@ -242,7 +242,7 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.4-xcode-14.3.1`
+#### `macos-ventura-13.4-xcode-14.3.1` (`default`)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -222,6 +222,8 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - Ruby 2.7
 - node-gyp 10.0.1
 
+</Collapsible>
+
 #### `macos-ventura-13.6-xcode-15.0` (`default`)
 
 <Collapsible summary="Details">

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -8,7 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **November 28, 2023**.
+> This document was last updated on **December 15, 2023**.
 
 ## Builder IP addresses
 
@@ -74,7 +74,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 8.9.2
 - npm 9.8.1
 - Java 17
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -91,7 +90,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 8.7.5
 - npm 9.8.1
 - Java 11
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -108,7 +106,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 7.0.0
 - npm 9.8.1
 - Java 8
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -125,7 +122,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 7.0.0
 - npm 9.8.1
 - Java 11
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -142,7 +138,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 7.0.0
 - npm 9.8.1
 - Java 8
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -159,7 +154,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 7.0.0
 - npm 9.8.1
 - Java 11
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -176,7 +170,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 - pnpm 7.0.0
 - npm 9.8.1
 - Java 8
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -213,7 +206,23 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-ventura-13.6-xcode-15.0` (`latest`)
+#### `macos-ventura-13.6-xcode-15.1` (`latest`)
+
+<Collapsible summary="Details">
+
+- macOS Ventura 13.6
+- Xcode 15.1 (15C65)
+- Node.js 18.18.0
+- Bun 1.0.14
+- Yarn 1.22.19
+- pnpm 8.12.1
+- npm 9.8.1
+- fastlane 2.217.0
+- CocoaPods 1.14.3
+- Ruby 2.7
+- node-gyp 10.0.1
+
+#### `macos-ventura-13.6-xcode-15.0` (`default`)
 
 <Collapsible summary="Details">
 
@@ -227,12 +236,11 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.216.0
 - CocoaPods 1.13.0
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
 
-#### `macos-ventura-13.4-xcode-14.3.1` (`default`)
+#### `macos-ventura-13.4-xcode-14.3.1`
 
 <Collapsible summary="Details">
 
@@ -246,7 +254,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.213.0
 - CocoaPods 1.12.1
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -265,7 +272,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.212.2
 - CocoaPods 1.12.0
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -284,7 +290,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.211.0
 - CocoaPods 1.11.3
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -303,7 +308,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.210.1
 - CocoaPods 1.11.3
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -322,7 +326,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.210.0
 - CocoaPods 1.11.3
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -341,7 +344,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -360,7 +362,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>
@@ -379,7 +380,6 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 - fastlane 2.201.0
 - CocoaPods 1.11.2
 - Ruby 2.7
-- Python 3.12.0
 - node-gyp 10.0.1
 
 </Collapsible>


### PR DESCRIPTION
# Why

We are adding a new Xcode 15.1 image

# How

Add docs for the new Xcode 15.1 image. Update `latest` and `default` tags.

Remove `Python` from image specs, because using 3.12 was causing troubles and we reverted the change and started to use system Python version again in our images.

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
