### PR TITLE
[doctor] metro-config deep dependency check

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -273,6 +273,7 @@ Once everything above is completed and Apple has approved Expo Go (iOS) for the 
   - `@expo/webpack-config`
   - `@expo/prebuild-config`
   - `expo-modules-autolinking`
+  - `metro-config`
 - One way to get the right version numbers is to run `yarn why <package-name>` to see which version is used by apps in the expo/expo repo. Generally the version numbers should use the caret (`^`) semver symbol, please refer to the semver symbol used for the package on the most recent release on the versions endpoint.
 
 ## 4.3. Re-publish project templates

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -273,7 +273,7 @@ Once everything above is completed and Apple has approved Expo Go (iOS) for the 
   - `@expo/webpack-config`
   - `@expo/prebuild-config`
   - `expo-modules-autolinking`
-  - `metro-config`
+  - `metro`
 - One way to get the right version numbers is to run `yarn why <package-name>` to see which version is used by apps in the expo/expo repo. Generally the version numbers should use the caret (`^`) semver symbol, please refer to the semver symbol used for the package on the most recent release on the versions endpoint.
 
 ## 4.3. Re-publish project templates

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Check if a custom metro config doesn't extend @expo/metro-config. ([#26860](https://github.com/expo/expo/pull/26860) by [@keith-kurak](https://github.com/keith-kurak))
+- Look for metro-config in deep dependency check, warn if inside resolutions. ([#26854](https://github.com/expo/expo/pull/26854) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -35,7 +35,7 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
+    jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValue(null);
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
@@ -61,12 +61,17 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
+      if (pkg.name === 'metro-config') {
+        return 'warning';
+      }
+      return null;
+    });
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,
     });
-    expect(result.advice).toContain('remove any resolutions from package.json');
+    expect(result.advice).toContain('remove resolutions from package.json');
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -14,7 +14,7 @@ const additionalProjectProps = {
   },
   pkg: {
     resolutions: {
-      'metro-config': '0.9.0',
+      metro: '0.9.0',
     },
   },
   hasUnusedStaticConfig: false,
@@ -27,7 +27,7 @@ const mockGetRemoteVersionsForSdkAsyncResult = {
   '@expo/config-plugins': '1.0.0',
   '@expo/prebuild-config': '1.0.0',
   '@expo/metro-config': '1.0.0',
-  'metro-config': '1.0.0',
+  metro: '1.0.0',
 };
 
 describe('runAsync', () => {
@@ -62,7 +62,7 @@ describe('runAsync', () => {
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
     jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
-      if (pkg.name === 'metro-config') {
+      if (pkg.name === 'metro') {
         return 'warning';
       }
       return null;
@@ -73,5 +73,23 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.advice).toContain('remove resolutions from package.json');
+  });
+
+  it('warns about selected related metro packages that are not explicitly referenced in remote versions', async () => {
+    jest
+      .mocked(getRemoteVersionsForSdkAsync)
+      .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
+    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
+      if (pkg.name === 'metro-config') {
+        return 'warning';
+      }
+      return null;
+    });
+    const check = new SupportPackageVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
   });
 });

--- a/packages/expo-doctor/src/utils/strings.ts
+++ b/packages/expo-doctor/src/utils/strings.ts
@@ -1,0 +1,26 @@
+/**
+ * Joins strings with commas and 'and', based on English rules, limiting the number of items enumerated to keep from filling the console.
+ * @param items strings to join
+ * @param limit max number of strings to enumerate before using 'others'
+ * @returns joined string
+ */
+export function joinWithCommasAnd(items: string[], limit: number | undefined = 10): string {
+  if (!items.length) {
+    return '';
+  }
+
+  const uniqueItems = items.filter((value, index, array) => array.indexOf(value) === index);
+
+  if (uniqueItems.length === 1) {
+    return uniqueItems[0];
+  }
+
+  if (limit && uniqueItems.length > limit) {
+    const first = uniqueItems.slice(0, limit);
+    const remaining = uniqueItems.length - limit;
+    return `${first.join(', ')}, and ${remaining} ${remaining > 1 ? 'others' : 'other'}`;
+  }
+
+  const last = uniqueItems.pop();
+  return `${uniqueItems.join(', ')}${uniqueItems.length >= 2 ? ',' : ''} and ${last}`;
+}


### PR DESCRIPTION
# Why
It looks like `npx expo install --check` (which is used by Doctor) will pickup a direct `metro-config` install of an invalid version, but not a deeply-installed dependency or a resolution.

Within the existing doctor test structure, this adds `metro-config` to the deep dependency checks and customizes the advice if the metro version check fails and it is contained in resolutions.

# How
I feel a little pinned by the current doctor structure in terms of making this check as nuanced as I'd like it. Namely, the versions API call is embedded inside `SupportPackageVersionCheck` along with the deep dependency version checks for all packages. Long-term, i'll move this API call (and really, all of the actual deep dependency checks, which are also expensive) outside of any checks and pass its data to all checks, who can then consider the data in constructing a very customized warning, without fetching the data again.

For now, I just added `metro-config` to the existing list of deep dependency versions to check, but also customized the warning to alert if any potential problem packages are in `resolutions`. 

# Test Plan
<img width="850" alt="image" src="https://github.com/expo/expo/assets/8053974/a36592f5-706e-485e-a52d-8ab7f02e24c4">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
