### PR TITLE
[ci] Fix workflow paths for new Expo Go location

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/android-instrumentation-tests.yml
-      - android/**
+      - apps/expo-go/android/**
       - fastlane/**
       # - packages/**/android/**
       - packages/expo-eas-client/android/**
@@ -19,7 +19,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/android-instrumentation-tests.yml
-      - android/**
+      - apps/expo-go/android/**
       - fastlane/**
       # - packages/**/android/**
       - packages/expo-eas-client/android/**

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/android-unit-tests.yml
-      - android/**
+      - apps/expo-go/android/**
       - fastlane/**
       - packages/**/android/**
       - tools/**
@@ -15,7 +15,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/android-unit-tests.yml
-      - android/**
+      - apps/expo-go/android/**
       - fastlane/**
       - packages/**/android/**
       - tools/**

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -6,13 +6,13 @@ on:
     paths:
       - .github/workflows/client-android-eas.yml
       - apps/eas-expo-go/**
-      - android/**
+      - apps/expo-go/android/**
   push:
     branches: [main, sdk-*]
     paths:
       - .github/workflows/client-android-eas.yml
       - apps/eas-expo-go/**
-      - android/**
+      - apps/expo-go/android/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -17,7 +17,7 @@ on:
     paths:
       - .github/workflows/client-ios-eas.yml
       - apps/eas-expo-go/**
-      - ios/**
+      - apps/expo-go/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
       - secrets/**

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ios-unit-tests.yml
-      - ios/**
+      - apps/expo-go/ios/**
       - packages/**/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
@@ -19,7 +19,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/ios-unit-tests.yml
-      - ios/**
+      - apps/expo-go/ios/**
       - packages/**/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts


### PR DESCRIPTION
# Why

Noticed in https://github.com/expo/expo/pull/26647 that most test suites weren't running. This was due to us moving android and ios into apps/expo-go directory.

# How

Fix them by watching the new locations of the expo go code.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
