### PR TITLE
Fix import in build-a-screen.mdx

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -413,7 +413,7 @@ To load and display the icon on the button, let's use `FontAwesome` from the lib
 {/* prettier-ignore */}
 ```jsx Button.js
 import { StyleSheet, View, Pressable, Text } from 'react-native';
-/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */
+/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons";/* @end */
 
 export default function Button({ label, /* @info The prop theme to detect the button variant. */theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */


### PR DESCRIPTION

# Why
When following along the tutorial for [building a screen](https://docs.expo.dev/tutorial/build-a-screen/), pasting the code in Button.js (when it uses FontAwesome) causes an error.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->
FontAwesome is imported from "@expo/vector-icons/FontAwesome", but is actually located in "@expo/vector-icons". 
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Tested by starting expo and copying the code in the documentation. 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

