### PR TITLE
[expo-updates] Fix metro asset call in embedded manifest creation step

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
+- Fix metro asset call in expo-updates embedded manifest creation step. ([#26307](https://github.com/expo/expo/pull/26307) by [@wschurman](https://github.com/wschurman))
 
 ## 0.16.5 - 2023-12-21
 

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -60,7 +60,7 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
     }
   }
 
-  const { bundle, assets } = await exportEmbedBundleAsync(projectRoot, options);
+  const { bundle, assets } = await exportEmbedBundleAndAssetsAsync(projectRoot, options);
 
   fs.mkdirSync(path.dirname(options.bundleOutput), { recursive: true, mode: 0o755 });
 
@@ -79,7 +79,21 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
   ]);
 }
 
-export async function exportEmbedBundleAsync(projectRoot: string, options: Options) {
+export async function createMetroServerAndBundleRequestAsync(
+  projectRoot: string,
+  options: Pick<
+    Options,
+    | 'maxWorkers'
+    | 'config'
+    | 'platform'
+    | 'sourcemapOutput'
+    | 'sourcemapUseAbsolutePath'
+    | 'entryFile'
+    | 'minify'
+    | 'dev'
+    | 'unstableTransformProfile'
+  >
+): Promise<{ server: Server; bundleRequest: BundleOptions }> {
   const exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
 
   // TODO: This is slow ~40ms
@@ -122,25 +136,44 @@ export async function exportEmbedBundleAsync(projectRoot: string, options: Optio
     watch: false,
   });
 
+  return { server, bundleRequest };
+}
+
+export async function exportEmbedBundleAndAssetsAsync(
+  projectRoot: string,
+  options: Options
+): Promise<{
+  bundle: Awaited<ReturnType<Server['build']>>;
+  assets: Awaited<ReturnType<typeof getAssets>>;
+}> {
+  const { server, bundleRequest } = await createMetroServerAndBundleRequestAsync(
+    projectRoot,
+    options
+  );
+
   try {
-    const bundle = await profile(
+    const bundle = await exportEmbedBundleAsync(server, bundleRequest, projectRoot, options);
+    const assets = await exportEmbedAssetsAsync(server, bundleRequest, projectRoot, options);
+    return { bundle, assets };
+  } finally {
+    server.end();
+  }
+}
+
+export async function exportEmbedBundleAsync(
+  server: Server,
+  bundleRequest: BundleOptions,
+  projectRoot: string,
+  options: Pick<Options, 'platform'>
+) {
+  try {
+    return await profile(
       server.build.bind(server),
       'metro-bundle'
     )({
       ...bundleRequest,
       bundleType: 'bundle',
     });
-
-    // Save the assets of the bundle
-    const outputAssets = await getAssets(server, {
-      ...bundleRequest,
-      bundleType: 'todo',
-    });
-
-    return {
-      bundle,
-      assets: outputAssets,
-    };
   } catch (error: any) {
     if (isError(error)) {
       // Log using Xcode error format so the errors are picked up by xcodebuild.
@@ -154,8 +187,33 @@ export async function exportEmbedBundleAsync(projectRoot: string, options: Optio
       }
     }
     throw error;
-  } finally {
-    server.end();
+  }
+}
+
+export async function exportEmbedAssetsAsync(
+  server: Server,
+  bundleRequest: BundleOptions,
+  projectRoot: string,
+  options: Pick<Options, 'platform'>
+) {
+  try {
+    return await getAssets(server, {
+      ...bundleRequest,
+      bundleType: 'todo',
+    });
+  } catch (error: any) {
+    if (isError(error)) {
+      // Log using Xcode error format so the errors are picked up by xcodebuild.
+      // https://developer.apple.com/documentation/xcode/running-custom-scripts-during-a-build#Log-errors-and-warnings-from-your-script
+      if (options.platform === 'ios') {
+        // If the error is about to be presented in Xcode, strip the ansi characters from the message.
+        if ('message' in error && isExecutingFromXcodebuild()) {
+          error.message = stripAnsi(error.message) as string;
+        }
+        logMetroErrorInXcode(projectRoot, error);
+      }
+    }
+    throw error;
   }
 }
 

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import type { LinkProps as OriginalLinkProps } from 'expo-router/build/link/Link';
-import type { Router as OriginalRouter } from 'expo-router/src/types';
+import type { Router as OriginalRouter } from 'expo-router/build/types';
 export * from 'expo-router/build';
 
 // prettier-ignore

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
+- Fix metro asset call in embedded manifest creation step. ([#26307](https://github.com/expo/expo/pull/26307) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -1,13 +1,10 @@
-const { isEnableHermesManaged } = require('@expo/cli/build/src/export/exportHermes');
-const { loadMetroConfigAsync } = require('@expo/cli/build/src/start/server/metro/instantiateMetro');
 const {
-  getMetroDirectBundleOptionsForExpoConfig,
-} = require('@expo/cli/build/src/start/server/middleware/metroOptions');
-const { getConfig } = require('@expo/config');
+  createMetroServerAndBundleRequestAsync,
+  exportEmbedAssetsAsync,
+} = require('@expo/cli/build/src/export/embed/exportEmbedAsync');
 const { resolveEntryPoint } = require('@expo/config/paths');
 const crypto = require('crypto');
 const fs = require('fs');
-const Server = require('metro/src/Server');
 const path = require('path');
 
 const filterPlatformAssetScales = require('./filterPlatformAssetScales');
@@ -55,42 +52,28 @@ function getRelativeEntryPoint(projectRoot, platform) {
 
   process.chdir(projectRoot);
 
-  let exp;
-  let metroConfig;
-  try {
-    exp = getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp;
+  const options = {
+    platform,
+    entryFile,
+    minify: false,
+    dev: false,
+  };
 
-    // Load the metro config the same way it would be loaded in Expo CLI.
-    // This ensures dynamic features like tsconfig paths can be used.
-    metroConfig = (
-      await loadMetroConfigAsync(
-        projectRoot,
-        {
-          // No config options can be passed to this point.
-        },
-        {
-          exp,
-          isExporting: true,
-        }
-      )
-    ).config;
-  } catch (e) {
-    let message = `Error loading Metro config and Expo app config: ${e.message}\n\nMake sure your project is configured properly and your app.json / app.config.js is valid.`;
-    if (process.env.EAS_BUILD) {
-      message +=
-        '\nIf you are using environment variables in app.config.js, verify that you have set them in your EAS Build profile configuration or secrets.';
-    }
-    throw new Error(message);
-  }
+  const { server, bundleRequest } = await createMetroServerAndBundleRequestAsync(
+    projectRoot,
+    options
+  );
 
   let assets;
   try {
-    assets = await fetchAssetManifestAsync(platform, projectRoot, entryFile, metroConfig, exp);
+    assets = await exportEmbedAssetsAsync(server, bundleRequest, projectRoot, options);
   } catch (e) {
     throw new Error(
       "Error loading assets JSON from Metro. Ensure you've followed all expo-updates installation steps correctly. " +
         e.message
     );
+  } finally {
+    server.end();
   }
 
   const manifest = {
@@ -163,41 +146,4 @@ function getBasePath(asset) {
     basePath = basePath.substr(1);
   }
   return basePath;
-}
-
-// Spawn a Metro server to get the asset manifest
-async function fetchAssetManifestAsync(platform, projectRoot, entryFile, metroConfig, exp) {
-  // Project-level babel config does not load unless we change to the
-  // projectRoot before instantiating the server
-  process.chdir(projectRoot);
-
-  const server = new Server(metroConfig);
-
-  const isHermes = isEnableHermesManaged(exp, platform);
-
-  let assetManifest;
-  let error;
-  try {
-    assetManifest = await server.getAssets({
-      ...Server.DEFAULT_BUNDLE_OPTIONS,
-      ...getMetroDirectBundleOptionsForExpoConfig(projectRoot, exp, {
-        mainModuleName: entryFile,
-        platform,
-        minify: false,
-        mode: 'production',
-        engine: isHermes ? 'hermes' : undefined,
-        isExporting: true,
-      }),
-    });
-  } catch (e) {
-    error = e;
-  } finally {
-    server.end();
-  }
-
-  if (error) {
-    throw error;
-  }
-
-  return assetManifest;
 }


### PR DESCRIPTION
# Why

The metro asset collection step in `@expo/cli` has evolved and diverged from the way that the expo-updates asset collection step was written. This causes nonstandard metro configs to not be respected by expo-updates, and assets to be missing.

We didn't notice this for a while because until https://github.com/expo/expo/pull/25613 landed a lot of common assets were present in the CDN and would resolve and be downloaded instead of getting the embedded ones. (they'd still present on screen, just erroneously download).

Closes #26195.
Closes ENG-11025.

# How

This fix is done in two commits. The first commit is sufficient to fix the issue (it copy/pastes the code from CLI into createManifest but still leaves the root issue open as it could diverge again in the future). The second commit tries to future-proof this by factoring out the functions into common functions used by both the CLI export and the expo-updates export.

# Test Plan

copy-paste the built JS for `createManifest` and `exportEmbedAsync` into a sample app that this repro's in. the repro is this comment: https://github.com/expo/expo/issues/26195#issuecomment-1880199885

Inspect the output of createManifest and see the image in a release build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
