### PR TITLE
[expo-font] Fix iOS support for font variants (i.e. tabular-nums)

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix iOS support font variants (i.e. tabular-nums) ([#26697](https://github.com/expo/expo/pull/26697) by [@robwalkerco](https://github.com/robwalkerco))
+- Fix iOS support for font variants (i.e. tabular-nums) ([#26697](https://github.com/expo/expo/pull/26697) by [@robwalkerco](https://github.com/robwalkerco))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS support font variants (i.e. tabular-nums) ([#26697](https://github.com/expo/expo/pull/26697) by [@robwalkerco](https://github.com/robwalkerco))
+
 ### 💡 Others
 
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-font/ios/EXFont/EXFontLoaderProcessor.m
+++ b/packages/expo-font/ios/EXFont/EXFontLoaderProcessor.m
@@ -5,6 +5,184 @@
 #import <EXFont/EXFont.h>
 #import <EXFont/EXFontManager.h>
 #import <objc/runtime.h>
+#import <React/RCTConvert.h>
+#import <React/RCTFont.h>
+#import <CoreText/CoreText.h>
+
+typedef CGFloat RCTFontWeight;
+
+@implementation RCTConvert (RCTFont)
+
++ (UIFont *)UIFont:(id)json
+{
+  json = [self NSDictionary:json];
+
+  return [RCTFont updateFont:nil
+                  withFamily:[RCTConvert NSString:json[@"fontFamily"]]
+                        size:[RCTConvert NSNumber:json[@"fontSize"]]
+                      weight:[RCTConvert NSString:json[@"fontWeight"]]
+                       style:[RCTConvert NSString:json[@"fontStyle"]]
+                     variant:[RCTConvert NSStringArray:json[@"fontVariant"]]
+             scaleMultiplier:1];
+}
+
+RCT_ENUM_CONVERTER(
+  RCTFontWeight,
+  (@{
+    @"normal" : @(UIFontWeightRegular),
+    @"bold" : @(UIFontWeightBold),
+    @"100" : @(UIFontWeightUltraLight),
+    @"200" : @(UIFontWeightThin),
+    @"300" : @(UIFontWeightLight),
+    @"400" : @(UIFontWeightRegular),
+    @"500" : @(UIFontWeightMedium),
+    @"600" : @(UIFontWeightSemibold),
+    @"700" : @(UIFontWeightBold),
+    @"800" : @(UIFontWeightHeavy),
+    @"900" : @(UIFontWeightBlack),
+  }),
+  UIFontWeightRegular,
+  doubleValue)
+
+typedef BOOL RCTFontStyle;
+
+RCT_ENUM_CONVERTER(
+  RCTFontStyle,
+  (@{
+    @"normal" : @NO,
+    @"italic" : @YES,
+    @"oblique" : @YES,
+  }),
+  NO,
+  boolValue)
+
+typedef NSDictionary RCTFontVariantDescriptor;
+
++ (RCTFontVariantDescriptor *)RCTFontVariantDescriptor:(id)json
+{
+  static NSDictionary *mapping;
+  static dispatch_once_t onceToken;
+
+  dispatch_once(&onceToken, ^{
+    mapping = @{
+      @"small-caps" : @{
+        UIFontFeatureTypeIdentifierKey : @(kLowerCaseType),
+        UIFontFeatureSelectorIdentifierKey : @(kLowerCaseSmallCapsSelector),
+      },
+      @"oldstyle-nums" : @{
+        UIFontFeatureTypeIdentifierKey : @(kNumberCaseType),
+        UIFontFeatureSelectorIdentifierKey : @(kLowerCaseNumbersSelector),
+      },
+      @"lining-nums" : @{
+        UIFontFeatureTypeIdentifierKey : @(kNumberCaseType),
+        UIFontFeatureSelectorIdentifierKey : @(kUpperCaseNumbersSelector),
+      },
+      @"tabular-nums" : @{
+        UIFontFeatureTypeIdentifierKey : @(kNumberSpacingType),
+        UIFontFeatureSelectorIdentifierKey : @(kMonospacedNumbersSelector),
+      },
+      @"proportional-nums" : @{
+        UIFontFeatureTypeIdentifierKey : @(kNumberSpacingType),
+        UIFontFeatureSelectorIdentifierKey : @(kProportionalNumbersSelector),
+      },
+      @"stylistic-one" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltOneOnSelector),
+      },
+      @"stylistic-two" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltTwoOnSelector),
+      },
+      @"stylistic-three" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltThreeOnSelector),
+      },
+      @"stylistic-four" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltFourOnSelector),
+      },
+      @"stylistic-five" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltFiveOnSelector),
+      },
+      @"stylistic-six" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltSixOnSelector),
+      },
+      @"stylistic-seven" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltSevenOnSelector),
+      },
+      @"stylistic-eight" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltEightOnSelector),
+      },
+      @"stylistic-nine" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltNineOnSelector),
+      },
+      @"stylistic-ten" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltTenOnSelector),
+      },
+      @"stylistic-eleven" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltElevenOnSelector),
+      },
+      @"stylistic-twelve" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltTwelveOnSelector),
+      },
+      @"stylistic-thirteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltThirteenOnSelector),
+      },
+      @"stylistic-fourteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltFourteenOnSelector),
+      },
+      @"stylistic-fifteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltFifteenOnSelector),
+      },
+      @"stylistic-sixteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltSixteenOnSelector),
+      },
+      @"stylistic-seventeen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltSeventeenOnSelector),
+      },
+      @"stylistic-eighteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltEighteenOnSelector),
+      },
+      @"stylistic-nineteen" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltNineteenOnSelector),
+      },
+      @"stylistic-twenty" : @{
+        UIFontFeatureTypeIdentifierKey : @(kStylisticAlternativesType),
+        UIFontFeatureSelectorIdentifierKey : @(kStylisticAltTwentyOnSelector),
+      }
+    };
+  });
+  
+  RCTFontVariantDescriptor *value = mapping[json];
+
+  if (RCT_DEBUG && !value && [json description].length > 0) {
+    RCTLogError(
+      @"Invalid RCTFontVariantDescriptor '%@'. should be one of: %@",
+      json,
+      [[mapping allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]);
+  }
+
+  return value;
+}
+
+RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
+
+@end
 
 @interface EXFontLoaderProcessor ()
 
