### PR TITLE
[sensors] Clear event emitter warning

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, add event name to definition in the `DeviceMotionModule`.
+
 ### 💡 Others
 
 ## 12.9.0 — 2023-12-12

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, add event name to definition in the `DeviceMotionModule`.
+- On `Android`, add event name to definition in the `DeviceMotionModule`. ([#26679](https://github.com/expo/expo/pull/26679) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -44,6 +44,8 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
   override fun definition() = ModuleDefinition {
     Name("ExponentDeviceMotion")
 
+    Events("deviceMotionDidUpdate")
+
     Constants("Gravity" to SensorManager.GRAVITY_EARTH)
 
     OnCreate {


### PR DESCRIPTION
# Why
Event emitter warning in `DeviceMotionModule`. Hopefully this clears the last of these warnings.

# How
Add event name to definition

# Test Plan
Warning is cleared in bare-expo

