### PR TITLE
[docs] correct code highlight and code comments in Learn section

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -380,7 +380,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <ImageSpotlight
   alt="Initial layout."
@@ -489,7 +489,7 @@ export default function App() {
 
 </SnackInline>
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <Video file="tutorial/02-complete-layout.mp4" />
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -113,14 +113,16 @@ export default function App() {
   return (
     <View style={styles.container}>
       /* @info Replace the default value of color property to '#fff'. */
-      <Text style={{ color: '#fff' }}>Open up App.js to start working on your app!</Text>
+      <Text style={{ color: '#fff' }}>
+        Open up App.js to start working on your app!
+      </Text>
       /* @end */
       <StatusBar style="auto" />
     </View>
   );
 }
 
-/* @hide const styles = StyleSheet.create({*/
+/* @hide const styles = StyleSheet.create( */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -152,7 +154,7 @@ We can use React Native's `<Image>` component to display the image in the app. T
 Next, import and use the `<Image>` component from React Native and `background-image.png` in the **App.js**. Let's also add styles to display the image.
 
 <SnackInline label="Display placeholder image" dependencies={['expo-status-bar']} files={{
-    'assets/images/background-image.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/503001f14bb7b8fe48a4e318ad07e910'
+  'assets/images/background-image.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/503001f14bb7b8fe48a4e318ad07e910'
 }}>
 
 {/* prettier-ignore */}
@@ -170,7 +172,8 @@ export default function App() {
       /* @info Wrap the Image component inside a container. Also, add the image component to display the placeholder image. */
       <View style={styles.imageContainer}>
         <Image source={PlaceholderImage} style={styles.image} />
-      </View> /* @end */
+      </View>
+      /* @end */
       <StatusBar style="auto" />
     </View>
   );
@@ -412,13 +415,12 @@ To load and display the icon on the button, let's use `FontAwesome` from the lib
 import { StyleSheet, View, Pressable, Text } from 'react-native';
 /* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */
 
-export default function Button({ label, /* @info The prop theme to detect the button variant. */ theme/* @end */ }) {
+export default function Button({ label, /* @info The prop theme to detect the button variant. */theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */
   if (theme === "primary") {
+  /* @end */
     return (
-      <View
-      style={[styles.buttonContainer, { borderWidth: 4, borderColor: "#ffd33d", borderRadius: 18 }]}
-      >
+      <View style={[styles.buttonContainer, { borderWidth: 4, borderColor: "#ffd33d", borderRadius: 18 }]}>
         <Pressable
           style={[styles.button, { backgroundColor: "#fff" }]}
           onPress={() => alert('You pressed a button.')}
@@ -431,10 +433,11 @@ export default function Button({ label, /* @info The prop theme to detect the bu
           />
           <Text style={[styles.buttonLabel, { color: "#25292e" }]}>{label}</Text>
         </Pressable>
-    </View>
+      </View>
     );
+  /* @info */
   }
- /* @end */
+  /* @end */
 
   return (
     <View style={styles.buttonContainer}>

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -257,7 +257,7 @@ const styles = StyleSheet.create({
 
 In the above snippet, the `onReset()` function is called when the user presses the reset button. When this button is pressed, we'll show the image picker button again.
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <ImageSpotlight
   alt="Button options displayed after a image is selected."
@@ -534,7 +534,7 @@ export default function App() {
 
 The `onSelect` prop on the `<EmojiList>` component selects the emoji and the `onCloseModal` prop closes the modal after emoji is selected.
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <Video file="tutorial/emoji-picker.mp4" />
 
@@ -614,7 +614,7 @@ export default function App() {
 
 </SnackInline>
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <Video file="tutorial/select-emoji.mp4" />
 

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -76,7 +76,7 @@ export default function App() {
   // ...
   return (
     <View style={styles.container}>
-      /* ...rest of the code remains same */
+      {/* ...rest of the code remains same */}
       /* @info Based on the value of showAppOptions, the buttons will be displayed. Also, move the existing buttons in the conditional operator block. */
       {showAppOptions ? (
         <View />
@@ -219,7 +219,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      /* ...rest of the code remains same */
+      {/* ...rest of the code remains same */}
       {showAppOptions ? (
         /* @info Replace empty View component with this snippet to display App option buttons. */
         <View style={styles.optionsContainer}>
@@ -231,7 +231,7 @@ export default function App() {
         </View>
         /* @end */
       ) : (
-        /* ...rest of the code remains same */
+        // ...rest of the code remains same
       )}
       <StatusBar style="auto" />
     </View>
@@ -413,7 +413,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      /* ...rest of the code remains same */
+      {/* ...rest of the code remains same */}
       /* @info Render the EmojiPicker component at the bottom of the App component, just before the StatusBar. */
       <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
         {/* A list of emoji component will go here */}
@@ -467,17 +467,15 @@ export default function EmojiList({ onSelect, onCloseModal }) {
       showsHorizontalScrollIndicator={Platform.OS === 'web'}
       data={emoji}
       contentContainerStyle={styles.listContainer}
-      renderItem={({ item, index }) => {
-        return (
-          <Pressable
-            onPress={() => {
-              onSelect(item);
-              onCloseModal();
-            }}>
-            <Image source={item} key={index} style={styles.image} />
-          </Pressable>
-        );
-      }}
+      renderItem={({ item, index }) => (
+        <Pressable
+          onPress={() => {
+            onSelect(item);
+            onCloseModal();
+          }}>
+          <Image source={item} key={index} style={styles.image} />
+        </Pressable>
+      )}
     />
   );
 }
@@ -522,7 +520,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      /* rest of the code remains unchanged */
+      {/* rest of the code remains unchanged */}
       <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
         /* @info Render the EmojiList component inside the EmojiPicker component. */
         <EmojiList onSelect={setPickedEmoji} onCloseModal={onModalClose} />
@@ -531,7 +529,6 @@ export default function App() {
       <StatusBar style="auto" />
     </View>
   );
-  )
 }
 ```
 
@@ -607,9 +604,9 @@ export default function App() {
     <View>
       <View style={styles.imageContainer}>
         <ImageViewer placeholderImageSource={PlaceholderImage} selectedImage={selectedImage} />
-        /* @info */{pickedEmoji !== null ? <EmojiSticker imageSize={40} stickerSource={pickedEmoji} /> : null} /* @end */
+        /* @info */{pickedEmoji && <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />}/* @end */
       </View>
-      /* ...rest of the code remains same*/
+      {/* ...rest of the code remains same */}
     </View>
   );
 }

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -216,7 +216,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
 In the above snippet, the `gesture` prop takes the value of the `doubleTap` which triggers a gesture when a user double-taps the sticker image.
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <Video file="tutorial/tap-gesture.mp4" />
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -67,9 +67,13 @@ To accomplish this, replace the root level `<View>` component in the **App.js** 
 
 export default function App() {
   return (
-    /* @info Replace the root level View component with GestureHandlerRootView. */<GestureHandlerRootView style={styles.container}> /* @end */
-    /* ...rest of the code remains */
-    /* @info */</GestureHandlerRootView>/* @end */
+    /* @info Replace the root level View component with GestureHandlerRootView. */
+    <GestureHandlerRootView style={styles.container}>
+    /* @end */
+      {/* ...rest of the code remains */}
+    /* @info */
+    </GestureHandlerRootView>
+    /* @end */
   )
 }
 ```
@@ -92,19 +96,18 @@ Reanimated exports animated components such as `<Animated.View>`, `<Animated.Tex
 
 Replace the `<Image>` component with `<Animated.Image>`.
 
-
-
-
 {/* prettier-ignore */}
 ```jsx EmojiSticker.js
 export default function EmojiSticker({ imageSize, stickerSource }) {
   return (
     <View style={{ top: -350 }}>
-      /* @info Replace the Image component with Animated.Image. */<Animated.Image /* @end */
+      /* @info Replace the Image component with Animated.Image. */
+      <Animated.Image
         source={stickerSource}
         resizeMode="contain"
         style={{ width: imageSize, height: imageSize }}
       />
+      /* @end */
     </View>
   );
 }
@@ -168,7 +171,7 @@ const imageStyle = useAnimatedStyle(() => {
 });
 ```
 
-Next, wrap the `<Animated.Image>` component that displays the sticker on the screen with the `<GestureDetector>` component.
+Next, wrap the `<Animated.Image>` component that displays the sticker on the screen with the `<GestureDetector>` component and modify the `style` prop on the `Animated.Image` to pass the `imageStyle`.
 
 <SnackInline
 label="Handling tap gesture"
@@ -197,11 +200,11 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
   // ...rest of the code remains same
   return (
     <View style={{ top: -350 }}>
-      /* @info Wrap the Animated.Image component with GestureDetector. */ <GestureDetector gesture={doubleTap}>/* @end */
+      /* @info Wrap the Animated.Image component with GestureDetector. */<GestureDetector gesture={doubleTap}>/* @end */
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
-          /* @info Modify the style prop on the AnimatedImage to pass the imageStyle. */ style={[imageStyle, { width: imageSize, height: imageSize }]} /* @end */
+          style={/* @info Modify the style prop on the AnimatedImage to pass the imageStyle. */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
         />
       /* @info */</GestureDetector>/* @end */
     </View>
@@ -324,7 +327,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
   return (
     /* @info Wrap all components inside GestureDetector. */<GestureDetector gesture={drag}>/* @end */
-      /* @info Add containerStyle to the AnimatedView style prop. */<Animated.View style={[containerStyle, { top: -350 }]}>/* @end */
+      <Animated.View style={/* @info Add containerStyle to the AnimatedView style prop. */[containerStyle, { top: -350 }]/* @end */}>
         <GestureDetector gesture={doubleTap}>
           <Animated.Image
             source={stickerSource}
@@ -340,7 +343,7 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 
 </SnackInline>
 
-Let's take a look at our app on iOS, Android and the web:
+Let's take a look at our app on Android, iOS and the web:
 
 <Video file="tutorial/pan-gesture.mp4" />
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -88,15 +88,15 @@ To call it, update the `onPress` property of the `<Button>` component in **compo
 
 {/* prettier-ignore */}
 ```jsx Button.js
-export default function Button({ label,  theme, /* @info Pass this prop to trigger the handler method from the parent component. */ onPress/* @end */}) {
+export default function Button({ label, theme, /* @info Pass this prop to trigger the handler method from the parent component. */onPress/* @end */}) {
   // ...rest of the code remains same
   if (theme === "primary") {
     return (
       <View>
-        /* ...rest of the code remains same */
+        {/* ...rest of the code remains same */}
         <Pressable
           style={[styles.button, { backgroundColor: '#fff' }]}
-          /* @info */ onPress={onPress} /* @end */
+          onPress={/* @info */onPress/* @end */}
         >
       </View>
     );
@@ -113,8 +113,8 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      /* ...rest of the code remains same */
-      <Button theme="primary" label="Choose a photo" /* @info */ onPress={pickImageAsync} /* @end */ />
+      {/* ...rest of the code remains same */}
+      <Button theme="primary" label="Choose a photo" onPress={/* @info */pickImageAsync/* @end */} />
     </View>
   );
 }
@@ -195,7 +195,7 @@ export default function App() {
         />
         /* @end */
       </View>
-      /* ...rest of the code remains same */
+      {/* ...rest of the code remains same */}
     </View>
   );
 }

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 >
 > <br />
 > Go ahead and press the above button. You will see the above code running in a Snack. Try to switch
-> between iOS, Android, or the web tabs. You can also open it on your device in the Expo Go app from
+> between Android, iOS or the web tabs. You can also open it on your device in the Expo Go app from
 > the **My device** tab.
 >
 > <br />

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -98,12 +98,10 @@ export default function App() {
       <View style={styles.imageContainer}>
         /* @info Add a View component to wrap the ImageViewer and EmojiSticker inside it. */<View ref={imageRef} collapsable={false}>/* @end */
           <ImageViewer placeholderImageSource={PlaceholderImage} selectedImage={selectedImage} />
-          {pickedEmoji !== null ? (
-            <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />
-          ) : null}
+          {pickedEmoji && <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />}
         /* @info */</View>/* @end */
       </View>
-      /* ...rest of the code remains same */
+      {/* ...rest of the code remains same */}
     </GestureHandlerRootView>
   );
 }

--- a/docs/pages/ui-programming/image-background.mdx
+++ b/docs/pages/ui-programming/image-background.mdx
@@ -19,9 +19,9 @@ The `ImageBackground` component accepts mostly the same props as the `Image` com
 <SnackInline label="Using ImageBackground component">
 
 {/* prettier-ignore */}
-```js
+```jsx
 import React from 'react';
-import { /* @info Import ImageBackground from react-native */ ImageBackground/* @end */, StyleSheet, Text, View } from 'react-native';
+import { /* @info Import ImageBackground from react-native */ImageBackground/* @end */, StyleSheet, Text, View } from 'react-native';
 
 const image = { uri: "https://docs.expo.dev/static/images/tutorial/splash.png" };
 
@@ -32,7 +32,7 @@ const App = () => (
       <Text style={styles.text}>Elements</Text>
       <Text style={styles.text}>in Front of</Text>
       <Text style={styles.text}>Background</Text>
-    /* @end */
+      /* @end */
     </ImageBackground>
   </View>
 );

--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -220,10 +220,8 @@ export default function App() {
         <MyCheckbox
           checked={checked}
           onChange={setChecked}
-          /* @info Pass in base and active styles for the checkbox */
-          buttonStyle={styles.checkboxBase}
-          activeButtonStyle={styles.checkboxChecked}
-          /* @end */
+          buttonStyle={/* @info Pass in base styles for the checkbox */styles.checkboxBase/* @end */}
+          activeButtonStyle={/* @info Pass in active styles for the checkbox */styles.checkboxChecked/* @end */}
         />
         <Text style={styles.checkboxLabel}>{`⬅️ Click!`}</Text>
       </View>

--- a/docs/pages/ui-programming/react-native-toast.mdx
+++ b/docs/pages/ui-programming/react-native-toast.mdx
@@ -95,7 +95,7 @@ import { RootSiblingParent } from 'react-native-root-siblings';
 
 // in your render function
 return (
-  <RootSiblingParent>  // <- use RootSiblingParent to wrap your root component
+  <RootSiblingParent>{/* <- use RootSiblingParent to wrap your root component */}
     <App />
   </RootSiblingParent>
 );


### PR DESCRIPTION
# Why

Several example looks off and even broken after upgrading Prism to the latest version.

# How

Update code example and code comments in the Snippets used on the Learn section pages.

Now, our custom comments need to be a valid in syntax comments in some cases, and cannot be used one directly after another because Prism parses them as a single plain text block. Also we cannot comment on JSX component props directly, since for this we need to use `{/* ... */}` notation too, which will leave the curly braces in the output.

Not all fixes are ideal, when it come to highlighted code portion, but it's the best what I was able to do without breaking the code syntax highlight at all.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-01-10 at 17 56 26](https://github.com/expo/expo/assets/719641/ef23f752-f4c4-4686-8c6d-7896d49bd70e)

