### PR TITLE
[docs] add Kadi's latest podcast to the list

### DIFF
--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -67,6 +67,13 @@ export const TALKS = [
 
 export const PODCASTS = [
   {
+    title: 'EAS, Expo Prebuild & SDK 50',
+    event: 'Rocket Ship #025',
+    description: "Kadi Kraman",
+    videoId: "pPQNDHCOoAE",
+    link: "https://podcast.galaxies.dev/episodes/025-eas-expo-prebuild-sdk-50-with-kadi-kraman"
+  },
+  {
     title: 'Improving Developer Experience with Expo',
     event: 'The React Native Show #28',
     description: "Jon Samp, Cedric van Putten",
@@ -92,7 +99,7 @@ export const PODCASTS = [
     event: 'Rocket Ship #007',
     description: "Cedric van Putten",
     videoId: "yK0UDiLjxNY",
-    link: "https://share.transistor.fm/s/952096ad"
+    link: "https://podcast.galaxies.dev/episodes/007-expo-router-debugging-with-cedric-van-putten"
   }
 ] as Talk[]
 


### PR DESCRIPTION
# Why

Let people know.

# How

Add the latest Kadi's podcast appearance to the resources section.

# Test Plan

Addition has been reviewed locally.

# Preview

![Screenshot 2024-01-22 at 12 35 06](https://github.com/expo/expo/assets/719641/2f11302c-68f8-4ae9-b927-7e69cf3d3f5b)

