### PR TITLE
[updates] introduce UpdatesController.overrideConfiguration

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Introduced the `UpdatesController.overrideConfiguration()` method to prevent ANR when overriding the `UpdatesConfiguration` on Android. ([#26078](https://github.com/expo/expo/pull/26078) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.18.18 — 2023-12-15

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -580,7 +580,7 @@ class UpdatesController private constructor(
     private const val UPDATES_STATE_CHANGE_EVENT_NAME = "Expo.nativeUpdatesStateChangeEvent"
 
     private var singletonInstance: UpdatesController? = null
-    private var _overrideConfiguration: UpdatesConfiguration? = null
+    private var overrideConfiguration: UpdatesConfiguration? = null
 
     @JvmStatic val instance: UpdatesController
       get() {
@@ -589,7 +589,7 @@ class UpdatesController private constructor(
 
     @JvmStatic fun initializeWithoutStarting(context: Context) {
       if (singletonInstance == null) {
-        val updatesConfiguration = _overrideConfiguration ?: UpdatesConfiguration(context, null)
+        val updatesConfiguration = overrideConfiguration ?: UpdatesConfiguration(context, null)
         singletonInstance = UpdatesController(context, updatesConfiguration)
       }
     }
@@ -614,7 +614,7 @@ class UpdatesController private constructor(
      */
     @JvmStatic fun initialize(context: Context, configuration: Map<String, Any>) {
       if (singletonInstance == null) {
-        val updatesConfiguration = _overrideConfiguration ?: UpdatesConfiguration(context, configuration)
+        val updatesConfiguration = overrideConfiguration ?: UpdatesConfiguration(context, configuration)
         singletonInstance = UpdatesController(context, updatesConfiguration)
         singletonInstance!!.start(context)
       }
@@ -625,13 +625,10 @@ class UpdatesController private constructor(
      */
     @JvmStatic
     fun overrideConfiguration(context: Context, configuration: Map<String, Any>) {
-      if (Looper.myLooper() != Looper.getMainLooper()) {
-        throw AssertionError("overrideConfiguration() should be called from main thread")
-      }
       if (singletonInstance != null) {
         throw AssertionError("The method should be called before UpdatesController.initialize()")
       }
-      _overrideConfiguration = UpdatesConfiguration(context, configuration)
+      overrideConfiguration = UpdatesConfiguration(context, configuration)
     }
   }
 


### PR DESCRIPTION
# Why

original the `UpdatesController.initialize(context, overrideConf)` will conflict with the expo-updates' `EX_UPDATES_ANDROID_DELAY_LOAD_APP` feature. the initialization will still happen on the main thread and potentially cause ANR.

# How

introduce the new `UpdatesController.overrideConfiguration()` method that only overrides the UpdatesConfiguration but not have an opinion on how expo-updates are initialized and started.

# Test Plan

1. create project
```sh
$ yarn create expo -t blank@sdk-49 sdk4
$ cd sdk49
$ npx expo install expo-updates
$ eas update:configure
$ npx expo prebuild -p android
```

2. apply the PR's patch and also the following patch
```patch
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,6 +104,7 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
+            debuggable true
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
--- a/android/app/src/main/java/dev/expo/kudo/sdk49/MainApplication.java
+++ b/android/app/src/main/java/dev/expo/kudo/sdk49/MainApplication.java
@@ -2,6 +2,8 @@ package dev.expo.kudo.sdk49;

 import android.app.Application;
 import android.content.res.Configuration;
+import android.util.ArrayMap;
+
 import androidx.annotation.NonNull;

 import com.facebook.react.PackageList;
@@ -15,6 +17,7 @@ import com.facebook.soloader.SoLoader;

 import expo.modules.ApplicationLifecycleDispatcher;
 import expo.modules.ReactNativeHostWrapper;
+import expo.modules.updates.UpdatesController;

 import java.util.List;

@@ -24,7 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
     new ReactNativeHostWrapper(this, new DefaultReactNativeHost(this) {
       @Override
       public boolean getUseDeveloperSupport() {
-        return BuildConfig.DEBUG;
+        return false;
       }

       @Override
@@ -60,6 +63,13 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public void onCreate() {
     super.onCreate();
+
+    ArrayMap<String, String> headers = new ArrayMap<>();
+    headers.put("Foo", "Bar");
+    ArrayMap<String, Object> overrideConfig = new ArrayMap<>();
+    overrideConfig.put("requestHeaders", headers);
+    UpdatesController.overrideConfiguration(this, overrideConfig);
+
     SoLoader.init(this, /* native exopackage */ false);
     if (!BuildConfig.REACT_NATIVE_UNSTABLE_USE_RUNTIME_SCHEDULER_ALWAYS) {
       ReactFeatureFlags.unstable_useRuntimeSchedulerAlways = false;
```

3. Open the project by Android Studio and set the build variant to release build. Set breakpoint at FileDownloader https://github.com/expo/expo/blob/8cd3d8502751c0326a3bcb8076ef55c816800554/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt#L806-L808. And check whether there's the Foo: Bar header is there

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
