### PR TITLE
[core][Android] Add an alternative way of installing the JSI bindings

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
+- Added an alternative way of installing the JSI bindings.
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
-- Added an alternative way of installing the JSI bindings.
+- Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -18,6 +18,7 @@ import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
 import expo.modules.kotlin.AppContext;
 import expo.modules.kotlin.CoreLoggerKt;
+import expo.modules.kotlin.ExpoBridgeModule;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 import expo.modules.kotlin.ModulesProvider;
 import expo.modules.kotlin.views.ViewWrapperDelegateHolder;
@@ -72,6 +73,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
+    nativeModules.add(new ExpoBridgeModule(reactContext));
     return nativeModules;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ReactAdapterPackage.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ReactAdapterPackage.java
@@ -4,6 +4,9 @@ import android.content.Context;
 
 import com.facebook.react.bridge.ReactContext;
 
+import java.util.Arrays;
+import java.util.List;
+
 import expo.modules.adapters.react.permissions.PermissionsService;
 import expo.modules.adapters.react.services.CookieManagerModule;
 import expo.modules.adapters.react.services.EventEmitterModule;
@@ -13,9 +16,6 @@ import expo.modules.adapters.react.services.UIManagerModuleWrapper;
 import expo.modules.core.BasePackage;
 import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * A {@link Package} creating modules provided with the @unimodules/react-native-adapter package.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -144,6 +144,11 @@ class AppContext(
    */
   @OptIn(FrameworkAPI::class)
   fun installJSIInterop() = synchronized(this) {
+    if (::jsiInterop.isInitialized) {
+      logger.warn("⚠️ JSI interop was already installed")
+      return
+    }
+
     trace("AppContext.installJSIInterop") {
       try {
         jsiInterop = JSIInteropModuleRegistry(this)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
@@ -1,0 +1,22 @@
+package expo.modules.kotlin
+
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import expo.modules.adapters.react.NativeModulesProxy
+
+/**
+ * The classic bridge module that is responsible for installing the host object to the runtime.
+ */
+class ExpoBridgeModule(private val context: ReactContext) : ReactContextBaseJavaModule() {
+  override fun getName(): String = "ExpoModulesCore"
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun installModules() {
+    val nativeModulesProxy = context.getNativeModule(NativeModulesProxy::class.java)
+    val kotlinInterop = nativeModulesProxy?.kotlinInteropModuleRegistry
+      ?: throw IllegalStateException("Couldn't find KotlinInteropModuleRegistry")
+
+    kotlinInterop.installJSIInterop()
+  }
+}


### PR DESCRIPTION
# Why

Adds an alternative way of installing the JSI bindings.
It's similar to how we're handling that on iOS right now. If the js bindings weren't installed, we're invoking the `installModules` method. On iOS, `ExpoBridgeModule` also stores the `AppContex`. I plan to move from `NativeModulesProxy`. However, the migration process won't be easy and requires more work.

# How

Export plane RN module with sync function - `installModuls` 

# Test Plan

- I've manually checked if everything was exported correctly via the new method.