### PR TITLE
[ENG-11092][docs] add docs for Xcode 15.2 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -8,7 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **December 15, 2023**.
+> This document was last updated on **January 17th, 2024**.
 
 ## Builder IP addresses
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -226,7 +226,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.1` (`latest`)
+#### `macos-ventura-13.6-xcode-15.1`
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -208,6 +208,24 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
+#### `macos-ventura-13.6-xcode-15.2` (`latest`)
+
+<Collapsible summary="Details">
+
+- macOS Ventura 13.6
+- Xcode 15.2 (15C500b)
+- Node.js 18.18.0
+- Bun 1.0.23
+- Yarn 1.22.21
+- pnpm 8.14.1
+- npm 9.8.1
+- fastlane 2.219.0
+- CocoaPods 1.14.3
+- Ruby 2.7
+- node-gyp 10.0.1
+
+</Collapsible>
+
 #### `macos-ventura-13.6-xcode-15.1` (`latest`)
 
 <Collapsible summary="Details">


### PR DESCRIPTION
# Why

Add docs for Xcode 15.2 image

# How

Add docs for Xcode 15.2 image

# Test Plan

Preview, tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
