### PR TITLE
Add macOS and tvOS to supported platforms in expo-module.config.json

### DIFF
--- a/packages/expo-application/expo-module.config.json
+++ b/packages/expo-application/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "tvos"],
   "ios": {
     "modules": ["ApplicationModule"]
   },

--- a/packages/expo-av/expo-module.config.json
+++ b/packages/expo-av/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-av",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "ios": {
     "modules": ["VideoViewModule"]
   },

--- a/packages/expo-constants/expo-module.config.json
+++ b/packages/expo-constants/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-constants",
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "macos", "tvos"],
   "ios": {
     "modules": ["ConstantsModule"]
   },

--- a/packages/expo-device/expo-module.config.json
+++ b/packages/expo-device/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-device",
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "tvos"],
   "ios": {
     "modules": ["DeviceModule"]
   },

--- a/packages/expo-eas-client/expo-module.config.json
+++ b/packages/expo-eas-client/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "ios": {
     "modulesClassNames": ["EASClientModule"]
   },

--- a/packages/expo-file-system/expo-module.config.json
+++ b/packages/expo-file-system/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-file-system",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "macos", "tvos"],
   "ios": {
     "modules": ["FileSystemModule"],
     "appDelegateSubscribers": ["FileSystemBackgroundSessionHandler"]

--- a/packages/expo-font/expo-module.config.json
+++ b/packages/expo-font/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-font",
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "macos", "tvos"],
   "android": {
     "modules": ["expo.modules.font.FontLoaderModule"]
   }

--- a/packages/expo-image/expo-module.config.json
+++ b/packages/expo-image/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "ios": {
     "modules": ["ImageModule"]
   },

--- a/packages/expo-json-utils/expo-module.config.json
+++ b/packages/expo-json-utils/expo-module.config.json
@@ -1,3 +1,3 @@
 {
-  "platforms": ["ios", "android"]
+  "platforms": ["ios", "android", "tvos"]
 }

--- a/packages/expo-keep-awake/expo-module.config.json
+++ b/packages/expo-keep-awake/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "macos", "tvos"],
   "ios": {
     "modules": ["KeepAwakeModule"]
   },

--- a/packages/expo-localization/expo-module.config.json
+++ b/packages/expo-localization/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-localization",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "ios": {
     "modulesClassNames": ["LocalizationModule"]
   },

--- a/packages/expo-manifests/expo-module.config.json
+++ b/packages/expo-manifests/expo-module.config.json
@@ -1,4 +1,4 @@
 {
   "name": "expo-manifests",
-  "platforms": ["ios", "android"]
+  "platforms": ["ios", "android", "tvos"]
 }

--- a/packages/expo-modules-core/expo-module.config.json
+++ b/packages/expo-modules-core/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "macos", "tvos"],
   "ios": {
     "podspecPath": "./ExpoModulesCore.podspec"
   }

--- a/packages/expo-splash-screen/expo-module.config.json
+++ b/packages/expo-splash-screen/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-splash-screen",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "android": {
     "modules": ["expo.modules.splashscreen.SplashScreenModule"]
   }

--- a/packages/expo-structured-headers/expo-module.config.json
+++ b/packages/expo-structured-headers/expo-module.config.json
@@ -1,3 +1,3 @@
 {
-  "platforms": ["ios", "android"]
+  "platforms": ["ios", "android", "tvos"]
 }

--- a/packages/expo-updates-interface/expo-module.config.json
+++ b/packages/expo-updates-interface/expo-module.config.json
@@ -1,3 +1,3 @@
 {
-  "platforms": ["ios", "android"]
+  "platforms": ["ios", "android", "tvos"]
 }

--- a/packages/expo-updates/expo-module.config.json
+++ b/packages/expo-updates/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-updates",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "tvos"],
   "ios": {
     "modules": ["UpdatesModule"],
     "appDelegateSubscribers": ["ExpoUpdatesAppDelegateSubscriber"],

--- a/packages/expo/expo-module.config.json
+++ b/packages/expo/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "android", "macos", "tvos"],
   "ios": {
     "podspecPath": "Expo.podspec"
   }


### PR DESCRIPTION
# Why

Following up on #26287.

# How

Added `macos` and `tvos` to `expo-module.config.json` files so that autolinking knows to link the module on those platforms.

# Test Plan

Tested in https://github.com/tsapeta/expo-macos-example as part of PR #22796.
I didn't test it against tvOS, but I believe it works if CI passes.