### PR TITLE
[docs] Add redirects based on Algolia 404 report

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -291,6 +291,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/v41.0.0/sdk/permissions/': '/guides/permissions/',
   '/versions/v42.0.0/sdk/permissions/': '/guides/permissions/',
   '/versions/v43.0.0/sdk/permissions/': '/guides/permissions/',
+  '/versions/v46.0.0/sdk/permissions/': '/guides/permissions/',
+  '/versions/v47.0.0/sdk/permissions/': '/guides/permissions/',
   '/versions/latest/sdk/permissions/': '/guides/permissions/',
 
   // Redirect bare guides to unified workflow guides
@@ -387,8 +389,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/using-preact/': '/guides/overview/',
   '/versions/latest/sdk/shared-element/': '/versions/latest/',
   '/workflow/hermes/': '/guides/using-hermes/',
-
-  // Push notifications
   '/config/app/': '/workflow/configuration/',
   '/versions/latest/sdk/settings/': '/versions/latest/',
   '/archive/expokit/eject/': '/archive/glossary/#eject',
@@ -416,4 +416,20 @@ const RENAMED_PAGES: Record<string, string> = {
   '/router/advance/platform-specific-modules': '/router/advanced/platform-specific-modules/',
   '/router/advance/shared-routes': '/router/advanced/shared-routes/',
   '/router/advance/router-settings': '/router/advanced/router-settings/',
+
+  // Redirects as per Algolia 404 report
+  '/workflow/build/building-on-ci': '/build/building-on-ci/',
+  'versions/latest/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
+  '/versions/v49.0.0/sdk/filesystem.md': '/versions/v49.0.0/sdk/filesystem/',
+  '/versions/v48.0.0/sdk/filesystem.md': '/versions/v48.0.0/sdk/filesystem/',
+  '/versions/v47.0.0/sdk/filesystem.md': '/versions/v47.0.0/sdk/filesystem/',
+  '/versions/v46.0.0/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
+  '/versions/v50.0.0/sdk/taskmanager': '/versions/v50.0.0/sdk/task-manager/',
+  '/versions/v49.0.0/sdk/taskmanager': '/versions/v49.0.0/sdk/task-manager/',
+  '/versions/v48.0.0/sdk/taskmanager': '/versions/v48.0.0/sdk/task-manager/',
+  '/versions/v47.0.0/sdk/taskmanager': '/versions/v48.0.0/sdk/task-manager/',
+  '/versions/v46.0.0/sdk/taskmanager': '/versions/latest/sdk/task-manager/',
+  '/task-manager/': '/versions/latest/sdk/task-manager',
+  'versions/v48.0.0/sdk': '/versions/latest',
+  'versions/v48.0.0/sdk/config/app': '/versions/v48.0.0/sdk/config/app/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -68,180 +68,180 @@ declare -A redirects # associative array variable
 # redirects[requests/for/this/path]=are/redirected/to/this/one
 
 # Temporarily create a redirect for a page that Home links to
-redirects[versions/latest/introduction/installation.html]=versions/latest/introduction/installation/
+redirects[versions/latest/introduction/installation.html]=versions/latest/introduction/installation
 # useful link on twitter
-redirects[versions/latest/guides/app-stores.html]=versions/latest/distribution/app-stores/
+redirects[versions/latest/guides/app-stores.html]=versions/latest/distribution/app-stores
 # Xdl caches
-redirects[versions/latest/guides/offline-support.html]=versions/latest/guides/offline-support/
+redirects[versions/latest/guides/offline-support.html]=versions/latest/guides/offline-support
 # xdl convert comment
-redirects[versions/latest/sdk/index.html]=versions/latest/sdk/overview/
+redirects[versions/latest/sdk/index.html]=versions/latest/sdk/overview
 # upgrading expo -> upgrading sdk walkthrough
-redirects[versions/latest/workflow/upgrading-expo]=versions/latest/workflow/upgrading-expo-sdk-walkthrough/
+redirects[versions/latest/workflow/upgrading-expo]=versions/latest/workflow/upgrading-expo-sdk-walkthrough
 # rename
-redirects[versions/latest/sdk/haptic/index.html]=versions/latest/sdk/haptics/
+redirects[versions/latest/sdk/haptic/index.html]=versions/latest/sdk/haptics
 redirects[development/eas-build]=development/build
 # duplicate docs file, consolidate into one page
-redirects[versions/latest/sdk/introduction/index.html]=versions/latest/sdk/overview/
+redirects[versions/latest/sdk/introduction/index.html]=versions/latest/sdk/overview
 # project-lifecycle is now covered by managed-vs-bare
-redirects[versions/latest/introduction/project-lifecycle/]=archive/managed-vs-bare/
+redirects[versions/latest/introduction/project-lifecycle]=archive/managed-vs-bare
 
 # exp-cli is now expo-cli
 # redirects[versions/latest/guides/exp-cli.html]=versions/latest/workflow/expo-cli/
 # redirects[versions/latest/guides/exp-cli]=versions/latest/workflow/expo-cli/
 
 # Migrated FAQ pages
-redirects[faq/image-background]=ui-programming/image-background/
-redirects[faq/react-native-styling-buttons]=ui-programming/react-native-styling-buttons/
-redirects[faq/react-native-version-mismatch]=troubleshooting/react-native-version-mismatch/
-redirects[faq/clear-cache-windows]=troubleshooting/clear-cache-windows/
-redirects[faq/clear-cache-macos-linux]=troubleshooting/clear-cache-macos-linux/
-redirects[faq/application-has-not-been-registered]=troubleshooting/application-has-not-been-registered/
-redirects[distribution/building-standalone-apps]=archive/classic-updates/building-standalone-apps/
-redirects[build-reference/build-webhook]=eas/webhooks/
-redirects[distribution/webhooks]=eas/webhooks/
-redirects[distribution/turtle-cli]=archive/classic-updates/turtle-cli/
-redirects[distribution/app-signing]=app-signing/app-credentials/
-redirects[guides/adhoc-builds]=develop/development-builds/introduction/
-redirects[archive/adhoc-builds]=develop/development-builds/introduction/
+redirects[faq/image-background]=ui-programming/image-background
+redirects[faq/react-native-styling-buttons]=ui-programming/react-native-styling-buttons
+redirects[faq/react-native-version-mismatch]=troubleshooting/react-native-version-mismatch
+redirects[faq/clear-cache-windows]=troubleshooting/clear-cache-windows
+redirects[faq/clear-cache-macos-linux]=troubleshooting/clear-cache-macos-linux
+redirects[faq/application-has-not-been-registered]=troubleshooting/application-has-not-been-registered
+redirects[distribution/building-standalone-apps]=archive/classic-updates/building-standalone-apps
+redirects[build-reference/build-webhook]=eas/webhooks
+redirects[distribution/webhooks]=eas/webhooks
+redirects[distribution/turtle-cli]=archive/classic-updates/turtle-cli
+redirects[distribution/app-signing]=app-signing/app-credentials
+redirects[guides/adhoc-builds]=develop/development-builds/introduction
+redirects[archive/adhoc-builds]=develop/development-builds/introduction
 
 # clients is now development
-redirects[clients/distribution-for-ios]=develop/development-builds/create-a-build/
-redirects[clients/distribution-for-android]=develop/development-builds/create-a-build/
-redirects[clients/compatibility]=develop/development-builds/introduction/
-redirects[development/compatibility]=develop/development-builds/introduction/
-redirects[clients/development-workflows]=development/development-workflows/
-redirects[clients/eas-build]=build/introduction/
-redirects[clients/extending-the-dev-menu]=develop/development-builds/development-workflows/
-redirects[clients/getting-started]=develop/development-builds/introduction/
-redirects[clients/installation]=develop/development-builds/create-a-build/
-redirects[clients/introduction]=develop/development-builds/introduction/
-redirects[clients/troubleshooting]=development/troubleshooting/
-redirects[clients/upgrading]=development/upgrading/
+redirects[clients/distribution-for-ios]=develop/development-builds/create-a-build
+redirects[clients/distribution-for-android]=develop/development-builds/create-a-build
+redirects[clients/compatibility]=develop/development-builds/introduction
+redirects[development/compatibility]=develop/development-builds/introduction
+redirects[clients/development-workflows]=development/development-workflows
+redirects[clients/eas-build]=build/introduction
+redirects[clients/extending-the-dev-menu]=develop/development-builds/development-workflows
+redirects[clients/getting-started]=develop/development-builds/introduction
+redirects[clients/installation]=develop/development-builds/create-a-build
+redirects[clients/introduction]=develop/development-builds/introduction
+redirects[clients/troubleshooting]=development/troubleshooting
+redirects[clients/upgrading]=development/upgrading
 
 # Expo Modules
-redirects[modules]=modules/overview/
-redirects[module-api]=modules/module-api/
-redirects[module-config]=modules/module-config/
+redirects[modules]=modules/overview
+redirects[module-api]=modules/module-api
+redirects[module-config]=modules/module-config
 
 # EAS Metadata
-redirects[eas-metadata]=eas/metadata/
-redirects[eas-metadata/introduction]=eas/metadata/
-redirects[eas-metadata/getting-started]=eas/metadata/getting-started/
+redirects[eas-metadata]=eas/metadata
+redirects[eas-metadata/introduction]=eas/metadata
+redirects[eas-metadata/getting-started]=eas/metadata/getting-started
 # EAS Build
-redirects[build-reference/eas-json]=eas/json/
+redirects[build-reference/eas-json]=eas/json
 
 # Development builds
-redirects[development/build]=develop/development-builds/create-a-build/
-redirects[development/getting-started]=develop/development-builds/create-a-build/
-redirects[development/troubleshooting]=develop/development-builds/introduction/
-redirects[development/upgrading]=develop/development-builds/introduction/
-redirects[development/extensions]=develop/development-builds/development-workflows/
-redirects[development/develop-your-project]=develop/development-builds/use-development-builds/
-redirects[develop/development-builds/installation/]=develop/development-builds/create-a-build/
+redirects[development/build]=develop/development-builds/create-a-build
+redirects[development/getting-started]=develop/development-builds/create-a-build
+redirects[development/troubleshooting]=develop/development-builds/introduction
+redirects[development/upgrading]=develop/development-builds/introduction
+redirects[development/extensions]=develop/development-builds/development-workflows
+redirects[development/develop-your-project]=develop/development-builds/use-development-builds
+redirects[develop/development-builds/installation]=develop/development-builds/create-a-build
 
 # Guides that have been deleted
 redirects[guides/using-gatsby]=guides/overview
 redirects[guides/testing-on-devices]=workflow/run-on-device
 redirects[distribution/uploading-apps]=submit/introduction
-redirects[guides/setup-native-firebase/]=guides/using-firebase
-redirects[guides/using-clojurescript/]=guides/overview
-redirects[distribution/hosting-your-app/]=distribution/publishing-websites/
+redirects[guides/setup-native-firebase]=guides/using-firebase
+redirects[guides/using-clojurescript]=guides/overview
+redirects[distribution/hosting-your-app]=distribution/publishing-websites
 
 # Redirects after adding Home to the docs
-redirects[next-steps/additional-resources/]=additional-resources/
-redirects[get-started/create-a-new-app/]=get-started/create-a-project
-redirects[guides/config-plugins/]=config-plugins/introduction/
-redirects[workflow/debugging/]=debugging/runtime-issues/
-redirects[guides/userinterface/]=ui-programming/user-interface-libraries/
-redirects[introduction/expo/]=core-concepts/
-redirects[introduction/faq/]=faq/
-redirects[workflow/expo-go/]=get-started/expo-go/
-redirects[errors-and-warnings/]=debugging/errors-and-warnings/
-redirects[develop/unit-testing/]=develop/unit-testing/
-redirects[guides/splash-screens/]=develop/user-interface/splash-screen/
-redirects[guides/app-icons/]=develop/user-interface/app-icons/
-redirects[guides/color-schemes/]=develop/user-interface/color-themes/
-redirects[development/introduction/]=develop/development-builds/introduction/
-redirects[development/create-development-builds/]=develop/development-builds/create-a-build/
-redirects[development/use-development-builds/]=develop/development-builds/use-development-builds/
-redirects[development/development-workflows/]=develop/development-builds/development-workflows
-redirects[debugging/]=debugging/runtime-issues/
-redirects[debugging/runtime-issue/]=debugging/runtime-issues/
-redirects[workflow/glossary-of-terms/]=more/glossary-of-terms/
-redirects[develop/development-builds/installation/]=develop/development-builds/create-a-build/
-redirects[get-started/errors/]=debugging/errors-and-warnings/
-redirects[develop/development-builds/parallel-installation]=build-reference/variants/
-redirects[home/develop/user-interface/safe-areas]=develop/user-interface/safe-areas/
-redirects[home/develop/development-builds/introduction]=develop/development-builds/introduction/
+redirects[next-steps/additional-resources]=additional-resources
+redirects[get-started/create-a-new-app]=get-started/create-a-project
+redirects[guides/config-plugins]=config-plugins/introduction
+redirects[workflow/debugging]=debugging/runtime-issues
+redirects[guides/userinterface]=ui-programming/user-interface-libraries
+redirects[introduction/expo]=core-concepts
+redirects[introduction/faq]=faq
+redirects[workflow/expo-go]=get-started/expo-go
+redirects[errors-and-warnings]=debugging/errors-and-warnings
+redirects[develop/unit-testing]=develop/unit-testing
+redirects[guides/splash-screens]=develop/user-interface/splash-screen
+redirects[guides/app-icons]=develop/user-interface/app-icons
+redirects[guides/color-schemes]=develop/user-interface/color-themes
+redirects[development/introduction]=develop/development-builds/introduction
+redirects[development/create-development-builds]=develop/development-builds/create-a-build
+redirects[development/use-development-builds]=develop/development-builds/use-development-builds
+redirects[development/development-workflows]=develop/development-builds/development-workflows
+redirects[debugging]=debugging/runtime-issues
+redirects[debugging/runtime-issue]=debugging/runtime-issues
+redirects[workflow/glossary-of-terms]=more/glossary-of-terms
+redirects[develop/development-builds/installation]=develop/development-builds/create-a-build
+redirects[get-started/errors]=debugging/errors-and-warnings
+redirects[develop/development-builds/parallel-installation]=build-reference/variants
+redirects[home/develop/user-interface/safe-areas]=develop/user-interface/safe-areas
+redirects[home/develop/development-builds/introduction]=develop/development-builds/introduction
 
 # Redirects after Guides organization
-redirects[guides/]=guides/overview/
-redirects[guides/routing-and-navigation/]=routing/introduction/
-redirects[guides/errors/]=debugging/runtime-issues/
-redirects[workflow/expo-cli/]=more/expo-cli/
-redirects[versions/latest/workflow/expo-cli/]=more/expo-cli/
-redirects[bare/hello-world/]=bare/overview/
-redirects[guides/using-graphql/]=guides/overview/
-redirects[guides/using-bugsnag/]=guides/overview/
-redirects[build/automating-submissions/]=build/automate-submissions/
-redirects[workflow/run-on-device/]=build/internal-distribution/
-redirects[archive/workflow/customizing/]=workflow/customizing/
-redirects[guides/building-standalone-apps/]=archive/classic-updates/building-standalone-apps/
-redirects[versions/latest/sdk/permissions#expopermissionscamera_roll]=guides/permissions/
-redirects[introduction/managed-vs-bare/]=archive/managed-vs-bare/
-redirects[push-notifications/using-fcm/]=push-notifications/push-notifications-setup/
-redirects[guides/using-custom-fonts/]=develop/user-interface/fonts/
+redirects[guides]=guides/overview
+redirects[guides/routing-and-navigation]=routing/introduction
+redirects[guides/errors]=debugging/runtime-issues
+redirects[workflow/expo-cli]=more/expo-cli
+redirects[versions/latest/workflow/expo-cli]=more/expo-cli
+redirects[bare/hello-world]=bare/overview
+redirects[guides/using-graphql]=guides/overview
+redirects[guides/using-bugsnag]=guides/overview
+redirects[build/automating-submissions]=build/automate-submissions
+redirects[workflow/run-on-device]=build/internal-distribution
+redirects[archive/workflow/customizing]=workflow/customizing
+redirects[guides/building-standalone-apps]=archive/classic-updates/building-standalone-apps
+redirects[versions/latest/sdk/permissions#expopermissionscamera_roll]=guides/permissions
+redirects[introduction/managed-vs-bare]=archive/managed-vs-bare
+redirects[push-notifications/using-fcm]=push-notifications/push-notifications-setup
+redirects[guides/using-custom-fonts]=develop/user-interface/fonts
 
 # Redirects reported from SEO tools list (MOZ, SEMRush, GSC, etc.)
 redirects[versions/v46.0.0/sdk/permissions]=guides/permissions
-redirects[development/development-workflows/]=develop/development-builds/development-workflows/
-redirects[bare/installing-unimodules/]=bare/installing-expo-modules/
-redirects[versions/latest/sdk/admob]=versions/latest/
-redirects[workflow/publishing/]=archive/classic-updates/publishing/
-redirects[workflow/already-used-react-native/]=workflow/overview/
-redirects[guides/setup-native-firebase/]=guides/using-firebase/
-redirects[eas-update/how-eas-update-works]=eas-update/how-it-works/
-redirects[development/installation/]=develop/development-builds/create-a-build/
-redirects[bare/updating-your-app/]=eas-update/updating-your-app/
-redirects[versions/latest/introduction/managed-vs-bare/]=archive/managed-vs-bare
-redirects[classic/turtle-cli/]=archive/classic-updates/turtle-cli/
-redirects[technical-specs/expo-updates-0/]=technical-specs/expo-updates-1/
-redirects[development/extending-the-dev-menu/]=develop/development-builds/development-workflows/
-redirects[archive/expokit/eject/]=archive/glossary/
-redirects[archive/expokit/overview/]=archive/glossary/
-redirects[expokit/overview/]=archive/glossary/
-redirects[more/latest]=versions/latest/
-redirects[versions/latest/sdk/error-recovery/]=versions/latest/
-redirects[eas-update/eas-update-with-local-build/]=eas-update/build-locally/
-redirects[bare/existing-apps/]=bare/installing-expo-modules/
-redirects[bare/exploring-bare-workflow/]=bare/overview/
-redirects[home/develop/development-builds/installation]=develop/development-builds/create-a-build/
-redirects[t/cant-upgrade-to-the-lastest-expo-cli-3-19-2]=faq/
-redirects[build-reference/custom-build-config/]=custom-builds/get-started/
-redirects[home/debugging/tools/]=debugging/tools/
-redirects[workflow/run-on-device/]=build/internal-distribution/
-redirects[build-reference/how-tos/]=build-reference/private-npm-packages
-redirects[home/navigation/installation/]=routing/introduction/
-redirects[home/authentication]=develop/authentication/
-redirects[home/develop/user-interface/app-icons]=develop/user-interface/app-icons/
-redirects[eas-update/migrate-codepush-to-eas-update/]=eas-update/codepush/
-redirects[home/get-started/create-a-project]=get-started/create-a-project/
-redirects[home/core-concepts/]=core-concepts/
-redirects[guides/testing-on-devices]=build/internal-distribution/
-redirects[router/advance/root-layout]=router/advanced/root-layout/
-redirects[router/advance/stack]=router/advanced/stack/
-redirects[router/advance/tabs]=router/advanced/tabs/
-redirects[router/advance/drawer]=router/advanced/drawer/
-redirects[router/advance/nesting-navigators]=router/advanced/nesting-navigators/
-redirects[router/advance/modal]=router/advanced/modals/
-redirects[router/advance/platform-specific-modules]=router/advanced/platform-specific-modules/
-redirects[router/advance/shared-routes]=router/advanced/shared-routes/
-redirects[router/advance/router-setttings]=router/advanced/router-settings/
-redirects[home/config-plugins/plugins-and-mods]=config-plugins/plugins-and-mods/
-redirects[home/unit-testing/]=develop/unit-testing/
-redirects[home/config-plugins/introduction/]=config-plugins/introduction/
-redirects[technical-specs/latest/]=technical-specs/expo-updates-1/
-redirects[guides/education]=additional-resources/
+redirects[development/development-workflows]=develop/development-builds/development-workflows
+redirects[bare/installing-unimodules]=bare/installing-expo-modules
+redirects[versions/latest/sdk/admob]=versions/latest
+redirects[workflow/publishing]=archive/classic-updates/publishing
+redirects[workflow/already-used-react-native]=workflow/overview
+redirects[guides/setup-native-firebase]=guides/using-firebase
+redirects[eas-update/how-eas-update-works]=eas-update/how-it-works
+redirects[development/installation]=develop/development-builds/create-a-build
+redirects[bare/updating-your-app]=eas-update/updating-your-app
+redirects[versions/latest/introduction/managed-vs-bare]=archive/managed-vs-bare
+redirects[classic/turtle-cli]=archive/classic-updates/turtle-cli
+redirects[technical-specs/expo-updates-0]=technical-specs/expo-updates-1
+redirects[development/extending-the-dev-menu]=develop/development-builds/development-workflows
+redirects[archive/expokit/eject]=archive/glossary
+redirects[archive/expokit/overview]=archive/glossary
+redirects[expokit/overview]=archive/glossary
+redirects[more/latest]=versions/latest
+redirects[versions/latest/sdk/error-recovery]=versions/latest
+redirects[eas-update/eas-update-with-local-build]=eas-update/build-locally
+redirects[bare/existing-apps]=bare/installing-expo-modules
+redirects[bare/exploring-bare-workflow]=bare/overview
+redirects[home/develop/development-builds/installation]=develop/development-builds/create-a-build
+redirects[t/cant-upgrade-to-the-lastest-expo-cli-3-19-2]=faq
+redirects[build-reference/custom-build-config]=custom-builds/get-started
+redirects[home/debugging/tools]=debugging/tools
+redirects[workflow/run-on-device]=build/internal-distribution
+redirects[build-reference/how-tos]=build-reference/private-npm-packages
+redirects[home/navigation/installation]=routing/introduction
+redirects[home/authentication]=develop/authentication
+redirects[home/develop/user-interface/app-icons]=develop/user-interface/app-icons
+redirects[eas-update/migrate-codepush-to-eas-update]=eas-update/codepush
+redirects[home/get-started/create-a-project]=get-started/create-a-project
+redirects[home/core-concepts]=core-concepts
+redirects[guides/testing-on-devices]=build/internal-distribution
+redirects[router/advance/root-layout]=router/advanced/root-layout
+redirects[router/advance/stack]=router/advanced/stack
+redirects[router/advance/tabs]=router/advanced/tabs
+redirects[router/advance/drawer]=router/advanced/drawer
+redirects[router/advance/nesting-navigators]=router/advanced/nesting-navigators
+redirects[router/advance/modal]=router/advanced/modals
+redirects[router/advance/platform-specific-modules]=router/advanced/platform-specific-modules
+redirects[router/advance/shared-routes]=router/advanced/shared-routes
+redirects[router/advance/router-setttings]=router/advanced/router-settings
+redirects[home/config-plugins/plugins-and-mods]=config-plugins/plugins-and-mods
+redirects[home/unit-testing]=develop/unit-testing
+redirects[home/config-plugins/introduction]=config-plugins/introduction
+redirects[technical-specs/latest]=technical-specs/expo-updates-1
+redirects[guides/education]=additional-resources
 
 # We should change this redirect to a more general EAS guide later
 redirects[guides/setting-up-continuous-integration]=build/building-on-ci
@@ -254,69 +254,89 @@ redirects[eas-update/custom-updates-server]=distribution/custom-updates-server
 redirects[guides/offline-support]=archive/classic-updates/offline-support
 redirects[guides/preloading-and-caching-assets]=archive/classic-updates/preloading-and-caching-assets
 redirects[guides/configuring-updates]=archive/classic-updates/configuring-updates
-redirects[eas-update/bare-react-native]=eas-update/updating-your-app/
+redirects[eas-update/bare-react-native]=eas-update/updating-your-app
 redirects[worfkflow/publishing]=archive/classic-updates/publishing
-redirects[classic/building-standalone-apps/]=archive/classic-updates/building-standalone-apps/
-redirects[classic/turtle-cli/]=archive/classic-updates/turtle-cli/
-redirects[archive/classic-updates/getting-started/]=eas-update/getting-started/
-redirects[archived/]=archive/
+redirects[classic/building-standalone-apps]=archive/classic-updates/building-standalone-apps
+redirects[classic/turtle-cli]=archive/classic-updates/turtle-cli
+redirects[archive/classic-updates/getting-started]=eas-update/getting-started
+redirects[archived]=archive
 
 # Old tutorial pages
-redirects[introduction/walkthrough]=tutorial/introduction/
-redirects[tutorial/planning]=tutorial/introduction/
-redirects[tutorial/sharing]=tutorial/introduction/
-redirects[tutorial/text]=tutorial/introduction/
-redirects[tutorial/button]=tutorial/introduction/
+redirects[introduction/walkthrough]=tutorial/introduction
+redirects[tutorial/planning]=tutorial/introduction
+redirects[tutorial/sharing]=tutorial/introduction
+redirects[tutorial/text]=tutorial/introduction
+redirects[tutorial/button]=tutorial/introduction
 
 # EAS Update
-redirects[technical-specs/expo-updates-0/]=archive/technical-specs/expo-updates-0/
-redirects[eas-update/developing-with-eas-update/]=eas-update/develop-faster/
-redirects[eas-update/eas-update-with-local-build/]=eas-update/build-locally/
-redirects[eas-update/eas-update-and-eas-cli/]=eas-update/eas-cli/
-redirects[eas-update/debug-updates/]=eas-update/debug/
-redirects[eas-update/how-eas-update-works/]=eas-update/how-it-works/
-redirects[eas-update/migrate-to-eas-update/]=eas-update/migrate-from-classic-updates/
+redirects[technical-specs/expo-updates-0]=archive/technical-specs/expo-updates-0
+redirects[eas-update/developing-with-eas-update]=eas-update/develop-faster
+redirects[eas-update/eas-update-with-local-build]=eas-update/build-locally
+redirects[eas-update/eas-update-and-eas-cli]=eas-update/eas-cli
+redirects[eas-update/debug-updates]=eas-update/debug
+redirects[eas-update/how-eas-update-works]=eas-update/how-it-works
+redirects[eas-update/migrate-to-eas-update]=eas-update/migrate-from-classic-updates
 
 # Redirects after Expo Router docs reorganization from Home to Guides
-redirects[routing/next-steps]=router/introduction/
-redirects[routing/introduction]=router/introduction/
-redirects[routing/installation]=router/installation/
-redirects[routing/create-pages]=router/create-pages/
-redirects[routing/navigating-pages]=router/navigating-pages/
-redirects[routing/layouts]=router/layouts/
-redirects[routing/appearance]=router/appearance/
-redirects[routing/error-handling]=router/error-handling/
+redirects[routing/next-steps]=router/introduction
+redirects[routing/introduction]=router/introduction
+redirects[routing/installation]=router/installation
+redirects[routing/create-pages]=router/create-pages
+redirects[routing/navigating-pages]=router/navigating-pages
+redirects[routing/layouts]=router/layouts
+redirects[routing/appearance]=router/appearance
+redirects[routing/error-handling]=router/error-handling
 
 # Removed API reference docs
-redirects[versions/latest/sdk/facebook]=guides/authentication/
-redirects[versions/latest/sdk/taskmanager]=versions/latest/sdk/task-manager/
-redirects[versions/latest/sdk/videothumbnails]=versions/latest/sdk/video-thumbnails/
-redirects[versions/latest/sdk/appearance]=versions/latest/react-native/appearance/
-redirects[versions/latest/sdk/app-loading]=versions/latest/sdk/splash-screen/
-redirects[versions/latest/sdk/app-auth]=guides/authentication/
-redirects[versions/latest/sdk/firebase-core]=guides/using-firebase/
-redirects[versions/latest/sdk/firebase-analytics]=guides/using-firebase/
-redirects[versions/latest/sdk/firebase-recaptcha]=guides/using-firebase/
-redirects[versions/latest/sdk/google-sign-in]=guides/authentication/
-redirects[versions/latest/sdk/google]=guides/authentication/
-redirects[versions/latest/sdk/amplitude/]=guides/using-analytics/
-redirects[versions/latest/sdk/util/]=versions/latest/
-redirects[versions/v45.0.0/sdk/google-sign-in/]=guides/google-authentication/
-redirects[versions/v44.0.0/sdk/google/]=guides/google-authentication/
-redirects[versions/latest/introduction/faq/]=faq/
+redirects[versions/latest/sdk/facebook]=guides/authentication
+redirects[versions/latest/sdk/taskmanager]=versions/latest/sdk/task-manager
+redirects[versions/latest/sdk/videothumbnails]=versions/latest/sdk/video-thumbnails
+redirects[versions/latest/sdk/appearance]=versions/latest/react-native/appearance
+redirects[versions/latest/sdk/app-loading]=versions/latest/sdk/splash-screen
+redirects[versions/latest/sdk/app-auth]=guides/authentication
+redirects[versions/latest/sdk/firebase-core]=guides/using-firebase
+redirects[versions/latest/sdk/firebase-analytics]=guides/using-firebase
+redirects[versions/latest/sdk/firebase-recaptcha]=guides/using-firebase
+redirects[versions/latest/sdk/google-sign-in]=guides/authentication
+redirects[versions/latest/sdk/google]=guides/authentication
+redirects[versions/latest/sdk/amplitude]=guides/using-analytics
+redirects[versions/latest/sdk/util]=versions/latest
+redirects[versions/v45.0.0/sdk/google-sign-in]=guides/google-authentication
+redirects[versions/v44.0.0/sdk/google]=guides/google-authentication
+redirects[versions/latest/introduction/faq]=faq
 
 # Redirects based on Sentry reports
-redirects[push-notifications/]=push-notifications/overview/
-redirects[eas/submit]=submit/introduction/
-redirects[development/tools/expo-dev-client/]=develop/development-builds/introduction/
-redirects[develop/user-interface/custom-fonts/]=develop/user-interface/fonts/
-redirects[workflow/snack/]=/more/glossary-of-terms/
-redirects[accounts/teams-and-accounts/]=accounts/account-types/
-redirects[push-notifications/fcm/]=push-notifications/sending-notifications-custom/
-redirects[troubleshooting/clear-cache-mac/]=troubleshooting/clear-cache-macos-linux/
-redirects[guides/using-preact/]=guides/overview/
-redirects[versions/latest/sdk/shared-element/]=versions/latest/
-redirects[workflow/hermes/]=guides/using-hermes/
+redirects[push-notifications]=push-notifications/overview
+redirects[eas/submit]=submit/introduction
+redirects[development/tools/expo-dev-client]=develop/development-builds/introduction
+redirects[develop/user-interface/custom-fonts]=develop/user-interface/fonts
+redirects[workflow/snack]=/more/glossary-of-terms
+redirects[accounts/teams-and-accounts]=accounts/account-types
+redirects[push-notifications/fcm]=push-notifications/sending-notifications-custom
+redirects[troubleshooting/clear-cache-mac]=troubleshooting/clear-cache-macos-linux
+redirects[guides/using-preact]=guides/overview
+redirects[versions/latest/sdk/shared-element]=versions/latest
+redirects[workflow/hermes]=guides/using-hermes
+
+# Redirects based on Algolia 404 report
+redirects[versions/latest/sdk/permissions]=guides/permissions
+redirects[versions/v47.0.0/sdk/permissions]=guides/permissions
+redirects[versions/v46.0.0/sdk/permissions.md]=guides/permissions
+redirects[workflow/build/building-on-ci]=build/building-on-ci
+redirects[versions/v50.0.0/sdk/taskmanager]=versions/v50.0.0/sdk/task-manager
+redirects[versions/v49.0.0/sdk/taskmanager]=versions/v49.0.0/sdk/task-manager
+redirects[versions/v48.0.0/sdk/taskmanager]=versions/v48.0.0/sdk/task-manager
+redirects[versions/v47.0.0/sdk/taskmanager]=versions/v47.0.0/sdk/task-manager
+redirects[task-manager]=versions/latest/sdk/task-manager
+redirects[versions/v49.0.0/sdk/filesystem.md]=versions/v49.0.0/sdk/filesystem
+redirects[versions/v48.0.0/sdk/filesystem.md]=versions/v48.0.0/sdk/filesystem
+redirects[versions/v47.0.0/sdk/filesystem.md]=versions/v47.0.0/sdk/filesystem
+redirects[versions/v46.0.0/sdk/filesystem.md]=versions/latest/sdk/filesystem
+redirects[versions/latest/sdk/filesystem.md]=versions/latest/sdk/filesystem
+redirects[versions/v48.0.0/sdk]=versions/latest
+redirects[versions/v48.0.0/sdk/config/app]=versions/v48.0.0/config/app
+redirects[guides/how-expo-works]=faq
+redirects[config/app]=workflow/configuration
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Went through Algolia's 404 report and added some redirects based on [that report](https://crawler.algolia.com/admin/crawlers/4dd4b03d-3266-4978-ab88-f93b12d4ad67/monitoring/summary).

Not sure why a few of the existing redirects are still coming as 404 in Algolia. Checked and also added missing server side redirects based in this report.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated `error-utilities.ts` and `deploy.sh` files
- Also removed trailing '/` in server side redirects (`deploy.sh`) as per the convention mentioned in the file to define a server side redirect. Not sure if it changes anything but will monitor in coming weeks if it helps us eliminate those 404 URLs in the Algolia report.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and manually check client-side redirects for the newly added ones.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
