### PR TITLE
fix(create-expo): properly filter tar files from github repos

### DIFF
--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -1,6 +1,6 @@
 import Minipass from 'minipass';
 import path from 'path';
-import picomatch, { type PicomatchOptions } from 'picomatch';
+import picomatch from 'picomatch';
 import { type ReadEntry } from 'tar';
 
 const debug = require('debug')('expo:init:fileTransform') as typeof console.log;
@@ -79,7 +79,10 @@ export function createFileTransform(name: string) {
   };
 }
 
-export function createGlobFilter(globPattern: string, options?: PicomatchOptions) {
+export function createGlobFilter(
+  globPattern: picomatch.Glob,
+  options?: picomatch.PicomatchOptions
+) {
   const matcher = picomatch(globPattern, options);
 
   debug('filter: created for pattern %s (%s)', globPattern);

--- a/packages/create-expo/src/utils/github.ts
+++ b/packages/create-expo/src/utils/github.ts
@@ -65,9 +65,17 @@ async function extractRemoteGitHubTarballAsync(
   const directory = repo.filePath.replace(/^\//, '').split('/').filter(Boolean);
   // Remove the (sub)directory paths, and the root folder added by GitHub
   const strip = directory.length + 1;
-  // Only extract the (sub)directory paths
-  const filter =
-    directory.length >= 1 ? createGlobFilter(`*/${directory.join('/')}/**`) : undefined;
+  // Only extract the relevant (sub)directories, ignoring irrelevant files
+  // The filder auto-ignores dotfiles, unless explicitly included
+  const filter = createGlobFilter(
+    !directory.length
+      ? ['*/**', '*/ios/.xcode.env']
+      : [`*/${directory.join('/')}/**`, `*/${directory.join('/')}/ios/.xcode.env`],
+    {
+      // Always ignore the `.xcworkspace` folder
+      ignore: ['**/ios/*.xcworkspace/**'],
+    }
+  );
 
   await extractNpmTarballAsync(response.body, { ...props, filter, strip });
 }


### PR DESCRIPTION
# Why

Backporting from #26631

# How

- Added filtering logic from `expo prebuild --template <github-url>`

# Test Plan

See tests

- `$ bun create expo ./test --template expo-template-bare-minimum@49`
- `$ cd ./test`
- `$ rm -rf android ios`
- `$ bun expo prebuild`
- `$ git add . && git commit -m 'chore: initial prebuild'`
- Delete everything, except `.git`
- `$ create-expod . --no-install --template https://github.com/expo/expo/tree/sdk-49/templates/expo-template-bare-minimum`
- Configure `com.test` in `app.json` as `android.package` and `ios.bundleIdentifier`
- `$ bun install && bun expo prebuild --clean`
- Result should pretty much be the same (there might be some differences in lockfiles and native files 🤷)

> ℹ️ In these examples `create-expod` is an alias for `node <create-expo>/build/index.js`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
