### PR TITLE
[docs] amend sentry updates guide

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -227,7 +227,7 @@ That's it! Errors for your updates will now be properly symbolicated in Sentry.
 
 You can chain the commands together with `&&` to publish an update and upload the sourcemaps in one step:
 
-<Terminal cmd={['$ eas update --channel <channel> && npx sentry-expo-upload-sourcemaps dist']} />
+<Terminal cmd={['$ eas update --branch <branch> && npx sentry-expo-upload-sourcemaps dist']} />
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

`eas update` is meant to publish an update on a branch (rather than a channel). We provided the `channel` flag as a convenience that will resolve to a singly mapped branch, but it does add a layer of indirection. We should encourage folks to use the `branch` flag instead. 


# Test Plan

- [ ] manually inspected with `yarn run dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
