### PR TITLE
[core] fix shared object leakage on android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed `SharedObjectRegistry` crash for accessing internal data structures from multi-threads. ([#25997](https://github.com/expo/expo/pull/25997) by [@kudo](https://github.com/kudo))
 - Fixed splash screen view flickering in dark mode on iOS. ([#26015](https://github.com/expo/expo/pull/26015), [#26029](https://github.com/expo/expo/pull/26029) by [@kudo](https://github.com/kudo))
+- Fixed `SharedObject` leakage on Android. ([#25995](https://github.com/expo/expo/pull/25995) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -19,9 +19,11 @@ namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 
 namespace expo {
-class JavaScriptValue;
 
 class JavaScriptFunction;
+class JavaScriptValue;
+class JavaScriptWeakObject;
+
 
 /**
  * Represents any JavaScript object. Its purpose is to exposes `jsi::Object` API back to Kotlin.
@@ -90,6 +92,8 @@ private:
   );
 
   jni::local_ref<jni::JArrayClass<jstring>> jniGetPropertyNames();
+
+  jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject> createWeak();
 
   jni::local_ref<jni::HybridClass<JavaScriptFunction, Destructible>::javaobject> jniAsFunction();
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
@@ -1,0 +1,115 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#include "JavaScriptWeakObject.h"
+#include "JSIInteropModuleRegistry.h"
+
+namespace expo {
+
+void JavaScriptWeakObject::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("lock", JavaScriptWeakObject::lock),
+  });
+}
+
+jni::local_ref<JavaScriptObject::javaobject> JavaScriptWeakObject::lock() {
+  jsi::Runtime &rt = _runtimeHolder.getJSRuntime();
+
+  std::shared_ptr<jsi::Object> objectPtr;
+  if (_weakObjectType == WeakObjectType::JSIWeakObject) {
+    jsi::Value value =
+        std::static_pointer_cast<jsi::WeakObject>(_weakObject)->lock(rt);
+    if (value.isUndefined()) {
+      return nullptr;
+    }
+    objectPtr = std::make_shared<jsi::Object>(value.asObject(rt));
+  } else if (_weakObjectType == WeakObjectType::WeakRef) {
+    objectPtr =
+        derefWeakRef(rt, std::static_pointer_cast<jsi::Object>(_weakObject));
+  } else {
+    objectPtr = std::static_pointer_cast<jsi::Object>(_weakObject);
+  }
+
+  if (!objectPtr) {
+    return nullptr;
+  }
+  return JavaScriptObject::newInstance(_runtimeHolder.getModuleRegistry(),
+                                       _runtimeHolder, objectPtr);
+}
+
+jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject>
+JavaScriptWeakObject::newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject) {
+  auto weakObject = JavaScriptWeakObject::newObjectCxxArgs(std::move(runtime),
+                                                           std::move(jsObject));
+  jsiInteropModuleRegistry->jniDeallocator->addReference(weakObject);
+  return weakObject;
+}
+
+JavaScriptWeakObject::JavaScriptWeakObject(
+    WeakRuntimeHolder runtime, std::shared_ptr<jsi::Object> jsObject)
+    : _runtimeHolder(std::move(runtime)) {
+  _runtimeHolder.ensureRuntimeIsValid();
+  jsi::Runtime &rt = _runtimeHolder.getJSRuntime();
+
+  try {
+    _weakObject = std::make_shared<jsi::WeakObject>(rt, *jsObject);
+    _weakObjectType = WeakObjectType::JSIWeakObject;
+    return;
+  } catch (const std::logic_error &) {
+    // JSCRuntime will throw std::logic_error from unimplemented jsi::WeakObject
+  }
+
+  // Check whether the runtime supports `WeakRef` objects. If it does not,
+  // we consciously hold a strong reference to the object and cause memory
+  // leaks.
+  if (isWeakRefSupported(rt)) {
+    _weakObject = createWeakRef(rt, jsObject);
+    _weakObjectType = WeakObjectType::WeakRef;
+  } else {
+    _weakObject = jsObject;
+    _weakObjectType = WeakObjectType::NotSupported;
+  }
+}
+
+// #region WeakRef runtime helpers (fallback when jsi::WeakObject is not
+// available).
+
+// static
+bool JavaScriptWeakObject::isWeakRefSupported(jsi::Runtime &runtime) {
+  return runtime.global().hasProperty(runtime, "WeakRef");
+}
+
+// static
+std::shared_ptr<jsi::Object>
+JavaScriptWeakObject::createWeakRef(jsi::Runtime &runtime,
+                                    std::shared_ptr<jsi::Object> object) {
+  jsi::Object weakRef =
+      runtime.global()
+          .getProperty(runtime, "WeakRef")
+          .asObject(runtime)
+          .asFunction(runtime)
+          .callAsConstructor(runtime, jsi::Value(runtime, *object))
+          .asObject(runtime);
+  return std::make_shared<jsi::Object>(std::move(weakRef));
+}
+
+// static
+std::shared_ptr<jsi::Object>
+JavaScriptWeakObject::derefWeakRef(jsi::Runtime &runtime,
+                                   std::shared_ptr<jsi::Object> object) {
+  jsi::Value ref = object->getProperty(runtime, "deref")
+                       .asObject(runtime)
+                       .asFunction(runtime)
+                       .callWithThis(runtime, *object);
+
+  if (ref.isUndefined()) {
+    return nullptr;
+  }
+  return std::make_shared<jsi::Object>(ref.asObject(runtime));
+}
+
+// #endregion
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
@@ -1,0 +1,69 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#include "JNIDeallocator.h"
+#include "JavaScriptObject.h"
+#include "WeakRuntimeHolder.h"
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+class JavaScriptObject;
+
+/**
+ * Represents JavaScript WeakRef to an jsi::Object.
+ */
+class JavaScriptWeakObject
+    : public jni::HybridClass<JavaScriptWeakObject, Destructible> {
+public:
+  static auto constexpr kJavaDescriptor =
+      "Lexpo/modules/kotlin/jni/JavaScriptWeakObject;";
+  static auto constexpr TAG = "JavaScriptWeakObject";
+
+  static void registerNatives();
+
+  static jni::local_ref<
+      jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject>
+  newInstance(JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+              std::weak_ptr<JavaScriptRuntime> runtime,
+              std::shared_ptr<jsi::Object> jsObject);
+
+  jni::local_ref<JavaScriptObject::javaobject> lock();
+
+  // #region WeakRef runtime helpers (fallback when jsi::WeakObject is not
+  // available).
+
+  static bool isWeakRefSupported(jsi::Runtime &runtime);
+  static std::shared_ptr<jsi::Object>
+  createWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+  static std::shared_ptr<jsi::Object>
+  derefWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+
+  // #endregion
+
+private:
+  JavaScriptWeakObject(WeakRuntimeHolder runtime,
+                       std::shared_ptr<jsi::Object> jsObject);
+
+private:
+  friend HybridBase;
+  enum class WeakObjectType : uint8_t {
+    NotSupported,
+    WeakRef,
+    JSIWeakObject,
+  };
+
+  WeakRuntimeHolder _runtimeHolder;
+  std::shared_ptr<jsi::Pointer> _weakObject;
+  WeakObjectType _weakObjectType;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
@@ -19,7 +19,7 @@ namespace expo {
 class JavaScriptObject;
 
 /**
- * Represents JavaScript WeakRef to an jsi::Object.
+ * Represents to a jsi::WeakObject.
  */
 class JavaScriptWeakObject
     : public jni::HybridClass<JavaScriptWeakObject, Destructible> {
@@ -38,32 +38,15 @@ public:
 
   jni::local_ref<JavaScriptObject::javaobject> lock();
 
-  // #region WeakRef runtime helpers (fallback when jsi::WeakObject is not
-  // available).
-
-  static bool isWeakRefSupported(jsi::Runtime &runtime);
-  static std::shared_ptr<jsi::Object>
-  createWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
-  static std::shared_ptr<jsi::Object>
-  derefWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
-
-  // #endregion
-
 private:
   JavaScriptWeakObject(WeakRuntimeHolder runtime,
                        std::shared_ptr<jsi::Object> jsObject);
 
 private:
   friend HybridBase;
-  enum class WeakObjectType : uint8_t {
-    NotSupported,
-    WeakRef,
-    JSIWeakObject,
-  };
 
   WeakRuntimeHolder _runtimeHolder;
-  std::shared_ptr<jsi::Pointer> _weakObject;
-  WeakObjectType _weakObjectType;
+  std::shared_ptr<jsi::WeakObject> _weakObject;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -43,6 +43,8 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
   }
 
   external fun getPropertyNames(): Array<String>
+  external fun createWeak(): JavaScriptWeakObject
+
   private external fun setBoolProperty(name: String, value: Boolean)
   private external fun setDoubleProperty(name: String, value: Double)
   private external fun setStringProperty(name: String, value: String?)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
@@ -1,0 +1,22 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+
+/**
+ * A Kotlin representation of WeakRef to a jsi::WeakObject
+ * Should be used only on the runtime thread.
+ */
+@Suppress("KotlinJniMissingFunction")
+@DoNotStrip
+class JavaScriptWeakObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
+    mHybridData.resetNative()
+  }
+  external fun lock(): JavaScriptObject
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
@@ -4,7 +4,7 @@ import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 
 /**
- * A Kotlin representation of WeakRef to a jsi::WeakObject
+ * A Kotlin representation to a jsi::WeakObject
  * Should be used only on the runtime thread.
  */
 @Suppress("KotlinJniMissingFunction")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -9,4 +9,9 @@ open class SharedObject {
    * When the object is not linked with any JavaScript object, its value is 0.
    */
   internal var sharedObjectId: SharedObjectId = SharedObjectId(0)
+
+  /**
+   * Called when the shared object being deallocated.
+   */
+  open fun deallocate() {}
 }


### PR DESCRIPTION
# Why

notice the shared objects have never been deallocated

# How

- introduce the `JavaScriptWeakObject` that is similar to what we had on ios and integrate to SharedObjectRegistry.
- add a new `deallocate` method for derived shared object to be notified when it is deallocated. 

# Test Plan

test repro on https://github.com/ospfranco/expo-sqlite-benchmark

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
