### PR TITLE
[dev-client] fix launching error when interop with expo-updates

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- Fixed missing `runtimeVersion` error when loading app with `expo-updates` and `expo-dev-client`. ([#26524](https://github.com/expo/expo/pull/26524) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -60,6 +60,7 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, installationID:
     "launchWaitMs" to 60000,
     "checkOnLaunch" to "ALWAYS",
     "enabled" to true,
-    "requestHeaders" to requestHeaders
+    "requestHeaders" to requestHeaders,
+    "runtimeVersion" to "1.0.0"
   )
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
     @"EXUpdatesHasEmbeddedUpdate": @(NO),
     @"EXUpdatesEnabled": @(YES),
     @"EXUpdatesRequestHeaders": requestHeaders,
+    @"EXUpdatesRuntimeVersion": @"1.0.0",
   };
 }
 


### PR DESCRIPTION
# Why

when running an app with both expo-dev-client and expo-updates (on latest main branch), it will show an error:
<img src="https://github.com/expo/expo/assets/46429/bbe1c065-b100-4892-abc7-14a2ad21f5a0" width="30%" />

# How

adding a dummy runtime version to the helper

# Test Plan

1. remove expo-updates from bare-expo's autolinking exclusion
2. add **Expo.plist** to bare-expo
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>EXUpdatesCheckOnLaunch</key>
    <string>ALWAYS</string>
    <key>EXUpdatesEnabled</key>
    <true/>
    <key>EXUpdatesLaunchWaitMs</key>
    <integer>0</integer>
  </dict>
</plist>
```
3. enable dev-launcher from bare-expo, by commenting out this line: https://github.com/expo/expo/blob/b8fa00e4f5d5fec2dc57e2752d1e6b6583cd3dc6/apps/bare-expo/ios/BareExpo/AppDelegate.mm#L25

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
