### PR TITLE
fix(cli): add missing `@react-native/dev-middleware` dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add missing `@expo/image-utils` dependency. ([#25990](https://github.com/expo/expo/pull/25990) by [@byCedric](https://github.com/byCedric))
 - Add missing `find-yarn-workspace-root` dependency. ([#25991](https://github.com/expo/expo/pull/25991) by [@byCedric](https://github.com/byCedric))
 - Add missing `lodash.debounce` dependency. ([#25990](https://github.com/expo/expo/pull/25990) by [@byCedric](https://github.com/byCedric))
+- Add missing `@react-native/dev-middleware` dependency. ([#26000](https://github.com/expo/expo/pull/26000) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -54,6 +54,7 @@
     "@expo/server": "^0.3.0",
     "@expo/spawn-async": "1.5.0",
     "@expo/xcpretty": "^4.3.0",
+    "@react-native/dev-middleware": "^0.73.6",
     "@urql/core": "2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",


### PR DESCRIPTION
# Why

`@expo/cli` does not have a direct dependency reference to `@react-native/dev-middleware`, yet we import it in [`src/start/server/metro/debugging/createDebugMiddleware.ts`](https://github.com/expo/expo/blob/23842ab218b08f556b9931152e78c045d31d399e/packages/%40expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts#L11-L12). This breaks isolated modules.

There is _no_ (implicit) dependency chain, the only unrelated chain exists from a direct project dependency:
- `react-native → @react-native/community-cli-plugin → @react-native/dev-middleware`

# How

- Added `@react-native/dev-middleware` as dependency to `@expo/cli`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
