### PR TITLE
[autolinking] Fix a list of packages to include in the generated modules provider

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a list of packages to include in the generated modules provider for tvOS and macOS platforms. ([#26497](https://github.com/expo/expo/pull/26497) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 1.10.1 - 2024-01-18

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -123,7 +123,13 @@ module Expo
 
     # Filters only these packages that needs to be included in the generated modules provider.
     public def packages_to_generate
-      @packages.select { |package| package.modules.any? }
+      platform = @target_definition.platform
+
+      @packages.select do |package|
+        # Check whether the package has any module to autolink
+        # and if there is any pod that supports target's platform.
+        package.modules.any? && package.pods.any? { |pod| pod.supports_platform?(platform) }
+      end
     end
 
     # Returns the provider name which is also a name of the generated file


### PR DESCRIPTION
# Why

Fixes something I missed in #26398. Right now the generated `ExpoModulesProvider.swift` can contain modules from packages that don't support macOS platform. It of course breaks the compilation.

# How

Added an additional condition for packages to include in the generated modules provider that checks whether the target's platform is supported.

# Test Plan

Added `react-native-macos` to bare-expo app, installed pods in `macos` folder and confirmed that `Pods/Target Support Files/Pods-BareExpo-macOS/expo-configure-project.sh` runs autolinking's `generate-module-provider` command with only packages that support macOS (that is `expo-constants`, `expo-file-system` and `expo-keep-awake`).