### PR TITLE
fix(cli): avoid locking progress bar to `100%` when a single file is transformed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed crash when launching React DevTools. ([#26550](https://github.com/expo/expo/pull/26550) by [@kudo](https://github.com/kudo))
 - Only show "Web is waiting" message after project is initialized with web. ([#26694](https://github.com/expo/expo/pull/26694) by [@byCedric](https://github.com/byCedric))
 - [Android] correct drawable types in updates embedded manifest. ([#26676](https://github.com/expo/expo/pull/26676) by [@douglowder](https://github.com/douglowder))
+- Fix progress bar locking in at `100%` when bundling app. ([#26775](https://github.com/expo/expo/pull/26775) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
@@ -22,6 +22,12 @@ export type BundleProgress = {
   ratio: number;
 };
 
+export type BundleProgressUpdate = {
+  buildID: string;
+  transformedFileCount: number;
+  totalFileCount: number;
+};
+
 export { TerminalReportableEvent };
 
 export type BuildPhase = 'in_progress' | 'done' | 'failed';
@@ -124,11 +130,7 @@ export interface TerminalReporterInterface {
     buildID,
     transformedFileCount,
     totalFileCount,
-  }: {
-    buildID: string;
-    transformedFileCount: number;
-    totalFileCount: number;
-  }): void;
+  }: BundleProgressUpdate): void;
 
   /**
    * This function is exclusively concerned with updating the internal state.


### PR DESCRIPTION
# Why

Our transformer is faster than the resolver, or at least at the start. Since the progress indicator does not go "back" in terms of the current progress, this causes the progress bar to be locked at 100%.

<img width="513" alt="image" src="https://github.com/expo/expo/assets/1203991/99ea5da4-38f3-46c0-8bef-d5786d8bdb6d">

It happens on the first resolve + transform operation. The resolver takes a bit more time before finding more than 1 file, but the transformer catches up quickly. Causing a whooping `1/1` or `100%` ratio to be locked (as the progress bar does not go back when more files are discovered).

Found this by adding the following code to `instantiateMetro`:

```tsx
    reporter: {
      update(event: any) {
        if (event.type === 'bundle_transform_progressed') {
          fs.appendFileSync(
            logPath, // E.g. path.join(projectRoot, 'metro.log')
            `${Date.now()} - Build #${event.buildID} - transformedFileCount: ${event.transformedFileCount} - totalFileCount: ${event.totalFileCount}\n`, 
            'utf8'
          );
        }

        terminalReporter.update(event);
        if (reportEvent) {
          reportEvent(event);
        }
      },
    },
```

> The **metro.log** output [can be found here](https://github.com/expo/expo/files/14089767/metro.log), line 2 is the event described above.


# How

- When ratio is calculated at `100%`, but only 1 file is resolved, reset the ratio

# Test Plan

- `$ bun create expo ./test --template tabs`
- `$ cd ./test`
- `$ bun expo start --ios`
- Check if the progress bar is not locked to `100%`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
