### PR TITLE
Update getting-started.mdx

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -13,7 +13,7 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 EAS CLI is the command line app you will use to interact with EAS services from your terminal. To install it, run the command:
 
-<Terminal cmd={['$ npm install --global eas-cli']} />
+<Terminal cmd={['$ npm install --location=global eas-cli']} />
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 


### PR DESCRIPTION
# Why

Updated `npm` command based on deprecation warnings:

```
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
