### PR TITLE
[tools] Update constants to reflect new location of Expo Go

### DIFF
--- a/tools/src/Constants.ts
+++ b/tools/src/Constants.ts
@@ -8,8 +8,9 @@ export const PRODUCTION_API_HOST = 'exp.host';
 
 export const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 export const EXPOTOOLS_DIR = Directories.getExpotoolsDir();
-export const IOS_DIR = Directories.getIosDir();
-export const ANDROID_DIR = Directories.getAndroidDir();
+export const EXPO_GO_DIR = Directories.getExpoGoDir();
+export const EXPO_GO_IOS_DIR = Directories.getExpoGoIosDir();
+export const EXPO_GO_ANDROID_DIR = Directories.getExpoGoAndroidDir();
 export const TEMPLATES_DIR = Directories.getTemplatesDir();
 export const PACKAGES_DIR = Directories.getPackagesDir();
 export const VERSIONED_RN_IOS_DIR = Directories.getVersionedReactNativeIosDir();
@@ -21,5 +22,5 @@ export const REACT_NATIVE_SUBMODULE_DIR = path.join(
 );
 
 // Vendored dirs
-export const ANDROID_VENDORED_DIR = path.join(ANDROID_DIR, 'vendored');
-export const IOS_VENDORED_DIR = path.join(IOS_DIR, 'vendored');
+export const ANDROID_VENDORED_DIR = path.join(EXPO_GO_ANDROID_DIR, 'vendored');
+export const IOS_VENDORED_DIR = path.join(EXPO_GO_IOS_DIR, 'vendored');

--- a/tools/src/Directories.ts
+++ b/tools/src/Directories.ts
@@ -6,8 +6,8 @@ export function getExpoRepositoryRootDir(): string {
   return process.env.EXPO_ROOT_DIR || path.join(__dirname, '..', '..');
 }
 
