### PR TITLE
[core] Prevent obfuscating `Pair` type

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On `Android`, remove type annotation on `View`.
+
 ## 12.7.0 — 2023-11-14
 
 ### 🛠 Breaking changes

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- On `Android`, remove type annotation on `View`.
+- On `Android`, remove type annotation on `View`. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 12.7.0 — 2023-11-14
 

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
@@ -3,32 +3,31 @@ package expo.modules.lineargradient
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
-typealias ViewType = LinearGradientView
 
 class LinearGradientModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoLinearGradient")
 
     View(LinearGradientView::class) {
-      Prop("colors") { view: ViewType, colors: IntArray ->
+      Prop("colors") { view, colors: IntArray ->
         view.setColors(colors)
       }
 
-      Prop("locations") { view: ViewType, locations: FloatArray? ->
+      Prop("locations") { view, locations: FloatArray? ->
         locations?.let {
           view.setLocations(it)
         }
       }
 
-      Prop("startPoint") { view: ViewType, startPoint: Pair<Float, Float>? ->
+      Prop("startPoint") { view, startPoint: Pair<Float, Float>? ->
         view.setStartPosition(startPoint?.first ?: 0.5f, startPoint?.second ?: 0f)
       }
 
-      Prop("endPoint") { view: ViewType, endPoint: Pair<Float, Float>? ->
+      Prop("endPoint") { view, endPoint: Pair<Float, Float>? ->
         view.setEndPosition(endPoint?.first ?: 0.5f, endPoint?.second ?: 1f)
       }
 
-      Prop("borderRadii") { view: ViewType, borderRadii: FloatArray? ->
+      Prop("borderRadii") { view, borderRadii: FloatArray? ->
         view.setBorderRadii(borderRadii ?: FloatArray(8) { 0f })
       }
     }

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
@@ -3,7 +3,6 @@ package expo.modules.lineargradient
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
-
 class LinearGradientModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoLinearGradient")

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- Fix proguard rules so `Serializable` types are not obfuscated.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
-- Fix proguard rules so `Serializable` types are not obfuscated.
+- Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -9,6 +9,7 @@
 -keep enum * implements expo.modules.kotlin.types.Enumerable {
   *;
 }
+-keepnames class * implements java.io.Serializable
 
 -keep,allowoptimization,allowobfuscation class * extends expo.modules.kotlin.modules.Module {
   public <init>();

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -9,7 +9,7 @@
 -keep enum * implements expo.modules.kotlin.types.Enumerable {
   *;
 }
--keepnames class * implements java.io.Serializable
+-keepnames class kotlin.Pair
 
 -keep,allowoptimization,allowobfuscation class * extends expo.modules.kotlin.modules.Module {
   public <init>();


### PR DESCRIPTION
# Why
Closes #26531
Closes ENG-11137
Proguard is obfuscating the `Pair` type causing the `PairTypeConverter` to lose type information. This leads to this error 
`java.lang.IllegalArgumentException: Class declares 0 type parameters, but 2 were provided.` when the app is running in release. The other converters seem fine. Confirmed by inspecting the dex classes.

# How
~Added a rule to keep the names of types implementing the `Serializable` interface.~
After discussing with @kudo narrowed it to just adding the rule to keep the `Pair` type

# Test Plan
- Expo Go running in release
- NCL 
- Using the provided repro

