### PR TITLE
[docs] Add redirects based on Algolia's 404 report

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -432,4 +432,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/task-manager/': '/versions/latest/sdk/task-manager',
   'versions/v48.0.0/sdk': '/versions/latest',
   'versions/v48.0.0/sdk/config/app': '/versions/v48.0.0/sdk/config/app/',
+  '/versions/v50.0.0/sdk': '/versions/v50.0.0',
+  '/versions/v49.0.0/sdk': '/versions/v49.0.0',
+  '/versions/v47.0.0/sdk': '/versions/v47.0.0',
+  '/versions/v46.0.0/sdk': '/versions/v46.0.0',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -327,6 +327,7 @@ redirects[versions/v50.0.0/sdk/taskmanager]=versions/v50.0.0/sdk/task-manager
 redirects[versions/v49.0.0/sdk/taskmanager]=versions/v49.0.0/sdk/task-manager
 redirects[versions/v48.0.0/sdk/taskmanager]=versions/v48.0.0/sdk/task-manager
 redirects[versions/v47.0.0/sdk/taskmanager]=versions/v47.0.0/sdk/task-manager
+redirects[versions/v46.0.0/sdk/taskmanager]=versions/v46.0.0/sdk/task-manager
 redirects[task-manager]=versions/latest/sdk/task-manager
 redirects[versions/v49.0.0/sdk/filesystem.md]=versions/v49.0.0/sdk/filesystem
 redirects[versions/v48.0.0/sdk/filesystem.md]=versions/v48.0.0/sdk/filesystem
@@ -337,6 +338,13 @@ redirects[versions/v48.0.0/sdk]=versions/latest
 redirects[versions/v48.0.0/sdk/config/app]=versions/v48.0.0/config/app
 redirects[guides/how-expo-works]=faq
 redirects[config/app]=workflow/configuration
+redirects[versions/v50.0.0/sdk]=versions/v50.0.0
+redirects[versions/v49.0.0/sdk]=versions/v49.0.0
+redirects[versions/v47.0.0/sdk]=versions/v47.0.0
+redirects[versions/v46.0.0/sdk]=versions/v46.0.0
+redirects[guides/authentication.md]=guides/authentication
+redirects[versions/latest/workflow/linking/]=guides/linking
+redirects[versions/latest/sdk/overview]=versions/latest
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds more redirects for our docs based on [Algolia's 404 report](https://crawler.algolia.com/admin/crawlers/4dd4b03d-3266-4978-ab88-f93b12d4ad67/monitoring/list?reason=http_not_found).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
