### PR TITLE
[docs] Guide to building Expo apps for TV

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -399,6 +399,7 @@ const general = [
         makePage('guides/using-eslint.mdx'),
         makePage('guides/using-nextjs.mdx'),
         makePage('guides/using-sentry.mdx'),
+        makePage('guides/building-for-tv.mdx'),
         makePage('guides/typescript.mdx'),
       ]),
       makeSection('Expo accounts', [

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -1,0 +1,224 @@
+---
+title: Building for TV
+description: A guide for building an Expo app for an Apple TV or Android TV target.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+> **Warning** TV development is available only in SDK 50 and later, and is still considered experimental. Not all Expo features and SDK modules are available on TV.
+
+React Native is supported on Apple TV and Android TV through the [React Native TV repo](https://github.com/react-native-tvos/react-native-tvos).  It is not just for TV — it is a full fork of the core repo, and supports both phone and TV targets, including Hermes and Fabric support
+
+By taking an Expo project and using the React Native TV repo as the `react-native` dependency, the project can be made to target either phone (Android, iOS) or TV (Android TV, Apple TV) devices.
+
+The changes needed to the native Android and iOS files are minimal, and are made with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv):
+
+- iOS:
+  - **ios/Podfile** is modified to target tvOS instead of iOS
+  - The Xcode project is modified to target tvOS instead of iOS
+  - The splash screen (**SplashScreen.storyboard**) is modified to work on tvOS
+- Android:
+  - **AndroidManifest.xml** is modified
+  - The default phone portrait orientation is removed
+  - The required intent for TV apps is added
+  - **MainApplication.kt** is modified to remove unsupported Flipper invocations
+
+## Quick start
+
+The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) in the Expo examples repo.
+
+## Step by step
+
+If you already have an existing Expo project, this walkthrough shows what is required to take an Expo project and modify it for TV.
+
+You will need
+
+- An Expo project using SDK 50 or later.
+- Apple TV:
+  - Xcode 15 or later
+  - tvOS SDK 17 or later. (This is not installed automatically with Xcode. If you did not install it at the prompt when first opening Xcode, you can install later with `xcodebuild -downloadAllPlatforms`).
+- Android TV:
+  - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For M1 Macs, choose the ARM 64 image, otherwise, choose the Intel x86_64 image).
+  - After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as for creating an Android phone emulator).
+
+> **Info** If you are starting with an SDK 49 project, you can execute the commands below to upgrade to SDK 50 before going through the steps:
+
+<Terminal cmd={['npx expo install expo@next', 'npx expo install --fix']} cmdCopy="npx expo install expo@next && npx expo install --fix" />
+
+## Limitations
+
+Some Expo features are not supported at this time:
+
+- Dev client and dev launcher
+- Expo Router
+
+<Step label="1">
+
+## Modify dependencies for TV
+
+In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from expo install changes.
+
+{/* prettier-ignore */}
+```json package.json
+{
+  /* @hide ... your existing package.json */ /* @end */
+  "dependencies": {
+    /* @hide ... your existing dependencies */ /* @end */
+    "react-native": "npm:react-native-tvos",
+    /* @hide ... your existing dependencies */ /* @end */
+  },
+  "expo": {
+    "install": {
+      "exclude": [
+        "react-native"
+      ]
+    }
+  }
+}
+```
+</Step>
+
+<Step label="2">
+
+## Add the TV config plugin
+
+<Terminal cmd={['npx expo install @react-native-tvos/config-tv']} />
+
+Installing the package adds the `@react-native-tvos/config-tv` plugin to your project's **app.json**.
+
+When installed, the plugin will modify the project for TV when either
+
+- The environment variable `EXPO_TV` is set to "1"
+- The plugin parameter `isTV` is set to true
+
+Optionally set `showVerboseWarnings` to true to see additional information during prebuild.
+
+```json app.json
+{
+  "plugins": [
+    [
+      "@react-native-tvos/config-tv",
+      {
+        "showVerboseWarnings": true
+      }
+    ]
+  ]
+}
+```
+
+</Step>
+
+<Step label="3">
+
+## Run prebuild
+
+Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifications to the project.
+
+<Terminal cmd={['export EXPO_TV=1', 'npx expo prebuild --clean']} />
+
+> **Note**: The `--clean` argument is recommended, and is required if you have existing Android and iOS directories in the project.
+
+</Step>
+
+<Step label="4">
+
+## Build for Apple TV
+
+After running prebuild, run the following command to build and run the app on an Apple TV simulator:
+
+<Terminal
+  cmd={[
+    'npx expo run:ios'
+  ]}
+/>
+
+</Step>
+
+<Step label="5">
+
+## Build for Android TV
+
+After running prebuild, start an Android TV emulator, and then use the same command as you would to start the app on an Android phone emulator.
+
+<Terminal
+  cmd={[
+    'npx expo run:android'
+  ]}
+/>
+
+</Step>
+
+<Step label="6">
+
+## Revert TV changes and build for phone
+
+You can revert the changes for TV and go back to phone development by unsetting `EXPO_TV` and running prebuild again:
+
+<Terminal cmd={['unset EXPO_TV', 'npx expo prebuild --clean']} />
+
+</Step>
+
+<Step label="7">
+
+## Create EAS build profiles for both TV and phone
+
+Since the TV build is driven by the value of an environment variable, it is easy to set up EAS build profiles that build from the same source but target TV instead of phone.
+
+The following example **eas.json** shows how to extend existing profiles (`development` and `preview`) to create TV profiles (`development_tv` and `preview_tv`).
+
+```json eas.json
+{
+  "cli": {
+    "version": ">= 5.2.0"
+  },
+  "build": {
+    "base": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk",
+        "withoutCredentials": true
+      },
+      "channel": "base"
+    },
+    "development": {
+      "extends": "base",
+      "android": {
+        "gradleCommand": ":app:assembleDebug"
+      },
+      "ios": {
+        "buildConfiguration": "Debug"
+      },
+      "channel": "development"
+    },
+    "development_tv": {
+      "extends": "development",
+      "env": {
+        "EXPO_TV": "1"
+      },
+      "channel": "development"
+    },
+    "preview": {
+      "extends": "base",
+      "channel": "preview"
+    },
+    "preview_tv": {
+      "extends": "preview",
+      "env": {
+        "EXPO_TV": "1"
+      },
+      "channel": "preview"
+    }
+  },
+  "submit": {}
+}
+```
+
+</Step>
+
+## More
+
+For a complete example, see [this project](https://github.com/douglowder/IgniteTV).

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -17,9 +17,9 @@ Using the React Native TV library as the `react-native` dependency in an Expo pr
 The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/workflow/prebuild/). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
 
 - Android:
