### PR TITLE
[home] Adjust bottom sheet animation

### DIFF
--- a/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
+++ b/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
@@ -1,7 +1,9 @@
 import BottomSheet, {
   BottomSheetBackdrop,
+  BottomSheetBackdropProps,
   BottomSheetView,
   useBottomSheetDynamicSnapPoints,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -67,17 +69,31 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
     };
   }, []);
 
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop {...props} opacity={0.5} appearsOnIndex={0} disappearsOnIndex={-1} />
+    ),
+    []
+  );
+
   const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
     useBottomSheetDynamicSnapPoints(initialSnapPoints);
+
+  const animationConfigs = useBottomSheetSpringConfigs({
+    damping: 80,
+    overshootClamping: true,
+    restDisplacementThreshold: 0.1,
+    restSpeedThreshold: 0.1,
+    stiffness: 250,
+  });
 
   return (
     <BottomSheet
       key={uuid}
       ref={bottomSheetRef}
-      backdropComponent={(props) => (
-        <BottomSheetBackdrop {...props} opacity={0.5} appearsOnIndex={0} disappearsOnIndex={-1} />
-      )}
+      backdropComponent={renderBackdrop}
       handleComponent={null}
+      animationConfigs={animationConfigs}
       // TODO: (gabrieldonadel) remove type assertion after upgrading @gorhom/bottom-sheet
       snapPoints={animatedSnapPoints as (string | number)[] | SharedValue<(string | number)[]>}
       handleHeight={animatedHandleHeight}


### PR DESCRIPTION
# Why

Closes [ENG-11073](https://linear.app/expo/issue/ENG-11073)

# How

There is a bug in the Gorhom bottom sheet that causes the backdrop component to flash. It was reported a while ago, but it doesn’t seem to be resolved. Here are related issues: https://github.com/gorhom/react-native-bottom-sheet/issues/208 and https://github.com/gorhom/react-native-bottom-sheet/issues/908.

I've adjusted the animation to mask the disappearing backdrop component. 

# Test Plan

- Expo Go with empty app ✅

https://github.com/expo/expo/assets/9578601/c3fe72b8-6e80-44a3-8855-847fb0cf1ddd


