### PR TITLE
[expo-go][1/n] Refactor to support only one SDK version

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -29,9 +29,7 @@ public class Constants {
   private static final String TAG = Constants.class.getSimpleName();
 
   public static String VERSION_NAME = null;
-  public static String ABI_VERSIONS;
-  public static String SDK_VERSIONS;
-  public static List<String> SDK_VERSIONS_LIST;
+  public static String SDK_VERSION = ExponentBuildConstants.TEMPORARY_SDK_VERSION;
   public static final String TEMPORARY_SDK_VERSION = ExponentBuildConstants.TEMPORARY_SDK_VERSION;
   public static final String EMBEDDED_KERNEL_PATH = "assets://kernel.android.bundle";
   public static boolean DISABLE_NUX = false;
@@ -39,29 +37,7 @@ public class Constants {
   public static boolean FCM_ENABLED;
   public static SplashScreenImageResizeMode SPLASH_SCREEN_IMAGE_RESIZE_MODE;
 
-  public static void setSdkVersions(List<String> sdkVersions) {
-    ABI_VERSIONS = TextUtils.join(",", sdkVersions);
-
-    // NOTE: Currently public-facing SDK versions and internal ABI versions are the same, but
-    // eventually we may decouple them
-    SDK_VERSIONS = ABI_VERSIONS;
-    SDK_VERSIONS_LIST = sdkVersions;
-  }
-
   static {
-    List<String> abiVersions = new ArrayList<>();
-    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-    // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
-    // ADD ABI VERSIONS HERE DO NOT MODIFY
-    // WHEN_PREPARING_SHELL_REMOVE_TO_HERE
-    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
-
-    if (TEMPORARY_SDK_VERSION != null) {
-      abiVersions.add(TEMPORARY_SDK_VERSION);
-    }
-
-    setSdkVersions(abiVersions);
-
     try {
       Class appConstantsClass = Class.forName("host.exp.exponent.generated.AppConstants");
       ExpoViewAppConstants appConstants = (ExpoViewAppConstants) appConstantsClass.getMethod("get").invoke(null);
@@ -86,21 +62,6 @@ public class Constants {
   public static final boolean ENABLE_LEAK_CANARY = false;
   public static final boolean WRITE_BUNDLE_TO_LOG = false;
   public static final boolean WAIT_FOR_DEBUGGER = false;
-
-  public static String getVersionName(Context context) {
-    if (VERSION_NAME != null) {
-      // This will be set in shell apps
-      return VERSION_NAME;
-    } else {
-      try {
-        PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-        return pInfo.versionName;
-      } catch (PackageManager.NameNotFoundException e) {
-        EXL.e(TAG, e.toString());
-        return "";
-      }
-    }
-  }
 
   private static boolean sIsTest = false;
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -144,7 +144,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
 
     val configuration = UpdatesConfiguration(null, configMap)
     val sdkVersionsList = mutableListOf<String>().apply {
-      (Constants.SDK_VERSIONS_LIST + listOf(RNObject.UNVERSIONED)).forEach {
+      listOf(Constants.SDK_VERSION, RNObject.UNVERSIONED).forEach {
         add(it)
         add("exposdk:$it")
       }
@@ -336,7 +336,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       if (KernelConfig.FORCE_UNVERSIONED_PUBLISHED_EXPERIENCES) {
         headers["Exponent-SDK-Version"] = "UNVERSIONED"
       } else {
-        headers["Exponent-SDK-Version"] = Constants.SDK_VERSIONS
+        headers["Exponent-SDK-Version"] = Constants.SDK_VERSION
       }
       return headers
     }
@@ -358,12 +358,8 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     if (RNObject.UNVERSIONED == sdkVersion) {
       return true
     }
-    for (version in Constants.SDK_VERSIONS_LIST) {
-      if (version == sdkVersion) {
-        return true
-      }
-    }
-    return false
+
+    return sdkVersion == Constants.SDK_VERSION
   }
 
   private fun formatExceptionForIncompatibleSdk(sdkVersion: String?): ManifestException {
@@ -372,7 +368,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       errorJson.put("message", "Invalid SDK version")
       if (sdkVersion == null) {
         errorJson.put("errorCode", "NO_SDK_VERSION_SPECIFIED")
-      } else if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSIONS_LIST[0])) {
+      } else if (ABIVersion.toNumber(sdkVersion) > ABIVersion.toNumber(Constants.SDK_VERSION)) {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_TOO_NEW")
       } else {
         errorJson.put("errorCode", "EXPERIENCE_SDK_VERSION_OUTDATED")

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -48,12 +48,8 @@ class ManifestException : ExponentException {
     return when (manifestUrl) {
       else -> {
         var formattedMessage = "Could not load $manifestUrl.$extraMessage"
-        val supportedSdks = Constants.SDK_VERSIONS_LIST.map {
+        val supportedSdk = Constants.SDK_VERSION.let {
           it.substring(0, it.indexOf('.')).toInt()
-        }.sorted()
-        val supportedSdksString = { conjunction: String ->
-          supportedSdks.subList(0, supportedSdks.size - 1)
-            .joinToString(", ") + " $conjunction ${supportedSdks.last()}"
         }
 
         if (errorJSON != null) {
@@ -74,15 +70,15 @@ class ManifestException : ExponentException {
                 }
 
                 formattedMessage =
-                  "This project uses SDK $sdkVersionRequired, but this version of Expo Go supports only SDKs ${supportedSdksString("and")}.<br><br>" +
+                  "This project uses SDK $sdkVersionRequired, but this version of Expo Go supports only SDK ${supportedSdk}.<br><br>" +
                   "To open this project:<br>" +
-                  "• Update it to SDK ${supportedSdksString("or")}.<br>" +
+                  "• Update it to SDK ${supportedSdk}.<br>" +
                   "• Install an older version of Expo Go that supports the project's SDK version.<br><br>" +
                   "If you are unsure how to update the project or install a suitable version of Expo Go, refer to the <a href='https://docs.expo.dev/get-started/expo-go/#sdk-versions'>SDK Versions Guide</a>."
               }
-              "SNACK_NOT_FOUND_FOR_SDK_VERSION" -> {
+              "NO_SDK_VERSION_SPECIFIED" -> {
                 formattedMessage =
-                  "Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): " + Constants.SDK_VERSIONS_LIST.joinToString() + ". A development build must be used to load other runtimes.<br><a href='https://docs.expo.dev/develop/development-builds/introduction/'>Learn more about development builds</a>."
+                  "Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDK (runtime): $supportedSdk. A development build must be used to load other runtimes.<br><a href='https://docs.expo.dev/develop/development-builds/introduction/'>Learn more about development builds</a>."
               }
               "EXPERIENCE_SDK_VERSION_TOO_NEW" ->
                 formattedMessage =
@@ -114,8 +110,8 @@ class ManifestException : ExponentException {
                   return@closure
                 }
                 formattedMessage =
-                  "The snack \"${fullName}\" was found, but it is not compatible with your version of Expo Go. It was released for SDK $snackSdkVersionValue, but your Expo Go supports only SDKs ${supportedSdksString("and")}."
-                formattedMessage += if (supportedSdks.last() < snackSdkVersionValue) {
+                  "The snack \"${fullName}\" was found, but it is not compatible with your version of Expo Go. It was released for SDK $snackSdkVersionValue, but this version of Expo Go supports only SDK ${supportedSdk}."
+                formattedMessage += if (supportedSdk < snackSdkVersionValue) {
                   "<br><br>You need to update your Expo Go app in order to run this Snack."
                 } else {
                   "<br><br>Snack needs to be upgraded to a current SDK version. To do it, open the project at <a href='https://snack.expo.dev'>Expo Snack website</a>. It will be automatically upgraded to a supported SDK version."

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -449,21 +449,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     // In detach/shell, we always use UNVERSIONED as the ABI.
     detachSdkVersion = sdkVersion
 
-    if (RNObject.UNVERSIONED != sdkVersion) {
-      var isValidVersion = false
-      for (version in Constants.SDK_VERSIONS_LIST) {
-        if (version == sdkVersion) {
-          isValidVersion = true
-          break
-        }
-      }
-      if (!isValidVersion) {
-        KernelProvider.instance.handleError(
-          sdkVersion + " is not a valid SDK version. Options are " +
-            TextUtils.join(", ", Constants.SDK_VERSIONS_LIST) + ", " + RNObject.UNVERSIONED + "."
-        )
-        return
-      }
+    if (RNObject.UNVERSIONED != sdkVersion && sdkVersion != Constants.SDK_VERSION) {
+      KernelProvider.instance.handleError(
+        "$sdkVersion is not a supported SDK version. Options are ${Constants.SDK_VERSION} and ${RNObject.UNVERSIONED}."
+      )
+      return
     }
 
     soLoaderInit()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -116,18 +116,9 @@ class InternalHeadlessAppLoader(private val context: Context) :
 
     detachSdkVersion = sdkVersion
 
-    if (RNObject.UNVERSIONED != sdkVersion) {
-      var isValidVersion = false
-      for (version in Constants.SDK_VERSIONS_LIST) {
-        if (version == sdkVersion) {
-          isValidVersion = true
-          break
-        }
-      }
-      if (!isValidVersion) {
-        callback!!.onComplete(false, Exception("$sdkVersion is not a valid SDK version."))
-        return
-      }
+    if (RNObject.UNVERSIONED != sdkVersion && sdkVersion != Constants.SDK_VERSION) {
+      callback!!.onComplete(false, Exception("$sdkVersion is not a valid SDK version."))
+      return
     }
 
     soLoaderInit()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -32,7 +32,7 @@ object ExponentUrls {
     // TODO: set user agent
     val builder = Request.Builder()
       .url(urlString)
-      .header("Exponent-SDK-Version", Constants.SDK_VERSIONS)
+      .header("Exponent-SDK-Version", Constants.SDK_VERSION)
       .header("Exponent-Platform", "android")
     val versionName = ExpoViewKernel.instance.versionName
     if (versionName != null) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/ExponentKernelModule.kt
@@ -33,7 +33,9 @@ class ExponentKernelModule(reactContext: ReactApplicationContext?) :
 
   override fun getConstants(): Map<String, Any> {
     return mapOf(
-      "sdkVersions" to Constants.SDK_VERSIONS
+      "sdkVersion" to Constants.SDK_VERSION,
+      // TODO(wschurman): remove once the home JS is only using sdkVersion
+      "sdkVersions" to listOf(Constants.SDK_VERSION)
     )
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
@@ -26,7 +26,7 @@ class ConstantsBinding(
       this["manifest"] = manifest.toString()
       this["nativeAppVersion"] = ExpoViewKernel.instance.versionName
       this["nativeBuildVersion"] = Constants.ANDROID_VERSION_CODE
-      this["supportedExpoSdks"] = Constants.SDK_VERSIONS_LIST
+      this["supportedExpoSdks"] = listOf(Constants.SDK_VERSION)
       this["appOwnership"] = appOwnership
       this["executionEnvironment"] = executionEnvironment.string
 


### PR DESCRIPTION
# Why

In SDK 51, Expo Go will only support the latest SDK version. This PR updates android to only look for a single SDK version in code.

Closes ENG-11002.

# How

Note we still support "UNVERSIONED" so a lot of the code still needs to operate on arrays, but definitely can clean some stuff up.

To review this: review the changes to `Constants.java` first. If they look good, the rest of the PR should be fine.

# Test Plan

Build Expo Go, run an app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
