### PR TITLE
chore(cli): speed up iOS launch

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- Eagerly perform iOS system checks to speed up iOS simulator launches.
+- Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.1 - 2024-01-18

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 💡 Others
 
+- Eagerly perform iOS system checks to speed up iOS simulator launches.
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.17.1 - 2024-01-18

--- a/packages/@expo/cli/jest.config.js
+++ b/packages/@expo/cli/jest.config.js
@@ -4,20 +4,23 @@ const roots = ['__mocks__', 'src'];
 
 module.exports = {
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
-  projects: [{
-    testEnvironment: 'node',
-    testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
-    rootDir: path.resolve(__dirname),
-    displayName: require('./package').name,
-    roots,
-    setupFiles: ['<rootDir>/e2e/setup.ts'],
-    clearMocks: true,
-  }, {
-    displayName: require('./package').name + "-types",
-    runner: 'jest-runner-tsd',
-    testRegex: '/__typetests__/.*(test|spec)\\.[jt]sx?$',
-    rootDir: path.resolve(__dirname),
-    roots,
-    globalSetup: '<rootDir>/src/start/server/type-generation/__typetests__/generateFixtures.ts',
-  }]
+  projects: [
+    {
+      testEnvironment: 'node',
+      testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
+      rootDir: path.resolve(__dirname),
+      displayName: require('./package').name,
+      roots,
+      setupFiles: ['<rootDir>/e2e/setup.ts'],
+      clearMocks: true,
+    },
+    {
+      displayName: require('./package').name + '-types',
+      runner: 'jest-runner-tsd',
+      testRegex: '/__typetests__/.*(test|spec)\\.[jt]sx?$',
+      rootDir: path.resolve(__dirname),
+      roots,
+      globalSetup: '<rootDir>/src/start/server/type-generation/__typetests__/generateFixtures.ts',
+    },
+  ],
 };

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithBaseUrl.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithBaseUrl.ts
@@ -2,7 +2,7 @@ import { URL } from 'url';
 
 import { FetchLike } from './client.types';
 
