### PR TITLE
[docs] fix typo in Prism styles

### DIFF
--- a/docs/global-styles/prism.ts
+++ b/docs/global-styles/prism.ts
@@ -49,12 +49,12 @@ export const globalPrism = css`
   .token.prolog,
   .token.doctype,
   .token.cdata {
-    color: ${theme.palette.gray10}
+    color: ${theme.palette.gray10};
   }
 
   .token.operator,
   .token.punctuation {
-    color: ${theme.palette.gray9}
+    color: ${theme.palette.gray9};
   }
 
   .token.attr-name,
@@ -63,7 +63,7 @@ export const globalPrism = css`
   .token.constant,
   .token.symbol,
   .token.deleted {
-    color: ${theme.palette.red11}
+    color: ${theme.palette.red11};
   }
 
   .token.selector,
@@ -71,41 +71,41 @@ export const globalPrism = css`
   .token.builtin,
   .token.script,
   .token.inserted {
-    color: ${theme.palette.green10}
+    color: ${theme.palette.green10};
   }
 
   .token.entity,
   .token.variable {
-    color: ${theme.palette.green11}
+    color: ${theme.palette.green11};
   }
 
   .token.keyword {
-    color: ${theme.palette.pink10}
+    color: ${theme.palette.pink10};
   }
 
   .token.property,
   .token.atrule,
   .token.attr-value,
   .token.function {
-    color: ${theme.palette.purple11}
+    color: ${theme.palette.purple11};
   }
 
   .token.class-name,
   .token.regex,
   .token.important,
   .token.tag {
-    color: ${theme.palette.orange11}
+    color: ${theme.palette.orange11};
   }
 
   .token.number,
   .token.string {
-    color: ${theme.palette.yellow11}
+    color: ${theme.palette.yellow11};
   }
 
   .token.url,
   .token.literal-property,
   .token.property-access {
-    color: ${theme.palette.blue11}
+    color: ${theme.palette.blue11};
   }
 
   .token.important {
@@ -138,7 +138,7 @@ export const globalPrism = css`
   .token.tab:not(:empty):before,
   .token.cr:before,
   .token.lf:before {
-    color: ${theme.palette.gray9}
+    color: ${theme.palette.gray9};
   }
 
   pre[class*='language-'].line-numbers {

--- a/docs/global-styles/prism.ts
+++ b/docs/global-styles/prism.ts
@@ -14,7 +14,6 @@ export const globalPrism = css`
     position: relative;
     padding: 0.2em;
     border-radius: 0.3em;
-    color: ${theme.palette.red11};
     border: 1px solid ${theme.border.default};
     display: inline;
     white-space: normal;

--- a/docs/global-styles/prism.ts
+++ b/docs/global-styles/prism.ts
@@ -14,7 +14,7 @@ export const globalPrism = css`
     position: relative;
     padding: 0.2em;
     border-radius: 0.3em;
-    color: color: ${theme.palette.red11};
+    color: ${theme.palette.red11};
     border: 1px solid ${theme.border.default};
     display: inline;
     white-space: normal;


### PR DESCRIPTION
# Why

There is a typo in the custom prism styles.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Remove the duplicate `color:`.
Also added the missing `;`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run docs and check that code blocks render correcty.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
