### PR TITLE
[audio][docs] Update examples in Usage section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -37,12 +37,12 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 >
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -55,7 +55,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -90,12 +90,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -96,11 +96,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,

--- a/docs/pages/versions/v46.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/audio.mdx
@@ -94,11 +94,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,

--- a/docs/pages/versions/v46.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/audio.mdx
@@ -35,12 +35,12 @@ files={{
   }}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -53,7 +53,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -88,12 +88,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/v47.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/audio.mdx
@@ -94,11 +94,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,

--- a/docs/pages/versions/v47.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/audio.mdx
@@ -35,12 +35,12 @@ files={{
   }}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -53,7 +53,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -88,12 +88,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/v48.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/audio.mdx
@@ -37,12 +37,12 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 >
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -55,7 +55,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -90,12 +90,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/v48.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/audio.mdx
@@ -96,11 +96,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -37,12 +37,12 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 >
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -55,7 +55,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -90,12 +90,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -96,11 +96,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,

--- a/docs/pages/versions/v50.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/audio.mdx
@@ -37,12 +37,12 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 >
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [sound, setSound] = React.useState();
+  const [sound, setSound] = useState();
 
   async function playSound() {
     console.log('Loading Sound');
@@ -55,7 +55,7 @@ export default function App() {
     await /* @info */ sound.playAsync(); /* @end */
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     return sound
       ? () => {
           console.log('Unloading Sound');
@@ -90,12 +90,12 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-av', 'expo-asset']}>
 
 ```jsx
-import * as React from 'react';
-import { Text, View, StyleSheet, Button } from 'react-native';
+import { useState } from 'react';
+import { View, StyleSheet, Button } from 'react-native';
 import { Audio } from 'expo-av';
 
 export default function App() {
-  const [recording, setRecording] = React.useState();
+  const [recording, setRecording] = useState();
 
   async function startRecording() {
     try {

--- a/docs/pages/versions/v50.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/audio.mdx
@@ -96,11 +96,14 @@ import { Audio } from 'expo-av';
 
 export default function App() {
   const [recording, setRecording] = useState();
+  const [permissionResponse, requestPermission] = Audio.usePermissions();
 
   async function startRecording() {
     try {
-      console.log('Requesting permissions..');
-      /* @info */ await Audio.requestPermissionsAsync();
+      /* @info */ if (permissionResponse.status !== 'granted') {
+        console.log('Requesting permission..');
+        await requestPermission();
+      }
       await Audio.setAudioModeAsync({
         allowsRecordingIOS: true,
         playsInSilentModeIOS: true,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10797

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Playing sounds and Recording sound examples in Usage section by
- removing unused import statements
- use `Audio.usePermission()` hook for permissions in recording sound example
- Changes backported from `unversioned` to all existing SDK versioned docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/audio/#usage. Can also click "Open in Snack" to verify the examples are working.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
