### PR TITLE
[launcher][Android] Fix HMR not working

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed HMR not working on Android.
+
 ### 💡 Others
 
 - Remove classic updates. ([#26036](https://github.com/expo/expo/pull/26036), [#26230](https://github.com/expo/expo/pull/26230) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed HMR not working on Android.
+- Fixed HMR not working on Android. ([#26441](https://github.com/expo/expo/pull/26441) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/26254.

# How

`HMR` was broken because the client registered a bundle without the proper `transform.engine=hermes&transform.appRoot=app` settings
- The error thrown also triggers an instant HMR client disconnect, without proper logs or error  handling 

I've fixed both the source URL and the source map URL.

# Test Plan

- [smashboy/expo-sdk-50-escape-char-bug](https://github.com/smashboy/expo-sdk-50-escape-char-bug) ✅
