### PR TITLE
[docs] Fix code snippet and code annotation in local build with EAS Update

### DIFF
--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -63,20 +63,19 @@ Inside the app config, make changes to use [`runtimeVersion`](/versions/latest/c
       }
       /* @hide ... */ /* @end */
     }
-    /* @hide ... */ /* @end */
-    runtimeVersion: '1.0.0',
+    "runtimeVersion": "1.0.0",
     /* @hide ... */ /* @end */
   }
 ```
 
-> In the [introductory guide](/eas-update/getting-started), the channel name is set by EAS Build and is different for various build profiles. Since this is a local build, it is necessary to set this request header explicitly in the app config.
+> In the [introduction guide](/eas-update/getting-started), the channel name is set by EAS Build and is different for various build profiles. Since this is a local build, it is necessary to set this request header explicitly in the app config.
 
 </Step>
 
 <Step label="4">
 ## Run prebuild
 
-This runs automatically when executing `npx expo run:android` or `npx expo run:ios`. However, we want to call this step out separately in this guide. In SDK 48 and above, this step adds our desired request headers to **AndroidManifest.xml** and **Expo.plist** in the Android and iOS builds.
+Prebuild runs automatically when executing `npx expo run:android` or `npx expo run:ios`. However, we want to call this step out separately in this guide. From SDK 48 and above, this step adds our desired request headers to **AndroidManifest.xml** and **Expo.plist** in the Android and iOS builds.
 
 <Terminal
   cmd={[
@@ -90,20 +89,22 @@ After running the above, inspect **android/app/src/main/AndroidManifest.xml** an
 
 {/* prettier-ignore */}
 ```xml Expo.plist
-<!-- @hide ... your existing configuration --> <!-- @end -->
-    <!-- @info New --> <key>EXUpdatesRequestHeaders</key> <!-- @end -->
-    <!-- @info New --> <dict> <!-- @end -->
-      <!-- @info New --> <key>expo-channel-name</key> <!-- @end -->
-      <!-- @info New --> <string>main</string> <!-- @end -->
-    <!-- @info New --> </dict> <!-- @end -->
-<!-- @hide ... your existing configuration --><!-- @end -->
+<!-- @hide ... Existing configuration --> <!-- @end -->
+  <!-- @info Changes added to Expo.plist on running prebuild command. -->
+  <key>EXUpdatesRequestHeaders</key>
+  <dict>
+    <key>expo-channel-name</key>
+    <string>main</string>
+  </dict>
+  <!-- @end -->
+<!-- @hide ... Existing configuration --><!-- @end -->
 ```
 
 {/* prettier-ignore */}
 ```xml AndroidManifest.xml
-<!-- @hide ... your existing configuration --> <!-- @end -->
-    <!-- @info New --> <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;main&quot;}"/> <!-- @end -->
-<!-- @hide ... your existing configuration --><!-- @end -->
+<!-- @hide ... Existing configuration --> <!-- @end -->
+  <!-- @info Changes added to AndroidManifest.xml on run running prebuild command. --> <meta-data android:name="expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY" android:value="{&quot;expo-channel-name&quot;:&quot;main&quot;}"/> <!-- @end -->
+<!-- @hide ... Existing configuration --><!-- @end -->
 ```
 
 > If you do not see the above lines added to these files, it means that you are using SDK 47 or earlier, and you should add these lines manually to **AndroidManifest.xml** and **Expo.plist**. In SDK 48 and later, the [`requestHeaders`](/versions/latest/config/app/#requestheaders) property from the app config is used to automatically add these lines to the native files.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1704932825580909)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix code highlight annotation to be meaningful under Prebuild section
- Fix code syntax in `app.json` under Configure project section

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/eas-update/build-locally/#run-prebuild

## Preview

![CleanShot 2024-01-11 at 18 36 20@2x](https://github.com/expo/expo/assets/10234615/01b98ca9-67d9-4a8f-a5ef-bbc2ecedbbbb)

![CleanShot 2024-01-11 at 18 36 35@2x](https://github.com/expo/expo/assets/10234615/d7913cf3-1c70-4cc0-91c5-9ccf21d4676c)

![CleanShot 2024-01-11 at 18 36 31@2x](https://github.com/expo/expo/assets/10234615/a694dc6d-42d8-416f-8ff0-282a823ee5f2)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
