### PR TITLE
[test-suite] fix failed expo-constants tests

### DIFF
--- a/apps/test-suite/tests/Constants.js
+++ b/apps/test-suite/tests/Constants.js
@@ -8,11 +8,7 @@ export function test(t) {
   t.describe('Constants', () => {
     ['expoVersion', 'linkingUri'].forEach((v) =>
       t.it(`can only use ${v} in the managed workflow`, () => {
-        if (
-          Constants.appOwnership === 'expo' ||
-          Constants.appOwnership === null ||
-          Platform.OS === 'web'
-        ) {
+        if (Constants.appOwnership === 'expo' || Platform.OS === 'web') {
           t.expect(Constants[v]).toBeDefined();
         } else {
           t.expect(Constants[v]).not.toBeDefined();


### PR DESCRIPTION
# Why

fix failed test-suite on bare-expo: https://github.com/expo/expo/actions/runs/7466356576/job/20318688702

# How

relevant change here: https://github.com/expo/expo/pull/26313#discussion_r1446401449 and i'm going to revert this part

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
