### PR TITLE
[docs][router] Fix broken tabs due to extra space

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -207,13 +207,11 @@ After updating the Babel config file, run the following command to clear the bun
 
 <Tabs>
 
-{' '}
-
-<Tab label="SDK 50 and above">
-  If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
-  resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
-  `metro-resolver`, `react-refresh` resolutions from your **package.json**.
-</Tab>
+  <Tab label="SDK 50 and above">
+    If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
+    resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
+    `metro-resolver`, `react-refresh` resolutions from your **package.json**.
+  </Tab>
 
   <Tab label="SDK 49">
     Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 / Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.


### PR DESCRIPTION
# Why

Tab layout on installation document's 'Update resolutions' section was broken due to an extra space.

# How

Removed extra space.

# Test Plan

Tested the fixed layout using `yarn dev` on docs module.

## Before fix

![before](https://github.com/expo/expo/assets/23395243/fdc466fe-1c3e-4dfd-af4e-4b1a25a48f24)
![before2](https://github.com/expo/expo/assets/23395243/6f33588a-b300-4bba-8773-e0ab371a51ea)

## After fix

![after](https://github.com/expo/expo/assets/23395243/24b058a6-0fc2-4ce4-90e7-a330593faeb7)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