-  - **AndroidManifest.xml** is modified
-  - The default phone portrait orientation is removed
-  - The required intent for TV apps is added
+  - **AndroidManifest.xml** is modified:
+    - The default phone portrait orientation is removed
+    - The required intent for TV apps is added
   - **MainApplication.kt** is modified to remove unsupported Flipper invocations
 - iOS:
   - **ios/Podfile** is modified to target tvOS instead of iOS
@@ -48,10 +48,10 @@ You will need:
 
 ## Limitations
 
-Certain Expo tools are not yet supported at this time, most notably:
+Certain Expo modules are not supported at this time, most notably:
 
 - `expo-dev-client`
-- Expo Router
+- `expo-router`
 
 <Step label="1">
 
@@ -92,7 +92,7 @@ When installed, the plugin will modify the project for TV when either:
 - The environment variable `EXPO_TV` is set to `1`
 - The plugin parameter `isTV` is set to `true`
 
-Optionally, set the `showVerboseWarnings` property to `true` to see additional information during prebuild.
+Make sure that this plugin appears in `app.json`. It is recommended to set the `showVerboseWarnings` property to `true` to see additional information during prebuild.
 
 ```json app.json
 {
@@ -221,7 +221,7 @@ The following example **eas.json** shows how to extend existing profiles (`devel
 
 <BoxLink
   title="IgniteTV"
-  description="A complete example is available at GitHub."
-  href="https://github.com/douglowder/IgniteTV"
+  description="A complete example is available on GitHub."
+  href="https://github.com/react-native-tvos/IgniteTV"
   Icon={GithubIcon}
 />

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -139,7 +139,7 @@ After running prebuild, run the following command to build and run the app on an
 
 ## Build for Android TV
 
-After running prebuild, start an Android TV emulator, and then use the same command as you would to start the app on an Android phone emulator.
+Start an Android TV emulator and use the following command to start the app on the emulator:
 
 <Terminal
   cmd={[

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -8,11 +8,11 @@ import { Step } from '~/ui/components/Step';
 
 > **Warning** TV development is available only in SDK 50 and later, and is still considered experimental. Not all Expo features and SDK modules are available on TV.
 
-React Native is supported on Apple TV and Android TV through the [React Native TV repo](https://github.com/react-native-tvos/react-native-tvos).  It is not just for TV — it is a full fork of the core repo, and supports both phone and TV targets, including Hermes and Fabric support
+React Native is supported on Apple TV and Android TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos).  It is not just for TV — it is a full fork of the core repo, and supports both phone and TV targets, including Hermes and Fabric support
 
-By taking an Expo project and using the React Native TV repo as the `react-native` dependency, the project can be made to target either phone (Android, iOS) or TV (Android TV, Apple TV) devices.
+By taking an Expo project and using the React Native TV package as the `react-native` dependency, the project can be made to target either mobile (Android, iOS) or TV (Android TV, Apple TV) devices.
 
-The changes needed to the native Android and iOS files are minimal, and are made with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv):
+The changes needed to the native Android and iOS files are minimal, and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/workflow/prebuild/). The following is a list of changes that the config plugin makes, which you can alternatively apply manually:
 
 - iOS:
   - **ios/Podfile** is modified to target tvOS instead of iOS
