### PR TITLE
[modules-core] Add macOS support

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1978,7 +1978,7 @@ SPEC CHECKSUMS:
   ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042
   ExpoMailComposer: 1f980bbdd0647500178625f453e509cef1282d43
   ExpoMaps: e9e83d84c3af7c25fc4a139917239881e319e08a
-  ExpoModulesCore: 94238d9653114ff9786634541688e1fdb7ed95e3
+  ExpoModulesCore: 67e0691f804f3fdb7b2827b1cc3d9ac1385fd3e2
   ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
   ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1975,7 +1975,7 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
   ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042
   ExpoMailComposer: 1f980bbdd0647500178625f453e509cef1282d43
-  ExpoModulesCore: 94238d9653114ff9786634541688e1fdb7ed95e3
+  ExpoModulesCore: 67e0691f804f3fdb7b2827b1cc3d9ac1385fd3e2
   ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
   ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for macOS platform. ([#26186](https://github.com/expo/expo/pull/26186) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -24,7 +24,11 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms       = { :ios => '13.4', :tvos => '13.4'}
+  s.platforms       = {
+    :ios => '13.4',
+    :osx => '10.15',
+    :tvos => '13.4'
+  }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -1,8 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/Platform.h>
+
 #if __cplusplus
 
-#import <UIKit/UIKit.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -4,7 +4,6 @@
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
 #import <ExpoModulesCore/Swift.h>
 
-
 @interface EXAppDelegateWrapper()
 
 @property (nonatomic, strong) EXReactDelegateWrapper *reactDelegate;
@@ -44,12 +43,32 @@
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>) || __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
 
+- (UIView *)findRootView:(UIApplication *)application
+{
+#if TARGET_OS_IOS || TARGET_OS_TV
+  UIWindow *mainWindow = application.delegate.window;
+  if (mainWindow == nil) {
+    return nil;
+  }
+  UIViewController *rootViewController = mainWindow.rootViewController;
+  if (rootViewController == nil) {
+    return nil;
+  }
+  UIView *rootView = rootViewController.view;
+  return rootView;
+#elif TARGET_OS_OSX
+  return [[[[NSApplication sharedApplication] keyWindow] contentViewController] view];
+#endif
+}
+
+#if !TARGET_OS_OSX
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   [super application:application didFinishLaunchingWithOptions:launchOptions];
   [_expoAppDelegate application:application didFinishLaunchingWithOptions:launchOptions];
   return YES;
 }
+#endif // !TARGET_OS_OSX
 
 - (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
 {
@@ -69,7 +88,7 @@
                                                        moduleName:moduleName
                                                 initialProperties:initProps
                                                     fabricEnabled:enableFabric];
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_OSX
   rootView.backgroundColor = UIColor.systemBackgroundColor;
 #endif
   return rootView;

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -43,24 +43,6 @@
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>) || __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
 
-- (UIView *)findRootView:(UIApplication *)application
-{
-#if TARGET_OS_IOS || TARGET_OS_TV
-  UIWindow *mainWindow = application.delegate.window;
-  if (mainWindow == nil) {
-    return nil;
-  }
-  UIViewController *rootViewController = mainWindow.rootViewController;
-  if (rootViewController == nil) {
-    return nil;
-  }
-  UIView *rootView = rootViewController.view;
-  return rootView;
-#elif TARGET_OS_OSX
-  return [[[[NSApplication sharedApplication] keyWindow] contentViewController] view];
-#endif
-}
-
 #if !TARGET_OS_OSX
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -70,8 +70,11 @@
                                                        moduleName:moduleName
                                                 initialProperties:initProps
                                                     fabricEnabled:enableFabric];
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if TARGET_OS_IOS
   rootView.backgroundColor = UIColor.systemBackgroundColor;
+#elif TARGET_OS_OSX
+  rootView.wantsLayer = YES;
+  rootView.layer.backgroundColor = NSColor.windowBackgroundColor.CGColor;
 #endif
   return rootView;
 }

--- a/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.h
@@ -1,7 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -9,7 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
  The legacy wrapper is still used to forward app delegate calls to singleton modules.
  See `EXAppDelegatesLoader.m` which registers this class as a subscriber of `ExpoAppDelegate`.
  */
+#if TARGET_OS_OSX
+@interface EXLegacyAppDelegateWrapper : NSResponder <NSApplicationDelegate>
+#else
 @interface EXLegacyAppDelegateWrapper : UIResponder <UIApplicationDelegate>
