### PR TITLE
docs(fix): remove navigate function from router object.

### DIFF
--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -81,7 +81,6 @@ export function logout() {
 
 The `router` object is immutable and contains the following functions:
 
-- **navigate**: `(href: Href) => void` Navigate to a route using the default behavior. You can provide a full path like **/profile/settings** or a relative path like **../settings**. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 - **push**: `(href: Href) => void` Navigate to a route by always pushing onto the stack. You can provide a full path like **/profile/settings** or a relative path like **../settings**. Navigate to dynamic routes by passing an object like `{ pathname: 'profile', params: { id: '123' } }`.
 - **replace**: `(href: Href) => void` Navigate to a route by substituting the current route with a new one. This is useful for redirects.
 - **back**: `() => void` Navigate back to previous route.


### PR DESCRIPTION
# Why

Inside router object we dont have a function called navigate.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
