### PR TITLE
[eslint-config] fix snapshots

### DIFF
--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update test snapshots. ([#26527](https://github.com/expo/expo/pull/26527) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 12.0.0 — 2023-08-11
 
 ### 🛠 Breaking changes

--- a/packages/eslint-config-universe/__tests__/__snapshots__/default-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/default-test.js.snap
@@ -87,7 +87,14 @@ function _fn() {}
 function* gen() {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 1,
 }
 `;
@@ -159,7 +166,14 @@ export class Example {
 function _fn(...args: any): void {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 2,
 }
 `;
@@ -212,7 +226,14 @@ function unused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 3,
 }
 `;
@@ -278,7 +299,14 @@ function tsUnused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 4,
 }
 `;
@@ -295,7 +323,14 @@ exports[`lints with the default config: fixtures/all-04.ts 1`] = `
 };
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -310,7 +345,14 @@ exports[`lints with the default config: fixtures/all-05.ts 1`] = `
   "output": "export const blah = 3!;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -330,7 +372,14 @@ export const stringTest: string | null = null;
 export const objectShorthandTest: object | null = null;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -353,7 +402,14 @@ const e = require('e');
 export default a + b + c + d + e;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;

--- a/packages/eslint-config-universe/__tests__/__snapshots__/native-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/native-test.js.snap
@@ -87,7 +87,14 @@ function _fn() {}
 function* gen() {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 1,
 }
 `;
@@ -159,7 +166,14 @@ export class Example {
 function _fn(...args: any): void {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 2,
 }
 `;
@@ -212,7 +226,14 @@ function unused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 3,
 }
 `;
@@ -278,7 +299,14 @@ function tsUnused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 4,
 }
 `;
@@ -295,7 +323,14 @@ exports[`lints with the React Native config: fixtures/all-04.ts 1`] = `
 };
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -310,7 +345,14 @@ exports[`lints with the React Native config: fixtures/all-05.ts 1`] = `
   "output": "export const blah = 3!;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -330,7 +372,14 @@ export const stringTest: string | null = null;
 export const objectShorthandTest: object | null = null;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -353,7 +402,14 @@ const e = require('e');
 export default a + b + c + d + e;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -366,7 +422,14 @@ exports[`lints with the React Native config: fixtures/web-native-00.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -379,7 +442,14 @@ exports[`lints with the React Native config: fixtures/web-native-01.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -392,7 +462,14 @@ exports[`lints with the React Native config: fixtures/web-native-02.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -412,7 +489,14 @@ export default function Example() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -474,7 +558,14 @@ function notAHook() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 1,
 }
 `;

--- a/packages/eslint-config-universe/__tests__/__snapshots__/node-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/node-test.js.snap
@@ -92,6 +92,12 @@ function* gen() {}
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
     },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
   ],
   "warningCount": 1,
 }
@@ -169,6 +175,12 @@ function _fn(...args: any): void {}
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
     },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
   ],
   "warningCount": 2,
 }
@@ -226,6 +238,12 @@ function unused2() {
     {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
+    },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
     },
   ],
   "warningCount": 3,
@@ -298,6 +316,12 @@ function tsUnused2() {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
     },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
   ],
   "warningCount": 4,
 }
@@ -320,6 +344,12 @@ exports[`lints with the Node config: fixtures/all-04.ts 1`] = `
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
     },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
   ],
   "warningCount": 0,
 }
@@ -339,6 +369,12 @@ exports[`lints with the Node config: fixtures/all-05.ts 1`] = `
     {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
+    },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
     },
   ],
   "warningCount": 0,
@@ -364,6 +400,12 @@ export const objectShorthandTest: object | null = null;
     {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
+    },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
     },
   ],
   "warningCount": 0,
@@ -392,6 +434,12 @@ export default a + b + c + d + e;
     {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
+    },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
     },
   ],
   "warningCount": 0,
@@ -435,6 +483,12 @@ exports[`lints with the Node config: fixtures/node-00.js 1`] = `
     {
       "replacedBy": [],
       "ruleId": "no-buffer-constructor",
+    },
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
     },
   ],
   "warningCount": 2,

--- a/packages/eslint-config-universe/__tests__/__snapshots__/web-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/web-test.js.snap
@@ -87,7 +87,14 @@ function _fn() {}
 function* gen() {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 1,
 }
 `;
@@ -159,7 +166,14 @@ export class Example {
 function _fn(...args: any): void {}
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 2,
 }
 `;
@@ -212,7 +226,14 @@ function unused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 3,
 }
 `;
@@ -278,7 +299,14 @@ function tsUnused2() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 4,
 }
 `;
@@ -295,7 +323,14 @@ exports[`lints with the web config: fixtures/all-04.ts 1`] = `
 };
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -310,7 +345,14 @@ exports[`lints with the web config: fixtures/all-05.ts 1`] = `
   "output": "export const blah = 3!;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -330,7 +372,14 @@ export const stringTest: string | null = null;
 export const objectShorthandTest: object | null = null;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -353,7 +402,14 @@ const e = require('e');
 export default a + b + c + d + e;
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -366,7 +422,14 @@ exports[`lints with the web config: fixtures/web-native-00.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -379,7 +442,14 @@ exports[`lints with the web config: fixtures/web-native-01.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -392,7 +462,14 @@ exports[`lints with the web config: fixtures/web-native-02.js 1`] = `
   "fixableWarningCount": 0,
   "messages": [],
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -412,7 +489,14 @@ export default function Example() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 0,
 }
 `;
@@ -474,7 +558,14 @@ function notAHook() {
 }
 ",
   "suppressedMessages": [],
-  "usedDeprecatedRules": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "no-object-constructor",
+      ],
+      "ruleId": "no-new-object",
+    },
+  ],
   "warningCount": 1,
 }
 `;


### PR DESCRIPTION
# Why
`check-packages` is failing in `eslint-config-universe`, probably because of the eslint version bump in #26370

# How
Update the snapshots

# Test Plan
`et cp eslint-config-universe`
