### PR TITLE
[expo-go] Fix update config crash due to no runtime version

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -131,6 +131,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_KEY] = 60000
     }
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY] = requestHeaders
+    configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY] = "exposdk:${Constants.TEMPORARY_SDK_VERSION}"
     // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates from the multipart manifest response part
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_CERTIFICATE] = context.assets.open("expo-root.pem").readBytes().decodeToString()
     configMap[UpdatesConfiguration.UPDATES_CONFIGURATION_CODE_SIGNING_METADATA] = mapOf(

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -342,7 +342,8 @@ NS_ASSUME_NONNULL_BEGIN
     EXUpdatesConfig.EXUpdatesConfigEnabledKey: @YES,
     EXUpdatesConfig.EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
     EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueNever,
-    EXUpdatesConfig.EXUpdatesConfigRequestHeadersKey: [self _requestHeaders]
+    EXUpdatesConfig.EXUpdatesConfigRequestHeadersKey: [self _requestHeaders],
+    EXUpdatesConfig.EXUpdatesConfigRuntimeVersionKey: [NSString stringWithFormat:@"exposdk:%@", [EXVersions sharedInstance].temporarySdkVersion],
   }];
 
   // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates


### PR DESCRIPTION
# Why

Expo Go used to supply SDK version, and one of SDK version or runtime version is required for a valid config. That being said, neither is actually used in Expo Go as we substitute the selection policy with one that checks all runtime versions that Expo Go supports (which is changing too soon as multiple versions have been removed).

Blame https://github.com/expo/expo/pull/26061.

# How

Supply runtime version.

# Test Plan

Run a project in Expo Go. (project still stalling out on splash screen but it launches)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
