### PR TITLE
chore(cli): hide the deprecated `export:web` command from the general help output.

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -33,7 +33,7 @@ Usage
   $ npx expo <command>
 
 Commands
-  start, export, export:web
+  start, export
   run:ios, run:android, prebuild
   install, customize, config
   login, logout, whoami, register
@@ -330,7 +330,7 @@ export default function Blog() {
 
 ### Exporting with webpack
 
-> webpack is only supported for the Web platform.
+> **warning** Expo Webpack has been deprecated in favor of universal Metro (`npx expo export`).
 
 You can export the JavaScript and assets for your web app using webpack by running the following:
 
@@ -500,8 +500,8 @@ From here, you can choose to generate basic project files like:
 | `EXPO_USE_TYPED_ROUTES`             | **boolean** | Use `expo.experiments.typedRoutes` to enable statically typed routes in Expo Router.                                                                                                                                                                                                                                                                                                 |
 | `EXPO_METRO_UNSTABLE_ERRORS`        | **boolean** | <StatusTag status="experimental" /><br/>Enable unstable error message improvements in Metro bundler. The features behind this flag are subject to removal and may be upstreamed.                                                                                                                                                                                                     |
 | `EXPO_USE_METRO_WORKSPACE_ROOT`     | **boolean** | Enable auto server root detection for Metro. This will change the server root to the workspace root. Useful for monorepos.                                                                                                                                                                                                                                                           |
-| `EXPO_USE_UNSTABLE_DEBUGGER`        | **boolean** | <StatusTag status="experimental" /><br/>Enable the experimental debugger from React Native.                                                                                                                                                                                                                                                                              |
-| `EXPO_ADB_USER`                     | **string** | <StatusTag status="SDK 50+" /><br/>Set the `user` number that should be passed to `--user` with ADB commands. Used for installing APKs on Android devices with multiple profiles. Defaults to `0`.                                                                                                                                                                                                                                                                              |
+| `EXPO_USE_UNSTABLE_DEBUGGER`        | **boolean** | <StatusTag status="experimental" /><br/>Enable the experimental debugger from React Native.                                                                                                                                                                                                                                                                                          |
+| `EXPO_ADB_USER`                     | **string**  | <StatusTag status="SDK 50+" /><br/>Set the `user` number that should be passed to `--user` with ADB commands. Used for installing APKs on Android devices with multiple profiles. Defaults to `0`.                                                                                                                                                                                   |
 
 ## Telemetry
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 💡 Others
 
+- Hide the deprecated `export:web` command from the general help output.
 - Move `@expo/server` to be a dependency of `expo-router`. ([#25937](https://github.com/expo/expo/pull/25937) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
 - Added `templateChecksum` for prebuild to check the current template version. ([#26414](https://github.com/expo/expo/pull/26414) by [@kudo](https://github.com/kudo))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- Hide the deprecated `export:web` command from the general help output.
+- Hide the deprecated `export:web` command from the general help output. ([#26480](https://github.com/expo/expo/pull/26480) by [@EvanBacon](https://github.com/EvanBacon))
 - Move `@expo/server` to be a dependency of `expo-router`. ([#25937](https://github.com/expo/expo/pull/25937) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
 - Added `templateChecksum` for prebuild to check the current template version. ([#26414](https://github.com/expo/expo/pull/26414) by [@kudo](https://github.com/kudo))

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -91,6 +91,8 @@ if (!isSubcommand && args['--help']) {
     // workaround until we can use `expo export` for all production bundling.
     // https://github.com/expo/expo/pull/21396/files#r1121025873
     'export:embed': exportEmbed_unused,
+    // The export:web command is deprecated. Hide it from the help prompt.
+    'export:web': exportWeb_unused,
     // Other ignored commands, these are intentially not listed in the `--help` output
     run: _run,
     // All other commands

--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -71,9 +71,13 @@ it(
   async () => {
     const projectRoot = await setupTestProjectAsync('basic-customize', 'with-blank');
     // `npx expo customize index.html serve.json babel.config.js`
-    await execa('node', [bin, 'customize', 'web/index.html', 'web/serve.json', 'babel.config.js'], {
-      cwd: projectRoot,
-    });
+    await execa(
+      'node',
+      [bin, 'customize', 'public/index.html', 'public/serve.json', 'babel.config.js'],
+      {
+        cwd: projectRoot,
+      }
+    );
 
     const files = klawSync(projectRoot)
       .map((entry) => {
@@ -90,8 +94,8 @@ it(
       'babel.config.js',
       'bun.lockb',
       'package.json',
-      'web/index.html',
-      'web/serve.json',
+      'public/index.html',
+      'public/serve.json',
     ]);
   },
   // Could take 45s depending on how fast npm installs

--- a/packages/@expo/cli/e2e/__tests__/export-web-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-web-test.ts
@@ -45,7 +45,7 @@ it('runs `npx expo export:web --help`', async () => {
   expect(results.stdout).toMatchInlineSnapshot(`
     "
       Info
-        Export the static files of the web app for hosting on a web server
+        (Deprecated) Bundle the static files of the web app with Webpack for hosting on a web server
 
       Usage
         $ npx expo export:web <dir>

--- a/packages/@expo/cli/e2e/__tests__/index-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/index-test.ts
@@ -32,7 +32,7 @@ it('runs `npx expo --help`', async () => {
         $ npx expo <command>
 
       Commands
-        start, export, export:web
+        start, export
         run:ios, run:android, prebuild
         install, customize, config
         login, logout, whoami, register

--- a/packages/@expo/cli/src/customize/customizeAsync.ts
+++ b/packages/@expo/cli/src/customize/customizeAsync.ts
@@ -25,7 +25,9 @@ export async function customizeAsync(files: string[], options: Options, extras: 
   // the query and select functions.
   const props: DestinationResolutionProps = {
     webStaticPath:
-      exp.web?.staticPath ?? getPlatformBundlers(exp).web === 'webpack' ? 'web' : 'public',
+      exp.web?.staticPath ?? getPlatformBundlers(projectRoot, exp).web === 'webpack'
+        ? 'web'
+        : 'public',
   };
 
   // If the user provided files, we'll generate them without prompting.

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -21,7 +21,7 @@ export const expoExportWeb: Command = async (argv) => {
 
   if (args['--help']) {
     printHelp(
-      `Export the static files of the web app for hosting on a web server`,
+      `(Deprecated) Bundle the static files of the web app with Webpack for hosting on a web server`,
       chalk`npx expo export:web {dim <dir>}`,
       [
         chalk`<dir>                         Directory of the Expo project. {dim Default: Current working directory}`,


### PR DESCRIPTION
# Why

- hide the `export:web` command from the help prompt since it's deprecated.
- mark `npx expo export:web -h` as deprecated.
