### PR TITLE
[Expo AV] fix: recording audio on Android

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Improve precision for syncing two videos and updating new video position when user sets tolerances to 0 ([#26018](https://github.com/expo/expo/pull/26018) by [@jpudysz](https://github.com/jpudysz))
 - [Android] Add `Events` `to AVModule` to prevent event emitter warning. ([#26434](https://github.com/expo/expo/pull/26434) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix recording audio on Android after converting to Expo Modules ([todo](https://github.com/expo/expo/pull/todo) by [@jpudysz](https://github.com/jpudysz))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Improve precision for syncing two videos and updating new video position when user sets tolerances to 0 ([#26018](https://github.com/expo/expo/pull/26018) by [@jpudysz](https://github.com/jpudysz))
 - [Android] Add `Events` `to AVModule` to prevent event emitter warning. ([#26434](https://github.com/expo/expo/pull/26434) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix recording audio on Android after converting to Expo Modules ([todo](https://github.com/expo/expo/pull/todo) by [@jpudysz](https://github.com/jpudysz))
+- [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -20,6 +20,7 @@ import com.facebook.jni.HybridData;
 
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;
+import expo.modules.core.arguments.MapArguments;
 import expo.modules.core.arguments.ReadableArguments;
 import expo.modules.core.interfaces.DoNotStrip;
 import expo.modules.core.interfaces.InternalModule;
@@ -48,6 +49,7 @@ import expo.modules.interfaces.permissions.Permissions;
 import expo.modules.interfaces.permissions.PermissionsResponseListener;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 
 import static android.media.MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED;
@@ -669,7 +671,8 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
     removeAudioRecorder();
 
-    final ReadableArguments androidOptions = options.getArguments(RECORDING_OPTIONS_KEY);
+    final ReadableNativeMap androidMap = (ReadableNativeMap) options.get(RECORDING_OPTIONS_KEY);
+    final ReadableArguments androidOptions = new MapArguments(androidMap.toHashMap());
 
     final String filename = "recording-" + UUID.randomUUID().toString()
       + androidOptions.getString(RECORDING_OPTION_EXTENSION_KEY);


### PR DESCRIPTION
# Why

Recording audio on Android has been broken since expo-av 13.4.1.
It was reported here: #24629 

The module is generating the following error:

```
[Error: Call to function 'ExponentAV.prepareAudioRecorder' has been rejected. → Caused by: java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.String expo.modules.core.arguments.ReadableArguments.getString(java.lang.String)' on a null object reference]
```

I believe it's because of this commit: #23902 which coverted the module to an Expo Module. Despite the code appearing to be correct, the devil is in the details.

Previously, the implementation utilized `ReadableArguments`, and the android key was passed as a `HashMap`:

![v1](https://github.com/expo/expo/assets/9088288/de30f205-7a9a-48af-8c5d-a519f1442475)

With the new version (Expo module), we are passing a `Map<String, Any?>`, which contains `ReadableNativeMap` internally. I believe that this change is due to the Expo Module having a different converter, in addition to the use of Kotlin.

![v2](https://github.com/expo/expo/assets/9088288/bd600088-3c86-404b-a1fe-99ab7b4d2ca6)

# How

Keeping the transition to the Expo Module in mind, the code is encountering issues at this point:

![v2-2](https://github.com/expo/expo/assets/9088288/b06423f6-3d07-48ec-a5d3-f9a6233a28ac)

The call to `options.getArguments(RECORDING_OPTIONS_KEY)` aims to retrieve a `Map`, but the underlying implementation, `ReadableNativeMap`, leads to a fallback to null.

Previously, when using a `HashMap`, `androidOptions` were parsed correctly:

![v1-2](https://github.com/expo/expo/assets/9088288/cce43057-881c-402a-b386-975fd375bdfe)


# Test Plan

I patched my local project with the code attached to this pull request and was able to record audio. I achieved this by converting React Native's `ReadableNativeMap` to `MapArguments`.

Pardon me if there's a better way to accomplish this. I'm not fully understand the underlying Expo Modules API, and I couldn't find any reference to this issue elsewhere in the codebase.

![v3](https://github.com/expo/expo/assets/9088288/8a04fb9a-159c-4530-8447-3d3b63d21542)


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
