### PR TITLE
[updates] fix e2e build error

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -327,6 +327,7 @@ async function preparePackageJson(
       ...expoResolutions,
       ...packageJson.resolutions,
       typescript: '5.2.2',
+      '@isaacs/cliui': 'npm:cliui@8.0.1', // Fix string-width ESM error
     },
   };
 


### PR DESCRIPTION
# Why

fix the build error: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/cb9e75ac-a1ba-455c-9b79-64a27b750f27

# How

pin the version of cliui

# Test Plan

ci passed