### PR TITLE
refactor: simplify `apps/*` metro configs

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -1,79 +1,63 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
-const baseConfig = getDefaultConfig(__dirname);
 const path = require('path');
 
 const root = path.join(__dirname, '../..');
+const config = getDefaultConfig(__dirname);
 
-baseConfig.watchFolders = [
+config.resolver.assetExts.push(
+  'db', // See: ../test-suite/assets/asset-db.db
+  'kml' // See: ../native-component-list/assets/expp-maps/sample_kml.kml
+);
+
+config.resolver.blockList = [
+  // Exclude react-native-lab from haste map.
+  // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+  // we should use the one from node_modules for bare-expo.
+  /\breact-native-lab\b/,
+
+  // Copied from expo-yarn-workspaces
+  /\/__tests__\//,
+  /\/android\/React(Android|Common)\//,
+  /\/versioned-react-native\//,
+];
+
+// Explicitly set all folders that needs to be watched
+// This is an optimization to avoid Metro watching the whole monorepo
+config.watchFolders = [
   __dirname,
   ...['packages', 'apps/test-suite', 'apps/native-component-list', 'node_modules'].map((v) =>
     path.join(root, v)
   ),
 ];
 
-/** @type {import('expo/metro-config').MetroConfig} */
-module.exports = {
-  ...baseConfig,
+// NOTE(brentvatne): This can be removed when
+// https://github.com/facebook/metro/issues/290 is fixed.
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    // When an asset is imported outside the project root, it has wrong path on Android
+    // This happens for the back button in stack, so we fix the path to correct one
+    const assets = '/node_modules/@react-navigation/elements/src/assets';
 
-  // NOTE(brentvatne): This can be removed when
-  // https://github.com/facebook/metro/issues/290 is fixed.
-  server: {
-    ...baseConfig.server,
-    enhanceMiddleware: (middleware) => {
-      return (req, res, next) => {
-        // When an asset is imported outside the project root, it has wrong path on Android
-        // This happens for the back button in stack, so we fix the path to correct one
-        const assets = '/node_modules/@react-navigation/elements/src/assets';
+    if (req.url.startsWith(assets)) {
+      req.url = req.url.replace(assets, `/assets/../..${assets}`);
+    }
 
-        if (req.url.startsWith(assets)) {
-          req.url = req.url.replace(assets, `/assets/../..${assets}`);
-        }
+    // Same as above when testing anything required via Asset.downloadAsync() in test-suite
+    const testSuiteAssets = '/test-suite/assets/';
 
-        // Same as above when testing anything required via Asset.downloadAsync() in test-suite
-        const testSuiteAssets = '/test-suite/assets/';
+    if (req.url.startsWith(testSuiteAssets)) {
+      req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
+    }
 
-        if (req.url.startsWith(testSuiteAssets)) {
-          req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
-        }
+    const nclAssets = '/native-component-list/';
 
-        const nclAssets = '/native-component-list/';
+    if (req.url.startsWith(nclAssets)) {
+      req.url = req.url.replace(nclAssets, '/assets/../native-component-list/');
+    }
 
-        if (req.url.startsWith(nclAssets)) {
-          req.url = req.url.replace(nclAssets, '/assets/../native-component-list/');
-        }
-
-        return middleware(req, res, next);
-      };
-    },
-  },
-
-  resolver: {
-    ...baseConfig.resolver,
-    assetExts: [
-      ...baseConfig.resolver.assetExts,
-      'db', // Copied from expo-yarn-workspaces
-      'kml',
-    ],
-    blockList: [
-      // Copied from expo-yarn-workspaces
-      /\/__tests__\//,
-      /\/android\/React(Android|Common)\//,
-      /\/versioned-react-native\//,
-
-      // Exclude react-native-lab from haste map.
-      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
-      // we should use the one from node_modules for bare-expo.
-      /\breact-native-lab\b/,
-    ],
-  },
-  transformer: {
-    ...baseConfig.transformer,
-    // Copied from expo-yarn-workspaces
-    // Ignore file-relative Babel configurations and apply only the project's
-    // NOTE: The Metro transformer still searches for and uses .babelrc and .babelrc.js files:
-    // https://github.com/facebook/react-native/blob/753bb2094d95c8eb2152d2a2c1f0b67bbeec36de/packages/react-native-babel-transformer/src/index.js#L81
-    // This is in contrast with Babel, which reads only babel.config.json before evaluating its
-    // "babelrc" option: https://babeljs.io/docs/options#configfile
-    enableBabelRCLookup: false,
-  },
+    return middleware(req, res, next);
+  };
 };
