### PR TITLE
  [tools] Fix vendoring script target directories

### DIFF
--- a/tools/src/commands/UpdateVendoredModule.ts
+++ b/tools/src/commands/UpdateVendoredModule.ts
@@ -110,16 +110,14 @@ async function action(options: ActionOptions) {
         continue;
       }
 
-      const relativeTargetDirectory = path.join(
+      const targetDirectory = path.join(
         targetConfig.platforms[platform].targetDirectory,
         moduleName
       );
-      const targetDirectory = path.join(EXPO_DIR, relativeTargetDirectory);
-
       logger.log(
         '🎯 Vendoring for %s to %s',
         chalk.yellow(platform),
-        chalk.magenta(relativeTargetDirectory)
+        chalk.magenta(targetDirectory)
       );
 
       // Clean up previous version

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -4,7 +4,13 @@ import minimatch from 'minimatch';
 import path from 'path';
 
 import { Podspec } from '../../CocoaPods';
-import { EXPO_DIR, EXPOTOOLS_DIR, REACT_NATIVE_SUBMODULE_DIR } from '../../Constants';
+import {
+  EXPO_DIR,
+  EXPO_GO_ANDROID_DIR,
+  EXPO_GO_IOS_DIR,
+  EXPOTOOLS_DIR,
+  REACT_NATIVE_SUBMODULE_DIR,
+} from '../../Constants';
 import logger from '../../Logger';
 import { transformFileAsync } from '../../Transforms';
 import { applyPatchAsync } from '../../Utils';
@@ -14,10 +20,10 @@ const config: VendoringTargetConfig = {
   name: 'Expo Go',
   platforms: {
     ios: {
-      targetDirectory: 'ios/vendored/unversioned',
+      targetDirectory: `${EXPO_GO_IOS_DIR}/vendored/unversioned`,
     },
     android: {
-      targetDirectory: 'android/vendored/unversioned',
+      targetDirectory: `${EXPO_GO_ANDROID_DIR}/vendored/unversioned`,
     },
   },
   modules: {

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -20,10 +20,10 @@ const config: VendoringTargetConfig = {
   name: 'Expo Go',
   platforms: {
     ios: {
-      targetDirectory: `${EXPO_GO_IOS_DIR}/vendored/unversioned`,
+      targetDirectory: path.join(EXPO_GO_IOS_DIR, 'vendored/unversioned'),
     },
     android: {
-      targetDirectory: `${EXPO_GO_ANDROID_DIR}/vendored/unversioned`,
+      targetDirectory: path.join(EXPO_GO_ANDROID_DIR, 'vendored/unversioned'),
     },
   },
   modules: {


### PR DESCRIPTION
# Why

Running `et uvm` on main adds module files to `/ios` and `/android` instead of the new patch under `apps/expo-go`

# How

Update `targetDirectory` inside expoGoConfig

# Test Plan

run `et uvm`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
