### PR TITLE
[screen-capture] Fix callback on api 34

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix screenshot listener not being called on Android 34.
+- Fix screenshot listener not being called on Android 34. ([#26549](https://github.com/expo/expo/pull/26549) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix screenshot listener not being called on Android 34.
+
 ### 💡 Others
 
 - Native module on iOS is now written in Swift using the Sweet API. ([#26103](https://github.com/expo/expo/pull/26103) by [@fobos531](https://github.com/fobos531))

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+  <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" android:maxSdkVersion="34" />
 </manifest>

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -1,6 +1,7 @@
 package expo.modules.screencapture
 
 import android.Manifest
+import android.app.Activity
 import android.content.Context
 import android.os.Build
 import android.view.WindowManager
@@ -11,17 +12,31 @@ import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
+const val eventName = "onScreenshot"
+
 class ScreenCaptureModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
   private val currentActivity
     get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+  private var screenCaptureCallback: Activity.ScreenCaptureCallback? = null
 
   override fun definition() = ModuleDefinition {
     Name("ExpoScreenCapture")
 
+    Events(eventName)
+
     OnCreate {
-      ScreenshotEventEmitter(context, appContext.legacyModuleRegistry)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        screenCaptureCallback = Activity.ScreenCaptureCallback {
+          sendEvent(eventName)
+        }
+        currentActivity.registerScreenCaptureCallback(currentActivity.mainExecutor, screenCaptureCallback!!)
+      } else {
+        ScreenshotEventEmitter(context) {
+          sendEvent(eventName)
+        }
+      }
     }
 
     AsyncFunction("getPermissionsAsync") { promise: Promise ->
@@ -47,5 +62,13 @@ class ScreenCaptureModule : Module() {
     AsyncFunction("allowScreenCapture") {
       currentActivity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }.runOnQueue(Queues.MAIN)
+
+    OnDestroy {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        screenCaptureCallback?.let {
+          currentActivity.unregisterScreenCaptureCallback(it)
+        }
+      }
+    }
   }
 }

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
@@ -6,32 +6,19 @@ import android.content.pm.PackageManager
 import android.database.ContentObserver
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
 import android.util.Log
-
-import androidx.core.content.ContextCompat
 import androidx.annotation.Nullable
-
-import expo.modules.core.ModuleRegistry
+import androidx.core.content.ContextCompat
 import expo.modules.core.interfaces.LifecycleEventListener
-import expo.modules.core.interfaces.services.EventEmitter
-import expo.modules.core.interfaces.services.UIManager
 
-import java.lang.Exception
-
-class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistry) : LifecycleEventListener {
-  private val onScreenshotEventName: String = "onScreenshot"
+class ScreenshotEventEmitter(val context: Context, onCapture: () -> Unit) : LifecycleEventListener {
   private var isListening: Boolean = true
-  private var eventEmitter: EventEmitter
   private var previousPath: String = ""
 
   init {
-    moduleRegistry.getModule(UIManager::class.java).registerLifecycleEventListener(this)
-    eventEmitter = moduleRegistry.getModule(EventEmitter::class.java)
-
     val contentObserver: ContentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
       override fun onChange(selfChange: Boolean, uri: Uri?) {
         super.onChange(selfChange, uri)
@@ -43,7 +30,7 @@ class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistr
           val path = getFilePathFromContentResolver(context, uri)
           if (path != null && isPathOfNewScreenshot(path)) {
             previousPath = path
-            eventEmitter.emit(onScreenshotEventName, Bundle())
+            onCapture()
           }
         }
       }


### PR DESCRIPTION
# Why
Closes #26476
Closes ENG-11138

Android 14 requires the permission `DETECT_SCREEN_CAPTURE` to listen for changes. We can also use a new activity callback on api 34.

# How
Added the permission and used the Activity callback when running on Android 14.

# Test Plan
- Tested in provided repro on physical device running android 14
- If someone with a device running android 13 can test because the callbacks don't fire in the emulator cc @lukmccall 