+
+module.exports = config;

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -1,13 +1,11 @@
 // Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
-const path = require('path');
 
-const root = path.join(__dirname, '../..');
 const config = getDefaultConfig(__dirname);
 
 config.resolver.assetExts.push(
   'db', // See: ../test-suite/assets/asset-db.db
-  'kml' // See: ../native-component-list/assets/expp-maps/sample_kml.kml
+  'kml' // See: ../native-component-list/assets/expo-maps/sample_kml.kml
 );
 
 config.resolver.blockList = [
@@ -21,43 +19,5 @@ config.resolver.blockList = [
   /\/android\/React(Android|Common)\//,
   /\/versioned-react-native\//,
 ];
-
-// Explicitly set all folders that needs to be watched
-// This is an optimization to avoid Metro watching the whole monorepo
-config.watchFolders = [
-  __dirname,
-  ...['packages', 'apps/test-suite', 'apps/native-component-list', 'node_modules'].map((v) =>
-    path.join(root, v)
-  ),
-];
-
-// NOTE(brentvatne): This can be removed when
-// https://github.com/facebook/metro/issues/290 is fixed.
-config.server.enhanceMiddleware = (middleware) => {
-  return (req, res, next) => {
-    // When an asset is imported outside the project root, it has wrong path on Android
-    // This happens for the back button in stack, so we fix the path to correct one
-    const assets = '/node_modules/@react-navigation/elements/src/assets';
-
-    if (req.url.startsWith(assets)) {
-      req.url = req.url.replace(assets, `/assets/../..${assets}`);
-    }
-
-    // Same as above when testing anything required via Asset.downloadAsync() in test-suite
-    const testSuiteAssets = '/test-suite/assets/';
-
-    if (req.url.startsWith(testSuiteAssets)) {
-      req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
-    }
-
-    const nclAssets = '/native-component-list/';
-
-    if (req.url.startsWith(nclAssets)) {
-      req.url = req.url.replace(nclAssets, '/assets/../native-component-list/');
-    }
-
-    return middleware(req, res, next);
-  };
-};
 
 module.exports = config;

--- a/apps/fabric-tester/metro.config.js
+++ b/apps/fabric-tester/metro.config.js
@@ -1,4 +1,0 @@
-// Learn more https://docs.expo.io/guides/customizing-metro
-const { getDefaultConfig } = require('expo/metro-config');
-
-module.exports = getDefaultConfig(__dirname);

--- a/apps/jest-expo-mock-generator/metro.config.js
+++ b/apps/jest-expo-mock-generator/metro.config.js
@@ -1,3 +1,0 @@
-const { getDefaultConfig } = require('expo/metro-config');
-
-module.exports = getDefaultConfig(__dirname);

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -1,81 +1,64 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const baseConfig = getDefaultConfig(__dirname);
-
 const root = path.join(__dirname, '../..');
+const config = getDefaultConfig(__dirname);
 
-// To test NCL from Expo Go, the react-native js source is from our fork.
-const reactNativeRoot = path.join(
-  root,
-  'react-native-lab',
-  'react-native',
-  'packages',
-  'react-native'
+config.resolver.assetExts.push(
+  'kml' // See: ../native-component-list/assets/expp-maps/sample_kml.kml
 );
 
-baseConfig.watchFolders = [
+config.resolver.blockList = [
+  // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+  // metro and react-native cannot serve duplicated files from different paths.
+  // Assuming NCL only serves for Expo Go,
+  // the strategy here is to serve react-native imports from `react-native-lab/react-native` but not its transitive dependencies.
+  // That is not ideal but should work for most cases if the two react-native versions do not have too much difference.
+  // For example, `react-native-lab/react-native/node_modules/@react-native/polyfills` and `node_modules/@react-native/polyfills` may be different,
+  // the metro config will use the transitive dependency from `node_modules/@react-native/polyfills`.
+  /\breact-native-lab\/react-native\/node_modules\b/,
+
+  // Copied from expo-yarn-workspaces
+  /\/__tests__\//,
+  /\/android\/React(Android|Common)\//,
+  /\/versioned-react-native\//,
+];
+
+// To test NCL from Expo Go, the react-native js source is from our fork.
+config.serializer.getPolyfills = () => {
+  const reactNativeRoot = path.join(
+    root,
+    'react-native-lab',
+    'react-native',
+    'packages',
+    'react-native'
+  );
+
+  return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
+};
+
+// Explicitly set all folders that needs to be watched
+// This is an optimization to avoid Metro watching the whole monorepo
+config.watchFolders = [
   __dirname,
   ...['packages', 'node_modules', 'react-native-lab'].map((v) => path.join(root, v)),
 ];
 
-module.exports = {
-  ...baseConfig,
+// NOTE(brentvatne): This can be removed when
+// https://github.com/facebook/metro/issues/290 is fixed.
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    // When an asset is imported outside the project root, it has wrong path on Android
+    // This happens for the back button in stack, so we fix the path to correct one
+    const assets = '/node_modules/@react-navigation/elements/src/assets';
 
-  // NOTE(brentvatne): This can be removed when
-  // https://github.com/facebook/metro/issues/290 is fixed.
-  server: {
-    ...baseConfig.server,
-    enhanceMiddleware: (middleware) => {
-      return (req, res, next) => {
-        // When an asset is imported outside the project root, it has wrong path on Android
-        // This happens for the back button in stack, so we fix the path to correct one
-        const assets = '/node_modules/@react-navigation/elements/src/assets';
+    if (req.url.startsWith(assets)) {
+      req.url = req.url.replace(assets, `/assets/../..${assets}`);
+    }
 
-        if (req.url.startsWith(assets)) {
-          req.url = req.url.replace(assets, `/assets/../..${assets}`);
-        }
-
-        return middleware(req, res, next);
-      };
-    },
-  },
-
-  resolver: {
-    ...baseConfig.resolver,
-    assetExts: [
-      ...baseConfig.resolver.assetExts,
-      'db', // Copied from expo-yarn-workspaces
-      'kml'
-    ],
-    blockList: [
-      // Copied from expo-yarn-workspaces
-      /\/__tests__\//,
-      /\/android\/React(Android|Common)\//,
-      /\/versioned-react-native\//,
-
-      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
-      // metro and react-native cannot serve duplicated files from different paths.
-      // Assuming NCL only serves for Expo Go,
-      // the strategy here is to serve react-native imports from `react-native-lab/react-native` but not its transitive dependencies.
-      // That is not ideal but should work for most cases if the two react-native versions do not have too much difference.
-      // For example, `react-native-lab/react-native/node_modules/@react-native/polyfills` and `node_modules/@react-native/polyfills` may be different,
-      // the metro config will use the transitive dependency from `node_modules/@react-native/polyfills`.
-      /\breact-native-lab\/react-native\/node_modules\b/,
-    ],
-  },
-  serializer: {
-    ...baseConfig.serializer,
-    getPolyfills: () => require(path.join(reactNativeRoot, 'rn-get-polyfills'))(),
-  },
-  transformer: {
-    ...baseConfig.transformer,
-    // Copied from expo-yarn-workspaces
-    // Ignore file-relative Babel configurations and apply only the project's
-    // NOTE: The Metro transformer still searches for and uses .babelrc and .babelrc.js files:
-    // https://github.com/facebook/react-native/blob/753bb2094d95c8eb2152d2a2c1f0b67bbeec36de/packages/react-native-babel-transformer/src/index.js#L81
-    // This is in contrast with Babel, which reads only babel.config.json before evaluating its
-    // "babelrc" option: https://babeljs.io/docs/options#configfile
-    enableBabelRCLookup: false,
-  },
+    return middleware(req, res, next);
+  };
 };
+
+module.exports = config;

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -2,11 +2,11 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const root = path.join(__dirname, '../..');
+const monorepoRoot = path.join(__dirname, '../..');
 const config = getDefaultConfig(__dirname);
 
 config.resolver.assetExts.push(
-  'kml' // See: ../native-component-list/assets/expp-maps/sample_kml.kml
+  'kml' // See: ../native-component-list/assets/expo-maps/sample_kml.kml
 );
 
 config.resolver.blockList = [
@@ -28,7 +28,7 @@ config.resolver.blockList = [
 // To test NCL from Expo Go, the react-native js source is from our fork.
 config.serializer.getPolyfills = () => {
   const reactNativeRoot = path.join(
-    root,
+    monorepoRoot,
     'react-native-lab',
     'react-native',
     'packages',
@@ -36,29 +36,6 @@ config.serializer.getPolyfills = () => {
   );
 
   return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
-};
-
-// Explicitly set all folders that needs to be watched
-// This is an optimization to avoid Metro watching the whole monorepo
-config.watchFolders = [
-  __dirname,
-  ...['packages', 'node_modules', 'react-native-lab'].map((v) => path.join(root, v)),
-];
-
-// NOTE(brentvatne): This can be removed when
-// https://github.com/facebook/metro/issues/290 is fixed.
-config.server.enhanceMiddleware = (middleware) => {
-  return (req, res, next) => {
-    // When an asset is imported outside the project root, it has wrong path on Android
-    // This happens for the back button in stack, so we fix the path to correct one
-    const assets = '/node_modules/@react-navigation/elements/src/assets';
-
-    if (req.url.startsWith(assets)) {
-      req.url = req.url.replace(assets, `/assets/../..${assets}`);
-    }
-
-    return middleware(req, res, next);
-  };
 };
 
 module.exports = config;

--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 

--- a/apps/sandbox/metro.config.js
+++ b/apps/sandbox/metro.config.js
@@ -1,3 +1,4 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -1,79 +1,61 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 /* eslint-env node */
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const baseConfig = getDefaultConfig(__dirname);
-
 const root = path.join(__dirname, '../..');
+const config = getDefaultConfig(__dirname);
 
-const reactNativeRoot = path.join(
-  root,
-  'react-native-lab',
-  'react-native',
-  'packages',
-  'react-native'
+config.resolver.assetExts.push(
+  'db' // See: ../test-suite/assets/asset-db.db
 );
 
-/** @type {import('expo/metro-config').MetroConfig} */
-module.exports = {
-  ...baseConfig,
+config.resolver.blockList = [
+  // Exclude react-native-lab from haste map.
+  // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+  // we should use the one from node_modules for bare-expo.
+  /\breact-native-lab\/react-native\/node_modules\b/,
 
-  // NOTE(brentvatne): This can be removed when
-  // https://github.com/facebook/metro/issues/290 is fixed.
-  server: {
-    ...baseConfig.server,
-    enhanceMiddleware: (middleware) => {
-      return (req, res, next) => {
-        // When an asset is imported outside the project root, it has wrong path on Android
-        // This happens for the back button in stack, so we fix the path to correct one
-        const assets = '/node_modules/@react-navigation/stack/src/views/assets';
+  // Copied from expo-yarn-workspaces
+  /\/__tests__\//,
+  /\/android\/React(Android|Common)\//,
+  /\/versioned-react-native\//,
+];
 
-        if (req.url.startsWith(assets)) {
-          req.url = req.url.replace(assets, `/assets/../..${assets}`);
-        }
+// To test test-suite from Expo Go, the react-native js source is from our fork.
+config.serializer.getPolyfills = () => {
+  const reactNativeRoot = path.join(
+    root,
+    'react-native-lab',
+    'react-native',
+    'packages',
+    'react-native'
+  );
 
-        // Same as above when testing anything required via Asset.downloadAsync() in test-suite
-        const testSuiteAssets = '/test-suite/assets/';
-
-        if (req.url.startsWith(testSuiteAssets)) {
-          req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
-        }
-
-        return middleware(req, res, next);
-      };
-    },
-  },
-  resolver: {
-    ...baseConfig.resolver,
-    assetExts: [
-      ...baseConfig.resolver.assetExts,
-      'db', // Copied from expo-yarn-workspaces
-      'kml',
-    ],
-    blockList: [
-      // Copied from expo-yarn-workspaces
-      /\/__tests__\//,
-      /\/android\/React(Android|Common)\//,
-      /\/versioned-react-native\//,
-
-      // Exclude react-native-lab from haste map.
-      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
-      // we should use the one from node_modules for bare-expo.
-      /\breact-native-lab\/react-native\/node_modules\b/,
-    ],
-  },
-  serializer: {
-    ...baseConfig.serializer,
-    getPolyfills: () => require(path.join(reactNativeRoot, 'rn-get-polyfills'))(),
-  },
-  transformer: {
-    ...baseConfig.transformer,
-    // Copied from expo-yarn-workspaces
-    // Ignore file-relative Babel configurations and apply only the project's
-    // NOTE: The Metro transformer still searches for and uses .babelrc and .babelrc.js files:
-    // https://github.com/facebook/react-native/blob/753bb2094d95c8eb2152d2a2c1f0b67bbeec36de/packages/react-native-babel-transformer/src/index.js#L81
-    // This is in contrast with Babel, which reads only babel.config.json before evaluating its
-    // "babelrc" option: https://babeljs.io/docs/options#configfile
-    enableBabelRCLookup: false,
-  },
+  return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
 };
+
+// NOTE(brentvatne): This can be removed when
+// https://github.com/facebook/metro/issues/290 is fixed.
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    // When an asset is imported outside the project root, it has wrong path on Android
+    // This happens for the back button in stack, so we fix the path to correct one
+    const assets = '/node_modules/@react-navigation/stack/src/views/assets';
+
+    if (req.url.startsWith(assets)) {
+      req.url = req.url.replace(assets, `/assets/../..${assets}`);
+    }
+
+    // Same as above when testing anything required via Asset.downloadAsync() in test-suite
+    const testSuiteAssets = '/test-suite/assets/';
+
+    if (req.url.startsWith(testSuiteAssets)) {
+      req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
+    }
+
+    return middleware(req, res, next);
+  };
+};
+
+module.exports = config;

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -3,7 +3,7 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const root = path.join(__dirname, '../..');
+const monorepoRoot = path.join(__dirname, '../..');
 const config = getDefaultConfig(__dirname);
 
 config.resolver.assetExts.push(
@@ -25,7 +25,7 @@ config.resolver.blockList = [
 // To test test-suite from Expo Go, the react-native js source is from our fork.
 config.serializer.getPolyfills = () => {
   const reactNativeRoot = path.join(
-    root,
+    monorepoRoot,
     'react-native-lab',
     'react-native',
     'packages',
@@ -33,29 +33,6 @@ config.serializer.getPolyfills = () => {
   );
 
   return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
-};
-
-// NOTE(brentvatne): This can be removed when
-// https://github.com/facebook/metro/issues/290 is fixed.
-config.server.enhanceMiddleware = (middleware) => {
-  return (req, res, next) => {
-    // When an asset is imported outside the project root, it has wrong path on Android
-    // This happens for the back button in stack, so we fix the path to correct one
-    const assets = '/node_modules/@react-navigation/stack/src/views/assets';
-
-    if (req.url.startsWith(assets)) {
-      req.url = req.url.replace(assets, `/assets/../..${assets}`);
-    }
-
-    // Same as above when testing anything required via Asset.downloadAsync() in test-suite
-    const testSuiteAssets = '/test-suite/assets/';
-
-    if (req.url.startsWith(testSuiteAssets)) {
-      req.url = req.url.replace(testSuiteAssets, '/assets/../test-suite/assets/');
-    }
-
-    return middleware(req, res, next);
-  };
 };
 
 module.exports = config;


### PR DESCRIPTION
# Why

This is a follow-up from https://github.com/expo/expo/pull/25844.

Following the best-practices when customizing the Metro config ([docs](https://docs.expo.dev/guides/customizing-metro/)), and dropping the legacy asset workarounds from the configs.

This also now fully uses the built-in [monorepo support](https://docs.expo.dev/guides/monorepos/) that we have had since SDK 49. It's in good shape and works in this repository, we just need to keep dogfooding it.

# How

- Dropped "empty" metro configs that just exports `module.exports = getDefaultConfig(__dirname);`
- Refactored `apps/bare-expo` metro config
- Refactored `apps/native-component-list` metro config
- Refactored `apps/test-suite` metro config
- Dropped all legacy workarounds (mostly `enhancedMiddleware`, now [fixed through `expo-asset`](https://github.com/expo/expo/blob/bf526ca325cd8073e00f6014f07f07450e7b6576/packages/expo-asset/tools/hashAssetFiles.js#L18-L29))

# Test Plan

After a fresh install, run all apps and see if Metro runs into trouble.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
