### PR TITLE
fix(cli): add missing `find-yarn-workspace-root` dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Add missing `@expo/image-utils` dependency. ([#25990](https://github.com/expo/expo/pull/25990) by [@byCedric](https://github.com/byCedric))
+- Add missing `find-yarn-workspace-root` dependency. ([#25991](https://github.com/expo/expo/pull/25991) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -66,6 +66,7 @@
     "connect": "^3.7.0",
     "debug": "^4.3.4",
     "env-editor": "^0.4.1",
+    "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^3.0.1",
     "freeport-async": "2.0.0",
     "fs-extra": "~8.1.0",


### PR DESCRIPTION
# Why

`@expo/cli` does not have a direct dependency reference to `find-yarn-workspace-root`, yet we import it in [`src/start/server/middleware/ManifestMiddleware.ts`](https://github.com/expo/expo/blob/23842ab218b08f556b9931152e78c045d31d399e/packages/%40expo/cli/src/start/server/middleware/ManifestMiddleware.ts#L9). This breaks isolated modules.

The current implicit dependency chains are:

- `@expo/cli → @expo/metro-config → find-yarn-workspace-root`
- `@expo/cli → @expo/package-manager → find-yarn-workspace-root`
- `@expo/cli → @expo/prebuild-config → find-yarn-workspace-root`

# How

- Added `find-yarn-workspace-root` as dependency to `@expo/cli`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
