### PR TITLE
[module-scripts] Update `tsconfig.plugin.json` to `node18` to match installed dependencies

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use `node18` tsconfig in `expo-module-scripts` to match the dependencies. ([#26738](https://github.com/expo/expo/pull/26738)) by ([@krystofwoldrich](https://github.com/krystofwoldrich))
+
 ### 💡 Others
 
 - Update Babel dependencies to the latest version from `7.23` releases. ([#26525](https://github.com/expo/expo/pull/26525) by [@simek](https://github.com/simek))

--- a/packages/expo-module-scripts/tsconfig.plugin.json
+++ b/packages/expo-module-scripts/tsconfig.plugin.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "declaration": true
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`package.json` contains tsconfig node18, but `tsconfig.plugin.json` still referenced `node14`. Which leads to the following error when using the package:

```bash
$ EXPO_NONINTERACTIVE=true expo-module build plugin
node_modules/expo-module-scripts/tsconfig.plugin.json:2:14 - error TS6053: File '@tsconfig/node14/tsconfig.json' not found.

2   "extends": "@tsconfig/node14/tsconfig.json",
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

https://github.com/krystofwoldrich/expo/blob/5f00734c0ffc375ded10011c9cc6d68f850252da/packages/expo-module-scripts/package.json#L35

# How

<!--
How did you build this feature or fix this bug and why?
-->

Match the `tsconfig.plugin.json` with the version in `package.json`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `expo-module build plugin` without the mentioned error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
