### PR TITLE
[docs] support rendering oneOf properties in AppConfig reference

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -13,6 +13,7 @@ import { SnippetHeader } from '~/ui/components/Snippet/SnippetHeader';
 import { CopyAction } from '~/ui/components/Snippet/actions/CopyAction';
 import { SettingsAction } from '~/ui/components/Snippet/actions/SettingsAction';
 import { CODE } from '~/ui/components/Text';
+import { TextTheme } from '~/ui/components/Text/types';
 
 // @ts-ignore Jest ESM issue https://github.com/facebook/jest/issues/9430
 const { default: testTippy } = tippy;
@@ -294,9 +295,9 @@ const codeBlockInlineContainerStyle = {
   padding: 0,
 };
 
-type CodeBlockProps = React.PropsWithChildren<{ inline?: boolean }>;
+type CodeBlockProps = React.PropsWithChildren<{ inline?: boolean; theme?: TextTheme }>;
 
-export const CodeBlock = ({ children, inline = false }: CodeBlockProps) => {
+export const CodeBlock = ({ children, theme, inline = false }: CodeBlockProps) => {
   const Element = inline ? 'span' : 'pre';
   return (
     <Element
@@ -306,7 +307,14 @@ export const CodeBlock = ({ children, inline = false }: CodeBlockProps) => {
         inline && codeBlockInlineContainerStyle,
       ]}
       {...attributes}>
-      <CODE css={[STYLES_CODE_BLOCK, inline && codeBlockInlineStyle, { fontSize: '80%' }]}>
+      <CODE
+        theme={theme}
+        css={[
+          STYLES_CODE_BLOCK,
+          inline && codeBlockInlineStyle,
+          { fontSize: '80%' },
+          theme && { color: 'inherit' },
+        ]}>
         {children}
       </CODE>
     </Element>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -153,7 +153,6 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
     </details>
-    <div />
   </div>
   <div
     class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
@@ -384,31 +383,124 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
     </details>
-    <div>
-      <div
-        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    <div
+      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    >
+      <p
+        class="  css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        <p
-          class="  css-1kfqm4n-TextComponent"
+        <a
+          class="css-1yk6eqh"
+          href="#visible"
+        >
+          <span
+            class="css-s3qkfm"
+            id="visible"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-10gpz29-PropertyName"
+              data-text="true"
+            >
+              visible
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
+      <p
+        class="css-1lwc34i-AppConfigProperty"
+        data-text="true"
+      >
+        Type: 
+        <code
+          class="css-ite7ne-TextComponent"
           data-text="true"
         >
+          enum
+        </code>
+         • Path:
+         
+        <code
+          class="css-te23k8-AppConfigProperty"
+        >
+          androidNavigationBar
+          .
+          visible
+        </code>
+      </p>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        Determines how and when the navigation bar is shown.
+      </p>
+      <details
+        class="css-xpa10j"
+        id="expokit-1"
+      >
+        <summary
+          class="css-zjlxe1"
+        >
+          <div
+            class="css-qos8r6"
+          >
+            <svg
+              class="icon-sm text-icon-default css-nlesit"
+              fill="none"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                id="triangle-down"
+              >
+                <path
+                  d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
+                  fill="currentColor"
+                  id="Vector 250"
+                />
+              </g>
+            </svg>
+          </div>
           <a
-            class="css-1yk6eqh"
-            href="#visible"
+            href="#expokit-1"
           >
             <span
-              class="css-s3qkfm"
-              id="visible"
-            />
-            <span
-              class="css-6n7j50"
+              class="css-1n5kx9e-TextComponent"
+              data-text="true"
             >
-              <code
-                class="css-10gpz29-PropertyName"
-                data-text="true"
-              >
-                visible
-              </code>
+              ExpoKit
             </span>
             <span
               class="css-13330di"
@@ -439,223 +531,42 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </svg>
             </span>
           </a>
-        </p>
-        <p
-          class="css-1lwc34i-AppConfigProperty"
-          data-text="true"
+        </summary>
+        <div
+          class="last:[&>*]:!mb-1 css-qbaxbl"
         >
-          Type: 
-          <code
-            class="css-ite7ne-TextComponent"
+          <p
+            class="mb-4 css-1kfqm4n-TextComponent"
             data-text="true"
           >
-            enum
-          </code>
-           • Path:
-           
-          <code
-            class="css-te23k8-AppConfigProperty"
-          >
-            androidNavigationBar
-            .
-            visible
-          </code>
-        </p>
+            Set this property using Xcode.
+          </p>
+        </div>
+      </details>
+      <div
+        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+      >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="  css-1kfqm4n-TextComponent"
           data-text="true"
         >
-          Determines how and when the navigation bar is shown.
-        </p>
-        <details
-          class="css-xpa10j"
-          id="expokit-1"
-        >
-          <summary
-            class="css-zjlxe1"
+          <a
+            class="css-1yk6eqh"
+            href="#always"
           >
-            <div
-              class="css-qos8r6"
+            <span
+              class="css-s3qkfm"
+              id="always"
+            />
+            <span
+              class="css-6n7j50"
             >
-              <svg
-                class="icon-sm text-icon-default css-nlesit"
-                fill="none"
-                role="img"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  id="triangle-down"
-                >
-                  <path
-                    d="M18.8831 9.43005H5.11694L12 16.3131L18.8831 9.43005Z"
-                    fill="currentColor"
-                    id="Vector 250"
-                  />
-                </g>
-              </svg>
-            </div>
-            <a
-              href="#expokit-1"
-            >
-              <span
-                class="css-1n5kx9e-TextComponent"
+              <code
+                class="css-10gpz29-PropertyName"
                 data-text="true"
               >
-                ExpoKit
-              </span>
-              <span
-                class="css-13330di"
-              >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </summary>
-          <div
-            class="last:[&>*]:!mb-1 css-qbaxbl"
-          >
-            <p
-              class="mb-4 css-1kfqm4n-TextComponent"
-              data-text="true"
-            >
-              Set this property using Xcode.
-            </p>
-          </div>
-        </details>
-        <div>
-          <div
-            class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
-          >
-            <p
-              class="  css-1kfqm4n-TextComponent"
-              data-text="true"
-            >
-              <a
-                class="css-1yk6eqh"
-                href="#always"
-              >
-                <span
-                  class="css-s3qkfm"
-                  id="always"
-                />
-                <span
-                  class="css-6n7j50"
-                >
-                  <code
-                    class="css-10gpz29-PropertyName"
-                    data-text="true"
-                  >
-                    always
-                  </code>
-                </span>
-                <span
-                  class="css-13330di"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </span>
-              </a>
-            </p>
-            <p
-              class="css-1lwc34i-AppConfigProperty"
-              data-text="true"
-            >
-              Type: 
-              <code
-                class="css-ite7ne-TextComponent"
-                data-text="true"
-              >
-                boolean
-              </code>
-               • Path:
-               
-              <code
-                class="css-te23k8-AppConfigProperty"
-              >
-                androidNavigationBar.visible
-                .
                 always
               </code>
-            </p>
-            <p
-              class="mb-4 css-1kfqm4n-TextComponent"
-              data-text="true"
-            >
-              Test sub-sub-property
-            </p>
-            <div />
-          </div>
-        </div>
-      </div>
-      <div
-        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
-      >
-        <p
-          class="  css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          <a
-            class="css-1yk6eqh"
-            href="#backgroundcolor"
-          >
-            <span
-              class="css-s3qkfm"
-              id="backgroundcolor"
-            />
-            <span
-              class="css-6n7j50"
-            >
-              <code
-                class="css-10gpz29-PropertyName"
-                data-text="true"
-              >
-                backgroundColor
-              </code>
             </span>
             <span
               class="css-13330di"
@@ -696,40 +607,122 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-ite7ne-TextComponent"
             data-text="true"
           >
-            string
+            boolean
           </code>
            • Path:
            
           <code
             class="css-te23k8-AppConfigProperty"
           >
-            androidNavigationBar
+            androidNavigationBar.visible
             .
-            backgroundColor
+            always
           </code>
         </p>
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
           data-text="true"
         >
-          Specifies the background color of the navigation bar.
+          Test sub-sub-property
         </p>
-        
-
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          6 character long hex color string, eg: 
-          <code
-            class="css-qyuze8-TextComponent"
-            data-text="true"
-          >
-            '#000000'
-          </code>
-        </p>
-        <div />
       </div>
+    </div>
+    <div
+      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    >
+      <p
+        class="  css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#backgroundcolor"
+        >
+          <span
+            class="css-s3qkfm"
+            id="backgroundcolor"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-10gpz29-PropertyName"
+              data-text="true"
+            >
+              backgroundColor
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
+      <p
+        class="css-1lwc34i-AppConfigProperty"
+        data-text="true"
+      >
+        Type: 
+        <code
+          class="css-ite7ne-TextComponent"
+          data-text="true"
+        >
+          string
+        </code>
+         • Path:
+         
+        <code
+          class="css-te23k8-AppConfigProperty"
+        >
+          androidNavigationBar
+          .
+          backgroundColor
+        </code>
+      </p>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        Specifies the background color of the navigation bar.
+      </p>
+      
+
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        6 character long hex color string, eg: 
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          '#000000'
+        </code>
+      </p>
     </div>
   </div>
   <div
@@ -883,49 +876,192 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
       </div>
     </details>
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
+    <span
+      class="grid grid-cols-1 gap-2 mb-6"
     >
-      <div
-        class="css-7jywx8-Callout"
+      <strong
+        class="css-bvflvn-TextComponent"
       >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            id="info-circle"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1m74yfi-Callout"
+        Example
+      </strong>
+      <span
+        class="css-1nzh6mw-CodeBlock"
+        data-text="true"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
-        >
-          Example
-        </strong>
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+        <code
+          class="css-1360qeq-CodeBlock"
           data-text="true"
         >
-          [{  "autoVerify": true,  "data": {"host": "*.example.com"  }  }]
-        </p>
-      </div>
-    </blockquote>
-    <div>
+          [
+  {
+    "autoVerify": true,
+    "data": {
+      "host": "*.example.com"
+    }
+  }
+]
+        </code>
+      </span>
+    </span>
+    <div
+      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    >
+      <p
+        class="  css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#autoverify"
+        >
+          <span
+            class="css-s3qkfm"
+            id="autoverify"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-10gpz29-PropertyName"
+              data-text="true"
+            >
+              autoVerify
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
+      <p
+        class="css-1lwc34i-AppConfigProperty"
+        data-text="true"
+      >
+        Type: 
+        <code
+          class="css-ite7ne-TextComponent"
+          data-text="true"
+        >
+          boolean
+        </code>
+         • Path:
+         
+        <code
+          class="css-te23k8-AppConfigProperty"
+        >
+          intentFilters
+          .
+          autoVerify
+        </code>
+      </p>
+      <p
+        class="mb-4 css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        You may also use an intent filter to set your app as the default handler for links
+      </p>
+    </div>
+    <div
+      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    >
+      <p
+        class="  css-1kfqm4n-TextComponent"
+        data-text="true"
+      >
+        <a
+          class="css-1yk6eqh"
+          href="#data"
+        >
+          <span
+            class="css-s3qkfm"
+            id="data"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="css-10gpz29-PropertyName"
+              data-text="true"
+            >
+              data
+            </code>
+          </span>
+          <span
+            class="css-13330di"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
+      <p
+        class="css-1lwc34i-AppConfigProperty"
+        data-text="true"
+      >
+        Type: 
+        <code
+          class="css-ite7ne-TextComponent"
+          data-text="true"
+        >
+          array || object
+        </code>
+         • Path:
+         
+        <code
+          class="css-te23k8-AppConfigProperty"
+        >
+          intentFilters
+          .
+          data
+        </code>
+      </p>
       <div
         class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
       >
@@ -935,11 +1071,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           <a
             class="css-1yk6eqh"
-            href="#autoverify"
+            href="#host"
           >
             <span
               class="css-s3qkfm"
-              id="autoverify"
+              id="host"
             />
             <span
               class="css-6n7j50"
@@ -948,224 +1084,60 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class="css-10gpz29-PropertyName"
                 data-text="true"
               >
-                autoVerify
-              </code>
-            </span>
-            <span
-              class="css-13330di"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </p>
-        <p
-          class="css-1lwc34i-AppConfigProperty"
-          data-text="true"
-        >
-          Type: 
-          <code
-            class="css-ite7ne-TextComponent"
-            data-text="true"
-          >
-            boolean
-          </code>
-           • Path:
-           
-          <code
-            class="css-te23k8-AppConfigProperty"
-          >
-            intentFilters
-            .
-            autoVerify
-          </code>
-        </p>
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          You may also use an intent filter to set your app as the default handler for links
-        </p>
-        <div />
-      </div>
-      <div
-        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
-      >
-        <p
-          class="  css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          <a
-            class="css-1yk6eqh"
-            href="#data"
-          >
-            <span
-              class="css-s3qkfm"
-              id="data"
-            />
-            <span
-              class="css-6n7j50"
-            >
-              <code
-                class="css-10gpz29-PropertyName"
-                data-text="true"
-              >
-                data
-              </code>
-            </span>
-            <span
-              class="css-13330di"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </p>
-        <p
-          class="css-1lwc34i-AppConfigProperty"
-          data-text="true"
-        >
-          Type: 
-          <code
-            class="css-ite7ne-TextComponent"
-            data-text="true"
-          >
-            array || object
-          </code>
-           • Path:
-           
-          <code
-            class="css-te23k8-AppConfigProperty"
-          >
-            intentFilters
-            .
-            data
-          </code>
-        </p>
-        <div>
-          <div
-            class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
-          >
-            <p
-              class="  css-1kfqm4n-TextComponent"
-              data-text="true"
-            >
-              <a
-                class="css-1yk6eqh"
-                href="#host"
-              >
-                <span
-                  class="css-s3qkfm"
-                  id="host"
-                />
-                <span
-                  class="css-6n7j50"
-                >
-                  <code
-                    class="css-10gpz29-PropertyName"
-                    data-text="true"
-                  >
-                    host
-                  </code>
-                </span>
-                <span
-                  class="css-13330di"
-                >
-                  <svg
-                    aria-label="permalink"
-                    class="anchor-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                    <path
-                      d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                      stroke="#9B9B9B"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </span>
-              </a>
-            </p>
-            <p
-              class="css-1lwc34i-AppConfigProperty"
-              data-text="true"
-            >
-              Type: 
-              <code
-                class="css-ite7ne-TextComponent"
-                data-text="true"
-              >
-                string
-              </code>
-               • Path:
-               
-              <code
-                class="css-te23k8-AppConfigProperty"
-              >
-                intentFilters.data
-                .
                 host
               </code>
-            </p>
-            <div />
-          </div>
-        </div>
+            </span>
+            <span
+              class="css-13330di"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </p>
+        <p
+          class="css-1lwc34i-AppConfigProperty"
+          data-text="true"
+        >
+          Type: 
+          <code
+            class="css-ite7ne-TextComponent"
+            data-text="true"
+          >
+            string
+          </code>
+           • Path:
+           
+          <code
+            class="css-te23k8-AppConfigProperty"
+          >
+            intentFilters.data
+            .
+            host
+          </code>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Why

Fixes #25516

# How

Add support for rendering `oneOf` properties from AppConfig schema.

Altered "Example" rendering a bit, since we always put code in there we can use a pre-made component to increase the readability.

Made few tweaks around `CodeBlock` to allow usage of text `theme` prop.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-01-04 at 17 40 05](https://github.com/expo/expo/assets/719641/3ff624e9-cf75-4478-99ff-1d4d04ef6d01)
![Screenshot 2024-01-04 at 18 04 43](https://github.com/expo/expo/assets/719641/2df9be25-fdd4-4992-9d40-3937ceb92860)

