### PR TITLE
[ci] fix slack url from matrix builds

### DIFF
--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-sdk'
           status: ${{ job.status }}

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -96,6 +96,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-sdk'
           status: ${{ job.status }}

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -122,6 +122,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-sdk'
           status: ${{ job.status }}


### PR DESCRIPTION
# Why

the updates-e2e ci failures have unfriendly error in slack notifications
![Screenshot 2024-01-02 at 9 33 24 PM](https://github.com/expo/expo/assets/46429/3343680b-2685-47dd-8046-2b9eaa96877b)

# How

add the `MATRIX_CONTEXT: ${{ toJson(matrix) }}` according to the doc https://action-slack.netlify.app/usage/fields/
we also use this in test-suite ci workflow
