### PR TITLE
[Android] Remove versioning comments

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -79,11 +79,8 @@ android {
 
   defaultConfig {
     applicationId 'host.exp.exponent'
-    // ADD VERSIONS HERE
-    // BEGIN VERSIONS
     versionCode 221
     versionName '2.30.5'
-    // END VERSIONS
 
     multiDexEnabled true
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -295,15 +292,9 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.mockito:mockito-core:1.10.19'
 
-  // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-
-  // BEGIN_SDK_UNVERSIONED
   implementation(project(':expoview'))
 
   implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
-  // END_SDK_UNVERSIONED
-
-  // ADD_NEW_SDKS_HERE
 }
 
 // This has to be down here for some reason

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -26,9 +26,7 @@ buildscript {
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
-    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
     classpath "com.facebook.react:react-native-gradle-plugin"
-    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
   }
 }
 
@@ -39,12 +37,10 @@ plugins {
    alias libs.plugins.download apply false
 }
 
-// WHEN_DISTRIBUTING_REMOVE_FROM_HERE
 // We don't need linter on turtle.
 plugins {
   id "com.diffplug.spotless" version "6.23.3"
 }
-// WHEN_DISTRIBUTING_REMOVE_TO_HERE
 
 def reactProperties = new Properties()
 file("${project(':packages:react-native:ReactAndroid').projectDir}/gradle.properties").withInputStream { reactProperties.load(it) }
@@ -99,8 +95,6 @@ allprojects {
 // because the "*/" in there could affect the resulted code by closing the comment to early.
 def ktlintTarget = '**/*.kt'
 
-// WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-// We don't need linter on turtle.
 subprojects { project ->
   if (project.name == "ReactAndroid") { return; }
   if (project.name.startsWith("vendored_")) { return; }
@@ -147,4 +141,3 @@ subprojects { project ->
     }
   }
 }
-// WHEN_DISTRIBUTING_REMOVE_TO_HERE

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -50,12 +50,6 @@ public class Constants {
 
   static {
     List<String> abiVersions = new ArrayList<>();
-    // WHEN_DISTRIBUTING_REMOVE_FROM_HERE
-    // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
-    // ADD ABI VERSIONS HERE DO NOT MODIFY
-    // WHEN_PREPARING_SHELL_REMOVE_TO_HERE
-    // WHEN_DISTRIBUTING_REMOVE_TO_HERE
-
     if (TEMPORARY_SDK_VERSION != null) {
       abiVersions.add(TEMPORARY_SDK_VERSION);
     }

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -19,7 +19,6 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import java.text.DecimalFormatSymbols
 import java.util.*
 
-
 // must be kept in sync with https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
 private const val SHARED_PREFS_NAME = "com.facebook.react.modules.i18nmanager.I18nUtil"
 private const val KEY_FOR_PREFS_ALLOWRTL = "RCTI18nUtil_allowRTL"

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -19,7 +19,6 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import java.text.DecimalFormatSymbols
 import java.util.*
 
-// EXPO_VERSIONING_NEEDS_PACKAGE_R
 
 // must be kept in sync with https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
 private const val SHARED_PREFS_NAME = "com.facebook.react.modules.i18nmanager.I18nUtil"

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -7,8 +7,6 @@ import android.util.Log
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.navigationbar.singletons.NavigationBar
 
-// this needs to stay for versioning to work
-// EXPO_VERSIONING_NEEDS_PACKAGE_R
 
 class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -7,7 +7,6 @@ import android.util.Log
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.navigationbar.singletons.NavigationBar
 
-
 class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
     // Execute static tasks before the JS engine starts.

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -5,8 +5,6 @@ package expo.modules.splashscreen
 import android.content.Context
 import androidx.core.content.ContextCompat
 
-// this needs to stay for versioning to work
-// EXPO_VERSIONING_NEEDS_PACKAGE_R
 
 /**
  * Default implementation that uses native resources.

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/NativeResourcesBasedSplashScreenViewProvider.kt
@@ -5,7 +5,6 @@ package expo.modules.splashscreen
 import android.content.Context
 import androidx.core.content.ContextCompat
 
-
 /**
  * Default implementation that uses native resources.
  */

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -8,9 +8,6 @@ import com.facebook.react.ReactRootView
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.splashscreen.singletons.SplashScreen
 
-// this needs to stay for versioning to work
-// EXPO_VERSIONING_NEEDS_PACKAGE_R
-
 class SplashScreenReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onContentChanged(activity: Activity) {
     SplashScreen.show(

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.systemui.singletons.SystemUI
 
-
 class SystemUIReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
     SystemUI.setUserInterfaceStyle(getUserInterfaceStyle(activity))

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.systemui.singletons.SystemUI
 
-// EXPO_VERSIONING_NEEDS_PACKAGE_R
 
 class SystemUIReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -187,9 +187,6 @@
 
 
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
-    <!-- WHEN_PREPARING_SHELL_REMOVE_FROM_HERE -->
-    <!-- ADD DEV SETTINGS HERE -->
-    <!-- WHEN_PREPARING_SHELL_REMOVE_TO_HERE -->
 
     <activity
         android:name="net.openid.appauth.RedirectUriReceiverActivity"


### PR DESCRIPTION
# Why

Removes `EXPO_VERSIONING_NEEDS_PACKAGE_R` and other comments that were used during the versioning process.
