### PR TITLE
[sqlite] fix build error on windows

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed building error on Windows. ([#26296](https://github.com/expo/expo/pull/26296) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 13.1.2 - 2023-12-21

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
@@ -15,6 +17,14 @@ if (expoModulesCorePlugin.exists()) {
     useExpoPublishing()
     useCoreDependencies()
   }
+}
+
+String toPlatformIndependentPath(File path) {
+  def result = path.toString()
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    result = result.replace(File.separatorChar, '/' as char)
+  }
+  return result
 }
 
 def SQLITE_VERSION = '3420000'
@@ -112,7 +122,7 @@ android {
       cmake {
         abiFilters (*reactNativeArchitectures())
         arguments "-DANDROID_STL=c++_shared",
-          "-DSQLITE3_SRC_DIR=${SQLITE3_SRC_DIR}"
+          "-DSQLITE3_SRC_DIR=${toPlatformIndependentPath(SQLITE3_SRC_DIR)}"
       }
     }
   }


### PR DESCRIPTION
# Why

fixes #26206
close ENG-10993

# How

cmake path separator should be `/` always. refer to https://github.com/Kudo/react-native-v8/pull/132 fix but refine the method name a little bit

# Test Plan

- ci passed
- test building on windows

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
