### PR TITLE
fix(install-expo-modules): move `dependencies` to `devDependencies`

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Avoid installing dependencies when running `npx install-expo-modules`. ([#26075](https://github.com/expo/expo/pull/26075) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.8.0 — 2023-12-14

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -1,8 +1,20 @@
 {
   "name": "install-expo-modules",
   "version": "0.8.0",
+  "license": "MIT",
   "description": "Tools to install expo-modules for existing react-native projects",
-  "main": "build",
+  "keywords": [
+    "expo",
+    "expo-modules",
+    "npx",
+    "react-native",
+    "react"
+  ],
+  "bin": "build/index.js",
+  "main": "build/index.js",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "ncc build ./src/index.ts -o build/",
     "build:prod": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register",
@@ -14,33 +26,24 @@
     "typecheck": "expo-module typecheck",
     "watch": "yarn run build --watch"
   },
-  "bin": "./build/index.js",
-  "files": [
-    "build"
-  ],
+  "homepage": "https://github.com/expo/expo/tree/main/packages/install-expo-modules#readme",
+  "bugs": {
+    "url": "https://github.com/expo/expo/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",
     "directory": "packages/install-expo-modules"
   },
-  "keywords": [
-    "expo",
-    "expo-modules",
-    "npx",
-    "react-native",
-    "react"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/expo/expo/issues"
-  },
-  "homepage": "https://github.com/expo/expo/tree/main/packages/install-expo-modules#readme",
-  "dependencies": {
+  "devDependencies": {
     "@expo/config": "^8.4.0",
     "@expo/config-plugins": "^7.7.0",
     "@expo/package-manager": "^1.0.3",
+    "@types/prompts": "^2.0.6",
+    "@types/semver": "^6.0.0",
     "chalk": "^4.1.2",
     "commander": "2.20.0",
+    "expo-module-scripts": "^3.3.0",
     "find-up": "^5.0.0",
     "glob": "7.1.6",
     "prompts": "^2.3.2",
@@ -48,11 +51,6 @@
     "semver": "7.3.2",
     "terminal-link": "^2.1.1",
     "xcparse": "^0.0.3"
-  },
-  "devDependencies": {
-    "@types/prompts": "^2.0.6",
-    "@types/semver": "^6.0.0",
-    "expo-module-scripts": "^3.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/install-expo-modules/tsconfig.json
+++ b/packages/install-expo-modules/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.node",
   "compilerOptions": {
     "outDir": "build",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["./src"],
   "exclude": [


### PR DESCRIPTION
# Why

This will cause no additional libraries to be installed when running `npx install-expo-modules`. Currently, it does that:

<img width="932" alt="image" src="https://github.com/expo/expo/assets/1203991/1fee58d6-2c37-489f-b4bb-0fc36c2bd6dc">

# How

- Updated `package.json` with `devDependencies` only

# Test Plan

We can only test this when publishing unfortunately. Once that's done, we can look up https://packagephobia.com/result?p=install-expo-modules to see if the `install` stage now does not add more data.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
