### PR TITLE
Add macOS support to expo-keep-awake

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1972,7 +1972,7 @@ SPEC CHECKSUMS:
   ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
   ExpoImagePicker: 247fc7d2c13426a835525b67d5fb221864b79612
   ExpoInsights: 28a5bab3d75d32c6266b00c5166668561a0bf756
-  ExpoKeepAwake: ed71bfe0e6ecd38e337586ba6e1ba27a56eb373b
+  ExpoKeepAwake: fe7be5056ccf39dd1e05afcdb32a5569973f3685
   ExpoLinearGradient: 6ff7b35f824f18f77d9c3ad3ee09fe0b4229e669
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
   ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1970,7 +1970,7 @@ SPEC CHECKSUMS:
   ExpoImage: 5ba424cbd89ba94103f21817cc310c26a009d967
   ExpoImageManipulator: c1d7cb865eacd620a35659f3da34c70531f10b59
   ExpoImagePicker: 247fc7d2c13426a835525b67d5fb221864b79612
-  ExpoKeepAwake: ed71bfe0e6ecd38e337586ba6e1ba27a56eb373b
+  ExpoKeepAwake: fe7be5056ccf39dd1e05afcdb32a5569973f3685
   ExpoLinearGradient: 6ff7b35f824f18f77d9c3ad3ee09fe0b4229e669
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
   ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for macOS platform.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added support for macOS platform.
+- Added support for macOS platform. ([#26221](https://github.com/expo/expo/pull/26221) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
+++ b/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
@@ -10,7 +10,11 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms       = { :ios => '13.4', :tvos => '13.4'}
+  s.platforms       = {
+    :ios => '13.4',
+    :osx => '10.15',
+    :tvos => '13.4'
+  }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-keep-awake/ios/KeepAwakeModule.swift
+++ b/packages/expo-keep-awake/ios/KeepAwakeModule.swift
@@ -25,9 +25,13 @@ public final class KeepAwakeModule: Module {
     }
 
     AsyncFunction("isActivated") { () -> Bool in
+      #if os(iOS) || os(tvOS)
       return DispatchQueue.main.sync {
         return UIApplication.shared.isIdleTimerDisabled
       }
+      #elseif os(macOS)
+      return false
+      #endif
     }
 
     OnAppEntersForeground {
@@ -45,7 +49,9 @@ public final class KeepAwakeModule: Module {
 }
 
 private func setActivated(_ activated: Bool) {
+  #if os(iOS) || os(tvOS)
   DispatchQueue.main.async {
     UIApplication.shared.isIdleTimerDisabled = activated
   }
+  #endif
 }


### PR DESCRIPTION
# Why

Following up on #26186, separated from #22796 
Although `expo-keep-awake` is not installed with the `expo` package, it's a dependency in our project template so many projects depend on it.

# How

The module is pretty simple and the keep awake functionality is not necessary on desktop, so I just added macOS to supported platforms and hid some code (calling to UIKit) on that platform.
As a result, this module is no-op on macOS.

# Test Plan

Tested in https://github.com/tsapeta/expo-macos-example as part of PR #22796 