### PR TITLE
[docs] correct code snippets highlight on few pages

### DIFF
--- a/docs/pages/bare/using-expo-client.mdx
+++ b/docs/pages/bare/using-expo-client.mdx
@@ -62,7 +62,7 @@ You can use this boolean to conditionally require custom native code. Here's an 
 
 <SnackInline dependencies={['expo-constants', 'react-native-blurhash']}>
 
-```js
+```jsx
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
@@ -121,7 +121,7 @@ Optional imports are supported by [Metro bundler](/guides/customizing-metro). Th
 
 <SnackInline dependencies={['expo-constants', 'react-native-blurhash']}>
 
-```js
+```jsx
 import React from 'react';
 import { View } from 'react-native';
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -61,7 +61,7 @@ Later, we're going to write a test that's going to tap the button and check whet
 
 <Collapsible summary="👀 See the source code">
 
-```js App.js
+```jsx App.js
 import { StatusBar } from 'expo-status-bar';
 import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -78,7 +78,7 @@ To write your first unit test, start by writing a simple test for **App.js**. Cr
 
 The test will expect the state of the `<App />` component to have one child element:
 
-```js App.test.js
+```jsx App.test.js
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -143,7 +143,7 @@ A snapshot test is used to make sure that UI stays consistent, especially when a
 
 To add a snapshot test for `<App />`, add the following code snippet in the `describe()` in **App.test.js**:
 
-```js App.test.js
+```jsx App.test.js
 it('renders correctly', () => {
   const tree = renderer.create(<App />).toJSON();
   expect(tree).toMatchSnapshot();

--- a/docs/pages/guides/configuring-js-engines.mdx
+++ b/docs/pages/guides/configuring-js-engines.mdx
@@ -49,14 +49,14 @@ You can run `npx expo prebuild -p android --clean` after the installation to pr
 To use a different engine on one specific platform, you can set the `"jsEngine"` value at the top level and then override it with a different value under the `"android"` or `"ios"` key. The value specified for the platform will take precedence over the common field.
 
 {/* prettier-ignore */}
-```js app.json
+```json app.json
 {
   "expo": {
     "jsEngine": "hermes",
     "ios": {
       /* @info jsEngine inside platform section will take precedence over the common field */
       "jsEngine": "jsc"
-    /* @end */
+      /* @end */
     }
   }
 }

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -128,7 +128,7 @@ module.exports = nextConfig;
 
 The package `react-native-web` builds on the assumption of reset CSS styles. Here's how you reset styles in Next.js using the **pages** directory.
 
-```js pages/_document.js
+```jsx pages/_document.js
 import { Children } from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { AppRegistry } from 'react-native';
@@ -188,7 +188,7 @@ export default class MyDocument extends Document {
 }
 ```
 
-```js pages/_app.js
+```jsx pages/_app.js
 import Head from 'next/head';
 
 export default function App({ Component, pageProps }) {

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -282,7 +282,7 @@ This will export the website with all resources prefixed with `/my-root`. For ex
 
 Expo Router has built-in support for `baseUrl`. When using the `Link` and `router` APIs, the `baseUrl` will be automatically prepended to the URL.
 
-```js app/blog/index.tsx
+```jsx app/blog/index.tsx
 import { Link } from 'expo-router';
 
 export default function Blog() {
@@ -302,7 +302,7 @@ The `baseUrl` functionality is production-only and must be set before exporting 
 
 Images and other assets will work automatically if you `require` or `import` them. If you directly reference a resource URL then you will need to append the **baseUrl** manually.
 
-```js app/index.tsx
+```jsx app/index.tsx
 import { Image } from 'expo-image';
 
 export default function Blog() {
@@ -318,7 +318,7 @@ This will **export** to the following:
 
 Manually passing a URL will need to be manually prefixed:
 
-```js app/index.tsx
+```jsx app/index.tsx
 export default function Blog() {
   return <img src="/my-root/assets/image.png" />;
 }

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -42,7 +42,7 @@ To follow the above example, set up a [React Context provider](https://react.dev
 
 This provider uses a mock implementation. You can replace it with your own [authentication provider](/guides/authentication/).
 
-```js ctx.tsx
+```jsx ctx.tsx
 import React from 'react';
 import { useStorageState } from './useStorageState';
 

--- a/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
@@ -26,7 +26,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js App.js
+```jsx App.js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/v48.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/splash-screen.mdx
@@ -27,7 +27,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js App.js
+```jsx App.js
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/v49.0.0/config/metro.mdx
+++ b/docs/pages/versions/v49.0.0/config/metro.mdx
@@ -91,7 +91,7 @@ Here, we'll define a global style for the class name `.container`:
 
 We can then use the class name in our component by importing the stylesheet and using `.container`:
 
-```js App.js
+```jsx App.js
 import './styles.css';
 import { View } from 'react-native';
 
@@ -144,7 +144,7 @@ Flipping the extension, for example, `App.ios.module.css` will not work and resu
 
 > You cannot pass styles to the `className` prop of a React Native or React Native for web component. Instead, you must use the `style` prop.
 
-```js App.js
+```jsx App.js
 import styles, { unstable_styles } from './App.module.css';
 
 export default function Page() {


### PR DESCRIPTION
# Why

Not all code block using JSX tag have the correct language specified for Prism.

# How

Replace several of code block languages to improve the code highlight on the pages.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-01-11 at 12 20 30](https://github.com/expo/expo/assets/719641/7751af5f-b3a2-412a-a0a4-f0518538a687)
