### PR TITLE
[location][android] Fix `expo-task-manager` being required on module start

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix the module requiring the `expo-task-manager` module for methods that don't use it.
+
 ### 💡 Others
 
 ## 16.5.1 - 2023-12-19

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix the module requiring the `expo-task-manager` module for methods that don't use it.
+- [Android] Fix the module requiring the `expo-task-manager` module for methods that don't use it. ([#26200](https://github.com/expo/expo/pull/26200) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -71,7 +71,6 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
   private lateinit var mSensorManager: SensorManager
   private lateinit var mUIManager: UIManager
   private lateinit var mLocationProvider: FusedLocationProviderClient
-  private lateinit var mTaskManager: TaskManagerInterface
   private lateinit var mActivityProvider: ActivityProvider
 
   private var mGravity: FloatArray = FloatArray(9)
@@ -82,14 +81,17 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
   private var mLastUpdate: Long = 0
   private var mGeocoderPaused = false
 
+  private val mTaskManager: TaskManagerInterface by lazy {
+    return@lazy appContext.legacyModule<TaskManagerInterface>()
+      ?: throw TaskManagerNotFoundException()
+  }
+
   override fun definition() = ModuleDefinition {
     Name("ExpoLocation")
 
     OnCreate {
       mContext = appContext.reactContext ?: throw Exceptions.ReactContextLost()
       mUIManager = appContext.legacyModule<UIManager>() ?: throw MissingUIManagerException()
-      mTaskManager = appContext.legacyModule<TaskManagerInterface>()
-        ?: throw TaskManagerNotFoundException()
       mActivityProvider = appContext.legacyModule<ActivityProvider>()
         ?: throw MissingActivityManagerException()
       mLocationProvider = LocationServices.getFusedLocationProviderClient(mContext)


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/25979

`expo-task-manager` should only be required by `expo-location` when necessary. After the recent migration to Kotlin it is being required in the `OnCreate` block, which leads to errors in projects without `expo-task-manager`

ENG-10952
# How

Made the `mTaskManager` variable lazy initialised which means that it will throw an unavailability exception only when used by a method. Also updated the error message. 

# Test Plan

Tested on a physical Android 13 device in BareExpo and a in fresh SDK 50 project without `expo-task-manager`.
