### PR TITLE
[andorid][av] Add events to module definition

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Improve precision for syncing two videos and updating new video position when user sets tolerances to 0 ([#26018](https://github.com/expo/expo/pull/26018) by [@jpudysz](https://github.com/jpudysz))
+- [Android] Add `Events` `to AVModule` to prevent event emitter warning.
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Improve precision for syncing two videos and updating new video position when user sets tolerances to 0 ([#26018](https://github.com/expo/expo/pull/26018) by [@jpudysz](https://github.com/jpudysz))
-- [Android] Add `Events` `to AVModule` to prevent event emitter warning.
+- [Android] Add `Events` `to AVModule` to prevent event emitter warning. ([#26434](https://github.com/expo/expo/pull/26434) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
@@ -20,6 +20,12 @@ class AVModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExponentAV")
 
+    Events(
+      "didUpdatePlaybackStatus",
+      "ExponentAV.onError",
+      "Expo.Recording.recorderUnloaded"
+    )
+
     AsyncFunction("setAudioIsEnabled") { value: Boolean ->
       avManager.setAudioIsEnabled(value)
     }


### PR DESCRIPTION
# Why
Closes #26401
Events were not added to the module definition resulting in a warning.

# How
Added the event names

# Test Plan
test-suite. Warnings are removed