### PR TITLE
[expo-intent-launcher] [Android] Fix the startActivityAsync number extra parameters that are converting to Double

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- On Android, intent number extras are converted to `double`. However, it must be `int`.
 
 ### 💡 Others
 

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- On Android, intent number extras are converted to `double`. However, it must be `int`.
+- On Android, intent number extras are converted to `double`. However, it must be `int`. ([#26164](https://github.com/expo/expo/pull/26164) by [@Alperengozum](https://github.com/Alperengozum))
 
 ### 💡 Others
 

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -57,7 +57,7 @@ class IntentLauncherModule : Module() {
 
       params.extra?.let {
         val valuesList = it.mapValues { (_, value) ->
-            if (value is Double) value.toInt() else value
+          if (value is Double) value.toInt() else value
         }
         intent.putExtras(valuesList.toBundle())
       }

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -55,7 +55,12 @@ class IntentLauncherModule : Module() {
         }
       }
 
-      params.extra?.let { intent.putExtras(it.toBundle()) }
+      params.extra?.let {
+        val valuesList = it.mapValues { (_, value) ->
+            if (value is Double) value.toInt() else value
+        }
+        intent.putExtras(valuesList.toBundle())
+      }
       params.flags?.let { intent.addFlags(it) }
       params.category?.let { intent.addCategory(it) }
 


### PR DESCRIPTION
# Why

When using `startActivityAsync(activityAction, params)` with the number required as an extra parameter, it converts the number to a double and causes problems.

# How

When a number parameter is given, it converts the double. Then I converted the double extra parameters to integer in `IntentLauncherModule.kt`

# Test Plan

Install expo-intent-launcher in the expo project.
Try to set an alarm with intent or any number extra parameter required for intent.
```typescript 
startActivityAsync("android.intent.action.SET_ALARM", {
  extra: {
    'android.intent.extra.alarm.HOUR': 10,
    'android.intent.extra.alarm.MESSAGE': 'Alarm',
    'android.intent.extra.alarm.MINUTE': 10,
     }
});
```
It will not respond to any error logs in the terminal, but it will cause an error that can be found in Android Studio logcat.
`Key android.intent.extra.alarm.HOUR expected Integer but value was a java.lang.Double. The default value -1 was returned.`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
