### PR TITLE
[docs] remove EAS subscription requirement from using the GitHub builds feature preview

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -10,7 +10,7 @@ This guide explains how to trigger builds directly from your GitHub repository u
 
 ## Prerequisites
 
-> **warning** While in preview, this feature is only available to EAS subscribers.
+> **warning** This feature is currently in preview/early access. It may undergo significant changes over time. As an early access feature, it might not perform with the same level of polish or reliability as our more established features. We appreciate your understanding and welcome any feedback to help us improve!
 
 ### Run a successful build from your local machine
 

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -8,9 +8,11 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
+> **warning** This feature is in early access and may change significantly. Its performance might
+> not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
+
 ## Prerequisites
 
-> **warning** This feature is currently in preview/early access. It may undergo significant changes over time. As an early access feature, it might not perform with the same level of polish or reliability as our more established features. We appreciate your understanding and welcome any feedback to help us improve!
 
 ### Run a successful build from your local machine
 
@@ -21,7 +23,6 @@ If you haven't successfully run `eas build -p [all|ios|android]` yet, see  [Crea
 The following must also be true:
 
 - An Expo user in the organization must have a linked GitHub user with access to the target repository. Check [User settings > Connections](https://expo.dev/settings#connections) and verify that your GitHub user account is linked.
-- The Expo account must have an active subscription for the feature preview.
 - You must accept the permissions requested by the [Expo GitHub app](https://github.com/settings/installations).
 
 ## Configure your app for GitHub

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -8,8 +8,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
-> **warning** This feature is in early access and may change significantly. Its performance might
-> not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
+> **warning** This feature is in early access and may change significantly. Its performance might not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
 
 ## Prerequisites
 


### PR DESCRIPTION
# Why

The GitHub builds feature preview is now available to all users, so we should update our docs disclaimer accordingly.

# How

I updated the guide to remove the EAS subscription prerequisite. I also updated the disclaimer to describe the service's potential behavior while in preview.

# Test Plan

![Screenshot 2024-01-25 at 18 15 05](https://github.com/expo/expo/assets/12488826/eab32a86-5a64-4d79-b525-f9a85e01c4f9)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
