### PR TITLE
[ci] Run code review workflow on pull_request_target event

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,7 +6,7 @@ on:
       pullNumber:
         description: 'Number of the pull request to review'
         required: true
-  pull_request:
+  pull_request_target:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pullNumber || github.event.number }}


### PR DESCRIPTION
# Why

Fixes code review workflow for external contributors. This job cannot run in forks because it uses the secrets, so it must run in our repository context.
This partially reverts #25215, but as far as I know it shouldn't cause a regression for stacked PRs.