### PR TITLE
[expo-constants] Copy app config to the correct bundle path when building for Catalyst

### DIFF
--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -22,4 +22,14 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
-"${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT" "$DEST/$RESOURCE_BUNDLE_NAME"
+if [ "$BUNDLE_FORMAT" == "shallow" ]; then
+  RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME"
+elif [ "$BUNDLE_FORMAT" == "deep" ]; then
+  RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME/Contents/Resources"
+  mkdir -p "$RESOURCE_DEST"
+else
+  echo "Unsupported bundle format: $BUNDLE_FORMAT"
+  exit 1
+fi
+
+"${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_CONSTANTS_PACKAGE_DIR}/scripts/getAppConfig.js" "$PROJECT_ROOT" "$RESOURCE_DEST"


### PR DESCRIPTION
# Why

(I know that Catalyst isn't a supported target—but I hope this fix is lightweight enough that you won't mind merging it.)

When building for macOS Catalyst, `+[EXConstantsService appConfig]` fails to find the app config in the `EXConstants.bundle` because `scripts/get-app-config-ios.sh` copies it into the root of the bundle. That's the appropriate location for iOS bundle resources, but [on macOS](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW1), resources are expected to be located at `EXConstants.bundle/Contents/Resources`, rather than at the root of the bundle.

# How

Xcode's build system sets an environment variable (`BUNDLE_FORMAT`) which specifies which bundle format is expected: `shallow` for iOS, and `deep` for macOS. I've updated `get-app-config-ios.sh` to check that variable and to use the correct path.

# Test Plan

I've created a minimal reproduction here: https://github.com/andymatuschak/catalyst-expo-constants-fix

First, to exhibit the bug:
1. `git clone git@github.com:andymatuschak/catalyst-expo-constants-fix.git`
2. `bun install`
3. Provide a valid Apple `developmentTeamID` in `app.json` (unfortunately, this is required for even development Catalyst builds)
4. `bunx expo prebuild -p ios`
5. `bunx expo run:ios`. The resulting app will display the contents of `Constants.expoConfig`.
6. Now, to run the app on macOS, run `bunx expo start` to start the bundler, then `open ios/catalystexpoconstantsfix.xcworkspace`, change the run destination to My Mac, and press Cmd+R. The resulting app will display "MISSING EXPO CONFIG"

To test the fix:
1. Patch `node_modules/expo-constants` with the proposed diff.
2. Regenerate the local iOS project: `rm -rf ios; bunx expo prebuild -p ios`
3. Repeat steps 5 and 6. Now both iOS and macOS builds should display `Constants.expoConfig` as expected.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
