### PR TITLE
[expo-modules-core][iOS] fix TV issue in AppDelegates

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -17,7 +17,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   @objc
   public let reactDelegate = ExpoReactDelegate(handlers: reactDelegateHandlers)
 
-  #if os(iOS)
+  #if os(iOS) || os(tvOS)
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {


### PR DESCRIPTION
One line fix for tvOS compilation of new app delegate code.

The CI that tests tvOS compilation didn't catch this, because the error only happens at runtime (crash with missing selector).

# Test Plan

- Tested locally with TV app
- CI should pass


