### PR TITLE
[docs] Fix broken "creating a local Expo module" link

### DIFF
--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -13,7 +13,7 @@ For most third-party native libraries, [autolinking](/modules/autolinking/) make
 
 By default, Expo projects use [Continuous Native Generation (CNG)](/workflow/continuous-native-generation). This means that projects do not have **android** and **ios** directories containing the native code and configuration. Instead, the native directories are generated right before building the app and is based on your [app config](/workflow/configuration) and native modules in **package.json**. This simplifies the management and upgrading of native code.
 
-It might seem you cannot add custom native code to a project using CNG. However, you can still add that by [creating a local Expo module](modules/get-started/#creating-the-local-expo-module).
+It might seem you cannot add custom native code to a project using CNG. However, you can still add that by [creating a local Expo module](/modules/get-started/#creating-the-local-expo-module).
 
 Local Expo Modules function similarly to [Expo Modules](/modules/overview/) used by library developers and within the Expo SDK. They are not published to npm. Instead, you create them directly inside your project.
 


### PR DESCRIPTION
# Why

The link redirects to 404 page causing confusion

https://github.com/expo/expo/assets/963490/4fbc84b6-c811-4f7f-b023-cac359704bee

# How

Fixed incorrect link (modules/get-started/#creating-the-local-expo-module -> /modules/get-started/#creating-the-local-expo-module)

# Test Plan

It works now on dev build of docs

https://github.com/expo/expo/assets/963490/1fd58ec0-9b92-486b-879a-e949313b3d88


# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
