### PR TITLE
[ci] fix ios unit test errors

### DIFF
--- a/.github/actions/expo-git-decrypt/action.yml
+++ b/.github/actions/expo-git-decrypt/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: 🍺 Install git-crypt on macOS
       if: ${{ runner.os == 'macOS' }}
       shell: bash
-      run: brew install git-crypt
+      run: brew install git-crypt || true
     - name: 🔓 Decrypt secrets if possible
       env:
         GIT_CRYPT_KEY_BASE64: ${{ inputs.key }}


### PR DESCRIPTION
# Why

fix ios unit test ci error: https://github.com/expo/expo/actions/runs/7239092140/job/19720588042

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.12'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.12

Possible conflicting files are:
/usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12
/usr/local/bin/idle3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3.12
/usr/local/bin/pydoc3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3.12
/usr/local/bin/python3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
/usr/local/bin/python3.12-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12-config
```

# How

same as #24823 to skip the error

# Test Plan

ios unit test ci pass: https://github.com/expo/expo/actions/runs/7250829440/job/19751877052
