### PR TITLE
[docs] Follow up example updates in SQLite reference

### DIFF
--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -62,6 +62,10 @@ module.exports = defaultConfig;
 Use the following function (or similar) to open your database:
 
 ```ts
+import * as FileSystem from 'expo-file-system';
+import * as SQLite from 'expo-sqlite';
+import { Asset } from 'expo-asset';
+
 async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
@@ -81,6 +85,8 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
 > You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>

--- a/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
@@ -62,6 +62,10 @@ module.exports = defaultConfig;
 Use the following function (or similar) to open your database:
 
 ```ts
+import * as FileSystem from 'expo-file-system';
+import * as SQLite from 'expo-sqlite';
+import { Asset } from 'expo-asset';
+
 async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
@@ -81,6 +85,8 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
 > You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>

--- a/docs/pages/versions/v48.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/sqlite.mdx
@@ -62,6 +62,10 @@ module.exports = defaultConfig;
 Use the following function (or similar) to open your database:
 
 ```ts
+import * as FileSystem from 'expo-file-system';
+import * as SQLite from 'expo-sqlite';
+import { Asset } from 'expo-asset';
+
 async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
@@ -81,6 +85,8 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
 > You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>

--- a/docs/pages/versions/v49.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sqlite.mdx
@@ -62,6 +62,10 @@ module.exports = defaultConfig;
 Use the following function (or similar) to open your database:
 
 ```ts
+import * as FileSystem from 'expo-file-system';
+import * as SQLite from 'expo-sqlite';
+import { Asset } from 'expo-asset';
+
 async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
@@ -81,6 +85,8 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
 > You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>

--- a/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
@@ -62,6 +62,10 @@ module.exports = defaultConfig;
 Use the following function (or similar) to open your database:
 
 ```ts
+import * as FileSystem from 'expo-file-system';
+import * as SQLite from 'expo-sqlite';
+import { Asset } from 'expo-asset';
+
 async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
@@ -79,6 +83,8 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
 ### Executing statements with an async transaction
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 const readOnly = true;
@@ -93,6 +99,8 @@ await db.transactionAsync(async tx => {
 > You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
+import * as SQLite from 'expo-sqlite';
+
 const db = SQLite.openDatabase('dbName', version);
 
 await db.execAsync([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Backport example updates from #26060 to versioned API references.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