@@ -22,6 +200,7 @@
     _fontFamilyPrefix = prefix;
     _manager = manager;
   }
+
   return self;
 }
 
@@ -31,12 +210,12 @@
 }
 
 - (UIFont *)updateFont:(UIFont *)uiFont
-              withFamily:(NSString *)family
-                    size:(NSNumber *)size
-                  weight:(NSString *)weight
-                   style:(NSString *)style
-                 variant:(NSArray<NSDictionary *> *)variant
-         scaleMultiplier:(CGFloat)scaleMultiplier
+            withFamily:(NSString *)family
+                  size:(NSNumber *)size
+                weight:(NSString *)weight
+                  style:(NSString *)style
+                variant:(NSArray<NSDictionary *> *)variant
+        scaleMultiplier:(CGFloat)scaleMultiplier
 {
   const CGFloat defaultFontSize = 14;
   EXFont *exFont = nil;
@@ -60,7 +239,21 @@
     if (scaleMultiplier > 0.0 && scaleMultiplier != 1.0) {
       computedSize = round(computedSize * scaleMultiplier);
     }
-    return [exFont UIFontWithSize:computedSize];
+
+    UIFont *font = [exFont UIFontWithSize:computedSize];
+    
+    if (variant) {
+      NSArray *fontFeatures = [RCTConvert RCTFontVariantDescriptorArray:variant];
+      
+      UIFontDescriptor *fontDescriptor =
+        [font.fontDescriptor fontDescriptorByAddingAttributes:@{
+          UIFontDescriptorFeatureSettingsAttribute : fontFeatures
+        }];
+
+      font = [UIFont fontWithDescriptor:fontDescriptor size:computedSize];
+    }
+
+    return font;
   }
 
   return nil;


### PR DESCRIPTION
# Why

Fixes #20048

This adds support for the various `fontVariant` values on iOS, which Expo has not yet supported, but which React Native does (see [this example of usage in rn-tester](https://github.com/facebook/react-native/blob/f322dc7a84eb72370910f6933d0a4fa7780f49bc/packages/rn-tester/js/examples/Text/TextExample.ios.js#L1111-L1147))

Android already supports `fontVariant`, so this is an iOS only fix

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR is 100% based on the work by @stefan-schweiger and taken from [his patch](https://github.com/expo/expo/issues/20048#issuecomment-1534540051) on the #20048

# Test Plan

I've used this change via patch-package, in particular the `tabular-nums` option, and its working great.

With the following JSX I took some screenshots to show a before/after state

```jsx
<>
    <Text>Example numbers</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>000000</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>111111</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>222222</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>333333</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>444444</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>555555</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>666666</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>777777</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>888888</Text>
    <Text style={{ fontVariant: ['tabular-nums'] }}>999999</Text>
</>
```

| Before | After |
| - | - |
| ![Screenshot 2024-01-25 at 18 25 39](https://github.com/expo/expo/assets/6524830/f8074af1-12c3-4895-a50b-b6f1b684c00d)|![Screenshot 2024-01-25 at 18 25 19](https://github.com/expo/expo/assets/6524830/e986a793-9665-4b29-82be-5bd2c62ba1f7) |

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
