### PR TITLE
[launcher][Android] Fix loading app without reverse proxy

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- [Android] Fixed unable to load dev client bundle on device. ([#26630](https://github.com/expo/expo/pull/26630) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -75,6 +75,11 @@ fun injectDebugServerHost(
     val mSettingsField = devServerHelper.javaClass.getDeclaredField("mSettings")
     mSettingsField.isAccessible = true
     mSettingsField[devServerHelper] = settings
+
+    val packagerConnectionSettingsField = devServerHelper.javaClass.getDeclaredField("mPackagerConnectionSettings")
+    packagerConnectionSettingsField.isAccessible = true
+    packagerConnectionSettingsField[devServerHelper] = settings.public_getPackagerConnectionSettings()
+
     // set useDeveloperSupport to true in case it was previously set to false from loading a published app
     val mUseDeveloperSupportField = instanceManager.javaClass.getDeclaredField("mUseDeveloperSupport")
     mUseDeveloperSupportField.isAccessible = true

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
@@ -11,6 +11,9 @@ internal class DevLauncherInternalSettings(
   private var packagerConnectionSettings = DevLauncherPackagerConnectionSettings(context, debugServerHost)
 
   override fun getPackagerConnectionSettings() = packagerConnectionSettings
+
+  @Suppress("FunctionName")
+  fun public_getPackagerConnectionSettings() = getPackagerConnectionSettings()
 }
 
 /**


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/26364.

# How

This PR: https://github.com/facebook/react-native/pull/37265 changes how the packager connection is received. Now, it's passed next to the dev support settings, so our swapping logic didn't cover that.

# Test Plan

```
- npx expo prebuild -p android --clean
- cd ./android
- ./gradlew app:assembleDebug
- Install the apk from ./android/app/build/outputs/apk/debug on your physical device
- npx expo start
- Connect to the dev server
```