### PR TITLE
chore(config-plugins): update failing snapshots based from template change

### DIFF
--- a/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Updates-test.ts.snap
+++ b/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Updates-test.ts.snap
@@ -146,25 +146,18 @@ dependencies {
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
     def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";
-    def frescoVersion = rootProject.ext.frescoVersion
-
-    // If your app supports Android versions before Ice Cream Sandwich (API level 14)
-    if (isGifEnabled || isWebpEnabled) {
-        implementation("com.facebook.fresco:fresco:\${frescoVersion}")
-        implementation("com.facebook.fresco:imagepipeline-okhttp3:\${frescoVersion}")
-    }
 
     if (isGifEnabled) {
         // For animated gif support
-        implementation("com.facebook.fresco:animated-gif:\${frescoVersion}")
+        implementation("com.facebook.fresco:animated-gif:\${reactAndroidLibs.versions.fresco.get()}")
     }
 
     if (isWebpEnabled) {
         // For webp support
-        implementation("com.facebook.fresco:webpsupport:\${frescoVersion}")
+        implementation("com.facebook.fresco:webpsupport:\${reactAndroidLibs.versions.fresco.get()}")
         if (isWebpAnimatedEnabled) {
             // Animated webp support
-            implementation("com.facebook.fresco:animated-webp:\${frescoVersion}")
+            implementation("com.facebook.fresco:animated-webp:\${reactAndroidLibs.versions.fresco.get()}")
         }
     }
 


### PR DESCRIPTION
# Why

`et check-packages @expo/config-plugins` is currently failing on `main`.

# How

- Updated snapshots with the newer template changes from https://github.com/expo/expo/pull/25959

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
