### PR TITLE
[ios][android] Update react-native-safe-area-context to 4.8.2

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaContextPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaContextPackage.kt
@@ -31,6 +31,7 @@ class SafeAreaContextPackage : TurboReactPackage() {
               moduleClass.name,
               true,
               reactModule.needsEagerInit,
+              /** TODO remove the parameter once support for RN < 0.73 is dropped */
               reactModule.hasConstants,
               reactModule.isCxxModule,
               TurboModule::class.java.isAssignableFrom(moduleClass))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewEdges.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewEdges.kt
@@ -1,7 +1,5 @@
 package versioned.host.exp.exponent.modules.api.safeareacontext
 
-import java.util.*
-
 enum class SafeAreaViewEdgeModes {
   OFF,
   ADDITIVE,

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewLocalData.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewLocalData.kt
@@ -1,7 +1,5 @@
 package versioned.host.exp.exponent.modules.api.safeareacontext
 
-import java.util.*
-
 data class SafeAreaViewLocalData(
     val insets: EdgeInsets,
     val mode: SafeAreaViewMode,

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/safeareacontext/SafeAreaViewManager.kt
@@ -10,7 +10,6 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import versioned.host.exp.exponent.modules.api.safeareacontext.RNCSafeAreaViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
-import java.util.*
 
 @ReactModule(name = SafeAreaViewManager.REACT_CLASS)
 class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
@@ -64,7 +63,7 @@ class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<
       props: ReactStylesDiffMap?,
       stateWrapper: StateWrapper?
   ): Any? {
-    (view as SafeAreaView).fabricViewStateManager.setStateWrapper(stateWrapper)
+    (view as SafeAreaView).setStateWrapper(stateWrapper)
     return null
   }
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -85,7 +85,7 @@
     "react-native-gesture-handler": "~2.14.0",
     "react-native-pager-view": "6.2.2",
     "react-native-reanimated": "~3.6.0",
-    "react-native-safe-area-context": "4.7.4",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "14.0.0",
     "react-native-view-shot": "3.8.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-pager-view": "6.2.2",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.6.0",
-    "react-native-safe-area-context": "4.7.4",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",
     "react-native-svg": "14.0.0",
     "react-native-view-shot": "3.8.0",

--- a/home/package.json
+++ b/home/package.json
@@ -65,7 +65,7 @@
     "react-native-maps": "1.8.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.6.0",
-    "react-native-safe-area-context": "4.7.4",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2028,7 +2028,7 @@ PODS:
     - React-Core
   - react-native-pager-view (6.2.2):
     - React-Core
-  - react-native-safe-area-context (4.7.4):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - react-native-segmented-control (2.4.1):
     - React-Core
@@ -3371,7 +3371,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: d2dc1c7d55d5a1283913120e1b647d007aa6817b
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
   react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
-  react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-skia: 1a2fbce7fc198eb229b13f15bce48a06b5c92d69
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d

--- a/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
+++ b/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safe-area-context",
-  "version": "4.7.4",
+  "version": "4.8.2",
   "summary": "A flexible way to handle safe area, also works on Android and web.",
   "license": "MIT",
   "authors": "Janic Duplessis <janicduplessis@gmail.com>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/th3rdwave/react-native-safe-area-context.git",
-    "tag": "v4.7.4"
+    "tag": "v4.8.2"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "exclude_files": "ios/Fabric",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -91,7 +91,7 @@
   "react-native-pager-view": "6.2.2",
   "react-native-reanimated": "~3.6.0",
   "react-native-screens": "~3.27.0",
-  "react-native-safe-area-context": "4.7.4",
+  "react-native-safe-area-context": "4.8.2",
   "react-native-svg": "14.0.0",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.6.3",


### PR DESCRIPTION
# Why
Closes ENG-11018

# How
`et uvm -m react-native-safe-area-context -c v4.8.2`

# Test Plan

- bare-expo + NCL ✅
- Expo Go + NCL ✅
