### PR TITLE
[core] Add Date type converters

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Added support for macOS platform. ([#26186](https://github.com/expo/expo/pull/26186) by [@tsapeta](https://github.com/tsapeta))
-- Add `Date` type converter.
+- Add `Date` type converter. ([#26148](https://github.com/expo/expo/pull/26148) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for macOS platform. ([#26186](https://github.com/expo/expo/pull/26186) by [@tsapeta](https://github.com/tsapeta))
+- Add `Date` type converter.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -18,19 +18,14 @@ class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalD
   override fun convertFromDynamic(value: Dynamic): LocalDate {
     return when (value.type) {
       ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
-      ReadableType.Number -> {
-        val instant = Instant.ofEpochMilli(value.asDouble().toLong())
-        instant.atZone(ZoneId.systemDefault()).toLocalDate()
-      }
+      ReadableType.Number -> convertFromLong(value.asDouble().toLong())
       else -> throw UnexpectedException("Unknown argument type: ${value.type}")
     }
   }
 
   override fun convertFromAny(value: Any): LocalDate {
     return when (value) {
-      is String -> {
-        LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
-      }
+      is String -> LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
       is Long -> convertFromLong(value)
       else -> throw UnexpectedException("Unknown argument type: ${value::class}")
     }
@@ -42,7 +37,7 @@ class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalD
   }
 
   override fun getCppRequiredTypes() = ExpectedType(
-    SingleType(CppType.LONG),
+    SingleType(CppType.INT),
     SingleType(CppType.STRING)
   )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -1,0 +1,50 @@
+package expo.modules.kotlin.types
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.jni.SingleType
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@RequiresApi(Build.VERSION_CODES.O)
+class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalDate>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): LocalDate {
+    return when (value.type) {
+      ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
+      ReadableType.Number -> {
+        val instant = Instant.ofEpochMilli(value.asDouble().toLong())
+        instant.atZone(ZoneId.systemDefault()).toLocalDate()
+      }
+      else -> throw UnexpectedException("Unknown argument type: ${value.type}")
+    }
+  }
+
+  override fun convertFromAny(value: Any): LocalDate {
+    return when (value) {
+      is String -> {
+        LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
+      }
+      is Long -> convertFromLong(value)
+      else -> throw UnexpectedException("Unknown argument type: ${value::class}")
+    }
+  }
+
+  private fun convertFromLong(value: Long): LocalDate {
+    val instant = Instant.ofEpochMilli(value)
+    return instant.atZone(ZoneId.systemDefault()).toLocalDate()
+  }
+
+  override fun getCppRequiredTypes() = ExpectedType(
+    SingleType(CppType.LONG),
+    SingleType(CppType.STRING)
+  )
+
+  override fun isTrivial() = false
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -41,6 +41,7 @@ import java.io.File
 import java.net.URI
 import java.net.URL
 import java.nio.file.Path
+import java.time.LocalDate
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -302,7 +303,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
       return converters + mapOf(
         Path::class to PathTypeConverter(isOptional),
-        Color::class to ColorTypeConverter(isOptional)
+        Color::class to ColorTypeConverter(isOptional),
+        LocalDate::class to DateTypeConverter(isOptional)
       )
     }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
@@ -1,0 +1,35 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.DynamicFromObject
+import com.google.common.truth.Truth
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.Month
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class DateTypeConverterTest {
+  @Test
+  fun `converts from ISO 8601 String to LocalDate`() {
+    val dateString = DynamicFromObject("2023-12-27T22:44:17.806Z")
+    val date = convert<LocalDate>(dateString)
+    Truth.assertThat(date.month).isEqualTo(Month.DECEMBER)
+    Truth.assertThat(date.monthValue).isEqualTo(12)
+    Truth.assertThat(date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+    Truth.assertThat(date.year).isEqualTo(2023)
+  }
+
+  @Test
+  fun `converts from Long to LocalDate`() {
+    val dateValue = 1703718341639
+    val date = convert<LocalDate>(dateValue)
+    Truth.assertThat(date.month).isEqualTo(Month.DECEMBER)
+    Truth.assertThat(date.monthValue).isEqualTo(12)
+    Truth.assertThat(date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+    Truth.assertThat(date.year).isEqualTo(2023)
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
@@ -24,9 +24,8 @@ class DateTypeConverterTest {
   }
 
   @Test
-  fun `converts from Long to LocalDate`() {
-    val dateValue = 1703718341639
-    val date = convert<LocalDate>(dateValue)
+  fun `converts from Number to LocalDate`() {
+    val date = convert<LocalDate>(1703718341639)
     Truth.assertThat(date.month).isEqualTo(Month.DECEMBER)
     Truth.assertThat(date.monthValue).isEqualTo(12)
     Truth.assertThat(date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)

--- a/packages/expo-modules-core/ios/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Arguments/Convertibles.swift
@@ -95,3 +95,21 @@ extension CGRect: Convertible {
     throw Conversions.ConvertingException<CGRect>(value)
   }
 }
+
+extension Date: Convertible {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> Date {
+    if let value = value as? String {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+      guard let date = formatter.date(from: value) else {
+        throw Conversions.ConvertingException<Date>(value)
+      }
+      return date
+    }
+    // For converting the value from `Date.now()`
+    if let value = value as? Int {
+      return Date(timeIntervalSince1970: Double(value) / 1000.0)
+    }
+    throw Conversions.ConvertingException<Date>(value)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -381,5 +381,21 @@ class ConvertiblesSpec: ExpoSpec {
         })
       }
     }
+    
+    describe("Date") {
+      it("converts from `ISO 8601` String to Date") {
+        let date = try Date.convert(from: "2023-12-27T10:58:20.654Z", appContext: appContext)
+        let components = Calendar.current.dateComponents([.day, .month], from: date)
+        expect(components.month) == 12
+        expect(components.day) == 27
+      }
+      
+      it("converts from `Date.now()` to Date") {
+        let date = try Date.convert(from: 1703718341639, appContext: appContext)
+        let components = Calendar.current.dateComponents([.day, .month], from: date)
+        expect(components.month) == 12
+        expect(components.day) == 27
+      }
+    }
   }
 }


### PR DESCRIPTION
# Why
Add converters to parse `Date` arguments. Can convert from a `ISO 8601` formatted string or from an epoch value.

# How
- Added `Convertible` conformance to `Date` on `iOS`
- Added type converter on Android that converts to a `LocalDate`

# Test Plan
Added new tests 

