### PR TITLE
[docs] Minor fixes (broken link, verbiage and formatting issues)

### DIFF
--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -131,6 +131,6 @@ Before transferring a project, make sure that it is on Expo SDK 43 or above. If 
 
 ## Teams
 
-> For all new accounts where you want to share access, we recommend you to [create a new Organization](#organizations) Account. It allows more flexibility in role assignments. Creating a Team Account is deprecated.
+> **warning** **Deprecated**: For all new accounts where you want to share access, we recommend you to [create a new Organization](#organizations) Account. It allows more flexibility in role assignments. Creating a Team Account is deprecated.
 
 To create a Team Account, simply [invite Team members](/accounts/working-together/#adding-members) to a Personal Account.

--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -3,7 +3,7 @@ title: Work together
 description: Learn how to work with other developers on Expo projects.
 ---
 
-> **warning** **Deprecation:** The following guidelines on giving access to other developers or team members have been deprecated and are no longer valid on a Personal Account. If you creating a new account and looking to add team members, we recommend creating an [Organization](/accounts/account-types/#organizations) instead of a Personal Account. Organizations are more flexible and allow you to manage and share access to your projects within a team.
+> **warning** **Deprecated:** The following guidelines on giving access to other developers or team members have been deprecated and are no longer valid on a Personal Account. If you creating a new account and looking to add team members, we recommend creating an [Organization](/accounts/account-types/#organizations) instead of a Personal Account. Organizations are more flexible and allow you to manage and share access to your projects within a team.
 
 You can grant other users access to the projects belonging to your Personal Account or Organizations. The type of access depends on the granted role.
 

--- a/docs/pages/archive/classic-updates/updating-your-app.mdx
+++ b/docs/pages/archive/classic-updates/updating-your-app.mdx
@@ -57,7 +57,7 @@ Say you have an existing build, build A, of your app running in production. Buil
 
 However, if build A of your app fetches JavaScript version 2 as an update and tries to run it, it will error on the `MediaLibrary.getAlbumsAsync()` method call because the `MediaLibrary` native module is not present in build A. If your JavaScript doesn't catch this error, it will propagate and your app will crash, rendering JavaScript version 2 unusable on build A of your app.
 
-We need some way, therefore, of preventing JavaScript version 2 from being deployed to build A - or, in general, controlling which updates are deployed to specific builds of your app. `expo-updates` provides two ways to control this: Runtime Version and Release Channels.
+We need some way of preventing JavaScript version 2 from being deployed to build A - or, in general, controlling which updates are deployed to specific builds of your app. `expo-updates` provides two ways to control this: Runtime Version and Release Channels.
 
 ### Runtime version
 

--- a/docs/pages/archive/customizing-webpack.mdx
+++ b/docs/pages/archive/customizing-webpack.mdx
@@ -5,7 +5,7 @@ description: Learn about different webpack bundler configurations that can be cu
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecation**: In SDK 50 and above, Expo Webpack has been deprecated in favor of [Expo Router](/router/introduction/). Learn how to [migrate from Expo Webpack to Expo Router](/router/migrate/from-expo-webpack/).
+> **warning** **Deprecated**: In SDK 50 and above, Expo Webpack has been deprecated in favor of [Expo Router](/router/introduction/). Learn how to [migrate from Expo Webpack to Expo Router](/router/migrate/from-expo-webpack/).
 
 To enable Webpack web support, modify your [app config](/workflow/configuration) using the `expo.web.bundler` field:
 

--- a/docs/pages/archive/publishing-websites-webpack.mdx
+++ b/docs/pages/archive/publishing-websites-webpack.mdx
@@ -7,7 +7,7 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import { NoIcon } from '~/ui/components/DocIcons';
 
-> **warning** **Deprecation**: In SDK 50 and above, publishing with `webpack` is deprecated in favor of `metro`. Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
+> **warning** **Deprecated**: In SDK 50 and above, publishing with `webpack` is deprecated in favor of `metro`. Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -4,11 +4,10 @@ sidebar_title: Environment variables and secrets
 description: Learn how to use environment variables and secrets in an EAS Build.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The [Environment variables in Expo guide](/guides/environment-variables) describes how to use **.env** files to set environment variables that can be inlined in your JavaScript code. The Expo CLI will substitute properly prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files present on your development machine.
+[Environment variables in Expo](/guides/environment-variables) describes how to use **.env** files to set environment variables that can be inlined in your JavaScript code. The Expo CLI will substitute properly prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files present on your development machine.
 
 Because your EAS Build job runs on a remote server, these **.env** files might not be available. For instance, **.env** files are excluded from your uploaded project if they are listed in **.gitignore** or not committed to your local version control system. Additionally, you may want to use environment variables outside of your JavaScript code to customize your app binary at build time, such as setting a bundle identifier or a private key for an error reporting service. Therefore, EAS Build lets you set per-build-profile environment variables within **eas.json** as well as sensitive values that should not be committed to source control via EAS Secrets.
 

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -496,7 +496,7 @@ Here is what the serialized config would look like:
 ## Why app.plugin.js for plugins
 
 Config resolution searches for a file named **app.plugin.js** first when a Node module ID is provided as a plugin.
-This is because Node environments are often different to iOS, Android, or web JS environments and therefore require different transpilation presets (ex: `module.exports` instead of `import/export`).
+This is because Node environments are often different to iOS, Android, or web JS environments and therefore require different transpilation presets (for example, `module.exports` instead of `import/export`).
 
 Because of this reasoning, the root of a Node module is searched instead of right next to the **index.js**.
 Imagine you had a TypeScript Node module where the transpiled main file was located at **build/index.js**,

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -1,6 +1,7 @@
 ---
 title: Asset selection and exclusion
 description: Select which assets should be included in updates.
+hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -5,13 +5,12 @@ description: Learn how to set up and use environment variables with EAS Update.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 ## Using .env files with EAS Update
 
-The [Environment variables in Expo guide](/guides/environment-variables) describes how to use **.env** files to set and use environment variables within your JavaScript code. The Expo CLI will substitute properly-prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files present on your development machine.
+[Environment variables in Expo](/guides/environment-variables) describes how to use **.env** files to set and use environment variables within your JavaScript code. The Expo CLI will substitute properly prefixed variables in your code (for example,`process.env.EXPO_PUBLIC_VARNAME`) with the corresponding environment variable values in **.env** files present on your development machine.
 
-When you run `eas update`, any **.env** files present will be evaluated when your JavaScript is bundled. Therefore, any `EXPO_PUBLIC_` variables in your application code will be replaced inline with the corresponding values from your **.env** files that are present on the machine from which the update is published, whether that is your local machine or your CI/ CD server.
+When you run `eas update`, any **.env** files present will be evaluated when your JavaScript is bundled. Any `EXPO_PUBLIC_` variables in your application code will be replaced inline with the corresponding values from your **.env** files that are present on the machine from which the update is published, whether that is your local machine or your CI/ CD server.
 
 > When publishing with EAS Update, `EXPO_PUBLIC_` variables in **.env** files will only be used when bundling your app's JavaScript. They will not be available when evaluating **app.config.js**.
 

--- a/docs/pages/modules/android-lifecycle-listeners.mdx
+++ b/docs/pages/modules/android-lifecycle-listeners.mdx
@@ -11,7 +11,7 @@ The React Native module API does not provide any mechanism to hook into these, a
 
 ## Get started
 
-First, you need to have created an Expo module or integrated the Expo modules API in the library using the React Native module API. [Learn more](./overview.mdx#setup)
+First, you need to have created an Expo module or integrated the Expo modules API in the library using the React Native module API. [Learn more](./overview.mdx#setup).
 
 Inside your module, create a concrete class that implements the [`Package`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Package.java) interface. For most cases, you only need to implement the `createReactActivityLifecycleListeners` or `createApplicationLifecycleListeners` methods.
 

--- a/docs/pages/modules/appdelegate-subscribers.mdx
+++ b/docs/pages/modules/appdelegate-subscribers.mdx
@@ -3,8 +3,6 @@ title: iOS AppDelegate subscribers
 description: Learn how to subscribe to iOS system events relevant to an app, such as inbound links and notifications using Expo modules API.
 ---
 
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-
 To respond to certain iOS system events relevant to an app, such as inbound links and notifications, it is necessary to handle the corresponding methods in the `AppDelegate`.
 
 The React Native module API does not provide any mechanism to hook into these methods, and so setup instructions for React Native libraries often include a step to copy code into the `AppDelegate` file. To simplify and automate setup and maintenance, the Expo Modules API provides a mechanism that allows your library to subscribe to calls to `AppDelegate` functions. For this to work, the app `AppDelegate` must inherit from `ExpoAppDelegate`, and this is a requirement for using Expo Modules.
@@ -13,7 +11,7 @@ The React Native module API does not provide any mechanism to hook into these me
 
 ## Get started
 
-First, you need to have created an Expo module or integrated the Expo modules API in library using the React Native module API. [Learn more](./overview.mdx#setup)
+First, you need to have created an Expo module or integrated the Expo modules API in library using the React Native module API. [Learn more](./overview.mdx#setup).
 
 Create a new public Swift class that extends `ExpoAppDelegateSubscriber` from `ExpoModulesCore` and add its name to the `ios.appDelegateSubscribers` array in the [module config](./module-config.mdx). Run `pod install`, and the subscriber will be generated in the **ExpoModulesProvider.swift** file within the application project.
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -330,7 +330,7 @@ export default function Blog() {
 
 ### Exporting with webpack
 
-> **warning** **Deprecation**: In SDK 50 and above, Expo Webpack has been deprecated in favor of universal Metro (`npx expo export`). Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
+> **warning** **Deprecated**: In SDK 50 and above, Expo Webpack has been deprecated in favor of universal Metro (`npx expo export`). Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
 
 You can export the JavaScript and assets for your web app using webpack by running the following:
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -115,7 +115,7 @@ import { ExpoRequest, ExpoResponse } from 'expo-router/server';
 
 export async function GET(request: ExpoRequest, { post }: Record<string, string>) {
   // const postId = request.expoUrl.searchParams.get('post')
-  // fetch data for `post`
+  // fetch data for 'post'
   return ExpoResponse.json({ ... });
 }
 ```

--- a/docs/pages/versions/v46.0.0/sdk/firebase-analytics.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/firebase-analytics.mdx
@@ -128,7 +128,7 @@ onPressProfileButton = uid => {
 
 ### React Navigation
 
-You can track the screens your users are interacting with by integrating our recommend navigation library: `react-navigation`. To see an example of how this works, see [Screen tracking](https://reactnavigation.org/docs/en/screen-tracking.html) in React Navigation documentation.
+You can track the screens your users are interacting with by integrating our recommended navigation library: `react-navigation`. To see an example of how this works, see [Screen tracking](https://reactnavigation.org/docs/screen-tracking/ in React Navigation documentation.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes minor formatting, and verbiage issues that I've come across while going through our docs.

Also, fixes link as a follow up for #26496


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
