### PR TITLE
Add macOS support to the expo package

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1949,7 +1949,7 @@ SPEC CHECKSUMS:
   EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
   EXMediaLibrary: 9ca30a11319813904316ac3910bc4beef6af5b8a
   EXNotifications: 6e3b49fa7f916bc2783d37fbd5599509b160776c
-  Expo: 00eaae3d5de1f2e9af393abf1b2c9efb57b3b599
+  Expo: 5096704437d0388c1ae6c622c8fd6d1b61889a53
   expo-dev-client: 62325d7ddd0b339eb2e50e472b2e058e222c1c2d
   expo-dev-launcher: 7b7e7c64a999c123201689fc36d9a6003149e32a
   expo-dev-menu: 0898881a6e3a546d1c933044c1d912920e3bf4e4

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1951,7 +1951,7 @@ SPEC CHECKSUMS:
   EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
   EXMediaLibrary: 9ca30a11319813904316ac3910bc4beef6af5b8a
   EXNotifications: 6e3b49fa7f916bc2783d37fbd5599509b160776c
-  Expo: 00eaae3d5de1f2e9af393abf1b2c9efb57b3b599
+  Expo: 5096704437d0388c1ae6c622c8fd6d1b61889a53
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
   ExpoBattery: c75a7c094d64d89d96d3e3f419627b152da94f29

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added support for macOS platform.
+- Added support for macOS platform. ([#26283](https://github.com/expo/expo/pull/26283) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for macOS platform.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -10,7 +10,11 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms       = { :ios => '13.4', :tvos => '13.4'}
+  s.platforms       = {
+    :ios => '13.4',
+    :osx => '10.15',
+    :tvos => '13.4'
+  }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.header_dir     = 'Expo'


### PR DESCRIPTION
# Why

`expo` is the last package that needs to declare support for macOS in order to install Expo modules in macOS target.

# How

- Added macOS platform to the podspec of the `expo` package
- Reinstalled pods

# Test Plan

Tested in https://github.com/tsapeta/expo-macos-example