### PR TITLE
[expo-modules-core] Add logger timer for iOS

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1975,14 +1975,14 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: c55ffb179683efed04cb144fc80ccf26891f0cb4
   ExpoLocalization: b3b77d35b8c7653700ae3045bf6d8175ab91d042
   ExpoMailComposer: 1f980bbdd0647500178625f453e509cef1282d43
-  ExpoModulesCore: 67e0691f804f3fdb7b2827b1cc3d9ac1385fd3e2
+  ExpoModulesCore: fdc0871aabd9a27e89849e809e5d3af520f10c9f
   ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
   ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7
   ExpoRandom: f0cd58e154e463d913462f3b445870b12d1c2f12
   ExpoScreenCapture: c3c120b095594bf7ae003251c1b89260566587f6
   ExpoScreenOrientation: b536311828c68fbe8ce5d5c46dadf14933a37812
-  ExpoSecureStore: 684e61c2fb2d5e61fee11b3bbd2c67610cd808b8
+  ExpoSecureStore: 20f5c59ba616b13794f2d42e97198cee70dab273
   ExpoSensors: 773adb32167d5d3c28280697ceee342b88f606ab
   ExpoSharing: 752ad6ae2b693de9cd4e7fddb78297bdc658b815
   ExpoSMS: aca5b62dbfef73670cb35d0ebd9a2017899bbb2d

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454) by [@wschurman](https://github.com/wschurman))
+- Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
@@ -5,9 +5,8 @@ import os.log
 public func createOSLogHandler(category: String) -> LogHandler {
   if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
     return OSLogHandler(category: category)
-  } else {
-    return PrintLogHandler()
   }
+  return PrintLogHandler()
 }
 
 public func createPersistentFileLogHandler(category: String) -> LogHandler {

--- a/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
@@ -2,12 +2,22 @@
 
 import os.log
 
+public func createOSLogHandler(category: String) -> LogHandler {
+  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+    return OSLogHandler(category: category)
+  } else {
+    return PrintLogHandler()
+  }
+}
+
+public func createPersistentFileLogHandler(category: String) -> LogHandler {
+  return PersistentFileLogHandler(category: category)
+}
+
 /**
  The protocol that needs to be implemented by log handlers.
  */
