### PR TITLE
[docs] Fix minor verbiage issues in AuthSession and Print

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -9,10 +9,9 @@ import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -173,4 +173,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.

--- a/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
@@ -8,10 +8,9 @@ packageName: 'expo-auth-session'
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx), [Crypto](crypto.mdx), and [Random](random.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v46.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/print.mdx
@@ -171,4 +171,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.

--- a/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
@@ -9,10 +9,9 @@ import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx), [Crypto](crypto.mdx), and [Random](random.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v47.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/print.mdx
@@ -171,4 +171,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.

--- a/docs/pages/versions/v48.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/auth-session.mdx
@@ -9,10 +9,9 @@ import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v48.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/print.mdx
@@ -173,4 +173,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.

--- a/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
@@ -9,10 +9,9 @@ import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/print.mdx
@@ -173,4 +173,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.

--- a/docs/pages/versions/v50.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/auth-session.mdx
@@ -9,10 +9,9 @@ import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
-
 import { Terminal } from '~/ui/components/Snippet';
 
-`AuthSession` is the easiest way to add web browser based authentication (for example, browser-based OAuth flows) to your app, built on top of [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). If you would like to understand how it does this, read this document from top to bottom. If you just want to use it, jump to the [Authentication Guide](/guides/authentication).
+`AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/print.mdx
@@ -173,4 +173,4 @@ They are set by `@page` style block and you can override them in your HTML code:
 </style>
 ```
 
-See [@page docs on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.
+See [`@page` documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for more details.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix verbiage and formatting issues in Expo AuthSession intro section and Expo Print to follow our writing style guide and make text concise where necessary for clarity.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
