### PR TITLE
[ios] Fix ExErrorView colors in dark mode

### DIFF
--- a/ios/Exponent/Images.xcassets/backgroundDefault.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/backgroundDefault.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.129",
+          "green" : "0.106",
+          "red" : "0.090"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Images.xcassets/buttonSecondaryBackground.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/buttonSecondaryBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.949",
+          "green" : "0.945",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.239",
+          "green" : "0.212",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Images.xcassets/buttonSecondaryText.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/buttonSecondaryText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.137",
+          "green" : "0.122",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Images.xcassets/buttonTertiaryBackground.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/buttonTertiaryBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.137",
+          "green" : "0.122",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.988",
+          "green" : "0.965",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Images.xcassets/buttonTertiaryText.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/buttonTertiaryText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.090",
+          "green" : "0.067",
+          "red" : "0.051"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Images.xcassets/textDefault.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/textDefault.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.184",
+          "green" : "0.161",
+          "red" : "0.141"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.933",
+          "green" : "0.929",
+          "red" : "0.925"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/ios/Exponent/Images.xcassets/textSecondary.colorset/Contents.json
+++ b/ios/Exponent/Images.xcassets/textSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.412",
+          "green" : "0.373",
+          "red" : "0.345"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.651",
+          "green" : "0.631",
+          "red" : "0.608"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -109,6 +109,7 @@
   UIFont *font = _txtErrorDetail.font;
   _txtErrorDetail.attributedText = attributedErrorString;
   _txtErrorDetail.font = font;
+  _txtErrorDetail.textColor = [UIColor colorNamed:@"textDefault"];
 
   [self _resetUIState];
 }
@@ -122,20 +123,9 @@
 - (void)layoutSubviews
 {
   [super layoutSubviews];
- 
-  if (@available(iOS 12.0, *)) {
-    switch (UIScreen.mainScreen.traitCollection.userInterfaceStyle) {
-      case UIUserInterfaceStyleDark:
-        self.backgroundColor = [EXUtil colorWithRGB:0x25292E];
-        break;
-      case UIUserInterfaceStyleLight:
-      case UIUserInterfaceStyleUnspecified:
-        break;
-      default:
-        break;
-    }
-  }
-  
+
+  self.backgroundColor = [UIColor colorNamed:@"backgroundDefault"];
+
   _vContainer.translatesAutoresizingMaskIntoConstraints = NO;
 
   UILayoutGuide *guide = self.safeAreaLayoutGuide;
@@ -143,12 +133,6 @@
   [_vContainer.trailingAnchor constraintEqualToAnchor:guide.trailingAnchor].active = YES;
   [_vContainer.topAnchor constraintEqualToAnchor:guide.topAnchor].active = YES;
   [_vContainer.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor].active = YES;
-
-  UIImage *btnRetryBgImage = [self imageWithSize:_btnRetry.frame.size color:  [EXUtil colorWithRGB:0x25292E]];
-  [_btnRetry setBackgroundImage:btnRetryBgImage forState:UIControlStateNormal];
-  
-  UIImage *btnBackBgImage = [self imageWithSize:_btnBack.frame.size color:  [EXUtil colorWithRGB:0xF0F1F2]];
-  [_btnBack setBackgroundImage:btnBackBgImage forState:UIControlStateNormal];
 }
 
 #pragma mark - Internal
@@ -187,17 +171,6 @@
       [url rangeOfString:@"172."].length > 0
     )
   );
-}
-
-// for creating a filled button background in iOS < 15
-- (UIImage *)imageWithSize:(CGSize)size color:(UIColor *)color
-{
-  UIGraphicsBeginImageContextWithOptions(size, true, 0.0);
-  [color setFill];
-  UIRectFill(CGRectMake(0.0, 0.0, size.width, size.height));
-  UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  return image;
 }
 
 @end