+#endif
 
 @end
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
+++ b/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
@@ -3,14 +3,20 @@
 #import <Foundation/FoundationErrors.h>
 
 #import <ExpoModulesCore/EXSingletonModule.h>
+#import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 #import <ExpoModulesCore/EXLegacyAppDelegateWrapper.h>
 
+#if !TARGET_OS_OSX
 static NSMutableArray<id<UIApplicationDelegate>> *subcontractors;
 static NSMutableDictionary<NSString *,NSArray<id<UIApplicationDelegate>> *> *subcontractorsForSelector;
 static dispatch_once_t onceToken;
+#endif
 
 @implementation EXLegacyAppDelegateWrapper
+
+// The legacy app delegate wrapper is not supported on macOS, but we keep it no-op for convenience.
+#if !TARGET_OS_OSX
 
 @synthesize window = _window;
 
@@ -216,7 +222,6 @@ static dispatch_once_t onceToken;
   }
 }
 
-
 #pragma mark - Subcontractors
 
 - (void)ensureSubcontractorsAreInitializedAndSorted {
@@ -260,5 +265,7 @@ static dispatch_once_t onceToken;
   
   return result;
 }
+
+#endif // !TARGET_OS_OSX
 
 @end

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -1,4 +1,3 @@
-import UIKit
 import Dispatch
 import Foundation
 
@@ -18,6 +17,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   @objc
   public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
 
+  #if os(iOS)
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -317,6 +317,8 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   }
 #endif
 
+  #endif // os(iOS)
+
   // MARK: - Statics
 
   @objc
@@ -354,7 +356,8 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
       }
   }
 }
-#if !os(tvOS)
+
+#if os(iOS)
 private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -> UIInterfaceOrientationMask {
   // For now only iPad-specific orientations are supported
   let deviceString = userInterfaceIdiom == .pad ? "~pad" : ""
@@ -379,4 +382,4 @@ private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -
   }
   return mask
 }
