### PR TITLE
[expo-updates] Remove support for multiple runtime versions

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Replace deprecated `com.facebook.react:react-native:+` Android dependency with `com.facebook.react:react-android`. ([#26237](https://github.com/expo/expo/pull/26237) by [@kudo](https://github.com/kudo))
 - [Android] Remove try/catch in expo-updates module constants block. ([#26228](https://github.com/expo/expo/pull/26228) by [@wschurman](https://github.com/wschurman))
 - Rename native classes. ([#26234](https://github.com/expo/expo/pull/26234), [#26235](https://github.com/expo/expo/pull/26235) by [@wschurman](https://github.com/wschurman))
+- Remove support for multiple runtime versions. ([#26258](https://github.com/expo/expo/pull/26258) by [@wschurman](https://github.com/wschurman))
 
 ## 0.24.5 - 2023-12-21
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedUpdate.kt
@@ -20,14 +20,14 @@ import java.util.*
  */
 class EmbeddedUpdate private constructor(
   override val manifest: EmbeddedManifest,
-  private val mId: UUID,
-  private val mScopeKey: String,
-  private val mCommitTime: Date,
-  private val mRuntimeVersion: String,
-  private val mAssets: JSONArray?
+  private val id: UUID,
+  private val scopeKey: String,
+  private val commitTime: Date,
+  private val runtimeVersion: String,
+  private val assets: JSONArray?
 ) : Update {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@EmbeddedUpdate.manifest.getRawJson()).apply {
+    UpdateEntity(id, commitTime, runtimeVersion, scopeKey, this@EmbeddedUpdate.manifest.getRawJson()).apply {
       status = UpdateStatus.EMBEDDED
     }
   }
@@ -35,16 +35,16 @@ class EmbeddedUpdate private constructor(
   override val assetEntityList: List<AssetEntity> by lazy {
     val assetList = mutableListOf<AssetEntity>()
 
-    val bundleKey = "bundle-$mId"
+    val bundleKey = "bundle-$id"
     val bundleAssetEntity = AssetEntity(bundleKey, "js").apply {
       isLaunchAsset = true
       embeddedAssetFilename = EmbeddedLoader.BARE_BUNDLE_FILENAME
     }
     assetList.add(bundleAssetEntity)
-    if (mAssets != null && mAssets.length() > 0) {
-      for (i in 0 until mAssets.length()) {
+    if (assets != null && assets.length() > 0) {
+      for (i in 0 until assets.length()) {
         try {
-          val assetObject = mAssets.getJSONObject(i)
+          val assetObject = assets.getJSONObject(i)
           val type = assetObject.getString("type")
           val assetEntity = AssetEntity(
             assetObject.getString("packagerHash"),
@@ -82,22 +82,13 @@ class EmbeddedUpdate private constructor(
     fun fromEmbeddedManifest(
       manifest: EmbeddedManifest,
       configuration: UpdatesConfiguration
-    ): EmbeddedUpdate {
-      val id = UUID.fromString(manifest.getID())
-      val commitTime = Date(manifest.getCommitTimeLong())
-      val runtimeVersion = configuration.getRuntimeVersion()
-      val assets = manifest.getAssets()
-      if (runtimeVersion.contains(",")) {
-        throw AssertionError("Should not be initializing a BareManifest in an environment with multiple runtime versions.")
-      }
-      return EmbeddedUpdate(
-        manifest,
-        id,
-        configuration.scopeKey,
-        commitTime,
-        runtimeVersion,
-        assets
-      )
-    }
+    ): EmbeddedUpdate = EmbeddedUpdate(
+      manifest,
+      id = UUID.fromString(manifest.getID()),
+      configuration.scopeKey,
+      commitTime = Date(manifest.getCommitTimeLong()),
+      runtimeVersion = configuration.getRuntimeVersion(),
+      assets = manifest.getAssets()
+    )
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LauncherSelectionPolicyFilterAware.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LauncherSelectionPolicyFilterAware.kt
@@ -9,8 +9,7 @@ import org.json.JSONObject
  * for ordering) is chosen, but the manifest filters are always taken into account before the
  * `commitTime`.
  */
-class LauncherSelectionPolicyFilterAware(private val runtimeVersions: List<String>) : LauncherSelectionPolicy {
-  constructor(runtimeVersion: String) : this(listOf<String>(runtimeVersion))
+class LauncherSelectionPolicyFilterAware(private val runtimeVersion: String) : LauncherSelectionPolicy {
 
   override fun selectUpdateToLaunch(
     updates: List<UpdateEntity>,
@@ -18,7 +17,7 @@ class LauncherSelectionPolicyFilterAware(private val runtimeVersions: List<Strin
   ): UpdateEntity? {
     var updateToLaunch: UpdateEntity? = null
     for (update in updates) {
-      if (!runtimeVersions.contains(update.runtimeVersion) || !SelectionPolicies.matchesFilters(update, filters)) {
+      if (runtimeVersion != update.runtimeVersion || !SelectionPolicies.matchesFilters(update, filters)) {
         continue
       }
       if (updateToLaunch == null || updateToLaunch.commitTime.before(update.commitTime)) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicyFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicyFactory.kt
@@ -5,14 +5,6 @@ package expo.modules.updates.selectionpolicy
  * the same ordering policy.
  */
 object SelectionPolicyFactory {
-  fun createFilterAwarePolicy(runtimeVersions: List<String>): SelectionPolicy {
-    return SelectionPolicy(
-      LauncherSelectionPolicyFilterAware(runtimeVersions),
-      LoaderSelectionPolicyFilterAware(),
-      ReaperSelectionPolicyFilterAware()
-    )
-  }
-
   @JvmStatic fun createFilterAwarePolicy(runtimeVersion: String): SelectionPolicy {
     return SelectionPolicy(
       LauncherSelectionPolicyFilterAware(runtimeVersion),

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicyFilterAware.swift
@@ -11,20 +11,16 @@ import Foundation
 @objc(EXUpdatesLauncherSelectionPolicyFilterAware)
 @objcMembers
 public final class LauncherSelectionPolicyFilterAware: NSObject, LauncherSelectionPolicy {
-  let runtimeVersions: [String]
+  let runtimeVersion: String
 
-  public convenience init(runtimeVersion: String) {
-    self.init(runtimeVersions: [runtimeVersion])
-  }
-
-  public init(runtimeVersions: [String]) {
-    self.runtimeVersions = runtimeVersions
+  public required init(runtimeVersion: String) {
+    self.runtimeVersion = runtimeVersion
   }
 
   public func launchableUpdate(fromUpdates updates: [Update], filters: [String: Any]?) -> Update? {
     var runnableUpdate: Update?
     for update in updates {
-      if !runtimeVersions.contains(update.runtimeVersion) || !SelectionPolicies.doesUpdate(update, matchFilters: filters) {
+      if runtimeVersion != update.runtimeVersion || !SelectionPolicies.doesUpdate(update, matchFilters: filters) {
         continue
       }
 

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicyFactory.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicyFactory.swift
@@ -16,12 +16,4 @@ public final class SelectionPolicyFactory: NSObject {
       reaperSelectionPolicy: ReaperSelectionPolicyFilterAware()
     )
   }
-
-  public static func filterAwarePolicy(withRuntimeVersions runtimeVersions: [String]) -> SelectionPolicy {
-    return SelectionPolicy.init(
-      launcherSelectionPolicy: LauncherSelectionPolicyFilterAware.init(runtimeVersions: runtimeVersions),
-      loaderSelectionPolicy: LoaderSelectionPolicyFilterAware(),
-      reaperSelectionPolicy: ReaperSelectionPolicyFilterAware()
-    )
-  }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/EmbeddedUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/EmbeddedUpdate.swift
@@ -46,7 +46,7 @@ public final class EmbeddedUpdate: Update {
       processedAssets.append(asset)
     }
 
-    let update = EmbeddedUpdate.init(
+    return EmbeddedUpdate.init(
       manifest: manifest,
       config: config,
       database: database,
@@ -59,16 +59,5 @@ public final class EmbeddedUpdate: Update {
       isDevelopmentMode: false,
       assetsFromManifest: processedAssets
     )
-
-    if update.runtimeVersion.contains(",") {
-      let exception = NSException(
-        name: NSExceptionName.internalInconsistencyException,
-        reason: "Should not be initializing BareUpdate in an environment with multiple runtime versions.",
-        userInfo: [:]
-      )
-      exception.raise()
-    }
-
-    return update
   }
 }


### PR DESCRIPTION
# Why

This can be removed now that SDK version configuration was removed in https://github.com/expo/expo/pull/26061.

This is essentially a revert of https://github.com/expo/expo/pull/9259.

Closes ENG-11001.

# How

This was also superseded in Expo Go by the `ExpoGoLauncherSelectionPolicyFilterAware` so the mutliple-runtime-version version of this was unused.

Now that we're removing versioning we can also reduce the scope of `ExpoGoLauncherSelectionPolicyFilterAware` but that's for a future PR.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
