### PR TITLE
[docs] typo: "Customzing" -> "Customizing" in web.mdx

### DIFF
--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -113,7 +113,7 @@ The app can be exported as a production website with:
 />
 
 <BoxLink
-  title="Customzing the JavaScript bundler"
+  title="Customizing the JavaScript bundler"
   description="Customize Metro bundler for your project."
   href="/guides/customizing-metro"
 />


### PR DESCRIPTION
Fixes a typo in the docs
