### PR TITLE
[constants] Fix prompts for password when reading the installationId

### DIFF
--- a/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
+++ b/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
@@ -9,6 +9,7 @@ static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUU
 
 - (NSString *)getOrCreateInstallationId
 {
+#if TARGET_OS_IOS || TARGET_OS_TV
   NSString *installationId = [self getInstallationId];
   if (installationId) {
     return installationId;
@@ -17,6 +18,9 @@ static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUU
   installationId = [[NSUUID UUID] UUIDString];
   [self setInstallationId:installationId error:NULL];
   return installationId;
+#elif TARGET_OS_OSX
+  return nil;
+#endif
 }
 
 - (nullable NSString *)getInstallationId

--- a/packages/expo-constants/ios/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstantsService.m
@@ -62,7 +62,7 @@ EX_REGISTER_MODULE();
            @"isHeadless": @(NO),
            @"nativeAppVersion": [self appVersion],
            @"nativeBuildVersion": EXNullIfNil([self buildVersion]),
-           @"installationId": [_installationIdProvider getOrCreateInstallationId],
+           @"installationId": EXNullIfNil([_installationIdProvider getOrCreateInstallationId]),
            @"manifest": EXNullIfNil([[self class] appConfig]),
            @"platform": @{
                @"ios": @{


### PR DESCRIPTION
# Why

Adding `expo-constants` to dependencies on macOS may result in showing the below prompt on launch 👇 
![image](https://github.com/expo/expo/assets/1714764/3bc9873d-187d-438f-a972-2d34d91c4c4c)

# How

It's not very consistent so it's quite hard to reproduce (it usually appears only on the first time and then reoccurs after some time), but I was able to narrow down the cause to reading and saving the `installationId` constant. I think its value is not very useful on macOS because the keychain is persistent even if you remove the app from the disk, so it should be fine to return `null` (at least for now).

Note that I'm **not** updating the docs and types! We still don't include macOS-specific things in the docs and this will need to be revisited after the SDK release.

# Test Plan

Tested in Expo Orbit