### PR TITLE
[templates] typeing for external url in tabs example  

### DIFF
--- a/templates/expo-template-tabs/components/ExternalLink.tsx
+++ b/templates/expo-template-tabs/components/ExternalLink.tsx
@@ -4,13 +4,12 @@ import React from 'react';
 import { Platform } from 'react-native';
 
 export function ExternalLink(
-  props: Omit<React.ComponentProps<typeof Link>, 'href'> & { href: string }
+  props: Omit<React.ComponentProps<typeof Link>, 'href'> & { href: `${string}:${string}` }
 ) {
   return (
     <Link
       target="_blank"
       {...props}
-      // @ts-expect-error: External URLs are not typed.
       href={props.href}
       onPress={(e) => {
         if (Platform.OS !== 'web') {


### PR DESCRIPTION
I am  wondering why not to use typing provided by expo-router for external URL in tabs template to make typescript happy?

```ts
type ExternalPathString = `${string}:${string}`;
```