### PR TITLE
fix(cli): add missing `@expo/image-utils` dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `@expo/image-utils` dependency. ([#25990](https://github.com/expo/expo/pull/25990) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.16.3 — 2023-12-15

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -43,6 +43,7 @@
     "@expo/config-plugins": "~7.8.0",
     "@expo/devcert": "^1.0.0",
     "@expo/env": "~0.2.0",
+    "@expo/image-utils": "^0.4.0",
     "@expo/json-file": "^8.2.37",
     "@expo/metro-config": "~0.17.0",
     "@expo/osascript": "^2.0.31",


### PR DESCRIPTION
# Why

`@expo/cli` does not have a direct dependency reference to `@expo/image-utils`, yet we import it in [`src/export/favicon.ts`](https://github.com/expo/expo/blob/23842ab218b08f556b9931152e78c045d31d399e/packages/%40expo/cli/src/export/favicon.ts#L2). This breaks isolated modules.

The current implicit dependency chain is:
- `@expo/cli → @expo/prebuild-config → @expo/image-utils`

# How

- Added `@expo/image-utils` as dependency to `@expo/cli`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
