### PR TITLE
fix(cli): only show `web ready` in `expo start` when enabled

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix stack traces for Node.js errors. ([#26607](https://github.com/expo/expo/pull/26607) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed crash when launching React DevTools. ([#26550](https://github.com/expo/expo/pull/26550) by [@kudo](https://github.com/kudo))
+- Only show "Web is waiting" message after project is initialized with web. ([#26694](https://github.com/expo/expo/pull/26694) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -25,7 +25,10 @@ interface MoreToolMenuItem extends ExpoChoice<string> {
 
 /** Wraps the DevServerManager and adds an interface for user actions. */
 export class DevServerManagerActions {
-  constructor(private devServerManager: DevServerManager) {}
+  constructor(
+    private devServerManager: DevServerManager,
+    private options: Pick<StartOptions, 'devClient' | 'platforms'>
+  ) {}
 
   printDevServerInfo(
     options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms'>
@@ -73,11 +76,13 @@ export class DevServerManagerActions {
       }
     }
 
-    const webDevServer = this.devServerManager.getWebDevServer();
-    const webUrl = webDevServer?.getDevServerUrl({ hostType: 'localhost' });
-    if (webUrl) {
-      Log.log();
-      Log.log(printItem(chalk`Web is waiting on {underline ${webUrl}}`));
+    if (this.options.platforms?.includes('web')) {
+      const webDevServer = this.devServerManager.getWebDevServer();
+      const webUrl = webDevServer?.getDevServerUrl({ hostType: 'localhost' });
+      if (webUrl) {
+        Log.log();
+        Log.log(printItem(chalk`Web is waiting on {underline ${webUrl}}`));
+      }
     }
 
     printUsage(options, { verbose: false });

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -38,7 +38,7 @@ export async function startInterfaceAsync(
   devServerManager: DevServerManager,
   options: Pick<StartOptions, 'devClient' | 'platforms'>
 ) {
-  const actions = new DevServerManagerActions(devServerManager);
+  const actions = new DevServerManagerActions(devServerManager, options);
 
   const isWebSocketsEnabled = devServerManager.getDefaultDevServer()?.isTargetingNative();
 


### PR DESCRIPTION
# Why

Fixes #26519

With Metro being the default (web) bundler, the "Web is waiting on ..." message incorrectly popped up (before web dependencies are installed, and opt-in through `expo.platforms: [..., 'web']`.

When opening the link, without actually enabling web support, users received the Expo Go manifest.

# How

- Check if platform web is explicitly enabled in `DevServerManagerActions` (by checking `this.options.platforms?.includes('web')`

# Test Plan

- `$ bun create expo ./test --template blank@50`
- `$ cd ./test`
- `$ expod start`

Before | after
--- | ---
![before](https://github.com/expo/expo/assets/1203991/5338589b-d81a-4160-bb20-40ab7244f24c) | ![after](https://github.com/expo/expo/assets/1203991/06f5a204-10fc-4217-9550-2b157190faa3)

- Press <kbd>w</kbd>

Should see: 
<img width="860" alt="image" src="https://github.com/expo/expo/assets/1203991/ce01bda2-703b-4a0c-bcdf-487a1bce1817">

- `$ bun expo install react-native-web react-dom @expo/metro-runtime`
- `$ expod start`
- This should now show "Web is waiting on ..."


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

