### PR TITLE
docs(metro-runtime): update import to `@expo/metro-runtime`

### DIFF
--- a/packages/@expo/metro-runtime/README.md
+++ b/packages/@expo/metro-runtime/README.md
@@ -13,7 +13,7 @@ yarn add @expo/metro-runtime
 Import this somewhere in the initial bundle. For example, the `App.js`:
 
 ```js
-import '@expo/metro-config';
+import '@expo/metro-runtime';
 ```
 
 `expo/metro-config` will automatically move this import to be first in the bundle.


### PR DESCRIPTION
# Why

This should of course be `import '@expo/metro-runtime'`. But if you are sleep deprived or not sure what you are doing, you'll get this error instead:

![image](https://github.com/expo/expo/assets/1203991/0b430103-d3a7-460b-b01d-468d77463460)


# How

- Changed the import in readme

# Test Plan

Docs change only 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