-internal protocol LogHandler {
-  init(category: String)
-
+public protocol LogHandler {
   func log(type: LogType, _ message: String)
 }
 
@@ -31,8 +41,6 @@ internal class OSLogHandler: LogHandler {
  Simple log handler that forwards all logs to `print` function.
  */
 internal class PrintLogHandler: LogHandler {
-  required init(category: String) {}
-
   func log(type: LogType, _ message: String) {
     print(message)
   }

--- a/packages/expo-modules-core/ios/Core/Logging/LoggerTimer.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LoggerTimer.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 
-
 typealias LoggerTimerStopBlock = () -> Void
 
 /**

--- a/packages/expo-modules-core/ios/Core/Logging/LoggerTimer.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LoggerTimer.swift
@@ -1,0 +1,23 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+import Foundation
+
+
+typealias LoggerTimerStopBlock = () -> Void
+
+/**
+ An instance of a timer.
+ */
+public class LoggerTimer {
+  private let stopBlock: LoggerTimerStopBlock
+
+  internal required init(stopBlock: @escaping LoggerTimerStopBlock) {
+    self.stopBlock = stopBlock
+  }
+  /**
+   End the timer and log a timer entry.
+   */
+  func stop() {
+    self.stopBlock()
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/LoggerSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/LoggerSpec.swift
@@ -1,0 +1,80 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class LoggerSpec: ExpoSpec {
+  class TestLogHandler : LogHandler {
+    struct TestLogHandlerLogEntry : Equatable {
+      let type: LogType
+      let message: String
+
+      static func == (lhs: TestLogHandlerLogEntry, rhs: TestLogHandlerLogEntry) -> Bool {
+        // slightly-fuzzy matching for testing only due to prepending emoji to message
+        return lhs.type == rhs.type && (lhs.message.contains(rhs.message) || rhs.message.contains(lhs.message))
+      }
+    }
+
+    var logEntries: [TestLogHandlerLogEntry] = []
+
+    func clear() {
+      logEntries = []
+    }
+
+    func log(type: ExpoModulesCore.LogType, _ message: String) {
+      logEntries.append(TestLogHandlerLogEntry(type: type, message: message))
+    }
+  }
+
+  override class func spec() {
+    it("should log various levels") {
+      let loggerHandler = TestLogHandler()
+      let logger = Logger(logHandlers: [loggerHandler])
+
+      logger.trace("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .trace, message: "hello")
+      loggerHandler.clear()
+
+      logger.debug("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .debug, message: "hello")
+      loggerHandler.clear()
+
+      logger.info("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .info, message: "hello")
+      loggerHandler.clear()
+
+      logger.warn("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .warn, message: "hello")
+      loggerHandler.clear()
+
+      logger.error("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .error, message: "hello")
+      loggerHandler.clear()
+
+      logger.fatal("hello")
+      expect(loggerHandler.logEntries.first) == TestLogHandler.TestLogHandlerLogEntry(type: .fatal, message: "hello")
+      loggerHandler.clear()
+    }
+
+    it("should run a timer") {
+      let loggerHandler = TestLogHandler()
+      let logger = Logger(logHandlers: [loggerHandler])
+
+      let timer = logger.startTimer { duration in
+        return "\(duration)"
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+      timer.stop()
+
+      let entry = loggerHandler.logEntries.first!
+      expect(entry.type) == .timer
+
+      // remove emoji prefix
+      let index = entry.message.index(entry.message.startIndex, offsetBy: 2)
+      expect(Double(entry.message[index...])) > 300
+
+      loggerHandler.clear()
+    }
+  }
+}

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add more failure logs in asset download. ([#26268](https://github.com/expo/expo/pull/26268) by [@wschurman](https://github.com/wschurman))
-- Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454) by [@wschurman](https://github.com/wschurman))
+- Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogEntry.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogEntry.swift
@@ -13,6 +13,7 @@ internal struct UpdatesLogEntry: Codable {
   var updateId: String? // EAS update ID, if any
   var assetId: String? // EAS asset ID, if any
   var stacktrace: [String]? // Stacktrace (for error and fatal logs)
+  var duration: Double? // Duration of timer if applicable
 
   /**
    Returns a JSON string representation from this UpdatesLogEntry object
@@ -36,6 +37,9 @@ internal struct UpdatesLogEntry: Codable {
     result["message"] = message
     result["code"] = code
     result["level"] = level
+    if let duration = duration {
+      result["duration"] = duration
+    }
     if let updateId = updateId {
       result["updateId"] = updateId
     }

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
@@ -11,7 +11,10 @@ import ExpoModulesCore
 internal final class UpdatesLogger {
   static let EXPO_UPDATES_LOG_CATEGORY = "expo-updates"
 
-  private let logger = Logger(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY, options: [.logToOS, .logToFile])
+  private let logger = Logger(logHandlers: [
+    createOSLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY),
+    createPersistentFileLogHandler(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
+  ])
 
   // MARK: - Public logging functions
 
@@ -21,7 +24,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .trace, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .trace, duration: nil, updateId: updateId, assetId: assetId)
     logger.trace(entry)
   }
 
@@ -42,7 +45,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .debug, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .debug, duration: nil, updateId: updateId, assetId: assetId)
     logger.debug(entry)
   }
 
@@ -63,7 +66,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .info, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .info, duration: nil, updateId: updateId, assetId: assetId)
     logger.info(entry)
   }
 
@@ -84,7 +87,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .warn, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .warn, duration: nil, updateId: updateId, assetId: assetId)
     logger.warn(entry)
   }
 
@@ -105,7 +108,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .error, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .error, duration: nil, updateId: updateId, assetId: assetId)
     logger.error(entry)
   }
 
@@ -122,7 +125,7 @@ internal final class UpdatesLogger {
     updateId: String?,
     assetId: String?
   ) {
-    let entry = logEntryString(message: message, code: code, level: .fatal, updateId: updateId, assetId: assetId)
+    let entry = logEntryString(message: message, code: code, level: .fatal, duration: nil, updateId: updateId, assetId: assetId)
     logger.fatal(entry)
   }
 
@@ -133,10 +136,17 @@ internal final class UpdatesLogger {
     fatal(message: message, code: code, updateId: nil, assetId: nil)
   }
 
+  func startTimer(label: String) -> LoggerTimer {
+    return logger.startTimer { duration in
+      self.logEntryString(message: label, code: .none, level: .timer, duration: duration, updateId: nil, assetId: nil)
+    }
+  }
+
   func logEntryString(
     message: String,
-    code: UpdatesErrorCode = .none,
-    level: LogType = .trace,
+    code: UpdatesErrorCode,
+    level: LogType,
+    duration: Double?,
     updateId: String?,
     assetId: String?
   ) -> String {
@@ -152,7 +162,8 @@ internal final class UpdatesLogger {
       level: "\(level)",
       updateId: updateId,
       assetId: assetId,
-      stacktrace: symbols
+      stacktrace: symbols,
+      duration: duration
     )
     return "\(logEntry.asString() ?? logEntry.message)"
   }

--- a/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
@@ -104,7 +104,7 @@ class EXUpdatesLogReaderTests: XCTestCase {
   func logErrorSync(message: String, code: UpdatesErrorCode) {
     let expectation = self.expectation(description: "error logged")
     let persistentLog = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
-    let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .error, updateId: nil, assetId: nil)
+    let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .error, duration: nil, updateId: nil, assetId: nil)
     persistentLog.appendEntry(entry: logEntryString) {_ in
       expectation.fulfill()
     }
@@ -114,7 +114,7 @@ class EXUpdatesLogReaderTests: XCTestCase {
   func logWarnSync(message: String, code: UpdatesErrorCode, updateId: String?, assetId: String?) {
     let expectation = self.expectation(description: "error logged")
     let persistentLog = PersistentFileLog(category: UpdatesLogger.EXPO_UPDATES_LOG_CATEGORY)
-    let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .warn, updateId: updateId, assetId: assetId)
+    let logEntryString = "xx" + UpdatesLogger().logEntryString(message: message, code: code, level: .warn, duration: nil, updateId: updateId, assetId: assetId)
     persistentLog.appendEntry(entry: logEntryString) {_ in
       expectation.fulfill()
     }

--- a/packages/expo-updates/ios/Tests/UpdatesLoggerTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLoggerTests.swift
@@ -51,4 +51,32 @@ class EXUpdatesLoggerTests: XCTestCase {
     XCTAssertTrue(logEntry2?.assetId == "myAssetId")
     XCTAssertNil(logEntry2?.stacktrace)
   }
+
+  func test_TimerWorks() {
+    let logger = UpdatesLogger()
+    let logReader = UpdatesLogReader()
+
+    // Mark the date
+    let epoch = Date()
+
+    let timer = logger.startTimer(label: "testlabel")
+    RunLoop.current.run(until: Date().addingTimeInterval(1))
+    timer.stop()
+
+    // Use reader to retrieve messages
+    let logEntries: [String] = logReader.getLogEntries(newerThan: epoch)
+
+    // Verify number of log entries and decoded values
+    XCTAssertTrue(logEntries.count == 1)
+    
+    let logEntryText: String = logEntries[0]
+    let logEntry = UpdatesLogEntry.create(from: logEntryText)
+    XCTAssertTrue(logEntry?.message == "testlabel")
+    XCTAssertTrue(logEntry?.code == UpdatesErrorCode.none.asString)
+    XCTAssertTrue(logEntry?.level == "\(LogType.timer)")
+    XCTAssertNil(logEntry?.updateId)
+    XCTAssertNil(logEntry?.assetId)
+    XCTAssertNil(logEntry?.stacktrace)
+    XCTAssertGreaterThanOrEqual(logEntry!.duration!, Double(300))
+  }
 }


### PR DESCRIPTION
# Why

iOS equivalent of https://github.com/expo/expo/pull/26454. I hadn't noticed that iOS already had a timer implementation, but it was unused. This PR changes it to match the API of the android one (which I prefer slightly as it's more type safe) and also adds tests and updates.

# How

Update timer API in iOS implementation, make same dependency injection constructor change for testability, add tests.

# Test Plan

Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