-#endif
+#endif // os(iOS)

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
@@ -1,14 +1,21 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-import UIKit
-
 /**
  Base class for app delegate subscribers. Ensures the class
  inherits from `UIResponder` and has `required init()` initializer.
  */
 @objc(EXBaseAppDelegateSubscriber)
 open class BaseExpoAppDelegateSubscriber: UIResponder {
-  public override required init() {}
+  public override required init() {
+    super.init()
+  }
+
+  #if os(macOS)
+  @available(*, unavailable)
+  public required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  #endif // os(macOS)
 }
 
 /**

--- a/packages/expo-modules-core/ios/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Arguments/Convertibles.swift
@@ -1,6 +1,5 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-import UIKit
 import CoreGraphics
 
 // Here we extend some common iOS types to implement `Convertible` protocol and

--- a/packages/expo-modules-core/ios/EXDefines.h
+++ b/packages/expo-modules-core/ios/EXDefines.h
@@ -78,7 +78,8 @@ if (var == nil) { return; }
 // Converts nil -> [NSNull null]
 #define EXNullIfNil(value) (value ?: [NSNull null])
 
-#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/Platform.h>
+
 #import <Foundation/Foundation.h>
 
 typedef struct EXMethodInfo {
@@ -103,6 +104,11 @@ EX_EXTERN void EXLogWarn(NSString *format, ...);
 EX_EXTERN void EXLogError(NSString *format, ...);
 EX_EXTERN void EXFatal(NSError *);
 EX_EXTERN NSError * EXErrorWithMessage(NSString *);
+
+#if TARGET_OS_OSX
+EX_EXTERN NSApplication *EXSharedApplication(void);
+#else
 EX_EXTERN UIApplication *EXSharedApplication(void);
+#endif
 
 EX_EXTERN_C_END

--- a/packages/expo-modules-core/ios/Interfaces/BarcodeScanner/EXBarcodeScannerInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/BarcodeScanner/EXBarcodeScannerInterface.h
@@ -2,7 +2,6 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-#import <UIKit/UIKit.h>
 
 @protocol EXBarCodeScannerInterface
 

--- a/packages/expo-modules-core/ios/Interfaces/FaceDetector/EXFaceDetectorManagerInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/FaceDetector/EXFaceDetectorManagerInterface.h
@@ -2,7 +2,6 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-#import <UIKit/UIKit.h>
 
 @protocol EXFaceDetectorManagerInterface
 #if !TARGET_OS_TV

--- a/packages/expo-modules-core/ios/Interfaces/Font/EXFontProcessorInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/Font/EXFontProcessorInterface.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/Platform.h>
 
 @protocol EXFontProcessorInterface
 

--- a/packages/expo-modules-core/ios/Interfaces/Font/EXFontScalerInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/Font/EXFontScalerInterface.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/Platform.h>
 
 @protocol EXFontScalerInterface
 

--- a/packages/expo-modules-core/ios/Interfaces/ImageLoader/EXImageLoaderInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/ImageLoader/EXImageLoaderInterface.h
@@ -1,6 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/Platform.h>
 
 typedef void (^EXImageLoaderCompletionBlock)(NSError *error, UIImage *image);
 

--- a/packages/expo-modules-core/ios/Legacy/EXUtilities.h
+++ b/packages/expo-modules-core/ios/Legacy/EXUtilities.h
@@ -1,8 +1,8 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
+#import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXUtilitiesInterface.h>
 #import <ExpoModulesCore/EXModuleRegistryConsumer.h>

--- a/packages/expo-modules-core/ios/Legacy/EXUtilities.m
+++ b/packages/expo-modules-core/ios/Legacy/EXUtilities.m
@@ -39,6 +39,7 @@ EX_REGISTER_MODULE();
 
 - (UIViewController *)currentViewController
 {
+#if TARGET_OS_IOS || TARGET_OS_TV
   id<EXUtilService> utilService = [_moduleRegistry getSingletonModuleForName:@"Util"];
 
   if (utilService != nil) {
@@ -47,12 +48,15 @@ EX_REGISTER_MODULE();
 
   UIViewController *controller = [[[UIApplication sharedApplication] keyWindow] rootViewController];
   UIViewController *presentedController = controller.presentedViewController;
-  
+
   while (presentedController && ![presentedController isBeingDismissed]) {
     controller = presentedController;
     presentedController = controller.presentedViewController;
   }
   return controller;
+#elif TARGET_OS_OSX
+  return [[[NSApplication sharedApplication] keyWindow] contentViewController];
+#endif
 }
 
 + (void)performSynchronouslyOnMainThread:(void (^)(void))block
@@ -102,7 +106,11 @@ EX_REGISTER_MODULE();
   static CGFloat scale;
   
   [self unsafeExecuteOnMainQueueOnceSync:&onceToken block:^{
-      scale = [UIScreen mainScreen].scale;
+#if TARGET_OS_IOS || TARGET_OS_TV
+    scale = [UIScreen mainScreen].scale;
+#elif TARGET_OS_OSX
+    scale = [NSScreen mainScreen].backingScaleFactor;
+#endif
   }];
   
   return scale;

--- a/packages/expo-modules-core/ios/Legacy/EXUtilities.m
+++ b/packages/expo-modules-core/ios/Legacy/EXUtilities.m
@@ -55,6 +55,7 @@ EX_REGISTER_MODULE();
   }
   return controller;
 #elif TARGET_OS_OSX
+  // Even though the function's return type is `UIViewController`, react-native-macos will alias `NSViewController` to `UIViewController`. 
   return [[[NSApplication sharedApplication] keyWindow] contentViewController];
 #endif
 }

--- a/packages/expo-modules-core/ios/Legacy/Protocols/EXUIManager.h
+++ b/packages/expo-modules-core/ios/Legacy/Protocols/EXUIManager.h
@@ -1,7 +1,8 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+
+#import <ExpoModulesCore/Platform.h>
 
 @protocol EXUIManager <NSObject>
 

--- a/packages/expo-modules-core/ios/Legacy/Protocols/EXUtilitiesInterface.h
+++ b/packages/expo-modules-core/ios/Legacy/Protocols/EXUtilitiesInterface.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
+#import <ExpoModulesCore/Platform.h>
 
 @protocol EXUtilitiesInterface
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -226,11 +226,11 @@ EX_REGISTER_MODULE();
       _isForegrounded && (
        [notification.name isEqualToString:UIApplicationWillResignActiveNotification] ||
        [notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification] ||
-       RCTSharedApplication().applicationState == UIApplicationStateBackground
+       [self isApplicationStateBackground]
       )
     ) {
     [self setAppStateToBackground];
-  } else if (!_isForegrounded && RCTSharedApplication().applicationState == UIApplicationStateActive) {
+  } else if (!_isForegrounded && [self isApplicationStateActive]) {
     [self setAppStateToForeground];
   }
 }
@@ -313,6 +313,24 @@ EX_REGISTER_MODULE();
       [strongSelf.bridge.uiManager setNeedsLayout];
     }
   });
+}
+
+- (BOOL)isApplicationStateBackground
+{
+#if TARGET_OS_IOS || TARGET_OS_TV
+  return RCTSharedApplication().applicationState == UIApplicationStateBackground;
+#elif TARGET_OS_OSX
+  return RCTSharedApplication().isHidden;
+#endif
+}
+
+- (BOOL)isApplicationStateActive
+{
+#if TARGET_OS_IOS || TARGET_OS_TV
+  return RCTSharedApplication().applicationState == UIApplicationStateActive;
+#elif TARGET_OS_OSX
+  return RCTSharedApplication().isActive;
+#endif
 }
 
 @end

--- a/packages/expo-modules-core/ios/Modules/ModuleDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Modules/ModuleDefinitionComponents.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 // MARK: - Module name
 
 /**

--- a/packages/expo-modules-core/ios/Platform.h
+++ b/packages/expo-modules-core/ios/Platform.h
@@ -1,0 +1,23 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+#import <UIKit/UIKit.h>
+
+#elif TARGET_OS_OSX
+
+#import <AppKit/AppKit.h>
+#import <React/RCTUIKit.h>
+
+@compatibility_alias UIView NSView;
+@compatibility_alias UIResponder NSResponder;
+@compatibility_alias UIColor NSColor;
+@compatibility_alias UIWindow NSWindow;
+
+#ifndef UIApplication
+@compatibility_alias UIApplication NSApplication;
+#endif
+
+@protocol UIApplicationDelegate <NSApplicationDelegate> @end
+
+#endif // TARGET_OS_OSX

--- a/packages/expo-modules-core/ios/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform.swift
@@ -1,0 +1,12 @@
+#if os(macOS)
+
+import AppKit
+
+public typealias UIApplication = NSApplication
+public typealias UIView = NSView
+public typealias UIViewController = NSViewController
+public typealias UIResponder = NSResponder
+public typealias UIApplicationDelegate = NSApplicationDelegate
+public typealias UIWindow = NSWindow
+
+#endif // os(macOS)

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactCompatibleHelpers.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactCompatibleHelpers.h
@@ -1,7 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
-
+#import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXDefines.h>
 #import <React/RCTBridge.h>
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.h
@@ -1,8 +1,8 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
+#import <ExpoModulesCore/Platform.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/Views/AnyViewProp.swift
+++ b/packages/expo-modules-core/ios/Views/AnyViewProp.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 /**
  Type-erased protocol for view props classes.
  */

