### PR TITLE
[docs] fix missing Types section in older reference docs

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -137,9 +137,10 @@ const renderAPI = (
 
     const types = filterDataByKind(
       data,
-      TypeDocKind.TypeAlias || TypeDocKind.TypeAlias_Legacy,
+      [TypeDocKind.TypeAlias, TypeDocKind.TypeAlias_Legacy],
       entry =>
         !isProp(entry) &&
+        !(entry?.variant === 'reference') &&
         !!(
           entry.type.declaration ||
           entry.type.types ||

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -190,6 +190,7 @@ export type TypeGeneralData = {
   type: TypeDefinitionData;
   typeParameter?: TypeGeneralData[];
   kind: TypeDocKind;
+  variant?: string;
 };
 
 export type TypeDeclarationContentData = {


### PR DESCRIPTION
# Why

Looks like one regression slipped through, when updating TypeDoc.

Refs:
* #26343

Fixes #26400
* #26400

# How

Make sure that "Types" section is correctly rendered on the older, versioned API reference pages, as-well-as on the newest one. The root cause here was the `Kind` enum value change combined with output JSON slight structure tweak.

# Test Plan

The changes have been reviewed locally. All expected data can be seen on reference pages, no matter of SDK version selected.
