### PR TITLE
[ios][android] Update react-native-pager-view to 6.2.3

### DIFF
--- a/android/vendored/unversioned/react-native-pager-view/android/build.gradle
+++ b/android/vendored/unversioned/react-native-pager-view/android/build.gradle
@@ -42,7 +42,7 @@ if(shouldUseNameSpace){
       manifestContent = manifestContent.replaceAll(
         PACKAGE_PROP,
         ''
-    )  
+    )
 } else {
     if(!manifestContent.contains("$PACKAGE_PROP")){
         manifestContent = manifestContent.replace(
@@ -61,7 +61,6 @@ def registrationCompat = {
   def reactAndroidProject = rootProject.allprojects.find { it.name == 'ReactAndroid' }
   if (reactAndroidProject == null) return false
 
-  println(reactAndroidProject.projectDir)
   def reactNativeManifest = file("${reactAndroidProject.projectDir}/../package.json")
   def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
   // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.71
@@ -83,6 +82,9 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   if (shouldUseNameSpace){
     namespace = "com.reactnativepagerview"
+    buildFeatures {
+      buildConfig true
+    }
   }
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -43,7 +43,7 @@ PODS:
     - React-Core
   - EXNotifications (0.27.2):
     - ExpoModulesCore
-  - Expo (50.0.0-preview.7):
+  - Expo (50.0.0-preview.8):
     - ExpoModulesCore
   - expo-dev-client (3.3.4):
     - EXManifests
@@ -1207,9 +1207,11 @@ PODS:
     - React-debug
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-pager-view (6.2.2):
+  - react-native-pager-view (6.2.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - react-native-safe-area-context (4.7.4):
+  - react-native-safe-area-context (4.8.2):
     - React-Core
   - react-native-segmented-control (2.4.1):
     - React-Core
@@ -1409,7 +1411,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNSVG (14.0.0):
+  - RNSVG (14.1.0):
     - React-Core
   - SDWebImage (5.17.0):
     - SDWebImage/Core (= 5.17.0)
@@ -1949,7 +1951,7 @@ SPEC CHECKSUMS:
   EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
   EXMediaLibrary: 5a74f7d9cce776ca07cb3090b948cedd7d4841a1
   EXNotifications: 3ee880b7474efd940c4aa7502c8a6f1f51e3dafa
-  Expo: cd2dc043dd1cc3d9e8e4e035fb9a41b421e8f13f
+  Expo: 87664535771d38d078a93d5db36a3f82f06eb7f9
   expo-dev-client: 21a0596a8b6e51425b0f0006ec942b61a633e643
   expo-dev-launcher: 90c05b0da0a9e1e27063510f019c4f8e0ef5b76d
   expo-dev-menu: 48359556db01e574b4f966ca39fe24c1efdee4c3
@@ -2038,8 +2040,8 @@ SPEC CHECKSUMS:
   React-logger: e0c1e918d9588a9f39c9bc62d9d6bfe9ca238d9d
   React-Mapbuffer: 9731a0a63ebaf8976014623c4d637744d7353a7c
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
-  react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
+  react-native-pager-view: d81ab2060b9caf57ca8c3a0d57467ff407cdb825
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688
@@ -2072,7 +2074,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 61bfdfc05db9b79dd61f894dcd29d3dcc6db3c02
   RNReanimated: 92958cd13e63c2c34c71bc50ee2c8d5561bc4e3f
   RNScreens: 5f4df9babb21d30723580377b5f52d9f9baf0005
-  RNSVG: 255767813dac22db1ec2062c8b7e7b856d4e5ae6
+  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
   SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -83,7 +83,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.73.1",
     "react-native-gesture-handler": "~2.14.0",
-    "react-native-pager-view": "6.2.2",
+    "react-native-pager-view": "6.2.3",
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.27.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -144,7 +144,7 @@
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-maps": "1.8.0",
-    "react-native-pager-view": "6.2.2",
+    "react-native-pager-view": "6.2.3",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.8.2",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -837,7 +837,7 @@ PODS:
     - React-Core
   - EXNotifications (0.27.2):
     - ExpoModulesCore
-  - Expo (50.0.0-preview.7):
+  - Expo (50.0.0-preview.8):
     - ExpoModulesCore
   - ExpoAppleAuthentication (6.3.0):
     - ExpoModulesCore
@@ -963,7 +963,7 @@ PODS:
   - EXTaskManager (11.7.0):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdates (0.24.5):
+  - EXUpdates (0.24.6):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -973,7 +973,7 @@ PODS:
     - ReachabilitySwift
     - React-Core
     - sqlite3 (~> 3.42.0)
-  - EXUpdates/Tests (0.24.5):
+  - EXUpdates/Tests (0.24.6):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -2026,7 +2026,7 @@ PODS:
     - React-debug
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-pager-view (6.2.2):
+  - react-native-pager-view (6.2.3):
     - React-Core
   - react-native-safe-area-context (4.8.2):
     - React-Core
@@ -3244,7 +3244,7 @@ SPEC CHECKSUMS:
   Analytics: 9655e0e1c71ea98107cfcb2b14891168acc6c6c9
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   ASN1Decoder: 4f4bbcaf1d1b8be56daa3280e82863a607f5bda9
-  boost: 9ccd0979c880976bc3f4dae93c0c7d6d185c8b2b
+  boost: 42fe04d4353fbd09a3e183ae133230469d587424
   Branch: 23b6b9351d5574377e7a764841cfb13a70c2799b
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -3262,7 +3262,7 @@ SPEC CHECKSUMS:
   EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
   EXMediaLibrary: 179f3ffc668ca2eb7b14e8ed7b404321624f9093
   EXNotifications: 3ee880b7474efd940c4aa7502c8a6f1f51e3dafa
-  Expo: cd2dc043dd1cc3d9e8e4e035fb9a41b421e8f13f
+  Expo: 87664535771d38d078a93d5db36a3f82f06eb7f9
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
   ExpoBattery: 60bf880aea8f769fe39f709a920442542c1bfd62
@@ -3308,7 +3308,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: 30e18a1afc6c8afbc5d7fe612232e1ffd119035c
   EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
   EXTaskManager: 81b2dfaaba6d9f9a4bc3e3e2a786a98004eb9e98
-  EXUpdates: 87277948b77dabde81251fbd07c831418dd10993
+  EXUpdates: 1f3f34454d39132504a194ca1ed8809e8f957309
   EXUpdatesInterface: 95d6bc086d7e043c1f33e30762ebc16a5cf4b153
   FBAEMKit: 4763aa27b8f69eb9d2c274189e91388de1dbd88a
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06
@@ -3370,7 +3370,7 @@ SPEC CHECKSUMS:
   React-logger: 9012a5b9c7f366d1aa4d9ca87ac35105b7819653
   React-Mapbuffer: d2dc1c7d55d5a1283913120e1b647d007aa6817b
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
+  react-native-pager-view: c29d484f19c49ff19525a94105e4ab2c4d4ae273
   react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-skia: 1a2fbce7fc198eb229b13f15bce48a06b5c92d69

--- a/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
+++ b/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pager-view",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "summary": "React Native wrapper for Android and iOS ViewPager",
   "homepage": "https://github.com/callstack/react-native-pager-view#readme",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/callstack/react-native-pager-view.git",
-    "tag": "6.2.2"
+    "tag": "6.2.3"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -88,7 +88,7 @@
   "react-native-gesture-handler": "~2.14.0",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.8.0",
-  "react-native-pager-view": "6.2.2",
+  "react-native-pager-view": "6.2.3",
   "react-native-reanimated": "~3.6.0",
   "react-native-screens": "~3.27.0",
   "react-native-safe-area-context": "4.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16735,10 +16735,10 @@ react-native-maps@1.8.0:
   dependencies:
     "@types/geojson" "^7946.0.10"
 
-react-native-pager-view@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.2.tgz#4c1c45d5f3f622c0922ef96ac114666392ebf5ec"
-  integrity sha512-MLkJB7iP6v0Hd4/B4/R/gLCSE+YBtjxG/vHZYBDU+fI3U7HBYgKAg4o6ad8HxbKVcWWyRDNeeVRGISw1MUjlHw==
+react-native-pager-view@6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.3.tgz#698f6387fdf06cecc3d8d4792604419cb89cb775"
+  integrity sha512-dqVpXWFtPNfD3D2QQQr8BP+ullS5MhjRJuF8Z/qml4QTILcrWaW8F5iAxKkQR3Jl0ikcEryG/+SQlNcwlo0Ggg==
 
 react-native-paper@^4.0.1:
   version "4.12.0"


### PR DESCRIPTION
# Why
Closes ENG-11021

# How
`et uvm -m react-native-pager-view -c "v6.2.3"`

# Test Plan
- bare-expo + NCL 
- unversioned expo go + NCL 
