### PR TITLE
[docs] Remove expo-linking from expo-store-review docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -22,9 +22,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-> `expo-linking` is a peer dependency and must be installed alongside `expo-store-review`.
-
-<APIInstallSection packageName="expo-store-review expo-linking" />
+<APIInstallSection packageName="expo-store-review" />
 
 ## Usage
 

--- a/docs/pages/versions/v50.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/storereview.mdx
@@ -22,9 +22,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-> `expo-linking` is a peer dependency and must be installed alongside `expo-store-review`.
-
-<APIInstallSection packageName="expo-store-review expo-linking" />
+<APIInstallSection packageName="expo-store-review" />
 
 ## Usage
 


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/26428

 `expo-store-review` no longer requires `expo-linking` as a peer dependency  

# How

Remove `expo-linking` references from `expo-store-review` docs

# Test Plan

Run docs locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
