### PR TITLE
[docs][image] Update readme and docs of expo-image

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -28,21 +28,19 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-|   Format   |                   Android                   |     iOS     |                                 Web                                 |
-| :--------: | :-----------------------------------------: | :---------: | :-----------------------------------------------------------------: |
-|    WebP    |                 <YesIcon />                 | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
-| PNG / APNG |                 <YesIcon />                 | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
-|    HEIC    |                 <YesIcon />                 | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
-|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    GIF     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    SVG     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICO     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                             <NoIcon />                              |
+|   Format   |                   Android                   |     iOS     |                            Web                            |
+| :--------: | :-----------------------------------------: | :---------: | :-------------------------------------------------------: |
+|    WebP    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+| PNG / APNG |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
+|    HEIC    |                 <YesIcon />                 | <YesIcon /> |  <NoIcon /> [not adopted yet](https://caniuse.com/heif)   |
+|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    GIF     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    SVG     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICO     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                        <NoIcon />                         |
 
 ## Installation
-
-> **Info** `expo-image` is not yet available in Snack.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v49.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/image.mdx
@@ -28,21 +28,19 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-|   Format   |                   Android                   |     iOS     |                                 Web                                 |
-| :--------: | :-----------------------------------------: | :---------: | :-----------------------------------------------------------------: |
-|    WebP    |                 <YesIcon />                 | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
-| PNG / APNG |                 <YesIcon />                 | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
-|    HEIC    |                 <YesIcon />                 | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
-|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    GIF     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    SVG     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICO     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                             <NoIcon />                              |
+|   Format   |                   Android                   |     iOS     |                            Web                            |
+| :--------: | :-----------------------------------------: | :---------: | :-------------------------------------------------------: |
+|    WebP    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+| PNG / APNG |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
+|    HEIC    |                 <YesIcon />                 | <YesIcon /> |  <NoIcon /> [not adopted yet](https://caniuse.com/heif)   |
+|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    GIF     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    SVG     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICO     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                        <NoIcon />                         |
 
 ## Installation
-
-> **Info** `expo-image` is not yet available in Snack.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v50.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/image.mdx
@@ -28,21 +28,19 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-|   Format   |                   Android                   |     iOS     |                                 Web                                 |
-| :--------: | :-----------------------------------------: | :---------: | :-----------------------------------------------------------------: |
-|    WebP    |                 <YesIcon />                 | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
-| PNG / APNG |                 <YesIcon />                 | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
-|    HEIC    |                 <YesIcon />                 | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
-|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    GIF     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    SVG     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICO     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
-|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                             <NoIcon />                              |
+|   Format   |                   Android                   |     iOS     |                            Web                            |
+| :--------: | :-----------------------------------------: | :---------: | :-------------------------------------------------------: |
+|    WebP    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+| PNG / APNG |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
+|    HEIC    |                 <YesIcon />                 | <YesIcon /> |  <NoIcon /> [not adopted yet](https://caniuse.com/heif)   |
+|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    GIF     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    SVG     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICO     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
+|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                        <NoIcon />                         |
 
 ## Installation
-
-> **Info** `expo-image` is not yet available in Snack.
 
 <APIInstallSection />
 

--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -21,33 +21,43 @@ A cross-platform, performant image component for React Native and Expo.
 
 ## Supported image formats
 
-|   Format   | Android | iOS |                        Web                        |
-| :--------: | :-----: | :-: | :-----------------------------------------------: |
-|    WebP    |   ✅    | ✅  |   ✅ [~96% adoption](https://caniuse.com/webp)    |
-| PNG / APNG |   ✅    | ✅  | ✅ / ✅ [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    |   ✅    | ✅  |   ⏳ [~79% adoption](https://caniuse.com/avif)    |
-|    HEIC    |   ✅    | ✅  |  ❌ [not adopted yet](https://caniuse.com/heif)   |
-|    JPEG    |   ✅    | ✅  |                        ✅                         |
-|    GIF     |   ✅    | ✅  |                        ✅                         |
-|    SVG     |   ✅    | ✅  |                        ✅                         |
-|    ICO     |   ✅    | ✅  |                        ✅                         |
-|    ICNS    |   ❌    | ✅  |                        ❌                         |
+|   Format   | Android | iOS |                      Web                       |
+| :--------: | :-----: | :-: | :--------------------------------------------: |
+|    WebP    |   ✅    | ✅  |                       ✅                       |
+| PNG / APNG |   ✅    | ✅  |                       ✅                       |
+|    AVIF    |   ✅    | ✅  |  ⏳ [~87% adoption](https://caniuse.com/avif)  |
+|    HEIC    |   ✅    | ✅  | ❌ [not adopted yet](https://caniuse.com/heif) |
+|    JPEG    |   ✅    | ✅  |                       ✅                       |
+|    GIF     |   ✅    | ✅  |                       ✅                       |
+|    SVG     |   ✅    | ✅  |                       ✅                       |
+|    ICO     |   ✅    | ✅  |                       ✅                       |
+|    ICNS    |   ❌    | ✅  |                       ❌                       |
 
 # API documentation
 
-- [Documentation for the latest release](https://docs.expo.dev/versions/unversioned/sdk/image/)
+- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/)
 
-# Installation
+# Installation in managed Expo projects
 
-> Currently `expo-image` can be used only with [development builds](https://docs.expo.dev/develop/development-builds/introduction/), in Expo Go, and bare React Native apps with [configured Expo modules](https://docs.expo.dev/bare/installing-expo-modules/).
-> It is not available with Snack yet.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/).
 
-Add the package to your dependencies with the following commands:
+# Installation in bare React Native projects
+
+For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
+
+### Add the package to your npm dependencies
 
 ```
 npx expo install expo-image
-npx pod-install
 ```
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+### Configure for Android
+
+No additional setup necessary.
 
 # Contributing
 

--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -39,7 +39,7 @@ A cross-platform, performant image component for React Native and Expo.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/).
 
 # Installation in bare React Native projects
 


### PR DESCRIPTION
# Why

Readme and docs are not pretty up to date. The adoption of some formats on web is now better and the package already works in Snack (so I backported the docs for SDK 48 and SDK 49 too).

# How

Updated readme and docs

# Test Plan

Tried the preview website