### PR TITLE
docs: with `expo-camera/next` we use `CameraView`

### DIFF
--- a/packages/expo-camera/build/next/Camera.types.d.ts
+++ b/packages/expo-camera/build/next/Camera.types.d.ts
@@ -290,7 +290,7 @@ export type CameraProps = ViewProps & {
     /**
      * @example
      * ```tsx
-     * <Camera
+     * <CameraView
      *   barCodeScannerSettings={{
      *     barCodeTypes: ["qr"],
      *   }}


### PR DESCRIPTION
# Why

As a dev,
I migrated to `expo-camera/next`
And reading the docs confuses me because we are using `CameraView` and not `Camera`

# How

just update readme

| before | after |
|--------|--------|
| ![CleanShot 2024-02-01 at 11 18 58](https://github.com/expo/expo/assets/360936/1ed0e906-2f06-400e-93aa-da1e77c497bf) | ![CleanShot 2024-02-01 at 11 19 10](https://github.com/expo/expo/assets/360936/7f36e791-0761-4703-a960-bf8d7d291f87) | 

# Test Plan

Check on https://docs.expo.dev/versions/latest/sdk/camera-next/

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
