### PR TITLE
[image][Android] Add downsampling when the asset exceeds the max bitmap size limit

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Adds new prop `decodeFormat` to specify the format that should be used during the decoding process. ([#26442](https://github.com/expo/expo/pull/26442) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added `generateBlurhashAsync` function. ([#26430](https://github.com/expo/expo/pull/26430) by [@aleqsio](https://github.com/aleqsio))
+- [Android] Adds automatic downsampling when the asset exceeds the hardware bitmap size limit.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [Android] Adds new prop `decodeFormat` to specify the format that should be used during the decoding process. ([#26442](https://github.com/expo/expo/pull/26442) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added `generateBlurhashAsync` function. ([#26430](https://github.com/expo/expo/pull/26430) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Adds automatic downsampling when the asset exceeds the hardware bitmap size limit.
+- [Android] Adds automatic downsampling when the asset exceeds the hardware bitmap size limit. ([#26792](https://github.com/expo/expo/pull/26792) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
@@ -1,9 +1,14 @@
 package expo.modules.image
 
+import android.os.Build
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.target.Target
 import expo.modules.image.enums.ContentFit
+import expo.modules.image.records.DecodeFormat
+import kotlin.math.floor
+import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.sqrt
 
 /**
  * Glide uses `hashCode` and `equals` of the `DownsampleStrategy` to calculate the cache key.
@@ -23,7 +28,7 @@ abstract class CustomDownsampleStrategy : DownsampleStrategy() {
   }
 }
 
-class NoopDownsampleStrategy : DownsampleStrategy() {
+object NoopDownsampleStrategy : DownsampleStrategy() {
   override fun getScaleFactor(
     sourceWidth: Int,
     sourceHeight: Int,
@@ -39,7 +44,10 @@ class NoopDownsampleStrategy : DownsampleStrategy() {
   ): SampleSizeRounding = SampleSizeRounding.QUALITY
 }
 
-class ContentFitDownsampleStrategy(private val target: ImageViewWrapperTarget, private val contentFit: ContentFit) : CustomDownsampleStrategy() {
+class ContentFitDownsampleStrategy(
+  private val target: ImageViewWrapperTarget,
+  private val contentFit: ContentFit
+) : CustomDownsampleStrategy() {
   private var wasTriggered = false
   override fun getScaleFactor(
     sourceWidth: Int,
@@ -86,7 +94,6 @@ class ContentFitDownsampleStrategy(private val target: ImageViewWrapperTarget, p
       requestedWidth / sourceWidth,
       requestedHeight / sourceHeight
     )
-    ContentFit.Fill, ContentFit.None -> 1f
     ContentFit.ScaleDown -> if (requestedWidth < sourceWidth || requestedHeight < sourceHeight) {
       // The container is smaller than the image — scale it down and behave like `contain`
       min(
@@ -97,6 +104,7 @@ class ContentFitDownsampleStrategy(private val target: ImageViewWrapperTarget, p
       // The container is bigger than the image — don't scale it and behave like `none`
       1f
     }
+    else -> 1f
   }
 
   override fun getSampleSizeRounding(
@@ -105,4 +113,95 @@ class ContentFitDownsampleStrategy(private val target: ImageViewWrapperTarget, p
     requestedWidth: Int,
     requestedHeight: Int
   ) = SampleSizeRounding.QUALITY
+}
+
+/**
+ * Android has hardware bitmap size limit that can be drown on the canvas.
+ * To prevents crashes, we need to downsample the image to fit into the maximum bitmap size.
+ */
+class SafeDownsampleStrategy(
+  private val decodeFormat: DecodeFormat
+) : CustomDownsampleStrategy() {
+  override fun getScaleFactor(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ): Float {
+    if (maxBitmapSize <= 0) {
+      return 1f
+    }
+
+    val sourceSize = sourceWidth * sourceHeight * decodeFormat.toBytes()
+    if (sourceSize <= maxBitmapSize) {
+      return 1f
+    }
+
+    // We need to downsample the image to fit into the maximum bitmap size.
+    // Calculate the aspect ratio of the source image. It's always <= 1.
+    val srcAspectRatio = min(sourceWidth, sourceHeight).toDouble() / max(sourceWidth, sourceHeight).toDouble()
+    // Calculate the area of the destination image.
+    val dstArea = maxBitmapSize / decodeFormat.toBytes()
+    // Calculate the longer side of the destination image using following formulas:
+    // dstLongerSide * dstSmallerSide = dstArea
+    // srcAspectRation * dstLongerSide = dstSmallerSide
+    // after substitution:
+    // srcAspectRation * dstLongerSide * dstLongerSide = dstArea
+    // dstLongerSide = sqrt(dstArea / srcAspectRatio)
+    val x = floor(sqrt(dstArea.toDouble() / srcAspectRatio)).toInt()
+
+    // Calculate the scale factor using longer side of both images.
+    val scaleFactor = x.toDouble() / max(sourceWidth, sourceHeight).toDouble()
+
+    return scaleFactor.toFloat()
+  }
+
+  override fun getSampleSizeRounding(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    requestedWidth: Int,
+    requestedHeight: Int
+  ): SampleSizeRounding {
+    return SampleSizeRounding.MEMORY
+  }
+
+  private val maxBitmapSize by lazy {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return@lazy -1
+    }
+
+    return@lazy try {
+      val defaultSize = 100 * 1024 * 1024 // 100 MB - from `RecordingCanvas` src
+
+      // We're trying to get the value of `ro.hwui.max_texture_allocation_size` property
+      // which is used by `RecordingCanvas` to determine the maximum bitmap size.
+      @Suppress("PrivateApi")
+      val getIntMethod = Class
+        .forName("android.os.SystemProperties")
+        .getMethod("getInt", String::class.java, Int::class.java)
+      getIntMethod.isAccessible = true
+      (getIntMethod.invoke(null, "ro.hwui.max_texture_allocation_size", defaultSize) as Int)
+        .coerceAtLeast(defaultSize)
+    } catch (e: Throwable) {
+      // If something goes wrong we just return -1 and don't downsample the image.
+      -1
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) {
+      return true
+    }
+    if (other !is SafeDownsampleStrategy) {
+      return false
+    }
+
+    return decodeFormat == other.decodeFormat
+  }
+
+  override fun hashCode(): Int {
+    var result = super.hashCode()
+    result = 31 * result + decodeFormat.hashCode()
+    return result
+  }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -43,7 +43,7 @@ class ExpoImageModule : Module() {
           .load(GlideUrl(it)) //  Use `load` instead of `download` to store the asset in the memory cache
           // We added `quality` and `downsample` to create the same cache key as in final image load.
           .encodeQuality(100)
-          .downsample(NoopDownsampleStrategy())
+          .downsample(NoopDownsampleStrategy)
           .apply {
             if (cachePolicy == CachePolicy.MEMORY) {
               diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -519,10 +519,16 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
       }
       newTarget.hasSource = sourceToLoad != null
 
-      val downsampleStrategy = if (allowDownscaling) {
+      val downsampleStrategy = if (!allowDownscaling) {
+        DownsampleStrategy.NONE
+      } else if (
+        contentFit != ContentFit.Fill &&
+        contentFit != ContentFit.None
+      ) {
         ContentFitDownsampleStrategy(newTarget, contentFit)
       } else {
-        DownsampleStrategy.NONE
+        // it won't downscale the image if the image is smaller than hardware bitmap size limit
+        SafeDownsampleStrategy(decodeFormat)
       }
 
       val request = requestManager

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/DecodeFormat.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/DecodeFormat.kt
@@ -12,4 +12,11 @@ enum class DecodeFormat(val value: String) : Enumerable {
       RGB_565 -> com.bumptech.glide.load.DecodeFormat.PREFER_RGB_565
     }
   }
+
+  fun toBytes(): Int {
+    return when (this) {
+      ARGB_8888 -> 4
+      RGB_565 -> 2
+    }
+  }
 }


### PR DESCRIPTION
# Why

Adds downsampling when the asset exceeds the max bitmap size limit.

# How

If a user tries to load an asset that is bigger than the hardware bitmap size limitation, it can cause the app to crash during drawing. We aim to prevent these crashes from happening. Unfortunately, the Android SDK does not provide an API to receive the hardware limit, so we have to use reflection to obtain it. This workaround may not work for some devices, but it's the best solution we have at the moment. 

# Test Plan

- Simple app that tries to load a huge asset - tested on: emulator, Pixel 7 and OnePlus 9 ✅ 