### PR TITLE
[docs] Update Expo Router installation guide

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -85,7 +85,7 @@ You'll need to install the following dependencies:
 
 <Tab label="SDK 49 and above">
 
-    For the attibute 'name' use the `expo-router/entry` value in the **package.json** file. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
+    For the property `main`, use the `expo-router/entry` as its value in the **package.json**. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
 
     ```json package.json
     {

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -85,7 +85,7 @@ You'll need to install the following dependencies:
 
 <Tab label="SDK 49 and above">
 
-    Use the `expo-router/entry` file in the **package.json**. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
+    For the attibute 'name' use the `expo-router/entry` value in the **package.json** file. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
 
     ```json package.json
     {


### PR DESCRIPTION
change the wording so this installation step is easier to understand.

# Why

<!--
 I think developers that are reading each line of the Install Expo Router documentation will need to read this line multiple times to make sure they understand the change needed.  The working I suggest is easier to understand because it uses better grammer and JSON terminology.  
-->

# How

<!--
I read the documentation multiple times
-->

# Test Plan

<!--
I read the documentation a final time
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
