### PR TITLE
[docs] Clarify the environments in which splash screen images can be previewed

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen.mdx
+++ b/docs/pages/develop/user-interface/splash-screen.mdx
@@ -48,7 +48,9 @@ Open the **app.json** and add the path as the value of `splash.image` to point t
 }
 ```
 
-Reopen the Expo Go and launch your project. You should see your new splash screen. However, there may be a delay before it appears in Expo Go. This doesn't happen in development builds or standalone apps. For more information, see [Differences between environments](#differences-between-environments-on-ios).
+Previewing the splash image is limited to Expo Go local development, standalone builds, and development builds. Published updates loaded in Expo Go will not show the splash image. For more information, see [Differences between environments](#differences-between-environments).
+
+To preview the splash image in Expo Go, reopen Expo Go and launch your project from the Expo CLI. You should see your new splash screen. However, there may be a delay before it appears.
 
 > On Android, you must press the notification drawer's refresh button. On iOS, it's required to close and re-open the Expo Go to see changes to the splash screen from the **app.json**.
 
@@ -131,19 +133,19 @@ Depending on the `resizeMode` you will get the following behavior on Android:
 - **cover** - This mode has the limitations as **contain** for the same reasons.
 - **native** - In this mode, your app will be leveraging Android's ability to present a static bitmap while the application is starting up. Android (unlike iOS) does not support stretching the provided image, so the application will present the given image centered on the screen. By default `splash.image` would be used as the `xxxdpi` resource. It's up to you to provide graphics that meet your expectations and fit the screen dimension. To achieve this, use different resolutions for [different device DPIs](/versions/latest/config/app/#mdpi) such as from `mdpi` to `xxxhdpi`.
 
-### Differences between environments on iOS
+### Differences between environments
 
 Your app can be opened from the Expo Go or in a standalone app, and it can be either published or in development. There are slight differences in the splash screen behavior between these environments.
 
 <ImageSpotlight
-  alt="iOS splash screen behavior"
+  alt="splash screen behavior"
   src="https://media.giphy.com/media/l378l98EI0VQdwRzy/giphy.gif"
 />
 
 {/* TODO: (@aman) Remove the second item in the list below. The published app in Expo Go is deprecated. Instead, replace it with development builds using expo-dev-client. */}
 
-- **On the left**, the Expo Go loads the project currently in development. Notice that on the bottom of the splash screen, you see an information bar that shows information relevant to preparing the JavaScript and downloading it to the device. We see an orange screen before the splash image appears because the background color is set immediately. However, the image needs to be downloaded.
-- **In the middle**, Expo Go loads a published app. Notice that again the splash image does not appear immediately.
+- **On the left**, Expo Go loads the project currently in development. Notice that on the bottom of the splash screen there is an information bar that shows information relevant to preparing the JavaScript and downloading it to the device. We see an orange screen before the splash image appears because the background color is set immediately. However, the image needs to be downloaded.
+- **In the middle**, Expo Go loads a published app. Notice that the splash image does not appear immediately or may not appear at all.
 - **On the right** is a standalone app. Notice that the splash image appears immediately.
 
 ### iOS caching


### PR DESCRIPTION
# Why

The docs needed to be updated for EAS Update, in which published updates can't preview splash screen images.

All splash screen previewing should be done via development builds or standalone builds generally. Expo Go local development does its best to simulate showing a splash screen (though delayed since it needs to download it), but it's not fully accurate.

Closes https://github.com/expo/expo/issues/25038.
Closes ENG-10508.

# How

Update docs.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
