### PR TITLE
[router] fix router.push issue with query params missing from route

### DIFF
--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -374,7 +374,7 @@ function getStateFromPathWithConfigs(
 
   // We match the whole path against the regex instead of segments
   // This makes sure matches such as wildcard will catch any unmatched routes, even if nested
-  const routes = matchAgainstConfigs(formattedPaths.nonstandardPathname, configs);
+  const routes = matchAgainstConfigs(formattedPaths.nonstandardPathname, formattedPaths.inputPathnameWithoutHash = '', configs);
 
   if (routes == null) {
     return undefined;
@@ -394,7 +394,7 @@ const joinPaths = (...paths: string[]): string =>
     .filter(Boolean)
     .join('/');
 
-function matchAgainstConfigs(remaining: string, configs: RouteConfig[]): ParsedRoute[] | undefined {
+function matchAgainstConfigs(remaining: string, path: string, configs: RouteConfig[]): ParsedRoute[] | undefined {
   let routes: ParsedRoute[] | undefined;
   let remainingPath = remaining;
 
@@ -437,7 +437,7 @@ function matchAgainstConfigs(remaining: string, configs: RouteConfig[]): ParsedR
 
       const segments = config.path.split('/');
 
-      const params: Record<string, any> = {};
+      let params: Record<string, any> = {};
 
       segments
         .filter((p) => p.match(/^[:*]/))
@@ -453,7 +453,12 @@ function matchAgainstConfigs(remaining: string, configs: RouteConfig[]): ParsedR
             params[key] = config.parse?.[key] ? config.parse[key](value) : value;
           }
         });
-
+    
+      const queryParams = parseQueryParams(path, null);
+      if (queryParams) {
+          params = Object.assign(Object.create(null), params, queryParams) as Record<string, any>;
+      }
+      
       if (params && Object.keys(params).length) {
         return { name, params };
       }


### PR DESCRIPTION
# Why

Original issue: [marklawlor/router/26669](https://github.com/expo/expo/pull/26678)
Fix: https://github.com/expo/expo/pull/26678#issuecomment-1911177148

# How

PR [marklawlor/router/26669](https://github.com/expo/expo/pull/26678) fixes pushing when changed params weren't being deeply compared. However, query params are missing from the route params. This change updates matchAgainstConfigs function in getStateFromPaths to include the full path passed in and allow it to parse the query params, then add them into the route params, enabling PR [marklawlor/router/26669](https://github.com/expo/expo/pull/26678) to also work with query params.

# Test Plan

May need assistance with the test plan. Should be able to update the tests @marklawlor made for PR [marklawlor/router/26669](https://github.com/expo/expo/pull/26678) to include a query param test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
