### PR TITLE
improve validation for metro web when exporting

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Add better validation for Metro web when exporting production bundles.
+- Add better validation for Metro web when exporting production bundles. ([#26732](https://github.com/expo/expo/pull/26732) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix stack traces for Node.js errors. ([#26607](https://github.com/expo/expo/pull/26607) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed crash when launching React DevTools. ([#26550](https://github.com/expo/expo/pull/26550) by [@kudo](https://github.com/kudo))
 - Only show "Web is waiting" message after project is initialized with web. ([#26694](https://github.com/expo/expo/pull/26694) by [@byCedric](https://github.com/byCedric))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Add better validation for Metro web when exporting production bundles.
 - Fix stack traces for Node.js errors. ([#26607](https://github.com/expo/expo/pull/26607) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed crash when launching React DevTools. ([#26550](https://github.com/expo/expo/pull/26550) by [@kudo](https://github.com/kudo))
 - Only show "Web is waiting" message after project is initialized with web. ([#26694](https://github.com/expo/expo/pull/26694) by [@byCedric](https://github.com/byCedric))

--- a/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportApp-test.ts
@@ -7,6 +7,10 @@ import { ExportAssetMap } from '../saveAssets';
 
 jest.mock('../../log');
 
+jest.mock('../../start/doctor/web/WebSupportProjectPrerequisite', () => ({
+  WebSupportProjectPrerequisite: jest.fn(() => ({ assertAsync: jest.fn() })),
+}));
+
 jest.mock('../exportStaticAsync', () => ({
   unstable_exportStaticAsync: jest.fn(
     async (_root: string, { files }: { files: ExportAssetMap }) => {

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -27,7 +27,7 @@ describe(resolveOptionsAsync, () => {
       exp: { web: { bundler: 'webpack' }, platforms: ['ios', 'android', 'web'] },
     });
     await expect(resolveOptionsAsync('/', { '--platform': ['web'] })).rejects.toThrow(
-      /^Platform "web" is not configured to use the Metro bundler in the project Expo config\./
+      /^Platform "web" is not configured to use the Metro bundler in the project Expo config,/
     );
   });
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -13,6 +13,7 @@ import { Options } from './resolveOptions';
 import { ExportAssetMap, getFilesFromSerialAssets, persistMetroFilesAsync } from './saveAssets';
 import { createAssetMap, createSourceMapDebugHtml } from './writeContents';
 import * as Log from '../log';
+import { WebSupportProjectPrerequisite } from '../start/doctor/web/WebSupportProjectPrerequisite';
 import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
 import { serializeHtmlWithAssets } from '../start/server/metro/serializeHtml';
 import {
@@ -54,6 +55,10 @@ export async function exportAppAsync(
     // Web doesn't require validation.
     skipValidation: platforms.length === 1 && platforms[0] === 'web',
   });
+
+  if (platforms.includes('web')) {
+    await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
+  }
 
   const useServerRendering = ['static', 'server'].includes(exp.web?.output ?? '');
   const baseUrl = getBaseUrlFromExpoConfig(exp);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -34,9 +34,15 @@ export function resolvePlatformOption(
 
   const assertPlatformBundler = (platform: Platform): Platform => {
     if (!platformsAvailable[platform]) {
+      if (!exp.platforms?.includes(platform) && platform === 'web') {
+        // Pass through so the more robust error message is shown.
+        return platform;
+      }
       throw new CommandError(
         'BAD_ARGS',
-        `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config.`
+        `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config, or is missing from the supported platforms in the platforms array: [${exp.platforms?.join(
+          ', '
+        )}].`
       );
     }
 

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -98,7 +98,7 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
 export function isWebPlatformExcluded(rootConfig: AppJSONConfig): boolean {
   // Detect if the 'web' string is purposefully missing from the platforms array.
   const isWebExcluded =
-    Array.isArray(rootConfig.expo?.platforms) &&
+    Array.isArray(rootConfig?.expo?.platforms) &&
     !!rootConfig.expo?.platforms.length &&
     !rootConfig.expo?.platforms.includes('web');
   return isWebExcluded;

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -35,7 +35,6 @@ import { installExitHooks } from '../../../utils/exit';
 import { isInteractive } from '../../../utils/interactive';
 import { loadTsConfigPathsAsync, TsConfigPaths } from '../../../utils/tsconfig/loadTsConfigPaths';
 import { resolveWithTsConfigPaths } from '../../../utils/tsconfig/resolveWithTsConfigPaths';
-import { WebSupportProjectPrerequisite } from '../../doctor/web/WebSupportProjectPrerequisite';
 import { PlatformBundlers } from '../platformBundlers';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
@@ -469,10 +468,6 @@ export async function withMetroMultiPlatformAsync(
   config.transformer._expoRouterWebRendering = webOutput;
   // @ts-expect-error: Invalidate the cache when the location of expo-router changes on-disk.
   config.transformer._expoRouterPath = resolveFrom.silent(projectRoot, 'expo-router');
-
-  if (exp.platforms?.includes('web') && platformBundlers.web === 'metro') {
-    await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
-  }
 
   let tsconfig: null | TsConfigPaths = null;
 


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo/issues/26698
- move the validation for web support out of the central metro config so it's never triggered for `export:embed`.
- improve validation error to account for weird state with metro web being the default.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `npx expo export -p web` in a project without web will still throw.
- `npx expo export:embed` never throws for web validation.
- `npx expo export` in a project without web will not throw, even if metro web is enabled in the bundler config.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
