### PR TITLE
[android] Clear event emitter warnings

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Throw `UnavailabilityError` when trying to use `setNotificationCategoryAsync` on web. ([#26511](https://github.com/expo/expo/pull/26511) by [@marklawlor](https://github.com/marklawlor))
 - Remove `.native` hardcoded platform imports ([#26511](https://github.com/expo/expo/pull/26511) by [@marklawlor](https://github.com/marklawlor))
+- On `Android`, added events to module definition to clear warnings.
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Throw `UnavailabilityError` when trying to use `setNotificationCategoryAsync` on web. ([#26511](https://github.com/expo/expo/pull/26511) by [@marklawlor](https://github.com/marklawlor))
 - Remove `.native` hardcoded platform imports ([#26511](https://github.com/expo/expo/pull/26511) by [@marklawlor](https://github.com/marklawlor))
-- On `Android`, added events to module definition to clear warnings.
+- On `Android`, added events to module definition to clear warnings. ([#26654](https://github.com/expo/expo/pull/26654) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
@@ -23,6 +23,12 @@ open class NotificationsEmitter : Module(), NotificationListener {
   override fun definition() = ModuleDefinition {
     Name("ExpoNotificationsEmitter")
 
+    Events(
+      "onDidReceiveNotification",
+      "onNotificationsDeleted",
+      "onDidReceiveNotificationResponse"
+    )
+
     OnCreate {
       eventEmitter = appContext.legacyModule<EventEmitter>()
         ?: throw ModuleNotFoundException(EventEmitter::class)

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
@@ -57,6 +57,11 @@ open class NotificationsHandler : Module(), NotificationListener {
   override fun definition() = ModuleDefinition {
     Name("ExpoNotificationsHandlerModule")
 
+    Events(
+      "onHandleNotification",
+      "onHandleNotificationTimeout"
+    )
+
     OnCreate {
       moduleRegistry = appContext.legacyModuleRegistry
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -23,6 +23,8 @@ class PushTokenModule : Module(), PushTokenListener {
   override fun definition() = ModuleDefinition {
     Name("ExpoPushTokenManager")
 
+    Events("onDevicePushToken")
+
     OnCreate {
       eventEmitter = appContext.legacyModule()
         ?: throw ModuleNotFoundException(EventEmitter::class)

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, added events to module definition to clear warnings.
+- On `Android`, added events to module definition to clear warnings. ([#26654](https://github.com/expo/expo/pull/26654) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, added events to module definition to clear warnings.
+
 ### 💡 Others
 
 ## 11.7.0 — 2023-11-14

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
@@ -23,12 +23,14 @@ class TaskManagerModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoTaskManager")
 
+    Events(TaskManagerInterface.EVENT_NAME)
+
     Constants(
       "EVENT_NAME" to TaskManagerInterface.EVENT_NAME
     )
 
     AsyncFunction("isAvailableAsync") {
-      taskService != null
+      return@AsyncFunction true
     }
 
     AsyncFunction("notifyTaskFinishedAsync") { taskName: String, response: Map<String, Any?> ->


### PR DESCRIPTION
# Why
Closes #26600
We had event emitter warnings in task manager and notifications. 

# How
Added these events to the module definitions

# Test Plan
Bare-expo. Warnings are all cleared.
