### PR TITLE
[rfc][issues] Update reproducible example prompt in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,10 +12,10 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        This should include as little code as possible and not include extraneous dependencies. Do not share your entire project. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to cause the issue.
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to reproduce the issue. Do not share your entire project.
+        List the steps you took to generate the reproducible example within that repository in the README or the summary field below along with any instructions needed to run the project.
         You should also test your issue against the latest SDK version to ensure that it hasn't already been resolved.
-        Sharing a link to a GitHub repository or [Snack](https://snack.expo.dev/) are best. If sharing a repository, include the steps you took to generate the reproducible example within that repository. Include any instructions to run the project in the README or the summary field below.
-        If a reproducible demo is not provided, your issue will be closed.
+        If a reproducible example is not provided, your issue will be closed.
         [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,9 +12,9 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        This should include as little code as possible and not include extraneous dependencies. Do not share your entire project. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to cause the issue.
         You should also test your issue against the latest SDK version to ensure that it hasn't already been resolved.
-        Sharing a link to a GitHub repository or [Snack](https://snack.expo.dev/) are best. Include any instructions to run the project in the README or the summary field below.
+        Sharing a link to a GitHub repository or [Snack](https://snack.expo.dev/) are best. If sharing a repository, include the steps you took to generate the reproducible example within that repository. Include any instructions to run the project in the README or the summary field below.
         If a reproducible demo is not provided, your issue will be closed.
         [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_cli.yml
@@ -42,8 +42,10 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
-        If a reproducible demo is not provided, your issue will be closed. You must also test your issue against the latest CLI version to ensure that it hasn't already been resolved.
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to reproduce the issue. Do not share your entire project.
+        List the steps you took to generate the reproducible example within that repository in the README or the summary field below along with any instructions needed to run the project.
+        You must also test your issue against the latest CLI version to ensure that it hasn't already been resolved.
+        If a reproducible example is not provided, your issue will be closed.
         [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_router.yml
@@ -12,10 +12,10 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to reproduce the issue. Do not share your entire project.
+        List the steps you took to generate the reproducible example within that repository in the README or the summary field below along with any instructions needed to run the project.
         You should also test your issue against the latest SDK version to ensure that it hasn't already been resolved.
-        Sharing a link to a GitHub repository is best. Include any instructions to run the project in the README or the summary field below.
-        If a reproducible demo is not provided, your issue will be closed.
+        If a reproducible example is not provided, your issue will be closed.
         [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml
@@ -55,9 +55,11 @@ body:
     attributes:
       label: Reproducible demo
       description: |
-        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project. If a reproducible demo is not provided, your issue will be closed. 
-        If you link to a project that contains multiple non-Expo-core modules, it is unlikely to help us narrow down the cause of your issue more quickly. 
-        Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
+        A link to a GitHub repository containing a minimal reproducible example. This repository should include as little code as possible and not include extraneous dependencies. The most effective reproducible examples are created by starting a new project from scratch and adding in only the necessary pieces to reproduce the issue. Do not share your entire project.
+        List the steps you took to generate the reproducible example within that repository in the README or the summary field below along with any instructions needed to run the project.
+        You must also test your issue against the latest `expo-dev-client` version to ensure that it hasn't already been resolved.
+        If a reproducible example is not provided, your issue will be closed.
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
# Why

A trend I've been noticing in issue reporting is that while the report often has a attached repo, there's still little we can do until the reporter supplies a set of steps indicating how that repro was generated, requiring a back-and-forth on the issue. Knowing the set of steps is invaluable when determining whether the repro is a case that is fully supported and expected to work, partially supported, or not supported.

This PR updates the instructions to include the repro repo plus the set of steps in the report. 

# How

Update the template.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
