### PR TITLE
[docs] Fix broken links in In app purchases reference and e2e guide

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -129,7 +129,7 @@ Let's add two development dependencies to the project - `jest` and `detox`. `jes
   ]}
 />
 
-> See the official Detox docs at https://wix.github.io/Detox/docs/introduction/getting-started/ and https://wix.github.io/Detox/docs/guide/jest to learn about any potential updates to this process.
+> See the [Getting started](https://wix.github.io/Detox/docs/introduction/getting-started) and [Project setup](https://wix.github.io/Detox/docs/introduction/project-setup) guides in official Detox documentation to learn about any potential updates to this process.
 
 #### Configure Detox
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. Development was paused in June 2022 and the package was deprecated in August 2023. We recommend one of the following, both of which are compatible with [EAS Build](/build/introduction/) and [development builds](/develop/development-builds/use-development-builds/):<br/><br/>
 > • [`react-native-iap`](https://github.com/dooboolab/react-native-iap), which provides an interface to client-side Google Play Billing and StoreKit API's<br/>
-> • [`react-native-purchases`](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which also integrates with RevenueCat's services for server-side receipt validation and more.
+> • [`react-native-purchases`](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/), which also integrates with RevenueCat's services for server-side receipt validation and more.
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v46.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/in-app-purchases.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [Storekit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v47.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/in-app-purchases.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v48.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/in-app-purchases.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. Development was paused in June 2022 and the package was deprecated in August 2023. We recommend one of the following, both of which are compatible with [EAS Build](/build/introduction/) and [development builds](/develop/development-builds/use-development-builds/):<br/><br/>
 > • [`react-native-iap`](https://github.com/dooboolab/react-native-iap), which provides an interface to client-side Google Play Billing and StoreKit API's<br/>
-> • [`react-native-purchases`](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which also integrates with RevenueCat's services for server-side receipt validation and more.
+> • [`react-native-purchases`](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/), which also integrates with RevenueCat's services for server-side receipt validation and more.
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v50.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/in-app-purchases.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. Development was paused in June 2022 and the package was deprecated in August 2023. We recommend one of the following, both of which are compatible with [EAS Build](/build/introduction/) and [development builds](/develop/development-builds/use-development-builds/):<br/><br/>
 > • [`react-native-iap`](https://github.com/dooboolab/react-native-iap), which provides an interface to client-side Google Play Billing and StoreKit API's<br/>
-> • [`react-native-purchases`](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which also integrates with RevenueCat's services for server-side receipt validation and more.
+> • [`react-native-purchases`](https://www.revenuecat.com/blog/engineering/expo-in-app-purchase-tutorial/), which also integrates with RevenueCat's services for server-side receipt validation and more.
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix broken links in In-app purchases API reference and e2e guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
