### PR TITLE
feat(expo-location)(android): add formattedAddress

### DIFF
--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
@@ -106,6 +106,13 @@ public class LocationHelpers {
     map.putString("isoCountryCode", address.getCountryCode());
     map.putString("timezone", null);
 
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i <= address.getMaxAddressLineIndex(); i++) {
+      sb.append(address.getAddressLine(i));
+    }
+
+    map.putString("formattedAddress", sb.toString());
+
     return map;
   }
 

--- a/packages/expo-location/src/Location.types.ts
+++ b/packages/expo-location/src/Location.types.ts
@@ -459,6 +459,7 @@ export type LocationGeocodedAddress = {
   timezone: string | null;
   /**
    * Composed string of the address components, for example, "111 8th Avenue, New York, NY".
+   * @platform android
    */
   formattedAddress: string | null;
 };

--- a/packages/expo-location/src/Location.types.ts
+++ b/packages/expo-location/src/Location.types.ts
@@ -457,6 +457,10 @@ export type LocationGeocodedAddress = {
    * @platform ios
    */
   timezone: string | null;
+  /**
+   * TODO: Docs for formattedAddress
+   */
+  formattedAddress: string | null;
 };
 
 // @needsAudit

--- a/packages/expo-location/src/Location.types.ts
+++ b/packages/expo-location/src/Location.types.ts
@@ -458,7 +458,7 @@ export type LocationGeocodedAddress = {
    */
   timezone: string | null;
   /**
-   * TODO: Docs for formattedAddress
+   * Composed string of the address components, for example, "111 8th Avenue, New York, NY".
    */
   formattedAddress: string | null;
 };


### PR DESCRIPTION
# Why

<!--
`reverseGeocodeAsync` on android does not return `formattedAddress`.
-->

# How

<!--
added some code to map `address.getMaxAddressLineIndex()` to a string
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
