### PR TITLE
[docs] Clarify how app-specific deep links work with dev builds

### DIFF
--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -36,7 +36,7 @@ To get your project's ID, use the URL in the [app config's `expo.updates.url`](/
 
 {/* TODO: @aman move this section out of this page -- make it part of the main path or a standalone guide, this is important part that should be searchable for eg: Deep linking URLs for Development builds/EAS Builds (when using expo-dev-client) */}
 
-### Deep linking URLs
+### Deep linking to an update's URL
 
 You can load your app on a device that has a compatible build of your custom client by opening a URL of the form `{scheme}://expo-development-client/?url={manifestUrl}`. You'll need to pass the following parameters:
 
@@ -52,6 +52,12 @@ exp+app-slug://expo-development-client/?url=https%3A%2F%2Fu.expo.dev%2F767ADF57-
 ```
 
 In the example above, the `scheme` is `exp+app-slug`, and the `manifestUrl` is a project with an ID of `F767ADF57-B487-4D8F-9522-85549C39F43F` and a channel of `main`.
+
+#### App-specific deep links
+
+When testing deep links in your development build, such as when navigating to a specific screen in an Expo Router app, or testing redirecting back to your app during an Oauth login flow, construct the URL exactly as you would as if you were deep-linking into a standalone build of your app (e.g., `myscheme://path/to/screen`).
+
+Your project must be already open in the development build in order for an app-specific deep link to work. Cold-launching a development build with an app-specific deep link is not currently supported. In your app-specific deep links, avoid using `expo-development-client` in the path, as this is a reseved path used for launching an updates URL.
 
 ### QR codes
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -57,7 +57,7 @@ In the example above, the `scheme` is `exp+app-slug`, and the `manifestUrl` is a
 
 When testing deep links in your development build, such as when navigating to a specific screen in an Expo Router app or testing redirecting back to your app during an Oauth login flow, construct the URL exactly as you would if you were deep-linking into a standalone build of your app (for example, `myscheme://path/to/screen`).
 
-Your project must be already open in the development build in order for an app-specific deep link to work. Cold-launching a development build with an app-specific deep link is not currently supported. In your app-specific deep links, avoid using `expo-development-client` in the path, as this is a reseved path used for launching an updates URL.
+Your project must be already open in the development build for an app-specific deep link to work. Cold-launching a development build with an app-specific deep link is not currently supported. Avoid using `expo-development-client` in your app-specific deep links in the path, as it is a reserved path used for launching an updated URL.
 
 ### QR codes
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -55,7 +55,7 @@ In the example above, the `scheme` is `exp+app-slug`, and the `manifestUrl` is a
 
 #### App-specific deep links
 
-When testing deep links in your development build, such as when navigating to a specific screen in an Expo Router app, or testing redirecting back to your app during an Oauth login flow, construct the URL exactly as you would as if you were deep-linking into a standalone build of your app (e.g., `myscheme://path/to/screen`).
+When testing deep links in your development build, such as when navigating to a specific screen in an Expo Router app or testing redirecting back to your app during an Oauth login flow, construct the URL exactly as you would if you were deep-linking into a standalone build of your app (for example, `myscheme://path/to/screen`).
 
 Your project must be already open in the development build in order for an app-specific deep link to work. Cold-launching a development build with an app-specific deep link is not currently supported. In your app-specific deep links, avoid using `expo-development-client` in the path, as this is a reseved path used for launching an updates URL.
 


### PR DESCRIPTION
# Why
There's been some confusion about how app-specific deep links work with development builds, since you can also deep link into a specific update / update channel with a deep link.

In (https://github.com/expo/expo/issues/25515), it was confusing as to why the deep link didn't work, and it turns out that the development build was intercepting it, because the path matched the path used for deep linking to an update.

Not sure where best to document this, but right next to other deep linking behavior for development builds seemed like a possibility.

# How
Updated the doc

# Test Plan
Looked at the doc

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
