### PR TITLE
[docs] Remove Unit testing guide redirect

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -157,7 +157,6 @@ redirects[introduction/expo]=core-concepts
 redirects[introduction/faq]=faq
 redirects[workflow/expo-go]=get-started/expo-go
 redirects[errors-and-warnings]=debugging/errors-and-warnings
-redirects[develop/unit-testing]=develop/unit-testing
 redirects[guides/splash-screens]=develop/user-interface/splash-screen
 redirects[guides/app-icons]=develop/user-interface/app-icons
 redirects[guides/color-schemes]=develop/user-interface/color-themes


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #26135 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Removes self redirect: `redirects[develop/unit-testing]=develop/unit-testing` which has been added due to a previous PR that required fixing server side redirects by me.


Remove 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
