### PR TITLE
feat(cli): Update `run:ios` build warning formatting for SDK 50.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Update `run:ios` build warning formatting for SDK 50.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Update `run:ios` build warning formatting for SDK 50.
+- Update `run:ios` build warning formatting for SDK 50. ([#25978](https://github.com/expo/expo/pull/25978) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -52,7 +52,7 @@
     "@expo/rudder-sdk-node": "1.1.1",
     "@expo/server": "^0.3.0",
     "@expo/spawn-async": "1.5.0",
-    "@expo/xcpretty": "^4.2.1",
+    "@expo/xcpretty": "^4.3.0",
     "@urql/core": "2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,10 +1572,10 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@expo/xcpretty@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.2.1.tgz#c5e2bd6e5255e83514f4f956cc2c942923fa96b1"
-  integrity sha512-pOUshZ2CFcwL/q0FfCDIt773u7/s3fg0W0K3FkiACePP8Qa0X+8ZngHN/d9xqefpeePeiIZtfU/Rcddjl8ZSkQ==
+"@expo/xcpretty@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@expo/xcpretty/-/xcpretty-4.3.0.tgz#d745c2c5ec38fc6acd451112bb05c6ae952a2c3a"
+  integrity sha512-whBbvHZ2Q10T5TNmN0z5NbO6C9ZDw+XUTu8h6vVMnMzQrbGexc9oaCCZfz+L3Q7TEL5vfr+9L86nY62c3Bsm+g==
   dependencies:
     "@babel/code-frame" "7.10.4"
     chalk "^4.1.0"


### PR DESCRIPTION
# Why

- Update to account for new warning types in latest Xcode / libraries https://github.com/expo/third-party/pull/94
