### PR TITLE
fix(create-expo): avoid corrupting .tar.gz files in templates

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Stop corrupting inner `.tar.gz` files when decompressing tarballs. ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
+- Mark compressed `.gz` files as binary to avoid corruption when unpacking with `expo prebuild --template`. ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
 - Add better validation for Metro web when exporting production bundles. ([#26732](https://github.com/expo/expo/pull/26732) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `tsconfig.json` resolution of `baseUrl` when `paths` is not defined. ([#26734](https://github.com/expo/expo/pull/26734) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix stack traces for Node.js errors. ([#26607](https://github.com/expo/expo/pull/26607) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Stop corrupting inner `.tar.gz` files when decompressing tarballs. ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
 - Add better validation for Metro web when exporting production bundles. ([#26732](https://github.com/expo/expo/pull/26732) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `tsconfig.json` resolution of `baseUrl` when `paths` is not defined. ([#26734](https://github.com/expo/expo/pull/26734) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix stack traces for Node.js errors. ([#26607](https://github.com/expo/expo/pull/26607) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/utils/createFileTransform.ts
+++ b/packages/@expo/cli/src/utils/createFileTransform.ts
@@ -82,6 +82,7 @@ export function createFileTransform(name: string) {
         '.svg',
         '.jar',
         '.keystore',
+        '.gz',
 
         // Font files
         '.otf',

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- - Mark compressed `.gz` files as binary to avoid corruption when unpacking with `create-expo --template` ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
+- Mark compressed `.gz` files as binary to avoid corruption when unpacking with `create-expo --template` ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
 
 ### 💡 Others
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Stop corrupting inner `.tar.gz` files when decompressing tarballs of templates. ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
+- - Mark compressed `.gz` files as binary to avoid corruption when unpacking with `create-expo --template` ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
 
 ### 💡 Others
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Stop corrupting inner `.tar.gz` files when decompressing tarballs of templates. ([#26741](https://github.com/expo/expo/pull/26741) by [@shirakaba](https://github.com/shirakaba))
+
 ### 💡 Others
 
 ## 2.1.3 — 2023-12-12

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -67,6 +67,7 @@ export function createFileTransform(name: string) {
         '.svg',
         '.jar',
         '.keystore',
+        '.gz',
         // Font files
         '.otf',
         '.ttf',


### PR DESCRIPTION
# Why

`tar.extract()` (from [node-tar](https://github.com/isaacs/node-tar), used by `create-expo` [here](https://github.com/expo/expo/blob/8d29bbba0ccd4ecb35bac0df7b512ee129d3cde8/packages/create-expo/src/Examples.ts#L87)), by default, parses files from within a `.tar.gz` as UTF-8. This is generally incorrect for binary files inside the tarball. I found, when creating an Expo template containing a `.tar.gz` file (or equally a `.zip` file) inside, that `create-expo` would successfully unpack most of the template, but corrupt the inner `.tar.gz` file. It affects both cloning from GitHub and from a local tarball.

I've provisionally applied this minimal fix to `create-expo`, and also to `@expo/cli` (as it seems the `createFileTransform()` implementation is mirrored there). We could of course cover more types like `.zip`, but as the scope is basically "all possible binary files", I think the list is endless.

Importance: I can give Expo superpowers if this PR lands 👀 

# How

```sh
# First, duplicate expo-template-bare-minimum.
# Installing it from npm is a convenient way to do so.
mkdir -vp workdir/expo-template-custom
cd workdir
npm install expo-template-bare-minimum
mv node_modules/expo-template-bare-minimum expo-template-custom

# Now, add any .tar.gz file to it.
# Let's say it's called example.tar.gz and is 70 MB in size.
mv path/to/example.tar.gz expo-template-custom
cd expo-template-custom
npm pack
cd ..

# Next, install the CLI locally.
npm install create-expo-app@latest

# Now make the patch to node_modules/create-expo-app/build/index.js.

# Create a new project using your local Expo template, via the forked CLI
./node_modules/.bin/create-expo-app --template ./expo-template-custom/expo-template-custom-50.0.33.tgz verificationapp

# Look inside the created app and check whether the size of example.tar.gz is still 70 MB.
# Without this patch, it was ballooning to 140 MB, so the difference is easy to spot.
ls -la verificationapp
```

# Test Plan

Local test plan covered in the "How" section above. I think there is no risk to this change as none of the templates include `.tar.gz` files currently, and all it does is fix something that's broken to begin with.

# Checklist

I think I'll check the same choices as Cedric did in this [similar PR](https://github.com/expo/expo/pull/26639).

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).