### PR TITLE
[docs] Update language for syntax highlights

### DIFF
--- a/docs/pages/archive/classic-updates/configuring-updates.mdx
+++ b/docs/pages/archive/classic-updates/configuring-updates.mdx
@@ -26,7 +26,7 @@ Setting `updates.checkAutomatically` to `"ON_ERROR_RECOVERY"` in app.json will p
 
 You can then use the `expo-updates` module to download new updates and, if appropriate, notify the user to reload their app.
 
-```javascript
+```js
 import * as Updates from 'expo-updates';
 
 try {

--- a/docs/pages/archive/classic-updates/updating-your-app.mdx
+++ b/docs/pages/archive/classic-updates/updating-your-app.mdx
@@ -167,7 +167,7 @@ Setting `checkOnLaunch` to `NEVER` will prevent `expo-updates` from automaticall
 
 You can then use the [`expo-updates`](../versions/latest/sdk/updates.mdx) module included with this library to download new updates and, if appropriate, notify the user and reload the experience.
 
-```javascript
+```js
 try {
   const update = await Updates.checkForUpdateAsync();
   if (update.isAvailable) {

--- a/docs/pages/archive/notification-channels.mdx
+++ b/docs/pages/archive/notification-channels.mdx
@@ -25,7 +25,7 @@ You can read more about notification channels on the [Android developer website]
 
 Creating a channel is easy -- before you create a local notification (or receive a push notification), simply call the following method:
 
-```javascript
+```js
 if (Platform.OS === 'android') {
   Notifications.createChannelAndroidAsync('chat-messages', {
     name: 'Chat messages',
@@ -38,7 +38,7 @@ Creating a channel that already exists is essentially a no-op, so it's safe to c
 
 Then, when you want to send a notification for a chat message, either add the `channelId: 'chat-messages'` field to your [push notification message](../push-notifications/#message-format), or create a local notification like this:
 
-```javascript
+```js
 Notifications.presentLocalNotificationAsync({
   title: 'New Message',
   body: 'Message!!!!',
@@ -66,7 +66,7 @@ Once you have decided on a set of channels, you need to add logic to your app to
 
 For example, if this is your code before:
 
-```javascript
+```js
 _createNotificationAsync = () => {
   Notifications.presentLocalNotificationAsync({
     title: 'Reminder',
@@ -82,7 +82,7 @@ _createNotificationAsync = () => {
 
 You might change it to something like this:
 
-```javascript
+```js
 componentDidMount() {
   // ...
   if (Platform.OS === 'android') {
@@ -112,7 +112,7 @@ This will create a channel called "Reminders" with default settings of `max` pri
 
 ## Send channel notification with Expo API service
 
-```javascript
+```js
 [
   {
     to: 'ExponentPushToken[xxxxxx]',

--- a/docs/pages/archive/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/archive/technical-specs/expo-updates-0.mdx
@@ -102,7 +102,7 @@ expo-signature: *
 
 The body of the response MUST be a manifest, which is defined as JSON conforming to both the following `Manifest` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 
-```typescript
+```ts
 type Manifest = {
   id: string;
   createdAt: string;
@@ -176,7 +176,7 @@ Each part is defined as follows:
 
 Defined as JSON conforming to both the following `ManifestExtensions` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 
-```typescript
+```ts
 type ManifestExtensions = {
   assetRequestHeaders: ExpoAssetHeaderDictionary;
   ...

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -139,7 +139,7 @@ The `@expo/vector-icons` library provides `createIconSetFromFontello` method to 
 
 It follows the similar configuration as `createIconSetFromIcoMoon` as shown in the example:
 
-```javascript
+```js
 // Import the createIconSetFromFontello method
 import { createIconSetFromFontello } from '@expo/vector-icons';
 

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -260,7 +260,7 @@ For more information, see [`expo-linking`](/versions/latest/sdk/linking) API ref
 
 Parse the **path**, **hostname**, and **query parameters** from a URL with the `Linking.parse()` function. Unlike other URL parsing methods, this function considers nonstandard implementations like [Expo Go linking](#linking-to-expo-go). Example:
 
-```javascript
+```js
 function App() {
   const url = Linking.useURL();
 

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -126,7 +126,7 @@ const withMyApiKey = config => {
 };
 ```
 
-Additionally, you can use `mods`, which are async functions that modify files in native projects such as source code or configuration (plist, xml) files. The `mods` object is different from the rest of the app config because it doesn't get serialized after the initial reading. This means you can use it to perform actions *during* code generation.
+Additionally, you can use `mods`, which are async functions that modify files in native projects such as source code or configuration (plist, xml) files. The `mods` object is different from the rest of the app config because it doesn't get serialized after the initial reading. This means you can use it to perform actions _during_ code generation.
 
 However, there are a few considerations that we should follow when writing config plugins:
 
@@ -153,7 +153,7 @@ Let's start by creating our plugin with this minimal boilerplate. This will crea
 
 2. Create a **plugin/src/index.ts** file for our plugin:
 
-   ```typescript plugin/src/index.ts
+   ```ts plugin/src/index.ts
    import { ConfigPlugin } from 'expo/config-plugins';
 
    const withMyApiKey: ConfigPlugin = config => {
@@ -189,7 +189,7 @@ To inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we
 
 As the name suggests, `withInfoPlist` allows us to read and modify **Info.plist** values. Using the `modResults` property, we can add custom values as demonstrated in the code snippet below:
 
-```typescript
+```ts
 const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
   config = withInfoPlist(config, config => {
     config.modResults['MY_CUSTOM_API_KEY'] = apiKey;
@@ -202,7 +202,7 @@ const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
 
 Similarly, we can use `withAndroidManifest` to modify the **AndroidManifest.xml** file. In this case, we will utilize `AndroidConfig` helpers to add a meta data item to the main application:
 
-```typescript
+```ts
 const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
   config = withAndroidManifest(config, config => {
     const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
@@ -221,7 +221,7 @@ const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
 
 We can create our custom plugin by merging everything into a single function:
 
-```typescript plugin/src/index.ts
+```ts plugin/src/index.ts
 import {
   withInfoPlist,
   withAndroidManifest,

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -64,7 +64,7 @@ class ExpoSettingsModule : Module() {
 }
 ```
 
-```typescript src/index.ts
+```ts src/index.ts
 import ExpoSettingsModule from './ExpoSettingsModule';
 
 export function getTheme(): string {
@@ -72,7 +72,7 @@ export function getTheme(): string {
 }
 ```
 
-```typescript example/App.tsx
+```tsx example/App.tsx
 import * as Settings from 'expo-settings';
 import { Text, View } from 'react-native';
 
@@ -176,7 +176,7 @@ class ExpoSettingsModule : Module() {
 
 Now we can call our native modules from TypeScript.
 
-```typescript src/index.ts
+```ts src/index.ts
 import ExpoSettingsModule from './ExpoSettingsModule';
 
 export function getTheme(): string {
@@ -192,7 +192,7 @@ export function setTheme(theme: string): void {
 
 We can now use the `Settings` API in our example app.
 
-```typescript example/App.tsx
+```tsx example/App.tsx
 import * as Settings from 'expo-settings';
 import { Button, Text, View } from 'react-native';
 
@@ -281,7 +281,7 @@ class ExpoSettingsModule : Module() {
 
 ### TypeScript module
 
-```typescript src/index.ts
+```ts src/index.ts
 import { EventEmitter, Subscription } from 'expo-modules-core';
 import ExpoSettingsModule from './ExpoSettingsModule';
 
@@ -306,7 +306,7 @@ export function setTheme(theme: string): void {
 
 ### Example app
 
-```typescript example/App.tsx
+```tsx example/App.tsx
 import * as Settings from 'expo-settings';
 import * as React from 'react';
 import { Button, Text, View } from 'react-native';
@@ -414,7 +414,7 @@ enum class Theme(val value: String) : Enumerable {
 
 ### TypeScript module
 
-```typescript src/index.ts
+```ts src/index.ts
 import { EventEmitter, Subscription } from 'expo-modules-core';
 
 import ExpoSettingsModule from './ExpoSettingsModule';

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -222,7 +222,7 @@ class ExpoWebViewModule : Module() {
 
 All we need to do here is add the `url` prop to the `Props` type.
 
-```typescript src/ExpoWebView.tsx
+```tsx src/ExpoWebView.tsx
 import { ViewProps } from 'react-native';
 import { requireNativeViewManager } from 'expo-modules-core';
 import * as React from 'react';
@@ -242,7 +242,7 @@ export default function ExpoWebView(props: Props) {
 
 Finally, we can pass in a URL to our WebView component in the example app.
 
-```typescript example/App.tsx
+```tsx example/App.tsx
 import { WebView } from 'expo-web-view';
 
 export default function App() {
@@ -374,7 +374,7 @@ class ExpoWebViewModule : Module() {
 
 Note that event payloads are included within the `nativeEvent` property of the event, so to access the `url` from the `onLoad` event we would read `event.nativeEvent.url`.
 
-```typescript src/ExpoWebView.tsx
+```tsx src/ExpoWebView.tsx
 import { ViewProps } from 'react-native';
 import { requireNativeViewManager } from 'expo-modules-core';
 import * as React from 'react';
@@ -399,7 +399,7 @@ export default function ExpoWebView(props: Props) {
 
 Now we can update the example app to show an alert when the page has loaded. Copy in the following code, then rebuild and run your app, and you should see the alert!
 
-```typescript example/App.tsx
+```tsx example/App.tsx
 import { WebView } from 'expo-web-view';
 
 export default function App() {
@@ -419,7 +419,7 @@ Now that we have a web view, we can build a web browser UI around it. Have some 
 
 <Collapsible summary="example/App.tsx">
 
-```typescript
+```tsx
 import { useState } from 'react';
 import { ActivityIndicator, Platform, Text, TextInput, View } from 'react-native';
 import { WebView } from 'expo-web-view';

--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -285,7 +285,7 @@ Each message must be a JSON object with the given fields (only the `to` field is
 
 ### Push ticket format
 
-```javascript
+```js
 {
   "data": [
     {
@@ -307,7 +307,7 @@ Each message must be a JSON object with the given fields (only the `to` field is
 
 ### Push receipt request format
 
-```javascript
+```js
 {
   "ids": string[]
 }
@@ -315,7 +315,7 @@ Each message must be a JSON object with the given fields (only the `to` field is
 
 ### Push receipt response format
 
-```javascript
+```js
 {
   "data": {
     Receipt ID: {

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -140,7 +140,7 @@ Each part is defined as follows:
 
 Defined as JSON conforming to both the following `Manifest` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 
-```typescript
+```ts
 type Manifest = {
   id: string;
   createdAt: string;
@@ -187,7 +187,7 @@ type Asset = {
 
 Defined as JSON conforming to both the following `Extensions` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 
-```typescript
+```ts
 type Extensions = {
   assetRequestHeaders: ExpoAssetHeaderDictionary;
   ...
@@ -206,7 +206,7 @@ type ExpoAssetHeaderDictionary = {
 
 Defined as JSON conforming to both the following `Directive` definition expressed in [TypeScript](https://www.typescriptlang.org/) and the detailed descriptions for each field:
 
-```typescript
+```ts
 type Directive = {
   type: string;
   parameters?: { [key: string]: any };

--- a/docs/pages/ui-programming/using-svgs.mdx
+++ b/docs/pages/ui-programming/using-svgs.mdx
@@ -20,7 +20,7 @@ Once we have a vector created inside a design program, like Figma, Illustrator, 
 
 Follow the installation steps to configure your Expo project to use this workflow. After your project is properly configured, you'll be able to use your local SVG files like this:
 
-```javascript
+```js
 import Logo from './assets/logo.svg';
 
 <Logo width={120} height={40} />;

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -75,7 +75,7 @@ On this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -91,7 +91,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -117,7 +117,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -153,7 +153,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/unversioned/sdk/keep-awake.mdx
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/unversioned/sdk/keep-awake.mdx
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/versions/v46.0.0/index.mdx
+++ b/docs/pages/versions/v46.0.0/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
@@ -38,8 +38,8 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
   href="/bare/installing-expo-modules"
   description={
     <>
-      Projects that were created with <CODE>npx react-native init</CODE> require
-      additional setup to use the Expo SDK.
+      Projects that were created with <CODE>npx react-native init</CODE> require additional setup to
+      use the Expo SDK.
     </>
   }
 />

--- a/docs/pages/versions/v46.0.0/sdk/app-loading.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/app-loading.mdx
@@ -23,7 +23,7 @@ This is useful to download and cache fonts, logos, icon images and other assets 
 ## Usage
 
 {/* prettier-ignore */}
-```javascript
+```js
 import React from 'react';
 import { Image, Text, View } from 'react-native';
 import { Asset } from 'expo-asset';

--- a/docs/pages/versions/v46.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/av.mdx
@@ -28,7 +28,7 @@ In this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -44,7 +44,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -70,7 +70,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -106,7 +106,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/v46.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/barometer.mdx
@@ -155,7 +155,7 @@ Removes all listeners.
 
 The altitude data returned from the native sensors.
 
-```typescript
+```tsx
 type BarometerMeasurement = {
   pressure: number;
   /* iOS Only */

--- a/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ files={{
     'GifManagement.ts': 'filesystem/gifManagement.ts'
   }}>
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
@@ -44,7 +44,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 #### Downloading files
 
-```javascript
+```js
 const callback = downloadProgress => {
   const progress = downloadProgress.totalBytesWritten / downloadProgress.totalBytesExpectedToWrite;
   this.setState({
@@ -111,7 +111,7 @@ files={{
     'GifManagement.ts': 'filesystem/gifManagement.ts'
   }}>
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';
@@ -384,7 +384,7 @@ Download the contents at a remote URI to a file in the app's file system. The di
 
 #### Example
 
-```javascript
+```js
 FileSystem.downloadAsync(
   'http://techslides.com/demos/sample-videos/small.mp4',
   FileSystem.documentDirectory + 'small.mp4'
@@ -431,7 +431,7 @@ Upload the contents of the file pointed by `fileUri` to the remote url.
 
 **client**
 
-```javascript
+```js
 import * as FileSystem from 'expo-file-system';
 
 try {
@@ -584,7 +584,7 @@ Take a `file://` URI and convert it into content URI (`content://`) so that it c
 
 #### Example
 
-```javascript
+```js
 FileSystem.getContentUriAsync(uri).then(cUri => {
   console.log(cUri);
   IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
@@ -608,7 +608,7 @@ Gets the available internal disk storage size, in bytes. This returns the free s
 
 #### Example
 
-```javascript
+```js
 FileSystem.getFreeDiskStorageAsync().then(freeDiskStorage => {
   // Android: 17179869184
   // iOS: 17179869184
@@ -625,7 +625,7 @@ Gets total internal disk storage size, in bytes. This is the total capacity of t
 
 #### Example
 
-```javascript
+```js
 FileSystem.getTotalDiskCapacityAsync().then(totalDiskCapacity => {
   // Android: 17179869184
   // iOS: 17179869184

--- a/docs/pages/versions/v46.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/keep-awake.mdx
@@ -31,7 +31,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -54,7 +54,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v46.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/keep-awake.mdx
@@ -31,7 +31,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -54,7 +54,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v46.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/versions/v46.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/task-manager.mdx
@@ -55,7 +55,7 @@ For bare React Native apps, you need to add those keys manually. You can do it b
 
 <SnackInline dependencies={["expo-task-manager", "expo-location"]}>
 
-```javascript
+```js
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 import * as TaskManager from 'expo-task-manager';

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
@@ -38,8 +38,8 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
   href="/bare/installing-expo-modules"
   description={
     <>
-      Projects that were created with <CODE>npx react-native init</CODE> require
-      additional setup to use the Expo SDK.
+      Projects that were created with <CODE>npx react-native init</CODE> require additional setup to
+      use the Expo SDK.
     </>
   }
 />

--- a/docs/pages/versions/v47.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/av.mdx
@@ -28,7 +28,7 @@ In this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -44,7 +44,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -70,7 +70,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -106,7 +106,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
@@ -112,7 +112,7 @@ try {
   }}
 >
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
@@ -112,7 +112,7 @@ try {
   }}
 >
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v47.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/keep-awake.mdx
@@ -31,7 +31,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -54,7 +54,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v47.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/keep-awake.mdx
@@ -31,7 +31,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -54,7 +54,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v47.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/versions/v48.0.0/index.mdx
+++ b/docs/pages/versions/v48.0.0/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';

--- a/docs/pages/versions/v48.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/av.mdx
@@ -75,7 +75,7 @@ On this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -91,7 +91,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -117,7 +117,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -153,7 +153,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v48.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v48.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v48.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/versions/v49.0.0/index.mdx
+++ b/docs/pages/versions/v49.0.0/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';

--- a/docs/pages/versions/v49.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/av.mdx
@@ -75,7 +75,7 @@ On this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -91,7 +91,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -117,7 +117,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -153,7 +153,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/versions/v50.0.0/index.mdx
+++ b/docs/pages/versions/v50.0.0/index.mdx
@@ -16,7 +16,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 
 After installing one or more packages, you can import them into your JavaScript code:
 
-```javascript
+```js
 import { Camera } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -75,7 +75,7 @@ On this page, we reference operations on `playbackObject`s. Here is an example o
 
 ### Example: `Audio.Sound`
 
-```javascript
+```js
 await Audio.setAudioModeAsync({ playsInSilentModeIOS: true });
 
 const playbackObject = new Audio.Sound();
@@ -91,7 +91,7 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 
 ### Example: `Video`
 
-```javascript
+```js
 ...
 _handleVideoRef = component => {
   const playbackObject = component;
@@ -117,7 +117,7 @@ See the [video documentation](video.mdx) for further information.
 
 ### Example: `setOnPlaybackStatusUpdate()`
 
-```javascript
+```js
 _onPlaybackStatusUpdate = playbackStatus => {
   if (!playbackStatus.isLoaded) {
     // Update your UI for the unloaded state
@@ -153,7 +153,7 @@ playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 
 ### Example: Loop media exactly 20 times
 
-```javascript
+```js
 const N = 20;
 ...
 

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```tsx
+```js
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -111,7 +111,7 @@ try {
   }}
 >
 
-```typescript
+```tsx
 import * as FileSystem from 'expo-file-system';
 
 const gifDir = FileSystem.cacheDirectory + 'giphy/';

--- a/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```javascript
+```js
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
@@ -25,7 +25,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Keep Awake hook' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { useKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Text, View } from 'react-native';
@@ -48,7 +48,7 @@ export default function KeepAwakeExample() {
 
 <SnackInline label='Keep Awake functions' dependencies={['expo-keep-awake']}>
 
-```js
+```jsx
 import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
 import React from 'react';
 import { Button, View } from 'react-native';

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
 
 ## API
 
-```javascript
+```js
 import LottieView from 'lottie-react-native';
 ```
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -207,7 +207,7 @@ Each SDK announcement blog post contains deprecations, breaking changes, and any
 
 - If using the default `.babelrc`, change it to **babel.config.js**:
 
-```javascript
+```js
 module.exports = function (api) {
   api.cache(true);
   return {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #26172 to update `javascript` and `typescript` language syntax highlight names to `js` and `ts`/`tsx`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
