### PR TITLE
[docs] add notes to reference pages for "next" package versions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-next.mdx
@@ -16,6 +16,8 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
+> **info** This page documents an upcoming version of Camera library. To try it, switch to `expo-camera/next` imports in your code.
+
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 <PlatformsSection android ios web />

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -12,6 +12,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
+> **info** This page documents an upcoming version of SQLite library. To try it, switch to `expo-sqlite/next` imports in your code.
+
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -16,6 +16,8 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
+> **info** This page documents an upcoming version of Camera library. To try it, switch to `expo-camera/next` imports in your code.
+
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 <PlatformsSection android ios web />

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -12,6 +12,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
+> **info** This page documents an upcoming version of SQLite library. To try it, switch to `expo-sqlite/next` imports in your code.
+
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
 
 <PlatformsSection android emulator ios simulator />


### PR DESCRIPTION
# Why

Let's add a note about what "Next" packages are, and remind users to switch to `/next` imports at the top of reference pages.

# How

Add a notes to Camera (Next) and SQlite (Next) docs, in both, unversioned and SDK 50 doc files.

# Test Plan

The changes have been reviewed locally. Lint checks are passing.

# Preview

![Screenshot 2024-01-27 at 10 53 49](https://github.com/expo/expo/assets/719641/ef3a2a68-701f-4ece-9ba6-c67a146d57f8)


