### PR TITLE
[cli] Update ngrok instance to use https

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add better error when `metro.config.js` does not extend `expo/metro-config`. ([#26726](https://github.com/expo/expo/pull/26726) by [@EvanBacon](https://github.com/EvanBacon))
 - Add support for GitHub URLs in `expo prebuild --template`. ([#26631](https://github.com/expo/expo/pull/26631) by [@byCedric](https://github.com/byCedric))
 - Added building only for connected CPU architectures on Android when using the new architecture. ([#26800](https://github.com/expo/expo/pull/26800) by [@alanjhughes](https://github.com/alanjhughes))
+- Add HTTPS support for using tunnels with ngrok. ([#26838](https://github.com/expo/expo/pull/26838) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -59,7 +59,7 @@ export class AsyncNgrok {
 
   /** Exposed for testing. */
   async _getProjectHostnameAsync(): Promise<string> {
-    return [...(await this._getIdentifyingUrlSegmentsAsync()), NGROK_CONFIG.domain].join('.');
+    return `${(await this._getIdentifyingUrlSegmentsAsync()).join('-')}.${NGROK_CONFIG.domain}`;
   }
 
   /** Exposed for testing. */
@@ -164,7 +164,6 @@ export class AsyncNgrok {
       const url = await instance.connect({
         ...urlProps,
         authtoken: NGROK_CONFIG.authToken,
-        proto: 'http',
         configPath,
         onStatusChange(status) {
           if (status === 'closed') {

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -60,7 +60,10 @@ export class UrlCreator {
       return null;
     }
 
-    const manifestUrl = this.constructUrl({ ...options, scheme: 'http' });
+    const manifestUrl = this.constructUrl({
+      ...options,
+      scheme: this.defaults?.hostType === 'tunnel' ? 'https' : 'http',
+    });
     const devClientUrl = `${protocol}://expo-development-client/?url=${encodeURIComponent(
       manifestUrl
     )}`;

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncNgrok-test.ts
@@ -151,14 +151,14 @@ describe('_getProjectHostnameAsync', () => {
     vol.fromJSON({}, projectRoot);
 
     const hostname = await ngrok._getProjectHostnameAsync();
-    expect(hostname).toEqual(expect.stringMatching(/.*\.anonymous\.3000\.exp\.direct/));
+    expect(hostname).toEqual(expect.stringMatching(/.*-anonymous-3000\.exp\.direct/));
 
     // URL-safe
     expect(encodeURIComponent(hostname)).toEqual(hostname);
 
     // Works twice in a row...
     expect(await ngrok._getProjectHostnameAsync()).toEqual(
-      expect.stringMatching(/.*\.anonymous\.3000\.exp\.direct/)
+      expect.stringMatching(/.*-anonymous-3000\.exp\.direct/)
     );
 
     // randomness is persisted

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -82,6 +82,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       platform,
       expectSignature: expectSignature ? String(expectSignature) : null,
       hostname: stripPort(req.headers['host']),
+      protocol: req.headers['x-forwarded-proto'] as 'http' | 'https' | undefined,
     };
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -96,6 +96,8 @@ export interface ManifestRequestInfo {
   platform: RuntimePlatform;
   /** Requested host name. */
   hostname?: string | null;
+  /** The protocol used to request the manifest */
+  protocol?: 'http' | 'https';
 }
 
 /** Project related info. */
@@ -144,7 +146,11 @@ export abstract class ManifestMiddleware<
   public async _resolveProjectSettingsAsync({
     platform,
     hostname,
-  }: Pick<TManifestRequestInfo, 'hostname' | 'platform'>): Promise<ResponseProjectSettings> {
+    protocol,
+  }: Pick<
+    TManifestRequestInfo,
+    'hostname' | 'platform' | 'protocol'
+  >): Promise<ResponseProjectSettings> {
     // Read the config
     const projectConfig = getConfig(this.projectRoot);
 
@@ -176,6 +182,7 @@ export abstract class ManifestMiddleware<
         platform
       ),
       routerRoot: getRouterDirectoryModuleIdWithManifest(this.projectRoot, projectConfig.exp),
+      protocol,
     });
 
     // Resolve all assets and set them on the manifest as URLs
@@ -231,6 +238,7 @@ export abstract class ManifestMiddleware<
     isExporting,
     asyncRoutes,
     routerRoot,
+    protocol,
   }: {
     platform: string;
     hostname?: string | null;
@@ -240,6 +248,7 @@ export abstract class ManifestMiddleware<
     asyncRoutes: boolean;
     isExporting?: boolean;
     routerRoot: string;
+    protocol?: 'http' | 'https';
   }): string {
     const path = createBundleUrlPath({
       mode: this.options.mode ?? 'development',
@@ -256,7 +265,7 @@ export abstract class ManifestMiddleware<
 
     return (
       this.options.constructUrl({
-        scheme: 'http',
+        scheme: protocol ?? 'http',
         // hostType: this.options.location.hostType,
         hostname,
       }) + path

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
@@ -30,16 +30,6 @@
 		<false/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>exp.direct</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>SplashScreen</string>


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/26573
Closes ENG-11158

# How

- Change ngrok URL format to separate values with dashes instead of dots. e.g. `${projectRandomValue}-${username}-${port}.exp.direct`. We need this because the TLS certificate uses wildcard and does not support multiple subdomain levels.
- Update UrlCreator to use https when tunneling  
-  Remove custom ATS configuration for exp.direct in the template
- Add protocol to ManifestRequestInfo


# Test Plan

run `yarn start --tunnel` in projects using expo go and dev-client and ensure the bundle is correctly loaded 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
