### PR TITLE
[expo-updates][sdk-50] Backport additional logs in FileDownloader

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add more failure logs in asset download. ([#26277](https://github.com/expo/expo/pull/26277) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -71,18 +71,16 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
       request,
       object : Callback {
         override fun onFailure(call: Call, e: IOException) {
+          logger.error("Failed to download asset from ${request.url}", UpdatesErrorCode.AssetsFailedToLoad, e)
           callback.onFailure(e)
         }
 
         @Throws(IOException::class)
         override fun onResponse(call: Call, response: Response) {
           if (!response.isSuccessful) {
-            callback.onFailure(
-              Exception(
-                "Network request failed: " + response.body!!
-                  .string()
-              )
-            )
+            val error = Exception("Network request failed: " + response.body!!.string())
+            logger.error("Failed to download file from ${request.url}", UpdatesErrorCode.AssetsFailedToLoad, error)
+            callback.onFailure(error)
             return
           }
           try {
@@ -91,7 +89,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
               callback.onSuccess(destination, hash)
             }
           } catch (e: Exception) {
-            logger.error("Failed to download file to destination $destination: ${e.localizedMessage}", UpdatesErrorCode.AssetsFailedToLoad, e)
+            logger.error("Failed to write file from ${request.url} to destination $destination", UpdatesErrorCode.AssetsFailedToLoad, e)
             callback.onFailure(e)
           }
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -141,7 +141,8 @@ public final class FileDownloader: NSObject, URLSessionDataDelegate {
       if let expectedBase64URLEncodedSHA256Hash = expectedBase64URLEncodedSHA256Hash,
         expectedBase64URLEncodedSHA256Hash != hashBase64String {
         let errorMessage = String(
-          format: "File download was successful but base64url-encoded SHA-256 did not match expected; expected: %@; actual: %@",
+          format: "Asset download was successful but base64url-encoded SHA-256 did not match expected; URL: %@; expected hash: %@; actual hash: %@",
+          url.absoluteString,
           expectedBase64URLEncodedSHA256Hash,
           hashBase64String
         )
@@ -160,7 +161,7 @@ public final class FileDownloader: NSObject, URLSessionDataDelegate {
         return
       } catch {
         let errorMessage = String(
-          format: "Could not write to path %@: %@",
+          format: "Could not write downloaded asset file to path %@: %@",
           destinationPath,
           error.localizedDescription
         )
@@ -176,6 +177,7 @@ public final class FileDownloader: NSObject, URLSessionDataDelegate {
         return
       }
     } errorBlock: { error in
+      self.logger.error(message: error.localizedDescription, code: UpdatesErrorCode.assetsFailedToLoad)
       errorBlock(error)
     }
   }


### PR DESCRIPTION
# Why

SDK 50 backported version of https://github.com/expo/expo/pull/26268

# How

Backport

# Test Plan

Wait for CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