--- a/ios/Exponent/Kernel/Views/EXErrorView.xib
+++ b/ios/Exponent/Kernel/Views/EXErrorView.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -32,15 +33,18 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error Title" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXc-4d-VpK">
                             <rect key="frame" x="16" y="24" width="382" height="29"/>
                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="24"/>
-                            <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" name="textDefault"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Error Detail" translatesAutoresizingMaskIntoConstraints="NO" id="b2p-se-FvF">
                             <rect key="frame" x="16" y="69" width="382" height="35.5"/>
-                            <color key="textColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" name="textDefault"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                            <variation key="heightClass=regular-widthClass=compact">
+                                <color key="textColor" name="textDefault"/>
+                            </variation>
                         </textView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3xg-me-cwE">
                             <rect key="frame" x="0.0" y="706" width="414" height="112"/>
@@ -50,18 +54,19 @@
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YsF-A3-kQ1">
                                             <rect key="frame" x="0.0" y="0.0" width="382" height="36"/>
+                                            <color key="backgroundColor" name="buttonTertiaryBackground"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="36" id="IBQ-Hh-Ax9"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                            <color key="tintColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                             <state key="normal" title="Try Again">
-                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="titleColor" name="buttonTertiaryText"/>
                                             </state>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1zt-0v-fnw">
                                             <rect key="frame" x="0.0" y="44" width="382" height="36"/>
+                                            <color key="backgroundColor" name="buttonSecondaryBackground"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="36" id="082-ip-q06"/>
                                             </constraints>
@@ -69,7 +74,7 @@
                                             <color key="tintColor" red="0.94117647059999998" green="0.94509803920000002" blue="0.94901960780000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                             <state key="normal" title="Go Home">
-                                                <color key="titleColor" red="0.14117647059999999" green="0.16078431369999999" blue="0.1843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleColor" name="buttonSecondaryText"/>
                                             </state>
                                         </button>
                                     </subviews>
@@ -83,7 +88,6 @@
                                     </constraints>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="Mh8-u0-LCN" secondAttribute="trailing" constant="16" id="2si-xy-CTa"/>
                                 <constraint firstAttribute="bottom" secondItem="Mh8-u0-LCN" secondAttribute="bottom" constant="16" id="Jxo-k5-Gsw"/>
@@ -98,7 +102,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" red="0.97254901959999995" green="0.97254901959999995" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="backgroundColor" name="backgroundDefault"/>
                     <constraints>
                         <constraint firstItem="uZA-n9-0bf" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="Cui-bY-DKE"/>
                         <constraint firstAttribute="bottom" secondItem="3xg-me-cwE" secondAttribute="bottom" id="EgY-Lw-8hH"/>
@@ -131,6 +135,24 @@
         </view>
     </objects>
     <resources>
+        <namedColor name="backgroundDefault">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
+        <namedColor name="buttonSecondaryBackground">
+            <color red="0.94117647058823528" green="0.94509803921568625" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="buttonSecondaryText">
+            <color red="0.10588235294117647" green="0.12156862745098039" blue="0.13725490196078433" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="buttonTertiaryBackground">
+            <color red="0.10588235294117647" green="0.12156862745098039" blue="0.13725490196078433" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="buttonTertiaryText">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="textDefault">
+            <color red="0.14117647058823529" green="0.16078431372549018" blue="0.18431372549019609" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
# Why

Closes [ENG-10822](https://linear.app/expo/issue/ENG-10822)

Dev client fix is in a different PR -> https://github.com/expo/expo/pull/25974

# How

Add  Color sets for `textDefault`, `textSecondary`, `backgroundDefault`, `buttonSecondaryBackground`, `buttonSecondaryText`, `buttonTertiaryBackground` and `buttonTertiaryText` to ensure that we use the correct color when using both light mode and dark mode. Also removed some unnecessary logic from EXErrorView.m by directly specifying the colors on the storyboard 

# Test Plan


https://github.com/expo/expo/assets/11707729/6502247e-e96d-4d40-901a-b77a8b7cf54b



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
