### PR TITLE
[expo-updates][e2e] Bump test timeout

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/jest.config.js
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   globalSetup: 'detox/runners/jest/globalSetup',
   globalTeardown: 'detox/runners/jest/globalTeardown',
   testEnvironment: 'detox/runners/jest/testEnvironment',
-  testTimeout: 100000,
+  testTimeout: 150000,
   testMatch: ['./**/*.e2e.ts'],
   verbose: true,
 };


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/25880 changed this, and since then things have been slightly more flakey. Bumping this a bit to see if it helps.

# How

Bump by 50%

# Test Plan

Run e2e tests locally, wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
