### PR TITLE
[Android][image] Fix tint color was applied to the mask element

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed ResizeObserver attaching on every image transition. ([#25819](https://github.com/expo/expo/pull/25819) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fixed the issue with the application of tint color when an element does not have a style assigned to it. ([#26251](https://github.com/expo/expo/pull/26251) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed the tine color was applied to the mask element.
+- [Android] Fixed the tine color was applied to the mask element. ([#26323](https://github.com/expo/expo/pull/26323) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### 🐛 Bug fixes
 
 - Fixed ResizeObserver attaching on every image transition. ([#25819](https://github.com/expo/expo/pull/25819) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Fixed the issue with the application of tint color when an element does not have a style assigned to it.
+- [Android] Fixed the issue with the application of tint color when an element does not have a style assigned to it. ([#26251](https://github.com/expo/expo/pull/26251) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed the tine color was applied to the mask element.
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
+++ b/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
@@ -85,6 +85,11 @@ internal fun defineStyles(element: SvgElementBase, newColor: Int, hasStyle: Bool
 }
 
 internal fun applyTintColor(element: SVG.SvgObject, newColor: Int, parentDefinesStyle: Boolean) {
+  // We want to keep the colors in the mask as they control the visibility of the element to which the mask is applied.
+  if (element is SVG.Mask) {
+    return
+  }
+
   val definesStyle = if (element is SvgElementBase) {
     val hasStyle = parentDefinesStyle || hasStyle(element)
 
@@ -107,6 +112,9 @@ internal fun applyTintColor(element: SVG.SvgObject, newColor: Int, parentDefines
 fun applyTintColor(svg: SVG, newColor: Int) {
   val root = svg.rootElement
 
+  svg.cssRules?.forEach { rule ->
+    replaceStyles(rule.style, newColor)
+  }
   replaceStyles(root.style, newColor)
   val hasStyle = hasStyle(root)
 


### PR DESCRIPTION
# Why

Fixes the tint color was applied to the mask element. 

# How

We want to keep the colors in the mask as they control the visibility of the element to which the mask is applied.


# Test Plan

- image with SVG: https://codepen.io/tsapeta/pen/qBvNVjp