### PR TITLE
[core] fix SharedObjectRegistry crash for accessing dict from multithreads

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `SharedObjectRegistry` crash for accessing internal data structures from multi-threads. ([#25997](https://github.com/expo/expo/pull/25997) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 1.11.2 — 2023-12-15

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -68,7 +68,7 @@ final class SharedObjectRegistrySpec: ExpoSpec {
         let nativeObject = TestSharedObject()
         let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
         SharedObjectRegistry.delete(id)
-        expect(nativeObject.sharedObjectId) == 0
+        expect(nativeObject.sharedObjectId).toEventually(equal(0))
       }
     }
 


### PR DESCRIPTION
# Why

fix the crash from https://github.com/ospfranco/expo-sqlite-benchmark

# How

the hermes gc thread may be different to js thread. we should protect the internal data structures with thread-safety. this pr added a DispatchQueue to protect the internal data structures.

# Test Plan

test repro on https://github.com/ospfranco/expo-sqlite-benchmark

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
