### PR TITLE
[expo-updates] dev launcher updates controller should not read embedded manifest

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
 - Fix metro asset call in embedded manifest creation step. ([#26307](https://github.com/expo/expo/pull/26307) by [@wschurman](https://github.com/wschurman))
+- [expo-updates] dev launcher updates controller should not read embedded manifest. ([#26336](https://github.com/expo/expo/pull/26336) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -279,7 +279,7 @@ class UpdatesDevLauncherController(
   override fun getConstantsForModule(): IUpdatesController.UpdatesModuleConstants {
     return IUpdatesController.UpdatesModuleConstants(
       launchedUpdate = launchedUpdate,
-      embeddedUpdate = updatesConfiguration?.let { EmbeddedManifestUtils.getEmbeddedUpdate(context, it) }?.updateEntity,
+      embeddedUpdate = null, // no embedded update in debug builds
       isEmergencyLaunch = isEmergencyLaunch,
       isEnabled = true,
       isUsingEmbeddedAssets = isUsingEmbeddedAssets,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -17,7 +17,6 @@ import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.loader.UpdateResponse
-import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.selectionpolicy.LauncherSelectionPolicySingleUpdate
 import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient
 import expo.modules.updates.selectionpolicy.SelectionPolicy

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -297,16 +297,9 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   }
 
   public func getConstantsForModule() -> UpdatesModuleConstants {
-    let embeddedUpdate: Update?
-    if isStarted {
-      embeddedUpdate = self.config.let { it in EmbeddedAppLoader.embeddedManifest(withConfig: it, database: self.database) }
-    } else {
-      embeddedUpdate = nil
-    }
-
     return UpdatesModuleConstants(
       launchedUpdate: launcher?.launchedUpdate,
-      embeddedUpdate: embeddedUpdate,
+      embeddedUpdate: nil, // no embedded update in debug builds
       isEmergencyLaunch: isEmergencyLaunch,
       isEnabled: true,
       isUsingEmbeddedAssets: isUsingEmbeddedAssets(),


### PR DESCRIPTION
# Why

A customer was able to reproduce an issue in Detox testing, where an app started by invoking the dev launcher deep link URL would crash when getConstants was called.

# How

Modify the dev launcher update controller to not attempt to read the embedded manifest when getConstants is called. By default, the embedded manifest should not be built for debug builds.

# Test Plan

- Tested against the customer's repro
- E2E should pass
- 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
