### PR TITLE
[expo-go] Fix build

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ConstantsBinding.kt
@@ -52,11 +52,6 @@ class ConstantsBinding(
   private val executionEnvironment: ExecutionEnvironment
     get() = ExecutionEnvironment.STORE_CLIENT
 
-  override fun getOrCreateInstallationId(): String {
-    // Override scoped installationId from ConstantsService with unscoped
-    return exponentSharedPreferences.getOrCreateUUID()
-  }
-
   companion object {
     private fun convertPixelsToDp(px: Float, context: Context): Int {
       val resources = context.resources


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/26329 removed this method from the base class. This removes it from the subclass. It is unused.

# How

Remove method. Grep for usage.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
