### PR TITLE
[ios][android] Update react-native-svg to 14.1.0

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -87,7 +87,7 @@
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",
-    "react-native-svg": "14.0.0",
+    "react-native-svg": "14.1.0",
     "react-native-view-shot": "3.8.0",
     "react-native-webview": "13.6.3",
     "test-suite": "*"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",
-    "react-native-svg": "14.0.0",
+    "react-native-svg": "14.1.0",
     "react-native-view-shot": "3.8.0",
     "react-native-web": "~0.19.6",
     "react-native-webview": "13.6.3",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2245,7 +2245,7 @@ PODS:
   - RNScreens (3.27.0):
     - React-Core
     - React-RCTImage
-  - RNSVG (14.0.0):
+  - RNSVG (14.1.0):
     - React-Core
   - SDWebImage (5.17.0):
     - SDWebImage/Core (= 5.17.0)
@@ -3401,7 +3401,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 4279931048471f17faf46d912b2e96e10f1da99b
   RNReanimated: c7706129cc5d41b737193456f549dca3a9b0a0ca
   RNScreens: 2b19e2471db8a581c83f381f4ea5d43071c9a3bf
-  RNSVG: 255767813dac22db1ec2062c8b7e7b856d4e5ae6
+  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
   SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/ios/vendored/unversioned/react-native-svg/RNSVG.podspec.json
+++ b/ios/vendored/unversioned/react-native-svg/RNSVG.podspec.json
@@ -1,13 +1,13 @@
 {
   "name": "RNSVG",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "summary": "SVG library for react-native",
   "license": "MIT",
   "homepage": "https://github.com/react-native-community/react-native-svg",
   "authors": "Horcrux Chen",
   "source": {
     "git": "https://github.com/react-native-community/react-native-svg.git",
-    "tag": "v14.0.0"
+    "tag": "v14.1.0"
   },
   "source_files": "apple/**/*.{h,m,mm}",
   "ios": {

--- a/ios/vendored/unversioned/react-native-svg/apple/Elements/RNSVGImage.mm
+++ b/ios/vendored/unversioned/react-native-svg/apple/Elements/RNSVGImage.mm
@@ -32,8 +32,6 @@
 #import <React/RCTImageResponseObserverProxy.h>
 #import <React/RCTImageSource.h>
 #import <react/renderer/components/rnsvg/ComponentDescriptors.h>
-#import <react/renderer/components/view/conversions.h>
-#import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
 #import <rnsvg/RNSVGImageComponentDescriptor.h>
 #import "RNSVGFabricConversions.h"
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "react-native-reanimated": "~3.6.0",
   "react-native-screens": "~3.27.0",
   "react-native-safe-area-context": "4.8.2",
-  "react-native-svg": "14.0.0",
+  "react-native-svg": "14.1.0",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.6.3",
   "sentry-expo": "~7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16759,10 +16759,10 @@ react-native-reanimated@~3.6.0:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.7.4.tgz#3dd8438971e70043d76f2428ede75b8a9639265e"
-  integrity sha512-3LR3DCq9pdzlbq6vsHGWBFehXAKDh2Ljug6jWhLWs1QFuJHM6AS2+mH2JfKlB2LqiSFZOBcZfHQFz0sGaA3uqg==
+react-native-safe-area-context@4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.8.2.tgz#e6b3d8acf3c6afcb4b5db03a97f9c37df7668f65"
+  integrity sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==
 
 react-native-screens@~3.27.0:
   version "3.27.0"
@@ -16777,10 +16777,10 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha512-haw7VtcK0Vg1p7CTE8vzhltICPhfuzLUNR1m9Rh55VYEGkD3o765Y5YTu88iA32uV/hMhJUopP5Tex/SvNidoA==
 
-react-native-svg@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-14.0.0.tgz#ea1974dec9a91a09c6a38b7bf58d85e857c291f5"
-  integrity sha512-17W/gWXRUMS7p7PSHu/WyGkZUc1NzRTGxxXc0VqBLjzKSchyb0EmgsiWf9aKmfC6gmY0wcsmKZcGV41bCcNfBA==
+react-native-svg@14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-14.1.0.tgz#7903bddd3c71bf3a8a503918253c839e6edaa724"
+  integrity sha512-HeseElmEk+AXGwFZl3h56s0LtYD9HyGdrpg8yd9QM26X+d7kjETrRQ9vCjtxuT5dCZEIQ5uggU1dQhzasnsCWA==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
# Why
Closes ENG-11015

# How
`et uvm -m react-native-svg -c v14.1.0`

# Test Plan

- bare-expo + NCL ✅
- Expo Go + NCL ✅
