### PR TITLE
fix(package-manager): add missing `ora@^3.4.0` dependency

### DIFF
--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `ora` dependency. ([#26023](https://github.com/expo/expo/pull/26023) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 1.4.0 — 2023-12-12

--- a/packages/@expo/package-manager/package.json
+++ b/packages/@expo/package-manager/package.json
@@ -46,15 +46,16 @@
     "js-yaml": "^3.13.1",
     "micromatch": "^4.0.2",
     "npm-package-arg": "^7.0.0",
+    "ora": "^3.4.0",
     "split": "^1.0.1",
     "sudo-prompt": "9.1.1"
   },
   "devDependencies": {
+    "@types/js-yaml": "^3.12.5",
+    "@types/micromatch": "^4.0.2",
     "@types/npm-package-arg": "^6.1.0",
     "@types/rimraf": "^3.0.0",
     "@types/split": "^1.0.0",
-    "@types/js-yaml": "^3.12.5",
-    "@types/micromatch": "^4.0.2",
     "expo-module-scripts": "^3.3.0"
   },
   "publishConfig": {


### PR DESCRIPTION
# Why

`@expo/package-manager` does not have a direct dependency reference to `ora`, yet we import it in [`src/ios/CocoaPodsPackageManager.ts`](https://github.com/expo/expo/blob/main/packages/@expo/package-manager/src/ios/CocoaPodsPackageManager.ts#L4). This breaks isolated modules.

There is _no_ (implicit) dependency chain, the only unrelated chain exists from a direct project dependency:

- `expo → @expo/cli → ora`

# How

- Added `ora@^3.4.0` as dependency to `@expo/package-manager`

# Test Plan

See if `yarn typecheck` has any typescript issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).