### PR TITLE
[image][Android] Fixed the tint color wasn't applied to the root element

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixed ResizeObserver attaching on every image transition. ([#25819](https://github.com/expo/expo/pull/25819) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fixed the issue with the application of tint color when an element does not have a style assigned to it. ([#26251](https://github.com/expo/expo/pull/26251) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed the tine color was applied to the mask element. ([#26323](https://github.com/expo/expo/pull/26323) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed the tine color wasn't applied to the root element.
+- [Android] Fixed the tint color wasn't applied to the root element. ([#26339](https://github.com/expo/expo/pull/26339) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed ResizeObserver attaching on every image transition. ([#25819](https://github.com/expo/expo/pull/25819) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fixed the issue with the application of tint color when an element does not have a style assigned to it. ([#26251](https://github.com/expo/expo/pull/26251) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed the tine color was applied to the mask element. ([#26323](https://github.com/expo/expo/pull/26323) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed the tine color wasn't applied to the root element.
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
+++ b/packages/expo-image/android/src/main/java/com/caverock/androidsvg/SVGStyler.kt
@@ -115,6 +115,7 @@ fun applyTintColor(svg: SVG, newColor: Int) {
   svg.cssRules?.forEach { rule ->
     replaceStyles(rule.style, newColor)
   }
+  replaceStyles(root.baseStyle, newColor)
   replaceStyles(root.style, newColor)
   val hasStyle = hasStyle(root)
 


### PR DESCRIPTION
# Why

Fixed the tint color wasn't applied to the root element.


# Test Plan

- app with SVG that has the fill defined in the root element:
```xml
<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
  <rect width="100%" height="100%" fill="#121212" />
  <text x="160" y="130" font-family="Courier,monospace" font-weight="700" font-size="20" text-anchor="middle" letter-spacing="1">
    <tspan dy="25" x="160" fill="#FCE74C"> /=\ = \=/</tspan>
    <tspan dy="25" x="160" fill="#00bfa0">/ 0 - \</tspan>
    <tspan dy="25" x="160" fill="#0bb4ff">( = B = )</tspan>
    <tspan dy="25" x="160" fill="#eeeeee">`$G$`</tspan>
    <tspan dy="25" x="160" fill="#eeeeee">/ O \</tspan>
  </text>
</svg>
```