### PR TITLE
[docs] Update EAS Insights introduction to include info on how to view Insights tab in Expo dashboard

### DIFF
--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -43,4 +43,4 @@ After installing the library, create a build either with [EAS](/build/setup/) or
 
 ### View insights
 
-To view insights data of your app, in the Expo dashboard, select the project under **Projects** tab and then click on the **Insights** tab in the sidebar.
+To view insights data of your app, in the Expo dashboard, go to projects list, select your project and then select **Insights** from the navigation menu.

--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -31,6 +31,7 @@ To use the `expo-insights`, make sure your app is linked to your EAS project in 
   cmd={[
     '# Install EAS CLI if you have not already',
     '$ npm i -g eas-cli',
+    '',
     '# Initialize your project EAS if you have not already ',
     '$ eas init',
     '',
@@ -40,3 +41,7 @@ To use the `expo-insights`, make sure your app is linked to your EAS project in 
 />
 
 After installing the library, create a build either with [EAS](/build/setup/) or [locally](/guides/local-app-development/). The module will automatically send events to EAS Insights when the app is launched.
+
+### View insights
+
+To view insights data of your app, go to your [project's page](https://expo.dev/accounts/[account]/projects/[project]/insights) in the Expo dashboard, select the project and then click on the **Insights** tab in the sidebar.

--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -1,7 +1,6 @@
 ---
 title: EAS Insights
 sidebar_title: Introduction
-hideTOC: true
 description: An introduction to EAS Insights which is a preview service for projects using the expo-insights library.
 ---
 

--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -39,8 +39,8 @@ To use the `expo-insights`, make sure your app is linked to your EAS project in 
   ]}
 />
 
-After installing the library, create a build either with [EAS](/build/setup/) or [locally](/guides/local-app-development/). The module will automatically send events to EAS Insights when the app is launched.
+After installing the library, create a build either with [EAS](/build/setup/) or [locally](/guides/local-app-development/). The library will automatically send events to EAS Insights when the app is launched.
 
 ### View insights
 
-To view insights data of your app, go to your [project's page](https://expo.dev/accounts/[account]/projects/[project]/insights) in the Expo dashboard, select the project and then click on the **Insights** tab in the sidebar.
+To view insights data of your app, in the Expo dashboard, select the project under **Projects** tab and then click on the **Insights** tab in the sidebar.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on [feedback](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1702467272095179), it seems it is a bit confusing as to where to find the Insights tab in the Expo dashboard.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- Add sub section about how to view insights tab for their project. Also provide a reference link directly to the tab.
- Format commands in the Terminal snippet
- Unhide the TOC

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/eas-insights/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
