### PR TITLE
chore(metro-config): bump postcss

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "morgan": "^1.10.0",
-    "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "tiny": "^0.0.10"
   },

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Bump `postcss` to 8.4.32.
+- Bump `postcss` to 8.4.32. ([#26385](https://github.com/expo/expo/pull/26385) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.1 - 2023-12-19
 

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `postcss` to 8.4.32.
+
 ## 0.17.1 - 2023-12-19
 
 ### 🎉 New features

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -51,7 +51,7 @@
     "glob": "^7.2.3",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "~1.19.0",
-    "postcss": "~8.4.21",
+    "postcss": "~8.4.32",
     "resolve-from": "^5.0.0",
     "sucrase": "^3.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14389,7 +14389,7 @@ nano-time@1.0.0:
   dependencies:
     big-integer "^1.6.16"
 
-nanoid@^3.1.23, nanoid@^3.3.1, nanoid@^3.3.6:
+nanoid@^3.1.23, nanoid@^3.3.1, nanoid@^3.3.6, nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
@@ -15968,12 +15968,12 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.2
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.4.23, postcss@^8.4.31, postcss@~8.4.21:
-  version "8.4.31"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
-  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
+postcss@^8.4.23, postcss@~8.4.32:
+  version "8.4.33"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
+  integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
   dependencies:
-    nanoid "^3.3.6"
+    nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 


### PR DESCRIPTION
# Why

- Not generated version of https://github.com/expo/expo/pull/26369
