### PR TITLE
Bump androidx.browser:browser to 1.6.0

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
+- Updated `androidx.browser:browser` to `1.6.0` [#26619](https://github.com/expo/expo/pull/26619) by [@zoontek](https://github.com/zoontek)
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -181,7 +181,7 @@ dependencies {
   // Needed by gesture handler
   implementation "androidx.core:core-ktx:1.6.0"
 
-  api "androidx.browser:browser:1.2.0"
+  api "androidx.browser:browser:1.6.0"
 
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.10"

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Updated `androidx.browser:browser` to `1.6.0` [#26619](https://github.com/expo/expo/pull/26619) by [@zoontek](https://github.com/zoontek)
+
 ## 12.8.1 - 2023-12-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   }
 
-  api "androidx.browser:browser:1.2.0"
+  api "androidx.browser:browser:1.6.0"
 
   implementation "androidx.core:core-ktx:1.7.0"
 


### PR DESCRIPTION
# Why

Our product can be embed in our clients applications, using in-app browser. But we noticed that the clients using Expo suffers from issues when it cames to WebAuthn.
As we were not able to reproduce in our [bare react-native implementation example](https://github.com/swan-io/swan-partner-mobile), we noticed that `expo-web-browser` is using a [quite old version](https://developer.android.com/jetpack/androidx/releases/browser#version_120_3) of the dependency.

This PR bump the dependency to `1.6.0`.

`1.7.0` is not doable at the moment as it requires `compileSdk` to at least `34` and would drop Expo 49 support:

<img width="840" alt="Screenshot 2024-01-23 at 10 19 36" src="https://github.com/expo/expo/assets/1902323/bdbc6532-57f2-41de-90bd-5d730e0c4bdf">

---

**EDIT:** I also added updating the `expo-dev-menu` module dependency as installing the two at the same time would leads to conflicts if the deps versions does not align.

# How

Just bump the dependency version. There's no breaking changes and it appears to be safe.

# Test Plan

Test that the module continues to behaves correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
