### PR TITLE
[crypto] Add support for macOS platform

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1964,7 +1964,7 @@ SPEC CHECKSUMS:
   ExpoCamera: a3f3681963815533c24f698a22c239e68724fb99
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
   ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
-  ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
+  ExpoCrypto: f1c0cbaa168759159e781abf16cf8055a9a1a624
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
   ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1966,7 +1966,7 @@ SPEC CHECKSUMS:
   ExpoCamera: a3f3681963815533c24f698a22c239e68724fb99
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
   ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
-  ExpoCrypto: e2ca148f5c93a0514959df86b34256bb3c50d358
+  ExpoCrypto: f1c0cbaa168759159e781abf16cf8055a9a1a624
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
   ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for macOS platform. ([#26831](https://github.com/expo/expo/pull/26831) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-crypto/expo-module.config.json
+++ b/packages/expo-crypto/expo-module.config.json
@@ -1,10 +1,9 @@
 {
-  "name": "expo-crypto",
-  "platforms": ["ios", "android"],
-  "ios": {
-    "modulesClassNames": ["CryptoModule"]
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["CryptoModule"]
   },
   "android": {
-    "modulesClassNames": ["expo.modules.crypto.CryptoModule"]
+    "modules": ["expo.modules.crypto.CryptoModule"]
   }
 }

--- a/packages/expo-crypto/ios/ExpoCrypto.podspec
+++ b/packages/expo-crypto/ios/ExpoCrypto.podspec
@@ -10,7 +10,10 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = {
+    :ios => '13.4',
+    :osx => '10.15'
+  }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true


### PR DESCRIPTION
# Why

It's pretty straightforward to add support for macOS to `expo-crypto` as the platform APIs are the same

# How

Followed the guide I made in #26769 
It just works without any other code modifications 🤷‍♂️ 

# Test Plan

- `cd apps/bare-expo`
- `yarn add react-native-macos`
- `xed macos`
- `npx react-native start` and build the project
- tests and examples are working as expected