### PR TITLE
fix(expo-module-scripts): configure jest with `prettier@2` to update inline snapshots

### DIFF
--- a/packages/expo-module-scripts/jest-preset-cli.js
+++ b/packages/expo-module-scripts/jest-preset-cli.js
@@ -9,4 +9,6 @@ module.exports = {
     require.resolve('jest-watch-typeahead/filename'),
     require.resolve('jest-watch-typeahead/testname'),
   ],
+  // See: https://jestjs.io/docs/configuration#prettierpath-string
+  prettierPath: require.resolve('jest-snapshot-prettier'),
 };

--- a/packages/expo-module-scripts/jest-preset-plugin.js
+++ b/packages/expo-module-scripts/jest-preset-plugin.js
@@ -9,4 +9,6 @@ module.exports = {
     require.resolve('jest-watch-typeahead/filename'),
     require.resolve('jest-watch-typeahead/testname'),
   ],
+  // See: https://jestjs.io/docs/configuration#prettierpath-string
+  prettierPath: require.resolve('jest-snapshot-prettier'),
 };

--- a/packages/expo-module-scripts/jest-preset.js
+++ b/packages/expo-module-scripts/jest-preset.js
@@ -9,4 +9,6 @@ module.exports = withWatchPlugins({
     createJestPreset(require('jest-expo/node/jest-preset')),
     // Remove sub-watch-plugins from the preset when using multi-project runner.
   ].map(({ watchPlugins, ...config }) => config),
+  // See: https://jestjs.io/docs/configuration#prettierpath-string
+  prettierPath: require.resolve('jest-snapshot-prettier'),
 });

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -40,7 +40,8 @@
     "eslint-config-universe": "^12.0.0",
     "find-yarn-workspace-root": "^2.0.0",
     "glob": "^7.1.7",
-    "jest-expo": "~50.0.0-alpha.0",
+    "jest-expo": "~50.0.1",
+    "jest-snapshot-prettier": "npm:prettier@^2",
     "jest-watch-typeahead": "2.2.1",
     "ts-jest": "~29.0.4",
     "typescript": "^5.1.3"


### PR DESCRIPTION
# Why

Follow-up from #26632

This adds `prettier@^2` as `jest-snapshot-prettier` and configures Jest to use this prettier when updating inline snapshots.

Unfortunately, this [is required as Jest is not compatible with pretteir@^3](https://jestjs.io/docs/configuration#prettierpath-string).

# How

- Updated `jest-expo` to stable SDK 50
- Added `"jest-snapshot-prettier": "npm:prettier@^2"`
- Configured `prettierPath` in all jest configs

# Test Plan

- `$ cd ./packages/fingerprint`
- `$ code ./e2e/__tests__/managed-test.ts`
- Modify any part of the snapshot in:
  - "diffFingerprintChangesAsync - should return diff after adding native library"
- `$ CI=true yarn test:e2e ./e2e/__tests__/managed-test.ts -u` (_notice the CI=true, to not enable watch mode_)
  - Snapshot should be updated back to it's original form, without erroring. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