-export function getExpoHomeJSDir(): string {
-  return path.join(getExpoRepositoryRootDir(), 'apps/expo-go');
+export function getExpoGoDir(): string {
+  return path.join(getAppsDir(), 'expo-go');
 }
 
 export function getExpotoolsDir(): string {
@@ -22,12 +22,12 @@ export function getPackagesDir(): string {
   return path.join(getExpoRepositoryRootDir(), 'packages');
 }
 
-export function getIosDir(): string {
-  return path.join(getAppsDir(), 'expo-go', 'ios');
+export function getExpoGoIosDir(): string {
+  return path.join(getExpoGoDir(), 'ios');
 }
 
-export function getAndroidDir(): string {
-  return path.join(getAppsDir(), 'expo-go', 'android');
+export function getExpoGoAndroidDir(): string {
+  return path.join(getExpoGoDir(), 'android');
 }
 
 export function getTemplatesDir(): string {
@@ -39,7 +39,7 @@ export function getReactNativeSubmoduleDir(): string {
 }
 
 export function getVersionedReactNativeIosDir(): string {
-  return path.join(getIosDir(), 'versioned-react-native');
+  return path.join(getExpoGoIosDir(), 'versioned-react-native');
 }
 
 export function getAppsDir(): string {

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -6,8 +6,8 @@ import { Podspec, readPodspecAsync } from './CocoaPods';
 import * as Directories from './Directories';
 import * as Npm from './Npm';
 
-const ANDROID_DIR = Directories.getAndroidDir();
-const IOS_DIR = Directories.getIosDir();
+const ANDROID_DIR = Directories.getExpoGoAndroidDir();
+const IOS_DIR = Directories.getExpoGoIosDir();
 const PACKAGES_DIR = Directories.getPackagesDir();
 
 /**

--- a/tools/src/ProjectVersions.ts
+++ b/tools/src/ProjectVersions.ts
@@ -4,7 +4,13 @@ import path from 'path';
 import plist from 'plist';
 import semver from 'semver';
 
-import { EXPO_DIR, ANDROID_DIR, PACKAGES_DIR, IOS_DIR } from './Constants';
+import {
+  EXPO_DIR,
+  EXPO_GO_ANDROID_DIR,
+  PACKAGES_DIR,
+  EXPO_GO_IOS_DIR,
+  EXPO_GO_DIR,
+} from './Constants';
 
 export type Platform = 'ios' | 'android';
 
@@ -20,7 +26,7 @@ export async function sdkVersionAsync(): Promise<string> {
 }
 
 export async function iosAppVersionAsync(): Promise<string> {
-  const infoPlistPath = path.join(IOS_DIR, 'Exponent', 'Supporting', 'Info.plist');
+  const infoPlistPath = path.join(EXPO_GO_IOS_DIR, 'Exponent', 'Supporting', 'Info.plist');
   const infoPlist = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
   const bundleVersion = infoPlist.CFBundleShortVersionString;
 
@@ -31,7 +37,7 @@ export async function iosAppVersionAsync(): Promise<string> {
 }
 
 export async function androidAppVersionAsync(): Promise<string> {
-  const buildGradlePath = path.join(ANDROID_DIR, 'app', 'build.gradle');
+  const buildGradlePath = path.join(EXPO_GO_ANDROID_DIR, 'app', 'build.gradle');
   const buildGradleContent = await fs.readFile(buildGradlePath, 'utf8');
   const match = buildGradleContent.match(/versionName ['"]([^'"]+?)['"]/);
 
@@ -41,9 +47,9 @@ export async function androidAppVersionAsync(): Promise<string> {
   return match[1];
 }
 
-export async function getHomeSDKVersionAsync(): Promise<string> {
-  const homeAppJsonPath = path.join(EXPO_DIR, 'apps', 'expo-go', 'app.json');
-  const appJson = (await JsonFile.readAsync(homeAppJsonPath, { json5: true })) as any;
+export async function getExpoGoSDKVersionAsync(): Promise<string> {
+  const expoGoAppJsonPath = path.join(EXPO_GO_DIR, 'app.json');
+  const appJson = (await JsonFile.readAsync(expoGoAppJsonPath, { json5: true })) as any;
 
   if (appJson?.expo?.sdkVersion) {
     return appJson.expo.sdkVersion as string;
@@ -52,7 +58,8 @@ export async function getHomeSDKVersionAsync(): Promise<string> {
 }
 
 export async function getSDKVersionsAsync(platform: Platform): Promise<string[]> {
-  const appDir = platform === 'ios' ? path.join(IOS_DIR, 'Exponent', 'Supporting') : ANDROID_DIR;
+  const appDir =
+    platform === 'ios' ? path.join(EXPO_GO_IOS_DIR, 'Exponent', 'Supporting') : EXPO_GO_ANDROID_DIR;
   const sdkVersionsPath = path.join(appDir, 'sdkVersions.json');
 
   if (!(await fs.pathExists(sdkVersionsPath))) {

--- a/tools/src/android-update-native-dependencies/androidProjectReports.ts
+++ b/tools/src/android-update-native-dependencies/androidProjectReports.ts
@@ -191,7 +191,7 @@ async function readAndConvertReports(): Promise<AndroidProjectReport[]> {
     await Promise.all(
       [
         Directories.getPackagesDir(),
-        Directories.getAndroidDir(),
+        Directories.getExpoGoAndroidDir(),
         path.join(Directories.getAppsDir(), 'bare-expo/android'),
       ].map(findGradleReportsFiles)
     )
@@ -231,7 +231,7 @@ export async function getAndroidProjectReports(
   }
 
   for (const androidProjectPath of [
-    Directories.getAndroidDir(),
+    Directories.getExpoGoAndroidDir(),
     path.join(Directories.getAppsDir(), 'bare-expo/android'),
   ]) {
     await executeGradleTask(androidProjectPath, options);

--- a/tools/src/client-build/AndroidClientBuilder.ts
+++ b/tools/src/client-build/AndroidClientBuilder.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import { ANDROID_DIR } from '../Constants';
+import { EXPO_GO_ANDROID_DIR } from '../Constants';
 import logger from '../Logger';
 import { androidAppVersionAsync } from '../ProjectVersions';
 import { spawnAsync } from '../Utils';
@@ -12,7 +12,7 @@ export default class AndroidClientBuilder implements ClientBuilder {
 
   getAppPath(): string {
     return path.join(
-      ANDROID_DIR,
+      EXPO_GO_ANDROID_DIR,
       'app',
       'build',
       'outputs',

--- a/tools/src/client-build/IosClientBuilder.ts
+++ b/tools/src/client-build/IosClientBuilder.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { podInstallAsync } from '../CocoaPods';
-import { EXPO_DIR, IOS_DIR } from '../Constants';
+import { EXPO_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import { iosAppVersionAsync } from '../ProjectVersions';
 import { spawnAsync } from '../Utils';
 import { ClientBuilder, ClientBuildFlavor, Platform } from './types';
@@ -12,7 +12,7 @@ export default class IosClientBuilder implements ClientBuilder {
 
   getAppPath(): string {
     return path.join(
-      IOS_DIR,
+      EXPO_GO_IOS_DIR,
       'simulator-build',
       'Build',
       'Products',
@@ -30,7 +30,7 @@ export default class IosClientBuilder implements ClientBuilder {
   }
 
   async buildAsync(flavor: ClientBuildFlavor = ClientBuildFlavor.VERSIONED) {
-    await podInstallAsync(IOS_DIR, {
+    await podInstallAsync(EXPO_GO_IOS_DIR, {
       stdio: 'inherit',
     });
     await spawnAsync('fastlane', ['ios', 'create_simulator_build', `flavor:${flavor}`], {

--- a/tools/src/commands/AndroidBuildPackages.ts
+++ b/tools/src/commands/AndroidBuildPackages.ts
@@ -34,7 +34,7 @@ export const EXCLUDED_PACKAGE_SLUGS = [
 ];
 
 const EXPO_ROOT_DIR = Directories.getExpoRepositoryRootDir();
-const ANDROID_DIR = Directories.getAndroidDir();
+const ANDROID_DIR = Directories.getExpoGoAndroidDir();
 
 const REACT_ANDROID_PKG = {
   name: 'ReactAndroid',

--- a/tools/src/commands/AndroidGenerateDynamicMacros.ts
+++ b/tools/src/commands/AndroidGenerateDynamicMacros.ts
@@ -5,7 +5,7 @@ import { generateDynamicMacrosAsync } from '../dynamic-macros/generateDynamicMac
 import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
-const ANDROID_DIR = Directories.getAndroidDir();
+const ANDROID_DIR = Directories.getExpoGoAndroidDir();
 const GENERATED_DIR = path.join(ANDROID_DIR, 'expoview/src/main/java/host/exp/exponent/generated');
 const TEMPLATE_FILES_DIR = path.join(EXPO_DIR, 'template-files');
 

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -11,7 +11,7 @@ import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
-import { EXPO_DIR, IOS_DIR } from '../Constants';
+import { EXPO_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import Git from '../Git';
 import logger from '../Logger';
 import { androidAppVersionAsync, iosAppVersionAsync } from '../ProjectVersions';
@@ -362,7 +362,7 @@ async function androidAPKBuildAndPublishAsync() {
 }
 
 async function internalRemoveBackgroundPermissionsFromInfoPlistAsync(): Promise<void> {
-  const INFO_PLIST_PATH = path.join(IOS_DIR, 'Exponent/Supporting/Info.plist');
+  const INFO_PLIST_PATH = path.join(EXPO_GO_IOS_DIR, 'Exponent/Supporting/Info.plist');
   const rawPlist = await fs.readFile(INFO_PLIST_PATH, 'utf-8');
   const parsedPlist = plist.parse(rawPlist);
 

--- a/tools/src/commands/IosGenerateDynamicMacros.ts
+++ b/tools/src/commands/IosGenerateDynamicMacros.ts
@@ -1,10 +1,10 @@
 import { Command } from '@expo/commander';
 import path from 'path';
 
-import { EXPO_DIR, IOS_DIR } from '../Constants';
+import { EXPO_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import { generateDynamicMacrosAsync } from '../dynamic-macros/generateDynamicMacros';
 
-const SUPPORTING_DIR = path.join(IOS_DIR, 'Exponent', 'Supporting');
+const SUPPORTING_DIR = path.join(EXPO_GO_IOS_DIR, 'Exponent', 'Supporting');
 const TEMPLATE_FILES_DIR = path.join(EXPO_DIR, 'template-files');
 
 async function generateAction(options): Promise<void> {

--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -24,7 +24,7 @@ type ExpoCliStateObject = {
   };
 };
 
-const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
+const EXPO_HOME_PATH = Directories.getExpoGoDir();
 const { EXPO_HOME_DEV_ACCOUNT_USERNAME, EXPO_HOME_DEV_ACCOUNT_PASSWORD } = process.env;
 
 /**

--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -11,7 +11,7 @@ import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
 
-import { ANDROID_DIR, IOS_DIR } from '../Constants';
+import { EXPO_GO_ANDROID_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import { deepCloneObject } from '../Utils';
 import { Directories, EASUpdate } from '../expotools';
 import AppConfig from '../typings/AppConfig';
@@ -22,20 +22,30 @@ type ExpoCliStateObject = {
   };
 };
 
-const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
+const EXPO_HOME_PATH = Directories.getExpoGoDir();
 
-const iosPublishBundlePath = path.join(IOS_DIR, 'Exponent', 'Supporting', 'kernel.ios.bundle');
+const iosPublishBundlePath = path.join(
+  EXPO_GO_IOS_DIR,
+  'Exponent',
+  'Supporting',
+  'kernel.ios.bundle'
+);
 const androidPublishBundlePath = path.join(
-  ANDROID_DIR,
+  EXPO_GO_ANDROID_DIR,
   'app',
   'src',
   'main',
   'assets',
   'kernel.android.bundle'
 );
-const iosManifestPath = path.join(IOS_DIR, 'Exponent', 'Supporting', 'kernel-manifest.json');
+const iosManifestPath = path.join(
+  EXPO_GO_IOS_DIR,
+  'Exponent',
+  'Supporting',
+  'kernel-manifest.json'
+);
 const androidManifestPath = path.join(
-  ANDROID_DIR,
+  EXPO_GO_ANDROID_DIR,
   'app',
   'src',
   'main',

--- a/tools/src/commands/UpdateReactNative.ts
+++ b/tools/src/commands/UpdateReactNative.ts
@@ -2,7 +2,7 @@ import { Command } from '@expo/commander';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 
-import { ANDROID_DIR } from '../Constants';
+import { EXPO_GO_ANDROID_DIR } from '../Constants';
 import { getNextSDKVersionAsync } from '../ProjectVersions';
 
 type ActionOptions = {
@@ -17,7 +17,7 @@ async function updateReactAndroidAsync(sdkVersion: string): Promise<void> {
     )} command...`
   );
   await spawnAsync('./gradlew', [':tools:execute', '--args', sdkVersion], {
-    cwd: ANDROID_DIR,
+    cwd: EXPO_GO_ANDROID_DIR,
     stdio: 'inherit',
   });
 }

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -12,8 +12,9 @@ import fetch, { Response } from 'node-fetch';
 import os from 'os';
 import path from 'path';
 
+import { EXPO_GO_DIR } from '../Constants';
 import { getExpoRepositoryRootDir } from '../Directories';
-import { getHomeSDKVersionAsync } from '../ProjectVersions';
+import { getExpoGoSDKVersionAsync } from '../ProjectVersions';
 
 interface Manifest {
   id: string;
@@ -32,8 +33,6 @@ interface Manifest {
 
 // some files are absent on turtle builders and we don't want log errors there
 const isTurtle = !!process.env.TURTLE_WORKING_DIR_PATH;
-
-const EXPO_DIR = getExpoRepositoryRootDir();
 
 type AssetRequestHeaders = { authorization: string };
 
@@ -92,7 +91,9 @@ async function getManifestAsync(
 }
 
 async function getSavedDevHomeEASUpdateUrlAsync(): Promise<string> {
-  const devHomeConfig = await new JsonFile(path.join(EXPO_DIR, 'dev-home-config.json')).readAsync();
+  const devHomeConfig = await new JsonFile(
+    path.join(getExpoRepositoryRootDir(), 'dev-home-config.json')
+  ).readAsync();
   return devHomeConfig.url as string;
 }
 
@@ -198,8 +199,7 @@ export default {
       return '';
     }
 
-    const pathToHome = 'apps/expo-go';
-    const url = await UrlUtils.constructManifestUrlAsync(path.join(EXPO_DIR, pathToHome));
+    const url = await UrlUtils.constructManifestUrlAsync(EXPO_GO_DIR);
 
     try {
       const manifestAndAssetRequestHeaders = await getManifestAsync(url, platform);
@@ -215,7 +215,7 @@ export default {
       console.error(
         chalk.red(
           `Unable to generate manifest from ${chalk.cyan(
-            pathToHome
+            EXPO_GO_DIR
           )}: Failed to fetch manifest from ${chalk.cyan(url)}`
         )
       );
@@ -224,6 +224,6 @@ export default {
   },
 
   async TEMPORARY_SDK_VERSION(): Promise<string> {
-    return await getHomeSDKVersionAsync();
+    return await getExpoGoSDKVersionAsync();
   },
 };

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -4,7 +4,7 @@ import glob from 'glob-promise';
 import path from 'path';
 
 import { Podspec } from '../CocoaPods';
-import { IOS_DIR } from '../Constants';
+import { EXPO_GO_IOS_DIR } from '../Constants';
 import logger from '../Logger';
 import { Package } from '../Packages';
 import {
@@ -15,7 +15,7 @@ import {
 import XcodeProject from './XcodeProject';
 import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
 
-const PODS_DIR = path.join(IOS_DIR, 'Pods');
+const PODS_DIR = path.join(EXPO_GO_IOS_DIR, 'Pods');
 
 // We will be increasing this list slowly. Once all are enabled,
 // find a better way to ignore some packages that shouldn't be prebuilt (like interfaces).

--- a/tools/src/prebuilds/XcodeGen.ts
+++ b/tools/src/prebuilds/XcodeGen.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import semver from 'semver';
 
 import { Podspec } from '../CocoaPods';
-import { EXPOTOOLS_DIR, IOS_DIR } from '../Constants';
+import { EXPOTOOLS_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import { arrayize, spawnAsync } from '../Utils';
 import {
   ProjectSpec,
@@ -12,7 +12,7 @@ import {
   XcodeConfig,
 } from './XcodeGen.types';
 
-const PODS_DIR = path.join(IOS_DIR, 'Pods');
+const PODS_DIR = path.join(EXPO_GO_IOS_DIR, 'Pods');
 const PODS_PUBLIC_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Public');
 const PODS_PRIVATE_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Private');
 const PLATFORMS_MAPPING: Record<string, ProjectSpecPlatform> = {

--- a/tools/src/vendoring/IosVendoring.ts
+++ b/tools/src/vendoring/IosVendoring.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer';
 import path from 'path';
 
 import { podInstallAsync, Podspec, readPodspecAsync } from '../CocoaPods';
-import { IOS_DIR } from '../Constants';
+import { EXPO_GO_IOS_DIR } from '../Constants';
 import logger from '../Logger';
 import { arrayize, searchFilesAsync } from '../Utils';
 import { copyVendoredFilesAsync } from './common';
@@ -55,8 +55,8 @@ export async function vendorAsync(
   logger.log('📄 Generating %s', chalk.magenta(podspecJsonFile));
 
   if (await promptToReinstallPodsAsync()) {
-    logger.log('♻️  Reinstalling pods at %s', chalk.magenta(IOS_DIR));
-    await podInstallAsync(IOS_DIR, {
+    logger.log('♻️  Reinstalling pods at %s', chalk.magenta(EXPO_GO_IOS_DIR));
+    await podInstallAsync(EXPO_GO_IOS_DIR, {
       noRepoUpdate: true,
     });
   }

--- a/tools/src/vendoring/legacy.ts
+++ b/tools/src/vendoring/legacy.ts
@@ -51,8 +51,8 @@ interface VendoredModuleConfig {
   warnings?: string[];
 }
 
-const IOS_DIR = Directories.getIosDir();
-const ANDROID_DIR = Directories.getAndroidDir();
+const IOS_DIR = Directories.getExpoGoIosDir();
+const ANDROID_DIR = Directories.getExpoGoAndroidDir();
 
 const SvgModifier: ModuleModifier = async function (
   moduleConfig: VendoredModuleConfig,


### PR DESCRIPTION
# Why

As requested in https://github.com/expo/expo/pull/26278#discussion_r1443325720.

This cleans up the constants.

# How

tsc renames.

# Test Plan

```
et android-generate-dynamic-macros
et ios-generate-dynamic-macros
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
