### PR TITLE
[github] add Vale check to Docs CI, uncomment links lint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,17 +43,18 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: 🧪 Run Docs tests
         run: yarn test
-      - name: 🚨 Lint Docs app
+      - name: 🚨 Lint Docs website code
         run: yarn lint --max-warnings 0
+      - name: 💬 Lint Docs website content
+        run: yarn lint-prose
       - run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗️ Build Docs website for deploy
         run: yarn export
         timeout-minutes: 20
-      # TODO(cedric): If we have time, we should make sure all links are valid and connected to a proper header
-      # - name: lint links
-      #   run: yarn lint-links --quiet
+      - name: 🔗 Lint pages links
+        run: yarn lint-links --quiet
       - name: ✅ Test links (legacy)
         run: |
           yarn export-server &


### PR DESCRIPTION
# Why

Fixes ENG-9433

# How

Add Vale check (content/writing style) to the Docs app workflow. Uncomment `links-lint` step, since all previous issues have been fixed.

# Test Plan

Run the CI.
