### PR TITLE
[expo-video-thumbnails][Android] Fix memory leaks

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Enhanced resource management in VideoThumbnails module by ensuring closure of `ParcelFileDescriptor` and releasing `MediaMetadataRetriever` post-use. ([#26100](https://github.com/expo/expo/pull/26100) by [@hirbod](https://github.com/hirbod))
+  
 ### 💡 Others
 
 ## 7.9.0 — 2023-12-12


### PR DESCRIPTION
# Why

1) Closing **ParcelFileDescriptor** properly: We were leaving the ParcelFileDescriptor open after use, which could lead to resource leaks
2) Releasing **MediaMetadataRetriever** after use: Previously, we weren't releasing the MediaMetadataRetriever, potentially leading to memory leaks.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

1) I wrapped the **ParcelFileDescriptor** in a _use block_. This way, it automatically closes once we're done with it.
2) Ensuring **MediaMetadataRetriever** _release_: I added a finally block in the GetThumbnail class. This block is executed after retrieving the frame, ensuring retriever.release() is called every time, which guarantees that the resources are freed up.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Emulator running SDK 33 and 34
- Real device: Google Pixel Pro 7

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
