### PR TITLE
[cli] fix react devtools launching error

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash when launching React DevTools. ([#26550](https://github.com/expo/expo/pull/26550) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.17.1 - 2024-01-18

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -145,7 +145,7 @@ export class DevServerManagerActions {
         {
           title: 'Open React devtools',
           value: 'openReactDevTools',
-          action: this.openReactDevToolsAsync,
+          action: this.openReactDevToolsAsync.bind(this),
         },
         // TODO: Maybe a "View Source" option to open code.
       ];


### PR DESCRIPTION
# Why

when launching react-devtools from cli on sdk 50, it will crash cli with the following error:
```
/Users/kudo/sdk50/node_modules/@expo/cli/build/src/start/interface/interactiveActions.js:189
        const url = this.devServerManager.getDefaultDevServer().getReactDevToolsUrl();
                                          ^

TypeError: Cannot read properties of undefined (reading 'getDefaultDevServer')
    at Object.openReactDevToolsAsync [as action] (/Users/kudo/sdk50/node_modules/@expo/cli/build/src/start/interface/interactiveActions.js:189:43)
```

# How

that's a regression from #24650. we should make sure the function point to valid "this".

# Test Plan

on sdk 50 project and trying to launch react-devtools

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
