### PR TITLE
[docs] Reference prebuild workaround for private package registry

### DIFF
--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -93,7 +93,7 @@ You can customize how the native folders are generated while remaining in the ma
 
 Prebuild generates template files before modifying them with config plugins. The template files are based on the Expo SDK version and come from the npm package [`expo-template-bare-minimum`][template]. You can change the template used by passing `--template /path/to/template.tgz` to the `npx expo prebuild` command. This is not generally recommended because the base modifiers in `@expo/prebuild-config` make some undocumented assumptions about the template files, so it may be tricky to maintain your custom template.
 
-> **Note:** In network environments where all packages are downloaded from a private registry and npm public registry access is blocked, a locally-available template must be passed to the prebuild command. Learn more about [using a local version of the default template](https://expo.fyi/prebuild-without-npm-access).
+> **Note:** In network environments where all packages are downloaded from a private registry and npm public registry access is blocked, a locally-available template must be passed to the prebuild command. [Learn more about using a local version of the default template](https://expo.fyi/prebuild-without-npm-access).
 
 ## Side effects
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -89,9 +89,11 @@ There are cases where developers may want to swap between workflows often. For e
 
 ## Templates
 
-You can customize how the native folders are generated while remaining in the managed workflow by building [config plugins][config-plugins]. Many config plugins already exist for lots of modifications. You can [see a list of some popular plugins][config-plugins-repo] for more information.
+You can customize how the native folders are generated while remaining in the managed workflow by building [config plugins](/config-plugins/introduction). Many config plugins already exist for lots of modifications. You can [see a list of some popular plugins][config-plugins-repo] for more information.
 
 Prebuild generates template files before modifying them with config plugins. The template files are based on the Expo SDK version and come from the npm package [`expo-template-bare-minimum`][template]. You can change the template used by passing `--template /path/to/template.tgz` to the `npx expo prebuild` command. This is not generally recommended because the base modifiers in `@expo/prebuild-config` make some undocumented assumptions about the template files, so it may be tricky to maintain your custom template.
+
+> **Note:** In network environments where all packages are downloaded from a private registry and npm public registry access is blocked, a locally-available template must be passed to the prebuild command. Learn more about [using a local version of the default template](https://expo.fyi/prebuild-without-npm-access).
 
 ## Side effects
 


### PR DESCRIPTION
# Why
Fulfills https://linear.app/expo/issue/ENG-10707/improved-documentation-for-workarounds-for-fully-private-npm-private.

I created an FYI for working around how prebuild downloads the template when npm isn't available, and wanted to find somewhere in the docs to reference it.

# How
Added a note to the prebuild doc, under templates.

# Test Plan
Look at the doc

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
