### PR TITLE
[ci] Use only unversioned-client profile in Expo Go builds

### DIFF
--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -1,23 +1,7 @@
 name: Android Client - EAS Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      buildType:
-        required: true
-        type: 'choice'
-        description: 'buildType'
-        options:
-          - versioned-client
-          - unversioned-client
-          - versioned-client-add-sdk
-  schedule:
-    # 5:20 AM UTC time on every Monday, Wednesday and Friday
-    # Build a versioned client
-    - cron: '20 5 * * 1,3,5'
-    # 5:20 AM UTC time on every Monday
-    # Run versioning process for the next sdk and build a versioned client
-    - cron: '20 5 * * 1'
+  workflow_dispatch: {}
   pull_request:
     paths:
       - .github/workflows/client-android-eas.yml
@@ -60,35 +44,6 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Install eas-cli
         run: npm install -g eas-cli
-      - name: 🔎 Check which flavor to build
-        id: flavor
-        uses: dorny/paths-filter@v2
-        with:
-          # this action fails when base is not set on schedule event
-          base: ${{ github.ref }}
-          filters: |
-            versioned:
-              - android/versioned-abis/**
-              - android/versioned-react-native/**
-              - android/expoview/src/versioned/**
-              - android/expoview/src/main/java/versioned/**
-              - android/**/*.gradle
-      - name: Resolve profile
-        id: profile
-        run: |
-          DISPATCH_PROFILE="${{ github.event.inputs.buildType }}"
-          IS_VERSIONED="${{ steps.flavor.outputs.versioned }}"
-          if [[ ! -z "$DISPATCH_PROFILE" ]]; then
-            echo "profile=$DISPATCH_PROFILE" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.schedule }}" == "20 5 * * 1,3,5" ]]; then
-            echo "profile=versioned-client" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.schedule }}" == "20 5 * * 1" ]]; then
-            echo "profile=versioned-client-add-sdk" >> $GITHUB_OUTPUT
-          elif [[ "$IS_VERSIONED" == "true" ]]; then
-            echo "profile=versioned-client" >> $GITHUB_OUTPUT
-          else
-            echo "profile=unversioned-client" >> $GITHUB_OUTPUT
-          fi
       - name: Generate local credentials.json
         working-directory: ./apps/eas-expo-go
         run: |
@@ -114,7 +69,7 @@ jobs:
         id: build
         with:
           platform: 'android'
-          profile: ${{ steps.profile.outputs.profile  }}
+          profile: 'unversioned-client'
           projectRoot: './apps/eas-expo-go'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           message: ${{ github.event.pull_request.title }}
@@ -124,7 +79,7 @@ jobs:
         working-directory: ./apps/eas-expo-go
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: ${{ steps.profile.outputs.profile  }}
+          EAS_BUILD_PROFILE: 'unversioned-client'
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -1,23 +1,7 @@
 name: iOS Client - EAS Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      buildType:
-        required: true
-        type: 'choice'
-        description: 'buildType'
-        options:
-          - versioned-client
-          - unversioned-client
-          - versioned-client-add-sdk
-  schedule:
-    # 5:20 AM UTC time on every Monday, Wednesday and Friday
-    # Build a versioned client
-    - cron: '20 5 * * 1,3,5'
-    # 5:20 AM UTC time on every Monday
-    # Run versioning process for the next sdk and build a versioned client
-    - cron: '20 5 * * 1'
+  workflow_dispatch: {}
   pull_request:
     paths:
       - .github/workflows/client-ios-eas.yml
@@ -70,38 +54,12 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Install eas-cli
         run: npm install -g eas-cli
-      - name: 🔎 Check which flavor to build
-        id: flavor
-        uses: dorny/paths-filter@v2
-        with:
-          # this action fails when base is not set on schedule event
-          base: ${{ github.ref }}
-          filters: |
-            versioned:
-              - ios/versioned-react-native/**
-              - ios/Exponent/Versioned/**
-      - name: Resolve profile
-        id: profile
-        run: |
-          DISPATCH_PROFILE="${{ github.event.inputs.buildType }}"
-          IS_VERSIONED="${{ steps.flavor.outputs.versioned }}"
-          if [[ ! -z "$DISPATCH_PROFILE" ]]; then
-            echo "profile=$DISPATCH_PROFILE" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.schedule }}" == "20 5 * * 1,3,5" ]]; then
-            echo "profile=versioned-client" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event.schedule }}" == "20 5 * * 1" ]]; then
-            echo "profile=versioned-client-add-sdk" >> $GITHUB_OUTPUT
-          elif [[ "$IS_VERSIONED" == "true" ]]; then
-            echo "profile=versioned-client" >> $GITHUB_OUTPUT
-          else
-            echo "profile=unversioned-client" >> $GITHUB_OUTPUT
-          fi
       - name: Build
         uses: ./.github/actions/eas-build
         id: build
         with:
           platform: 'ios'
-          profile: ${{ steps.profile.outputs.profile  }}
+          profile: 'unversioned-client'
           projectRoot: './apps/eas-expo-go'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
           message: ${{ github.event.pull_request.title }}
@@ -111,7 +69,7 @@ jobs:
         working-directory: ./apps/eas-expo-go
         env:
           EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          EAS_BUILD_PROFILE: ${{ steps.profile.outputs.profile  }}
+          EAS_BUILD_PROFILE: 'unversioned-client'
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))


### PR DESCRIPTION
# Why

Workflows that build Expo Go no longer need to build versioned flavors or test versioning.

# How

Updated `client-android-eas` and `client-ios-eas` workflows by
- removing steps that determine the flavor and profile to use
- removing the `buildType` input
- removing scheduled jobs as they were intended for versioned flavors

# Test Plan

