### PR TITLE
[CLI] export can verify assets when asset exclusion is enabled

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-test.ts
@@ -66,6 +66,7 @@ it('runs `npx expo export --help`', async () => {
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
         -s, --source-maps          Emit JavaScript source maps
         -c, --clear                Clear the bundler cache
+        -v, --verify-assets <path> Given a path to the build's embedded manifest, check for assets omitted from the export (android, ios)
         -h, --help                 Usage info
     "
   `);

--- a/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
@@ -1,4 +1,83 @@
-import { resolveAssetPatternsToBeBundled } from '../exportAssets';
+import { filterAssets, resolveAssetPatternsToBeBundled } from '../exportAssets';
+
+describe(filterAssets, () => {
+  const assets = [
+    {
+      __packager_asset: true,
+      files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
+      hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
+      name: 'icon',
+      type: 'png',
+      fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
+    },
+    {
+      __packager_asset: true,
+      files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+      hash: 'foobar',
+      name: 'somn',
+      fileHashes: [
+        'foobar',
+        'foobar2',
+        // duplicates are stripped
+        'foobar2',
+      ],
+    },
+    {
+      // Wont match
+      __packager_asset: false,
+      files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+      hash: 'foobar',
+      name: 'somn',
+      fileHashes: ['foobar3'],
+    },
+  ];
+  it(`no missing assets with empty bundle patterns`, () => {
+    const exp = {
+      name: 'Foo',
+      slug: 'Foo',
+    };
+    const result = filterAssets('/', {
+      assets,
+      exp,
+      buildManifestAssetSet: new Set(),
+    });
+    expect(result.missingAssetFiles.size).toBe(0);
+  });
+  it(`no missing assets`, () => {
+    const exp = {
+      name: 'Foo',
+      slug: 'Foo',
+      extra: {
+        updates: {
+          assetPatternsToBeBundled: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/*'],
+        },
+      },
+    };
+    const result = filterAssets('/', {
+      assets,
+      exp,
+      buildManifestAssetSet: new Set(['foobar', 'foobar2', 'foobar3']),
+    });
+    expect(result.missingAssetFiles.size).toBe(0);
+  });
+  it(`missing assets with build manifest set`, () => {
+    const exp = {
+      name: 'Foo',
+      slug: 'Foo',
+      extra: {
+        updates: {
+          assetPatternsToBeBundled: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/*'],
+        },
+      },
+    };
+    const result = filterAssets('/', {
+      assets,
+      exp,
+      buildManifestAssetSet: new Set(['foobar3']),
+    });
+    expect(result.missingAssetFiles.size).toBe(1);
+  });
+});
 
 describe(resolveAssetPatternsToBeBundled, () => {
   it(`does nothing with empty bundle patterns`, () => {

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -34,6 +34,7 @@ export async function exportAppAsync(
     sourceMaps,
     minify,
     maxWorkers,
+    embeddedManifestPath,
   }: Pick<
     Options,
     | 'dumpAssetmap'
@@ -44,6 +45,7 @@ export async function exportAppAsync(
     | 'platforms'
     | 'minify'
     | 'maxWorkers'
+    | 'embeddedManifestPath'
   >
 ): Promise<void> {
   setNodeEnv(dev ? 'development' : 'production');
@@ -108,6 +110,7 @@ export async function exportAppAsync(
       outputDir: outputPath,
       bundles,
       baseUrl,
+      embeddedManifestPath,
     });
 
     if (dumpAssetmap) {

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -18,6 +18,7 @@ export const expoExport: Command = async (argv) => {
       '--output-dir': String,
       '--platform': [String],
       '--no-minify': Boolean,
+      '--verify-assets': String,
 
       // Hack: This is added because EAS CLI always includes the flag.
       // If supplied, we'll do nothing with the value, but at least the process won't crash.
@@ -53,6 +54,7 @@ export const expoExport: Command = async (argv) => {
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
         `-s, --source-maps          Emit JavaScript source maps`,
         `-c, --clear                Clear the bundler cache`,
+        `-v, --verify-assets <path> Given a path to the build's embedded manifest, check for assets omitted from the export (android, ios)`,
         `-h, --help                 Usage info`,
       ].join('\n')
     );

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -12,6 +12,7 @@ export type Options = {
   minify: boolean;
   dumpAssetmap: boolean;
   sourceMaps: boolean;
+  embeddedManifestPath?: string;
 };
 
 /** Returns an array of platforms based on the input platform identifier and runtime constraints. */
@@ -77,5 +78,6 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     maxWorkers: args['--max-workers'],
     dumpAssetmap: !!args['--dump-assetmap'],
     sourceMaps: !!args['--source-maps'],
+    embeddedManifestPath: args['--verify-assets'],
   };
 }


### PR DESCRIPTION
# Why

Now that `expo export` supports asset selection and exclusion, a method is needed for the developer to check whether all assets resolved by Metro are included either in the native build, or in the export used in updates.

# How

New flag `--verify-assets`:

```sh
$ npx expo export --help

  Info
    Export the static files of the app for hosting it on a web server

  Usage
    $ npx expo export <dir>

  Options
    <dir>                      Directory of the Expo project. Default: Current working directory
    --output-dir <dir>         The directory to export the static files to. Default: dist
    --dev                      Configure static files for developing locally using a non-https server
    --no-minify                Prevent minifying source
    --max-workers <number>     Maximum number of tasks to allow the bundler to spawn
    --dump-assetmap            Emit an asset map for further processing
    -p, --platform <platform>  Options: android, ios, web, all. Default: all
    -s, --source-maps          Emit JavaScript source maps
    -c, --clear                Clear the bundler cache
    -v, --verify-assets <path> Given a path to the build's embedded manifest, check for assets omitted from the export (android, ios)
    -h, --help                 Usage info

```

Example run:

```sh
$ npx expo export --verify-assets ios/build/Build/Products/Debug-iphonesimulator/EXUpdates/EXUpdates.bundle/app.manifest 
Starting Metro Bundler
iOS Bundling complete 6039ms (node_modules/expo/AppEntry.js)
Android Bundling complete 6596ms (node_modules/expo/AppEntry.js)
Android node_modules/expo/AppEntry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ 100.0% (531/531)
Processing asset bundle patterns:
- /Users/dlowder/iosProjects/e2eworking/MyUpdateableApp/assetsInUpdates/*
Some assets were resolved by Metro that are not in the exported manifest, and are not in the embedded manifest:
  embeddedAssets/coffee-prep.jpg

Exporting 1 asset:
assetsInUpdates/coffee-prep.jpg (3.89 MB)

Exporting 1 bundle for ios:
_expo/static/js/ios/AppEntry-baf0fd52b2c479d3f190a0386fabc86b.hbc (1.52 MB)

Exporting 1 bundle for android:
_expo/static/js/android/AppEntry-5fab26ece15a21a9bd7ce945f112df28.hbc (1.53 MB)

Exporting 1 file:
metadata.json (374 B)

App exported to: dist
```

# Test Plan

- Tested with a local app
- Unit tests implemented

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
