### PR TITLE
[cli] Update expo go installation prompt message

### DIFF
--- a/packages/@expo/cli/src/start/platforms/DeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/DeviceManager.ts
@@ -25,11 +25,13 @@ export abstract class DeviceManager<IDevice> {
 
   abstract uninstallAppAsync(applicationId: string): Promise<void>;
 
-  abstract isAppInstalledAsync(applicationId: string): Promise<boolean | string>;
+  abstract isAppInstalledAndIfSoReturnContainerPathForIOSAsync(
+    applicationId: string
+  ): Promise<boolean | string>;
 
   abstract openUrlAsync(url: string): Promise<void>;
 
   abstract activateWindowAsync(): Promise<void>;
 
-  abstract ensureExpoGoAsync(sdkVersion?: string): Promise<boolean>;
+  abstract ensureExpoGoAsync(sdkVersion: string): Promise<boolean>;
 }

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -6,6 +6,7 @@ import * as Log from '../../log';
 import { downloadExpoGoAsync } from '../../utils/downloadExpoGoAsync';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
+import { learnMore } from '../../utils/link';
 import { logNewSection } from '../../utils/ora';
 import { confirmAsync } from '../../utils/prompts';
 
@@ -21,29 +22,30 @@ export class ExpoGoInstaller<IDevice> {
     private platform: 'ios' | 'android',
     // Ultimately this should be inlined since we know the platform.
     private appId: string,
-    private sdkVersion?: string
+    private sdkVersion: string
   ) {}
 
   /** Returns true if the installed app matching the previously provided `appId` is outdated. */
