### PR TITLE
Add macOS support to expo-file-system

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1965,7 +1965,7 @@ SPEC CHECKSUMS:
   ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
-  ExpoFileSystem: ebbbe77366bff2e66876e3b3bf09e61d3bb72c70
+  ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc
   ExpoGL: 085542f97b13f2428ac2edb077c9a90f4566944d
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
   ExpoImage: 5ba424cbd89ba94103f21817cc310c26a009d967

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1963,7 +1963,7 @@ SPEC CHECKSUMS:
   ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
-  ExpoFileSystem: ebbbe77366bff2e66876e3b3bf09e61d3bb72c70
+  ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc
   ExpoGL: 085542f97b13f2428ac2edb077c9a90f4566944d
   ExpoHaptics: 76961bc7692870eb8ddac0527260a7ecaf28300d
   ExpoHead: 573e78cb221b5461376d0cc88ee0611337c3c3cb

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added support for macOS platform.
+- Added support for macOS platform. ([#26253](https://github.com/expo/expo/pull/26253) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for macOS platform.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-file-system/ios/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem.m
@@ -5,7 +5,12 @@
 #import <ExpoFileSystem/EXFileSystem.h>
 
 #import <CommonCrypto/CommonDigest.h>
+
+#if TARGET_OS_IOS || TARGET_OS_TV
 #import <MobileCoreServices/MobileCoreServices.h>
+#elif TARGET_OS_OSX
+#import <CoreServices/CoreServices.h>
+#endif
 
 #import <ExpoFileSystem/EXFileSystemLocalFileHandler.h>
 #import <ExpoFileSystem/EXFileSystemAssetLibraryHandler.h>

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -25,7 +25,7 @@
     result[@"uri"] = fileUri;
     result[@"modificationTime"] = @(asset.modificationDate.timeIntervalSince1970);
     if (options[@"md5"] || options[@"size"]) {
-      [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
+      [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {
         result[@"size"] = @(imageData.length);
         if (options[@"md5"]) {
           result[@"md5"] = [imageData md5String];
@@ -84,7 +84,7 @@
         [EXFileSystemAssetLibraryHandler copyData:data toPath:toPath resolver:resolve rejecter:reject];
       }];
     } else {
-      [[PHImageManager defaultManager] requestImageDataForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, UIImageOrientation orientation, NSDictionary * _Nullable info) {
+      [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {
         [EXFileSystemAssetLibraryHandler copyData:imageData toPath:toPath resolver:resolve rejecter:reject];
       }];
     }
@@ -110,10 +110,12 @@
       hasWarned = YES;
     }
     return nil;
-#else
+#elif TARGET_OS_IOS || TARGET_OS_TV
     // This is the older, deprecated way of fetching assets from assets-library
     // using the "assets-library://" protocol
     return [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil];
+#elif TARGET_OS_OSX
+    return nil;
 #endif
   }
 

--- a/packages/expo-file-system/ios/EXSessionTasks/EXSessionHandler.h
+++ b/packages/expo-file-system/ios/EXSessionTasks/EXSessionHandler.h
@@ -1,8 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import <ExpoModulesCore/Platform.h>
 #import <ExpoModulesCore/EXSingletonModule.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-file-system/ios/ExpoFileSystem.podspec
+++ b/packages/expo-file-system/ios/ExpoFileSystem.podspec
@@ -10,7 +10,11 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms       = { :ios => '13.4', :tvos => '13.4'}
+  s.platforms       = {
+    :ios => '13.4',
+    :osx => '10.15',
+    :tvos => '13.4'
+  }
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-file-system/ios/FileSystemBackgroundSessionHandler.swift
+++ b/packages/expo-file-system/ios/FileSystemBackgroundSessionHandler.swift
@@ -19,7 +19,9 @@ public final class FileSystemBackgroundSessionHandler: ExpoAppDelegateSubscriber
 
   // MARK: - ExpoAppDelegateSubscriber
 
+  #if os(iOS) || os(tvOS)
   public func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
     completionHandlers[identifier] = completionHandler
   }
+  #endif
 }


### PR DESCRIPTION
# Why

Following up on enabling macOS platform in packages that are necessary to install Expo modules. Separated from #22796 

# How

- Enabled macOS platform in the podspec
- Reinstalled pods
- Use CoreServices instead of MobileServices when building for macOS
- Replaced the deprecated `requestImageDataForAsset` method with `requestImageDataAndOrientationForAsset` that works on more platforms

# Test Plan

Tested in https://github.com/tsapeta/expo-macos-example as part of #22796 