### PR TITLE
fix(cli): let last arguments take precedence when repeated on `export:embed` command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- When repeated, later boolean arguments on `export:embed`, `run android`, and `run ios` should take precedence ([#26471](https://github.com/expo/expo/pull/26471) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -57,10 +57,13 @@ describe(_resolveStringOrBooleanArgs, () => {
   });
   it(`prefers last argument when arguments are repeated`, () => {
     expect(
-      _resolveStringOrBooleanArgs(
-        { '--basic': Boolean },
-        ['--basic', 'true', '--basic', 'false', 'root'],
-      )
+      _resolveStringOrBooleanArgs({ '--basic': Boolean }, [
+        '--basic',
+        'true',
+        '--basic',
+        'false',
+        'root',
+      ])
     ).toEqual({
       args: { '--basic': 'false' },
       projectRoot: 'root',

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -55,26 +55,14 @@ describe(_resolveStringOrBooleanArgs, () => {
       _resolveStringOrBooleanArgs({ '--basic': Boolean }, ['foobar', 'root', '--basic'])
     ).toThrow(/Unknown argument: root/);
   });
-  it(`prefers last argument when arguments are repeated and 'lastArgTakesPrecedence' is set to true`, () => {
+  it(`prefers last argument when arguments are repeated`, () => {
     expect(
       _resolveStringOrBooleanArgs(
         { '--basic': Boolean },
         ['--basic', 'true', '--basic', 'false', 'root'],
-        /* lastArgTakesPrecedence */ true
       )
     ).toEqual({
       args: { '--basic': 'false' },
-      projectRoot: 'root',
-    });
-
-    expect(
-      _resolveStringOrBooleanArgs(
-        { '--basic': Boolean },
-        ['--basic', 'true', '--basic', 'false', 'root'],
-        /* lastArgTakesPrecedence */ false
-      )
-    ).toEqual({
-      args: { '--basic': 'true' },
       projectRoot: 'root',
     });
   });

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -55,6 +55,29 @@ describe(_resolveStringOrBooleanArgs, () => {
       _resolveStringOrBooleanArgs({ '--basic': Boolean }, ['foobar', 'root', '--basic'])
     ).toThrow(/Unknown argument: root/);
   });
+  it(`prefers last argument when arguments are repeated and 'lastArgTakesPrecedence' is set to true`, () => {
+    expect(
+      _resolveStringOrBooleanArgs(
+        { '--basic': Boolean },
+        ['--basic', 'true', '--basic', 'false', 'root'],
+        /* lastArgTakesPrecedence */ true
+      )
+    ).toEqual({
+      args: { '--basic': 'false' },
+      projectRoot: 'root',
+    });
+
+    expect(
+      _resolveStringOrBooleanArgs(
+        { '--basic': Boolean },
+        ['--basic', 'true', '--basic', 'false', 'root'],
+        /* lastArgTakesPrecedence */ false
+      )
+    ).toEqual({
+      args: { '--basic': 'true' },
+      projectRoot: 'root',
+    });
+  });
 });
 
 describe(assertUnknownArgs, () => {
@@ -95,6 +118,26 @@ describe(resolveStringOrBooleanArgsAsync, () => {
         '--device': 'my-device',
         '--no-bundler': true,
         '--scheme': true,
+      },
+      projectRoot: 'custom-root',
+    });
+  });
+
+  it(`prefers last argument, when argument is repeated`, async () => {
+    await expect(
+      resolveStringOrBooleanArgsAsync(
+        ['--dev=false', '--minify=false', '--minify', 'true', '--dev', 'true', 'custom-root'],
+        {
+          '--dev': Boolean,
+        },
+        {
+          '--minify': Boolean,
+        }
+      )
+    ).resolves.toEqual({
+      args: {
+        '--minify': 'true',
+        '--dev': 'true',
       },
       projectRoot: 'custom-root',
     });

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -89,10 +89,7 @@ export async function resolveCustomBooleanArgsAsync(
   };
 }
 
-export function _resolveStringOrBooleanArgs(
-  arg: Spec,
-  args: string[],
-) {
+export function _resolveStringOrBooleanArgs(arg: Spec, args: string[]) {
   // Default project root, if a custom one is defined then it will overwrite this.
   let projectRoot: string = '.';
   // The resolved arguments.

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -50,7 +50,7 @@ export async function resolveStringOrBooleanArgsAsync(
   args = collapseAliases(extraArgs, args);
 
   // Resolve all of the string or boolean arguments and the project root.
-  return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args, /* lastArgTakesPrecedence */ true);
+  return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args);
 }
 
 /**
@@ -92,7 +92,6 @@ export async function resolveCustomBooleanArgsAsync(
 export function _resolveStringOrBooleanArgs(
   arg: Spec,
   args: string[],
-  lastArgTakesPrecedence = false,
 ) {
   // Default project root, if a custom one is defined then it will overwrite this.
   let projectRoot: string = '.';
@@ -111,16 +110,16 @@ export function _resolveStringOrBooleanArgs(
     if (value.startsWith('--')) {
       // If we ever find an argument then it must be a boolean because we are checking in reverse
       // and removing arguments from the array if we find a string.
-      // We only override arguments that are already set when `lastArgTakesPrecedence` is false
-      if (!(value in settings) || !lastArgTakesPrecedence) {
+      // We don't override arguments that are already set
+      if (!(value in settings)) {
         settings[value] = true;
       }
     } else {
       // Get the previous argument in the array.
       const nextValue = i > 0 ? args[i - 1] : null;
       if (nextValue && possibleArgs.includes(nextValue)) {
-        // We only override arguments that are already set when `lastArgTakesPrecedence` is false
-        if (!(nextValue in settings) || !lastArgTakesPrecedence) {
+        // We don't override arguments that are already set
+        if (!(nextValue in settings)) {
           settings[nextValue] = value;
         }
         i--;


### PR DESCRIPTION
# Why

Resolves #25505

When `export:embed` was called with arguments being repeated, later arguments would be overridden by earlier arguments since we parse them in reverse order. This is problematic for our Gradle scripts and build processes that allow users to append override arguments.

# How

Previously, the options on `export:embed` would resolve in reverse order, meaning, earlier arguments would override the values of later ones, since we parse them in reverse order. Instead, we now don't allow arguments to be overridden once we've parsed them.

This affects the following commands and extra arguments:
- `expo export:embed`
  - `--dev`
  - `--minify`
  - `--sourcemap-use-absolute-path`
  - `--reset-cache`
  - `--read-global-cache`
- `expo run android`
  - `--device`
- `expo run ios`
  - `--device`

# Test Plan

Unit tests have been added to validate that this change works as intended.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
