### PR TITLE
fix(config-plugins): add missing `slugify@^1.6.6` dependency

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `slugify` dependency. ([#26019](https://github.com/expo/expo/pull/26019) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 7.8.1 — 2023-12-15

--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -47,6 +47,7 @@
     "resolve-from": "^5.0.0",
     "semver": "^7.5.3",
     "slash": "^3.0.0",
+    "slugify": "^1.6.6",
     "xcode": "^3.0.1",
     "xml2js": "0.6.0"
   },


### PR DESCRIPTION
# Why

~~⚠️ Blocked by https://github.com/expo/expo/pull/26038~~

`@expo/config-plugins` does not have a direct dependency reference to `slugify`, yet we import it in [`src/ios/utils/Xcodeproj.ts`](https://github.com/expo/expo/blob/8a86278f9013847bb26b1db83b3ce71a655c0c8a/packages/%40expo/config-plugins/src/ios/utils/Xcodeproj.ts#L11). This breaks isolated modules.

There is _no_ (implicit) dependency chain, the only unrelated chain exists from a direct project dependency:

- `expo → @expo/cli → slugify`

# How

- Added `slugify@^1.6.6` as dependency to `@expo/config-plugins`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
