### PR TITLE
[issues] Commenting on resolved issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -228,3 +228,25 @@ jobs:
               repo: context.repo.repo,
               state: 'closed'
             })
+  comments-on-closed:
+    runs-on: ubuntu-22.04
+    if: "${{ github.event.label.name == 'Comments on closed issue' }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks you are commenting on an issue that has been marked as resolved.
+
+              We beleive further discussion here is unhelpful and would recommend opening a new issue if you are still experiencing this problem or a related one.
+            `})
+            github.rest.issues.lock({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              lock_reason: 'resolved'
+            })

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -242,7 +242,7 @@ jobs:
               repo: context.repo.repo,
               body: `Hi there! It looks you are commenting on an issue that has been marked as resolved.
 
-              We beleive further discussion here is unhelpful and would recommend opening a new issue if you are still experiencing this problem or a related one.
+              If you are still experiencing this problem or a related one, please [open a new issue](https://github.com/expo/expo/issues/new/choose) and fill out the issue template.
             `})
             github.rest.issues.lock({
               issue_number: context.issue.number,


### PR DESCRIPTION
# Why
A common trend is to comment on closed issues with related problems. These are difficult to keep track of so I added a new label `Comments on closed issue` that adds a comment recommending opening a new issue and locks this one. 

# How
Add an action for the new label
