### PR TITLE
[docs] Update local-app-development.mdx

### DIFF
--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -57,7 +57,7 @@ We recommend JDK 17. Run the following commands in a terminal window to install 
 
 <Terminal
   cmd={['$ brew tap homebrew/cask-versions', '$ brew install --cask zulu17']}
-  cmdCopy="brew tap homebrew/cask-versions && brew install --cask zulu11"
+  cmdCopy="brew tap homebrew/cask-versions && brew install --cask zulu17"
 />
 
 After you install the JDK, add the `JAVA_HOME` environment variable in **~/.bash_profile** (or **~/.zshrc** if you use Zsh):


### PR DESCRIPTION

# Why

When clicking copy on the [Expo docs](https://docs.expo.dev/guides/local-app-development/#prerequisites), `zulu11` is copied and not `zulu17`.

# How

N/A

# Test Plan

Verify the docs "copy command" results in `zulu17` being used when `zulu17` is described. Thank you

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
