### PR TITLE
[expo-updates][android] Remove try/catch in expo-updates constants block

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Migrate to requireNativeModule/requireOptionalNativeModule. ([#25648](https://github.com/expo/expo/pull/25648) by [@wschurman](https://github.com/wschurman))
 - Remove classic updates. ([#26036](https://github.com/expo/expo/pull/26036), [#26037](https://github.com/expo/expo/pull/26037), [#26048](https://github.com/expo/expo/pull/26048), [#26059](https://github.com/expo/expo/pull/26059), [#26061](https://github.com/expo/expo/pull/26061), [#26065](https://github.com/expo/expo/pull/26065), [#26080](https://github.com/expo/expo/pull/26080) by [@wschurman](https://github.com/wschurman))
 - Replace deprecated `com.facebook.react:react-native:+` Android dependency with `com.facebook.react:react-android`. ([#26237](https://github.com/expo/expo/pull/26237) by [@kudo](https://github.com/kudo))
+- [Android] Remove try/catch in expo-updates module constants block. ([#26228](https://github.com/expo/expo/pull/26228) by [@wschurman](https://github.com/wschurman))
 
 ## 0.24.5 - 2023-12-21
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -37,27 +37,25 @@ class UpdatesModule : Module() {
 
     Constants {
       UpdatesLogger(context).info("UpdatesModule: getConstants called", UpdatesErrorCode.None)
-
-      val constants = mutableMapOf<String, Any>()
-      try {
+      mutableMapOf<String, Any>().apply {
         val constantsForModule = UpdatesController.instance.getConstantsForModule()
         val launchedUpdate = constantsForModule.launchedUpdate
         val embeddedUpdate = constantsForModule.embeddedUpdate
         val isEmbeddedLaunch = launchedUpdate?.id?.equals(embeddedUpdate?.id) ?: false
 
-        constants["isEmergencyLaunch"] = constantsForModule.isEmergencyLaunch
-        constants["isEmbeddedLaunch"] = isEmbeddedLaunch
-        constants["isEnabled"] = constantsForModule.isEnabled
-        constants["isUsingEmbeddedAssets"] = constantsForModule.isUsingEmbeddedAssets
-        constants["runtimeVersion"] = constantsForModule.runtimeVersion ?: ""
-        constants["checkAutomatically"] = constantsForModule.checkOnLaunch.toJSString()
-        constants["channel"] = constantsForModule.requestHeaders["expo-channel-name"] ?: ""
-        constants["shouldDeferToNativeForAPIMethodAvailabilityInDevelopment"] = constantsForModule.shouldDeferToNativeForAPIMethodAvailabilityInDevelopment || BuildConfig.EX_UPDATES_NATIVE_DEBUG
+        this["isEmergencyLaunch"] = constantsForModule.isEmergencyLaunch
+        this["isEmbeddedLaunch"] = isEmbeddedLaunch
+        this["isEnabled"] = constantsForModule.isEnabled
+        this["isUsingEmbeddedAssets"] = constantsForModule.isUsingEmbeddedAssets
+        this["runtimeVersion"] = constantsForModule.runtimeVersion ?: ""
+        this["checkAutomatically"] = constantsForModule.checkOnLaunch.toJSString()
+        this["channel"] = constantsForModule.requestHeaders["expo-channel-name"] ?: ""
+        this["shouldDeferToNativeForAPIMethodAvailabilityInDevelopment"] = constantsForModule.shouldDeferToNativeForAPIMethodAvailabilityInDevelopment || BuildConfig.EX_UPDATES_NATIVE_DEBUG
 
         if (launchedUpdate != null) {
-          constants["updateId"] = launchedUpdate.id.toString()
-          constants["commitTime"] = launchedUpdate.commitTime.time
-          constants["manifestString"] = launchedUpdate.manifest.toString()
+          this["updateId"] = launchedUpdate.id.toString()
+          this["commitTime"] = launchedUpdate.commitTime.time
+          this["manifestString"] = launchedUpdate.manifest.toString()
         }
         val localAssetFiles = constantsForModule.localAssetFiles
         if (localAssetFiles != null) {
@@ -67,13 +65,9 @@ class UpdatesModule : Module() {
               localAssets[asset.key!!] = localAssetFiles[asset]!!
             }
           }
-          constants["localAssets"] = localAssets
+          this["localAssets"] = localAssets
         }
-      } catch (e: Exception) {
-        // do nothing; this is expected in a development client
-        constants["isEnabled"] = false
       }
-      constants
     }
 
     AsyncFunction("reload") { promise: Promise ->


### PR DESCRIPTION
# Why

This shouldn't be necessary as the comment about this being expected for dev-client is no longer true.

Closes ENG-10969.

# How

Remove.

# Test Plan

Wait for CI. Test locally with dev client.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
