### PR TITLE
feature(tools): add `validate-workspace-dependencies` command

### DIFF
--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -9,10 +9,10 @@ export default (program: Command) => {
     .command('validate-workspace-dependencies')
     .alias('vwd')
     .description('Verifies if all workspace packages are linked from monorepo.')
-    .asyncAction(action);
+    .asyncAction(actionAsync);
 };
 
-async function action() {
+async function actionAsync() {
   const workspaces = await getWorkspacesAsync();
   const workspacesMismatched = Object.values(workspaces).filter(
     (workspace) => workspace.mismatchedWorkspaceDependencies.length

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -4,10 +4,6 @@ import path from 'path';
 import { getExpoRepositoryRootDir } from '../Directories';
 import { getInfoAsync } from '../Workspace';
 
-type ActionOptions = {
-  workspace?: string;
-};
-
 export default (program: Command) => {
   program
     .command('validate-workspace-dependencies')
@@ -16,7 +12,7 @@ export default (program: Command) => {
     .asyncAction(action);
 };
 
-async function action(options: ActionOptions) {
+async function action() {
   const workspaces = await getWorkspacesAsync();
   const workspacesMismatched = Object.values(workspaces).filter(
     (workspace) => workspace.mismatchedWorkspaceDependencies.length

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -14,7 +14,7 @@ export default (program: Command) => {
 
 async function actionAsync() {
   const workspacePackages = await getWorkspacePackagesAsync();
-  const workspacesMismatched = Object.values(workspaces).filter(
+  const workspacesMismatched = Object.values(workspacePackages).filter(
     (workspace) => workspace.mismatchedWorkspaceDependencies.length
   );
 
@@ -40,7 +40,7 @@ async function actionAsync() {
     );
 
     for (const dependency of mismatched) {
-      const workspaceVersion = workspaces[dependency]._version;
+      const workspaceVersion = workspacePackages[dependency]._version;
       const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
 
       console.warn(
@@ -52,7 +52,7 @@ async function actionAsync() {
   process.exit(1);
 }
 
-async function getWorkspacesAsync() {
+async function getWorkspacePackagesAsync() {
   const root = getExpoRepositoryRootDir();
   const workspaces = await getInfoAsync();
 

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -13,7 +13,7 @@ export default (program: Command) => {
 };
 
 async function actionAsync() {
-  const workspaces = await getWorkspacesAsync();
+  const workspacePackages = await getWorkspacePackagesAsync();
   const workspacesMismatched = Object.values(workspaces).filter(
     (workspace) => workspace.mismatchedWorkspaceDependencies.length
   );

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -12,7 +12,7 @@ export default (program: Command) => {
   program
     .command('validate-workspace-dependencies')
     .alias('vwd')
-    .description('Verifies if all workspaces are linked from monorepo.')
+    .description('Verifies if all workspace packages are linked from monorepo.')
     .asyncAction(action);
 };
 
@@ -23,14 +23,14 @@ async function action(options: ActionOptions) {
   );
 
   if (!workspacesMismatched.length) {
-    console.log(`✅  Verified that all workspace dependencies are symlinked.`);
-    return
+    console.log(`✅  Verified that all workspace packages are symlinked.`);
+    return;
   }
 
   console.warn(
     workspacesMismatched.length === 1
-      ? `⚠️  Found 1 workspace installed from npm instead of this repository.`
-      : `⚠️  Found ${workspacesMismatched.length} workspaces installed from npm instead of this repository.`
+      ? `⚠️  Found 1 workspace package installed from npm instead of this repository.`
+      : `⚠️  Found ${workspacesMismatched.length} workspace packages installed from npm instead of this repository.`
   );
 
   for (const workspace of workspacesMismatched) {
@@ -39,8 +39,8 @@ async function action(options: ActionOptions) {
     console.warn();
     console.warn(
       mismatched.length === 1
-        ? `${workspace._name} has 1 workspace that isn't symlinked:`
-        : `${workspace._name} has ${mismatched.length} workspace that aren't symlinked:`
+        ? `${workspace._name} has 1 workspace package that isn't symlinked:`
+        : `${workspace._name} has ${mismatched.length} workspace packages that aren't symlinked:`
     );
 
     for (const dependency of mismatched) {
@@ -48,7 +48,7 @@ async function action(options: ActionOptions) {
       const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
 
       console.warn(
-        `- ${dependency}@${installedVersion} is installed, but workspace is at ${workspaceVersion}`
+        `- ${dependency}@${installedVersion} is installed, but workspace package is at ${workspaceVersion}`
       );
     }
   }

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -1,0 +1,75 @@
+import { Command } from '@expo/commander';
+import path from 'path';
+
+import { getExpoRepositoryRootDir } from '../Directories';
+import { getInfoAsync } from '../Workspace';
+
+type ActionOptions = {
+  workspace?: string;
+};
+
+export default (program: Command) => {
+  program
+    .command('validate-workspace-dependencies')
+    .alias('vwd')
+    .description('Verifies if all workspaces are linked from monorepo.')
+    .asyncAction(action);
+};
+
+async function action(options: ActionOptions) {
+  const workspaces = await getWorkspacesAsync();
+  const workspacesMismatched = Object.values(workspaces).filter(
+    (workspace) => workspace.mismatchedWorkspaceDependencies.length
+  );
+
+  if (!workspacesMismatched.length) {
+    return console.log(`✅  Verified that all workspace dependencies are symlinked.`);
+  }
+
+  console.warn(
+    workspacesMismatched.length === 1
+      ? `⚠️  Found 1 workspace installed from npm instead of this repository.`
+      : `⚠️  Found ${workspacesMismatched.length} workspaces installed from npm instead of this repository.`
+  );
+
+  for (const workspace of workspacesMismatched) {
+    const mismatched = workspace.mismatchedWorkspaceDependencies;
+
+    console.warn();
+    console.warn(
+      mismatched.length === 1
+        ? `${workspace._name} has 1 workspace that isn't symlinked:`
+        : `${workspace._name} has ${mismatched.length} workspace that aren't symlinked:`
+    );
+
+    for (const dependency of mismatched) {
+      const workspaceVersion = workspaces[dependency]._package.version;
+      const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
+
+      console.warn(
+        `- ${dependency}@${installedVersion} is installed, but workspace is at ${dependency}@${workspaceVersion}`
+      );
+    }
+  }
+
+  process.exit(1);
+}
+
+async function getWorkspacesAsync() {
+  const root = getExpoRepositoryRootDir();
+  const workspaces = await getInfoAsync();
+
+  return Object.fromEntries(
+    Object.entries(workspaces).map(([_name, workspace]) => {
+      const _directory = path.join(root, workspace.location);
+      const _package = require(path.join(_directory, 'package.json'));
+
+      return [_name, { _name, _package, _directory, ...workspace }];
+    })
+  );
+}
+
+async function getResolvedVersionAsync(directory: string, packageName: string) {
+  const packageFile = require.resolve(`${packageName}/package.json`, { paths: [directory] });
+  return require(packageFile).version;
+}

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -47,7 +47,7 @@ async function action(options: ActionOptions) {
       const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
 
       console.warn(
-        `- ${dependency}@${installedVersion} is installed, but workspace is at ${dependency}@${workspaceVersion}`
+        `- ${dependency}@${installedVersion} is installed, but workspace is at ${workspaceVersion}`
       );
     }
   }

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -44,7 +44,7 @@ async function action(options: ActionOptions) {
     );
 
     for (const dependency of mismatched) {
-      const workspaceVersion = workspaces[dependency]._package.version;
+      const workspaceVersion = workspaces[dependency]._version;
       const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
 
       console.warn(
@@ -63,9 +63,9 @@ async function getWorkspacesAsync() {
   return Object.fromEntries(
     Object.entries(workspaces).map(([_name, workspace]) => {
       const _directory = path.join(root, workspace.location);
-      const _package = require(path.join(_directory, 'package.json'));
+      const _version = require(path.join(_directory, 'package.json')).version;
 
-      return [_name, { _name, _package, _directory, ...workspace }];
+      return [_name, { _name, _version, _directory, ...workspace }];
     })
   );
 }

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -23,7 +23,8 @@ async function action(options: ActionOptions) {
   );
 
   if (!workspacesMismatched.length) {
-    return console.log(`✅  Verified that all workspace dependencies are symlinked.`);
+    console.log(`✅  Verified that all workspace dependencies are symlinked.`);
+    return
   }
 
   console.warn(


### PR DESCRIPTION
# Why

This command helps us validate that all monorepo workspaces are symlinked to each other, instead of being installed from npm. This is a replacement for the `expo-yarn-workspaces check-workspace-dependencies` command, [from this discussion](https://github.com/expo/expo/pull/25846#issuecomment-1865158315)

# How

- Moved `expo-yarn-workspaces`'s script into `expo-tools`
- Added more info in warnings about workspace and installed versions

All green | When issues are detected
--- | ---
![no-issues](https://github.com/expo/expo/assets/1203991/01ab62a1-7c9e-41b8-b54e-288a60c34f9c) | ![two-non-symlinked-issues](https://github.com/expo/expo/assets/1203991/8386eef6-a148-4f4d-9f1e-269bacf26d6d)

# Test Plan

To test the current (valid) repo:

- `$ et vwd` (or `$ et validate-workspace-dependencies`)
  - → Should be green

To test a faulty dependency link:

- `$ cd packages/expo`
- `$ yarn add "expo-asset@^8"` (this isn't valid for SDK 50+)
- `$ et vwd`
  - → Should error with helpful info 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
