### PR TITLE
[expo-updates][e2e] Re-add static file consumption artificial delay in tests

### DIFF
--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -185,6 +185,8 @@ describe('Basic tests', () => {
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1);
 
     // restart the app so it will launch the new update
@@ -229,6 +231,8 @@ describe('Basic tests', () => {
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1);
 
     // restart the app to verify the new update isn't used
@@ -284,7 +288,10 @@ describe('Basic tests', () => {
     await device.launchApp({
       newInstance: true,
     });
+
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     await waitForAppToBecomeVisible();
     const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
@@ -366,6 +373,8 @@ describe('Basic tests', () => {
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(4);
 
     // restart the app so it will launch the new update
@@ -406,6 +415,8 @@ describe('Basic tests', () => {
     jestExpect(firstMessage).toBe('test');
 
     // give the app time to load the new update in the background (i.e. to make sure it doesn't)
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(0);
 
     // restart the app and make sure it's still running the initial update
@@ -445,6 +456,8 @@ describe('Basic tests', () => {
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1);
 
     // restart the app so it will launch the new update
@@ -1025,6 +1038,8 @@ describe('Asset deletion recovery tests', () => {
     await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
 
     // give the app time to load the new update in the background
+    await setTimeout(5000);
+
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
 
     // Stop and restart the app so it will launch the new update. Immediately send it a message to


### PR DESCRIPTION
# Why

This test was failing sporadically in CI. It seemed to be failing on all the same steps though.

Some failing builds in CI:
https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/1f97e255-e552-4759-ade2-e9c3a375dd4f
https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/8a7f0546-8210-467a-8a51-144b1efcd52b
https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/31a8e020-c10d-4c54-ba47-25b7f32f23f3
https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/0e85cea1-acbf-42bb-a957-1009dc66c40d

# How

Notice that there's a comment indicating that a wait should occur. Looking back at the blame, it seems we used to wait but removed it since it seemed fine without it (removed in consolidation https://github.com/expo/expo/pull/21458). It passes locally without it though so it's reasonable that we figured it could be removed.

This PR adds back in the wait to see if it fixes it.

# Test Plan

Commit, see if it improves failing test on main.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
