### PR TITLE
[docs] Update formatting and verbiage in Icons guide

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -4,14 +4,15 @@ description: Learn how to use various types of icons in your Expo app, including
 ---
 
 import { SnackInline } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-As trendy as it is these days, not every app has to use emoji for all icons &mdash; maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
+Not every app needs to use emojis for icons. You can use a popular icon set through an icon font such as FontAwesome, Glyphicons, or Ionicons, or choose PNGs from [The Noun Project](https://thenounproject.com/). This guide explains various ways to use icons in your Expo app.
 
 ## `@expo/vector-icons`
 
-This library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets that you can browse at [icons.expo.fyi](https://icons.expo.fyi).
+The `@expo/vector-icons` library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 
-In the example below, the component loads the `Ionicons` font, and renders a checkmark icon.
+The component loads the `Ionicons` font and renders a checkmark icon in the following example:
 
 <SnackInline label='Vector icons' dependencies={['@expo/vector-icons']}>
 
@@ -43,19 +44,19 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> As with [any custom font](/develop/user-interface/fonts/#use-a-custom-font) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. Read more about [pre-loading and caching assets](preloading-and-caching-assets#pre-loading-and-caching-assets).
+> As with [any custom font](/develop/user-interface/fonts/#use-a-custom-font) in Expo, you can preload icon fonts before rendering your app. The font object is available as a static property on the font component. So, in the case above, it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`.
 
 ## Custom icon fonts
 
-To use a custom icon font, you have to make sure you import them into your project. Only after a font has loaded, you can create an Icon set. [Learn more about loading custom fonts](/develop/user-interface/fonts/#use-a-custom-font).
+To use a custom icon font, first import it into your project. Only after the font has loaded, can you create an Icon set. [Learn more about loading custom fonts](/develop/user-interface/fonts/#use-a-custom-font).
 
 `@expo/vector-icons` exposes three methods to help you create an icon set:
 
 ### `createIconSet`
 
-This method returns your own custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or it's character code.
+The `createIconSet` method returns a custom font based on the `glyphMap` where the key is the icon name and the value is either a UTF-8 character or its character code.
 
-In the example below, the `glyphMap` object is defined which is then passed as the first argument to the `createIconSet` method. The second argument `fontFamily` is the name of the font (not the filename). Optionally, you can pass the third argument for Android support, which is the custom font file name.
+In the example below, the `glyphMap` object is defined and then passed as the first argument to the `createIconSet` method. The second argument `fontFamily` is the name of the font (not the filename). Optionally, you can pass the third argument for Android support, which is the custom font file name.
 
 ```jsx
 import * as React from 'react';
@@ -72,7 +73,7 @@ export default function CustomIconExample() {
 
 ### `createIconSetFromIcoMoon`
 
-The `@expo/vector-icons` library provides `createIconSetFromIcoMoon` method to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** somewhere convenient in your project, preferably in the `assets/*` folder, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
+The `createIconSetFromIcoMoon` method is used to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
 See the example below that uses the `useFonts` hook to load the font:
 
@@ -135,9 +136,9 @@ const styles = StyleSheet.create({
 
 ### `createIconSetFromFontello`
 
-The `@expo/vector-icons` library provides `createIconSetFromFontello` method to create a custom font based on a [Fontello](http://fontello.com/) config file. You have to save the **config.json** and **.ttf** somewhere convenient in your project, preferably in the `assets/*` folder, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
+The `createIconSetFromFontello` method is used to create a custom font based on a [Fontello](http://fontello.com/) config file. You have to save the **config.json** and **.ttf** somewhere convenient in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
-It follows the similar configuration as `createIconSetFromIcoMoon` as shown in the example:
+It follows a similar configuration as `createIconSetFromIcoMoon` as shown in the example:
 
 ```js
 // Import the createIconSetFromFontello method
@@ -152,8 +153,38 @@ const Icon = createIconSetFromFontello(fontelloConfig, 'fontello', 'fontello.ttf
 
 ## Icon images
 
-You can use the `Image` component from React Native to display an icon. The `source` prop takes the relative path to refer the image.
+You can use the `Image` component from [Expo Image](/versions/latest/sdk/image/) or React Native to display an icon. The `source` prop takes the relative path to refer to the image.
 
+<Tabs>
+
+<Tab label="Expo Image">
+
+```jsx
+import { Image } from 'expo-image';
+import { View, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Image source={require('./assets/images/slack-icon.png')} style={{ width: 50, height: 50 }} />
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+/* @end */
+```
+
+</Tab>
+
+<Tab label="React Native Image">
 <SnackInline
 label='Icon images'
 files={{
@@ -161,17 +192,12 @@ files={{
   }}>
 
 ```jsx
-import React from 'react';
 import { Image, View, StyleSheet } from 'react-native';
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Image
-        source={require('./assets/images/slack-icon.png')}
-        fadeDuration={0}
-        style={{ width: 50, height: 50 }}
-      />
+      <Image source={require('./assets/images/slack-icon.png')} style={{ width: 50, height: 50 }} />
     </View>
   );
 }
@@ -189,7 +215,11 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-You can also provide different versions of your icon at various pixel densities. The `Image` component takes care of using the image with appropriate pixel density automatically. For example, if the image has variants like `icon@2x.png` and `icon@3x.png`, the `@2x` suffix is served for a device's screen density for older devices such as iPhone 8 and the `@3x` suffix is served for a device's screen density on newer devices such as iPhone 13. [You can learn more about serving different densities in React Native documentation](https://reactnative.dev/docs/images#static-image-resources).
+</Tab>
+
+</Tabs>
+
+You can also provide different versions of your icon at various pixel densities. The `Image` component takes care of using the image with appropriate pixel density automatically. For example, if the image has variants such as `icon@2x.png` and `icon@3x.png`, the `@2x` suffix is served for a device's screen density for older devices such as iPhone 8 and the `@3x` suffix is served for a device's screen density on newer devices such as iPhone 13. [Learn more about serving different densities in React Native documentation](https://reactnative.dev/docs/images#static-image-resources).
 
 ## Button component
 
@@ -233,7 +263,7 @@ const styles = StyleSheet.create({
 
 ### Properties
 
-Any [`Text`](http://reactnative.dev/docs/text), [`TouchableHighlight`](http://reactnative.dev/docs/touchablehighlight) or [`TouchableWithoutFeedback`](http://reactnative.dev/docs/touchablewithoutfeedback) property in addition to these:
+Any [`Text`](http://reactnative.dev/docs/text), [`TouchableHighlight`](http://reactnative.dev/docs/touchablehighlight), or [`TouchableWithoutFeedback`](http://reactnative.dev/docs/touchablewithoutfeedback) property in addition to these:
 
 | Prop                  | Description                                                                                                                                       | Default             |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The formatting and verbiage do not match our writing style guide.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the formatting and verbiage and also
- removes archived preloading fonts and icons link from the callout
- adds an example of using Expo Image to load & display an icon

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/icons/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