-  async isInstalledClientVersionMismatchedAsync(
-    device: DeviceManager<IDevice>,
-    { containerPath }: { containerPath?: string } = {}
-  ): Promise<boolean> {
-    const installedVersion = await device.getAppVersionAsync(this.appId);
+  isInstalledClientVersionMismatched(
+    installedVersion: string | null,
+    expectedExpoGoVersion: string | null
+  ): boolean {
     if (!installedVersion) {
       return true;
     }
-    const version = await this._getExpectedClientVersionAsync();
-    debug(`Expected Expo Go version: ${version}, installed version: ${installedVersion}`);
-    return version ? !semver.eq(installedVersion, version) : true;
+
+    debug(
+      `Expected Expo Go version: ${expectedExpoGoVersion}, installed version: ${installedVersion}`
+    );
+    return expectedExpoGoVersion ? !semver.eq(installedVersion, expectedExpoGoVersion) : true;
   }
 
   /** Returns the expected version of Expo Go given the project SDK Version. Exposed for testing. */
-  async _getExpectedClientVersionAsync(): Promise<string | null> {
+  async getExpectedExpoGoClientVersionAsync(): Promise<string | null> {
     const versions = await getVersionsAsync();
     // Like `sdkVersions['44.0.0']['androidClientVersion'] = '1.0.0'`
     const specificVersion =
-      versions?.sdkVersions?.[this.sdkVersion!]?.[`${this.platform}ClientVersion`];
+      versions?.sdkVersions?.[this.sdkVersion]?.[`${this.platform}ClientVersion`];
     const latestVersion = versions[`${this.platform}Version`];
     return specificVersion ?? latestVersion ?? null;
   }
@@ -61,7 +63,14 @@ export class ExpoGoInstaller<IDevice> {
     }
     ExpoGoInstaller.cache[cacheId] = true;
 
-    if (await this.isInstalledClientVersionMismatchedAsync(deviceManager, { containerPath })) {
+    const [installedExpoGoVersion, expectedExpoGoVersion] = await Promise.all([
+      deviceManager.getAppVersionAsync(this.appId, {
+        containerPath,
+      }),
+      this.getExpectedExpoGoClientVersionAsync(),
+    ]);
+
+    if (this.isInstalledClientVersionMismatched(installedExpoGoVersion, expectedExpoGoVersion)) {
       if (this.sdkVersion === 'UNVERSIONED') {
         // This should only happen in the expo/expo repo, e.g. `apps/test-suite`
         Log.log(
@@ -73,8 +82,14 @@ export class ExpoGoInstaller<IDevice> {
       // Only prompt once per device, per run.
       const confirm = await confirmAsync({
         initial: true,
-        message: `Expo Go on ${deviceManager.name} is not compatible with this project's SDK version. Would you like to install a compatible Expo Go?`,
+        message: `Expo Go ${expectedExpoGoVersion} is recommended for SDK ${this.sdkVersion} (${
+          deviceManager.name
+        }
+          is using ${installedExpoGoVersion}). ${learnMore(
+            'https://docs.expo.dev/get-started/expo-go/#sdk-versions'
+          )}. Install the recommended Expo Go version?`,
       });
+
       if (confirm) {
         // Don't need to uninstall to update on iOS.
         if (this.platform !== 'ios') {
@@ -89,10 +104,11 @@ export class ExpoGoInstaller<IDevice> {
 
   /** Check if a given device has Expo Go installed, if not then download and install it. */
   async ensureAsync(deviceManager: DeviceManager<IDevice>): Promise<boolean> {
-    const hasInstall = await deviceManager.isAppInstalledAsync(this.appId);
-    let shouldInstall = !hasInstall;
+    const isExpoGoInstalledAndIfSoContainerPathForIOS =
+      await deviceManager.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(this.appId);
+    let shouldInstall = !isExpoGoInstalledAndIfSoContainerPathForIOS;
     if (env.EXPO_OFFLINE) {
-      if (hasInstall) {
+      if (isExpoGoInstalledAndIfSoContainerPathForIOS) {
         Log.warn(`Skipping Expo Go version validation in offline mode`);
         return false;
       }
@@ -102,13 +118,16 @@ export class ExpoGoInstaller<IDevice> {
       );
     }
 
-    if (hasInstall) {
+    if (isExpoGoInstalledAndIfSoContainerPathForIOS) {
       shouldInstall =
         await this.promptForUninstallExpoGoIfInstalledClientVersionMismatchedAndReturnShouldInstallAsync(
           deviceManager,
           {
             // iOS optimization to prevent duplicate calls to `getContainerPathAsync`.
-            containerPath: typeof hasInstall === 'string' ? hasInstall : undefined,
+            containerPath:
+              typeof isExpoGoInstalledAndIfSoContainerPathForIOS === 'string'
+                ? isExpoGoInstalledAndIfSoContainerPathForIOS
+                : undefined,
           }
         );
     }

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -83,7 +83,9 @@ export class PlatformManager<
         debug(`Resolving launch URL: (appId: ${applicationId}, redirect URL: ${redirectUrl})`);
         // NOTE(EvanBacon): This adds considerable amount of time to the command, we should consider removing or memoizing it.
         // Finally determine if the target device has a custom dev client installed.
-        if (await deviceManager.isAppInstalledAsync(applicationId)) {
+        if (
+          await deviceManager.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(applicationId)
+        ) {
           return redirectUrl;
         } else {
           // Log a warning if no development build is available on the device, but the
@@ -112,7 +114,9 @@ export class PlatformManager<
 
     // TODO: Expensive, we should only do this once.
     const { exp } = getConfig(this.projectRoot);
-    const installedExpo = await deviceManager.ensureExpoGoAsync(exp.sdkVersion);
+    const sdkVersion = exp.sdkVersion;
+    assert(sdkVersion, 'sdkVersion should be resolved by getConfig');
+    const installedExpo = await deviceManager.ensureExpoGoAsync(sdkVersion);
 
     deviceManager.activateWindowAsync();
     await deviceManager.openUrlAsync(url);
@@ -142,7 +146,7 @@ export class PlatformManager<
 
     const deviceManager = await this.props.resolveDeviceAsync(resolveSettings);
 
-    if (!(await deviceManager.isAppInstalledAsync(applicationId))) {
+    if (!(await deviceManager.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(applicationId))) {
       throw new CommandError(
         `No development build (${applicationId}) for this project is installed. ` +
           `Please make and install a development build on the device first.\n${learnMore(

--- a/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
@@ -39,7 +39,7 @@ describe('openAsync', () => {
       ensureExpoGoAsync: jest.fn(),
       activateWindowAsync: jest.fn(),
       openUrlAsync: jest.fn(),
-      isAppInstalledAsync: jest.fn(async () => isAppInstalled),
+      isAppInstalledAndIfSoReturnContainerPathForIOSAsync: jest.fn(async () => isAppInstalled),
     } as unknown as DeviceManager<unknown>;
     const resolveDeviceAsync = jest.fn(async () => device);
 
@@ -91,7 +91,7 @@ describe('openAsync', () => {
     expect(getExpoGoUrl).toHaveBeenCalledTimes(1);
 
     // Ensure we don't make the expensive call to check if the app is installed.
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(0);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(0);
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
@@ -120,8 +120,11 @@ describe('openAsync', () => {
     expect(getExpoGoUrl).toHaveBeenCalledTimes(0);
 
     // Ensure we check if the app is installed (once!).
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
-    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenNthCalledWith(
+      1,
+      'dev.bacon.app'
+    );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
@@ -151,8 +154,11 @@ describe('openAsync', () => {
     expect(getExpoGoUrl).toHaveBeenCalledTimes(1);
 
     // Ensure we check if the app is installed (once!).
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
-    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenNthCalledWith(
+      1,
+      'dev.bacon.app'
+    );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
@@ -235,8 +241,11 @@ describe('openAsync', () => {
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(0);
 
     // But does check the custom dev client
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
-    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenNthCalledWith(
+      1,
+      'dev.bacon.app'
+    );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
@@ -265,8 +274,11 @@ describe('openAsync', () => {
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(0);
 
     // But does check the custom dev client
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
-    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenNthCalledWith(
+      1,
+      'dev.bacon.app'
+    );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(0);
     expect(device.openUrlAsync).toHaveBeenCalledTimes(0);
@@ -298,8 +310,11 @@ describe('openAsync', () => {
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(0);
 
     // But does check the custom dev client
-    expect(device.isAppInstalledAsync).toHaveBeenCalledTimes(1);
-    expect(device.isAppInstalledAsync).toHaveBeenNthCalledWith(1, 'dev.bacon.app');
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenCalledTimes(1);
+    expect(device.isAppInstalledAndIfSoReturnContainerPathForIOSAsync).toHaveBeenNthCalledWith(
+      1,
+      'dev.bacon.app'
+    );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -89,7 +89,7 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
 
   async uninstallAppAsync(appId: string) {
     // we need to check if the app is installed, else we might bump into "Failure [DELETE_FAILED_INTERNAL_ERROR]"
-    const isInstalled = await this.isAppInstalledAsync(appId);
+    const isInstalled = await this.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(appId);
     if (!isInstalled) {
       return;
     }
@@ -127,7 +127,7 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     }
   }
 
-  async isAppInstalledAsync(applicationId: string) {
+  async isAppInstalledAndIfSoReturnContainerPathForIOSAsync(applicationId: string) {
     return await AndroidDebugBridge.isPackageInstalledAsync(this.device, applicationId);
   }
 
@@ -160,7 +160,7 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     await activateWindowAsync(this.device);
   }
 
-  async ensureExpoGoAsync(sdkVersion?: string): Promise<boolean> {
+  async ensureExpoGoAsync(sdkVersion: string): Promise<boolean> {
     const installer = new ExpoGoInstaller('android', EXPO_GO_APPLICATION_IDENTIFIER, sdkVersion);
     return installer.ensureAsync(this);
   }

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidPlatformManager-test.ts
@@ -20,7 +20,9 @@ describe('openAsync', () => {
   beforeEach(() => {
     AndroidDeviceManager.resolveAsync = jest.fn(async () => {
       const manager = new AndroidDeviceManager({ udid: '123', name: 'Pixel 5' } as any);
-      manager.isAppInstalledAsync = jest.fn(() => Promise.resolve(true));
+      manager.isAppInstalledAndIfSoReturnContainerPathForIOSAsync = jest.fn(() =>
+        Promise.resolve(true)
+      );
       return manager;
     });
   });

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -163,7 +163,7 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
 
   private async waitForAppInstalledAsync(applicationId: string): Promise<boolean> {
     while (true) {
-      if (await this.isAppInstalledAsync(applicationId)) {
+      if (await this.isAppInstalledAndIfSoReturnContainerPathForIOSAsync(applicationId)) {
         return true;
       }
       await delayAsync(100);
@@ -176,7 +176,7 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     });
   }
 
-  async isAppInstalledAsync(appId: string) {
+  async isAppInstalledAndIfSoReturnContainerPathForIOSAsync(appId: string) {
     return (
       (await SimControl.getContainerPathAsync(this.device, {
         appId,
@@ -214,7 +214,7 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     await osascript.execAsync(`tell application "Simulator" to activate`);
   }
 
-  async ensureExpoGoAsync(sdkVersion?: string): Promise<boolean> {
+  async ensureExpoGoAsync(sdkVersion: string): Promise<boolean> {
     const installer = new ExpoGoInstaller('ios', EXPO_GO_BUNDLE_IDENTIFIER, sdkVersion);
     return installer.ensureAsync(this);
   }

--- a/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
+++ b/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
@@ -74,7 +74,7 @@ export async function downloadExpoGoAsync(
     sdkVersion,
   }: {
     url?: string;
-    sdkVersion?: string;
+    sdkVersion: string;
   }
 ): Promise<string> {
   const { getFilePath, versionsKey, shouldExtractResults } = platformSettings[platform];
@@ -85,12 +85,6 @@ export async function downloadExpoGoAsync(
 
   try {
     if (!url) {
-      if (!sdkVersion) {
-        throw new CommandError(
-          `Unable to determine which Expo Go version to install (platform: ${platform})`
-        );
-      }
-
       const version = await getExpoGoVersionEntryAsync(sdkVersion);
 
       debug(`Installing Expo Go version for SDK ${sdkVersion} at URL: ${version[versionsKey]}`);


### PR DESCRIPTION
# Why

This message is a bit of a misnomer, both for previous releases and upcoming SDK 51 release (singly-versioned Expo Go).

This PR updates it for the upcoming release to indicate a mismatch rather than "outdated". If we also want to backport something similar to SDK 50, we'll need to do a release-branch-only PR since it's a bit different.

Closes https://github.com/expo/expo/issues/26699.
Closes ENG-11231.

# How

Update message and function names accordingly.

# Test Plan

Run all tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