-const debug = require('debug')('expo:api:fetch:base') as typeof console.log;
+// const debug = require('debug')('expo:api:fetch:base') as typeof console.log;
 
 /**
  * Wrap a fetch function with support for a predefined base URL.
@@ -18,7 +18,7 @@ export function wrapFetchWithBaseUrl(fetch: FetchLike, baseUrl: string): FetchLi
     if (init?.searchParams) {
       parsed.search = init.searchParams.toString();
     }
-    debug('fetch:', parsed.toString().trim());
+    // debug('fetch:', parsed.toString().trim());
     return fetch(parsed.toString(), init);
   };
 }

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveDevice-test.ts
@@ -1,4 +1,4 @@
-import { assertSystemRequirementsAsync } from '../../../../start/platforms/ios/assertSystemRequirements';
+import { AppleDeviceManager } from '../../../../start/platforms/ios/AppleDeviceManager';
 import { sortDefaultDeviceToBeginningAsync } from '../../../../start/platforms/ios/promptAppleDevice';
 import { promptDeviceAsync } from '../promptDevice';
 import { resolveDeviceAsync } from '../resolveDevice';
@@ -51,6 +51,7 @@ jest.mock('../../../../start/platforms/ios/AppleDeviceManager', () => ({
   ensureSimulatorOpenAsync: jest.fn(async (obj) => obj),
 
   AppleDeviceManager: {
+    assertSystemRequirementsAsync: jest.fn(),
     resolveAsync: jest.fn(async () => ({ device: simulator })),
   },
 }));
@@ -58,7 +59,7 @@ jest.mock('../../../../start/platforms/ios/AppleDeviceManager', () => ({
 describe(resolveDeviceAsync, () => {
   it(`resolves a default device`, async () => {
     expect((await resolveDeviceAsync(undefined, { osType: undefined })).name).toEqual('iPhone 8');
-    expect(assertSystemRequirementsAsync).toBeCalled();
+    expect(AppleDeviceManager.assertSystemRequirementsAsync).toBeCalled();
   });
   it(`prompts the user to select a device`, async () => {
     expect((await resolveDeviceAsync(true, { osType: undefined })).name).toEqual(`Evan's phone`);
@@ -69,7 +70,7 @@ describe(resolveDeviceAsync, () => {
       expect.anything(),
     ]);
 
-    expect(assertSystemRequirementsAsync).toBeCalled();
+    expect(AppleDeviceManager.assertSystemRequirementsAsync).toBeCalled();
     expect(sortDefaultDeviceToBeginningAsync).toBeCalled();
   });
   it(`searches for the provided device by name`, async () => {
@@ -79,7 +80,7 @@ describe(resolveDeviceAsync, () => {
 
     expect(promptDeviceAsync).not.toBeCalled();
 
-    expect(assertSystemRequirementsAsync).toBeCalled();
+    expect(AppleDeviceManager.assertSystemRequirementsAsync).toBeCalled();
     expect(sortDefaultDeviceToBeginningAsync).toBeCalled();
   });
   it(`searches for the provided device by id`, async () => {
@@ -89,7 +90,7 @@ describe(resolveDeviceAsync, () => {
 
     expect(promptDeviceAsync).not.toBeCalled();
 
-    expect(assertSystemRequirementsAsync).toBeCalled();
+    expect(AppleDeviceManager.assertSystemRequirementsAsync).toBeCalled();
     expect(sortDefaultDeviceToBeginningAsync).toBeCalled();
   });
   it(`asserts the requested device could not be found`, async () => {
@@ -99,7 +100,7 @@ describe(resolveDeviceAsync, () => {
 
     expect(promptDeviceAsync).not.toBeCalled();
 
-    expect(assertSystemRequirementsAsync).toBeCalled();
+    expect(AppleDeviceManager.assertSystemRequirementsAsync).toBeCalled();
     expect(sortDefaultDeviceToBeginningAsync).toBeCalled();
   });
 });

--- a/packages/@expo/cli/src/run/ios/options/resolveDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveDevice.ts
@@ -4,7 +4,6 @@ import {
   AppleDeviceManager,
   ensureSimulatorOpenAsync,
 } from '../../../start/platforms/ios/AppleDeviceManager';
-import { assertSystemRequirementsAsync } from '../../../start/platforms/ios/assertSystemRequirements';
 import { sortDefaultDeviceToBeginningAsync } from '../../../start/platforms/ios/promptAppleDevice';
 import { OSType } from '../../../start/platforms/ios/simctl';
 import * as SimControl from '../../../start/platforms/ios/simctl';
@@ -41,7 +40,7 @@ export async function resolveDeviceAsync(
   device?: string | boolean,
   { osType }: { osType?: OSType } = {}
 ): Promise<AnyDevice> {
-  await assertSystemRequirementsAsync();
+  await AppleDeviceManager.assertSystemRequirementsAsync();
 
   if (!device) {
     /** Finds the first possible device and returns in a booted state. */

