### PR TITLE
[expo-updates][Android] Fix case where launch wait ms timeout is greater than okhttp default timeout

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -4,19 +4,18 @@
 
 ### 🛠 Breaking changes
 
+- Deprecated `UpdatesController.initialize(Context, Map)` and replaced with `UpdatesController.overrideConfiguration()` method to prevent ANR when overriding the `UpdatesConfiguration` on Android. [#26093](https://github.com/expo/expo/pull/26093) by [@kudo](https://github.com/kudo))
+
 ### 🎉 New features
 
 - Add more failure logs in asset download. ([#26268](https://github.com/expo/expo/pull/26268) by [@wschurman](https://github.com/wschurman))
 - Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
 
-### 🛠 Breaking changes
-
-- Deprecated `UpdatesController.initialize(Context, Map)` and replaced with `UpdatesController.overrideConfiguration()` method to prevent ANR when overriding the `UpdatesConfiguration` on Android. [#26093](https://github.com/expo/expo/pull/26093) by [@kudo](https://github.com/kudo))
-
 ### 🐛 Bug fixes
 
 - Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
 - [Android] correct drawable types in updates embedded manifest. ([#26676](https://github.com/expo/expo/pull/26676) by [@douglowder](https://github.com/douglowder))
+- [Android] Fix case where launch wait ms timeout is greater than okhttp default timeout. ([#26731](https://github.com/expo/expo/pull/26731) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -47,7 +47,7 @@ class EnabledUpdatesController(
     null
   }
   private val logger = UpdatesLogger(context)
-  private val fileDownloader = FileDownloader(context)
+  private val fileDownloader = FileDownloader(context, updatesConfiguration)
   private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
     updatesConfiguration.getRuntimeVersion()
   )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -52,7 +52,6 @@ class UpdatesDevLauncherController(
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
 
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
-  private val fileDownloader = FileDownloader(context)
 
   private var mSelectionPolicy: SelectionPolicy? = null
   private var defaultSelectionPolicy: SelectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
@@ -132,6 +131,7 @@ class UpdatesDevLauncherController(
 
     setDevelopmentSelectionPolicy()
 
+    val fileDownloader = FileDownloader(context, updatesConfiguration!!)
     val loader = RemoteLoader(
       context,
       updatesConfiguration!!,
@@ -155,7 +155,7 @@ class UpdatesDevLauncherController(
           callback.onSuccess(null)
           return
         }
-        launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, context, callback)
+        launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, fileDownloader, context, callback)
       }
 
       override fun onAssetLoaded(
@@ -200,6 +200,7 @@ class UpdatesDevLauncherController(
   private fun launchUpdate(
     update: UpdateEntity,
     configuration: UpdatesConfiguration,
+    fileDownloader: FileDownloader,
     context: Context,
     callback: UpdatesInterface.UpdateCallback
   ) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -202,7 +202,6 @@ class DatabaseLauncher(
       fileDownloader.downloadAsset(
         asset,
         updatesDirectory,
-        configuration,
         context,
         object : AssetDownloadCallback {
           override fun onFailure(e: Exception, assetEntity: AssetEntity) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -15,6 +15,7 @@ import java.io.File
 import java.io.IOException
 import java.util.*
 import kotlin.math.min
+import kotlin.math.max
 import org.apache.commons.fileupload.MultipartStream
 import org.apache.commons.fileupload.ParameterParser
 import java.io.ByteArrayOutputStream
@@ -28,19 +29,23 @@ import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.*
 import java.security.cert.CertificateException
+import java.util.concurrent.TimeUnit
 
 /**
  * Utility class that holds all the logic for downloading data and files, such as update manifests
  * and assets, using an instance of [OkHttpClient].
  */
-open class FileDownloader(context: Context, private val client: OkHttpClient) {
-  constructor(context: Context) : this(
-    context,
-    OkHttpClient.Builder()
-      .cache(getCache(context))
-      .addInterceptor(BrotliInterceptor)
-      .build()
-  )
+class FileDownloader(context: Context, private val configuration: UpdatesConfiguration) {
+  // If the configured launch wait milliseconds is greater than the okhttp default (10_000)
+  // we should use that as the timeout. For example, let's say launchWaitMs is 20 seconds,
+  // the HTTP timeout should be at least 20 seconds.
+  private val client: OkHttpClient = OkHttpClient.Builder()
+    .cache(getCache(context))
+    .connectTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)
+    .readTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)
+    .addInterceptor(BrotliInterceptor)
+    .build()
+
   private val logger = UpdatesLogger(context)
 
   interface FileDownloadCallback {
@@ -94,7 +99,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     )
   }
 
-  internal fun parseRemoteUpdateResponse(response: Response, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
+  internal fun parseRemoteUpdateResponse(response: Response, callback: RemoteUpdateDownloadCallback) {
     val responseHeaders = response.headers
     val responseHeaderData = ResponseHeaderData(
       protocolVersionRaw = responseHeaders["expo-protocol-version"],
@@ -140,7 +145,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         return
       }
 
-      parseMultipartRemoteUpdateResponse(responseBody, responseHeaderData, boundaryParameter, configuration, callback)
+      parseMultipartRemoteUpdateResponse(responseBody, responseHeaderData, boundaryParameter, callback)
     } else {
       val manifestResponseInfo = ResponsePartInfo(
         responseHeaderData = responseHeaderData,
@@ -154,7 +159,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         manifestResponseInfo,
         null,
         null,
-        configuration,
         object : ParseManifestCallback {
           override fun onFailure(message: String, e: Exception) {
             callback.onFailure(message, e)
@@ -189,7 +193,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     return headers.toHeaders()
   }
 
-  private fun parseMultipartRemoteUpdateResponse(responseBody: ResponseBody, responseHeaderData: ResponseHeaderData, boundary: String, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
+  private fun parseMultipartRemoteUpdateResponse(responseBody: ResponseBody, responseHeaderData: ResponseHeaderData, boundary: String, callback: RemoteUpdateDownloadCallback) {
     var manifestPartBodyAndHeaders: Pair<String, Headers>? = null
     var extensionsBody: String? = null
     var certificateChainString: String? = null
@@ -303,7 +307,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
       parseDirective(
         directiveResponseInfo,
         certificateChainString,
-        configuration,
         object : ParseDirectiveCallback {
           override fun onFailure(message: String, e: Exception) {
             if (!didError) {
@@ -325,7 +328,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         manifestResponseInfo,
         extensions,
         certificateChainString,
-        configuration,
         object : ParseManifestCallback {
           override fun onFailure(message: String, e: Exception) {
             if (!didError) {
@@ -355,7 +357,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
   private fun parseDirective(
     directiveResponsePartInfo: ResponsePartInfo,
     certificateChainFromManifestResponse: String?,
-    configuration: UpdatesConfiguration,
     callback: ParseDirectiveCallback
   ) {
     try {
@@ -414,7 +415,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     manifestResponseInfo: ResponsePartInfo,
     extensions: JSONObject?,
     certificateChainFromManifestResponse: String?,
-    configuration: UpdatesConfiguration,
     callback: ParseManifestCallback
   ) {
     try {
@@ -440,14 +440,13 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
   }
 
   fun downloadRemoteUpdate(
-    configuration: UpdatesConfiguration,
     extraHeaders: JSONObject?,
     context: Context,
     callback: RemoteUpdateDownloadCallback
   ) {
     try {
       downloadData(
-        createRequestForRemoteUpdate(configuration, extraHeaders, context),
+        createRequestForRemoteUpdate(extraHeaders, configuration, context),
         object : Callback {
           override fun onFailure(call: Call, e: IOException) {
             val message = "Failed to download remote update from URL: ${configuration.updateUrl}: ${e.localizedMessage}"
@@ -470,7 +469,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
               return
             }
 
-            parseRemoteUpdateResponse(response, configuration, callback)
+            parseRemoteUpdateResponse(response, callback)
           }
         }
       )
@@ -487,7 +486,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
   fun downloadAsset(
     asset: AssetEntity,
     destinationDirectory: File?,
-    configuration: UpdatesConfiguration,
     context: Context,
     callback: AssetDownloadCallback
   ) {
@@ -659,8 +657,8 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     }
 
     internal fun createRequestForRemoteUpdate(
-      configuration: UpdatesConfiguration,
       extraHeaders: JSONObject?,
+      configuration: UpdatesConfiguration,
       context: Context
     ): Request {
       return Request.Builder()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -46,7 +46,7 @@ class RemoteLoader internal constructor(
   ) {
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(database, configuration, launchedUpdate, embeddedUpdate)
-    mFileDownloader.downloadRemoteUpdate(configuration, extraHeaders, context, callback)
+    mFileDownloader.downloadRemoteUpdate(extraHeaders, context, callback)
   }
 
   override fun loadAsset(
@@ -56,7 +56,7 @@ class RemoteLoader internal constructor(
     configuration: UpdatesConfiguration,
     callback: AssetDownloadCallback
   ) {
-    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, configuration, context, callback)
+    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, context, callback)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -40,7 +40,6 @@ class CheckForUpdateProcedure(
       )
       databaseHolder.releaseDatabase()
       fileDownloader.downloadRemoteUpdate(
-        updatesConfiguration,
         extraHeaders,
         context,
         object : FileDownloader.RemoteUpdateDownloadCallback {


### PR DESCRIPTION
# Why

Noticed this while trying to debug e2e test failures, though this is unrelated to the failures.

I noticed that okhttp has a default timeout of 10 seconds for connecting and reading data. This results in a socket timeout even if the expo-updates library is configured to allow more than 10 seconds on startup.

# How

The fix is to configure the okhttp timeout to be at least the expo-updates configured timeout.

# Test Plan

Manually create a test app that has a launchWaitMs of 20_000 and connects to a server that waits 15_000 after a request before sending back the manifest.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
