### PR TITLE
[docs] Fix Vale CI issues

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -215,6 +215,7 @@ exceptions:
   - '.*Transporter.*'
   - '.*TTF.*'
   - '.*Turtle.*'
+  - '.*TV.*'
   - '.*TypeScript.*'
   - '.*TypeScript module.*'
   - '.*Update.*'
@@ -245,3 +246,4 @@ exceptions:
   - Two-factor
   - (experimental support)
   - How can I implement a custom
+  - Drizzle ORM


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found a couple of sentence case warnings from Vale on the CI and locally after reviewing some PRs recently. These cases should be added to our exception list.

![CleanShot 2024-01-17 at 18 38 02](https://github.com/expo/expo/assets/10234615/b14b97ee-fd1e-4a50-87e9-5fab78cb9fb4)


![CleanShot 2024-01-17 at 18 49 28](https://github.com/expo/expo/assets/10234615/d1e588a3-52db-4f5a-93c4-747dc647d639)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

run `yarn run lint-prose` locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
