### PR TITLE
[create-expo-modules] fix multiple react version issue from npm

### DIFF
--- a/packages/expo-module-template/example/metro.config.js
+++ b/packages/expo-module-template/example/metro.config.js
@@ -4,11 +4,12 @@ const path = require('path');
 
 const config = getDefaultConfig(__dirname);
 
-// npm v7+ will install ../node_modules/react-native because of peerDependencies.
+// npm v7+ will install ../node_modules/react and ../node_modules/react-native because of peerDependencies.
 // To prevent the incompatible react-native bewtween ./node_modules/react-native and ../node_modules/react-native,
 // excludes the one from the parent folder when bundling.
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
+  new RegExp(path.resolve('..', 'node_modules', 'react')),
   new RegExp(path.resolve('..', 'node_modules', 'react-native')),
 ];
 


### PR DESCRIPTION
# Why

fixes #26162

# How

react hooks will throw errors from multiple react versions. this happens because npm will implicitly install react. this pr excludes the react for metro.

# Test Plan

test repro from #26162

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
