### PR TITLE
[docs] Fix Platform compatibility table's layout on mobile viewports

### DIFF
--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -1,9 +1,8 @@
 import { StatusWaitingIcon } from '@expo/styleguide-icons';
-import { useState, useEffect } from 'react';
 
 import { ElementType } from '~/types/common';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
-import { Cell, HeaderCell, Row, Table, TableHead, TableLayout } from '~/ui/components/Table';
+import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { A, H4 } from '~/ui/components/Text';
 
 const platforms = [
@@ -52,29 +51,10 @@ type Props = {
 type PlatformProps = Omit<Props, 'title'>;
 
 const PlatformsSection = (props: Props) => {
-  const [tableLayout, setTableLayout] = useState(TableLayout.Fixed);
-
-  useEffect(() => {
-    function handleResize() {
-      if (window.innerWidth <= 480) {
-        setTableLayout(TableLayout.Auto);
-      } else {
-        setTableLayout(TableLayout.Fixed);
-      }
-    }
-
-    // Add event listener
-    window.addEventListener('resize', handleResize);
-
-    handleResize();
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
   return (
     <>
       <H4 className="mb-1">{props.title || 'Platform Compatibility'}</H4>
-      <Table layout={tableLayout}>
+      <Table className="table-fixed max-sm-gutters:table-auto">
         <TableHead>
           <Row>
             {platforms.map(({ title }) => (

--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -1,4 +1,5 @@
 import { StatusWaitingIcon } from '@expo/styleguide-icons';
+import { useState, useEffect } from 'react';
 
 import { ElementType } from '~/types/common';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
@@ -50,29 +51,50 @@ type Props = {
 
 type PlatformProps = Omit<Props, 'title'>;
 
-const PlatformsSection = (props: Props) => (
-  <>
-    <H4 className="mb-1">{props.title || 'Platform Compatibility'}</H4>
-    <Table layout={TableLayout.Fixed}>
-      <TableHead>
-        <Row>
-          {platforms.map(({ title }) => (
-            <HeaderCell key={title}>{title}</HeaderCell>
-          ))}
-        </Row>
-      </TableHead>
-      <tbody>
-        <Row>
-          {platforms.map(platform => (
-            <Cell
-              key={platform.title}
-              {...getInfo(props[platform.propName as keyof PlatformProps], platform)}
-            />
-          ))}
-        </Row>
-      </tbody>
-    </Table>
-  </>
-);
+const PlatformsSection = (props: Props) => {
+  const [tableLayout, setTableLayout] = useState(TableLayout.Fixed);
+
+  useEffect(() => {
+    function handleResize() {
+      if (window.innerWidth <= 480) {
+        setTableLayout(TableLayout.Auto);
+      } else {
+        setTableLayout(TableLayout.Fixed);
+      }
+    }
+
+    // Add event listener
+    window.addEventListener('resize', handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return (
+    <>
+      <H4 className="mb-1">{props.title || 'Platform Compatibility'}</H4>
+      <Table layout={tableLayout}>
+        <TableHead>
+          <Row>
+            {platforms.map(({ title }) => (
+              <HeaderCell key={title}>{title}</HeaderCell>
+            ))}
+          </Row>
+        </TableHead>
+        <tbody>
+          <Row>
+            {platforms.map(platform => (
+              <Cell
+                key={platform.title}
+                {...getInfo(props[platform.propName as keyof PlatformProps], platform)}
+              />
+            ))}
+          </Row>
+        </tbody>
+      </Table>
+    </>
+  );
+};
 
 export default PlatformsSection;

--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -50,31 +50,29 @@ type Props = {
 
 type PlatformProps = Omit<Props, 'title'>;
 
-const PlatformsSection = (props: Props) => {
-  return (
-    <>
-      <H4 className="mb-1">{props.title || 'Platform Compatibility'}</H4>
-      <Table className="table-fixed max-sm-gutters:table-auto">
-        <TableHead>
-          <Row>
-            {platforms.map(({ title }) => (
-              <HeaderCell key={title}>{title}</HeaderCell>
-            ))}
-          </Row>
-        </TableHead>
-        <tbody>
-          <Row>
-            {platforms.map(platform => (
-              <Cell
-                key={platform.title}
-                {...getInfo(props[platform.propName as keyof PlatformProps], platform)}
-              />
-            ))}
-          </Row>
-        </tbody>
-      </Table>
-    </>
-  );
-};
+const PlatformsSection = (props: Props) => (
+  <>
+    <H4 className="mb-1">{props.title || 'Platform Compatibility'}</H4>
+    <Table className="table-fixed max-sm-gutters:table-auto">
+      <TableHead>
+        <Row>
+          {platforms.map(({ title }) => (
+            <HeaderCell key={title}>{title}</HeaderCell>
+          ))}
+        </Row>
+      </TableHead>
+      <tbody>
+        <Row>
+          {platforms.map(platform => (
+            <Cell
+              key={platform.title}
+              {...getInfo(props[platform.propName as keyof PlatformProps], platform)}
+            />
+          ))}
+        </Row>
+      </tbody>
+    </Table>
+  </>
+);
 
 export default PlatformsSection;

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1005,7 +1005,7 @@ properties.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -1409,7 +1409,7 @@ value depending on the state of the credential.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -1642,7 +1642,7 @@ refresh operation.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -1922,7 +1922,7 @@ sign-in operation.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -2236,7 +2236,7 @@ sign-out operation.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -2551,7 +2551,7 @@ for more details.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -2993,7 +2993,7 @@ may be
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -3382,7 +3382,7 @@ for more details.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -3696,7 +3696,7 @@ for more details.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -4027,7 +4027,7 @@ for more details.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -4199,7 +4199,7 @@ OAuth 2.0 protocol
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -7048,7 +7048,7 @@ Same as
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -7713,7 +7713,7 @@ This uses both
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8064,7 +8064,7 @@ code.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8345,7 +8345,7 @@ in order to enable/disable the permission.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8529,7 +8529,7 @@ in order to enable/disable the permission.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8656,7 +8656,7 @@ in order to enable/disable the permission.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8789,7 +8789,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -8960,7 +8960,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
         class="css-1uyflf8-Table"
       >
         <table
-          class="css-txbaae-Table"
+          class="css-e41t9x-Table"
         >
           <thead
             class="bg-subtle border-b border-b-default border-solid"
@@ -9087,7 +9087,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -9366,7 +9366,7 @@ you don't get this value.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -10131,7 +10131,7 @@ exports[`APISection expo-pedometer 1`] = `
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -10696,7 +10696,7 @@ available on this device.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -10975,7 +10975,7 @@ provided with a single argument that is
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -11256,7 +11256,7 @@ in order to enable/disable the permission.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"
@@ -11386,7 +11386,7 @@ in order to enable/disable the permission.
         class="css-1uyflf8-Table"
       >
         <table
-          class="css-txbaae-Table"
+          class="css-e41t9x-Table"
         >
           <thead
             class="bg-subtle border-b border-b-default border-solid"
@@ -11600,7 +11600,7 @@ in order to enable/disable the permission.
       class="css-1uyflf8-Table"
     >
       <table
-        class="css-txbaae-Table"
+        class="css-e41t9x-Table"
       >
         <thead
           class="bg-subtle border-b border-b-default border-solid"

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -4,22 +4,17 @@ import { borderRadius, spacing } from '@expo/styleguide-base';
 import type { PropsWithChildren } from 'react';
 
 import { TableHeaders } from './TableHeaders';
-import { TableLayout, TextAlign } from './types';
+import { TextAlign } from './types';
 
 type TableProps = PropsWithChildren<{
   headers?: string[];
   headersAlign?: TextAlign[];
-  layout?: TableLayout;
+  className?: string;
 }>;
 
-export const Table = ({
-  children,
-  headers = [],
-  headersAlign,
-  layout = TableLayout.Auto,
-}: TableProps) => (
+export const Table = ({ children, headers = [], headersAlign, className }: TableProps) => (
   <div css={tableWrapperStyle}>
-    <table css={[tableStyle, { tableLayout: layout }]}>
+    <table css={tableStyle} className={className}>
       {headers.length ? (
         <>
           <TableHeaders headers={headers} headersAlign={headersAlign} />

--- a/docs/ui/components/Table/index.ts
+++ b/docs/ui/components/Table/index.ts
@@ -3,5 +3,4 @@ export { HeaderCell } from './HeaderCell';
 export { Row } from './Row';
 export { Table } from './Table';
 export { TableHead } from './TableHead';
-export { TableLayout } from './types';
 export type { TextAlign } from './types';

--- a/docs/ui/components/Table/types.ts
+++ b/docs/ui/components/Table/types.ts
@@ -1,6 +1,1 @@
-export enum TableLayout {
-  Auto = 'auto',
-  Fixed = 'fixed',
-}
-
 export type TextAlign = 'left' | 'right' | 'center' | 'justify';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, in the Platforms compatibility table, the text overflows for "Android Emulator" and "iOS Simulator".

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1689789036510169).

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the `PlatformsSecton` component to enable horizontal scrolling on mobile viewports.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview
On a mobile view port:

![CleanShot 2024-01-09 at 20 52 40@2x](https://github.com/expo/expo/assets/10234615/1e7e562f-f14e-4373-8287-27aa8bb1911d)

![CleanShot 2024-01-09 at 20 52 28@2x](https://github.com/expo/expo/assets/10234615/13e3070c-13eb-4931-810b-91fa1779f095)

![IMG_0526](https://github.com/expo/expo/assets/10234615/ca887a81-0e2c-463b-ac24-c1c0a9fedfae)

On desktop the current component implementation remains same:

![CleanShot 2024-01-09 at 20 52 17@2x](https://github.com/expo/expo/assets/10234615/e3e3088e-8897-4a80-80ec-541bc440688d)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
