### PR TITLE
[ENG-11094][docs] improve local builds docs

### DIFF
--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -52,4 +52,4 @@ Some of the options available for cloud builds are not available locally. Limita
   - fastlane (iOS only)
   - CocoaPods (iOS only)
   - Android SDK and NDK
-- Windows is not supported (only macOS and Linux are supported). The suggested way to run local EAS builds on Windows is to use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) even though it's also not officially supported (we do not test it), but it seems to work well.
+- On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds as it seems to work well. However, we do not officially test it and do not support Windows. Only macOS and Linux are supported.

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -5,9 +5,9 @@ description: Learn how to use EAS Build locally on your machine or a custom infr
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Local builds are a way to create builds using [EAS Build](/build/introduction) locally, on your machine. When using local builds you can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
+You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
 
-> **Note:** For making builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
+> **Note:** For making builds using the Expo framework locally use `npx expo run:android` or `npx expo run:ios` [commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -35,7 +35,7 @@ If you encounter build failures on EAS servers and you're unable to determine th
 - `EAS_LOCAL_BUILD_WORKINGDIR` - Specify the working directory for the build process, by default it's somewhere (it's platform dependent) in **/tmp** directory.
 - `EAS_LOCAL_BUILD_ARTIFACTS_DIR` - The directory where artifacts are copied after a successful build. By default these files are copied to the current directory, which may be undesirable if you are running many consecutive builds.
 
-If you use `EAS_LOCAL_BUILD_SKIP_CLEANUP` and `EAS_LOCAL_BUILD_WORKINGDIR` for iOS builds you should be able to inspect the contents of the `logs` subdirectory of the working directory to take a look at your Xcode logs.
+If you use `EAS_LOCAL_BUILD_SKIP_CLEANUP` and `EAS_LOCAL_BUILD_WORKINGDIR` for iOS builds you should be able to inspect the contents of the `logs` subdirectory of the working directory to read your Xcode logs.
 
 ## Limitations
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -50,4 +50,4 @@ Some of the options available for cloud builds are not available locally. Limita
   - fastlane (iOS only)
   - CocoaPods (iOS only)
   - Android SDK and NDK
-- On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds as it seems to work well. However, we do not officially test it and do not support Windows. Only macOS and Linux are supported.
+- On Windows, you can use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) for local EAS Builds — however, we do not officially test against this platform and do not support Windows for local builds (macOS and Linux are supported).

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
 
-> **Note:** For making builds using the Expo framework locally use `npx expo run:android` or `npx expo run:ios` [commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
+> **Note:** To make builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
@@ -24,7 +24,7 @@ You need to be authenticated with Expo:
 
 ## Use cases for local builds
 
-- [Debugging](#using-local-builds-for-debugging) build failures on EAS servers.
+- [Debugging](#use-local-builds-for-debugging) build failures on EAS servers.
 - Company policies that restrict the use of third-party CI/CD services. With local builds, the entire process runs on your infrastructure and the only communication with EAS servers is:
   - to make sure project `@account/slug` exists
   - if you are using managed credentials to download them

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -7,13 +7,11 @@ import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
 
-> **Note:** To make builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
+> **Note:** To make builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
 />
-
-> **Note:** If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project. It's not necessary to run `eas build --local`. However, it handles more of the build process for you &mdash; see [Use cases for local builds](#use-cases-for-local-builds).
 
 ## Prerequisites
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
 
-> **Note:** To make builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project.
+> **Note:** The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) on your local machine, following the same process that would otherwise run remotely on our cloud. To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead.  If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -5,7 +5,9 @@ description: Learn how to use EAS Build locally on your machine or a custom infr
 
 import { Terminal } from '~/ui/components/Snippet';
 
-You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag.
+Local builds are a way to create builds using [EAS Build](/build/introduction) locally, on your machine. When using local builds you can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
+
+> **Note:** For making builds using the Expo framework locally use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) locally.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
@@ -22,10 +24,10 @@ You need to be authenticated with Expo:
 
 ## Use cases for local builds
 
+- [Debugging](#using-local-builds-for-debugging) build failures on EAS servers.
 - Company policies that restrict the use of third-party CI/CD services. With local builds, the entire process runs on your infrastructure and the only communication with EAS servers is:
   - to make sure project `@account/slug` exists
   - if you are using managed credentials to download them
-- [Debugging](#using-local-builds-for-debugging) build failures on EAS servers.
 
 ## Use local builds for debugging
 
@@ -34,6 +36,8 @@ If you encounter build failures on EAS servers and you're unable to determine th
 - `EAS_LOCAL_BUILD_SKIP_CLEANUP=1` - Set this to disable cleaning up the working directory after the build process is finished.
 - `EAS_LOCAL_BUILD_WORKINGDIR` - Specify the working directory for the build process, by default it's somewhere (it's platform dependent) in **/tmp** directory.
 - `EAS_LOCAL_BUILD_ARTIFACTS_DIR` - The directory where artifacts are copied after a successful build. By default these files are copied to the current directory, which may be undesirable if you are running many consecutive builds.
+
+If you use `EAS_LOCAL_BUILD_SKIP_CLEANUP` and `EAS_LOCAL_BUILD_WORKINGDIR` for iOS builds you should be able to inspect the contents of the `logs` subdirectory of the working directory to take a look at your Xcode logs.
 
 ## Limitations
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -52,3 +52,4 @@ Some of the options available for cloud builds are not available locally. Limita
   - fastlane (iOS only)
   - CocoaPods (iOS only)
   - Android SDK and NDK
+- Windows is not supported (only macOS and Linux are supported). The suggested way to run local EAS builds on Windows is to use [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) even though it's also not officially supported (we do not test it), but it seems to work well.

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -5,7 +5,7 @@ description: Learn how to use EAS Build locally on your machine or a custom infr
 
 import { Terminal } from '~/ui/components/Snippet';
 
-You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag which is a useful way to debug build failures happening on your EAS cloud builds.
+You can run the same build process that is typically run on the EAS Build servers directly on your machine by using the `eas build --local` flag. This is a useful way to debug build failures that are happening on your cloud builds, which you may not be able to reproduce without running the exact same set of steps.
 
 > **Note:** The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) on your local machine, following the same process that would otherwise run remotely on our cloud. To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead.  If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project.
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that is typically run on the EAS Build servers directly on your machine by using the `eas build --local` flag. This is a useful way to debug build failures that are happening on your cloud builds, which you may not be able to reproduce without running the exact same set of steps.
 
-> **Note:** The `eas build --local` command is a way to make builds using [EAS cloud services](/build/introduction) on your local machine, following the same process that would otherwise run remotely on our cloud. To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead.  If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project.
+> **Note:** To compile and run your app locally with Expo CLI, use [`npx expo run:android` or `npx expo run:ios` commands](/more/expo-cli/#compiling) instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. With both of these approaches, you will not be following the exact process that is run on the cloud with EAS Build — that is what the `eas build --local` flag is for.
 
 <Terminal
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1703091810263259?thread_ts=1703091145.267299&cid=C02123T524U
https://exponent-internal.slack.com/archives/C02123T524U/p1703074315932489

# How

Improve local builds docs. Mention that the `npx expo:run` is a primary way of making local builds using the Expo framework and `eas build --local` is a way of creating local builds using the EAS cloud (mostly for debugging purposes).

# Test Plan

Preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
