### PR TITLE
[docs] Update links to Location reference in Netinfo API reference & fix minor issues

### DIFF
--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -47,11 +47,11 @@ unsubscribe();
 
 ## Accessing the SSID
 
-To access the `ssid` property (available under `state.details.ssid`), there are few additional configuration steps:
+To access the `ssid` property (available under `state.details.ssid`), there are a few additional configuration steps:
 
 #### Android and iOS
 
-- Request location permissions with [`Location.requestForegroundPermissionsAsync()`](location.mdx#locationrequestforegroundpermissionsasync) or [`Location.requestBackgroundPermissionsAsync()`](location.mdx#locationrequestbackgroundpermissionsasync)
+- Request location permissions with [`Location.requestForegroundPermissionsAsync()`](location.mdx#locationrequestforegroundpermissionsasync) or [`Location.requestBackgroundPermissionsAsync()`](location.mdx#locationrequestbackgroundpermissionsasync).
 
 #### iOS only
 
@@ -65,7 +65,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   }
 ```
 
-- Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling)
+- Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
-For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).
+For more information on API and usage, see [`react-native-netinfo` documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).

--- a/docs/pages/versions/v50.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/netinfo.mdx
@@ -47,11 +47,11 @@ unsubscribe();
 
 ## Accessing the SSID
 
-To access the `ssid` property (available under `state.details.ssid`), there are few additional configuration steps:
+To access the `ssid` property (available under `state.details.ssid`), there are a few additional configuration steps:
 
 #### Android and iOS
 
-- Request location permissions with [`Location.requestPermissionsAsync()`](location.mdx#locationrequestpermissionsasync)
+- Request location permissions with [`Location.requestForegroundPermissionsAsync()`](location.mdx#locationrequestforegroundpermissionsasync) or [`Location.requestBackgroundPermissionsAsync()`](location.mdx#locationrequestbackgroundpermissionsasync).
 
 #### iOS only
 
@@ -65,7 +65,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
   }
 ```
 
-- Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list)
-- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling)
+- Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
+- Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
-For more information on API and usage, see [react-native-netinfo documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).
+For more information on API and usage, see [`react-native-netinfo` documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #26785 to backport changes in SDK 50 reference.
Also, fix some minor verbiage issues.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
