### PR TITLE
chore(cli): Improve warning for favicon missing during web export.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 💡 Others
 
+- Improve warning for favicon missing during web export.
+
 ## 0.17.1 - 2024-01-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Improve warning for favicon missing during web export.
+- Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.1 - 2024-01-18
 

--- a/packages/@expo/cli/src/export/favicon.ts
+++ b/packages/@expo/cli/src/export/favicon.ts
@@ -59,7 +59,10 @@ export async function getVirtualFaviconAssetsAsync(
   return injectFaviconTag;
 }
 
-export async function getFaviconFromExpoConfigAsync(projectRoot: string) {
+export async function getFaviconFromExpoConfigAsync(
+  projectRoot: string,
+  { force = false }: { force?: boolean } = {}
+) {
   const { exp } = getConfig(projectRoot);
 
   const src = exp.web?.favicon ?? null;
@@ -89,7 +92,7 @@ export async function getFaviconFromExpoConfigAsync(projectRoot: string) {
     return { source: faviconBuffer, path: 'favicon.ico' };
   } catch (error: any) {
     // Check for ENOENT
-    if (error.code === 'ENOENT') {
+    if (!force && error.code === 'ENOENT') {
       Log.warn(`Favicon source file in Expo config (web.favicon) does not exist: ${src}`);
       return null;
     }

--- a/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
@@ -26,7 +26,7 @@ export class FaviconMiddleware extends ExpoMiddleware {
 
     let faviconImageData: Buffer | null;
     try {
-      const data = await getFaviconFromExpoConfigAsync(this.projectRoot);
+      const data = await getFaviconFromExpoConfigAsync(this.projectRoot, { force: true });
       if (!data) {
         debug('No favicon defined in the Expo Config, skipping generation.');
         return next();


### PR DESCRIPTION
# Why

- fix ENG-11242
- related to malformed repro in https://github.com/expo/expo/issues/26701

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Catch missing file error and log a warning instead.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
