### PR TITLE
[constants] fix build error on agp 8.2

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build error on AGP 8.2. ([#26362](https://github.com/expo/expo/pull/26362) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - [expo-updates] Migrate to requireNativeModule/requireOptionalNativeModule. ([#25648](https://github.com/expo/expo/pull/25648) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -10,63 +10,32 @@ def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
 
 afterEvaluate {
   def projectRoot = file("${rootProject.projectDir}")
+  def assetsDir = file("$buildDir/generated/assets/expo-constants")
 
-  if (!android.hasProperty('libraryVariants')) {
-    // For traditional application level integration, will be no-op to prevent duplicated app.config creation.
-    return;
+  def currentCreateConfigTask = tasks.register('createExpoConfig', Exec) {
+    description = 'expo-constants: Create app.config.'
+
+    doFirst {
+      assetsDir.deleteDir()
+      assetsDir.mkdirs()
+    }
+
+    // Add generated assetsDir into assets.srcDirs
+    project.android.sourceSets.main.assets.srcDirs += assetsDir
+
+    // Set up outputs so gradle can cache the result
+    outputs.dir assetsDir
+
+    // Switch to project root and generate the app config
+    workingDir projectRoot
+
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
+    } else {
+      commandLine(*nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
+    }
   }
-  android.libraryVariants.each { variant ->
-    def targetName = variant.name.capitalize()
-    def targetPath = variant.dirName
 
-    def assetsDir = file("$buildDir/generated/assets/expo-constants/${targetPath}")
-    def packageTaskName = "package${targetName}Assets"
-
-    def currentBundleTask = tasks.register("create${targetName}ExpoConfig", Exec) {
-      description = "expo-constants: Create config for ${targetName}."
-
-      doFirst {
-        assetsDir.deleteDir()
-        assetsDir.mkdirs()
-      }
-
-      // Set up outputs so gradle can cache the result
-      outputs.dir assetsDir
-
-      // Switch to project root and generate the app config
-      workingDir projectRoot
-
-      if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine("cmd", "/c", *nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
-      } else {
-        commandLine(*nodeExecutableAndArgs, "$expoConstantsDir/scripts/getAppConfig.js", projectRoot, assetsDir)
-      }
-    }
-
-    def currentCopyAppConfigTask = tasks.register("copy${targetName}ExpoConfig", Copy) {
-      description = "expo-constants: Copy generated app.config into ${targetName}."
-
-      from(assetsDir)
-      into("${projectDir}/src/${targetPath}/assets")
-      include('app.config')
-
-      dependsOn(currentBundleTask)
-    }
-
-    def currentCleanupAppConfigTask = tasks.register("cleanup${targetName}ExpoConfig", Delete) {
-      description = "expo-constants: Cleanup generated app.config from ${targetName}."
-
-      // In the past, the `app.config` file was placed in the `main` directory.
-      // However, this is no longer the case. To ensure a smooth transition,
-      // we’re also cleaning the `app.config` from the old location.
-      delete files("${projectDir}/src/main/assets/app.config")
-      delete files("${projectDir}/src/${targetPath}/assets/app.config")
-      dependsOn(packageTaskName)
-    }
-
-    // In summary, these tasks try to create `src/${targetPath}/assets/app.config` in building time for gradle to merge the asset.
-    // And cleanup the generated app.config after building time.
-    tasks.findByPath(packageTaskName).dependsOn(currentCopyAppConfigTask)
-    tasks.findByPath("process${targetName}JavaRes").dependsOn(currentCleanupAppConfigTask)
-  }
+  // Generate app.config at preBuild
+  tasks.getByName('preBuild').dependsOn(currentCreateConfigTask)
 }


### PR DESCRIPTION
# Why

fixes #26069 
close ENG-10985

# How

the previous constants's gradle task depenency will have a error. this pr tries to simplify the setup and generate the app.config at `preBuild` and point out `project.android.sourceSets.main.assets.srcDirs += assetsDir` to the generated assetsDir

# Test Plan

- ci passed
- unzip and verify app.config is inside apk
- change `agp = "8.2.0"` in node_modules/@react-native/gradle-pluign/gradle/libs.versions.toml`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
