### PR TITLE
Backport "[ios][android] Update react-native-pager-view to 6.2.3 (#26279)" to main

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1207,7 +1207,9 @@ PODS:
     - React-debug
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-pager-view (6.2.2):
+  - react-native-pager-view (6.2.3):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - react-native-safe-area-context (4.7.4):
     - React-Core
@@ -2038,7 +2040,7 @@ SPEC CHECKSUMS:
   React-logger: 66b168e2b2bee57bd8ce9e69f739d805732a5570
   React-Mapbuffer: 9ee041e1d7be96da6d76a251f92e72b711c651d6
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
+  react-native-pager-view: d81ab2060b9caf57ca8c3a0d57467ff407cdb825
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -74,7 +74,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.73.2",
     "react-native-gesture-handler": "~2.14.0",
-    "react-native-pager-view": "6.2.2",
+    "react-native-pager-view": "6.2.3",
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.7.4",
     "react-native-screens": "~3.27.0",

--- a/apps/expo-go/android/vendored/unversioned/react-native-pager-view/android/build.gradle
+++ b/apps/expo-go/android/vendored/unversioned/react-native-pager-view/android/build.gradle
@@ -42,7 +42,7 @@ if(shouldUseNameSpace){
       manifestContent = manifestContent.replaceAll(
         PACKAGE_PROP,
         ''
-    )  
+    )
 } else {
     if(!manifestContent.contains("$PACKAGE_PROP")){
         manifestContent = manifestContent.replace(
@@ -61,7 +61,6 @@ def registrationCompat = {
   def reactAndroidProject = rootProject.allprojects.find { it.name == 'ReactAndroid' }
   if (reactAndroidProject == null) return false
 
-  println(reactAndroidProject.projectDir)
   def reactNativeManifest = file("${reactAndroidProject.projectDir}/../package.json")
   def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
   // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.71
@@ -83,6 +82,9 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   if (shouldUseNameSpace){
     namespace = "com.reactnativepagerview"
+    buildFeatures {
+      buildConfig true
+    }
   }
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1201,7 +1201,7 @@ PODS:
     - React-debug
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-pager-view (6.2.2):
+  - react-native-pager-view (6.2.3):
     - React-Core
   - react-native-safe-area-context (4.7.4):
     - React-Core
@@ -2048,7 +2048,7 @@ SPEC CHECKSUMS:
   React-logger: 66b168e2b2bee57bd8ce9e69f739d805732a5570
   React-Mapbuffer: 9ee041e1d7be96da6d76a251f92e72b711c651d6
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-pager-view: 02a5c4962530f7efc10dd51ee9cdabeff5e6c631
+  react-native-pager-view: c29d484f19c49ff19525a94105e4ab2c4d4ae273
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-skia: 1a2fbce7fc198eb229b13f15bce48a06b5c92d69

--- a/apps/expo-go/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
+++ b/apps/expo-go/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pager-view",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "summary": "React Native wrapper for Android and iOS ViewPager",
   "homepage": "https://github.com/callstack/react-native-pager-view#readme",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/callstack/react-native-pager-view.git",
-    "tag": "6.2.2"
+    "tag": "6.2.3"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "dependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -136,7 +136,7 @@
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-maps": "1.8.0",
-    "react-native-pager-view": "6.2.2",
+    "react-native-pager-view": "6.2.3",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.6.0",
     "react-native-safe-area-context": "4.7.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -88,7 +88,7 @@
   "react-native-gesture-handler": "~2.14.0",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.8.0",
-  "react-native-pager-view": "6.2.2",
+  "react-native-pager-view": "6.2.3",
   "react-native-reanimated": "~3.6.0",
   "react-native-screens": "~3.27.0",
   "react-native-safe-area-context": "4.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16681,10 +16681,10 @@ react-native-maps@1.8.0:
   dependencies:
     "@types/geojson" "^7946.0.10"
 
-react-native-pager-view@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.2.tgz#4c1c45d5f3f622c0922ef96ac114666392ebf5ec"
-  integrity sha512-MLkJB7iP6v0Hd4/B4/R/gLCSE+YBtjxG/vHZYBDU+fI3U7HBYgKAg4o6ad8HxbKVcWWyRDNeeVRGISw1MUjlHw==
+react-native-pager-view@6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.3.tgz#698f6387fdf06cecc3d8d4792604419cb89cb775"
+  integrity sha512-dqVpXWFtPNfD3D2QQQr8BP+ullS5MhjRJuF8Z/qml4QTILcrWaW8F5iAxKkQR3Jl0ikcEryG/+SQlNcwlo0Ggg==
 
 react-native-paper@^4.0.1:
   version "4.12.0"


### PR DESCRIPTION
# Why

Backport #26279 to main

# How

`git cherry-pick 7666e623881da63df54ca2ad2fecf64ea02348f2 `

# Test Plan

- bare-expo + NCL
- unversioned expo go + NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
