### PR TITLE
[docs] Update callout verbiage and minor fixes

### DIFF
--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -34,7 +34,7 @@ In-app purchases (IAP) are transactions within a mobile or desktop application w
 
 ## Libraries
 
-The following libraries provide robust support for in-app purchase functionality and out-of-the-box compatibility with Expo apps using [CNG](workflow/continuous-native-generation/) and [Config Plugins](/config-plugins/introduction/) for seamless integration in your app.
+The following libraries provide robust support for in-app purchase functionality and out-of-the-box compatibility with Expo apps using [CNG](/workflow/continuous-native-generation/) and [Config Plugins](/config-plugins/introduction/) for seamless integration in your app.
 
 <BoxLink
   title={
@@ -42,15 +42,7 @@ The following libraries provide robust support for in-app purchase functionality
       <CODE>react-native-purchases</CODE>
     </>
   }
-  description={
-    <>
-      <CODE>react-native-purchases</CODE> is an open-source framework that provides a wrapper around
-      Google Play Billing and StoreKit APIs, and integration with RevenueCat services supporting
-      in-app purchases. It enables product management, analytics, and simplified workflows for
-      in-app purchase requirements that may extend beyond your client code, such as validating
-      purchases on an app's backend.
-    </>
-  }
+  description=" An open-source framework that provides a wrapper around Google Play Billing and StoreKit APIs, and integration with RevenueCat services supporting in-app purchases. It enables product management, analytics, and simplified workflows for in-app purchase requirements that may extend beyond your client code, such as validating purchases on an app's backend."
   href="https://github.com/RevenueCat/react-native-purchases"
   Icon={GithubIcon}
 />

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -8,8 +8,15 @@ import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
+import RedirectNotification from '~/components/plugins/RedirectNotification';
 
-[Firebase](https://firebase.google.com/) is a Backend-as-a-Service (BaaS) app development platform that provides hosted backend services such as realtime database, cloud storage, authentication, crash reporting, analytics, and so on.
+<RedirectNotification>
+  The `expo-firebase-analytics` and `expo-firebase-recaptcha` libraries have been removed from SDK
+  48 onwards. We recommend using [React Native Firebase](#using-react-native-firebase) which
+  provides capabilities similar to these libraries.
+</RedirectNotification>
+
+[Firebase](https://firebase.google.com/) is a Backend-as-a-Service (BaaS) app development platform that provides hosted backend services such as real-time database, cloud storage, authentication, crash reporting, analytics, and so on.
 It is built on Google's infrastructure and scales automatically.
 
 There are two different ways you can use Firebase in your projects:
@@ -42,7 +49,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
-The following sub-sections use `firebase@9.x.x`. Expo SDK do not enforce or recommend any specific version of Firebase to use in your app.
+The following sub-sections use `firebase@9.x.x`. Expo SDK does not enforce or recommend any specific version of Firebase to use in your app.
 
 If you are using an older version of the firebase library in your project, you may have to adapt the code examples to match the version that you are using with the help of the [Firebase JS SDK documentation](https://github.com/firebase/firebase-js-sdk).
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend using [expo-camera/next](camera-next) which has barcode scanning built in instead.
+> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend using [`expo-camera/next`](camera-next) which has barcode scanning built-in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -11,9 +11,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend [react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
+> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend [`react-native-vision-camera`](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -13,7 +13,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 > **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend [`react-native-vision-camera`](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v46.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/facedetector.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v46.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/facedetector.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v48.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v48.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend using [expo-camera/next](camera-next) which has barcode scanning built in instead.
+> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend using [`expo-camera/next`](camera-next) which has barcode scanning built-in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -11,9 +11,9 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This module will no longer be available in SDK 51. We recommend [react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
+> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend [`react-native-vision-camera`](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
+**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -13,7 +13,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 > **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend [`react-native-vision-camera`](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
 
-**`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
+`expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
 
 <PlatformsSection android ios />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR address the following:
- Follow up #26743 to update callout verbiage and use inline syntax highlight for library names.
- Add a Redirect notification in Use Firebase guide for `expo-firebase-recaptcha` and `expo-firebase-analytics`.
- Fix minor grammatical issues in Use Firebase guide.
- Fix broken redirect link in Facedetector API reference.
- Fixes BoxLink in IAP guide for `react-native-purchases`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
