### PR TITLE
doc: "manually configured" vs. "JS-configured" native projects

### DIFF
--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -19,7 +19,7 @@ To learn how to start using custom native code in your app by switching from Go 
 
 ## Generate native projects with prebuild
 
-If you want to take control of Android and iOS native projects and move away from JavaScript-based project, you can generate native directories by running `npx expo prebuild` or `npx expo run:[android|iOS]` (which will run `prebuild` automatically). You can also use development builds in this context &mdash; run `npx expo install expo-dev-client` before `prebuild` or `run`. It is also possible to [add this library](/develop/development-builds/create-a-build/) later.
+If you want to manually configure and manage the Android and iOS native projects, moving away from Expo managing your JavaScript-configured projects, then you can generate the native directories by running `npx expo prebuild` or `npx expo run:[android|iOS]` (which runs `prebuild` automatically). You can also use development builds in this context &mdash; run `npx expo install expo-dev-client` before `prebuild` or `run`. It is also possible to [add this library](/develop/development-builds/create-a-build/) later.
 
 <Terminal
   cmd={[


### PR DESCRIPTION
# Why

Previous wording implied "extra control" but didn't emphasize "extra responsibilities/fragilities" with the move to `prebuild`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