@@ -32,32 +32,30 @@ The fastest way to generate a new project is described in the [TV Example](https
 
 If you already have an existing Expo project, this walkthrough shows what is required to take an Expo project and modify it for TV.
 
-You will need
+You will need:
 
 - An Expo project using SDK 50 or later.
-- Apple TV:
+- **Apple TV**:
   - Xcode 15 or later
   - tvOS SDK 17 or later. (This is not installed automatically with Xcode. If you did not install it at the prompt when first opening Xcode, you can install later with `xcodebuild -downloadAllPlatforms`).
-- Android TV:
-  - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For M1 Macs, choose the ARM 64 image, otherwise, choose the Intel x86_64 image).
+- **Android TV**:
+  - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For Apple Silicon Macs, choose the ARM 64 image, otherwise, choose the Intel x86_64 image).
   - After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as for creating an Android phone emulator).
 
-> **Info** If you are starting with an SDK 49 project, you can execute the commands below to upgrade to SDK 50 before going through the steps:
-
-<Terminal cmd={['npx expo install expo@next', 'npx expo install --fix']} cmdCopy="npx expo install expo@next && npx expo install --fix" />
+> **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
 
 ## Limitations
 
-Some Expo features are not supported at this time:
+Certain Expo tools are not yet supported at this time, most notably:
 
-- Dev client and dev launcher
+- expo-dev-client
 - Expo Router
 
 <Step label="1">
 
 ## Modify dependencies for TV
 
