### PR TITLE
Uncomment all Metro tests and add splitting tests back

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Uncomment all Metro tests.
+- Uncomment all Metro tests. ([#26610](https://github.com/expo/expo/pull/26610) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove lazy loading in build process for easier development. ([#26559](https://github.com/expo/expo/pull/26559) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.3 - 2024-01-18

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Uncomment all Metro tests.
 - Remove lazy loading in build process for easier development. ([#26559](https://github.com/expo/expo/pull/26559) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.3 - 2024-01-18

--- a/packages/@expo/metro-config/src/serializer/__tests__/withExpoSerializers.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/withExpoSerializers.test.ts
@@ -130,7 +130,7 @@ describe('serializes', () => {
     });
   });
 
-  /*   describe('debugId', () => {
+  describe('debugId', () => {
     describe('legacy serializer', () => {
       it(`serializes with debugId annotation`, async () => {
         const artifacts = await serializeTo({
@@ -583,6 +583,14 @@ describe('serializes', () => {
     expect(bundle.map).toMatch(/debugId/);
   });
 
+  // Serialize to a split bundle
+  async function serializeSplitAsync(fs: Record<string, string>) {
+    return await serializeTo({
+      fs,
+      options: { platform: 'web', dev: false, output: 'static' },
+    });
+  }
+
   it(`bundle splits an async import`, async () => {
     const artifacts = await serializeSplitAsync({
       'index.js': `
@@ -878,5 +886,5 @@ describe('serializes', () => {
     // });
     // // Ensure the dedupe chunk isn't run, just loaded.
     // expect(artifacts[3].source).not.toMatch(/TEST_RUN_MODULE/);
-  }); */
+  });
 });


### PR DESCRIPTION
# Why

All the metro tests were removed in https://github.com/expo/expo/pull/25859
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
