### PR TITLE
[ios][file-system] Fix: Set httpMethod on file uploads

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, set `httpMethod` on upload requests.
+- On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, set `httpMethod` on upload requests.
+
 ### 💡 Others
 
 ## 16.0.4 - 2024-01-18

--- a/packages/expo-file-system/ios/NetworkingHelpers.swift
+++ b/packages/expo-file-system/ios/NetworkingHelpers.swift
@@ -32,6 +32,7 @@ func createUrlRequest(url: URL, headers: [String: String]?) -> URLRequest {
 
 func createUploadTask(session: URLSession, targetUrl: URL, sourceUrl: URL, options: UploadOptions) -> URLSessionUploadTask {
   var request = createUrlRequest(url: targetUrl, headers: options.headers)
+  request.httpMethod = options.httpMethod.rawValue
 
   switch options.uploadType {
   case .binaryContent:


### PR DESCRIPTION
# Why
Closes #26508
We were not setting the `httpMethod` on upload requests.

# How
Set the method

# Test Plan
bare-expo. 
Local project using the provided repro.

