### PR TITLE
[docs] Add links to Android and iOS compilation in Production mode section

### DIFF
--- a/docs/pages/workflow/development-mode.mdx
+++ b/docs/pages/workflow/development-mode.mdx
@@ -22,7 +22,7 @@ Development mode also performs validations while your app is running to give you
 
 ### View the developer menu
 
-The menu gives access to a host of features that make development and debugging much easier. For more information on to open it on Android and iOS, see [Developer menu](/debugging/tools/#developer-menu).
+The menu gives access to a host of features that make development and debugging much easier. For more information on how to open it on Android and iOS, see [Developer menu](/debugging/tools/#developer-menu).
 
 ## Production mode
 
@@ -35,6 +35,6 @@ The easiest way to simulate how your project will run on end users' devices is w
 
 <Terminal cmd={['$ npx expo start --no-dev --minify']} />
 
-Besides running in production mode (which tells the Metro bundler to set the `__DEV__` environment variable to `false`, among a few other things), the `--minify` flag will minify your app. This flag will also eliminate unnecessary data such as comments, formatting, and unused code.
+It runs the JavaScript of your app in production mode (which tells the Metro bundler to set the `__DEV__` environment variable to `false`, among a few other things). The `--minify` flag minifies your app. This flag also eliminates unnecessary data such as comments, formatting, and unused code. If you are getting an error or crash in your standalone app, running your project with this command can save you a lot of time in finding the root cause.
 
-If you're getting an error or crash in your standalone app, running your project with this command can save you a lot of time in finding the root cause.
+To completely compile your app for production see [Compiling Android](/more/expo-cli/#compiling-android) and [Compiling iOS](/more/expo-cli/#compiling-ios).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C05R8KJK1PC/p1698346925340639)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add links to Android and iOS compilation section for Production
- Update verbiage and context about JS production mode

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/workflow/development-mode/#production-mode

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
