### PR TITLE
[ios][camera] fix scanner not starting 

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix naming of web files. ([#26505](https://github.com/expo/expo/pull/26505) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, barcode types were not converted correctly causing the scanner to not start immediately.
+- On `iOS`, barcode types were not converted correctly causing the scanner to not start immediately. ([#26704](https://github.com/expo/expo/pull/26704) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix naming of web files. ([#26505](https://github.com/expo/expo/pull/26505) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, barcode types were not converted correctly causing the scanner to not start immediately.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Next/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Next/BarcodeRecord.swift
@@ -3,11 +3,63 @@ import Vision
 
 struct BarcodeSettings: Record {
   @Field var interval: Double?
-  @Field var barCodeTypes: [String]
+  @Field var barCodeTypes: [BarcodeType]
 
   func toMetadataObjectType() -> [AVMetadataObject.ObjectType] {
     barCodeTypes.map {
-      AVMetadataObject.ObjectType(rawValue: $0)
+      $0.toMetadataObjectType()
+    }
+  }
+}
+
+enum BarcodeType: String, Enumerable {
+  case aztec
+  case ean13
+  case ean8
+  case qr
+  case pdf417
+  case upce
+  case datamatrix
+  case code39
+  case code93
+  case itf14
+  case codabar
+  case code128
+  case upca
+  
+  func toMetadataObjectType() -> AVMetadataObject.ObjectType {
+    if #available(iOS 15.4, *) {
+      if self == .codabar {
+        return .codabar
+      }
+    }
+    switch self {
+    case .aztec:
+      return .aztec
+    case .qr:
+      return .qr
+    case .ean13:
+      return .ean13
+    case .ean8:
+      return .ean8
+    case .pdf417:
+      return .pdf417
+    case .itf14:
+      return .itf14
+    case .upca:
+      return .upce
+    case .upce:
+      return .upce
+    case .code39:
+      return .code39
+    case .code93:
+      return .code93
+    case .datamatrix:
+      return .dataMatrix
+    case .code128:
+      return .code128
+    default:
+      return .aztec
     }
   }
 }

--- a/packages/expo-camera/ios/Next/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Next/BarcodeRecord.swift
@@ -26,7 +26,7 @@ enum BarcodeType: String, Enumerable {
   case codabar
   case code128
   case upca
-  
+
   func toMetadataObjectType() -> AVMetadataObject.ObjectType {
     if #available(iOS 15.4, *) {
       if self == .codabar {

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -217,7 +217,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       self.session.commitConfiguration()
       self.session.startRunning()
       self.onCameraReady()
-      
+
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
         self.barcodeScanner.maybeStartBarCodeScanning()

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -214,11 +214,13 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
 
       self.addErrorNotification()
 
-      self.sessionQueue.asyncAfter(deadline: .now() + round(50 / 1_000_000)) {
+      self.session.commitConfiguration()
+      self.session.startRunning()
+      self.onCameraReady()
+      
+      // Delay starting the scanner
+      self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
         self.barcodeScanner.maybeStartBarCodeScanning()
-        self.session.commitConfiguration()
-        self.session.startRunning()
-        self.onCameraReady()
       }
     }
   }
@@ -476,7 +478,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
         if updatedMetadata[kCGImagePropertyGPSDictionary as String] == nil {
           updatedMetadata[kCGImagePropertyGPSDictionary as String] = gpsDict
         } else {
-          if var metadataGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? NSMutableDictionary {
+          if let metadataGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? NSMutableDictionary {
             metadataGpsDict.addEntries(from: gpsDict)
           }
         }


### PR DESCRIPTION
# Why
Closes #26687
Closes #26712

# How
Fixes two issues. 
- Barcode types were not correctly converted to `AVMetadataObject.ObjectType`. 
- If launching the camera with the scanner active, we need a slight delay to allow the camera to fully mount and then start the scanner


# Test Plan
- Bare-expo
- The provided repro

