### PR TITLE
[expo-manifests][android] Remove unsafe internal mutation capability

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.AsyncTask
 import android.text.TextUtils
 import android.util.LruCache
-import expo.modules.manifests.core.InternalJSONMutator
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.generated.ExponentBuildConstants
@@ -271,32 +270,6 @@ class ExponentManifest @Inject constructor(
     private const val EXPONENT_SERVER_HEADER = "Exponent-Server"
 
     private var hasShownKernelManifestLog = false
-
-    @Throws(JSONException::class)
-    fun normalizeManifestInPlace(manifest: Manifest, manifestUrl: String) {
-      manifest.mutateInternalJSONInPlace(object : InternalJSONMutator {
-        override fun updateJSON(json: JSONObject) {
-          if (!json.has(MANIFEST_ID_KEY)) {
-            json.put(MANIFEST_ID_KEY, manifestUrl)
-          }
-          if (!json.has(MANIFEST_NAME_KEY)) {
-            json.put(MANIFEST_NAME_KEY, "My New Experience")
-          }
-          if (!json.has(MANIFEST_PRIMARY_COLOR_KEY)) {
-            json.put(MANIFEST_PRIMARY_COLOR_KEY, "#023C69")
-          }
-          if (!json.has(MANIFEST_ICON_URL_KEY)) {
-            json.put(
-              MANIFEST_ICON_URL_KEY,
-              "https://d3lwq5rlu14cro.cloudfront.net/ExponentEmptyManifest_192.png"
-            )
-          }
-          if (!json.has(MANIFEST_ORIENTATION_KEY)) {
-            json.put(MANIFEST_ORIENTATION_KEY, "default")
-          }
-        }
-      })
-    }
   }
 
   init {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -727,7 +727,6 @@ class Kernel : KernelInterface() {
     val bundleUrl = toHttp(manifest.getBundleURL())
     val task = getExperienceActivityTask(manifestUrl)
     task.bundleUrl = bundleUrl
-    ExponentManifest.normalizeManifestInPlace(manifest, manifestUrl)
     if (existingTask == null) {
       sendManifestToExperienceActivity(manifestUrl, manifest, bundleUrl)
     }

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Remove unsafe internal mutation capability. ([#26229](https://github.com/expo/expo/pull/26229) by [@wschurman](https://github.com/wschurman))
+
 ## 0.13.0 — 2023-12-12
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -6,20 +6,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-interface InternalJSONMutator {
-  @Throws(JSONException::class)
-  fun updateJSON(json: JSONObject)
-}
-
 abstract class Manifest(protected val json: JSONObject) {
-  @Deprecated(message = "Strive for manifests to be immutable")
-  @Throws(JSONException::class)
-  fun mutateInternalJSONInPlace(internalJSONMutator: InternalJSONMutator) {
-    json.apply {
-      internalJSONMutator.updateJSON(this)
-    }
-  }
-
   @Deprecated(message = "Prefer to use specific field getters")
   fun getRawJson(): JSONObject = json
 


### PR DESCRIPTION
# Why

In an effort to remove deprecated methods in Manifest, this one can be removed. These fields are only applicable for legacy manifests (which were removed and are no longer supported in Expo Go where this code lives), so this method is having no effect.

Closes ENG-10971.

# How

Remove.

# Test Plan

Wait for build. Load experience in Expo Go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
