### PR TITLE
[docs] Update Expo Router installation guide for SDK 50

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -16,7 +16,7 @@ Find the steps below to create a new project with Expo Router library or add it 
 
 We recommend creating a new Expo app using `create-expo-app`. This will create a minimal project with the Expo Router library already installed. To create a project, run the command:
 
-<Terminal cmd={['$ npx create-expo-app@latest --template tabs@49']} />
+<Terminal cmd={['$ npx create-expo-app@latest --template tabs@50']} />
 
 </Step>
 
@@ -37,6 +37,7 @@ Ensure the version of Expo Router is compatible with the Expo SDK version your p
 
 | Expo SDK | Expo Router |
 | -------- | ----------- |
+| 50.0.0   | 3.0.0       |
 | 49.0.0   | 2.0.0       |
 | 48.0.0   | 1.0.0       |
 
@@ -207,11 +208,13 @@ After updating the Babel config file, run the following command to clear the bun
 
 <Tabs>
 
-  <Tab label="SDK 50 and above">
-    If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
-    resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
-    `metro-resolver`, `react-refresh` resolutions from your **package.json**.
-  </Tab>
+{' '}
+
+<Tab label="SDK 50 and above">
+  If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
+  resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
+  `metro-resolver`, `react-refresh` resolutions from your **package.json**.
+</Tab>
 
   <Tab label="SDK 49">
     Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 / Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -208,11 +208,9 @@ After updating the Babel config file, run the following command to clear the bun
 
 <Tabs>
 
-{' '}
-
 <Tab label="SDK 50 and above">
   If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
-  resolutions or npm overrides in your **package.json**. Specifically remove `metro`,
+  resolutions or npm overrides in your **package.json**. Specifically, remove `metro`,
   `metro-resolver`, `react-refresh` resolutions from your **package.json**.
 </Tab>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the Install Expo Router has outdated instructions. This PR updates the command Quick start section to create a new project and versioning table in the Manual installation section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally: http://localhost:3002/router/installation/

## Preview

![CleanShot 2024-01-19 at 01 20 29](https://github.com/expo/expo/assets/10234615/19678296-9648-46c5-aa68-05b25040320c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
