### PR TITLE
[doc] add 3rd party libs integrations for expo-sqlite/next

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -349,7 +349,7 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node, Bun, Deno, and React Native. It also comes with a [CLI compansion called drizzle-kit](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI compansion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -353,7 +353,6 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 
-
 ### Knex.js
 
 [Knex.js](https://knexjs.org/) is a SQL query builder that is ["flexible, portable, and fun to use!"](https://github.com/knex/knex)

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -343,20 +343,20 @@ const row = await db.getFirstAsync<{ data: Uint8Array }>('SELECT * FROM blobs');
 expect(row.data).toEqual(blob);
 ```
 
-## Third-party libraries integrations
+## Third-party library integrations
 
-The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced features. Here are some of the libraries that you can use with `expo-sqlite`.
+The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced higher-level features. Here are some of the libraries that you can use with `expo-sqlite`.
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too! It comes with a [drizzle-kit](https://orm.drizzle.team/kit-docs/overview) CLI companion for automatic SQL migrations generation and it is Expo ready.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node, Bun, Deno, and React Native. It also comes with a [CLI compansion called drizzle-kit](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 
 
 ### Knex.js
 
-[Knex.js](https://knexjs.org/) is a SQL query builder that is flexible, portable, and fun to use!
+[Knex.js](https://knexjs.org/) is a SQL query builder that is ["flexible, portable, and fun to use!"](https://github.com/knex/knex)
 
 Check out the [`expo-sqlite` integration guide](https://github.com/expo/knex-expo-sqlite-dialect) for more details.
 

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -343,6 +343,23 @@ const row = await db.getFirstAsync<{ data: Uint8Array }>('SELECT * FROM blobs');
 expect(row.data).toEqual(blob);
 ```
 
+## Third-party libraries integrations
+
+The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced features. Here are some of the libraries that you can use with `expo-sqlite`.
+
+### Drizzle ORM
+
+[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM for SQL databases designed with maximum type safety in mind. It comes with a [drizzle-kit](https://github.com/drizzle-team/drizzle-kit-mirror) CLI companion for automatic SQL migrations generation. Drizzle ORM is meant to be a library, not a framework. It stays as an opt-in solution all the time at any levels.
+The ORM's main philosophy is "If you know SQL, you know Drizzle ORM". We follow the SQL-like syntax whenever possible, are strongly typed ground up, and fail at compile time, not in runtime.
+
+Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
+
+### Knex.js
+
+[Knex.js](https://knexjs.org/) is a SQL query builder that is flexible, portable, and fun to use!
+
+Check out the [`expo-sqlite` integration guide](https://github.com/expo/knex-expo-sqlite-dialect) for more details.
+
 ## API
 
 ### Cheatsheet for the common API

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -349,10 +349,10 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM for SQL databases designed with maximum type safety in mind. It comes with a [drizzle-kit](https://github.com/drizzle-team/drizzle-kit-mirror) CLI companion for automatic SQL migrations generation. Drizzle ORM is meant to be a library, not a framework. It stays as an opt-in solution all the time at any levels.
-The ORM's main philosophy is "If you know SQL, you know Drizzle ORM". We follow the SQL-like syntax whenever possible, are strongly typed ground up, and fail at compile time, not in runtime.
+[Drizzle](https://orm.drizzle.team/) is a headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too! It comes with a [drizzle-kit](https://orm.drizzle.team/kit-docs/overview) CLI companion for automatic SQL migrations generation and it is Expo ready.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
+
 
 ### Knex.js
 

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -349,8 +349,7 @@ The `expo-sqlite` library is designed to be a solid SQLite foundation. It enable
 
 ### Drizzle ORM
 
-[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM for SQL databases designed with maximum type safety in mind. It comes with a [drizzle-kit](https://github.com/drizzle-team/drizzle-kit-mirror) CLI companion for automatic SQL migrations generation. Drizzle ORM is meant to be a library, not a framework. It stays as an opt-in solution all the time at any levels.
-The ORM's main philosophy is "If you know SQL, you know Drizzle ORM". We follow the SQL-like syntax whenever possible, are strongly typed ground up, and fail at compile time, not in runtime.
+[Drizzle](https://orm.drizzle.team/) is a headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too! It comes with a [drizzle-kit](https://orm.drizzle.team/kit-docs/overview) CLI companion for automatic SQL migrations generation and it is Expo ready.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -343,6 +343,23 @@ const row = await db.getFirstAsync<{ data: Uint8Array }>('SELECT * FROM blobs');
 expect(row.data).toEqual(blob);
 ```
 
+## Third-party libraries integrations
+
+The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced features. Here are some of the libraries that you can use with `expo-sqlite`.
+
+### Drizzle ORM
+
+[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM for SQL databases designed with maximum type safety in mind. It comes with a [drizzle-kit](https://github.com/drizzle-team/drizzle-kit-mirror) CLI companion for automatic SQL migrations generation. Drizzle ORM is meant to be a library, not a framework. It stays as an opt-in solution all the time at any levels.
+The ORM's main philosophy is "If you know SQL, you know Drizzle ORM". We follow the SQL-like syntax whenever possible, are strongly typed ground up, and fail at compile time, not in runtime.
+
+Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
+
+### Knex.js
+
+[Knex.js](https://knexjs.org/) is a SQL query builder that is flexible, portable, and fun to use!
+
+Check out the [`expo-sqlite` integration guide](https://github.com/expo/knex-expo-sqlite-dialect) for more details.
+
 ## API
 
 ### Cheatsheet for the common API

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -343,19 +343,19 @@ const row = await db.getFirstAsync<{ data: Uint8Array }>('SELECT * FROM blobs');
 expect(row.data).toEqual(blob);
 ```
 
-## Third-party libraries integrations
+## Third-party library integrations
 
-The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced features. Here are some of the libraries that you can use with `expo-sqlite`.
+The `expo-sqlite` library is designed to be a solid SQLite foundation. It enables broader integrations with third-party libraries for more advanced higher-level features. Here are some of the libraries that you can use with `expo-sqlite`.
 
 ### Drizzle ORM
 
-[Drizzle](https://orm.drizzle.team/) is a headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too! It comes with a [drizzle-kit](https://orm.drizzle.team/kit-docs/overview) CLI companion for automatic SQL migrations generation and it is Expo ready.
+[Drizzle](https://orm.drizzle.team/) is a ["headless TypeScript ORM with a head"](https://orm.drizzle.team/docs/overview). It runs on Node.js, Bun, Deno, and React Native. It also has a CLI compansion called [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview) for generating SQL migrations.
 
 Check out the [Drizzle ORM documentation](https://orm.drizzle.team/) and the [`expo-sqlite` integration guide](https://orm.drizzle.team/docs/get-started-sqlite#expo-sqlite) for more details.
 
 ### Knex.js
 
-[Knex.js](https://knexjs.org/) is a SQL query builder that is flexible, portable, and fun to use!
+[Knex.js](https://knexjs.org/) is a SQL query builder that is ["flexible, portable, and fun to use!"](https://github.com/knex/knex)
 
 Check out the [`expo-sqlite` integration guide](https://github.com/expo/knex-expo-sqlite-dialect) for more details.
 


### PR DESCRIPTION
# Why

add 3rd party integrations like Drizzle ORM

# How

add a section for 3rd party libs integrations and add Drizzle ORM and Knex.js

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
