### PR TITLE
[expo-constants] Bring back interface compatiblity

### DIFF
--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -56,7 +56,7 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
 
   override fun getIsDevice(): Boolean {
     // Kept for compatibility with older expo-modules-core. TODO: remove in SDK 51
-    return true;
+    return true
   }
 
   override fun getSystemVersion(): String = Build.VERSION.RELEASE

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -54,7 +54,7 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
 
   override fun getStatusBarHeight() = statusBarHeightInternal
 
-  override fun getIsDevice(): Boolean {
+  fun getIsDevice(): Boolean {
     // Kept for backwards compatibility with the interface from older expo-modules-core (SDK 50).
     // TODO: Can be removed once SDK 51 is out.
     return true

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -55,7 +55,8 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
   override fun getStatusBarHeight() = statusBarHeightInternal
 
   override fun getIsDevice(): Boolean {
-    // Kept for compatibility with older expo-modules-core. TODO: remove in SDK 51
+    // Kept for backwards compatibility with the interface from older expo-modules-core (SDK 50).
+    // TODO: Can be removed once SDK 51 is out.
     return true
   }
 

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -54,6 +54,11 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
 
   override fun getStatusBarHeight() = statusBarHeightInternal
 
+  override fun getIsDevice(): Boolean {
+    // Kept for compatibility with older expo-modules-core. TODO: remove in SDK 51
+    return true;
+  }
+
   override fun getSystemVersion(): String = Build.VERSION.RELEASE
 
   // From https://github.com/dabit3/react-native-fonts


### PR DESCRIPTION
# Why

This is essentially a revert of removed code, @tsapeta suggested to keep it for some time to prevent incompatibility of older expo-modules-core and newer expo-constants.
