### PR TITLE
Fix to issues #26111 #22473

### DIFF
--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -73,7 +73,7 @@ export async function isPackageInstalledAsync(
   androidPackage: string
 ): Promise<boolean> {
   const packages = await getServer().runAsync(
-    adbArgs(device.pid, 'shell', 'pm', 'list', 'packages', androidPackage)
+    adbArgs(device.pid, 'shell', 'pm', 'list', 'packages', "--user 0",  androidPackage)
   );
 
   const lines = packages.split(/\r?\n/);


### PR DESCRIPTION
Expo fails to install app on Android device with a work profile/secure folder

# Why
https://github.com/expo/expo/issues/26111
https://github.com/expo/expo/issues/22473

This issue prevents app installation using adb on a device with more than one user, such as a Work device or a device that uses Samsung's Secure folder.

# How
I have added the --user 0 parameter to the adb command. This is safe since user 0 always exists on any android device

# Test Plan

I ran the open on android command on expo on several devices with more than one user and it works.

# Checklist

- [V] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [V] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [V] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
