### PR TITLE
[docs] facedetector and barcodeScanner deprecations

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. Use [expo-camera](camera-next.mdx) instead.
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend using [expo-camera/next](camera-next) which has barcode scanning built in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -19,6 +19,8 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. Use [expo-camera](camera-next.mdx) instead.
+
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
 <PlatformsSection android ios />

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -11,6 +11,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend [react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
+
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
 <PlatformsSection android ios />

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. Use [expo-camera](camera-next.mdx) instead.
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend using [expo-camera/next](camera-next) which has barcode scanning built in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -19,6 +19,8 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. Use [expo-camera](camera-next.mdx) instead.
+
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
 <PlatformsSection android ios />

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -11,6 +11,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
+> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend [react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
+
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
 <PlatformsSection android ios />


### PR DESCRIPTION
# Why
Closes ENG-11241
`expo-face-detector` and `expo-barcode-scanner` are now deprecated. 

# How
Add deprecation notices to these packages

# Test Plan
<img width="845" alt="Screenshot 2024-01-27 at 11 21 39" src="https://github.com/expo/expo/assets/30924086/6d09515b-705c-47a5-9689-6b1f6cbf023c">
<img width="1034" alt="Screenshot 2024-01-27 at 10 46 34" src="https://github.com/expo/expo/assets/30924086/0d43b463-d0f1-4b36-a723-eda6d1615cd0">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
