### PR TITLE
[docs] Clean up SDK 46 and 47 references from non-API docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -231,7 +231,7 @@ In the terminal window and run the following command with to generate the JSON d
 - Read the **NOTE** in the below snippet for updating the docs for `unversioned`:
 
 ```shell
-et generate-docs-api-data --packageName expo-constants --sdk 47
+et generate-docs-api-data --packageName expo-constants --sdk 50
 
 #### NOTE ####
 # To update unversioned docs, run the command without mentioning the SDK version

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -62,17 +62,6 @@ Config types are exported directly from `expo/config`, so there is no need to in
 import { ExpoConfig, ConfigContext } from 'expo/config';
 ```
 
-<Collapsible summary="Using SDK 46 or lower?">
-
-For SDK 46 and lower, import the `@expo/config-plugins` package directly. This is installed automatically by the `expo` package, but not re-exported as it is in SDK 47 and higher.
-
-{/* prettier-ignore */}
-```js
-const { /* @hide ...*//* @end */ } = require('@expo/config-plugins');
-```
-
-</Collapsible>
-
 ### Best practices for mods
 
 - Avoid regex: [static modification](#static-modification) is key. If you want to modify a value in an Android gradle file, consider using `gradle.properties`. If you want to modify some code in the Podfile, consider writing to JSON and having the Podfile read the static values.
@@ -132,10 +121,6 @@ Here's an example of adding a `<meta-data android:name="..." android:value="..."
 import { AndroidConfig, ConfigPlugin, withAndroidManifest } from 'expo/config-plugins';
 import { ExpoConfig } from 'expo/config';
 
-// Use these imports in SDK 46 and lower
-// import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
-// import { ExpoConfig } from '@expo/config-types';
-
 // Using helpers keeps error messages unified and helps cut down on XML format changes.
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest;
 
@@ -177,10 +162,6 @@ Here's an example of adding a `GADApplicationIdentifier` to the **Info.plist**:
 ```ts my-config-plugin.ts
 import { ConfigPlugin, withInfoPlist } from 'expo/config-plugins';
 
-// Use these imports in SDK 46 and lower
-// import { ConfigPlugin, InfoPlist, withInfoPlist } from '@expo/config-plugins';
-// import { ExpoConfig } from '@expo/config-types';
-
 // Pass `<string>` to specify that this plugin requires a string property.
 export const withCustomConfig: ConfigPlugin<string> = (config, id) => {
   return withInfoPlist(config, config => {
@@ -213,9 +194,6 @@ This is used by [expo-build-properties](/versions/latest/sdk/build-properties) a
 
 ```ts my-config-plugin.ts
 import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
-
-// Use this import in SDK 46 and lower
-// import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 
 // Keeping the name, and version in sync with it's package.
 const pkg = require('my-cool-plugin/package.json');

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -130,16 +130,6 @@ withPlugins(config, [
 ]);
 ```
 
-<Collapsible summary="Using SDK 46 or lower?">
-
-For SDK 46 and lower, import the `@expo/config-plugins` package directly. This is installed automatically by the `expo` package, but not re-exported as it is in SDK 47 and higher.
-
-```js app.config.js
-const { withPlugins } = require('@expo/config-plugins');
-```
-
-</Collapsible>
-
 To support JSON configs, we also added the `plugins` array which just uses `withPlugins` under the hood.
 Here is the same config as above, but even simpler:
 
@@ -301,16 +291,6 @@ const config = {
 /// Use the plugin
 export default withCustomProductName(config, 'new_name');
 ```
-
-<Collapsible summary="Using SDK 46 or lower?">
-
-For SDK 46 and lower, import the `@expo/config-plugins` package directly. This is installed automatically by the `expo` package, but not re-exported as it is in SDK 47 and higher.
-
-```js
-const { ConfigPlugin, withXcodeProject } = require('@expo/config-plugins');
-```
-
-</Collapsible>
 
 ### Experimental functionality
 

--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -107,7 +107,7 @@ After running the above, inspect **android/app/src/main/AndroidManifest.xml** an
 <!-- @hide ... Existing configuration --><!-- @end -->
 ```
 
-> If you do not see the above lines added to these files, it means that you are using SDK 47 or earlier, and you should add these lines manually to **AndroidManifest.xml** and **Expo.plist**. In SDK 48 and later, the [`requestHeaders`](/versions/latest/config/app/#requestheaders) property from the app config is used to automatically add these lines to the native files.
+> In SDK 48 and later, the [`requestHeaders`](/versions/latest/config/app/#requestheaders) property from the app config is used to automatically add these lines to the native files.
 
 </Step>
 

--- a/docs/pages/guides/configuring-js-engines.mdx
+++ b/docs/pages/guides/configuring-js-engines.mdx
@@ -12,7 +12,7 @@ JavaScript engines execute your application code and provide various features su
 
 We recommend Hermes because it is purpose built and optimized for React Native apps, and it has the best debugging experience. If you are familiar with the tradeoffs of different JavaScript engines and would like to change away from Hermes, the [`jsEngine`](/versions/latest/config/app/#jsengine) field inside [app config](/workflow/configuration/) allows you to specify the JavaScript engine for your app. The default value is `hermes`.
 
-If you want to use JSC instead, set the `jsEngine` field in the app config:
+If you want to use JSC instead, set the `jsEngine` field in the app config:
 
 ```json app.json
 {
@@ -40,7 +40,7 @@ Make sure to remove the `jsEngine` field from the app config.
 
 <Collapsible summary="Are you using the bare workflow?">
 
-You can run `npx expo prebuild -p android --clean` after the installation to prebuild again.
+You can run `npx expo prebuild -p android --clean` after the installation to prebuild again.
 
 </Collapsible>
 

--- a/docs/pages/guides/minify.mdx
+++ b/docs/pages/guides/minify.mdx
@@ -58,7 +58,6 @@ Different minifiers have tradeoffs between speed and compression. You can custom
 ### Terser
 
 > [`terser`](https://github.com/terser/terser) is the default minifier in SDK 48 and above: ([Metro@0.73.0 changelog](https://github.com/facebook/metro/releases/tag/v0.73.0)).
-> For projects SDK 47 and below, you can use [`terser`](https://github.com/terser/terser) instead of `uglify-es` to mangle and compress your project.
 
 <Step label="1">
 
@@ -123,8 +122,6 @@ module.exports = config;
 [`esbuild`](https://esbuild.github.io/) is used to minify exponentially faster than `uglify-es` and `terser`. For more information, see [`metro-minify-esbuild`](https://github.com/EvanBacon/metro-minify-esbuild#usage) usage.
 
 ### Uglify
-
-> [`uglify-es`](https://github.com/mishoo/UglifyJS) is the default minifier in SDK 47 and below. It uses [these options](https://github.com/facebook/metro/blob/b629f44239bbb3414491755185cf19b5834b4b7a/packages/metro-config/src/defaults/index.js#L94-L111).
 
 For projects SDK 48 and above, you can use [`uglify-es`](https://github.com/mishoo/UglifyJS) by following the steps below:
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -63,7 +63,7 @@ Rename files to convert them to TypeScript. For example, rename **App.js** to **
 
 <Terminal cmd={['$ mv App.js App.tsx']} />
 
-> **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`. **For SDK 47 and below**, the command also prompts you to install `@types/react-native` as an additional dependency.
+> **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`.
 
 For npm, add the following `script` to the **package.json**:
 

--- a/docs/pages/guides/using-flipper.mdx
+++ b/docs/pages/guides/using-flipper.mdx
@@ -75,24 +75,6 @@ Installing the package adds the `expo-build-properties` plugin to your project's
 }
 ```
 
-<Collapsible summary="Using SDK 47 or lower?">
-
-> The above configuration only works with SDK 48 or above. For SDK 47 and lower, use the following steps described:
-
-The [`expo-community-flipper`](https://github.com/jakobo/expo-community-flipper#expo-community-flipper) plugin depends on the `react-native-flipper` library. Run the following command to install both of them:
-
-<Terminal cmd={['$ npx expo install expo-community-flipper react-native-flipper']} />
-
-Then, in the **app.json**, add `expo-community-flipper` to the `plugins` array:
-
-```json app.json
-{
-  "plugins": ["expo-community-flipper"]
-}
-```
-
-</Collapsible>
-
 </Step>
 
 <Step label="4">

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -17,25 +17,6 @@ The Hermes engine is the default JavaScript engine used by Expo and it is fully 
 | Android  | SDK 42  | SDK 42                                                          |
 | iOS      | SDK 47  | SDK 43                                                          |
 
-<Collapsible summary="Using SDK 47 or lower?">
-
-For SDK 47 and lower, JSC is the default JavaScript engine and to use Hermes you need to add the `jsEngine` field in [app config](/workflow/configuration):
-
-{/* prettier-ignore */}
-```js
-{
-  "expo": {
-    /* @info Add the "jsEngine" field here. Supported values are "hermes" or "jsc" */
-    "jsEngine": "hermes"
-   /* @end */
-  }
-}
-```
-
-Development builds will need to be recompiled with `eas build`.
-
-</Collapsible>
-
 ### Switch JavaScript engine on a specific platform
 
 You may want to use Hermes on one platform and JSC on another. One way to do this is to set the `"jsEngine"` to `"hermes"` at the top level and then override it with `"jsc"` under the `"ios"` key. You may alternatively prefer to explicitly set `"hermes"` on just the `"android"` key in this case.

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -476,8 +476,6 @@ Skipping or misconfiguring either of these can lead to invalid source maps, and 
 
 ### Uploading source maps for updates
 
-> This requires SDK 47, with `sentry-expo@6.0.0` or above and `expo-updates@0.15.5` or above.
-
 If you're using EAS Update, or if you're self-hosting your updates (this means you run `npx expo export` manually), you need to take the following steps to upload the source maps for your update to Sentry:
 
 - Run `eas update`. This will generate a **dist** folder in your project root, which contains your JavaScript bundles and source maps. This command will also output the 'Android update ID' and 'iOS update ID' that we'll need in the next step.

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -8,7 +8,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { StatusTag } from '~/ui/components/Tag';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This documentation refers to the Local Expo CLI (SDK 46 and above). For information on legacy Expo CLI, see [Global Expo CLI](/archive/expo-cli).
+> **info** This documentation refers to the Local Expo CLI. For information on legacy CLI, see [Global Expo CLI](/archive/expo-cli).
 
 The `expo` package provides a small and powerful CLI tool `npx expo` which is designed to keep you moving fast during app development.
 

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -95,7 +95,7 @@ Prebuild generates template files before modifying them with config plugins. The
 
 ## Side effects
 
-As of SDK 46, `npx expo prebuild` performs several side effects outside of generating the **android** and **ios** directories. Work is in progress to eliminate these side effects — ideally, running `npx expo prebuild` would generate the Android and iOS projects and leave the rest of the project untouched.
+`npx expo prebuild` performs several side effects outside of generating the **android** and **ios** directories. Work is in progress to eliminate these side effects — ideally, running `npx expo prebuild` would generate the Android and iOS projects and leave the rest of the project untouched.
 
 In addition to generating the native folders, prebuild also makes the following modifications:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up  #26806

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR clean ups collapsibles, notes, and code snippets that were relevant to SDK 46 and 47 from various docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
