### PR TITLE
[expo-go][sdk-50] Fix task info for dev menu for SDK 49 experiences

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -35,13 +35,15 @@ function getInfoFromManifest(
       isVerified: (manifest as any).isVerified,
     };
   } else {
-    // no properties for bare manifests
+    // classic manifests no longer have types, but we still want to show info for
+    // them
+    const maybeClassicManifest = manifest as any;
     return {
-      iconUrl: undefined,
-      taskName: undefined,
-      sdkVersion: undefined,
-      runtimeVersion: undefined,
-      isVerified: undefined,
+      iconUrl: maybeClassicManifest.iconUrl,
+      taskName: maybeClassicManifest.name,
+      sdkVersion: maybeClassicManifest.sdkVersion,
+      runtimeVersion: stringOrUndefined(maybeClassicManifest.runtimeVersion),
+      isVerified: maybeClassicManifest.isVerified,
     };
   }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/24312 fixed tsc in expo go by just showing a generic UI for 49 classic updates. This PR reverts that portion and does its best to show the relevant information (correct title and isVerified status) by ignoring types.

# How

Cast as any, revert non-modern-manifest case.

# Test Plan

Log in to an account with a published 49 experience, load it, see the menu now looks correct (verified status and title).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
