### PR TITLE
[docs][core] Remove confusing usage of `launch` function

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -127,18 +127,14 @@ It is recommended to use `AsyncFunction` over `Function` when it:
 <CodeBlocksTable>
 
 ```swift
-AsyncFunction("asyncFunction") { (message: String, promise: Promise) in
-  DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-    promise.resolve(message)
-  }
+AsyncFunction("asyncFunction") { (message: String) in
+  return message
 }
 ```
 
 ```kotlin
-AsyncFunction("asyncFunction") { message: String, promise: Promise ->
-  launch(Dispatchers.Main) {
-    promise.resolve(message)
-  }
+AsyncFunction("asyncFunction") { message: String ->
+  return@AsyncFunction message
 }
 ```
 
@@ -154,6 +150,24 @@ async function getMessageAsync() {
   return await MyModule.asyncFunction('bar');
 }
 ```
+
+It's possible to change the native queue of `AsyncFunction` by calling the `.runOnQueue` function on the result of that component.
+
+<CodeBlocksTable>
+
+```swift
+AsyncFunction("asyncFunction") { (message: String) in
+  return message
+}.runOnQueue(.main)
+```
+
+```kotlin
+AsyncFunction("asyncFunction") { message: String ->
+  return@AsyncFunction message
+}.runOnQueue(Queues.MAIN)
+```
+
+</CodeBlocksTable>
 
 ---
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -165,7 +165,7 @@ async function getMessageAsync() {
 }
 ```
 
-It's possible to change the native queue of `AsyncFunction` by calling the `.runOnQueue` function on the result of that component.
+It is possible to change the native queue of `AsyncFunction` by calling the `.runOnQueue` function on the result of that component.
 
 <CodeBlocksTable>
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -130,12 +130,26 @@ It is recommended to use `AsyncFunction` over `Function` when it:
 AsyncFunction("asyncFunction") { (message: String) in
   return message
 }
+
+// or
+
+AsyncFunction("asyncFunction") { (message: String, promise: Promise) in
+  promise.resolve(message)
+}
+
 ```
 
 ```kotlin
 AsyncFunction("asyncFunction") { message: String ->
   return@AsyncFunction message
 }
+
+// or
+
+AsyncFunction("asyncFunction") { message: String, promise: Promise ->
+  promise.resolve(message)
+}
+
 ```
 
 </CodeBlocksTable>


### PR DESCRIPTION
# Why

Removes confusing usage of the `launch` function.
Adds information about the `runOnQueue` function.
