### PR TITLE
[docs] Add Dev process overview guide link and fix other things in Core concepts

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -6,7 +6,7 @@ description: An overview of Expo tools, features and services.
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { ExpoGoLogo, DocsLogo } from '@expo/styleguide';
-import { PlanEnterpriseIcon } from '@expo/styleguide-icons';
+import { PlanEnterpriseIcon, CpuChip01Icon, BookOpen02Icon } from '@expo/styleguide-icons';
 
 Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
@@ -17,23 +17,32 @@ The `expo` npm package enables a suite of incredible features for React Native a
 <BoxLink
   title="Expo SDK"
   description="Comprehensive suite of well-tested React Native modules that run on Android, iOS, and web."
-  href="/versions/latest"
+  href="/versions/latest/"
   Icon={DocsLogo}
+/>
+<BoxLink
+  title="Develop an app with Expo"
+  description="An overview of the development process of building an Expo app to help build a mental model of the core development loop."
+  href="/workflow/overview/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Expo Modules API"
   description="Write highly performant native code with modern Swift and Kotlin API."
-  href="/modules/overview"
+  href="/modules/overview/"
+  Icon={CpuChip01Icon}
 />
 <BoxLink
   title="Prebuild"
   description="Separate React from Native to develop from any computer, upgrade easily, white label apps, and maintain larger projects."
-  href="/workflow/prebuild"
+  href="/workflow/prebuild/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Expo CLI"
   description="Manage dependencies, compile native apps, develop for the web, and connect to any device with a powerful dev server."
   href="/more/expo-cli/"
+  Icon={BookOpen02Icon}
 />
 <BoxLink
   title="Expo Go"
@@ -44,17 +53,17 @@ The `expo` npm package enables a suite of incredible features for React Native a
 
 > **info** All features are free, optional, and can be used independently of each other. Unused features add no additional bloat to your app.
 
-| Feature                                                                         | With `expo` | Without `expo` (bare React Native) |
-| ------------------------------------------------------------------------------- | ----------- | ---------------------------------- |
-| Develop complex apps **entirely** in JavaScript.                                | <YesIcon /> | <NoIcon />                         |
-| Write JSI native modules with Swift and Kotlin.                                 | <YesIcon /> | <NoIcon />                         |
-| Develop apps without Xcode or Android Studio.                                   | <YesIcon /> | <NoIcon />                         |
-| Create and share example apps in the browser with [Snack][build/introduction/]. | <YesIcon /> | <NoIcon />                         |
-| Major upgrades without native changes.                                          | <YesIcon /> | <NoIcon />                         |
-| First-class TypeScript support.                                                 | <YesIcon /> | <NoIcon />                         |
-| Install natively compatible libraries from the command line.                    | <YesIcon /> | <NoIcon />                         |
-| Develop performant websites with the same codebase.                             | <YesIcon /> | <NoIcon />                         |
-| [Tunnel](/more/expo-cli/#tunneling) your dev server to any device.              | <YesIcon /> | <NoIcon />                         |
+| Feature                                                                             | With `expo` | Without `expo` (bare React Native) |
+| ----------------------------------------------------------------------------------- | ----------- | ---------------------------------- |
+| Develop complex apps **entirely** in JavaScript.                                    | <YesIcon /> | <NoIcon />                         |
+| Write JSI native modules with Swift and Kotlin.                                     | <YesIcon /> | <NoIcon />                         |
+| Develop apps without Xcode or Android Studio.                                       | <YesIcon /> | <NoIcon />                         |
+| Create and share example apps in the browser with [Snack](https://snack.expo.dev/). | <YesIcon /> | <NoIcon />                         |
+| Major upgrades without native changes.                                              | <YesIcon /> | <NoIcon />                         |
+| First-class TypeScript support.                                                     | <YesIcon /> | <NoIcon />                         |
+| Install natively compatible libraries from the command line.                        | <YesIcon /> | <NoIcon />                         |
+| Develop performant websites with the same codebase.                                 | <YesIcon /> | <NoIcon />                         |
+| [Tunnel](/more/expo-cli/#tunneling) your dev server to any device.                  | <YesIcon /> | <NoIcon />                         |
 
 ## Services
 


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a BoxLink for Develop an app overview page, add icons for other BoxLinks (it looks a visually odd that some in the same list have icons and some don't) and fix broken link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/core-concepts/

## Preview

![CleanShot 2024-01-05 at 01 53 57@2x](https://github.com/expo/expo/assets/10234615/f2827398-93a7-443b-a6f9-11416006d0c0)

![CleanShot 2024-01-05 at 01 53 51@2x](https://github.com/expo/expo/assets/10234615/eee7e958-2ee3-46e8-9551-2cf17a0e8100)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
