### PR TITLE
[dev-client] fix dev-launcher crash

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
+++ b/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
@@ -105,12 +105,19 @@
 
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
 {
-  return [super extraModulesForBridge:bridge];
+  // Since we defined this selector but pretend that we don't implement it,
+  // we should also fallthrough modouleProvider case at
+  // https://github.com/facebook/react-native/blob/fd0ca4dd6209d79ac8c93dbffac2e3dca1caeadc/packages/react-native/React/CxxBridge/RCTCxxBridge.mm#L774-L778
+  RCTBridgeModuleListProvider moduleProvider = [bridge valueForKey:@"_moduleProvider"];
+  if (moduleProvider) {
+    return moduleProvider();
+  }
+  return @[];
 }
 
 - (BOOL)bridge:(RCTBridge *)bridge didNotFindModule:(NSString *)moduleName
 {
-  return [super bridge:bridge didNotFindModule:moduleName];
+  return NO;
 }
 
 @end


### PR DESCRIPTION
# Why

a regression from #26357, when using dev-launcher to load an app, it will crash because `RCTAppDelegate` does not implement the `extraModulesForBridge:` selector.

# How

rather than calling super, return empty array with fallback

# Test Plan

enable dev-launcher in bare-expo (by commenting out the line), and load the app by dev-launcher https://github.com/expo/expo/blob/b8fa00e4f5d5fec2dc57e2752d1e6b6583cd3dc6/apps/bare-expo/ios/BareExpo/AppDelegate.mm#L25

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
