### PR TITLE
[ci] Pin cocoapods to version 1.14.3 in nightly workflow

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ruby-version: 3.2.2
       - name: 💎 Install Ruby gems
-        run: gem install cocoapods xcpretty
+        run: gem install 'cocoapods:1.14.3' xcpretty
       - name: ♻️ Restore workspace node modules
         # Use restore only cache here because we don't want to nightly react-native version saving back to the cache
         uses: actions/cache/restore@v3


### PR DESCRIPTION
# Why

Cocoapods released  version 1.15.0 a few days ago and ended up breaking react-native pod install https://github.com/facebook/react-native/issues/42698

# How

Pin cocoapods to v1.14.3 in nightly workflow 

# Test Plan

Run test-react-native-nightly workflow 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