--- a/packages/@expo/cli/src/start/platforms/DeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/DeviceManager.ts
@@ -16,13 +16,16 @@ export abstract class DeviceManager<IDevice> {
 
   abstract startAsync(): Promise<IDevice>;
 
-  abstract getAppVersionAsync(applicationId: string): Promise<string | null>;
+  abstract getAppVersionAsync(
+    applicationId: string,
+    options?: { containerPath?: string }
+  ): Promise<string | null>;
 
   abstract installAppAsync(binaryPath: string): Promise<void>;
 
   abstract uninstallAppAsync(applicationId: string): Promise<void>;
 
-  abstract isAppInstalledAsync(applicationId: string): Promise<boolean>;
+  abstract isAppInstalledAsync(applicationId: string): Promise<boolean | string>;
 
   abstract openUrlAsync(url: string): Promise<void>;
 

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -25,8 +25,11 @@ export class ExpoGoInstaller<IDevice> {
   ) {}
 
   /** Returns true if the installed app matching the previously provided `appId` is outdated. */
-  async isClientOutdatedAsync(device: DeviceManager<IDevice>): Promise<boolean> {
-    const installedVersion = await device.getAppVersionAsync(this.appId);
+  async isClientOutdatedAsync(
+    device: DeviceManager<IDevice>,
+    { containerPath }: { containerPath?: string } = {}
+  ): Promise<boolean> {
+    const installedVersion = await device.getAppVersionAsync(this.appId, { containerPath });
     if (!installedVersion) {
       return true;
     }
@@ -46,7 +49,10 @@ export class ExpoGoInstaller<IDevice> {
   }
 
   /** Returns a boolean indicating if Expo Go should be installed. Returns `true` if the app was uninstalled. */
-  async uninstallExpoGoIfOutdatedAsync(deviceManager: DeviceManager<IDevice>): Promise<boolean> {
+  async uninstallExpoGoIfOutdatedAsync(
+    deviceManager: DeviceManager<IDevice>,
+    { containerPath }: { containerPath?: string } = {}
+  ): Promise<boolean> {
     const cacheId = `${this.platform}-${deviceManager.identifier}`;
 
     if (ExpoGoInstaller.cache[cacheId]) {
@@ -55,7 +61,7 @@ export class ExpoGoInstaller<IDevice> {
     }
     ExpoGoInstaller.cache[cacheId] = true;
 
-    if (await this.isClientOutdatedAsync(deviceManager)) {
+    if (await this.isClientOutdatedAsync(deviceManager, { containerPath })) {
       if (this.sdkVersion === 'UNVERSIONED') {
         // This should only happen in the expo/expo repo, e.g. `apps/test-suite`
         Log.log(
@@ -83,10 +89,10 @@ export class ExpoGoInstaller<IDevice> {
 
   /** Check if a given device has Expo Go installed, if not then download and install it. */
   async ensureAsync(deviceManager: DeviceManager<IDevice>): Promise<boolean> {
-    let shouldInstall = !(await deviceManager.isAppInstalledAsync(this.appId));
-
+    const hasInstall = await deviceManager.isAppInstalledAsync(this.appId);
+    let shouldInstall = !hasInstall;
     if (env.EXPO_OFFLINE) {
-      if (!shouldInstall) {
+      if (hasInstall) {
         Log.warn(`Skipping Expo Go version validation in offline mode`);
         return false;
       }
@@ -96,8 +102,11 @@ export class ExpoGoInstaller<IDevice> {
       );
     }
 
-    if (!shouldInstall) {
-      shouldInstall = await this.uninstallExpoGoIfOutdatedAsync(deviceManager);
+    if (hasInstall) {
+      shouldInstall = await this.uninstallExpoGoIfOutdatedAsync(deviceManager, {
+        // iOS optimization to prevent duplicate calls to `getContainerPathAsync`.
+        containerPath: typeof hasInstall === 'string' ? hasInstall : undefined,
+      });
     }
 
     if (shouldInstall) {

--- a/packages/@expo/cli/src/start/platforms/android/AndroidAppIdResolver.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidAppIdResolver.ts
@@ -17,7 +17,7 @@ export class AndroidAppIdResolver extends AppIdResolver {
       await AndroidConfig.Paths.getProjectPathOrThrowAsync(this.projectRoot);
       return true;
     } catch (error: any) {
-      debug('Expected error checking for native project:', error);
+      debug('Expected error checking for native project:', error.message);
       return false;
     }
   }

--- a/packages/@expo/cli/src/start/platforms/ios/AppleAppIdResolver.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleAppIdResolver.ts
@@ -18,7 +18,7 @@ export class AppleAppIdResolver extends AppIdResolver {
       // Never returns nullish values.
       return !!IOSConfig.Paths.getAllPBXProjectPaths(this.projectRoot).length;
     } catch (error: any) {
-      debug('Expected error checking for native project:', error);
+      debug('Expected error checking for native project:', error.message);
       return false;
     }
   }

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -96,10 +96,14 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     return this.device.udid;
   }
 
-  async getAppVersionAsync(appId: string): Promise<string | null> {
+  async getAppVersionAsync(
+    appId: string,
+    { containerPath }: { containerPath?: string } = {}
+  ): Promise<string | null> {
     return await SimControl.getInfoPlistValueAsync(this.device, {
       appId,
       key: 'CFBundleShortVersionString',
+      containerPath,
     });
   }
 
@@ -173,9 +177,11 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
   }
 
   async isAppInstalledAsync(appId: string) {
-    return !!(await SimControl.getContainerPathAsync(this.device, {
-      appId,
-    }));
+    return (
+      (await SimControl.getContainerPathAsync(this.device, {
+        appId,
+      })) ?? false
+    );
   }
 
   async openUrlAsync(url: string) {

--- a/packages/@expo/cli/src/start/platforms/ios/assertSystemRequirements.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/assertSystemRequirements.ts
@@ -1,10 +1,20 @@
+import { profile } from '../../../utils/profile';
 import { SimulatorAppPrerequisite } from '../../doctor/apple/SimulatorAppPrerequisite';
 import { XcodePrerequisite } from '../../doctor/apple/XcodePrerequisite';
 import { XcrunPrerequisite } from '../../doctor/apple/XcrunPrerequisite';
 
 export async function assertSystemRequirementsAsync() {
   // Order is important
-  await XcodePrerequisite.instance.assertAsync();
-  await XcrunPrerequisite.instance.assertAsync();
-  await SimulatorAppPrerequisite.instance.assertAsync();
+  await profile(
+    XcodePrerequisite.instance.assertAsync.bind(XcodePrerequisite.instance),
+    'XcodePrerequisite'
+  )();
+  await profile(
+    XcrunPrerequisite.instance.assertAsync.bind(XcrunPrerequisite.instance),
+    'XcrunPrerequisite'
+  )();
+  await profile(
+    SimulatorAppPrerequisite.instance.assertAsync.bind(SimulatorAppPrerequisite.instance),
+    'SimulatorAppPrerequisite'
+  )();
 }

--- a/packages/@expo/cli/src/start/platforms/ios/simctl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctl.ts
@@ -88,17 +88,23 @@ export async function getInfoPlistValueAsync(
   {
     appId,
     key,
+    containerPath,
   }: {
     appId: string;
     key: string;
+    containerPath?: string;
   }
 ): Promise<string | null> {
-  const containerPath = await getContainerPathAsync(device, { appId });
-  if (containerPath) {
+  const ensuredContainerPath = containerPath ?? (await getContainerPathAsync(device, { appId }));
+  if (ensuredContainerPath) {
     try {
-      const { output } = await spawnAsync('defaults', ['read', `${containerPath}/Info`, key], {
-        stdio: 'pipe',
-      });
+      const { output } = await spawnAsync(
+        'defaults',
+        ['read', `${ensuredContainerPath}/Info`, key],
+        {
+          stdio: 'pipe',
+        }
+      );
       return output.join('\n').trim();
     } catch {
       return null;

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -65,7 +65,7 @@ export class DevelopmentSession {
       }
 
       if (this.url) {
-        debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
+        // debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
 
         await updateDevelopmentSessionAsync({
           url: this.url,


### PR DESCRIPTION
# Why

iOS launches have gotten slower over the last few releases. This PR aims to optimize the validation logic to try and mitigate this slowness.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Eagerly validate the computer system requirements in `expo start` when iOS is enabled and the device supports Apple development.
- Reuse certain simulator properties to reduce additional checks when possible.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Manually tested a number of cases but it's difficult to test every case here. Hoping all goes well but there may be some minor regressions for edge cases where people are trying to do iOS development without a mac or with certain requirements missing. Confident that the UI should be reflective though since we capture the error messages and present them again when the user attempts to launch on iOS.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
