### PR TITLE
[iOS] Remove reflections used to load the versioned code

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -110,12 +110,6 @@ NSString * const kEXHomeLaunchUrlDefaultsKey = @"EXKernelLaunchUrlDefaultsKey";
   return modules;
 }
 
-- (void)computeVersionSymbolPrefix
-{
-  self.validatedVersion = nil;
-  self.versionSymbolPrefix = [[EXVersions sharedInstance] symbolPrefixForSdkVersion:self.validatedVersion isKernel:YES];
-}
-
 - (RCTLogFunction)logFunction
 {
   return EXGetKernelRCTLogFunction();

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -163,7 +163,7 @@
 		B5D0D65F204F4BF500DDFC99 /* EXLog.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D65D204F4BF400DDFC99 /* EXLog.m */; };
 		B5D0D673204F4C0400DDFC99 /* EXApiUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D661204F4C0400DDFC99 /* EXApiUtil.m */; };
 		B5D0D677204F4C0400DDFC99 /* EXFileDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66B204F4C0400DDFC99 /* EXFileDownloader.m */; };
-		B5D0D679204F4C0400DDFC99 /* EXReactAppManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */; };
+		B5D0D679204F4C0400DDFC99 /* EXReactAppManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */; };
 		B5D0D67A204F4C0400DDFC99 /* EXReactAppExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */; };
 		B5E49B571D1346FA00AA6436 /* Exponent.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = B5E49B551D1346FA00AA6436 /* Exponent.entitlements */; };
 		B5E49B631D1347B800AA6436 /* EXSDKVersions.plist in Resources */ = {isa = PBXBuildFile; fileRef = B5E49B621D1347B800AA6436 /* EXSDKVersions.plist */; };
@@ -575,7 +575,7 @@
 		B5D0D667204F4C0400DDFC99 /* EXApiUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXApiUtil.h; sourceTree = "<group>"; };
 		B5D0D66B204F4C0400DDFC99 /* EXFileDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXFileDownloader.m; sourceTree = "<group>"; };
 		B5D0D66E204F4C0400DDFC99 /* EXReactAppExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXReactAppExceptionHandler.h; sourceTree = "<group>"; };
-		B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EXReactAppManager.mm; sourceTree = "<group>"; };
+		B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXReactAppManager.m; sourceTree = "<group>"; };
 		B5D0D670204F4C0400DDFC99 /* EXReactAppManager+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXReactAppManager+Private.h"; sourceTree = "<group>"; };
 		B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXReactAppExceptionHandler.m; sourceTree = "<group>"; };
 		B5D0D672204F4C0400DDFC99 /* EXReactAppManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXReactAppManager.h; sourceTree = "<group>"; };
@@ -1265,7 +1265,7 @@
 				B5D0D66E204F4C0400DDFC99 /* EXReactAppExceptionHandler.h */,
 				B5D0D671204F4C0400DDFC99 /* EXReactAppExceptionHandler.m */,
 				B5D0D672204F4C0400DDFC99 /* EXReactAppManager.h */,
-				B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.mm */,
+				B5D0D66F204F4C0400DDFC99 /* EXReactAppManager.m */,
 				B5D0D670204F4C0400DDFC99 /* EXReactAppManager+Private.h */,
 			);
 			path = ReactAppManager;
@@ -2087,7 +2087,7 @@
 				B5C2740C1EC24AE1003355CE /* EXKernelLinkingManager.m in Sources */,
 				B5FB74E51FF6DADC001C764B /* EXAppState.m in Sources */,
 				0726F0592007E438004992E7 /* EXKernelAppRecord.m in Sources */,
-				B5D0D679204F4C0400DDFC99 /* EXReactAppManager.mm in Sources */,
+				B5D0D679204F4C0400DDFC99 /* EXReactAppManager.m in Sources */,
 				31AD99E82285B51100F19090 /* AIRGoogleMapCalloutManager.m in Sources */,
 				31AD99E32285B51100F19090 /* AIRGoogleMapMarkerManager.m in Sources */,
 				B5A473DA204A66F70035C61C /* EXAppViewController.m in Sources */,

--- a/ios/Exponent/Kernel/Environment/EXVersions.h
+++ b/ios/Exponent/Kernel/Environment/EXVersions.h
@@ -13,10 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nonnull) NSDictionary *versions;
 @property (nonatomic, readonly, nonnull) NSString *temporarySdkVersion;
 
-- (NSString *)symbolPrefixForSdkVersion: (NSString * _Nullable)version isKernel:(BOOL)isKernel;
 - (NSString *)availableSdkVersionForManifest: (EXManifestsManifest * _Nullable)manifest;
 - (BOOL)supportsVersion:(NSString *)sdkVersion;
-+ (NSString * _Nullable)versionedString: (NSString * _Nullable)string withPrefix: (NSString * _Nullable)symbolPrefix;
 
 @end
 

--- a/ios/Exponent/Kernel/Environment/EXVersions.m
+++ b/ios/Exponent/Kernel/Environment/EXVersions.m
@@ -48,28 +48,6 @@
   return self;
 }
 
