### PR TITLE
[expo-updates] Limit allowed states for state machine depending on use case

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -53,14 +53,14 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_defaultState() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
   }
 
   @Test
   fun test_handleCheckAndCheckCompleteAvailable() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -83,7 +83,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleCheckCompleteUnavailable() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -103,7 +103,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleDownloadAndDownloadComplete() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Download())
 
@@ -128,7 +128,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleRollback() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
     val commitTime = Date()
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -147,7 +147,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_checkError() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -168,7 +168,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_invalidTransitions() {
     val testStateChangeEventSender = TestStateChangeEventSender()
-    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender)
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, UpdatesStateValue.values().toSet())
     machine.processEventTest(UpdatesStateEvent.Check())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
 
@@ -182,5 +182,18 @@ class UpdatesStateMachineInstrumentationTest {
       machine.processEventTest(UpdatesStateEvent.DownloadComplete())
     }
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
+  }
+
+  @Test
+  fun test_invalidStateValues() {
+    val testStateChangeEventSender = TestStateChangeEventSender()
+    // can only be idle
+    val machine = UpdatesStateMachine(androidContext, testStateChangeEventSender, setOf(UpdatesStateValue.Idle))
+
+    // Test invalid value and ensure that state does not change
+    Assert.assertThrows(AssertionError::class.java) {
+      machine.processEventTest(UpdatesStateEvent.Download())
+    }
+    Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -19,6 +19,7 @@ import expo.modules.updates.statemachine.UpdatesStateChangeEventSender
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updates.statemachine.UpdatesStateEventType
 import expo.modules.updates.statemachine.UpdatesStateMachine
+import expo.modules.updates.statemachine.UpdatesStateValue
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -39,7 +40,9 @@ class DisabledUpdatesController(
     null
   }
   private val logger = UpdatesLogger(context)
-  private val stateMachine = UpdatesStateMachine(context, this)
+
+  // disabled controller state machine can only be idle or restarting
+  private val stateMachine = UpdatesStateMachine(context, this, setOf(UpdatesStateValue.Idle, UpdatesStateValue.Restarting))
 
   private var isStarted = false
   private var launcher: Launcher? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -31,6 +31,7 @@ import expo.modules.updates.statemachine.UpdatesStateChangeEventSender
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updates.statemachine.UpdatesStateEventType
 import expo.modules.updates.statemachine.UpdatesStateMachine
+import expo.modules.updates.statemachine.UpdatesStateValue
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -54,7 +55,7 @@ class EnabledUpdatesController(
   private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
     updatesConfiguration.getRuntimeVersion()
   )
-  private val stateMachine = UpdatesStateMachine(context, this)
+  private val stateMachine = UpdatesStateMachine(context, this, UpdatesStateValue.values().toSet())
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
 
   private fun purgeUpdatesLogsOlderThanOneDay() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -12,7 +12,8 @@ import java.util.Date
  */
 class UpdatesStateMachine(
   androidContext: Context,
-  private val changeEventSender: UpdatesStateChangeEventSender
+  private val changeEventSender: UpdatesStateChangeEventSender,
+  private val validUpdatesStateValues: Set<UpdatesStateValue>
 ) {
   private val serialExecutorQueue = StateMachineSerialExecutorQueue(object : StateMachineProcedure.StateMachineProcedureContext {
     override fun processStateEvent(event: UpdatesStateEvent) {
@@ -79,7 +80,12 @@ class UpdatesStateMachine(
       assert(false) { "UpdatesState: invalid transition requested: state = $state, event = ${event.type}" }
       return false
     }
-    state = updatesStateTransitions[event.type] ?: UpdatesStateValue.Idle
+    val newStateValue = updatesStateTransitions[event.type] ?: UpdatesStateValue.Idle
+    if (!validUpdatesStateValues.contains(newStateValue)) {
+      assert(false) { "UpdatesState: invalid transition requested: state = $state, event = ${event.type}" }
+      return false
+    }
+    state = newStateValue
     return true
   }
 

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -16,7 +16,8 @@ public class DisabledAppController: InternalAppControllerInterface {
 
   public weak var delegate: AppControllerDelegate?
 
-  private let stateMachine = UpdatesStateMachine()
+  // disabled controller state machine can only be idle or restarting
+  private let stateMachine = UpdatesStateMachine(validUpdatesStateValues: [UpdatesStateValue.idle, UpdatesStateValue.restarting])
 
   internal private(set) var isEmergencyLaunch: Bool = false
   private let initializationError: Error?

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -31,7 +31,7 @@ public class EnabledAppController: UpdatesStateChangeDelegate, InternalAppContro
 
   private var eventsToSendToJS: [[String: Any?]] = []
 
-  private let stateMachine = UpdatesStateMachine()
+  private let stateMachine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
 
   private let selectionPolicy: SelectionPolicy
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -18,7 +18,7 @@ internal protocol UpdatesStateChangeDelegate: AnyObject {
 /**
  All the possible states the machine can take.
  */
-internal enum UpdatesStateValue: String {
+internal enum UpdatesStateValue: String, CaseIterable {
   case idle
   case checking
   case downloading
@@ -287,6 +287,12 @@ extension UpdatesStateContext {
  in a production app, instantiated as a property of AppController.
  */
 internal class UpdatesStateMachine {
+  private let validUpdatesStateValues: Set<UpdatesStateValue>
+
+  required init(validUpdatesStateValues: Set<UpdatesStateValue>) {
+    self.validUpdatesStateValues = validUpdatesStateValues
+  }
+
   private let logger = UpdatesLogger()
 
   private lazy var serialExecutorQueue: StateMachineSerialExecutorQueue = {
@@ -371,8 +377,13 @@ internal class UpdatesStateMachine {
       assertionFailure("UpdatesState: invalid transition requested: state = \(state), event = \(event.type)")
       return false
     }
+    let newStateValue = UpdatesStateMachine.updatesStateTransitions[event.type] ?? .idle
+    if !validUpdatesStateValues.contains(newStateValue) {
+      assertionFailure("UpdatesState: invalid transition requested: state = \(state), event = \(event.type)")
+      return false
+    }
     // Successful transition
-    state = UpdatesStateMachine.updatesStateTransitions[event.type] ?? .idle
+    state = newStateValue
     return true
   }
 

--- a/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesStateMachineSpec.swift
@@ -22,14 +22,14 @@ class UpdatesStateMachineSpec: ExpoSpec {
     describe("default state") {
       it("instantiates") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
         expect(machine.getStateForTesting()) == .idle
       }
 
       it("should handle check and checkCompleteAvailable") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
 
         machine.processEventForTesting(UpdatesStateEventCheck())
@@ -52,7 +52,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle check and checkCompleteUnavailable") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
 
         machine.processEventForTesting(UpdatesStateEventCheck())
@@ -69,7 +69,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle download and downloadComplete") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
 
         machine.processEventForTesting(UpdatesStateEventDownload())
@@ -90,7 +90,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("should handle rollback") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
         let commitTime = Date()
         machine.processEventForTesting(UpdatesStateEventCheck())
@@ -108,7 +108,7 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
       it("invalid transitions are handled as expected") {
         let testStateChangeDelegate = TestStateChangeDelegate()
-        let machine = UpdatesStateMachine()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: Set(UpdatesStateValue.allCases))
         machine.changeEventDelegate = testStateChangeDelegate
 
         machine.processEventForTesting(UpdatesStateEventCheck())
@@ -149,6 +149,17 @@ class UpdatesStateMachineSpec: ExpoSpec {
 
         expect(machine.processEventForTesting(UpdatesStateEventDownloadComplete())).to(throwAssertion())
         expect(machine.getStateForTesting()) == .restarting
+      }
+
+      it("invalid state values are handled as expected") {
+        let testStateChangeDelegate = TestStateChangeDelegate()
+        let machine = UpdatesStateMachine(validUpdatesStateValues: [UpdatesStateValue.idle])
+        machine.changeEventDelegate = testStateChangeDelegate
+
+        expect(machine.processEventForTesting(UpdatesStateEventDownload())).to(throwAssertion())
+        expect(machine.getStateForTesting()) == .idle
+        expect(testStateChangeDelegate.lastEventType).to(beNil())
+        expect(testStateChangeDelegate.lastEventBody).to(beNil())
       }
     }
   }


### PR DESCRIPTION
# Why

Suggested in a previous PR review: we should be strict about which states are allowed depending on the state machine instance. Currently we have two use cases:
- enabled: all states are valid
- disabled: can only be idle or reloading.

Closes ENG-10956.

# How

Add check for valid state value.

# Test Plan

Run new tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
