### PR TITLE
[docs] Remove Google Fit requirement in Pedometer API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/pedometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.

--- a/docs/pages/versions/v46.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.

--- a/docs/pages/versions/v47.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.

--- a/docs/pages/versions/v48.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.

--- a/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.

--- a/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
@@ -88,7 +88,3 @@ import { Pedometer } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-pedometer" apiName="Pedometer" />
-
-## Standalone applications
-
-You'll need to [configure an Android OAuth client](https://developers.google.com/fit/android/get-api-key) for your app on the Google Play console for it to work as a standalone application on the Android platform.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on a question from @wodin on [Discord](https://discord.com/channels/695411232856997968/1012054197409165387/1197203309623250945), @alanjhughes, [confirmed](https://discord.com/channels/695411232856997968/1012054197409165387/1197696889672433836) that it is not required to configure an API key for Google Fit. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes the Standalone applications section from Pedometer API reference doc. Changes backported to all SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
