### PR TITLE
[expo-updates][ios][4/n] Remove classic updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [ios] Remove unnecessary delegate from FileDownloader. ([#25783](https://github.com/expo/expo/pull/25783) by [@wschurman](https://github.com/wschurman))
 - Migrate to requireNativeModule/requireOptionalNativeModule. ([#25648](https://github.com/expo/expo/pull/25648) by [@wschurman](https://github.com/wschurman))
-- Remove classic updates. ([#26036](https://github.com/expo/expo/pull/26036), [#26037](https://github.com/expo/expo/pull/26037), [#26048](https://github.com/expo/expo/pull/26048) by [@wschurman](https://github.com/wschurman))
+- Remove classic updates. ([#26036](https://github.com/expo/expo/pull/26036), [#26037](https://github.com/expo/expo/pull/26037), [#26048](https://github.com/expo/expo/pull/26048), [#26059](https://github.com/expo/expo/pull/26059) by [@wschurman](https://github.com/wschurman))
 
 ## 0.24.5 - 2023-12-21
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/Crypto.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/Crypto.swift
@@ -1,12 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
-// swiftlint:disable legacy_objc_type
-
 import Foundation
-import CommonCrypto
-
-internal typealias VerifySignatureSuccessBlock = (_ success: Bool) -> Void
-internal typealias VerifySignatureErrorBlock = (_ error: Error) -> Void
 
 internal enum PEMType {
   case publicKey
@@ -31,22 +25,7 @@ internal enum PEMType {
   }
 }
 
-private let ErrorDomain = "EXUpdatesCrypto"
-private enum CryptoErrorCode: Int {
-  case PublicKeyDownloadError = 1049
-}
-
-/**
- * Methods for legacy signature verification of manifests.
- */
 internal final class Crypto {
-  // this always succeeds since it is hardcoded
-  // swiftlint:disable:next force_unwrapping
-  private static let PublicKeyUrl = URL(string: "https://exp.host/--/manifest-public-key")!
-
-  private static let PublicKeyTag = "exp.host.publickey"
-  private static let PublicKeyFilename = "manifestPublicKey.pem"
-
   static func decodePEMToDER(pem: Data, pemType: PEMType) -> Data? {
     // Mostly from ASN1Decoder with the fix for disallowing multiple bodies in the PEM.
 
@@ -77,129 +56,5 @@ internal final class Crypto {
     }
 
     return nil
-  }
-
-  static func verifySignature(
-    withData data: String,
-    signature: String,
-    config: UpdatesConfig,
-    successBlock: @escaping VerifySignatureSuccessBlock,
-    errorBlock: @escaping VerifySignatureErrorBlock
-  ) {
-    guard !data.isEmpty && !signature.isEmpty else {
-      errorBlock(NSError(
-        domain: "EXUpdatesCrypto",
-        code: 1001,
-        userInfo: [NSLocalizedDescriptionKey: "Cannot verify the manifest because it is empty or has no signature."]
-      ))
-      return
-    }
-
-    func fetchRemotelyBlock() {
-      fetchAndVerifySignature(withData: data, signature: signature, config: config, successBlock: successBlock, errorBlock: errorBlock)
-    }
-
-    let configuration = URLSessionConfiguration.default
-    configuration.requestCachePolicy = .returnCacheDataDontLoad
-    let fileDownloader = FileDownloader(config: config, urlSessionConfiguration: configuration)
-    fileDownloader.downloadData(
-      fromURL: PublicKeyUrl,
-      extraHeaders: [:]
-    ) { publicKeyData, _ in
-      guard let publicKeyData = publicKeyData else {
-        fetchRemotelyBlock()
-        return
-      }
-
-      verify(withPublicKey: publicKeyData, signature: signature, signedString: data) { isValid in
-        if isValid {
-          successBlock(isValid)
-        } else {
-          fetchRemotelyBlock()
-        }
-      }
-    } errorBlock: { _ in
-      fetchRemotelyBlock()
-    }
-  }
-
-  private static func fetchAndVerifySignature(
-    withData data: String,
-    signature: String,
-    config: UpdatesConfig,
-    successBlock: @escaping VerifySignatureSuccessBlock,
-    errorBlock: @escaping VerifySignatureErrorBlock
-  ) {
-    let configuration = URLSessionConfiguration.default
-    configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
-    let fileDownloader = FileDownloader(config: config, urlSessionConfiguration: configuration)
-    fileDownloader.downloadData(
-      fromURL: PublicKeyUrl,
-      extraHeaders: [:]
-    ) { publicKeyData, _ in
-      guard let publicKeyData = publicKeyData else {
-        errorBlock(NSError(
-          domain: ErrorDomain,
-          code: CryptoErrorCode.PublicKeyDownloadError.rawValue,
-          userInfo: [NSLocalizedDescriptionKey: "Public key response body empty"]
-        ))
-        return
-      }
-      verify(withPublicKey: publicKeyData, signature: signature, signedString: data, callback: successBlock)
-    } errorBlock: { error in
-      errorBlock(error)
-    }
-  }
-
-  private static func verify(
-    withPublicKey publicKeyData: Data,
-    signature: String,
-    signedString: String,
-    callback: @escaping VerifySignatureSuccessBlock
-  ) {
-    guard !publicKeyData.isEmpty else {
-      callback(false)
-      return
-    }
-
-    DispatchQueue.main.async {
-      if let publicKey = keyRefFromPEMData(publicKeyData),
-        let signatureData = NSData(base64Encoded: signature) as? Data,
-        let signedData = signedString.data(using: .utf8) {
-        callback(verifyRSASHA256SignedData(signedData, signatureData: signatureData, publicKey: publicKey))
-      } else {
-        callback(false)
-      }
-    }
-  }
-
-  private static func keyRefFromPEMData(_ pemData: Data) -> SecKey? {
-    guard let publicKey = decodePEMToDER(pem: pemData, pemType: .publicKey) else {
-      return nil
-    }
-
-    let sizeInBits = publicKey.count * 8
-    let keyDict: [CFString: Any] = [
-      kSecAttrKeyType: kSecAttrKeyTypeRSA,
-      kSecAttrKeyClass: kSecAttrKeyClassPublic,
-      kSecAttrKeySizeInBits: NSNumber(value: sizeInBits),
-      kSecReturnPersistentRef: true
-    ]
-    var error: Unmanaged<CFError>?
-    if let key = SecKeyCreateWithData(publicKey as CFData, keyDict as CFDictionary, &error) {
-      return key
-    } else {
-      return nil
-    }
-  }
-
-  private static func verifyRSASHA256SignedData(_ signedData: Data, signatureData: Data, publicKey: SecKey) -> Bool {
-    var hashBytes = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-    signedData.withUnsafeBytes { bytes in
-      _ = CC_SHA256(bytes.baseAddress, CC_LONG(signedData.count), &hashBytes)
-    }
-    let hashData = Data(hashBytes)
-    var error: Unmanaged<CFError>?
-    return SecKeyVerifySignature(publicKey, .rsaSignatureDigestPKCS1v15SHA256, hashData as CFData, signatureData as CFData, &error)
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/ResponseHeaderData.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/ResponseHeaderData.swift
@@ -27,16 +27,10 @@ public final class ResponseHeaderData {
    */
   private let manifestFiltersRaw: String?
 
-  /**
-   * Classic updates Expo Go manifest signature
-   */
-  let manifestSignature: String?
-
-  public required init(protocolVersionRaw: String?, serverDefinedHeadersRaw: String?, manifestFiltersRaw: String?, manifestSignature: String?) {
+  public required init(protocolVersionRaw: String?, serverDefinedHeadersRaw: String?, manifestFiltersRaw: String?) {
     self.protocolVersionRaw = protocolVersionRaw
     self.serverDefinedHeadersRaw = serverDefinedHeadersRaw
     self.manifestFiltersRaw = manifestFiltersRaw
-    self.manifestSignature = manifestSignature
   }
 
   lazy var protocolVersion: Int? = {

--- a/packages/expo-updates/ios/Tests/UpdateSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdateSpec.swift
@@ -26,8 +26,7 @@ class UpdateSpec : ExpoSpec {
         let responseHeaderData = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: nil,
-          manifestSignature: nil
+          manifestFiltersRaw: nil
         )
         
         expect { try Update.update(
@@ -53,8 +52,7 @@ class UpdateSpec : ExpoSpec {
         let responseHeaderData = ResponseHeaderData(
           protocolVersionRaw: "0",
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: nil,
-          manifestSignature: nil
+          manifestFiltersRaw: nil
         )
         
         expect(try! Update.update(
@@ -80,8 +78,7 @@ class UpdateSpec : ExpoSpec {
         let responseHeaderData = ResponseHeaderData(
           protocolVersionRaw: "2",
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: nil,
-          manifestSignature: nil
+          manifestFiltersRaw: nil
         )
         
         expect(try Update.update(

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
@@ -104,8 +104,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData1 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: "branch-name=\"rollout-1\",test=\"value\"",
-          manifestSignature: nil
+          manifestFiltersRaw: "branch-name=\"rollout-1\",test=\"value\""
         )
         
         db.databaseQueue.sync {
@@ -115,8 +114,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData2 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: "branch-name=\"rollout-2\"",
-          manifestSignature: nil
+          manifestFiltersRaw: "branch-name=\"rollout-2\""
         )
         
         db.databaseQueue.sync {
@@ -134,8 +132,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData1 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: "branch-name=\"rollout-1\"",
-          manifestSignature: nil
+          manifestFiltersRaw: "branch-name=\"rollout-1\""
         )
         
         db.databaseQueue.sync {
@@ -145,8 +142,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData2 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: "",
-          manifestSignature: nil
+          manifestFiltersRaw: ""
         )
         
         db.databaseQueue.sync {
@@ -164,8 +160,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData1 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: "branch-name=\"rollout-1\"",
-          manifestSignature: nil
+          manifestFiltersRaw: "branch-name=\"rollout-1\""
         )
         
         db.databaseQueue.sync {
@@ -175,8 +170,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         let responseHeaderData2 = ResponseHeaderData(
           protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
-          manifestFiltersRaw: nil,
-          manifestSignature: nil
+          manifestFiltersRaw: nil
         )
         
         db.databaseQueue.sync {


### PR DESCRIPTION
# Why

Depends on https://github.com/expo/expo/pull/26048. iOS equivalent of https://github.com/expo/expo/pull/26037.

# How

Same as android.

# Test Plan

Same as android.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
