### PR TITLE
[docs] Update Terminal component to display commands without using `$` prefix

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -24,7 +24,7 @@ To use Expo, you need to have the following tools installed on your machine:
 
 After installing Node.js, you can use `npx` to create a new app.
 
-<Terminal cmd={['$ npx create-expo-app --template']} />
+<Terminal cmd={['npx create-expo-app --template']} />
 
 <BoxLink
   title="Create a new project"

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -76,7 +76,7 @@ function cmdMapper(line: string, index: number) {
           -&nbsp;
         </CODE>
         <CODE className="whitespace-pre !bg-[transparent] !border-none text-default">
-          {line.startsWith('$') ? line.substring(2).trim() : line.substring(0).trim()}
+          {line.startsWith('$') ? line.substring(1).trim() : line.substring(0).trim()}
         </CODE>
       </div>
     );

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -69,14 +69,14 @@ function cmdMapper(line: string, index: number) {
     );
   }
 
-  if (line.startsWith('$')) {
+  if (line.startsWith('$') || line.length > 0) {
     return (
       <div key={key}>
         <CODE className="whitespace-pre !bg-[transparent] !border-none select-none !text-secondary">
           -&nbsp;
         </CODE>
         <CODE className="whitespace-pre !bg-[transparent] !border-none text-default">
-          {line.substring(1).trim()}
+          {line.startsWith('$') ? line.substring(2).trim() : line.substring(0).trim()}
         </CODE>
       </div>
     );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, using `Terminal` component, we have to add `$` as prefix to represent a command.

For example, in the [Installation > Get started section](https://docs.expo.dev/get-started/installation/#get-started), the command is displayed as:

![CleanShot 2024-01-31 at 18 22 01@2x](https://github.com/expo/expo/assets/10234615/d9321244-38d1-46e1-b8d9-1fbbf52c1ff3)

In the code, we use the `$` prefix to represent that string as a command in the above example:

```md
<Terminal cmd={['npx create-expo-app --template']} />
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a condition by checking the value of `line.length` to avoid using `$` prefix to display the command on the docs page same as it would with a `$` prefix.

Right now, it is added as an OR condition because there might be edge cases that could lead to regression and we also want to keep `$` around to clean that up in a follow up PR.

# Test Plan

As a test, see the Installation > Get started `Terminal` component usage.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
