### PR TITLE
[docs] Home: fix API tiles style

### DIFF
--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -99,7 +99,7 @@ export const TalkGridCell = ({
         }}
         className="border-b border-b-default bg-cover bg-center h-[138px]"
       />
-      <div css={cellTitleWrapperStyle} className="px-4 py-3 gap-1">
+      <div css={cellTitleWrapperStyle} className="!py-3 gap-1">
         <LABEL className="block leading-normal">{title}</LABEL>
         <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />
       </div>
@@ -233,6 +233,7 @@ const cellTitleWrapperStyle = css({
   backgroundColor: theme.background.default,
   textDecoration: 'none',
   minHeight: 30,
+  padding: spacing[4],
   color: theme.text.default,
   alignItems: 'center',
 });


### PR DESCRIPTION
# Why

![Screenshot 2024-01-09 at 10 15 01 AM](https://github.com/expo/expo/assets/719641/9d9e00cc-4bff-4a92-8cb1-14b4ebc1081d)

# How

Fix small visual regression after tweaks to shared cell style and an addition of Podcasts section.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-01-09 at 17 58 30](https://github.com/expo/expo/assets/719641/72cdf165-f5ca-48d6-bc8b-97cfcf0f0209)

