### PR TITLE
[docs] Remove duplicate instances of Bundle with metro from navigation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -142,7 +142,6 @@ const general = [
       [
         makePage('workflow/web.mdx'),
         makePage('distribution/publishing-websites.mdx'),
-        makePage('guides/customizing-metro.mdx'),
         makePage('guides/progressive-web-apps.mdx'),
       ],
       { expanded: false }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, there are duplicate instances of Bundle with metro guide in navigation.

![CleanShot 2024-01-25 at 14 17 53@2x](https://github.com/expo/expo/assets/10234615/94541067-ab3f-4aa7-b975-83d45feaf755)



# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes the instance from Guides > Web section since Evan's PR specifically added it under Guides > Bundling.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

## Preview

![CleanShot 2024-01-25 at 14 56 01@2x](https://github.com/expo/expo/assets/10234615/e93f9c9a-890a-4481-89e7-8f44c7cc8061)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
