### PR TITLE
fix(cli): import `ExpoConfig` from `@expo/config` instead of `@expo/config-types`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add missing `find-yarn-workspace-root` dependency. ([#25991](https://github.com/expo/expo/pull/25991) by [@byCedric](https://github.com/byCedric))
 - Add missing `lodash.debounce` dependency. ([#25990](https://github.com/expo/expo/pull/25990) by [@byCedric](https://github.com/byCedric))
 - Add missing `@react-native/dev-middleware` dependency. ([#26000](https://github.com/expo/expo/pull/26000) by [@byCedric](https://github.com/byCedric))
+- Import `ExpoConfig` from direct dependency `@expo/config`. ([#25989](https://github.com/expo/expo/pull/25989) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config-types';
+import { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
 import fs from 'fs';
 import { Ora } from 'ora';

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config-types';
+import { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
 import qrcode from 'qrcode-terminal';
 import wrapAnsi from 'wrap-ansi';

--- a/packages/@expo/cli/src/utils/analytics/getMetroProperties.ts
+++ b/packages/@expo/cli/src/utils/analytics/getMetroProperties.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from '@expo/config-types';
+import { ExpoConfig } from '@expo/config';
 
 /**
  * Get the unstable / experimental properties used within the Metro config.


### PR DESCRIPTION
# Why

`@expo/cli` does not have a direct dependency reference to `@expo/config-types`, yet we import it in various places. This breaks isolated modules.

The current implicit dependency chains are:

- `@expo/cli → @expo/config → @expo/config-types`
- `@expo/cli → @expo/config-plugins → @expo/config-types`

# How

- Since [we re-export the `ExpoConfig` type in `@expo/config`](https://github.com/expo/expo/blob/23842ab218b08f556b9931152e78c045d31d399e/packages/%40expo/config/src/Config.types.ts#L4), I swapped the imports without adding the missing dependency reference.
  - from: `import { ExpoConfig } from '@expo/config-types`
  - to: `import { ExpoConfig } from '@expo/config`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
