### PR TITLE
[expo-updates] Fix development status for updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 - [ios] Remove unnecessary delegate from FileDownloader. ([#25783](https://github.com/expo/expo/pull/25783) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -10,6 +10,7 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.EmbeddedLoader
 import expo.modules.manifests.core.NewManifest
+import expo.modules.updates.db.enums.UpdateStatus
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -31,7 +32,11 @@ class NewUpdateManifest private constructor(
   private val mExtensions: JSONObject?
 ) : UpdateManifest {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@NewUpdateManifest.manifest.getRawJson())
+    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@NewUpdateManifest.manifest.getRawJson()).apply {
+      if (isDevelopmentMode) {
+        status = UpdateStatus.DEVELOPMENT
+      }
+    }
   }
 
   private val assetHeaders: Map<String, JSONObject> by lazy {
@@ -81,7 +86,9 @@ class NewUpdateManifest private constructor(
     assetList
   }
 
-  override val isDevelopmentMode: Boolean = false
+  override val isDevelopmentMode: Boolean by lazy {
+    manifest.isDevelopmentMode()
+  }
 
   companion object {
     private val TAG = UpdateManifest::class.java.simpleName

--- a/packages/expo-updates/ios/EXUpdates/Update/NewUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/NewUpdate.swift
@@ -68,6 +68,15 @@ public final class NewUpdate: Update {
       processedAssets.append(asset)
     }
 
+    var isDevelopmentMode: Bool = false
+    var status: UpdateStatus
+    if manifest.isDevelopmentMode() {
+      isDevelopmentMode = true
+      status = UpdateStatus.StatusDevelopment
+    } else {
+      status = UpdateStatus.StatusPending
+    }
+
     return Update(
       manifest: manifest,
       config: config,
@@ -77,8 +86,8 @@ public final class NewUpdate: Update {
       commitTime: RCTConvert.nsDate(commitTime),
       runtimeVersion: runtimeVersion,
       keep: true,
-      status: UpdateStatus.StatusPending,
-      isDevelopmentMode: false,
+      status: status,
+      isDevelopmentMode: isDevelopmentMode,
       assetsFromManifest: processedAssets
     )
   }


### PR DESCRIPTION
# Why

Stumbled across this while removing legacy manifests. Currently legacy manifests are the only type to have this. The PR that added the concept probably didn't add them to new manifests since development was still using legacy manifests at the time: https://github.com/expo/expo/pull/9599. This is only a guess though.

As for what this is used for, it preempts loading in AppLoader:
https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt#L175
https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift#L118

# How

Copy from legacy manifest. Not sure if this has an effect.

# Test Plan

I didn't notice any differences in behavior. But reading the code, it seems like maybe expo-updates is loading assets in development? Hard to verify.

Either way, the test plan here is to open a project in development (`npx expo start`) that uses an asset.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
