### PR TITLE
[notifications][android] Fix `expo-task-manager` being required on module start

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `expo-notifications` requiring the `expo-task-manager` module to start.
+- [Android] Fix `expo-notifications` requiring the `expo-task-manager` module to start. ([#26227](https://github.com/expo/expo/pull/26227) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `expo-notifications` requiring the `expo-task-manager` module to start.
+
 ### 💡 Others
 
 ## 0.27.2 - 2023-12-19

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/ExpoBackgroundNotificationTasksModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/ExpoBackgroundNotificationTasksModule.kt
@@ -6,14 +6,13 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.notifications.ModuleNotFoundException
 
 class ExpoBackgroundNotificationTasksModule : Module() {
-  private lateinit var taskManager: TaskManagerInterface
+  private val taskManager: TaskManagerInterface by lazy {
+    return@lazy appContext.legacyModule()
+      ?: throw ModuleNotFoundException(TaskManagerInterface::class)
+  }
 
   override fun definition() = ModuleDefinition {
     Name("ExpoBackgroundNotificationTasksModule")
-    OnCreate {
-      taskManager = appContext.legacyModule()
-        ?: throw ModuleNotFoundException(TaskManagerInterface::class)
-    }
 
     AsyncFunction("registerTaskAsync") { taskName: String ->
       taskManager.registerTask(


### PR DESCRIPTION
# Why

Similarly to #26200, `expo-task-manager` is currently necessary for any project using `expo-notifications`. This is a regression compared to previous versions.

fixes https://github.com/expo/expo/issues/26058
# How

Used a lazy variable to initialise the task manager

# Test Plan

Tested in a clean SDK 50 project and in BareExpo

