### PR TITLE
fix(metro-config): add missing `glob@^7.2.3` dependency

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix matching async chunks with special characters in the file names. ([#26008](https://github.com/expo/expo/pull/26008) by [@EvanBacon](https://github.com/EvanBacon))
-
+- Add missing `glob` dependency. ([#26020](https://github.com/expo/expo/pull/26020) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -46,6 +46,7 @@
     "debug": "^4.3.2",
     "find-yarn-workspace-root": "~2.0.0",
     "getenv": "^1.0.0",
+    "glob": "^7.2.3",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "~1.19.0",
     "postcss": "~8.4.21",


### PR DESCRIPTION
# Why

`@expo/metro-config` does not have a direct dependency reference to `glob`, yet we import it in [`src/getWatchFolders.ts`](https://github.com/expo/expo/blob/8a86278f9013847bb26b1db83b3ce71a655c0c8a/packages/%40expo/metro-config/src/getWatchFolders.ts#L3). This breaks isolated modules.

There is _no_ (implicit) dependency chain, the only unrelated chain exists from a direct project dependency:

- `react-native → @react-native-community/cli-platform-android → glob`

# How

- Added `glob@^7.2.3` as dependency to `@expo/metro-config`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
