### PR TITLE
fix(prebuild-config): move `expo-module-script` to `devDependencies`

### DIFF
--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Move `expo-module-scripts` to `devDependencies` instead of `peerDependencies`. ([#25994](https://github.com/expo/expo/pull/25994) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 6.7.1 — 2023-12-15

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -33,7 +33,8 @@
   ],
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "@types/xml2js": "~0.4.11"
+    "@types/xml2js": "~0.4.11",
+    "expo-module-scripts": "^3.3.0"
   },
   "dependencies": {
     "@expo/config": "~8.5.0",
@@ -48,7 +49,6 @@
     "xml2js": "0.6.0"
   },
   "peerDependencies": {
-    "expo-module-scripts": "^3.3.0",
     "expo-modules-autolinking": ">=0.8.1"
   },
   "publishConfig": {


### PR DESCRIPTION
# Why

Discovered in the dependency chains of #25992.

# How

- Moved `expo-module-scripts` to `devDependencies` instead of `peerDependencies`

# Test Plan

Check if `yarn typecheck` still works for `@expo/prebuild-config`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
