### PR TITLE
[docs] Fix bare additional instructions doc link

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -22,8 +22,6 @@ const InstallSection = ({
   cmd = [getInstallCmd(packageName)],
   href = getPackageLink(packageName),
 }: InstallSectionProps) => {
-  const { sourceCodeUrl } = usePageMetadata();
-
   return (
     <>
       <Terminal cmd={cmd} />
@@ -31,7 +29,7 @@ const InstallSection = ({
         <P>
           If you're installing this in a <A href="/bare/overview/">bare React Native app</A>, you
           should also follow{' '}
-          <A href={sourceCodeUrl ?? href}>
+          <A href="/bare/installing-expo-modules/">
             <DEMI>these additional installation instructions</DEMI>
           </A>
           .


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #24258

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the link to redirect to ["Install Expo modules"](https://docs.expo.dev/bare/installing-expo-modules/).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, go to API reference page and click on link "these additional instructions...".

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
