### PR TITLE
[docs] Update hooks.mdx

### DIFF
--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -21,13 +21,17 @@ Given a function, the `useFocusEffect` hook will invoke the function whenever th
 /* @info */
 import { useFocusEffect } from 'expo-router';
 /* @end */
+import { useCallback } from 'react';
 
 export default function Route() {
-  useFocusEffect(() => {
-    /* @info Invoked whenever the route is focused */
-    console.log('Hello')
+  useFocusEffect(
+    /* @info Callback should be wrapped in `React.useCallback` to avoid running the effect too often */
+    useCallback(() => {
     /* @end */
-  })
+      /* @info Invoked whenever the route is focused */
+      console.log('Hello')
+      /* @end */
+  }))
 
   return </>
 }

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -31,7 +31,8 @@ export default function Route() {
       /* @info Invoked whenever the route is focused */
       console.log('Hello')
       /* @end */
-  }))
+    }, [])
+  )
 
   return </>
 }


### PR DESCRIPTION
Update `useFocusEffect` to use the `useCallback`, because the JSDocs for `expo-router` state this.

# Why

The callback in the `useFocusEffect` should be wrapped in a `useCallback`, and the JSDoc for the function even say so:

![useFocusEffectDocs](https://github.com/expo/expo/assets/17122123/6e6f6aed-cd26-451c-88db-cdbc137175fc)

# How

I just changed the docs

# Test Plan

Don't think a test is necessary

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
