### PR TITLE
[location][Android] Fix `NullPointerException: it must not be null`

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed: `NullPointerException: it must not be null`.
+
 ### 💡 Others
 
 ## 16.5.2 - 2024-01-10

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed: `NullPointerException: it must not be null`.
+- [Android] Fixed: `NullPointerException: it must not be null`. ([#26688](https://github.com/expo/expo/pull/26688) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
@@ -14,6 +14,9 @@ internal class LocationBackgroundUnauthorizedException :
 internal class LocationRequestRejectedException(cause: Exception) :
   CodedException("Location request has been rejected: " + cause.message)
 
+internal class CurrentLocationIsUnavailableException :
+  CodedException("Current location is unavailable. Make sure that location services are enabled")
+
 internal class LocationRequestCancelledException :
   CodedException("Location request has been cancelled")
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
@@ -69,8 +69,13 @@ class LocationHelpers {
     fun requestSingleLocation(locationProvider: FusedLocationProviderClient, locationRequest: CurrentLocationRequest, promise: Promise) {
       try {
         locationProvider.getCurrentLocation(locationRequest, null)
-          .addOnSuccessListener {
-            promise.resolve(LocationResponse(it))
+          .addOnSuccessListener { location: Location? ->
+            if (location == null) {
+              promise.reject(CurrentLocationIsUnavailableException())
+              return@addOnSuccessListener
+            }
+
+            promise.resolve(LocationResponse(location))
           }
           .addOnFailureListener {
             promise.reject(LocationRequestRejectedException(it))
@@ -166,7 +171,8 @@ class LocationHelpers {
     }
 
     fun isAnyProviderAvailable(context: Context?): Boolean {
-      val locationManager = context?.getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return false
+      val locationManager = context?.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+        ?: return false
       return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
     }
 
@@ -177,7 +183,8 @@ class LocationHelpers {
           contextPermissions,
           object : Promise {
             override fun resolve(value: Any?) {
-              val result = value as? Bundle ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle")
+              val result = value as? Bundle
+                ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle")
               continuation.resume(PermissionRequestResponse(result))
             }
 
@@ -197,7 +204,8 @@ class LocationHelpers {
           contextPermissions,
           object : Promise {
             override fun resolve(value: Any?) {
-              it.resume(value as? Bundle ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle"))
+              it.resume(value as? Bundle
+                ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle"))
             }
 
             override fun reject(code: String, message: String?, cause: Throwable?) {

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
@@ -204,8 +204,10 @@ class LocationHelpers {
           contextPermissions,
           object : Promise {
             override fun resolve(value: Any?) {
-              it.resume(value as? Bundle
-                ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle"))
+              it.resume(
+                value as? Bundle
+                  ?: throw ConversionException(Any::class.java, Bundle::class.java, "value returned by the permission promise is not a Bundle")
+              )
             }
 
             override fun reject(code: String, message: String?, cause: Throwable?) {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/26620.
Special thanks go to @efstathiosntonas, for finding the root cause. 
 
# How

The current location may not be available, for instance, when the GPS is turned off. 

# Test Plan

- [kamui545/expo-location-issues](https://github.com/kamui545/expo-location-issues) ✅ 