### PR TITLE
[docs] improvements and fixes for API Reference sections

### DIFF
--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -32,7 +32,6 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
             <Cell>
               {!!property.platform && (
                 <APISectionPlatformTags
-                  prefix="Only for:"
                   platforms={[
                     { content: [{ kind: 'text', text: property.platform }], tag: 'platform' },
                   ]}

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -342,7 +342,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -401,7 +401,7 @@ for more details.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -426,7 +426,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -485,7 +485,7 @@ for more details.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -510,7 +510,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -569,12 +569,12 @@ for more details.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Optional • 
           </span>
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -602,7 +602,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -661,7 +661,7 @@ for more details.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -670,8 +670,17 @@ for more details.
             class="css-ite7ne-TextComponent"
             data-text="true"
           >
-            (
-            ) =&gt; 
+            <span
+              class="text-quaternary"
+            >
+              (
+            </span>
+            <span
+              class="text-quaternary"
+            >
+              ) =&gt;
+            </span>
+             
             void
           </code>
         </p>
@@ -696,7 +705,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -755,12 +764,12 @@ in here.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Optional • 
           </span>
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -770,7 +779,11 @@ in here.
             data-text="true"
           >
             StyleProp
-            &lt;
+            <span
+              class="text-quaternary"
+            >
+              &lt;
+            </span>
             <span>
               <a
                 class="css-1na8e0o-A"
@@ -780,7 +793,11 @@ in here.
               >
                 Omit
               </a>
-              &lt;
+              <span
+                class="text-quaternary"
+              >
+                &lt;
+              </span>
               <span>
                 <a
                   class="css-1na8e0o-A"
@@ -790,20 +807,36 @@ in here.
                 >
                   ViewStyle
                 </a>
-                , 
+                <span
+                  class="text-quaternary"
+                >
+                  , 
+                </span>
               </span>
               <span>
                 <span>
                   'backgroundColor'
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   'borderRadius'
                 </span>
               </span>
+              <span
+                class="text-quaternary"
+              >
+                &gt;
+              </span>
+            </span>
+            <span
+              class="text-quaternary"
+            >
               &gt;
             </span>
-            &gt;
           </code>
         </p>
         <p
@@ -947,7 +980,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -1047,7 +1080,7 @@ properties.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -1169,7 +1202,7 @@ This should come from the user field of an
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -1180,7 +1213,11 @@ This should come from the user field of an
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -1189,7 +1226,11 @@ This should come from the user field of an
               AppleAuthenticationCredentialState
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -1215,7 +1256,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -1309,7 +1350,7 @@ value depending on the state of the credential.
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -1320,11 +1361,19 @@ value depending on the state of the credential.
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             boolean
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -1351,7 +1400,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -1451,7 +1500,7 @@ value depending on the state of the credential.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1530,7 +1579,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -1541,7 +1590,11 @@ Calling this method will show the sign in modal before actually refreshing the u
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -1550,7 +1603,11 @@ Calling this method will show the sign in modal before actually refreshing the u
               AppleAuthenticationCredential
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -1584,7 +1641,7 @@ refresh operation.
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -1681,7 +1738,7 @@ refresh operation.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -1690,7 +1747,7 @@ refresh operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1810,7 +1867,7 @@ the user, since this remains the same for apps released by the same developer.
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -1821,7 +1878,11 @@ the user, since this remains the same for apps released by the same developer.
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -1830,7 +1891,11 @@ the user, since this remains the same for apps released by the same developer.
               AppleAuthenticationCredential
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -1864,7 +1929,7 @@ sign-in operation.
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -1964,7 +2029,7 @@ sign-in operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -2077,7 +2142,7 @@ from using
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -2088,7 +2153,11 @@ from using
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -2097,7 +2166,11 @@ from using
               AppleAuthenticationCredential
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -2178,7 +2251,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -2278,10 +2351,14 @@ sign-out operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
-                () =&gt;
+                <span
+                  class="text-quaternary"
+                >
+                  () =&gt;
+                </span>
                  
                 void
               </code>
@@ -2290,7 +2367,7 @@ sign-out operation.
               class="css-zstkv9-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -2334,7 +2411,7 @@ sign-out operation.
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -2593,12 +2670,16 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -2640,12 +2721,16 @@ the app's server counterpart. Unlike
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -2689,7 +2774,7 @@ an Apple domain.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2699,7 +2784,11 @@ an Apple domain.
                   >
                     AppleAuthenticationFullName
                   </a>
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -2756,12 +2845,16 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -2795,7 +2888,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -2833,12 +2926,16 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -2896,7 +2993,7 @@ will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -3035,12 +3132,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3051,7 +3152,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3073,12 +3174,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3089,7 +3194,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3111,12 +3216,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3127,7 +3236,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3149,12 +3258,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3165,7 +3278,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3187,12 +3300,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3203,7 +3320,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3225,12 +3342,16 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <span>
                   string
-                   | 
+                  <span
+                    class="text-quaternary"
+                  >
+                     | 
+                  </span>
                 </span>
                 <span>
                   null
@@ -3241,7 +3362,7 @@ may be
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3421,7 +3542,7 @@ for more details.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -3430,7 +3551,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3491,7 +3612,7 @@ requests they will be
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -3500,7 +3621,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -3545,7 +3666,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -3555,7 +3676,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -3735,7 +3856,7 @@ for more details.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -3744,7 +3865,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -3784,7 +3905,7 @@ for more details.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -3793,7 +3914,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3854,7 +3975,7 @@ requests they will be
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -3863,7 +3984,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -4066,7 +4187,7 @@ for more details.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -4075,7 +4196,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -4120,7 +4241,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -4130,7 +4251,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -4241,10 +4362,14 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
-                () =&gt;
+                <span
+                  class="text-quaternary"
+                >
+                  () =&gt;
+                </span>
                  
                 void
               </code>
@@ -4450,7 +4575,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -4518,7 +4643,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -4586,7 +4711,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -4738,7 +4863,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -4806,7 +4931,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -4826,7 +4951,7 @@ OAuth 2.0 protocol
         data-text="true"
       >
         <span
-          class="!text-inherit css-1n5kx9e-TextComponent"
+          class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
           data-text="true"
         >
           Only for:
@@ -4913,7 +5038,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -5118,7 +5243,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5180,7 +5305,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5242,7 +5367,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5304,7 +5429,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5432,7 +5557,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -5500,7 +5625,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5562,7 +5687,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5624,7 +5749,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5867,7 +5992,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -5929,7 +6054,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6116,7 +6241,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -6184,7 +6309,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -6252,7 +6377,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -6451,7 +6576,11 @@ exports[`APISection expo-barcode-scanner 1`] = `
       >
         React.
         Component
-        &lt;
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
         <span>
           <a
             class="css-1na8e0o-A"
@@ -6460,7 +6589,11 @@ exports[`APISection expo-barcode-scanner 1`] = `
             BarCodeScannerProps
           </a>
         </span>
-        &gt;
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
       </code>
     </p>
     <h2
@@ -6514,7 +6647,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -6573,12 +6706,12 @@ exports[`APISection expo-barcode-scanner 1`] = `
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Optional • 
           </span>
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -6637,7 +6770,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -6696,12 +6829,12 @@ minimize battery usage.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Optional • 
           </span>
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -6798,7 +6931,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-11xr3cd"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
       >
         <h3
           class="  css-nikr5x-TextComponent"
@@ -6857,12 +6990,12 @@ data has been retrieved.
           data-text="true"
         >
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Optional • 
           </span>
           <span
-            class="css-1lk0cux"
+            class="text-secondary font-medium text-[90%]"
           >
             Type:
           </span>
@@ -6873,11 +7006,19 @@ data has been retrieved.
           >
             <span>
               'front'
-               | 
+              <span
+                class="text-quaternary"
+              >
+                 | 
+              </span>
             </span>
             <span>
               'back'
-               | 
+              <span
+                class="text-quaternary"
+              >
+                 | 
+              </span>
             </span>
             <span>
               number
@@ -6885,7 +7026,7 @@ data has been retrieved.
           </code>
           <span>
             <span
-              class="css-1lk0cux"
+              class="text-secondary font-medium text-[90%]"
             >
                • Default:
             </span>
@@ -7053,7 +7194,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -7150,7 +7291,7 @@ Same as
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -7159,7 +7300,7 @@ Same as
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -7168,18 +7309,26 @@ Same as
                 >
                   PermissionHookOptions
                 </a>
-                &lt;
+                <span
+                  class="text-quaternary"
+                >
+                  &lt;
+                </span>
                 <span>
                   object
                 </span>
-                &gt;
+                <span
+                  class="text-quaternary"
+                >
+                  &gt;
+                </span>
               </code>
             </td>
             <td
               class="css-zstkv9-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -7318,14 +7467,18 @@ This uses both
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           [
           <span>
             <span>
               null
-               | 
+              <span
+                class="text-quaternary"
+              >
+                 | 
+              </span>
             </span>
             <span>
               <a
@@ -7339,7 +7492,11 @@ This uses both
           </span>
           <span>
             RequestPermissionMethod
-            &lt;
+            <span
+              class="text-quaternary"
+            >
+              &lt;
+            </span>
             <span>
               <a
                 class="css-1na8e0o-A"
@@ -7348,12 +7505,20 @@ This uses both
                 PermissionResponse
               </a>
             </span>
-            &gt;
+            <span
+              class="text-quaternary"
+            >
+              &gt;
+            </span>
             , 
           </span>
           <span>
             GetPermissionMethod
-            &lt;
+            <span
+              class="text-quaternary"
+            >
+              &lt;
+            </span>
             <span>
               <a
                 class="css-1na8e0o-A"
@@ -7362,7 +7527,11 @@ This uses both
                 PermissionResponse
               </a>
             </span>
-            &gt;
+            <span
+              class="text-quaternary"
+            >
+              &gt;
+            </span>
           </span>
           ]
         </code>
@@ -7418,7 +7587,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -7512,7 +7681,7 @@ This uses both
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -7523,7 +7692,11 @@ This uses both
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -7532,7 +7705,11 @@ This uses both
               PermissionResponse
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -7557,7 +7734,7 @@ This uses both
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -7673,7 +7850,7 @@ This uses both
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -7684,7 +7861,11 @@ This uses both
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -7693,7 +7874,11 @@ This uses both
               PermissionResponse
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -7718,7 +7903,7 @@ This uses both
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -7818,7 +8003,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -7848,7 +8033,7 @@ This uses both
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -7857,7 +8042,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string[]
@@ -7967,7 +8152,7 @@ the platform.
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -7978,7 +8163,11 @@ the platform.
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -7988,7 +8177,11 @@ the platform.
               []
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -8057,7 +8250,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -8169,7 +8362,7 @@ code.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8204,7 +8397,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8242,7 +8435,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8275,7 +8468,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8450,7 +8643,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8488,7 +8681,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8631,7 +8824,7 @@ in order to enable/disable the permission.
               </strong>
               <br />
               <span
-                class="css-1g95u6x"
+                class="text-secondary pt-5 !text-[13px]"
               >
                 (optional)
               </span>
@@ -8640,7 +8833,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -8650,7 +8843,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -8761,7 +8954,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8776,7 +8969,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <span
-                class="text-tertiary"
+                class="text-quaternary"
               >
                 -
               </span>
@@ -8894,7 +9087,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -8934,7 +9127,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -9065,7 +9258,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-ite7ne-TextComponent"
+                  class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -9080,7 +9273,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-zstkv9-Cell"
               >
                 <span
-                  class="text-tertiary"
+                  class="text-quaternary"
                 >
                   -
                 </span>
@@ -9192,7 +9385,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9254,7 +9447,7 @@ For some types, they will represent the area used by the scanner.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9316,7 +9509,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -9349,7 +9542,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 string
@@ -9471,7 +9664,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -9504,7 +9697,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -9581,6 +9774,19 @@ you don't get this value.
       </a>
     </h3>
     <p
+      class="mb-3 css-1yjys1n-TextComponent"
+      data-text="true"
+    >
+      <span
+        class="css-oecriz-TextComponent"
+        data-text="true"
+      >
+        Literal Type:
+         
+      </span>
+      multiple types
+    </p>
+    <p
       class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
@@ -9593,7 +9799,9 @@ you don't get this value.
         >
           PermissionHookBehavior
         </code>
-        , 
+        <span>
+           
+        </span>
       </span>
       <span>
         <code
@@ -9602,7 +9810,6 @@ you don't get this value.
         >
           Options
         </code>
-        .
       </span>
     </p>
   </div>
@@ -9774,7 +9981,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -9842,7 +10049,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -9910,7 +10117,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
@@ -9976,7 +10183,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -10070,7 +10277,7 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -10081,7 +10288,11 @@ exports[`APISection expo-pedometer 1`] = `
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -10090,21 +10301,25 @@ exports[`APISection expo-pedometer 1`] = `
               PermissionResponse
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
     <br />
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <span
       class="flex items-center mb-2 css-1yjys1n-TextComponent"
       data-text="true"
     >
       <span
-        class="!text-inherit css-1n5kx9e-TextComponent"
+        class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
         data-text="true"
       >
         Only for:
@@ -10236,7 +10451,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10276,7 +10491,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10344,7 +10559,7 @@ exports[`APISection expo-pedometer 1`] = `
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -10355,7 +10570,11 @@ exports[`APISection expo-pedometer 1`] = `
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -10364,7 +10583,11 @@ exports[`APISection expo-pedometer 1`] = `
               PedometerResult
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -10450,7 +10673,7 @@ a start date that is more than seven days in the past returns only the available
     </blockquote>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -10544,7 +10767,7 @@ a start date that is more than seven days in the past returns only the available
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -10555,11 +10778,19 @@ a start date that is more than seven days in the past returns only the available
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             boolean
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
@@ -10580,7 +10811,7 @@ available on this device.
     </p>
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -10674,7 +10905,7 @@ available on this device.
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -10685,7 +10916,11 @@ available on this device.
           >
             Promise
           </a>
-          &lt;
+          <span
+            class="text-quaternary"
+          >
+            &lt;
+          </span>
           <span>
             <a
               class="css-1na8e0o-A"
@@ -10694,14 +10929,18 @@ available on this device.
               PermissionResponse
             </a>
           </span>
-          &gt;
+          <span
+            class="text-quaternary"
+          >
+            &gt;
+          </span>
         </code>
       </li>
     </ul>
     <br />
   </div>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -10801,7 +11040,7 @@ available on this device.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10880,7 +11119,7 @@ provided with a single argument that is
           </g>
         </svg>
         <code
-          class="css-ite7ne-TextComponent"
+          class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           <a
@@ -10968,7 +11207,7 @@ provided with a single argument that is
     </a>
   </h2>
   <div
-    class="css-11xr3cd"
+    class="css-uj1dnj"
   >
     <h3
       class="  css-nikr5x-TextComponent"
@@ -11080,7 +11319,7 @@ provided with a single argument that is
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11115,7 +11354,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11153,7 +11392,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11186,7 +11425,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11361,7 +11600,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
                 number
@@ -11491,7 +11730,7 @@ in order to enable/disable the permission.
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-ite7ne-TextComponent"
+                  class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -11506,7 +11745,7 @@ in order to enable/disable the permission.
                 class="css-zstkv9-Cell"
               >
                 <span
-                  class="text-tertiary"
+                  class="text-quaternary"
                 >
                   -
                 </span>
@@ -11573,6 +11812,19 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
+      class="mb-3 css-1yjys1n-TextComponent"
+      data-text="true"
+    >
+      <span
+        class="css-oecriz-TextComponent"
+        data-text="true"
+      >
+        Literal Type:
+         
+      </span>
+      multiple types
+    </p>
+    <p
       class="mb-4 css-1kfqm4n-TextComponent"
       data-text="true"
     >
@@ -11591,7 +11843,9 @@ in order to enable/disable the permission.
         >
           'never'
         </code>
-        , 
+        <span>
+           
+        </span>
       </span>
       <span>
         <code
@@ -11600,7 +11854,6 @@ in order to enable/disable the permission.
         >
           number
         </code>
-        .
       </span>
     </p>
   </div>
@@ -11705,10 +11958,14 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-ite7ne-TextComponent"
+                class="[&>span]:!text-inherit css-ite7ne-TextComponent"
                 data-text="true"
               >
-                () =&gt;
+                <span
+                  class="text-quaternary"
+                >
+                  () =&gt;
+                </span>
                  
                 void
               </code>
@@ -11896,7 +12153,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -11964,7 +12221,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -12032,7 +12289,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="mb-4 css-fmaglm-TextComponent"
+        class="mb-3 css-fmaglm-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"

--- a/docs/components/plugins/api/APIDataType.tsx
+++ b/docs/components/plugins/api/APIDataType.tsx
@@ -27,6 +27,8 @@ export const APIDataType = ({ typeDefinition, inline = true }: APIDataTypeProps)
       {resolveTypeName(typeDefinition)}
     </CodeBlock>
   ) : (
-    <CODE key={typeDefinition.name}>{resolveTypeName(typeDefinition)}</CODE>
+    <CODE key={typeDefinition.name} className="[&>span]:!text-inherit">
+      {resolveTypeName(typeDefinition)}
+    </CODE>
   );
 };

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -23,7 +23,7 @@ import {
   BoxSectionHeader,
   DEFAULT_BASE_NESTING_LEVEL,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, BOLD, P, CODE, MONOSPACE } from '~/ui/components/Text';
