### PR TITLE
[core][tools] fix build error for react-native@0.74.0-nightly-20240121-a58ec074b

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
+- Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.common.UIManagerType
@@ -141,6 +142,7 @@ class AppContext(
    * Initializes a JSI part of the module registry.
    * It will be a NOOP if the remote debugging was activated.
    */
+  @OptIn(FrameworkAPI::class)
   fun installJSIInterop() = synchronized(this) {
     trace("AppContext.installJSIInterop") {
       try {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
+import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.DoNotStrip
@@ -29,6 +30,7 @@ class JSIInteropModuleRegistry(appContext: AppContext) : Destructible {
   /**
    * Initializes the `ExpoModulesHostObject` and adds it to the global object.
    */
+  @OptIn(FrameworkAPI::class)
   external fun installJSI(
     jsRuntimePointer: Long,
     jniDeallocator: JNIDeallocator,

--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -54,6 +54,7 @@ async function main() {
 
   const patches = [
     'datetimepicker.patch',
+    'lottie-react-native.patch',
     'react-native-gesture-handler.patch',
     'react-native-reanimated.patch',
     'react-native-safe-area-context.patch',

--- a/tools/src/react-native-nightlies/patches/lottie-react-native.patch
+++ b/tools/src/react-native-nightlies/patches/lottie-react-native.patch
@@ -1,0 +1,32 @@
+--- a/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
++++ b/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+@@ -18,7 +18,6 @@ import com.facebook.react.bridge.ReadableArray
+ import com.facebook.react.bridge.ReadableMap
+ import com.facebook.react.bridge.ReadableType
+ import com.facebook.react.views.text.ReactFontManager
+-import com.facebook.react.views.text.TextAttributeProps.UNSET
+ import com.facebook.react.util.RNLog
+ import java.lang.ref.WeakReference
+ import java.util.regex.Pattern
+@@ -69,7 +68,7 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
+         view.setFontAssetDelegate(object : FontAssetDelegate() {
+             override fun fetchFont(fontFamily: String): Typeface {
+                 return ReactFontManager.getInstance()
+-                    .getTypeface(fontFamily, UNSET, UNSET, view.context.assets)
++                    .getTypeface(fontFamily, -1, -1, view.context.assets)
+             }
+         
+             override fun fetchFont(fontFamily: String, fontStyle: String, fontName: String): Typeface {
+@@ -80,10 +79,10 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
+                     "Medium" -> 500
+                     "Bold" -> 700
+                     "Black" -> 900
+-                    else -> UNSET
++                    else -> -1
+                 }
+                 return ReactFontManager.getInstance()
+-                    .getTypeface(fontName, UNSET, weight, view.context.assets)
++                    .getTypeface(fontName, -1, weight, view.context.assets)
+             }
+         })
+     }

--- a/tools/src/react-native-nightlies/patches/lottie-react-native.patch
+++ b/tools/src/react-native-nightlies/patches/lottie-react-native.patch
@@ -1,32 +1,11 @@
 --- a/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
 +++ b/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
-@@ -18,7 +18,6 @@ import com.facebook.react.bridge.ReadableArray
+@@ -18,7 +18,7 @@ import com.facebook.react.bridge.ReadableArray
  import com.facebook.react.bridge.ReadableMap
  import com.facebook.react.bridge.ReadableType
  import com.facebook.react.views.text.ReactFontManager
 -import com.facebook.react.views.text.TextAttributeProps.UNSET
++import com.facebook.react.common.ReactConstants.UNSET
  import com.facebook.react.util.RNLog
  import java.lang.ref.WeakReference
  import java.util.regex.Pattern
-@@ -69,7 +68,7 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
-         view.setFontAssetDelegate(object : FontAssetDelegate() {
-             override fun fetchFont(fontFamily: String): Typeface {
-                 return ReactFontManager.getInstance()
--                    .getTypeface(fontFamily, UNSET, UNSET, view.context.assets)
-+                    .getTypeface(fontFamily, -1, -1, view.context.assets)
-             }
-         
-             override fun fetchFont(fontFamily: String, fontStyle: String, fontName: String): Typeface {
-@@ -80,10 +79,10 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
-                     "Medium" -> 500
-                     "Bold" -> 700
-                     "Black" -> 900
--                    else -> UNSET
-+                    else -> -1
-                 }
-                 return ReactFontManager.getInstance()
--                    .getTypeface(fontName, UNSET, weight, view.context.assets)
-+                    .getTypeface(fontName, -1, weight, view.context.assets)
-             }
-         })
-     }


### PR DESCRIPTION
# Why

react-native nightlies testing is broken on 0.74.0-nightly-20240121-a58ec074b

# How

- [core] CallInvokerHolderImpl requires a framework api: https://github.com/facebook/react-native/pull/42399
- [lottie-react-native] breaking change discussed at: https://github.com/facebook/react-native/pull/39630#issuecomment-1903771993

# Test Plan

ci passed (test-suite and test-suite-nightly)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
