### PR TITLE
[docs] Ensure native diff page has SDK versions in URL on first load

### DIFF
--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { spacing } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
+import { useEffect } from 'react';
 
 import { VersionSelector } from './VersionSelector';
 
@@ -25,6 +26,14 @@ export const TemplateBareMinimumDiffViewer = () => {
 
   const fromVersion = router?.query.fromSdk || lastTwoProductionVersions[0];
   const toVersion = router?.query.toSdk || lastTwoProductionVersions[1];
+
+  // Ensure that URL always contains from and to SDK version, even on first load
+  // to avoid copying links that would change with new SDK versions.
+  useEffect(() => {
+    if (router?.isReady && (!router?.query.fromSdk || !router?.query.toSdk)) {
+      router?.push({ query: { fromSdk: fromVersion, toSdk: toVersion } });
+    }
+  }, [router?.query.fromSdk, router?.query.toSdk, router?.isReady]);
 
   // remove unversioned if this environment doesn't show it in the SDK reference
   if (!VERSIONS.find((version: string) => version === 'unversioned')) {


### PR DESCRIPTION
# Why
I noticed when copying a link to a file's diff from the URL bar, that, if the diff was for the last two SDK versions (and I hadn't touched the dropdowns), the URL that I copied would be missing the SDK versions. Thus, when the SDK changes, that would mess up my link.

# How
Added a check after load to see if the from and to SDK versions were present in the URL, and, if they're not, added them. The `isReady` check is used to work around [this issue](https://stackoverflow.com/questions/61040790/userouter-withrouter-receive-undefined-on-query-in-first-render).

# Test Plan
- See if `toSdk` and `fromSdk` are populated when loading the page fresh without touching the dropdowns. 
- Ensure there's no errors when reloading the page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [s] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
