### PR TITLE
fix(cli): remove unused `@ts-expect-error` from `CocoapodsPackageManager`

### DIFF
--- a/packages/@expo/cli/src/utils/cocoapods.ts
+++ b/packages/@expo/cli/src/utils/cocoapods.ts
@@ -110,10 +110,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
   }
 
   try {
-    await packageManager.installAsync({
-      // @ts-expect-error: multiple versions in the monorepo
-      spinner: step,
-    });
+    await packageManager.installAsync({ spinner: step });
     // Create cached list for later
     await hasPackageJsonDependencyListChangedAsync(projectRoot).catch(() => null);
     step.succeed('Installed CocoaPods');


### PR DESCRIPTION
# Why

Noticed in https://github.com/expo/expo/pull/26000

# How

- Removed `@ts-expect-error` directive, as we now just have the `@expo/package-manager` from the workspace + proper dependency chain.

# Test Plan

See if CI passes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
