### PR TITLE
[core][android] Adjust proguard

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Adjust proguard rules to prevent issues with types implementing `Enumerable`.
+
 ### 💡 Others
 
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Adjust proguard rules to prevent issues with types implementing `Enumerable`.
+- Adjust proguard rules to prevent issues with types implementing `Enumerable`. ([#26108](https://github.com/expo/expo/pull/26108) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -14,7 +14,7 @@
 -keep class * implements expo.modules.kotlin.records.Record {
   *;
 }
--keepclassmembers enum * implements expo.modules.kotlin.types.Enumerable {
+-keep enum * implements expo.modules.kotlin.types.Enumerable {
   *;
 }
 


### PR DESCRIPTION
# Why
Closes #26056

# How
`-keepclassmembers` seems to lose the primary constructor. I'm not sure why the problem isn't seen more often so maybe @lukmccall knows more. 

# Test Plan
