### PR TITLE
[go][Android] Recreate root view each time the menu is opened

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -296,12 +296,10 @@ class DevMenuManager {
       throw Exception("Kernel's React instance manager is not initialized yet.")
     }
 
-    if (reactRootView == null) {
-      reactRootView = ReactUnthemedRootView(kernel.activityContext)
-      reactRootView?.startReactApplication(kernel.reactInstanceManager, DEV_MENU_JS_MODULE_NAME, initialProps)
-    } else {
-      reactRootView?.appProperties = initialProps
-    }
+    reactRootView?.unmountReactApplication()
+
+    reactRootView = ReactUnthemedRootView(kernel.activityContext)
+    reactRootView?.startReactApplication(kernel.reactInstanceManager, DEV_MENU_JS_MODULE_NAME, initialProps)
 
     val rootView = reactRootView!!
 


### PR DESCRIPTION
# Why

Closes [ENG-11073](https://linear.app/expo/issue/ENG-11073)

# How

We are reusing the root view component, which causes the UI to jump between open, close, and open states (the menu isn’t closed during the first frame). To resolve this, we can create a fresh root view each time.

That approach may not be the best one. We'll optimize it later, but for now, let's get rid of the annoying flash.

# Test Plan

- Expo Go with empty app ✅ 