### PR TITLE
[cli] remove versions from manual install command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
 - Added `templateChecksum` for prebuild to check the current template version. ([#26414](https://github.com/expo/expo/pull/26414) by [@kudo](https://github.com/kudo))
+- Clean up manual package install command
 
 ## 0.16.8 - 2024-01-15
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
 - Added `templateChecksum` for prebuild to check the current template version. ([#26414](https://github.com/expo/expo/pull/26414) by [@kudo](https://github.com/kudo))
-- Clean up manual package install command
+- Clean up manual package install command ([#26457](https://github.com/expo/expo/pull/26457) by [@marklawlor](https://github.com/marklawlor))
 
 ## 0.16.8 - 2024-01-15
 

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@expo/config';
+import { getConfig, getPackageJson } from '@expo/config';
 import * as PackageManager from '@expo/package-manager';
 import chalk from 'chalk';
 
@@ -113,11 +113,7 @@ export async function installPackagesAsync(
   }
 ): Promise<void> {
   // Read the project Expo config without plugins.
-  const { pkg } = getConfig(projectRoot, {
-    // Sometimes users will add a plugin to the config before installing the library,
-    // this wouldn't work unless we dangerously disable plugin serialization.
-    skipPlugins: true,
-  });
+  const pkg = getPackageJson(projectRoot);
 
   //assertNotInstallingExcludedPackages(projectRoot, packages, pkg);
 

--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/ensureDependenciesAsync-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/ensureDependenciesAsync-test.ts
@@ -160,6 +160,6 @@ describe(createInstallCommand, () => {
           { pkg: 'other', file: '' },
         ],
       })
-    ).toBe('npx expo install bacon@~1.0.0 other');
+    ).toBe('npx expo install bacon other');
   });
 });

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -83,9 +83,7 @@ export async function ensureDependenciesAsync(
     title = '';
   }
 
-  const installCommand = createInstallCommand({
-    packages: missing,
-  });
+  const installCommand = 'npx expo install ' + missing.map(({ pkg }) => pkg).join(', ');
 
   const disableMessage = warningMessage;
 
@@ -100,29 +98,6 @@ export async function ensureDependenciesAsync(
 /**  Wrap long messages to fit smaller terminals. */
 function wrapForTerminal(message: string): string {
   return wrapAnsi(message, process.stdout.columns || 80);
-}
-
-/** Create the bash install command from a given set of packages and settings. */
-export function createInstallCommand({
-  packages,
-}: {
-  packages: {
-    file: string;
-    pkg: string;
-    version?: string | undefined;
-  }[];
-}) {
-  return (
-    'npx expo install ' +
-    packages
-      .map(({ pkg, version }) => {
-        if (version) {
-          return [pkg, version].join('@');
-        }
-        return pkg;
-      })
-      .join(' ')
-  );
 }
 
 /** Install packages in the project. */

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -100,6 +100,19 @@ function wrapForTerminal(message: string): string {
   return wrapAnsi(message, process.stdout.columns || 80);
 }
 
+/** Create the bash install command from a given set of packages and settings. */
+export function createInstallCommand({
+  packages,
+}: {
+  packages: {
+    file: string;
+    pkg: string;
+    version?: string | undefined;
+  }[];
+}) {
+  return 'npx expo install ' + packages.map(({ pkg }) => pkg).join(' ');
+}
+
 /** Install packages in the project. */
 async function installPackagesAsync(projectRoot: string, { packages }: { packages: string[] }) {
   const packagesStr = chalk.bold(packages.join(', '));


### PR DESCRIPTION
# Why

**Previous**
```
CommandError: It looks like you're trying to use web support but don't have the required dependencies installed.

Please install react-native-web@~0.19.6, react-dom@18.2.0, @expo/webpack-config@^19.0.0 by running:

npx expo install react-native-web@~0.19.6 react-dom@18.2.0 @expo/webpack-config@^19.0.0

If you're not using web, please ensure you remove the "web" string from the platforms array in the project Expo
config.
```

**Updated**
```
CommandError: It looks like you're trying to use web support but don't have the required dependencies installed.

Please install react-native-web@~0.19.6, react-dom@18.2.0, @expo/webpack-config@^19.0.0 by running:

npx expo install react-native-web, react-dom, @expo/webpack-config

If you're not using web, please ensure you remove the "web" string from the platforms array in the project Expo
config.
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
