### PR TITLE
[go] update lottie-react-native to 6.5.1

### DIFF
--- a/android/vendored/unversioned/lottie-react-native/android/build.gradle
+++ b/android/vendored/unversioned/lottie-react-native/android/build.gradle
@@ -124,7 +124,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+' // From node_modules
 
-    implementation "com.airbnb.android:lottie:6.1.0"
+    implementation "com.airbnb.android:lottie:6.2.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -133,7 +133,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "6.4.1",
+    "lottie-react-native": "6.5.1",
     "moment": "^2.29.4",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1135,8 +1135,10 @@ PODS:
   - libwebp/webp (1.3.2):
     - libwebp/sharpyuv
   - lottie-ios (4.3.3)
-  - lottie-react-native (6.4.1):
+  - lottie-react-native (6.5.1):
+    - glog
     - lottie-ios (~> 4.3.3)
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - MBProgressHUD (1.2.0)
   - nanopb (2.30909.0):
@@ -3340,7 +3342,7 @@ SPEC CHECKSUMS:
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   lottie-ios: 25e7b2675dad5c3ddad369ac9baab03560c5bfdd
-  lottie-react-native: a2ae9c27c273b060b2affff2957bc0ff7fdca353
+  lottie-react-native: c1c6a1fd86e1942d69c2bc2e14212be72b55f3be
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7

--- a/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieAnimationViewComponentView.mm
+++ b/ios/vendored/unversioned/lottie-react-native/ios/Fabric/LottieAnimationViewComponentView.mm
@@ -19,18 +19,22 @@ using namespace facebook::react;
     LottieContainerView *_view;
 }
 
++(void) load {
+    [super load];
+}
+
 - (instancetype) initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const LottieAnimationViewProps>();
         _props = defaultProps;
-        
+
         _view = [LottieContainerView new];
         _view.delegate = self;
-        
+
         self.contentView = _view;
     }
-    
+
     return self;
 }
 
@@ -44,55 +48,55 @@ using namespace facebook::react;
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps {
     const auto &oldLottieProps = *std::static_pointer_cast<const LottieAnimationViewProps>(_props);
     const auto &newLottieProps = *std::static_pointer_cast<const LottieAnimationViewProps>(props);
-    
+
     if(oldLottieProps.resizeMode != newLottieProps.resizeMode) {
         [_view setResizeMode:RCTNSStringFromString(newLottieProps.resizeMode)];
     }
-    
+
     if(oldLottieProps.sourceJson != newLottieProps.sourceJson) {
         [_view setSourceJson:RCTNSStringFromString(newLottieProps.sourceJson.c_str())];
     }
-    
+
     if(oldLottieProps.sourceDotLottieURI != newLottieProps.sourceDotLottieURI) {
         [_view setSourceDotLottieURI:RCTNSStringFromString(newLottieProps.sourceDotLottieURI)];
     }
-    
+
     if(oldLottieProps.sourceName != newLottieProps.sourceName) {
         [_view setSourceName:RCTNSStringFromString(newLottieProps.sourceName)];
     }
-    
+
     if(oldLottieProps.sourceURL != newLottieProps.sourceURL) {
         [_view setSourceURL:RCTNSStringFromString(newLottieProps.sourceURL)];
     }
-    
+
     if(oldLottieProps.progress != newLottieProps.progress) {
         [_view setProgress:newLottieProps.progress];
     }
-    
+
     if(oldLottieProps.loop != newLottieProps.loop) {
         [_view setLoop:newLottieProps.loop];
     }
-    
+
     if(oldLottieProps.speed != newLottieProps.speed) {
         [_view setSpeed:newLottieProps.speed];
     }
-    
+
     if(oldLottieProps.colorFilters != newLottieProps.colorFilters) {
         [_view setColorFilters:convertColorFilters(newLottieProps.colorFilters)];
     }
-    
+
     if(oldLottieProps.textFiltersIOS != newLottieProps.textFiltersIOS) {
         [_view setTextFiltersIOS:convertTextFilters(newLottieProps.textFiltersIOS)];
     }
-    
+
     if(oldLottieProps.renderMode != newLottieProps.renderMode) {
         [_view setRenderMode:RCTNSStringFromString(newLottieProps.renderMode)];
     }
-    
+
     if(oldLottieProps.autoPlay != newLottieProps.autoPlay) {
         [_view setAutoPlay:newLottieProps.autoPlay];
     }
-    
+
     [super updateProps:props oldProps:oldProps];
 }
 
@@ -132,11 +136,11 @@ using namespace facebook::react;
     if(!_eventEmitter) {
         return;
     }
-    
+
     LottieAnimationViewEventEmitter::OnAnimationFinish event = {
         .isCancelled = isCancelled
     };
-    
+
     std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationFinish(event);
 }
 
@@ -145,11 +149,11 @@ using namespace facebook::react;
     if(!_eventEmitter) {
         return;
     }
-    
+
     LottieAnimationViewEventEmitter::OnAnimationFailure event = {
         .error = std::string([error UTF8String])
     };
