### PR TITLE
[docs] Fix canonical URL path with trailing slash

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -68,7 +68,6 @@ export const getPageSection = (path: string) => {
 };
 
 export const getCanonicalUrl = (path: string) => {
-  console.log(path);
   if (isReferencePath(path)) {
     return `https://docs.expo.dev${Utilities.replaceVersionInUrl(path, 'latest')}/`;
   } else if (path !== `/`) {

--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -68,10 +68,13 @@ export const getPageSection = (path: string) => {
 };
 
 export const getCanonicalUrl = (path: string) => {
+  console.log(path);
   if (isReferencePath(path)) {
-    return `https://docs.expo.dev${Utilities.replaceVersionInUrl(path, 'latest')}`;
+    return `https://docs.expo.dev${Utilities.replaceVersionInUrl(path, 'latest')}/`;
+  } else if (path !== `/`) {
+    return `https://docs.expo.dev${path}/`;
   } else {
-    return `https://docs.expo.dev${path}`;
+    return `https://docs.expo.dev`;
   }
 };
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the self-referencing canonical URLs are missing a trailing slash at the end of the URL except the docs home page URL (https://docs.expo.dev/).

![CleanShot 2024-01-02 at 00 54 52](https://github.com/expo/expo/assets/10234615/b7cebb0e-6ef3-4e5a-9807-56cda70aa078)

![CleanShot 2024-01-02 at 00 54 43](https://github.com/expo/expo/assets/10234615/dbe83e30-8913-40e8-a4d8-5a5d3a604364)


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates `getCanonicalUrl` method by adding the a trailing slash for paths that are not home page (that is `/`).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

After updating the `getCanonicalUrl` method, the canonicalized URL has a trailing slash. The following screenshot shows that:

![CleanShot 2024-01-02 at 01 00 00](https://github.com/expo/expo/assets/10234615/a68530c5-df2e-48d6-b945-a2ff750a5351)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
