### PR TITLE
[autolinking] Fix generating a list of app delegate subscribers

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed generating a list of app delegate subscribers.
+
 ### 💡 Others
 
 ## 1.10.2 - 2024-01-18

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed generating a list of app delegate subscribers.
+- Fixed generating a list of app delegate subscribers. ([#26851](https://github.com/expo/expo/pull/26851) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -56,7 +56,7 @@ module Expo
             # `pod install` may fail if there is no `use_modular_headers!` declaration or
             # `:modular_headers => true` is not used for this particular dependency.
             # The latter require adding transitive dependencies to user's Podfile that we'd rather like to avoid.
-            if package.has_swift_modules_to_link?
+            if package.has_something_to_link?
               use_modular_headers_for_dependencies(pod.spec.all_dependencies)
             end
 
@@ -128,7 +128,7 @@ module Expo
       @packages.select do |package|
         # Check whether the package has any module to autolink
         # and if there is any pod that supports target's platform.
-        package.modules.any? && package.pods.any? { |pod| pod.supports_platform?(platform) }
+        package.has_something_to_link? && package.pods.any? { |pod| pod.supports_platform?(platform) }
       end
     end
 

--- a/packages/expo-modules-autolinking/scripts/ios/package.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/package.rb
@@ -47,7 +47,13 @@ module Expo
 
     # Whether this module should only be added to the debug configuration.
     attr_reader :debugOnly
-    
+
+    # Names of Swift classes that hooks into `ExpoAppDelegate` to receive AppDelegate life-cycle events.
+    attr_reader :appDelegateSubscribers
+
+    # Names of Swift classes that implement `ExpoReactDelegateHandler` to hook React instance creation.
+    attr_reader :reactDelegateHandlers
+
     def initialize(json)
       @name = json['packageName']
       @version = json['packageVersion']
@@ -55,10 +61,13 @@ module Expo
       @flags = json.fetch('flags', {})
       @modules = json.fetch('modules', [])
       @debugOnly = json['debugOnly']
+      @appDelegateSubscribers = json.fetch('appDelegateSubscribers', [])
+      @reactDelegateHandlers = json.fetch('reactDelegateHandlers', [])
     end
 
-    def has_swift_modules_to_link?
-      return !@modules.empty?
+    # Returns a boolean value whether the package has any module, app delegate subscriber or react delegate handler to link.
+    def has_something_to_link?
+      return !@modules.empty? || !@appDelegateSubscribers.empty? || !@reactDelegateHandlers.empty?
     end
 
   end # class Package


### PR DESCRIPTION
# Why

Fixes #26805
Fixes ENG-11301

# How

Autolinking was generating the modules provider with only those packages that have any native module. However, expo module may have only the app delegate subscriber or React delegate handler. It regressed in #26398 

# Test Plan

- Removed `"modules": ["ScreenOrientationModule"]` from the module config in `expo-screen-orientation`
- Ran `pod install`
- Confirmed `ExpoModulesProvider.swift` includes `ScreenOrientationAppDelegate` and `ScreenOrientationReactDelegateHandler` even without the native module
