### PR TITLE
[expo-updates][e2e] Poll for test continuation conditions instead of hardcoded waits

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
@@ -47,6 +47,10 @@ function stop() {
   requestedStaticFiles = [];
 }
 
+function getRequestedStaticFilesLength() {
+  return requestedStaticFiles.length;
+}
+
 function consumeRequestedStaticFiles() {
   const returnArray = requestedStaticFiles;
   requestedStaticFiles = [];
@@ -268,6 +272,7 @@ const Server = {
   serveManifest,
   serveSignedManifest,
   serveSignedDirective,
+  getRequestedStaticFilesLength,
   consumeRequestedStaticFiles,
 };
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/26449 re-added the wait steps back in to attempt to address test flakiness. This PR goes one step further and only waits as long as necessary up until a max, at which point it throws.

This should both speed up the tests by only waiting as long as necessary while at the same time making them less flakey by waiting longer in the worst case.

Example recent failure: https://github.com/expo/expo/runs/20587187507

Closes ENG-11130.

# How

Add utility and use it for most hardcoded waits in the test.

# Test Plan

Run tests locally, see they work.
Wait for e2e, see it still passes on CI for this PR.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
