### PR TITLE
[dev-launcher] Fix launcher bridge not filtering modules

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix launcher bridge not filtering native modules. ([#26332](https://github.com/expo/expo/pull/26332) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Remove classic updates. ([#26036](https://github.com/expo/expo/pull/26036), [#26230](https://github.com/expo/expo/pull/26230) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherBridgeDelegate.mm
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherBridgeDelegate.mm
@@ -1,5 +1,6 @@
 #import <EXDevLauncher/EXDevLauncherBridgeDelegate.h>
 #import <EXDevLauncher/EXDevLauncherController.h>
+#import <EXDevLauncher/EXDevLauncherRCTBridge.h>
 
 #import <React/RCTBundleURLProvider.h>
 #if __has_include(<React_RCTAppDelegate/RCTAppSetupUtils.h>)
@@ -19,6 +20,10 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
   return [[EXDevLauncherController sharedInstance] sourceURLForBridge:bridge];
+}
+
+- (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions {
+   return [[EXDevLauncherRCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
 }
 
 - (RCTRootView *)createRootViewWithModuleName:(NSString *)moduleName launchOptions:(NSDictionary * _Nullable)launchOptions application:(UIApplication *)application{

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherRCTBridge.m
@@ -48,7 +48,7 @@
     @"ExpoBridgeModule",
     @"EXNativeModulesProxy",
     @"ViewManagerAdapter_",
-    @"ExpoModulesCore"
+    @"ExpoModulesCore",
     @"EXReactNativeEventEmitter"
   ];
   NSArray<Class> *filteredModuleList = [modules filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable clazz, NSDictionary<NSString *,id> * _Nullable bindings) {


### PR DESCRIPTION
# Why

Closes ENG-11046
Closes https://github.com/expo/expo/issues/26298

# How

Overwrite `EXDevLauncherBridgeDelegate` `createBridgeWithDelegate` method to ensure we use `EXDevLauncherRCTBridge` instead of the standard `RCTBridge` for the launcher, preventing native modules like RealmJS from getting wrongly initialized.


# Test Plan

Temporarily added `realm` to bare-expo and fabric-tester 

# Checklist


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
