### PR TITLE
[modules-scripts] rename migrated plugin in CLI preset

### DIFF
--- a/packages/expo-module-scripts/babel.config.cli.js
+++ b/packages/expo-module-scripts/babel.config.cli.js
@@ -15,7 +15,7 @@ module.exports = function (api) {
     ],
     plugins: [
       require('babel-plugin-dynamic-import-node'),
-      require('@babel/plugin-proposal-export-namespace-from'),
+      require('@babel/plugin-transform-export-namespace-from'),
       [
         require('@babel/plugin-transform-modules-commonjs'),
         {


### PR DESCRIPTION
# Why

Refs https://github.com/expo/expo/actions/runs/7609029401/job/20719395636

# How

Change the name of swapped transform plugin in Babel CLI preset included in `expo-modules-script`.

# Test Plan

`@expo/fingerprint` tests are working.

![Screenshot 2024-01-22 at 10 40 14](https://github.com/expo/expo/assets/719641/af71d1bb-3403-4640-82f3-1ea6afc72743)

