### PR TITLE
[docs] Fix markdown component warning for Build resource list

### DIFF
--- a/docs/ui/components/utils/infrastructure.tsx
+++ b/docs/ui/components/utils/infrastructure.tsx
@@ -56,17 +56,14 @@ export function BuildResourceList({ platform }: { platform: keyof typeof Resourc
   const spec = platform === 'ios' ? IosResourceClassToSpec : AndroidResourceClassToSpec;
   return (
     <markdownComponents.ul>
-      {ResourceClasses[platform].map(resourceClass => {
-        console.log(`${platform}-${resourceClass}`);
-        return (
-          <markdownComponents.li key={`${platform}-${resourceClass}`}>
-            <markdownComponents.code>
-              <ResourceClassSpecLink platform={platform} resourceClass={resourceClass} />
-            </markdownComponents.code>
-            : {spec[resourceClass]}
-          </markdownComponents.li>
-        );
-      })}
+      {ResourceClasses[platform].map(resourceClass => (
+        <markdownComponents.li key={`${platform}-${resourceClass}`}>
+          <markdownComponents.code>
+            <ResourceClassSpecLink platform={platform} resourceClass={resourceClass} />
+          </markdownComponents.code>
+          : {spec[resourceClass]}
+        </markdownComponents.li>
+      ))}
     </markdownComponents.ul>
   );
 }

--- a/docs/ui/components/utils/infrastructure.tsx
+++ b/docs/ui/components/utils/infrastructure.tsx
@@ -56,14 +56,17 @@ export function BuildResourceList({ platform }: { platform: keyof typeof Resourc
   const spec = platform === 'ios' ? IosResourceClassToSpec : AndroidResourceClassToSpec;
   return (
     <markdownComponents.ul>
-      {ResourceClasses[platform].map(resourceClass => (
-        <markdownComponents.li>
-          <markdownComponents.code>
-            <ResourceClassSpecLink platform={platform} resourceClass={resourceClass} />
-          </markdownComponents.code>
-          : {spec[resourceClass]}
-        </markdownComponents.li>
-      ))}
+      {ResourceClasses[platform].map(resourceClass => {
+        console.log(`${platform}-${resourceClass}`);
+        return (
+          <markdownComponents.li key={`${platform}-${resourceClass}`}>
+            <markdownComponents.code>
+              <ResourceClassSpecLink platform={platform} resourceClass={resourceClass} />
+            </markdownComponents.code>
+            : {spec[resourceClass]}
+          </markdownComponents.li>
+        );
+      })}
     </markdownComponents.ul>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, on Build server infrastructure, rendering `BuildResourceList` component gives the following warning:

![CleanShot 2024-01-31 at 21 37 02](https://github.com/expo/expo/assets/10234615/e23efc44-90b1-4eb1-85d4-df66c9bf211c)

 
# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR uses a key prop on the list item to provide a unique `key`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit http://localhost:3002/build-reference/infrastructure and see the warning either in terminal or in Browser > Developer tools > Console tab. After applying changes from this PR, the warning is resolved.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
