### PR TITLE
[core] fix systemBackgroundColor build error on tvos

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `SharedObjectRegistry` crash for accessing internal data structures from multi-threads. ([#25997](https://github.com/expo/expo/pull/25997) by [@kudo](https://github.com/kudo))
-- Fixed splash screen view flickering in dark mode on iOS. ([#26015](https://github.com/expo/expo/pull/26015) by [@kudo](https://github.com/kudo))
+- Fixed splash screen view flickering in dark mode on iOS. ([#26015](https://github.com/expo/expo/pull/26015), [#26029](https://github.com/expo/expo/pull/26029) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -69,7 +69,9 @@
                                                        moduleName:moduleName
                                                 initialProperties:initProps
                                                     fabricEnabled:enableFabric];
+#if !TARGET_OS_TV
   rootView.backgroundColor = UIColor.systemBackgroundColor;
+#endif
   return rootView;
 }
 


### PR DESCRIPTION
# Why

#26015 breaks the build on tvos: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/a2f1abba-1712-4121-a6b0-d69c179d00a4

# How

only set systemBackgroundColor on non-tvos

# Test Plan

ci passed: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/2f54cf61-ae0d-4890-a7e7-64d907ae10e1

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