+import { H2, P, CODE, MONOSPACE, DEMI } from '~/ui/components/Text';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
@@ -87,13 +87,13 @@ const renderClass = (
   return (
     <div key={`class-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
       <APISectionDeprecationNote comment={comment} />
-      <APISectionPlatformTags comment={comment} prefix="Only for:" />
+      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
       {(extendedTypes?.length || implementedTypes?.length) && (
         <P className="mb-3">
-          <BOLD>Type: </BOLD>
+          <DEMI theme="secondary">Type: </DEMI>
           {type ? <CODE>{resolveTypeName(type)}</CODE> : 'Class'}
           {extendedTypes?.length && (
             <>

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -1,3 +1,5 @@
+import { ELEMENT_SPACING } from './styles';
+
 import {
   CommentData,
   GeneratedData,
@@ -13,7 +15,6 @@ import {
   STYLES_APIBOX,
   getTagNamesList,
   H3Code,
-  ELEMENT_SPACING,
 } from '~/components/plugins/api/APISectionUtils';
 import { H2, DEMI, P, CODE, MONOSPACE } from '~/ui/components/Text';
 

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -8,7 +8,7 @@ import {
   STYLES_APIBOX,
   H3Code,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, BOLD, P, MONOSPACE } from '~/ui/components/Text';
+import { H2, DEMI, P, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
@@ -21,7 +21,7 @@ const renderConstant = (
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} css={STYLES_APIBOX} className="[&>*:last-child]:!mb-0">
     <APISectionDeprecationNote comment={comment} />
-    <APISectionPlatformTags comment={comment} prefix="Only for:" />
+    <APISectionPlatformTags comment={comment} />
     <H3Code tags={getTagNamesList(comment)}>
       <MONOSPACE weight="medium">
         {apiName ? `${apiName}.` : ''}
@@ -30,7 +30,7 @@ const renderConstant = (
     </H3Code>
     {type && (
       <P>
-        <BOLD>Type:</BOLD> <APIDataType typeDefinition={type} />
+        <DEMI theme="secondary">Type:</DEMI> <APIDataType typeDefinition={type} />
       </P>
     )}
     {comment && (

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -32,7 +32,7 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
   <div key={`enum-definition-${name}`} css={STYLES_APIBOX} className="!p-0">
     <div className="px-5 pt-4">
       <APISectionDeprecationNote comment={comment} />
-      <APISectionPlatformTags comment={comment} prefix="Only for:" />
+      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
@@ -42,11 +42,11 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
     {children.sort(sortByValue).map((enumValue: EnumValueData) => (
       <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
         <APISectionDeprecationNote comment={enumValue.comment} />
-        <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={enumValue.comment} />
         <H4 className="!mt-0">
           <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
         </H4>
-        <CODE theme="secondary" className="mb-4">
+        <CODE theme="secondary" className="mb-3">
           {`${name}.${enumValue.name} ＝ ${renderEnumValue(
             enumValue.type.value,
             enumValue.type.name

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -1,4 +1,5 @@
 import { renderMethod } from './APISectionMethods';
+import { ELEMENT_SPACING } from './styles';
 
 import { APIDataType } from '~/components/plugins/api/APIDataType';
 import {
@@ -21,13 +22,12 @@ import {
   STYLES_APIBOX,
   getTagNamesList,
   STYLES_APIBOX_NESTED,
-  ELEMENT_SPACING,
   H3Code,
   getCommentContent,
   BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, P, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
+import { H2, BOLD, CALLOUT, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
@@ -120,17 +120,19 @@ const renderInterface = ({
   return (
     <div key={`interface-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
       <APISectionDeprecationNote comment={comment} />
-      <APISectionPlatformTags comment={comment} prefix="Only for:" />
+      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
       {extendedTypes?.length ? (
-        <P className={ELEMENT_SPACING}>
-          <DEMI>Extends: </DEMI>
+        <CALLOUT className={ELEMENT_SPACING}>
+          <CALLOUT tag="span" theme="secondary" weight="semiBold">
+            Extends:{' '}
+          </CALLOUT>
           {extendedTypes.map(extendedType => (
             <CODE key={`extend-${extendedType.name}`}>{resolveTypeName(extendedType)}</CODE>
           ))}
-        </P>
+        </CALLOUT>
       ) : null}
       <CommentTextBlock comment={comment} includePlatforms={false} />
       {interfaceMethods.length ? (

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -61,7 +61,7 @@ export const renderMethod = (
           key={`method-signature-${method.name || name}-${parameters?.length || 0}`}
           css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
           <APISectionDeprecationNote comment={comment} />
-          <APISectionPlatformTags comment={comment} prefix="Only for:" />
+          <APISectionPlatformTags comment={comment} />
           <HeaderComponent tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}>
               {getMethodName(method as MethodDefinitionData, apiName, name, parameters)}

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -10,7 +10,7 @@ type Props = {
   platforms?: CommentTagData[];
 };
 
-export const APISectionPlatformTags = ({ comment, prefix, platforms }: Props) => {
+export const APISectionPlatformTags = ({ comment, platforms, prefix = 'Only for:' }: Props) => {
   const platformsData = platforms || getAllTagData('platform', comment);
   const platformNames = platformsData?.map(platformData => getCommentContent(platformData.content));
 

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -1,5 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { ELEMENT_SPACING, STYLES_SECONDARY } from './styles';
+
 import {
   DefaultPropsDefinitionData,
   PropData,
@@ -10,7 +12,6 @@ import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDe
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
-  ELEMENT_SPACING,
   getCommentContent,
   getCommentOrSignatureComment,
   getH3CodeWithBaseNestingLevel,
@@ -22,7 +23,6 @@ import {
   STYLES_APIBOX_NESTED,
   STYLES_NESTED_SECTION_HEADER,
   STYLES_NOT_EXPOSED_HEADER,
-  STYLES_SECONDARY,
   TypeDocKind,
 } from '~/components/plugins/api/APISectionUtils';
 import { CODE, H2, H3, H4, LI, MONOSPACE, P, UL } from '~/ui/components/Text';
@@ -128,25 +128,24 @@ export const renderProp = (
       css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}
       className="!pb-4 [&>*:last-child]:!mb-0">
       <APISectionDeprecationNote comment={extractedComment} />
-      <APISectionPlatformTags comment={comment} prefix="Only for:" />
+      <APISectionPlatformTags comment={comment} />
       <HeaderComponent tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}>
           {name}
         </MONOSPACE>
       </HeaderComponent>
       <P className={mergeClasses(extractedComment && ELEMENT_SPACING)}>
-        {flags?.isOptional && <span css={STYLES_SECONDARY}>Optional&emsp;&bull;&emsp;</span>}
-        <span css={STYLES_SECONDARY}>Type:</span>{' '}
+        {flags?.isOptional && <span className={STYLES_SECONDARY}>Optional&emsp;&bull;&emsp;</span>}
+        <span className={STYLES_SECONDARY}>Type:</span>{' '}
         {renderTypeOrSignatureType(type, extractedSignatures)}
         {defaultValue && defaultValue !== UNKNOWN_VALUE ? (
           <span>
-            <span css={STYLES_SECONDARY}>&emsp;&bull;&emsp;Default:</span>{' '}
+            <span className={STYLES_SECONDARY}>&emsp;&bull;&emsp;Default:</span>{' '}
             <CODE>{defaultValue}</CODE>
           </span>
         ) : null}
       </P>
       <CommentTextBlock comment={extractedComment} includePlatforms={false} />
-      {/*{!extractedComment && <br />}*/}
     </div>
   );
 };

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -28,7 +28,7 @@ import {
   getCommentContent,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, P, CODE, MONOSPACE } from '~/ui/components/Text';
+import { H2, BOLD, DEMI, P, CODE, MONOSPACE, CALLOUT } from '~/ui/components/Text';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
@@ -39,12 +39,7 @@ const defineLiteralType = (types: TypeDefinitionData[]): JSX.Element | null => {
     new Set(types.map((t: TypeDefinitionData) => t.value && typeof t.value))
   );
   if (uniqueTypes.length === 1 && uniqueTypes.filter(Boolean).length === 1) {
-    return (
-      <>
-        <CODE>{uniqueTypes[0]}</CODE>
-        {' - '}
-      </>
-    );
+    return <CODE>{uniqueTypes[0]}</CODE>;
   }
   return null;
 };
@@ -113,7 +108,7 @@ const renderType = ({
     return (
       <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium">
             {name}
@@ -141,7 +136,7 @@ const renderType = ({
       return (
         <div key={`prop-type-definition-${name}`} css={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} />
-          <APISectionPlatformTags comment={comment} prefix="Only for:" />
+          <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium">{name}</MONOSPACE>
           </H3Code>
@@ -168,21 +163,27 @@ const renderType = ({
         </div>
       );
     } else if (literalTypes.length) {
+      const acceptedLiteralTypes = defineLiteralType(literalTypes);
       return (
         <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} />
-          <APISectionPlatformTags comment={comment} prefix="Only for:" />
+          <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium">{name}</MONOSPACE>
           </H3Code>
+          <CALLOUT className="mb-3">
+            <CALLOUT tag="span" theme="secondary" weight="semiBold">
+              Literal Type:{' '}
+            </CALLOUT>
+            {acceptedLiteralTypes ?? 'multiple types'}
+          </CALLOUT>
           <CommentTextBlock comment={comment} includePlatforms={false} />
           <P>
-            {defineLiteralType(literalTypes)}
             Acceptable values are:{' '}
             {literalTypes.map((lt, index) => (
               <span key={`${name}-literal-type-${index}`}>
                 <CODE>{resolveTypeName(lt)}</CODE>
-                {index + 1 !== literalTypes.length ? ', ' : '.'}
+                {index + 1 !== literalTypes.length ? <span>&ensp;</span> : ''}
               </span>
             ))}
           </P>
@@ -196,12 +197,12 @@ const renderType = ({
     return (
       <div key={`record-definition-${name}`} css={STYLES_APIBOX} className="[&>*:last-child]:!mb-0">
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
         <P className="mb-3">
-          <BOLD theme="secondary">Type: </BOLD>
+          <DEMI theme="secondary">Type: </DEMI>
           <APIDataType typeDefinition={type} />
         </P>
         <CommentTextBlock comment={comment} includePlatforms={false} />
@@ -211,13 +212,13 @@ const renderType = ({
     return (
       <div key={`generic-type-definition-${name}`} css={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
         <P>
-          <BOLD theme="secondary">Type: </BOLD>
+          <DEMI theme="secondary">Type: </DEMI>
           <CODE>{type.name}</CODE>
         </P>
       </div>
@@ -226,7 +227,7 @@ const renderType = ({
     return (
       <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium">
             {name}&lt;{type.checkType.name}&gt;
@@ -234,14 +235,14 @@ const renderType = ({
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
         <P>
-          <BOLD theme="secondary">Generic: </BOLD>
+          <DEMI theme="secondary">Generic: </DEMI>
           <CODE>
             {type.checkType.name}
             {typeParameter && <> extends {resolveTypeName(typeParameter[0].type)}</>}
           </CODE>
         </P>
         <P>
-          <BOLD theme="secondary">Type: </BOLD>
+          <DEMI theme="secondary">Type: </DEMI>
           <CODE>
             {type.checkType.name}
             {typeParameter && <> extends {type.extendsType && resolveTypeName(type.extendsType)}</>}
@@ -265,7 +266,7 @@ const renderType = ({
     return (
       <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} />
-        <APISectionPlatformTags comment={comment} prefix="Only for:" />
+        <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     data-text="true"
   >
     <span
-      class="!text-inherit css-1n5kx9e-TextComponent"
+      class="!text-inherit !font-medium css-1ibdfwu-TextComponent"
       data-text="true"
     >
       Only for:
@@ -145,11 +145,19 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
   >
     Promise
   </a>
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     void
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
@@ -163,7 +171,11 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
   >
     Promise
   </a>
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     <a
       class="css-1na8e0o-A"
@@ -172,47 +184,83 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
       AppleAuthenticationCredential
     </a>
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName Record 1`] = `
 <div>
   Record
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     string
-    , 
+    <span
+      class="text-quaternary"
+    >
+      , 
+    </span>
   </span>
   <span>
     any
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName Record with union 1`] = `
 <div>
   Record
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     string
-    , 
+    <span
+      class="text-quaternary"
+    >
+      , 
+    </span>
   </span>
   <span>
     <span>
       number
-       | 
+      <span
+        class="text-quaternary"
+      >
+         | 
+      </span>
     </span>
     <span>
       boolean
-       | 
+      <span
+        class="text-quaternary"
+      >
+         | 
+      </span>
     </span>
     <span>
       string
     </span>
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
@@ -261,7 +309,11 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
   >
     Pick
   </a>
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     <a
       class="css-1na8e0o-A"
@@ -269,22 +321,38 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
     >
       FontResource
     </a>
-    , 
+    <span
+      class="text-quaternary"
+    >
+      , 
+    </span>
   </span>
   <span>
     'display'
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName function 1`] = `
 <div>
-  () =&gt;
+  <span
+    class="text-quaternary"
+  >
+    () =&gt;
+  </span>
    
   <span>
     void
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     <a
@@ -299,10 +367,19 @@ exports[`APISectionUtils.resolveTypeName function 1`] = `
 
 exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
 <div>
-  (
+  <span
+    class="text-quaternary"
+  >
+    (
+  </span>
   <span>
     error
-    : 
+    <span
+      class="text-quaternary"
+    >
+      :
+    </span>
+     
     <a
       class="css-1na8e0o-A"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
@@ -312,12 +389,25 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
       Error
     </a>
   </span>
-  ) 
-  =&gt;
+  <span
+    class="text-quaternary"
+  >
+    )
+  </span>
+   
+  <span
+    class="text-quaternary"
+  >
+    =&gt;
+  </span>
    
   <span>
     void
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     <a
@@ -332,10 +422,19 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
 
 exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 1`] = `
 <div>
-  (
+  <span
+    class="text-quaternary"
+  >
+    (
+  </span>
   <span>
     error
-    : 
+    <span
+      class="text-quaternary"
+    >
+      :
+    </span>
+     
     <a
       class="css-1na8e0o-A"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
@@ -345,8 +444,17 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
       Error
     </a>
   </span>
-  ) 
-  =&gt;
+  <span
+    class="text-quaternary"
+  >
+    )
+  </span>
+   
+  <span
+    class="text-quaternary"
+  >
+    =&gt;
+  </span>
    
   void
 </div>
@@ -366,7 +474,11 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
   >
     PagedInfo
   </a>
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     <a
       class="css-1na8e0o-A"
@@ -375,7 +487,11 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
       Asset
     </a>
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
@@ -389,7 +505,11 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
   >
     Promise
   </a>
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     <a
       class="css-1na8e0o-A"
@@ -397,7 +517,11 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
     >
       PagedInfo
     </a>
-    &lt;
+    <span
+      class="text-quaternary"
+    >
+      &lt;
+    </span>
     <span>
       <a
         class="css-1na8e0o-A"
@@ -406,16 +530,28 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
         Asset
       </a>
     </span>
+    <span
+      class="text-quaternary"
+    >
+      &gt;
+    </span>
+  </span>
+  <span
+    class="text-quaternary"
+  >
     &gt;
   </span>
-  &gt;
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName object reflection 1`] = `
 <div>
-  {
+  <span
+    class="text-quaternary"
+  >
+    {
 
+  </span>
   <span>
       
     target: 
@@ -431,14 +567,22 @@ exports[`APISectionUtils.resolveTypeName object reflection 1`] = `
     
 
   </span>
-  }
+  <span
+    class="text-quaternary"
+  >
+    }
+  </span>
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
 <div>
   StyleProp
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     <a
       class="css-1na8e0o-A"
@@ -448,7 +592,11 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     >
       Omit
     </a>
-    &lt;
+    <span
+      class="text-quaternary"
+    >
+      &lt;
+    </span>
     <span>
       <a
         class="css-1na8e0o-A"
@@ -458,31 +606,55 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
       >
         ViewStyle
       </a>
-      , 
+      <span
+        class="text-quaternary"
+      >
+        , 
+      </span>
     </span>
     <span>
       <span>
         'backgroundColor'
-         | 
+        <span
+          class="text-quaternary"
+        >
+           | 
+        </span>
       </span>
       <span>
         'borderRadius'
       </span>
     </span>
+    <span
+      class="text-quaternary"
+    >
+      &gt;
+    </span>
+  </span>
+  <span
+    class="text-quaternary"
+  >
     &gt;
   </span>
-  &gt;
 </div>
 `;
 
 exports[`APISectionUtils.resolveTypeName query type 1`] = `
 <div>
   React.ComponentProps
-  &lt;
+  <span
+    class="text-quaternary"
+  >
+    &lt;
+  </span>
   <span>
     View
   </span>
-  &gt;
+  <span
+    class="text-quaternary"
+  >
+    &gt;
+  </span>
 </div>
 `;
 
@@ -514,7 +686,11 @@ exports[`APISectionUtils.resolveTypeName union 1`] = `
     >
       SpeechEventCallback
     </a>
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     null
@@ -532,7 +708,11 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
     >
       ResultSetError
     </a>
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     <a
@@ -551,7 +731,11 @@ exports[`APISectionUtils.resolveTypeName union with array 1`] = `
 <div>
   <span>
     number[]
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     null
@@ -569,7 +753,11 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
       AssetRef
       []
     </a>
-     | 
+    <span
+      class="text-quaternary"
+    >
+       | 
+    </span>
   </span>
   <span>
     <a

--- a/docs/components/plugins/api/styles.ts
+++ b/docs/components/plugins/api/styles.ts
@@ -1,0 +1,7 @@
+import { mergeClasses } from '@expo/styleguide';
+
+export const ELEMENT_SPACING = mergeClasses('mb-4');
+
+export const STYLES_SECONDARY = mergeClasses('text-secondary font-medium text-[90%]');
+
+export const STYLES_OPTIONAL = mergeClasses('text-secondary pt-5 !text-[13px]');

--- a/docs/ui/components/Tag/PlatformTags.tsx
+++ b/docs/ui/components/Tag/PlatformTags.tsx
@@ -9,13 +9,19 @@ type PlatformTagsProps = {
 };
 
 export const PlatformTags = ({ prefix, platforms }: PlatformTagsProps) => {
-  return platforms?.length ? (
+  if (!platforms?.length) return null;
+
+  return (
     <CALLOUT tag="span" className="flex items-center mb-2">
-      {prefix && <DEMI className="!text-inherit">{prefix}&ensp;</DEMI>}
-      {platforms.map(platform => {
-        return <PlatformTag key={platform} platform={platform} />;
-      })}
+      {prefix && (
+        <DEMI theme="secondary" className="!text-inherit !font-medium">
+          {prefix}&ensp;
+        </DEMI>
+      )}
+      {platforms.map(platform => (
+        <PlatformTag key={platform} platform={platform} />
+      ))}
       {prefix && <br />}
     </CALLOUT>
-  ) : null;
+  );
 };


### PR DESCRIPTION
# Why

Fixes for small issues I have spot on lately on API Reference pages, small improvements for literal types.

# How

The following changes have been made:
* make sure that code tags and their content are sized correctly
* de-emphasize non important characters, when rendering type
* add fallback to literal types resolution, to always display a type information
* tweak API sections layout and spacing here and there

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-01-15 at 13 46 23](https://github.com/expo/expo/assets/719641/4d91e2ae-7215-4ec9-9236-2ab5a3150bcb)
![Screenshot 2024-01-15 at 13 47 53](https://github.com/expo/expo/assets/719641/cf51eb62-546b-4ad7-a302-965031475fc4)
![Screenshot 2024-01-15 at 13 49 18](https://github.com/expo/expo/assets/719641/f712c044-9fa2-4fb2-8ce0-af24cf7f8724)

