### PR TITLE
chore(apps): add `watchFolders` back to speed up Metro

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -1,6 +1,8 @@
 // Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
 
+const monorepoRoot = path.join(__dirname, '../..');
 const config = getDefaultConfig(__dirname);
 
 config.resolver.assetExts.push(
@@ -18,6 +20,17 @@ config.resolver.blockList = [
   /\/__tests__\//,
   /\/android\/React(Android|Common)\//,
   /\/versioned-react-native\//,
+];
+
+// Minimize the "watched" folders that Metro crawls through to speed up Metro in big monorepos.
+// Note, omitting folders disables Metro from resolving files within these folders
+// This also happens when symlinks falls within these folders, but the real location doesn't.
+config.watchFolders = [
+  __dirname, // Allow Metro to resolve all files within this project
+  path.join(monorepoRoot, 'apps/native-component-list'), // Allow Metro to resolve all files within NCL
+  path.join(monorepoRoot, 'apps/test-suite'), // Allow Metro to resolve all files within test-suite
+  path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
+  path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
 ];
 
 module.exports = config;

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -38,4 +38,14 @@ config.serializer.getPolyfills = () => {
   return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
 };
 
+// Minimize the "watched" folders that Metro crawls through to speed up Metro in big monorepos.
+// Note, omitting folders disables Metro from resolving files within these folders
+// This also happens when symlinks falls within these folders, but the real location doesn't.
+config.watchFolders = [
+  __dirname, // Allow Metro to resolve all files within this project
+  path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
+  path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
+  path.join(monorepoRoot, 'react-native-lab'), // Allow Metro to resolve `react-native-lab/react-native` files
+];
+
 module.exports = config;

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -35,4 +35,14 @@ config.serializer.getPolyfills = () => {
   return require(path.join(reactNativeRoot, 'rn-get-polyfills'))();
 };
 
+// Minimize the "watched" folders that Metro crawls through to speed up Metro in big monorepos.
+// Note, omitting folders disables Metro from resolving files within these folders
+// This also happens when symlinks falls within these folders, but the real location doesn't.
+config.watchFolders = [
+  __dirname, // Allow Metro to resolve all files within this project
+  path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
+  path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
+  path.join(monorepoRoot, 'react-native-lab'), // Allow Metro to resolve `react-native-lab/react-native` files
+];
+
 module.exports = config;


### PR DESCRIPTION
# Why

🤷 

# How

- Add back `watchFolders` from before the EYW deprecation

# Test Plan

See if apps still work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
