### PR TITLE
[docs] Update Sentry imports in code examples

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -154,7 +154,7 @@ Create a new release build of your app and verify that it uploads source maps co
 import { Button } from 'react-native';
 
 // Inside some component
-<Button title="Press me" onPress={() => throw new Error('Hello, Sentry!')} />;
+<Button title="Press me" onPress={() => { throw new Error('Hello, Sentry!')}; } />;
 ```
 
 </Step>
@@ -168,7 +168,7 @@ If your app uses [Expo Router](/router/introduction), then you can configure Sen
 ```tsx app/_layout.tsx
 import { Slot, useNavigationContainerRef } from 'expo-router';
 import React from 'react';
-import * as Sentry from 'sentry-expo';
+import * as Sentry from '@sentry/react-native';
 
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
 const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
@@ -238,6 +238,7 @@ Configuring Sentry to tag your scope with information about your update allows t
 Add the following snippet in the global scope as early as possible in your application's lifecycle.
 
 ```js
+import * as Sentry from '@sentry/react-native';
 import * as Updates from 'expo-updates';
 
 const manifest = Updates.manifest;


### PR DESCRIPTION
# Why
The Expo Router screen tracking section of the SDK 50 Sentry guide mentioned `sentry-expo` instead of `@sentry/react-native`, that's primarily why I was in here.

But also noticed a missing import from the EAS Update example, and thanks to @frankcalise for noting the missing enclosure for the test button example!

# How
Updated the doc

# Test Plan
Look at doc

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
