### PR TITLE
[Android][core] Remove deprecated functions `newInstance`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -46,7 +46,7 @@ class ModuleRegistry(
 
   fun register(provider: ModulesProvider) = apply {
     provider.getModulesList().forEach { type ->
-      val module = type.newInstance()
+      val module = type.getDeclaredConstructor().newInstance()
       register(module)
     }
   }


### PR DESCRIPTION
# Why

Removes deprecated functions `newInstance`

# How

The `newInstance` function was deprecated. The new version should return more descriptive errors.  

# Test Plan

- bare-expo ✅