-    
+
     std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationFailure(event);
 }
 

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
@@ -242,15 +242,8 @@ class ContainerView: RCTView {
     }
 
     @objc func setResizeMode(_ resizeMode: String) {
-        switch resizeMode {
-        case "cover":
-            animationView?.contentMode = .scaleAspectFill
-        case "contain":
-            animationView?.contentMode = .scaleAspectFit
-        case "center":
-            animationView?.contentMode = .center
-        default: break
-        }
+        self.resizeMode = resizeMode
+        applyContentMode()
     }
 
     @objc func setColorFilters(_ newColorFilters: [NSDictionary]) {
@@ -287,21 +280,17 @@ class ContainerView: RCTView {
     }
 
     // The animation view is a child of the RCTView, so if the bounds ever change, add those changes to the animation view as well
-    override var bounds: CGRect {
-        didSet {
-            animationView?.frame = self.bounds
-        }
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        animationView?.frame = self.bounds
     }
 
     // MARK: Private
     func replaceAnimationView(next: LottieAnimationView) {
         super.removeReactSubview(animationView)
 
-        let contentMode = animationView?.contentMode ?? .scaleAspectFit
-
         animationView = next
 
-        animationView?.contentMode = contentMode
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.animationSpeed = speed
         animationView?.loopMode = loop
@@ -309,12 +298,27 @@ class ContainerView: RCTView {
 
         addSubview(next)
 
+        applyContentMode()
         applyColorProperties()
         playIfNeeded()
 
-        animationView?.animationLoaded = { [weak self] animationView, animation in
+        animationView?.animationLoaded = { [weak self] _, _ in
             guard let self = self else { return }
             self.loadedCallback()
+        }
+    }
+
+    func applyContentMode() {
+        guard let animationView = animationView else { return }
+
+        switch resizeMode {
+        case "cover":
+            animationView.contentMode = .scaleAspectFill
+        case "contain":
+            animationView.contentMode = .scaleAspectFit
+        case "center":
+            animationView.contentMode = .center
+        default: break
         }
     }
 

--- a/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
+++ b/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "6.4.1",
+  "version": "6.5.1",
   "summary": "React Native bindings for Lottie",
   "license": "Apache-2.0",
   "authors": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
@@ -12,16 +12,25 @@
   },
   "source": {
     "git": "https://github.com/lottie-react-native/lottie-react-native.git",
-    "tag": "v6.4.1"
+    "tag": "v6.5.1"
   },
   "source_files": "ios/**/*.{h,m,mm,swift}",
   "dependencies": {
     "lottie-ios": [
       "~> 4.3.3"
     ],
-    "React-Core": []
+    "React-Core": [],
+    "RCT-Folly": [
+      "2022.05.16.00"
+    ],
+    "glog": []
   },
   "swift_versions": "5.6",
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -Wno-comma -Wno-shorten-64-to-32",
+  "pod_target_xcconfig": {
+    "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\"",
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++20"
+  },
   "exclude_files": "ios/Fabric",
   "swift_version": "5.6"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -80,7 +80,7 @@
   "expo-video-thumbnails": "~7.9.0",
   "expo-web-browser": "~12.8.1",
   "jest-expo": "~50.0.1",
-  "lottie-react-native": "6.4.1",
+  "lottie-react-native": "6.5.1",
   "react": "18.2.0",
   "react-dom": "18.2.0",
   "react-native": "0.73.1",

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -51,7 +51,23 @@ const config: VendoringTargetConfig = {
     'lottie-react-native': {
       source: 'lottie-react-native',
       sourceType: 'npm',
-      ios: {},
+      ios: {
+        async preReadPodspecHookAsync(podspecPath: string): Promise<string> {
+          let content = await fs.readFile(podspecPath, 'utf-8');
+          // load `install_modules_dependencies()` from react-native_pods.rb
+          content = content.replace(
+            /^(\s*install_modules_dependencies\(.*$)/gm,
+            `\
+    unless defined?(install_modules_dependencies)
+      require File.join('${REACT_NATIVE_SUBMODULE_DIR}', 'scripts/react_native_pods')
+    end\n$1`
+          );
+          // comment out `Pod::UI.puts` calls that will break JSON parsing
+          content = content.replace(/Pod::UI.puts\(.+\)/gm, '');
+          await fs.writeFile(podspecPath, content);
+          return podspecPath;
+        },
+      },
       android: {
         includeFiles: ['android/**'],
         excludeFiles: ['src/android/gradle.properties', 'src/android/gradle-maven-push.gradle'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -13483,10 +13483,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react-native@6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-6.4.1.tgz#0b3202a0fb914db4f236c4b0658f21b97cb997d7"
-  integrity sha512-DPsUPSxLc3ZffeRQ/AtKtcUl4PzmJEEPt965tNpWSE4vhDkoGFxRe0TPZ45xX8/3HbGsUl48aMdLlAu28MEDsQ==
+lottie-react-native@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-6.5.1.tgz#7986078648d1ff274a704ae3bd979a4c3aa235c6"
+  integrity sha512-pjih71P6qX6Ax5ucUBA+YJO7+fnveI581Bd8LmYeARm3spq3AnoGzEkrWaieM8odnK6WI4d5dwEJsxge/QjFPw==
 
 lower-case-first@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
# Why

close ENG-11016

# How

- update vendoring config to fix undefined `install_modules_dependencies` during `pod ipc spec`
- `et uvm -m lottie-react-native -c 6.5.1`

# Test Plan

versioned expo-go + ncl lottie test case

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