--- a/packages/expo-modules-core/ios/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Views/ConcreteViewProp.swift
@@ -1,7 +1,5 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
-import UIKit
-
 /**
  Specialized class for the view prop. Specifies the prop name and its setter.
  */

--- a/packages/expo-modules-core/ios/Views/ViewFactory.swift
+++ b/packages/expo-modules-core/ios/Views/ViewFactory.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 /**
  A definition of the view factory that creates views.
  */

--- a/packages/expo-modules-core/ios/Views/ViewManagerDefinition.swift
+++ b/packages/expo-modules-core/ios/Views/ViewManagerDefinition.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 /**
  The definition of the view manager. It's part of the module definition to scope only view-related definitions.
  */

--- a/packages/expo-modules-core/ios/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Views/ViewModuleWrapper.swift
@@ -1,4 +1,3 @@
-import UIKit
 import ObjectiveC
 
 /**


### PR DESCRIPTION
# Why

Adds support for macOS platform to the `expo-modules-core` package. It's been separated from #22796.

# How

- Added appropriate aliases so we can refer to UIKit-specific classes on macOS as well. This is also what `react-native-macos` does, but we need to expose that to Swift.
- Removed UIKit imports (replaced with `Platform.h` if needed).
- Added custom implementation when necessary, e.g. app lifecycle notifications, finding the root view, getting the current view controller.

# Test Plan

Tested in https://github.com/tsapeta/expo-macos-example as part of the bigger PR #22796 