### PR TITLE
[expo-updates] Add timers to all procedures

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/procedures/StateMachineSerialExecutorQueueTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/procedures/StateMachineSerialExecutorQueueTest.kt
@@ -3,6 +3,8 @@ package expo.modules.updates.procedures
 import android.os.Handler
 import android.os.HandlerThread
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import expo.modules.updates.statemachine.UpdatesStateValue
 import org.junit.Test
@@ -16,7 +18,12 @@ class StateMachineSerialExecutorQueueTest {
   fun test_SerialExecution() {
     val latch = CountDownLatch(3)
 
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val logger = UpdatesLogger(context)
+
     class TestStateMachineProcedure : StateMachineProcedure() {
+      override val loggerTimerLabel = "timer-test"
+
       var executionTime: Long = 0
 
       override fun run(procedureContext: ProcedureContext) {
@@ -36,18 +43,21 @@ class StateMachineSerialExecutorQueueTest {
       }
     }
 
-    val executorQueue = StateMachineSerialExecutorQueue(object : StateMachineProcedure.StateMachineProcedureContext {
-      override fun processStateEvent(event: UpdatesStateEvent) {
-      }
+    val executorQueue = StateMachineSerialExecutorQueue(
+      logger,
+      object : StateMachineProcedure.StateMachineProcedureContext {
+        override fun processStateEvent(event: UpdatesStateEvent) {
+        }
 
-      @Deprecated("Avoid needing to access current state to know how to transition to next state")
-      override fun getCurrentState(): UpdatesStateValue {
-        return UpdatesStateValue.Idle
-      }
+        @Deprecated("Avoid needing to access current state to know how to transition to next state")
+        override fun getCurrentState(): UpdatesStateValue {
+          return UpdatesStateValue.Idle
+        }
 
-      override fun resetState() {
+        override fun resetState() {
+        }
       }
-    })
+    )
 
     val procedure1 = TestStateMachineProcedure()
     val procedure2 = TestStateMachineProcedure()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -25,6 +25,8 @@ class CheckForUpdateProcedure(
   private val launchedUpdate: UpdateEntity?,
   private val callback: (IUpdatesController.CheckForUpdateResult) -> Unit
 ) : StateMachineProcedure() {
+  override val loggerTimerLabel = "timer-check-for-update"
+
   override fun run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEvent.Check())
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -26,6 +26,8 @@ class FetchUpdateProcedure(
   private val launchedUpdate: UpdateEntity?,
   private val callback: (IUpdatesController.FetchUpdateResult) -> Unit
 ) : StateMachineProcedure() {
+  override val loggerTimerLabel = "timer-fetch-update"
+
   override fun run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEvent.Download())
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -11,6 +11,8 @@ class RecreateReactContextProcedure(
   private val reactNativeHost: WeakReference<ReactNativeHost>?,
   private val callback: Launcher.LauncherCallback
 ) : StateMachineProcedure() {
+  override val loggerTimerLabel = "timer-recreate-react-context"
+
   override fun run(procedureContext: ProcedureContext) {
     val host = reactNativeHost?.get()
     if (host == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -31,6 +31,8 @@ class RelaunchProcedure(
   private val shouldRunReaper: Boolean,
   private val callback: Launcher.LauncherCallback
 ) : StateMachineProcedure() {
+  override val loggerTimerLabel = "timer-relaunch"
+
   override fun run(procedureContext: ProcedureContext) {
     val host = reactNativeHost?.get()
     if (host == null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -37,6 +37,8 @@ class StartupProcedure(
   private val logger: UpdatesLogger,
   private val callback: StartupProcedureCallback
 ) : StateMachineProcedure() {
+  override val loggerTimerLabel = "timer-startup"
+
   interface StartupProcedureCallback {
     fun onFinished()
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineProcedure.kt
@@ -36,4 +36,6 @@ abstract class StateMachineProcedure {
   }
 
   abstract fun run(procedureContext: ProcedureContext)
+
+  abstract val loggerTimerLabel: String
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -15,19 +15,24 @@ class UpdatesStateMachine(
   private val changeEventSender: UpdatesStateChangeEventSender,
   private val validUpdatesStateValues: Set<UpdatesStateValue>
 ) {
-  private val serialExecutorQueue = StateMachineSerialExecutorQueue(object : StateMachineProcedure.StateMachineProcedureContext {
-    override fun processStateEvent(event: UpdatesStateEvent) {
-      this@UpdatesStateMachine.processEvent(event)
-    }
+  private val logger = UpdatesLogger(androidContext)
 
-    override fun getCurrentState(): UpdatesStateValue {
-      return state
-    }
+  private val serialExecutorQueue = StateMachineSerialExecutorQueue(
+    logger,
+    object : StateMachineProcedure.StateMachineProcedureContext {
+      override fun processStateEvent(event: UpdatesStateEvent) {
+        this@UpdatesStateMachine.processEvent(event)
+      }
 
-    override fun resetState() {
-      reset()
+      override fun getCurrentState(): UpdatesStateValue {
+        return state
+      }
+
+      override fun resetState() {
+        reset()
+      }
     }
-  })
+  )
 
   /**
    * Queue a StateMachineProcedure procedure for serial execution.
@@ -35,8 +40,6 @@ class UpdatesStateMachine(
   fun queueExecution(stateMachineProcedure: StateMachineProcedure) {
     serialExecutorQueue.queueExecution(stateMachineProcedure)
   }
-
-  private val logger = UpdatesLogger(androidContext)
 
   /**
    * The current state

--- a/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/CheckForUpdateProcedure.swift
@@ -31,6 +31,10 @@ final class CheckForUpdateProcedure: StateMachineProcedure {
     self.errorBlock = errorBlock
   }
 
+  func getLoggerTimerLabel() -> String {
+    "timer-check-for-update"
+  }
+
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventCheck())
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -37,6 +37,10 @@ final class FetchUpdateProcedure: StateMachineProcedure {
     self.errorBlock = errorBlock
   }
 
+  func getLoggerTimerLabel() -> String {
+    "timer-fetch-update"
+  }
+
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventDownload())
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
@@ -17,6 +17,10 @@ final class RecreateReactContextProcedure: StateMachineProcedure {
     self.errorBlock = errorBlock
   }
 
+  func getLoggerTimerLabel() -> String {
+    "timer-recreate-react-context"
+  }
+
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventRestart())
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -47,6 +47,10 @@ final class RelaunchProcedure: StateMachineProcedure {
     self.errorBlock = errorBlock
   }
 
+  func getLoggerTimerLabel() -> String {
+    "timer-relaunch"
+  }
+
   func run(procedureContext: ProcedureContext) {
     procedureContext.processStateEvent(UpdatesStateEventRestart())
     let launcherWithDatabase = AppLauncherWithDatabase(

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StartupProcedure.swift
@@ -32,6 +32,10 @@ final class StartupProcedure: StateMachineProcedure, AppLoaderTaskDelegate, AppL
     self.errorRecovery.delegate = self
   }
 
+  func getLoggerTimerLabel() -> String {
+    "timer-startup"
+  }
+
   internal weak var delegate: StartupProcedureDelegate?
 
   // swiftlint:disable implicitly_unwrapped_optional

--- a/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/StateMachineProcedure.swift
@@ -80,4 +80,5 @@ final class ProcedureContext: StateMachineProcedureContext {
  */
 protocol StateMachineProcedure {
   func run(procedureContext: ProcedureContext)
+  func getLoggerTimerLabel() -> String
 }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -296,17 +296,20 @@ internal class UpdatesStateMachine {
   private let logger = UpdatesLogger()
 
   private lazy var serialExecutorQueue: StateMachineSerialExecutorQueue = {
-    return StateMachineSerialExecutorQueue(stateMachineProcedureContext: StateMachineProcedureContext(
-      processStateEventCallback: { event in
-        self.processEvent(event)
-      },
-      getCurrentStateCallback: {
-        return self.state
-      },
-      resetStateCallback: {
-        return self.reset()
-      }
-    ))
+    return StateMachineSerialExecutorQueue(
+      updatesLogger: logger,
+      stateMachineProcedureContext: StateMachineProcedureContext(
+        processStateEventCallback: { event in
+          self.processEvent(event)
+        },
+        getCurrentStateCallback: {
+          return self.state
+        },
+        resetStateCallback: {
+          return self.reset()
+        }
+      )
+    )
   }()
 
   // MARK: - Public methods and properties


### PR DESCRIPTION
# Why

This is the first of a series of PRs I have planned to add some basic instrumentation to pieces of the expo-updates library.

This PR adds timing to the asynchronous serially-executed procedures.

Future PRs may investigate things like:
- waterfall logging

Also plan to do some perf tuning but I'm struggling to even compile expo-go in a lot of scenarios currently.

Closes ENG-11201.

# How

Add timer.

# Test Plan

Inspect/build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
