### PR TITLE
[ios] [sensors] Fix barometer resolution on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- **`expo-sensors`**
+  - On `iOS`, fixed a rounding error of the barometric pressure in expo go ([#26345](https://github.com/expo/expo/pull/26345) by [@TwoTenPvP](https://github.com/TwoTenPvP))
 - **`expo-asset`**
   - URL encode asset paths defined as query parameter. ([#24562](https://github.com/expo/expo/pull/24562) by [@byCedric](https://github.com/byCedric))
   - fix URLs in development. ([#25202](https://github.com/expo/expo/pull/25202) by [@EvanBacon](https://github.com/EvanBacon))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,8 +397,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
-- **`expo-sensors`**
-  - On `iOS`, fixed a rounding error of the barometric pressure in expo go ([#26345](https://github.com/expo/expo/pull/26345) by [@TwoTenPvP](https://github.com/TwoTenPvP))
 - **`expo-asset`**
   - URL encode asset paths defined as query parameter. ([#24562](https://github.com/expo/expo/pull/24562) by [@byCedric](https://github.com/byCedric))
   - fix URLs in development. ([#25202](https://github.com/expo/expo/pull/25202) by [@EvanBacon](https://github.com/EvanBacon))

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSensorManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSensorManager.m
@@ -288,7 +288,7 @@
     if (strongSelf && data) {
       for (void (^handler)(NSDictionary *) in strongSelf.barometerHandlers.allValues) {
         handler(@{
-                  @"pressure": @([data.pressure intValue] * 10), // conversion from kPa to hPa
+                  @"pressure": @([data.pressure doubleValue] * 10), // conversion from kPa to hPa
                   @"relativeAltitude": data.relativeAltitude,
                   });
       }

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXSensorManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXSensorManager.m
@@ -288,7 +288,7 @@
     if (strongSelf && data) {
       for (void (^handler)(NSDictionary *) in strongSelf.barometerHandlers.allValues) {
         handler(@{
-                  @"pressure": @([data.pressure doubleValue] * 10), // conversion from kPa to hPa
+                  @"pressure": @([data.pressure doubleValue] * 10.0), // conversion from kPa to hPa
                   @"relativeAltitude": data.relativeAltitude,
                   });
       }


### PR DESCRIPTION
# Why
Fixes a rounding of the Barometric pressure on Expo Go.
This was previously fixed in the sensors package but not in Expo Go.
https://github.com/expo/expo/pull/9441

# How

By not converting the value to integer, we do the same as the sensors package and use a double.
https://github.com/expo/expo/pull/9441

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
