### PR TITLE
[tools] fix nightlies testing for callinvokerholderimpl

### DIFF
--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -52,8 +52,6 @@ async function main() {
   logger.info('Yarning...');
   await workspaceInstallAsync();
 
-  await patchAndroidCallInvokerHolderAsync();
-
   const patches = [
     'datetimepicker.patch',
     'react-native-gesture-handler.patch',
@@ -112,66 +110,6 @@ async function addPinnedPackagesAsync(packages: Record<string, string>) {
     json.resolutions[name] = version;
   }
   await JsonFile.writeAsync(workspacePackageJsonPath, json);
-}
-
-async function patchAndroidCallInvokerHolderAsync() {
-  const nodeModulesDir = path.join(EXPO_DIR, 'node_modules');
-  const targetFiles = [
-    path.join(
-      EXPO_DIR,
-      'packages',
-      'expo-modules-core',
-      'android/src/main/java/expo/modules/adapters/react/services/UIManagerModuleWrapper.java'
-    ),
-    path.join(
-      EXPO_DIR,
-      'packages',
-      'expo-modules-core',
-      'android/src/main/java/expo/modules/core/interfaces/JavaScriptContextProvider.java'
-    ),
-    path.join(
-      EXPO_DIR,
-      'packages',
-      'expo-modules-core',
-      'android/src/main/java/expo/modules/core/interfaces/JavaScriptContextProvider.java'
-    ),
-    path.join(
-      EXPO_DIR,
-      'packages',
-      'expo-modules-core',
-      'android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt'
-    ),
-    path.join(
-      EXPO_DIR,
-      'packages',
-      'expo-av',
-      'android/src/main/java/expo/modules/av/AVManager.java'
-    ),
-    path.join(
-      nodeModulesDir,
-      'react-native-reanimated',
-      'android/src/paper/java/com/swmansion/reanimated/NativeProxy.java'
-    ),
-    path.join(
-      nodeModulesDir,
-      'react-native-reanimated',
-      'android/src/fabric/java/com/swmansion/reanimated/NativeProxy.java'
-    ),
-    path.join(
-      nodeModulesDir,
-      '@shopify/react-native-skia',
-      'android/src/main/java/com/shopify/reactnative/skia/SkiaManager.java'
-    ),
-  ];
-
-  for (const file of targetFiles) {
-    await transformFileAsync(file, [
-      {
-        find: /^(import )(com\.facebook\.react\.turbomodule\.core\.CallInvokerHolderImpl)(;?)$/gm,
-        replaceWith: '$1com.facebook.react.internal.turbomodule.core.CallInvokerHolderImpl$3',
-      },
-    ]);
-  }
 }
 
 async function updateExpoModulesAsync() {


### PR DESCRIPTION
# Why

fixed nightlies testing because https://github.com/facebook/react-native/pull/42362 is landed and we don't need this workaround

# How

remove the `CallInvokerHolderImpl` renaming 

# Test Plan

pass nightlies testing

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
