### PR TITLE
[modules-core] add convertible support for `PlatformColor` and `DynamicColorIOS`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
+- Add iOS support for `PlatformColor` and `DynamicColorIOS` color props. ([#26724](https://github.com/expo/expo/pull/26724) by [@dlindenkreuz](https://github.com/dlindenkreuz))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -4,7 +4,7 @@ extension UIColor: Convertible {
   private static func resolveNamedColor(name: String) -> UIColor? {
     return UIColor(named: name) ?? UIColor.fromSemanticName(name: name)
   }
-  
+
   public static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     // swiftlint:disable force_cast
     if let value = value as? String {
@@ -21,7 +21,7 @@ extension UIColor: Convertible {
     }
     if let opaqueValue = value as? [String: Any] {
       if let semanticName = opaqueValue["semantic"] as? String,
-         let color = UIColor.resolveNamedColor(name: semanticName) {
+        let color = UIColor.resolveNamedColor(name: semanticName) {
         return color as! Self
       }
       if let semanticArray = opaqueValue["semantic"] as? [String] {
@@ -32,27 +32,24 @@ extension UIColor: Convertible {
         }
       }
       if let dynamic = opaqueValue["dynamic"] as? [String: Any],
-          let appearances = dynamic as? [String: Any],
-          let lightColor = try appearances["light"].map({ try UIColor.convert(from: $0, appContext: appContext) }),
-          let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0, appContext: appContext) }) {
-        
+        let appearances = dynamic as? [String: Any],
+        let lightColor = try appearances["light"].map({ try UIColor.convert(from: $0, appContext: appContext) }),
+        let darkColor = try appearances["dark"].map({ try UIColor.convert(from: $0, appContext: appContext) }) {
         let highContrastLightColor = try appearances["highContrastLight"].map({ try UIColor.convert(from: $0, appContext: appContext) })
         let highContrastDarkColor = try appearances["highContrastDark"].map({ try UIColor.convert(from: $0, appContext: appContext) })
-        
+
         let color = UIColor { (traitCollection: UITraitCollection) -> UIColor in
           if traitCollection.userInterfaceStyle == .dark {
             if traitCollection.accessibilityContrast == .high, let highContrastDarkColor {
               return highContrastDarkColor
-            } else {
-              return darkColor
             }
-          } else {
-            if traitCollection.accessibilityContrast == .high, let highContrastLightColor {
-              return highContrastLightColor
-            } else {
-              return lightColor
-            }
+            return darkColor
           }
+
+          if traitCollection.accessibilityContrast == .high, let highContrastLightColor {
+            return highContrastLightColor
+          }
+          return lightColor
         }
         return color as! Self
       }
@@ -83,8 +80,10 @@ private extension UIColor {
     } else {
       selector = Selector("\(name)Color")
     }
-    guard UIColor.responds(to: selector) else { return nil }
-    
+    guard UIColor.responds(to: selector) else {
+      return nil
+    }
+
     return UIColor.perform(selector).takeUnretainedValue() as? UIColor
   }
 }

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -15,7 +15,7 @@ extension UIColor: Convertible {
     if let value = value as? Int {
       return try Conversions.toColor(argb: UInt64(value)) as! Self
     }
-    
+
     // Handle `PlatformColor` and `DynamicColorIOS`
     if let opaqueValue = value as? [String: Any] {
       if let semanticName = opaqueValue["semantic"] as? String,

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -85,7 +85,6 @@ private extension UIColor {
     }
     guard UIColor.responds(to: selector) else { return nil }
     
-    // should be unretained? https://stackoverflow.com/questions/33527382/performselector-for-static-methods-with-swift/33527499#33527499
     return UIColor.perform(selector).takeUnretainedValue() as? UIColor
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -363,6 +363,22 @@ class ConvertiblesSpec: ExpoSpec {
         let transparent = try CGColor.convert(from: "transparent", appContext: appContext)
         expect(transparent.alpha) == .zero
       }
+      
+      it("converts from PlatformColor") {
+        let color = try CGColor.convert(from: ["semantic": ["invalid_color", "systemRed", "systemBlue"]], appContext: appContext)
+        expect(color) == UIColor.systemRed.cgColor
+      }
+      
+      it("converts from DynamicColorIOS") {
+        let color = try CGColor.convert(from: ["dynamic": ["light": "#000", "dark": ["semantic": "systemGray"]]], appContext: appContext)
+        testColorComponents(color, 0x00, 0x00, 0x00, 0xFF)
+      }
+      
+      it("converts from DynamicColorIOS with traits") {
+        let color = try UIColor.convert(from: ["dynamic": ["light": "#000", "dark": ["semantic": "systemGray"]]], appContext: appContext)
+        let traits = UITraitCollection(userInterfaceStyle: .dark)
+        expect(color.resolvedColor(with: traits)) == UIColor.systemGray.resolvedColor(with: traits)
+      }
 
       it("throws when string is invalid") {
         testInvalidHexColor("")


### PR DESCRIPTION
# Why

`PlatformColor` and `DynamicColorIOS` are currently not supported by expo-modules-core.

Packages based on Expo Modules should be able to use colors that are resolved at runtime, allowing for Dark Mode adjustments and system colors. React Native has supported this since a while upstream and it's time to bring this to Expo Modules as well.

**Important**: This PR only adds support for iOS. It looks like [`ColorPropConverter`](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java#L66) needs to be called from Expo but I have no experience with the Android platform.

# How

- Add implementation to `Convertibles+Color.swift`
- Implementation mimics [original React Native `RCTConvert` implementation](https://github.com/facebook/react-native/blob/5f75e9b90d4f998403101ae92924778df31d36fb/packages/react-native/React/Base/RCTConvert.m#L881)
- Notable differences from original implementation:
  - No fallback colors (originally added to support iOS <13.0) are required, since Expo only supports iOS >=13.2 as of now
  - `UIColor` class vars like `UIColor.systemRed` never return an array in Swift → no [`NSArray` handler](https://github.com/facebook/react-native/blob/5f75e9b90d4f998403101ae92924778df31d36fb/packages/react-native/React/Base/RCTConvert.m#L851-L856) required

# Test Plan

- Added unit tests to `ConvertiblesSpec.swift`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
