### PR TITLE
[sqlite] fix `NativeStatementBinding` leakage on Android.

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `NativeStatementBinding` leakage on Android. ([#25996](https://github.com/expo/expo/pull/25996) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 13.1.0 — 2023-12-13

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -10,4 +10,9 @@ internal class NativeDatabase(val databaseName: String, val openOptions: OpenDat
   override fun equals(other: Any?): Boolean {
     return other is NativeDatabase && this.ref == other.ref
   }
+
+  override fun deallocate() {
+    super.deallocate()
+    this.ref.close()
+  }
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
@@ -4,12 +4,13 @@ package expo.modules.sqlite
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
+import java.io.Closeable
 
 private typealias UpdateListener = (databaseName: String, tableName: String, operationType: Int, rowID: Long) -> Unit
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-internal class NativeDatabaseBinding {
+internal class NativeDatabaseBinding : Closeable {
   @DoNotStrip
   private val mHybridData: HybridData
 
@@ -17,6 +18,10 @@ internal class NativeDatabaseBinding {
 
   init {
     mHybridData = initHybrid()
+  }
+
+  override fun close() {
+    mHybridData.resetNative()
   }
 
   /**

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
@@ -7,6 +7,11 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 internal class NativeStatement : SharedRef<NativeStatementBinding>(NativeStatementBinding()) {
   var isFinalized = false
 
+  override fun deallocate() {
+    super.deallocate()
+    this.ref.close()
+  }
+
   override fun equals(other: Any?): Boolean {
     return other is NativeStatement && this.ref == other.ref
   }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
@@ -4,18 +4,23 @@ package expo.modules.sqlite
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
+import java.io.Closeable
 
 internal typealias SQLiteColumnNames = ArrayList<String>
 internal typealias SQLiteColumnValues = ArrayList<Any>
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-internal class NativeStatementBinding {
+internal class NativeStatementBinding : Closeable {
   @DoNotStrip
   private val mHybridData: HybridData
 
   init {
     mHybridData = initHybrid()
+  }
+
+  override fun close() {
+    mHybridData.resetNative()
   }
 
   // region sqlite3 bindings


### PR DESCRIPTION
# Why

based on #25995 to integrate the new `deallocate()` in sqlite and fix the NativeStatementBinding leakage

# How

integrate `deallocate()` from `SharedObject` and cleanup jni data

# Test Plan

test repro on https://github.com/ospfranco/expo-sqlite-benchmark

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
