### PR TITLE
[docs] Update SDK 50 section on Upgrade Expo SDK

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -79,11 +79,11 @@ Each SDK announcement blog post contains deprecations, breaking changes, and any
 
 ### SDK 50
 
-[Blog Post](/versions/latest/#using-pre-release-versions)
+[Blog Post](https://expo.dev/changelog/2024/01-18-sdk-50)
 
 ### SDK 49
 
-[Blog Post](https://expo.dev/changelog/2024/01-18-sdk-50)
+[Blog Post](https://blog.expo.dev/expo-sdk-49-c6d398cdf740)
 
 ### SDK 48
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -77,13 +77,13 @@ If you manage your own native projects, you will need to manually apply any chan
 
 Each SDK announcement blog post contains deprecations, breaking changes, and anything else that might be unique to that particular SDK version. When upgrading, be sure to check these out to make sure you don't miss anything.
 
-### SDK 50 (canary)
+### SDK 50
 
-[How to use pre-release versions](/versions/latest/#using-pre-release-versions)
+[Blog Post](/versions/latest/#using-pre-release-versions)
 
 ### SDK 49
 
-[Blog Post](https://blog.expo.dev/expo-sdk-49-c6d398cdf740)
+[Blog Post](https://expo.dev/changelog/2024/01-18-sdk-50)
 
 ### SDK 48
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

@tchayen caught and pointed out that Upgrade Expo SDK page is outdated because it doesn't contain SDK 50 blog post release.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- removes canary from SDK 50
- Adds the link to the changelog post for SDK 50 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and go to Upgrade Expo SDK page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
