### PR TITLE
[tools] Update project paths

### DIFF
--- a/tools/src/commands/PodInstallCommand.ts
+++ b/tools/src/commands/PodInstallCommand.ts
@@ -14,7 +14,7 @@ type ActionOptions = {
   all: boolean;
 };
 
-const importantProjects = ['ios', 'apps/bare-expo/ios'];
+const importantProjects = ['apps/bare-expo/ios', 'apps/expo-go/ios'];
 const otherProjects = ['apps/fabric-tester/ios', 'apps/native-tests/ios'];
 
 async function action(options: ActionOptions) {


### PR DESCRIPTION
# Why
Expo go is now in the `apps` directory so `et pods` fails.

# How
Update the project paths so `et pods` works again


