### PR TITLE
[Android] Use cache-friendly exec

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -9,13 +9,28 @@ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
  * By default you don't need to apply any configuration, just uncomment the lines you need.
  */
 react {
-    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-    reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
-    hermesCommand = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc"
-    codegenDir = new File(["node", "--print", "require.resolve('@react-native/codegen/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
+    entryFile = file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute")
+    }.standardOutput.asText.get().trim())
+    def reactNativeRelativeDir = file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('react-native/package.json')")
+    }.standardOutput.asText.get().trim()).getParentFile()
+    reactNativeDir = reactNativeRelativeDir.getAbsoluteFile()
+    hermesCommand = reactNativeRelativeDir.getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc"
+    codegenDir = file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@react-native/codegen/package.json')")
+    }.standardOutput.asText.get().trim()).getParentFile().getAbsoluteFile()
+
 
     // Use Expo CLI to bundle the JS code
-    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
+    cliFile = file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@expo/cli')")
+    }.standardOutput.asText.get().trim())
+
     bundleCommand = "export:embed"
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
@@ -170,7 +185,7 @@ dependencies {
 class ExecuteSetupAndroidProject implements Plugin<Project> {
     @Override
     void apply(Project target) {
-        target.exec {
+        target.providers.exec {
             def configuration = target.gradle.startParameter.taskNames.any {
                 it.toLowerCase().contains("release")
             } ? "release" : "debug"
@@ -183,7 +198,11 @@ class ExecuteSetupAndroidProject implements Plugin<Project> {
 
 apply plugin: ExecuteSetupAndroidProject
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute(null, rootDir).text.trim(), "../native_modules.gradle")
+apply from: new File(providers.exec {
+  workingDir(rootDir)
+  commandLine("node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')")
+}.standardOutput.asText.get().trim(), "../native_modules.gradle")
+
 applyNativeModulesAppBuildGradle(project)
 
 apply plugin: 'com.google.gms.google-services'

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -3,82 +3,114 @@ import groovy.json.JsonSlurper
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {
-        buildToolsVersion = '34.0.0'
-        minSdkVersion = 23
-        compileSdkVersion = 34
-        targetSdkVersion = 34
-        // Some dependencies still expect supportLibVersion to be defined
-        supportLibVersion = "29.0.0"
-        kotlinVersion = '1.8.10'
-        // for expo-dev-client
-        expoUpdatesVersion = null
+  ext {
+    buildToolsVersion = '34.0.0'
+    minSdkVersion = 23
+    compileSdkVersion = 34
+    targetSdkVersion = 34
+    // Some dependencies still expect supportLibVersion to be defined
+    supportLibVersion = "29.0.0"
+    kotlinVersion = '1.8.10'
+    // for expo-dev-client
+    expoUpdatesVersion = null
 
-        ndkVersion = "25.1.8937393"
-    }
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle")
+    ndkVersion = "25.1.8937393"
+  }
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle")
 
-        classpath("com.facebook.react:react-native-gradle-plugin")
+    classpath("com.facebook.react:react-native-gradle-plugin")
 
-        classpath 'com.google.gms:google-services:4.3.5'  // Google Services plugin
+    classpath 'com.google.gms:google-services:4.3.5'  // Google Services plugin
 
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.23.3"
-    }
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:6.23.3"
+  }
 }
 
 allprojects {
-    // [Custom]
-    configurations.all {
-        if (findProperty("buildReactNativeFromSource") == "true") {
-            resolutionStrategy.dependencySubstitution {
-                substitute(module("com.facebook.react:react-native"))
-                    .using(project(":ReactAndroid"))
-                    .because("Building React Native from source")
-                substitute(module("com.facebook.react:react-android"))
-                    .using(project(":ReactAndroid"))
-                    .because("Building React Native from source")
-                substitute(module("com.facebook.react:hermes-engine"))
-                    .using(project(":ReactAndroid:hermes-engine"))
-                    .because("Building Hermes from source")
-                substitute(module("com.facebook.react:hermes-android"))
-                    .using(project(":ReactAndroid:hermes-engine"))
-                    .because("Building Hermes from source")
-            }
-        }
+  // [Custom]
+  configurations.all {
+    if (findProperty("buildReactNativeFromSource") == "true") {
+      resolutionStrategy.dependencySubstitution {
+        substitute(module("com.facebook.react:react-native"))
+            .using(project(":ReactAndroid"))
+            .because("Building React Native from source")
+        substitute(module("com.facebook.react:react-android"))
+            .using(project(":ReactAndroid"))
+            .because("Building React Native from source")
+        substitute(module("com.facebook.react:hermes-engine"))
+            .using(project(":ReactAndroid:hermes-engine"))
+            .because("Building Hermes from source")
+        substitute(module("com.facebook.react:hermes-android"))
+            .using(project(":ReactAndroid:hermes-engine"))
+            .because("Building Hermes from source")
+      }
+    }
+  }
+
+  repositories {
+    mavenLocal()
+    maven {
+      // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+      url(
+          new File(
+              providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('react-native/package.json')")
+              }.standardOutput.asText.get().trim(),
+              "../android"
+          )
+      )
+    }
+    maven {
+      // Android JSC is installed from npm
+      url(
+          new File(
+              providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('jsc-android/package.json')")
+              }.standardOutput.asText.get().trim(),
+              "../dist"
+          )
+      )
+    }
+    maven {
+      // expo-camera bundles a custom com.google.android:cameraview
+      url "$rootDir/../node_modules/expo-camera/android/maven"
+    }
+    maven {
+      url(
+          new File(
+              providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('expo-camera/package.json')")
+              }.standardOutput.asText.get().trim(),
+              "../android/maven"
+          )
+      )
+    }
+    maven {
+      url(
+          new File(
+              providers.exec {
+                workingDir(rootDir)
+                commandLine("node", "--print", "require.resolve('detox/package.json')")
+              }.standardOutput.asText.get().trim(),
+              "../Detox-android"
+          )
+      )
     }
 
-    repositories {
-        mavenLocal()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../android"))
-        }
-        maven {
-            // Android JSC is installed from npm
-            url(new File(["node", "--print", "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), "../dist"))
-        }
-        maven {
-            // expo-camera bundles a custom com.google.android:cameraview
-            url "$rootDir/../node_modules/expo-camera/android/maven"
-        }
-        maven {
-          url(new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven"))
-        }
-        maven {
-            url(new File(["node", "--print", "require.resolve('detox/package.json')"].execute(null, rootDir).text.trim(), "../Detox-android"))
-        }
-
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
+    google()
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
+  }
 }
 
 subprojects {
@@ -87,28 +119,28 @@ subprojects {
     kotlin {
       target '**/*.kt'
       ktlint("1.0.1")
-        .editorConfigOverride([
-          "ktlint_standard_no-wildcard-imports"           : "disabled",
-          "ktlint_standard_import-ordering"               : "disabled",
-          "ktlint_standard_filename"                      : "disabled",
-          "ktlint_standard_property-naming"               : "disabled",
-          "ktlint_standard_discouraged-comment-location"  : "disabled",
-          "ktlint_standard_comment-wrapping"              : "disabled",
-          "ktlint_standard_function-naming"               : "disabled",
-          "ktlint_standard_class-naming"                  : "disabled",
-          "ktlint_standard_package-name"                  : "disabled",
-          "ktlint_standard_multiline-expression-wrapping" : "disabled",
-          "charset"                  : "utf-8",
-          "end_of_line"              : "lf",
-          "indent_size"              : "2",
-          "continuation_indent_size" : "2",
-          "indent_style"             : "space",
-          "insert_final_newline"     : "true",
-          "tab_width"                : "2",
-          "trim_trailing_whitespace" : "true",
-          "ij_kotlin_allow_trailing_comma_on_call_site": "false",
-          "ij_kotlin_allow_trailing_comma": "false"
-        ])
+          .editorConfigOverride([
+              "ktlint_standard_no-wildcard-imports"          : "disabled",
+              "ktlint_standard_import-ordering"              : "disabled",
+              "ktlint_standard_filename"                     : "disabled",
+              "ktlint_standard_property-naming"              : "disabled",
+              "ktlint_standard_discouraged-comment-location" : "disabled",
+              "ktlint_standard_comment-wrapping"             : "disabled",
+              "ktlint_standard_function-naming"              : "disabled",
+              "ktlint_standard_class-naming"                 : "disabled",
+              "ktlint_standard_package-name"                 : "disabled",
+              "ktlint_standard_multiline-expression-wrapping": "disabled",
+              "charset"                                      : "utf-8",
+              "end_of_line"                                  : "lf",
+              "indent_size"                                  : "2",
+              "continuation_indent_size"                     : "2",
+              "indent_style"                                 : "space",
+              "insert_final_newline"                         : "true",
+              "tab_width"                                    : "2",
+              "trim_trailing_whitespace"                     : "true",
+              "ij_kotlin_allow_trailing_comma_on_call_site"  : "false",
+              "ij_kotlin_allow_trailing_comma"               : "false"
+          ])
       trimTrailingWhitespace()
       indentWithSpaces()
       endWithNewline()

--- a/apps/bare-expo/android/settings.gradle
+++ b/apps/bare-expo/android/settings.gradle
@@ -1,31 +1,55 @@
 rootProject.name = 'BareExpo'
 
+def reactNativePackage = providers.exec {
+  workingDir(rootDir)
+  commandLine("node", "--print", "require.resolve('react-native/package.json')")
+}.standardOutput.asText.get().trim()
+
 dependencyResolutionManagement {
   versionCatalogs {
     reactAndroidLibs {
-      from(files(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../gradle/libs.versions.toml")))
+      from(files(new File(reactNativePackage, "../gradle/libs.versions.toml")))
     }
   }
 }
 
-apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
+apply from: new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')")
+    }.standardOutput.asText.get().trim(),
+    "../native_modules.gradle"
+)
 applyNativeModulesSettingsGradle(settings)
 
 include(":expo-modules-test-core")
 project(":expo-modules-test-core").projectDir = new File("../../../packages/expo-modules-test-core/android")
 
 // Include Expo modules
-apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle");
+apply from: new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('expo/package.json')")
+    }.standardOutput.asText.get().trim(),
+    "../scripts/autolinking.gradle"
+)
 useExpoModules()
 
 include ':app'
-includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile())
+includeBuild(
+    file(
+        providers.exec {
+          workingDir(rootDir)
+          commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
+        }.standardOutput.asText.get().trim()
+    ).getParentFile()
+)
 
 if (settings.hasProperty("buildReactNativeFromSource") && settings.buildReactNativeFromSource == "true") {
   include(":ReactAndroid")
-  project(":ReactAndroid").projectDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../ReactAndroid");
+  project(":ReactAndroid").projectDir = new File(reactNativePackage, "../ReactAndroid");
   include(":ReactAndroid:hermes-engine")
-  project(":ReactAndroid:hermes-engine").projectDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../ReactAndroid/hermes-engine");
+  project(":ReactAndroid:hermes-engine").projectDir = new File(reactNativePackage, "../ReactAndroid/hermes-engine");
 }
 
 include ':detox'

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -10,7 +10,10 @@ version = '13.10.0'
 def REACT_NATIVE_BUILD_FROM_SOURCE = findProject(":ReactAndroid") != null
 def REACT_NATIVE_DIR = REACT_NATIVE_BUILD_FROM_SOURCE
   ? findProject(":ReactAndroid").getProjectDir().parent
-  : new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).parent
+  : file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('react-native/package.json')")
+    }.standardOutput.asText.get().trim()).parent
 
 def reactNativeArchitectures() {
     def value = project.getProperties().get("reactNativeArchitectures")

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -3,7 +3,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 
-def expoConstantsDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-constants/package.json')));"].execute(null, projectDir).text.trim()
+def expoConstantsDir = project.providers.exec {
+  workingDir(projectDir)
+  commandLine("node", "-e", "console.log(require('path').dirname(require.resolve('expo-constants/package.json')));")
+}.standardOutput.asText.get().trim()
 
 def config = project.hasProperty("react") ? project.react : [];
 def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -188,7 +188,10 @@ def versionToNumber(major, minor, patch) {
 }
 
 def getNodeModulesPackageVersion(packageName, overridePropName) {
-  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute(null, projectDir).text.trim()
+  def nodeModulesVersion = providers.exec {
+    workingDir(projectDir)
+    commandLine("node", "-e", "console.log(require('$packageName/package.json').version);")
+  }.standardOutput.asText.get().trim()
   def version = safeExtGet(overridePropName, nodeModulesVersion)
 
   def coreVersion = version.split("-")[0]

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -198,7 +198,10 @@ def versionToNumber(major, minor, patch) {
 }
 
 def getNodeModulesPackageVersion(packageName, overridePropName) {
-  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute(null, projectDir).text.trim()
+  def nodeModulesVersion = providers.exec {
+    workingDir(projectDir)
+    commandLine("node", "-e", "console.log(require('$packageName/package.json').version);")
+  }.standardOutput.asText.get().trim()
   def version = safeExtGet(overridePropName, nodeModulesVersion)
 
   def coreVersion = version.split("-")[0]

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -79,7 +79,7 @@ class ExpoAutolinkingManager {
     this.options = options
   }
 
-  Object resolve(shouldUseCachedValue=false) {
+  Object resolve(ProviderFactory providers, shouldUseCachedValue=false) {
     if (cachedResolvingResults) {
       return cachedResolvingResults
     }
@@ -89,7 +89,10 @@ class ExpoAutolinkingManager {
     String[] args = convertOptionsToCommandArgs('resolve', this.options)
     args += ['--json']
 
-    String output = exec(args, projectDir)
+    String output = providers.exec {
+      workingDir(projectDir)
+      commandLine(args)
+    }.standardOutput.asText.get().trim()
     Object json = new JsonSlurper().parseText(output)
 
     cachedResolvingResults = json
@@ -100,13 +103,13 @@ class ExpoAutolinkingManager {
     return options?.useAAR == true
   }
 
-  ExpoModule[] getModules(shouldUseCachedValue=false) {
-    Object json = resolve(shouldUseCachedValue)
+  ExpoModule[] getModules(ProviderFactory providers, shouldUseCachedValue=false) {
+    Object json = resolve(providers, shouldUseCachedValue)
     return json.modules.collect { new ExpoModule(it) }
   }
 
-  MavenRepo[] getExtraMavenRepos(shouldUseCachedValue=false) {
-    Object json = resolve(shouldUseCachedValue)
+  MavenRepo[] getExtraMavenRepos(ProviderFactory providers, shouldUseCachedValue=false) {
+    Object json = resolve(providers, shouldUseCachedValue)
     return json.extraDependencies.androidMavenRepos.collect { new MavenRepo(it) }
   }
 
@@ -138,14 +141,10 @@ class ExpoAutolinkingManager {
       args += '--empty'
     }
 
-    exec(args, project.rootDir)
-  }
-
-  static String exec(String[] commandArgs, File dir) {
-    Process proc = commandArgs.execute(null, dir)
-    StringBuffer outputStream = new StringBuffer()
-    proc.waitForProcessOutput(outputStream, System.err)
-    return outputStream.toString()
+    project.providers.exec {
+      workingDir(project.rootDir)
+      commandLine(args)
+    }.result.get().assertNormalExitValue()
   }
 
   static private String[] convertOptionsToCommandArgs(String command, Map options) {
@@ -207,8 +206,8 @@ if (rootProject instanceof ProjectDescriptor) {
   // i.e. adding the dependencies and generating the package list.
   ext.useExpoModules = { Map options = [:] ->
     ExpoAutolinkingManager manager = new ExpoAutolinkingManager(rootProject.projectDir, options)
-    ExpoModule[] modules = manager.getModules()
-    MavenRepo[] extraMavenRepos = manager.getExtraMavenRepos()
+    ExpoModule[] modules = manager.getModules(providers)
+    MavenRepo[] extraMavenRepos = manager.getExtraMavenRepos(providers)
 
     for (module in modules) {
       for (moduleProject in module.projects) {
@@ -275,7 +274,7 @@ if (rootProject instanceof ProjectDescriptor) {
 
   def addDependencies = { DependencyHandler handler, Project project ->
     def manager = validateExpoAutolinkingManager(gradle.ext.expoAutolinkingManager)
-    def modules = manager.getModules(true)
+    def modules = manager.getModules(project.providers, true)
 
     if (!modules.length) {
       return
@@ -351,7 +350,7 @@ if (rootProject instanceof ProjectDescriptor) {
       return null
     }
 
-    def modules = gradle.ext.expoAutolinkingManager.resolve(true).modules
+    def modules = gradle.ext.expoAutolinkingManager.resolve(project.providers, true).modules
     return modules.toString()
   }
 
@@ -360,7 +359,7 @@ if (rootProject instanceof ProjectDescriptor) {
       return
     }
 
-    def modules = gradle.ext.expoAutolinkingManager.getModules(true)
+    def modules = gradle.ext.expoAutolinkingManager.getModules(project.providers, true)
     for (module in modules) {
       for (moduleProject in module.projects) {
         def dependency = project.findProject(":${moduleProject.name}")

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -55,7 +55,10 @@ def isExpoModulesCoreTests = {
 def REACT_NATIVE_BUILD_FROM_SOURCE = findProject(":packages:react-native:ReactAndroid") != null
 def REACT_NATIVE_DIR = REACT_NATIVE_BUILD_FROM_SOURCE
   ? findProject(":packages:react-native:ReactAndroid").getProjectDir().parent
-  : new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).parent
+  : file(providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('react-native/package.json')")
+    }.standardOutput.asText.get().trim()).parent
 
 def reactProperties = new Properties()
 file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -21,14 +21,10 @@ static def versionToNumber(major, minor, patch) {
 }
 
 def getRNVersion() {
-  def nodeModulesVersion = [
-      "node",
-      "-e",
-      "console.log(require('react-native/package.json').version);"
-  ]
-      .execute(null, projectDir)
-      .text
-      .trim()
+  def nodeModulesVersion = providers.exec {
+    workingDir(projectDir)
+    commandLine("node", "-e", "console.log(require('react-native/package.json').version);")
+  }.standardOutput.asText.get().trim()
 
   def version = safeExtGet("reactNativeVersion", nodeModulesVersion)
   def coreVersion = version.split("-")[0]
@@ -163,7 +159,7 @@ dependencies { dependencyHandler ->
 }
 
 // A task generating a package list of expo modules.
-task generateExpoModulesPackageList {
+task generateExpoModulesPackageListTask {
   def modulesConfig = getModulesConfig()
   def outputPath = getGenerateExpoModulesPackagesListPath()
   if (modulesConfig) {
@@ -171,10 +167,11 @@ task generateExpoModulesPackageList {
     inputs.property("modulesConfig", modulesConfig)
   }
 
+  // TOOD(@lukmccall): fix not working with configuration cache enabled
   doLast {
     generateExpoModulesPackageList()
   }
 }
 
 // Run that task during prebuilding phase.
-preBuild.dependsOn "generateExpoModulesPackageList"
+preBuild.dependsOn "generateExpoModulesPackageListTask"

--- a/packages/expo/scripts/autolinking.gradle
+++ b/packages/expo/scripts/autolinking.gradle
@@ -1,4 +1,9 @@
 // Resolve `expo` > `expo-modules-autolinking` dependency chain
-def autolinkingPath = ["node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim()
-apply from: new File(autolinkingPath, "../scripts/android/autolinking_implementation.gradle");
-
+def autolinkingPath = ["node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })"]
+apply from: new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine(autolinkingPath)
+  }.standardOutput.asText.get().trim(), 
+  "../scripts/android/autolinking_implementation.gradle"
+)


### PR DESCRIPTION
# Why

Uses a cache-friendly method of executing external processes. The Gradle now has a new cache configuration setting which allows skipping the configuration step. However, the old `exec` API doesn't support running during the cacheable configuration phase. To fix this, new functions can be used. You can find more information on this topic here: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:external_processes

Just to let you know, this pull request is quite similar to the one that was submitted by the community CLI. You can find the link for it here: https://github.com/react-native-community/cli/pull/2201

PR only affects `bare-expo` projects; I didn't modify our template or Expo Go since I'm still testing different approaches. 

> ⚠️ At the moment, this PR doesn't support enabling the cache configuration. We still have a lot of work to do before we can achieve that goal. However, I was able to turn on the configuration cache by making a few changes and using some hacks. This resulted in a significant improvement in build time, reducing it by around 40%.   

# How

Used new cache-friendly API to run external processes. 

# Test Plan

- bare-expo ✅