-In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from expo install changes.
+In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from [`npx expo install` version validation](/more/expo-cli/#configuring-dependency-validation).
 
 {/* prettier-ignore */}
 ```json package.json
@@ -87,12 +85,12 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 Installing the package adds the `@react-native-tvos/config-tv` plugin to your project's **app.json**.
 
-When installed, the plugin will modify the project for TV when either
+When installed, the plugin will modify the project for TV when either:
 
-- The environment variable `EXPO_TV` is set to "1"
-- The plugin parameter `isTV` is set to true
+- The environment variable `EXPO_TV` is set to `1`
+- The plugin parameter `isTV` is set to `true`
 
-Optionally set `showVerboseWarnings` to true to see additional information during prebuild.
+Optionally, set the `showVerboseWarnings` property to `true` to see additional information during prebuild.
 
 ```json app.json
 {
@@ -163,7 +161,7 @@ You can revert the changes for TV and go back to phone development by unsetting 
 
 ## Create EAS build profiles for both TV and phone
 
-Since the TV build is driven by the value of an environment variable, it is easy to set up EAS build profiles that build from the same source but target TV instead of phone.
+Since the TV build is driven by the value of an environment variable, it is easy to set up EAS Build profiles that build from the same source but target TV instead of phone.
 
 The following example **eas.json** shows how to extend existing profiles (`development` and `preview`) to create TV profiles (`development_tv` and `preview_tv`).
 
@@ -219,6 +217,6 @@ The following example **eas.json** shows how to extend existing profiles (`devel
 
 </Step>
 
-## More
+## Learn more
 
-For a complete example, see [this project](https://github.com/douglowder/IgniteTV).
+For a complete example, refer to the [douglowder/IgniteTV repository](https://github.com/douglowder/IgniteTV).

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -123,20 +123,6 @@ Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifica
 
 <Step label="4">
 
-## Build for Apple TV
-
-After running prebuild, run the following command to build and run the app on an Apple TV simulator:
-
-<Terminal
-  cmd={[
-    'npx expo run:ios'
-  ]}
-/>
-
-</Step>
-
-<Step label="4">
-
 ## Build for Android TV
 
 Start an Android TV emulator and use the following command to start the app on the emulator:

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -1,46 +1,48 @@
 ---
-title: Building for TV
-description: A guide for building an Expo app for an Apple TV or Android TV target.
+title: Build Expo apps for TV
+description: A guide for building an Expo app for an Android TV or Apple TV target.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 > **Warning** TV development is available only in SDK 50 and later, and is still considered experimental. Not all Expo features and SDK modules are available on TV.
 
-React Native is supported on Apple TV and Android TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos).  It is not just for TV — it is a full fork of the core repo, and supports both phone and TV targets, including Hermes and Fabric support
+React Native is supported on Android TV and Apple TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos).  This technology extends beyond TV, offering a comprehensive core repo fork with support for phone and TV targets, including Hermes and Fabric.
 
-By taking an Expo project and using the React Native TV package as the `react-native` dependency, the project can be made to target either mobile (Android, iOS) or TV (Android TV, Apple TV) devices.
+Using the React Native TV library as the `react-native` dependency in an Expo project, it becomes capable of targeting both mobile (Android, iOS) and TV (Android TV, Apple TV) devices.
 
-The changes needed to the native Android and iOS files are minimal, and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/workflow/prebuild/). The following is a list of changes that the config plugin makes, which you can alternatively apply manually:
+The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/workflow/prebuild/). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
 
-- iOS:
-  - **ios/Podfile** is modified to target tvOS instead of iOS
-  - The Xcode project is modified to target tvOS instead of iOS
-  - The splash screen (**SplashScreen.storyboard**) is modified to work on tvOS
 - Android:
   - **AndroidManifest.xml** is modified
   - The default phone portrait orientation is removed
   - The required intent for TV apps is added
   - **MainApplication.kt** is modified to remove unsupported Flipper invocations
+- iOS:
+  - **ios/Podfile** is modified to target tvOS instead of iOS
+  - The Xcode project is modified to target tvOS instead of iOS
+  - The splash screen (**SplashScreen.storyboard**) is modified to work on tvOS
 
 ## Quick start
 
-The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) in the Expo examples repo.
+The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) within the Expo examples repository.
 
-## Step by step
+## Integration with an existing Expo project
 
-If you already have an existing Expo project, this walkthrough shows what is required to take an Expo project and modify it for TV.
+If you have an existing Expo project, the following walkthrough describes the steps required to modify an Expo project for TV.
 
 You will need:
 
 - An Expo project using SDK 50 or later.
-- **Apple TV**:
-  - Xcode 15 or later
-  - tvOS SDK 17 or later. (This is not installed automatically with Xcode. If you did not install it at the prompt when first opening Xcode, you can install later with `xcodebuild -downloadAllPlatforms`).
 - **Android TV**:
-  - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For Apple Silicon Macs, choose the ARM 64 image, otherwise, choose the Intel x86_64 image).
-  - After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as for creating an Android phone emulator).
+  - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image).
+  - After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as creating an Android phone emulator).
+- **Apple TV**:
+  - Xcode 15 or later.
+  - tvOS SDK 17 or later. (This is not installed automatically with Xcode. You can install it later with `xcodebuild -downloadAllPlatforms`).
 
 > **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
 
@@ -48,7 +50,7 @@ You will need:
 
 Certain Expo tools are not yet supported at this time, most notably:
 
-- expo-dev-client
+- `expo-dev-client`
 - Expo Router
 
 <Step label="1">
@@ -64,7 +66,7 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
   "dependencies": {
     /* @hide ... your existing dependencies */ /* @end */
     "react-native": "npm:react-native-tvos",
-    /* @hide ... your existing dependencies */ /* @end */
+    /* @hide ... */ /* @end */
   },
   "expo": {
     "install": {
@@ -83,7 +85,7 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 <Terminal cmd={['npx expo install @react-native-tvos/config-tv']} />
 
-Installing the package adds the `@react-native-tvos/config-tv` plugin to your project's **app.json**.
+Installing the library adds the `@react-native-tvos/config-tv` plugin to your project's **app.json**.
 
 When installed, the plugin will modify the project for TV when either:
 
@@ -133,7 +135,7 @@ After running prebuild, run the following command to build and run the app on an
 
 </Step>
 
-<Step label="5">
+<Step label="4">
 
 ## Build for Android TV
 
@@ -146,7 +148,19 @@ After running prebuild, start an Android TV emulator, and then use the same comm
 />
 
 </Step>
+<Step label="5">
 
+## Build for Apple TV
+
+Run the following command to build and run the app on an Apple TV simulator:
+
+<Terminal
+  cmd={[
+    'npx expo run:ios'
+  ]}
+/>
+
+</Step>
 <Step label="6">
 
 ## Revert TV changes and build for phone
@@ -217,6 +231,11 @@ The following example **eas.json** shows how to extend existing profiles (`devel
 
 </Step>
 
-## Learn more
+## More
 
-For a complete example, refer to the [douglowder/IgniteTV repository](https://github.com/douglowder/IgniteTV).
+<BoxLink
+  title="IgniteTV"
+  description="A complete example is available at GitHub."
+  href="https://github.com/douglowder/IgniteTV"
+  Icon={GithubIcon}
+/>


### PR DESCRIPTION
# Why

Provide information on building Expo apps for TV:

- quick start
- step by step guide
- limitations

# How

New doc in the "Integrations" section.

# Test Plan

- Manually test that the steps work
- Doc review

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
