### PR TITLE
[docs] fix Terminal display quirk on mobile, while used in Tabs

### DIFF
--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -21,7 +21,7 @@ export const Terminal = ({ cmd, cmdCopy, hideOverflow, title = 'Terminal' }: Ter
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
-    <SnippetContent alwaysDark hideOverflow={hideOverflow} className="grid grid-cols-auto-min-1">
+    <SnippetContent alwaysDark hideOverflow={hideOverflow} className="flex flex-col">
       {cmd.map(cmdMapper)}
     </SnippetContent>
   </Snippet>


### PR DESCRIPTION
# Why

Fixes quirk on mobile, when Terminal is used inside Tabs.

<img src="https://github.com/expo/expo/assets/719641/104a8e71-53cb-4f2c-80b0-725095857939" width="400" />

# How

Replace rows grid layout with flex one, looks like there is a quirk on mobile when auto-sized grid is used inside an another grid.

# Test Plan

The changes have been tested locally, and on the device via local network.

# Preview

<img src="https://github.com/expo/expo/assets/719641/8ba3b1ef-aa9f-400d-8c69-a441f031bad7" width="400" />