-+ (NSString *)versionedString:(NSString *)string withPrefix:(NSString *)symbolPrefix
-{
-  if (!string || !symbolPrefix) {
-    return nil;
-  }
-  return [NSString stringWithFormat:@"%@%@", symbolPrefix, string];
-}
-
-- (NSString *)symbolPrefixForSdkVersion:(NSString *)version isKernel:(BOOL)isKernel
-{
-#ifdef INCLUDES_VERSIONED_CODE
-  // Projects that use the latest SDK version use unversioned code
-  if (isKernel || [version isEqualToString:_temporarySdkVersion]) {
-    return @"";
-  }
-  if (version && version.length && ![version isEqualToString:@"UNVERSIONED"]) {
-    return [[@"ABI" stringByAppendingString:version] stringByReplacingOccurrencesOfString:@"." withString:@"_"];
-  }
-#endif
-  return @"";
-}
-
 - (NSString *)availableSdkVersionForManifest:(EXManifestsManifest * _Nullable)manifest
 {
   return [self _versionForManifest:manifest];
@@ -131,12 +109,9 @@
   _versions = mutableVersions;
 }
 
-- (BOOL)supportsVersion:(NSString *)sdkVersion {
-#ifdef INCLUDES_VERSIONED_CODE
+- (BOOL)supportsVersion:(NSString *)sdkVersion
+{
   return [_versions[@"sdkVersions"] containsObject:(NSString *) sdkVersion];
-#else
-  return YES;
-#endif
 }
 
 @end

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager+Private.h
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager+Private.h
@@ -12,9 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) id versionManager;
 @property (nonatomic, assign) BOOL hasBridgeEverLoaded; // has the bridge ever succeeded at loading?
 
-@property (nonatomic, strong) NSString *versionSymbolPrefix;
-@property (nonatomic, strong, nullable) NSString *validatedVersion;
-
 @property (nonatomic, strong) EXReactAppExceptionHandler *exceptionHandler;
 
 - (NSDictionary *)launchOptionsForBridge;

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
@@ -1,7 +1,13 @@
 
 #import <UIKit/UIKit.h>
+#import <React/RCTBridgeDelegate.h>
+
 #import "EXAppFetcher.h"
 #import "EXKernelAppRecord.h"
+
+#ifdef __cplusplus
+#import <React/RCTCxxBridgeDelegate.h>
+#endif // __cplusplus
 
 typedef enum EXReactAppManagerStatus {
   kEXReactAppManagerStatusNew,
@@ -22,7 +28,7 @@ typedef enum EXReactAppManagerStatus {
 
 @end
 
-@interface EXReactAppManager : NSObject <EXAppFetcherDataSource>
+@interface EXReactAppManager : NSObject <RCTBridgeDelegate, EXAppFetcherDataSource>
 
 - (instancetype)initWithAppRecord:(EXKernelAppRecord *)record initialProps:(NSDictionary *)initialProps;
 - (void)rebuildBridge;
@@ -31,8 +37,6 @@ typedef enum EXReactAppManagerStatus {
 // these are piped in from the view controller when the app manager is waiting for a bundle.
 - (void)appLoaderFinished;
 - (void)appLoaderFailedWithError:(NSError *)error;
-
-- (Class)versionedClassFromString:(NSString *)classString;
 
 @property (nonatomic, assign) BOOL isHeadless;
 @property (nonatomic, readonly) BOOL isBridgeRunning;
@@ -70,3 +74,8 @@ typedef enum EXReactAppManagerStatus {
 - (void)selectDevMenuItemWithKey:(NSString *)key;
 
 @end
+
+#ifdef __cplusplus
+@interface EXReactAppManager (RCTCxxBridgeDelegate) <RCTCxxBridgeDelegate>
+@end
+#endif // __cplusplus

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -28,6 +28,8 @@
 
 #import <React/RCTAppearance.h>
 
+#import <RNScreens/RNSScreenWindowTraits.h>
+
 #import "Expo_Go-Swift.h"
 
 @import EXManifests;
@@ -569,12 +571,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)shouldUseRNScreenOrientation
 {
-  Class screenWindowTraitsClass = [self->_appRecord.appManager versionedClassFromString:@"RNSScreenWindowTraits"];
-  if ([screenWindowTraitsClass respondsToSelector:@selector(shouldAskScreensForScreenOrientationInViewController:)]) {
-    id<EXKernelRNSScreenWindowTraits> screenWindowTraits = (id<EXKernelRNSScreenWindowTraits>)screenWindowTraitsClass;
-    return [screenWindowTraits shouldAskScreensForScreenOrientationInViewController:self];
-  }
-  return NO;
+  return [RNSScreenWindowTraits shouldAskScreensForScreenOrientationInViewController:self];
 }
 
 - (UIInterfaceOrientationMask)orientationMaskFromManifestOrDefault


### PR DESCRIPTION
# Why

Following up on removing versioning in Expo Go

# How

- Removed functions determining the versioned prefix.
- `EXVersionManager`, `RCTBridge`, `RCTRootView` and `RNSScreenWindowTraits` are no longer loaded with `NSClassFromString`.
- `EXReactAppManager` now needs to refer to a Swift class (`EXVersionManager`), so I had to change the file to use plain Objective-C. Otherwise importing a Swift header crashes the compiler 🤷‍♂️

# Test Plan

Expo Go builds and correctly loads NCL app
