### PR TITLE
[docs] Fix modify babel config step in Router installation guide

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -151,34 +151,41 @@ Then, enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro)
 
 <Tabs>
 
-  <Tab label="SDK 50 and above">
+<Tab label="SDK 50 and above">
 
-    Ensure you use `babel-preset-expo` as the `preset`, in the **babel.config.js** file or delete the file:
+Ensure you use `babel-preset-expo` as the `preset`, in the **babel.config.js** file or delete the file:
 
-    ```js babel.config.js
-    module.exports = function (api) {
-      api.cache(true);
-      return {
-        presets: ['babel-preset-expo'],
-      };
-    };
-    ```
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};
+```
 
-    If you're upgrading from a version of Expo Router that is older than v3, remove the `plugins: ['expo-router/babel']`. `expo-router/babel` was merged in `babel-preset-expo` in SDK 50 (Expo Router v3).
+If you're upgrading from a version of Expo Router that is older than v3, remove the `plugins: ['expo-router/babel']`. `expo-router/babel` was merged in `babel-preset-expo` in SDK 50 (Expo Router v3).
 
-  </Tab>
+</Tab>
 
-  <Tab label="SDK 49 and below">
+<Tab label="SDK 49 and below">
 
-   Add `expo-router/babel` plugin as the last item in the `plugins` array to your project's **babel.config.js**:
+Add `expo-router/babel` plugin as the last item in the `plugins` array to your project's **babel.config.js**:
 
-  {/* prettier-ignore */}
-  ```js babel.config.js
-  plugins: ['expo-router/babel']
-  ```
+{/* prettier-ignore */}
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    /* @info Add the following line. */
+    plugins: ['expo-router/babel'],
+    /* @end */
+  };
+};
+```
 
-
-  </Tab>
+</Tab>
 
 </Tabs>
 
@@ -200,9 +207,13 @@ After updating the Babel config file, run the following command to clear the bun
 
 <Tabs>
 
-  <Tab label="SDK 50 and above">
-    If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn resolutions or npm overrides in your **package.json**. Specifically remove `metro`, `metro-resolver`, `react-refresh` resolutions from your **package.json**.
-  </Tab>
+{' '}
+
+<Tab label="SDK 50 and above">
+  If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
+  resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
+  `metro-resolver`, `react-refresh` resolutions from your **package.json**.
+</Tab>
 
   <Tab label="SDK 49">
     Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 / Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
@@ -231,6 +242,7 @@ After updating the Babel config file, run the following command to clear the bun
           ```
       </Tab>
     </Tabs>
+
   </Tab>
 
   <Tab label="SDK 48 and below">
@@ -259,6 +271,7 @@ After updating the Babel config file, run the following command to clear the bun
           ```
       </Tab>
     </Tabs>
+
   </Tab>
 </Tabs>
 </Step>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on [feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1702929515069559) it seems it might be unclear for some users whether to add the `plugins` array on their own or not.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates to a more comprehensive example. Also fix Prettier formatting issues for `Tabs` usage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2023-12-19 at 16 21 59](https://github.com/expo/expo/assets/10234615/1b7b3be9-8084-4dde-8f6c-84d008efe321)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
