### PR TITLE
[core] fix splash flickering in dark mode

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed splash screen view flickering in dark mode on iOS. ([#26015](https://github.com/expo/expo/pull/26015) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 1.11.2 — 2023-12-15

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -65,10 +65,12 @@
   enableFabric = self.fabricEnabled;
 #endif
 
-  return [self.reactDelegate createRootViewWithBridge:bridge
-                                         moduleName:moduleName
-                                    initialProperties:initProps
-                                        fabricEnabled:enableFabric];
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge
+                                                       moduleName:moduleName
+                                                initialProperties:initProps
+                                                    fabricEnabled:enableFabric];
+  rootView.backgroundColor = UIColor.systemBackgroundColor;
+  return rootView;
 }
 
 - (UIViewController *)createRootViewController


### PR DESCRIPTION
# Why

aside from #25946 and #25971, i also noticed a splash flickering without expo-system-ui. this one is coming from 
 RCTRootView setup.

# How

we didn't setup backgroundColor [as react-native](https://github.com/facebook/react-native/blob/43826facfab8eed7d01a801778d1c477e60730a6/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L154). in dark mode after splash screen and before App fully loaded, it will show white screen in between. this pr tries to set the RCTRootView's background color as system background color.

- Note that with expo-system-ui, it may override the RCTRootView's background color from it's OnCreate lifecycle.
- The downside of this pr's approach is that, ReactDelegate subscribers have no way to change the background color. i think it is okay if we don't support the use case.

# Test Plan

as #25971

```sh
$ yarn create expo -t blank@sdk-50 sdk50
$ cd sdk 50
$ patch << EOF
--- a/App.js
+++ b/App.js
@@ -13,7 +13,7 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: '#000',
     alignItems: 'center',
     justifyContent: 'center',
   },
--- a/app.json
+++ b/app.json
@@ -5,11 +5,11 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "dark",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#000000"
     },
     "assetBundlePatterns": [
       "**/*"
EOF
$ npx expo run:ios

# should not keep all screen in black
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
