### PR TITLE
[docs] Add a section about supporting safe areas in Appearance elements guide

### DIFF
--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -55,7 +55,7 @@ export default function Layout() {
 }
 ```
 
-In SDK 50 and above, Expo Router's [static rendering](/router/reference/static-rendering) provides [automatic static optimization](/router/reference/static-rendering#fonts) for font loading on web. This enables best-practices for working with fonts in the browser.
+In SDK 50 and above, Expo Router's [static rendering](/router/reference/static-rendering) provides [automatic static optimization](/router/reference/static-rendering#fonts) for font loading on web. This enables best practices for working with fonts in the browser.
 
 ## Images
 
@@ -72,8 +72,7 @@ We recommend you use Expo Image for the best cross-platform experience:
 
 > In Expo Router v3 and greater, you can import SplashScreen from `expo-splash-screen` directly.
 
-
-Splash screens are required on native platforms. Expo Router automatically orchestrates the native splash screen to keep it visible until the first route is rendered, this applies to any route that the user deep links into. To enable this functionality, install expo-splash-screen in your project.
+Splash screens are required on native platforms. Expo Router automatically orchestrates the native splash screen to keep it visible until the first route is rendered, this applies to any route that the user deep links into. To enable this functionality, [install `expo-splash-screen`](/versions/latest/sdk/splash-screen/#installation) in your project.
 
 The default behavior is to hide the splash screen when the first route is rendered, this is optimal for the majority of routes. For some routes, you may want to prolong the splash screen until additional data or asset loading has concluded. This can be achieved with the `SplashScreen` module from `expo-router`. If `SplashScreen.preventAutoHideAsync` is called before the splash screen is hidden, then the splash screen will remain visible until the `SplashScreen.hideAsync()` function has been invoked.
 
@@ -87,6 +86,7 @@ SplashScreen.preventAutoHideAsync();
 
 export default function App() {
   const [isReady, setReady] = React.useState(false);
+
   React.useEffect(() => {
     // Perform some sort of async data or asset fetching.
     setTimeout(() => {
@@ -97,6 +97,48 @@ export default function App() {
   }, []);
 
   return <Text>My App</Text>;
+}
+```
+
+## Supporting safe areas
+
+Expo Router comes with the `react-native-safe-area-context` library installed. This library provides a flexible API for accessing device-safe area inset information for both Android and iOS.
+
+To use it, import the `SafeAreaProvider` component from `react-native-safe-area-context` and wrap your root layout with it:
+
+```tsx app/_layout_.tsx
+/* @hide Other import statements */ /* @end */
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+function RootLayoutNav() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <SafeAreaProvider>
+      <Stack>
+        <Screen name="index" options={{ headerShown: false }} />
+      </Stack>
+    </SafeAreaProvider>
+  );
+}
+```
+
+On a page component, you can use `<SafeAreaProvider>` component or `useSafeAreaInsets` hook to access the safe area insets and use them with `<View>`. The following example shows how to use `useSafeAreaInsets`:
+
+```tsx app/index.tsx
+import { StyleSheet, View, Text } from "react-native";
+/* @info Import useSafeAreaInsets hook*/import { useSafeAreaInsets } from "react-native-safe-area-context";*/* @end */
+
+export default function TabOneScreen() {
+  /* @info */const insets = useSafeAreaInsets();/* @end */
+
+  return (
+    /* @info You can use "insets.top" to apply the top padding from the useSafeAreaInsets() hook.*/
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+    /* @end */
+      <Text style={styles.title}>Home page</Text>
+    </View>
+  );
 }
 ```
 

--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -127,7 +127,7 @@ On a page component, you can use `<SafeAreaView>` component or `useSafeAreaInset
 
 ```tsx app/index.tsx
 import { StyleSheet, View, Text } from "react-native";
-/* @info Import useSafeAreaInsets hook*/import { useSafeAreaInsets } from "react-native-safe-area-context";*/* @end */
+/* @info Import useSafeAreaInsets hook */import { useSafeAreaInsets } from "react-native-safe-area-context";/* @end */
 
 export default function TabOneScreen() {
   /* @info */const insets = useSafeAreaInsets();/* @end */

--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -123,7 +123,7 @@ function RootLayoutNav() {
 }
 ```
 
-On a page component, you can use `<SafeAreaProvider>` component or `useSafeAreaInsets` hook to access the safe area insets and use them with `<View>`. The following example shows how to use `useSafeAreaInsets`:
+On a page component, you can use `<SafeAreaView>` component or `useSafeAreaInsets` hook to access the safe area insets and use them with `<View>`. The following example shows how to use `useSafeAreaInsets`:
 
 ```tsx app/index.tsx
 import { StyleSheet, View, Text } from "react-native";


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8402

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a section with a minimal example on how to Safe area views with `react-native-safe-area-context` library when using Expo Route.

Also, updated minor verbiage issues.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/appearance/#supporting-safe-areas

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
