### PR TITLE
fix(cli): catch locked devices when launching apps through devicectl

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Update import for type generation. ([#26145](https://github.com/expo/expo/pull/26145) by [@EvanBacon](https://github.com/EvanBacon))
+- Handle locked iOS devices when launching app through devicectl. ([#26203](https://github.com/expo/expo/pull/26203) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/__tests__/AppleDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/__tests__/AppleDevice-test.ts
@@ -1,0 +1,30 @@
+import { xcrunAsync } from '../../../../start/platforms/ios/xcrun';
+import { launchAppWithDeviceCtl } from '../AppleDevice';
+
+jest.mock('../../../../start/platforms/ios/xcrun');
+
+describe(launchAppWithDeviceCtl, () => {
+  it('throws generic error when `xcrun` fails without error logs', async () => {
+    const error = new Error('Test: unknown error');
+
+    jest.mocked(xcrunAsync).mockImplementationOnce(() => Promise.reject(error));
+
+    await expect(() =>
+      launchAppWithDeviceCtl('fake-device-id', 'com.exponent.Test')
+    ).rejects.toThrow(`There was an error launching app: ${error}`);
+  });
+
+  it('throws `APPLE_DEVICE_LOCKED` error when device is locked', async () => {
+    const error = {
+      message: 'xcrun exited with non-zero code: 1',
+      stderr:
+        'ERROR: The application failed to launch. (com.apple.dt.CoreDeviceError error 10002.)\n         BundleIdentifier = com.exponent.Test\n       ----------------------------------------\n       The request to open "com.exponent.Test" failed. (FBSOpenApplicationServiceErrorDomain error 1.)\n         NSLocalizedFailureReason = The request was denied by service delegate (SBMainWorkspace) for reason: Locked ("Unable to launch com.exponent.Test because the device was not, or could not be, unlocked").\n         BSErrorCodeDescription = RequestDenied\n         FBSOpenApplicationRequestID = 0xc34a\n       ----------------------------------------\n       The operation couldn’t be completed. Unable to launch com.exponent.Test because the device was not, or could not be, unlocked. (FBSOpenApplicationErrorDomain error 7.)\n         NSLocalizedFailureReason = Unable to launch com.exponent.Test because the device was not, or could not be, unlocked.\n         BSErrorCodeDescription = Locked',
+    };
+
+    jest.mocked(xcrunAsync).mockImplementationOnce(() => Promise.reject(error));
+
+    await expect(() =>
+      launchAppWithDeviceCtl('fake-device-id', 'com.exponent.Test')
+    ).rejects.toThrow('Device is locked, unlock and try again.');
+  });
+});


### PR DESCRIPTION
# Why

This was previously handled with `usbmux`. But, since iOS 17 we fallback to `devicectl`, which didn't have the proper `throw new CommandError('APPLE_DEVICE_LOCKED', ...)` error handling.

before | after
--- | ---
![Unhandled locked device state](https://github.com/expo/expo/assets/1203991/9a7e2d85-8812-4051-aba3-040fb836eb89) | ![handled locked device state](https://github.com/expo/expo/assets/1203991/90a1c250-f965-4a9c-b25e-e3bde77052b2)

# How

- Added tests from actual `xcrun devicectl device process launch --device XXX com.exponent.Test`
- Added error handling to pull out `BSErrorCodeDescription = Locked` and throw proper `CommandError`

# Test Plan

See tests

- `$ bun create expo ./test-locked-ios`
- `$ cd ./test-locked-ios`
- `$ bun expo run ios --device`
- Build the app, but lock your iOS 17+ device
- Should be handled as in the screenshot above

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
