### PR TITLE
[image-picker] convert WEBP to PNG instead JPEG

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ### 💡 Others
 
-- Convert WEBP to PNG instead JPEG when selecting an item in the Media Library with cropping enabled. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
-- [Android] Receiving correct file extension for WEBP files instead `.jpeg` in the ImagePicker selection result. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
+- Convert WEBP to PNG instead JPEG when selecting an item in the Media Library with editing enabled. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
+- [Android] Receiving a correct file extension for WEBP files instead `.jpeg` in the ImagePicker result. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
 
 ## 14.7.1 - 2023-12-19
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### 💡 Others
 
+### 💡 Others
+
+- Convert WEBP to PNG instead JPEG when selecting an item in the Media Library with cropping enabled. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
+- [Android] Receiving correct file extension for WEBP files instead `.jpeg` in the ImagePicker selection result. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
+
 ## 14.7.1 - 2023-12-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Convert WEBP to PNG instead JPEG when selecting an item in the Media Library with editing enabled. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
-- [Android] Receiving a correct file extension for WEBP files instead `.jpeg` in the ImagePicker result. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
+- Receiving a correct file extension for WEBP files instead `.jpeg` in the ImagePicker result. ([#26419](https://github.com/expo/expo/pull/26419) by [@NikitaDudin](https://github.com/NikitaDudin))
 
 ## 14.7.1 - 2023-12-19
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -88,7 +88,7 @@ internal fun Uri.toMediaType(contentResolver: ContentResolver): MediaType {
 internal fun String.toBitmapCompressFormat(): Bitmap.CompressFormat = when {
   this.endsWith("png", ignoreCase = true) ||
     this.endsWith("gif", ignoreCase = true) ||
-    this.endsWith("bmp", ignoreCase = true) || 
+    this.endsWith("bmp", ignoreCase = true) ||
     this.endsWith("webp", ignoreCase = true) -> {
     // The result image won't ever be a GIF of a BMP as the cropper doesn't support it.
     Bitmap.CompressFormat.PNG

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -68,6 +68,7 @@ internal fun String.toImageFileExtension(): String = when {
   this.endsWith("png", ignoreCase = true) -> ".png"
   this.endsWith("gif", ignoreCase = true) -> ".gif"
   this.endsWith("bmp", ignoreCase = true) -> ".bmp"
+  this.endsWith("webp", ignoreCase = true) -> ".webp"
   !this.endsWith("jpeg", ignoreCase = true) -> {
     Log.w(TAG, "Image file $this is of unsupported type. Falling back to JPEG instead.")
     ".jpeg"
@@ -87,7 +88,8 @@ internal fun Uri.toMediaType(contentResolver: ContentResolver): MediaType {
 internal fun String.toBitmapCompressFormat(): Bitmap.CompressFormat = when {
   this.endsWith("png", ignoreCase = true) ||
     this.endsWith("gif", ignoreCase = true) ||
-    this.endsWith("bmp", ignoreCase = true) -> {
+    this.endsWith("bmp", ignoreCase = true) || 
+    this.endsWith("webp", ignoreCase = true) -> {
     // The result image won't ever be a GIF of a BMP as the cropper doesn't support it.
     Bitmap.CompressFormat.PNG
   }

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -381,6 +381,14 @@ private struct ImageUtils {
       let data = image.pngData()
       return (data, ".png")
 
+    case .some(let s) where s.contains("ext=WEBP"):
+      if options.allowsEditing {
+        // switch to png if editing
+        let data = image.pngData()
+        return (data, ".png")
+      }
+      return (nil, ".webp")
+
     case .some(let s) where s.contains("ext=BMP"):
       if options.allowsEditing {
         // switch to png if editing
@@ -429,6 +437,13 @@ private struct ImageUtils {
     case UTType.png.identifier:
       let data = image.pngData()
       return (data, ".png")
+    case UTType.webP.identifier:
+      if options.allowsEditing {
+        // switch to png if editing
+        let data = image.pngData()
+        return (data, ".png")
+      }
+      return (rawData, ".webp")
     case UTType.gif.identifier:
       let gifData = try processGifData(inputData: rawData,
                                        compressionQuality: options.quality,


### PR DESCRIPTION
# Why

JPEG format doesn't support alpha channel. 

# How

Convert WEBP to PNG instead JPEG when selecting an image in the Media Library with active allowEditing option.
Add webp to supported image file extensions list. Received file path ends with `.webp` instead `.jpeg` for WEBP image with options { quality: 1, allowEditing: false }. 

# Test Plan

- Manually test

