### PR TITLE
[ENG-10883][docs] deprecate sdkVersion runtime policy

### DIFF
--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -22,7 +22,7 @@ To make managing the `"runtimeVersion"` property easier between builds and updat
 
 ### `"appVersion"` runtime version policy (available in SDK 46 and higher)
 
-The `"appVersion"` runtime is intended for projects that have custom native code that may change between builds. By default, we provide the `"appVersion"` runtime version policy after running `eas update:configure`:
+The `"appVersion"` runtime is provided for projects that have custom native code that may change between builds. By default, the runtime version policy is set to `"appVersion"` after running `eas update:configure`:
 
 ```json
 {

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -20,27 +20,9 @@ Since updates must be compatible with a build's native code, any time native cod
 
 To make managing the `"runtimeVersion"` property easier between builds and updates, we've created runtime version policies that will update automatically based on other fields inside the app config (**app.json**/**app.config.js**). If these policies do not match the development flow of a project, there's also an option to set the `"runtimeVersion"` manually.
 
-### `"sdkVersion"` runtime version policy
-
-By default, we provide the `"sdkVersion"` runtime version policy after running `eas update:configure`:
-
-```json
-{
-  "expo": {
-    "runtimeVersion": {
-      "policy": "sdkVersion"
-    }
-  }
-}
-```
-
-The `"sdkVersion"` policy will set the runtime version to the current SDK version of a project. For instance, if the project is on Expo SDK 1.0.0, the runtime version with this policy will be `"exposdk:1.0.0"`. This runtime version will update any time we update the project's Expo SDK. So, if we ran `expo upgrade` and installed Expo SDK 2.0.0, then the runtime version would become `"exposdk:2.0.0"`.
-
-This runtime version policy is perfect if you are not including custom native code in your project and the only native changes you make are when upgrading Expo SDKs.
-
 ### `"appVersion"` runtime version policy (available in SDK 46 and higher)
 
-We provide the `"appVersion"` runtime version policy for projects that have custom native code that may change between builds:
+The `"appVersion"` runtime is intended for projects that have custom native code that may change between builds. By default, we provide the `"appVersion"` runtime version policy after running `eas update:configure`:
 
 ```json
 {
@@ -137,6 +119,22 @@ This policy is well-suited for projects incorporating custom native code that re
 Enabling fingerprinting may lengthen build times, as the fingerprinting process can be resource-intensive.
 
 > **warning** Using the experimental `fingerprintExperimental` runtime policy may result in unexpected system behavior. This policy is still under active development as part of the `@expo/fingerprint` beta package, and its specifications may change in the future.
+
+### `"sdkVersion"` runtime version policy (deprecated)
+
+> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used if you are trying to test updates from a project with Expo Go on SDK 48 or lower.
+
+The `"sdkVersion"` policy will set the runtime version to the current SDK version of a project. For instance, if the project is on Expo SDK 1.0.0, the runtime version with this policy will be `"exposdk:1.0.0"`. This runtime version will update any time we update the project's Expo SDK. So, if we ran `expo upgrade` and installed Expo SDK 2.0.0, then the runtime version would become `"exposdk:2.0.0"`.
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    }
+  }
+}
+```
 
 ### Custom `"runtimeVersion"`
 

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -22,7 +22,7 @@ To make managing the `"runtimeVersion"` property easier between builds and updat
 
 ### `"appVersion"` runtime version policy (available in SDK 46 and higher)
 
-The `"appVersion"` runtime is provided for projects that have custom native code that may change between builds. By default, the runtime version policy is set to `"appVersion"` after running `eas update:configure`:
+The `"appVersion"` runtime is provided for projects with custom native code that may change between builds. By default, the runtime version policy is set to `"appVersion"` after running `eas update:configure`:
 
 ```json
 {

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -122,7 +122,7 @@ Enabling fingerprinting may lengthen build times, as the fingerprinting process 
 
 ### `"sdkVersion"` runtime version policy (deprecated)
 
-> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used if you are trying to test updates from a project with Expo Go on SDK 48 or lower.
+> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used for testing updates from a project with Expo Go on SDK 48 or lower.
 
 The `"sdkVersion"` policy will set the runtime version to the current SDK version of a project. For instance, if the project is on Expo SDK 1.0.0, the runtime version with this policy will be `"exposdk:1.0.0"`. This runtime version will update any time we update the project's Expo SDK. So, if we ran `expo upgrade` and installed Expo SDK 2.0.0, then the runtime version would become `"exposdk:2.0.0"`.
 

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -122,7 +122,7 @@ Enabling fingerprinting may lengthen build times, as the fingerprinting process 
 
 ### `"sdkVersion"` runtime version policy (deprecated)
 
-> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used for testing updates with Expo Go on SDK 48 or lower.
+> **warning** **Deprecated**: The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used for testing updates with Expo Go on SDK 48 or lower.
 
 The `"sdkVersion"` policy will set the runtime version to the current SDK version of a project. For instance, if the project is on Expo SDK 1.0.0, the runtime version with this policy will be `"exposdk:1.0.0"`. This runtime version will update any time we update the project's Expo SDK. So, if we ran `expo upgrade` and installed Expo SDK 2.0.0, then the runtime version would become `"exposdk:2.0.0"`.
 

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -122,7 +122,7 @@ Enabling fingerprinting may lengthen build times, as the fingerprinting process 
 
 ### `"sdkVersion"` runtime version policy (deprecated)
 
-> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used for testing updates from a project with Expo Go on SDK 48 or lower.
+> **info** The `"sdkVersion"` runtime version policy is deprecated, and the `"appVersion"` policy is recommended instead. This policy should only be used for testing updates with Expo Go on SDK 48 or lower.
 
 The `"sdkVersion"` policy will set the runtime version to the current SDK version of a project. For instance, if the project is on Expo SDK 1.0.0, the runtime version with this policy will be `"exposdk:1.0.0"`. This runtime version will update any time we update the project's Expo SDK. So, if we ran `expo upgrade` and installed Expo SDK 2.0.0, then the runtime version would become `"exposdk:2.0.0"`.
 


### PR DESCRIPTION
# Why

We want to discourage our users from declaring the `sdkVersion` runtime policy and recommend `appVersion` as the default since it is better able to express an app's native compatibility. We already set `appVersion` as the default in `eas-cli` when users run `update:configure` when SDK 49 was released.

We originally had this policy because users wanted to test their updates in Expo Go, and for SDK 48 and lower, you weren't able to use Expo Go unless your runtime policy was `sdkVersion`. In SDK 49  and higher, we changed it so Expo Go would look at the `sdkVersion` field instead of looking at whatever your runtime policy was. 

# Test Plan

inspected manually with `yarn run dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
