### PR TITLE
[doctor] Check that custom metro config extends @expo/metro-config

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Check if a custom metro config doesn't extend @expo/metro-config. ([#26860](https://github.com/expo/expo/pull/26860) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/MetroConfigCheck.ts
+++ b/packages/expo-doctor/src/checks/MetroConfigCheck.ts
@@ -1,0 +1,74 @@
+import type MetroConfig from 'metro-config';
+import resolveFrom from 'resolve-from';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { learnMore } from '../utils/TerminalLink';
+
+export class MetroConfigCheck implements DoctorCheck {
+  description = 'Check for issues with metro config';
+
+  sdkVersionRange = '>=46.0.0';
+
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+
+    // configuration check and companion functions adapted from:
+    // https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/project/metroConfig.ts
+    if (await configExistsAsync(projectRoot)) {
+      console.warn('config exists');
+      const metroConfig = await loadConfigAsync(projectRoot);
+      console.warn(metroConfig);
+      const hasHashAssetFilesPlugin = metroConfig.transformer?.assetPlugins?.find(
+        (plugin: string) => plugin.match(/expo-asset[/|\\]tools[/|\\]hashAssetFiles/)
+      );
+      if (!hasHashAssetFilesPlugin) {
+        issues.push(
+          'It looks like that you are using a custom metro.config.js that does not extend @expo/metro-config. This can lead to unexpected and hard to debug issues. ' +
+            learnMore('https://docs.expo.dev/guides/customizing-metro/')
+        );
+      }
+    }
+
+    return {
+      isSuccessful: !issues.length,
+      issues,
+      advice: issues.length
+        ? `Update your custom metro.config.js to extend @expo/metro-config.`
+        : undefined,
+    };
+  }
+}
+
+function importMetroConfigFromProject(projectDir: string): typeof MetroConfig {
+  const resolvedPath = resolveFrom.silent(projectDir, 'metro-config');
+  if (!resolvedPath) {
+    throw new MetroConfigPackageMissingError(
+      'Missing package "metro-config" in the project. ' +
+        'This usually means `react-native` is not installed. ' +
+        'Verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+  return require(resolvedPath);
+}
+
+export async function configExistsAsync(projectRoot: string): Promise<boolean> {
+  try {
+    const MetroConfig = importMetroConfigFromProject(projectRoot);
+    const result = await MetroConfig.resolveConfig(undefined, projectRoot);
+    return !result.isEmpty;
+  } catch (err) {
+    if (err instanceof MetroConfigPackageMissingError) {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}
+
+export async function loadConfigAsync(projectDir: string): Promise<MetroConfig.ConfigT> {
+  const MetroConfig = importMetroConfigFromProject(projectDir);
+  return await MetroConfig.loadConfig({ cwd: projectDir }, {});
+}
+
+class MetroConfigPackageMissingError extends Error {}

--- a/packages/expo-doctor/src/checks/__tests__/MetroConfigCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/MetroConfigCheck.test.ts
@@ -1,0 +1,62 @@
+import { configExistsAsync, loadConfigAsync } from '../../utils/metroConfigLoader';
+import { MetroConfigCheck } from '../MetroConfigCheck';
+
+jest.mock('../../utils/metroConfigLoader');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: {},
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if there is no custom metro config', async () => {
+    jest.mocked(configExistsAsync).mockResolvedValueOnce(false);
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = true if there is a custom metro config and it includes Expo asset hashes', async () => {
+    jest.mocked(configExistsAsync).mockResolvedValueOnce(true);
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      // @ts-ignore: we don't need to mock the entire config
+      transformer: {
+        assetPlugins: [
+          '/Users/keith/Github/just-kana/node_modules/expo-asset/tools/hashAssetFiles.js',
+        ],
+      },
+    });
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if there is a custom metro config and it does not include Expo asset hashes', async () => {
+    jest.mocked(configExistsAsync).mockResolvedValueOnce(true);
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      // @ts-ignore: we don't need to mock the entire config
+      transformer: {
+        assetPlugins: [],
+      },
+    });
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -9,6 +9,7 @@ import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledChec
 import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
 import { IllegalPackageCheck } from './checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from './checks/InstalledDependencyVersionCheck';
+import { MetroConfigCheck } from './checks/MetroConfigCheck';
 import { PackageJsonCheck } from './checks/PackageJsonCheck';
 import { ProjectSetupCheck } from './checks/ProjectSetupCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
@@ -118,7 +119,7 @@ export async function runChecksAsync(
 export function getChecksInScopeForProject(exp: ExpoConfig) {
   // add additional checks here
   const checks = [
-    new GlobalPrereqsVersionCheck(),
+    /*new GlobalPrereqsVersionCheck(),
     new IllegalPackageCheck(),
     new GlobalPackageInstalledCheck(),
     new SupportPackageVersionCheck(),
@@ -126,7 +127,8 @@ export function getChecksInScopeForProject(exp: ExpoConfig) {
     new ExpoConfigCommonIssueCheck(),
     new DirectPackageInstallCheck(),
     new PackageJsonCheck(),
-    new ProjectSetupCheck(),
+    new ProjectSetupCheck(),*/
+    new MetroConfigCheck(),
   ];
   if (env.EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK) {
     Log.log(

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -119,7 +119,7 @@ export async function runChecksAsync(
 export function getChecksInScopeForProject(exp: ExpoConfig) {
   // add additional checks here
   const checks = [
-    /*new GlobalPrereqsVersionCheck(),
+    new GlobalPrereqsVersionCheck(),
     new IllegalPackageCheck(),
     new GlobalPackageInstalledCheck(),
     new SupportPackageVersionCheck(),
@@ -127,7 +127,7 @@ export function getChecksInScopeForProject(exp: ExpoConfig) {
     new ExpoConfigCommonIssueCheck(),
     new DirectPackageInstallCheck(),
     new PackageJsonCheck(),
-    new ProjectSetupCheck(),*/
+    new ProjectSetupCheck(),
     new MetroConfigCheck(),
   ];
   if (env.EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK) {

--- a/packages/expo-doctor/src/utils/metroConfigLoader.ts
+++ b/packages/expo-doctor/src/utils/metroConfigLoader.ts
@@ -1,0 +1,36 @@
+import type MetroConfig from 'metro-config';
+import resolveFrom from 'resolve-from';
+
+function importMetroConfigFromProject(projectDir: string): typeof MetroConfig {
+  const resolvedPath = resolveFrom.silent(projectDir, 'metro-config');
+  if (!resolvedPath) {
+    throw new MetroConfigPackageMissingError(
+      'Missing package "metro-config" in the project. ' +
+        'This usually means `react-native` is not installed. ' +
+        'Verify that dependencies in package.json include "react-native" ' +
+        'and run `yarn` or `npm install`.'
+    );
+  }
+  return require(resolvedPath);
+}
+
+export async function configExistsAsync(projectRoot: string): Promise<boolean> {
+  try {
+    const MetroConfig = importMetroConfigFromProject(projectRoot);
+    const result = await MetroConfig.resolveConfig(undefined, projectRoot);
+    return !result.isEmpty;
+  } catch (err) {
+    if (err instanceof MetroConfigPackageMissingError) {
+      return false;
+    } else {
+      throw err;
+    }
+  }
+}
+
+export async function loadConfigAsync(projectDir: string): Promise<MetroConfig.ConfigT> {
+  const MetroConfig = importMetroConfigFromProject(projectDir);
+  return await MetroConfig.loadConfig({ cwd: projectDir }, {});
+}
+
+class MetroConfigPackageMissingError extends Error {}

--- a/packages/expo-doctor/ts-declarations/metro-config/index.d.ts
+++ b/packages/expo-doctor/ts-declarations/metro-config/index.d.ts
@@ -1,0 +1,230 @@
+declare module 'metro-config' {
+  import { IncomingMessage, ServerResponse } from 'http';
+  import type {
+    DeltaResult,
+    Graph,
+    JsTransformerConfig,
+    Module,
+    Reporter,
+    SerializerOptions,
+    Server,
+    TransformVariants,
+  } from 'metro';
+
+  type CacheStore = unknown;
+  type CustomResolver = unknown;
+
+  import type { BasicSourceMap, MixedSourceMap } from 'metro-source-map';
+
+  //#region metro/packages/metro-config/src/configTypes.flow.js
+
+  export type PostMinifyProcess = (arg: {
+    code: string;
+    map: BasicSourceMap | null | undefined;
+  }) => {
+    code: string;
+    map: BasicSourceMap | null | undefined;
+  };
+
+  export type PostProcessBundleSourcemap = (arg: {
+    code: Buffer | string;
+    map: MixedSourceMap;
+    outFileName: string;
+  }) => {
+    code: Buffer | string;
+    map: MixedSourceMap | string;
+  };
+
+  interface ExtraTransformOptions {
+    readonly preloadedModules:
+      | {
+          [path: string]: true;
+        }
+      | false;
+    readonly ramGroups: string[];
+    readonly transform: {
+      readonly experimentalImportSupport: boolean;
+      readonly inlineRequires:
+        | {
+            readonly blacklist: {
+              [key: string]: true;
+            };
+          }
+        | boolean;
+      readonly nonInlinedRequires?: string[];
+      readonly unstable_disableES6Transforms?: boolean;
+    };
+  }
+
+  export interface GetTransformOptionsOpts {
+    dev: boolean;
+    hot: boolean;
+    platform: string | null | undefined;
+  }
+
+  export type GetTransformOptions = (
+    entryPoints: readonly string[],
+    options: GetTransformOptionsOpts,
+    getDependenciesOf: (path: string) => Promise<string[]>
+  ) => Promise<ExtraTransformOptions>;
+
+  export type Middleware = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (e: Error | null | undefined) => unknown
+  ) => unknown;
+
+  interface ResolverConfigT {
+    assetExts: readonly string[];
+    assetResolutions: readonly string[];
+    blacklistRE: RegExp;
+    dependencyExtractor: string | null | undefined;
+    extraNodeModules: {
+      [name: string]: string;
+    };
+    hasteImplModulePath: string | null | undefined;
+    platforms: readonly string[];
+    resolverMainFields: readonly string[];
+    resolveRequest: CustomResolver | null | undefined;
+    sourceExts: readonly string[];
+    useWatchman: boolean;
+  }
+
+  interface SerializerConfigT {
+    createModuleIdFactory: () => (path: string) => number;
+    customSerializer: (
+      entryPoint: string,
+      preModules: Module[],
+      graph: Graph,
+      options: SerializerOptions
+    ) => string | { code: string; map: string } | null | undefined;
+    experimentalSerializerHook: (graph: Graph, delta: DeltaResult) => unknown;
+    getModulesRunBeforeMainModule: (entryFilePath: string) => string[];
+    getPolyfills: (arg: { platform: string | null | undefined }) => readonly string[];
+    getRunModuleStatement: (moduleId: number | string) => string;
+    polyfillModuleNames: readonly string[];
+    postProcessBundleSourcemap: PostProcessBundleSourcemap;
+    processModuleFilter: (modules: Module) => boolean;
+  }
+
+  type TransformerConfigT = JsTransformerConfig & {
+    getTransformOptions: GetTransformOptions;
+    postMinifyProcess: PostMinifyProcess;
+    transformVariants: TransformVariants;
+    workerPath: string;
+    publicPath: string;
+    experimentalImportBundleSupport: false;
+  };
+
+  interface MetalConfigT {
+    cacheStores: readonly any[];
+    cacheVersion: string;
+    hasteMapCacheDirectory?: string;
+    maxWorkers: number;
+    projectRoot: string;
+    stickyWorkers: boolean;
+    transformerPath: string;
+    reporter: Reporter;
+    resetCache: boolean;
+    watchFolders: readonly string[];
+  }
+
+  interface ServerConfigT {
+    enhanceMiddleware: (middleware: Middleware, server: Server) => Middleware;
+    useGlobalHotkey: boolean;
+    port: number;
+    runInspectorProxy: boolean;
+    verifyConnections: boolean;
+  }
+
+  type StackFrameCustomizations = undefined | { collapse?: boolean };
+
+  interface SymbolicatorConfigT {
+    customizeFrame: (
+      frame: Readonly<{
+        file: string | null;
+        lineNumber: number | null;
+        column: number | null;
+        methodName: string | null;
+      }>
+    ) => StackFrameCustomizations | Promise<StackFrameCustomizations>;
+  }
+
+  export type InputConfigT = Partial<
+    MetalConfigT &
+      Readonly<{
+        resolver: Partial<ResolverConfigT>;
+        server: Partial<ServerConfigT>;
+        serializer: Partial<SerializerConfigT>;
+        symbolicator: Partial<SymbolicatorConfigT>;
+        transformer: Partial<TransformerConfigT>;
+      }>
+  >;
+
+  export type IntermediateConfigT = MetalConfigT & {
+    resolver: ResolverConfigT;
+    server: ServerConfigT;
+    serializer: SerializerConfigT;
+    symbolicator: SymbolicatorConfigT;
+    transformer: TransformerConfigT;
+  };
+
+  export type ConfigT = Readonly<
+    Readonly<MetalConfigT> &
+      Readonly<{
+        resolver: Readonly<ResolverConfigT>;
+        server: Readonly<ServerConfigT>;
+        serializer: Readonly<SerializerConfigT>;
+        symbolicator: Readonly<SymbolicatorConfigT>;
+        transformer: Readonly<TransformerConfigT>;
+      }>
+  >;
+
+  //#endregion
+  //#region metro/packages/metro-config/src/index.js
+
+  interface CosmiConfigResult {
+    filepath: string;
+    isEmpty: boolean;
+    config: ((arg: ConfigT) => Promise<ConfigT>) | ((arg: ConfigT) => ConfigT) | InputConfigT;
+  }
+
+  interface YargArguments {
+    config?: string;
+    cwd?: string;
+    port?: string | number;
+    host?: string;
+    projectRoot?: string;
+    watchFolders?: string[];
+    assetExts?: string[];
+    sourceExts?: string[];
+    platforms?: string[];
+    'max-workers'?: string | number;
+    maxWorkers?: string | number;
+    transformer?: string;
+    'reset-cache'?: boolean;
+    resetCache?: boolean;
+    runInspectorProxy?: boolean;
+    verbose?: boolean;
+  }
+
+  export function resolveConfig(path?: string, cwd?: string): Promise<CosmiConfigResult>;
+
+  export function mergeConfig<T extends InputConfigT>(
+    defaultConfig: T,
+    ...configs: InputConfigT[]
+  ): T;
+
+  export function loadConfig(
+    argv: YargArguments,
+    defaultConfigOverrides: InputConfigT
+  ): Promise<ConfigT>;
+
+  export function getDefaultConfig(rootPath?: string): Promise<ConfigT>;
+
+  namespace getDefaultConfig {
+    function getDefaultValues(rootPath?: string): ConfigT;
+  }
+
+  //#endregion
+}

--- a/packages/expo-doctor/ts-declarations/metro/index.d.ts
+++ b/packages/expo-doctor/ts-declarations/metro/index.d.ts
@@ -1,0 +1,486 @@
+declare module 'metro' {
+  //#region metro/src/Assets.js
+
+  type AssetDataWithoutFiles = {
+    readonly __packager_asset: true;
+    readonly fileSystemLocation: string;
+    readonly hash: string;
+    readonly height: number | null | undefined;
+    readonly httpServerLocation: string;
+    readonly name: string;
+    readonly scales: number[];
+    readonly type: string;
+    readonly width: number | null | undefined;
+  };
+
+  export type AssetData = AssetDataWithoutFiles & { readonly files: string[] };
+
+  //#endregion
+  //#region metro/src/DeltaBundler/types.flow.js
+
+  type DynamicRequiresBehavior = unknown;
+  type MinifierConfig = unknown;
+  type BundleDetails = unknown;
+  type GlobalCacheDisabledReason = unknown;
+  type MixedSourceMap = unknown;
+  type MetroSourceMapSegmentTuple = unknown;
+
+  interface MixedOutput {
+    readonly data: unknown;
+    readonly type: string;
+  }
+
+  interface BabelSourceLocation {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+    identifierName?: string;
+  }
+
+  interface TransformResultDependency {
+    /**
+     * The literal name provided to a require or import call. For example 'foo' in
+     * case of `require('foo')`.
+     */
+    readonly name: string;
+
+    /**
+     * Extra data returned by the dependency extractor. Whatever is added here is
+     * blindly piped by Metro to the serializers.
+     */
+    readonly data: {
+      /**
+       * If `true` this dependency is due to a dynamic `import()` call. If `false`,
+       * this dependency was pulled using a synchronous `require()` call.
+       */
+      readonly isAsync: boolean;
+
+      /**
+       * The dependency is actually a `__prefetchImport()` call.
+       */
+      readonly isPrefetchOnly?: true;
+
+      /**
+       * The condition for splitting on this dependency edge.
+       */
+      readonly splitCondition?: {
+        readonly mobileConfigName: string;
+      };
+
+      /**
+       * The dependency is enclosed in a try/catch block.
+       */
+      readonly isOptional?: boolean;
+
+      readonly locs: readonly BabelSourceLocation[];
+    };
+  }
+
+  interface Dependency {
+    readonly absolutePath: string;
+    readonly data: TransformResultDependency;
+  }
+
+  export interface Module<T = MixedOutput> {
+    readonly dependencies: Map<string, Dependency>;
+    readonly inverseDependencies: Set<string>;
+    readonly output: readonly T[];
+    readonly path: string;
+    readonly getSource: () => Buffer;
+  }
+
+  export interface Graph<T = MixedOutput> {
+    dependencies: Map<string, Module<T>>;
+    importBundleNames: Set<string>;
+    readonly entryPoints: readonly string[];
+  }
+
+  export type TransformResult<T = MixedOutput> = Readonly<{
+    dependencies: readonly TransformResultDependency[];
+    output: readonly T[];
+  }>;
+
+  interface AllowOptionalDependenciesWithOptions {
+    readonly exclude: string[];
+  }
+  type AllowOptionalDependencies = boolean | AllowOptionalDependenciesWithOptions;
+
+  export interface DeltaResult<T = MixedOutput> {
+    readonly added: Map<string, Module<T>>;
+    readonly modified: Map<string, Module<T>>;
+    readonly deleted: Set<string>;
+    readonly reset: boolean;
+  }
+
+  export interface SerializerOptions {
+    readonly asyncRequireModulePath: string;
+    readonly createModuleId: (arg0: string) => number;
+    readonly dev: boolean;
+    readonly getRunModuleStatement: (arg0: number | string) => string;
+    readonly inlineSourceMap: boolean | null | undefined;
+    readonly modulesOnly: boolean;
+    readonly processModuleFilter: (module: Module) => boolean;
+    readonly projectRoot: string;
+    readonly runBeforeMainModule: readonly string[];
+    readonly runModule: boolean;
+    readonly sourceMapUrl: string | null | undefined;
+    readonly sourceUrl: string | null | undefined;
+  }
+
+  //#endregion
+  //#region metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+
+  interface RamBundleInfo {
+    getDependencies: (filePath: string) => Set<string>;
+    startupModules: readonly ModuleTransportLike[];
+    lazyModules: readonly ModuleTransportLike[];
+    groups: Map<number, Set<number>>;
+  }
+
+  //#endregion
+  //#region metro/src/index.js
+
+  import { Server as HttpServer, IncomingMessage, ServerResponse } from 'http';
+  import { Server as HttpsServer } from 'https';
+  import { ConfigT, InputConfigT, Middleware, loadConfig } from 'metro-config';
+
+  type MetroMiddleWare = {
+    attachHmrServer: (httpServer: HttpServer | HttpsServer) => void;
+    end: () => void;
+    metroServer: Server;
+    middleware: Middleware;
+  };
+
+  type RunServerOptions = {
+    hasReducedPerformance?: boolean;
+    hmrEnabled?: boolean;
+    host?: string;
+    onError?: (arg0: Error & { code?: string }) => void;
+    onReady?: (server: HttpServer | HttpsServer) => void;
+    runInspectorProxy?: boolean;
+    secure?: boolean;
+    secureCert?: string;
+    secureKey?: string;
+  };
+
+  type BuildGraphOptions = {
+    entries: readonly string[];
+    customTransformOptions?: CustomTransformOptions;
+    dev?: boolean;
+    minify?: boolean;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+    platform?: string;
+    type?: 'module' | 'script';
+  };
+
+  type RunBuildOptions = {
+    entry: string;
+    dev?: boolean;
+    out?: string;
+    onBegin?: () => void;
+    onComplete?: () => void;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+    minify?: boolean;
+    output?: {
+      build: (
+        arg0: Server,
+        arg1: RequestOptions
+      ) => Promise<{
+        code: string;
+        map: string;
+      }>;
+      save: (
+        arg0: {
+          code: string;
+          map: string;
+        },
+        arg1: OutputOptions,
+        arg2: (...args: string[]) => void
+      ) => Promise<unknown>;
+    };
+    platform?: string;
+    sourceMap?: boolean;
+    sourceMapUrl?: string;
+  };
+
+  export function runMetro(config: InputConfigT, options?: ServerOptions): Promise<Server>;
+
+  export { loadConfig };
+
+  export function createConnectMiddleware(
+    config: ConfigT,
+    options?: ServerOptions
+  ): Promise<MetroMiddleWare>;
+
+  export function runServer(
+    config: ConfigT,
+    options: RunServerOptions
+  ): Promise<HttpServer | HttpsServer>;
+
+  export function runBuild(
+    config: ConfigT,
+    options: RunBuildOptions
+  ): Promise<{
+    code: string;
+    map: string;
+  }>;
+
+  export function buildGraph(config: InputConfigT, options: BuildGraphOptions): Promise<Graph>;
+  //#endregion
+  //#region metro/src/JSTransformer/worker.js
+
+  type CustomTransformOptions = {
+    [key: string]: unknown;
+  };
+
+  export type JsTransformerConfig = Readonly<{
+    assetPlugins: readonly string[];
+    assetRegistryPath: string;
+    asyncRequireModulePath: string;
+    babelTransformerPath: string;
+    dynamicDepsInPackages: DynamicRequiresBehavior;
+    enableBabelRCLookup: boolean;
+    enableBabelRuntime: boolean;
+    experimentalImportBundleSupport: boolean;
+    minifierConfig: MinifierConfig;
+    minifierPath: string;
+    optimizationSizeLimit: number;
+    publicPath: string;
+    allowOptionalDependencies: AllowOptionalDependencies;
+  }>;
+
+  //#endregion
+  //#region metro/src/lib/reporting.js
+
+  /**
+   * A tagged union of all the actions that may happen and we may want to
+   * report to the tool user.
+   */
+  export type ReportableEvent =
+    | {
+        port: number;
+        hasReducedPerformance: boolean;
+        type: 'initialize_started';
+      }
+    | {
+        type: 'initialize_failed';
+        port: number;
+        error: Error;
+      }
+    | {
+        buildID: string;
+        type: 'bundle_build_done';
+      }
+    | {
+        buildID: string;
+        type: 'bundle_build_failed';
+      }
+    | {
+        buildID: string;
+        bundleDetails: BundleDetails;
+        type: 'bundle_build_started';
+      }
+    | {
+        error: Error;
+        type: 'bundling_error';
+      }
+    | {
+        type: 'dep_graph_loading';
+        hasReducedPerformance: boolean;
+      }
+    | { type: 'dep_graph_loaded' }
+    | {
+        buildID: string;
+        type: 'bundle_transform_progressed';
+        transformedFileCount: number;
+        totalFileCount: number;
+      }
+    | {
+        type: 'global_cache_error';
+        error: Error;
+      }
+    | {
+        type: 'global_cache_disabled';
+        reason: GlobalCacheDisabledReason;
+      }
+    | { type: 'transform_cache_reset' }
+    | {
+        type: 'worker_stdout_chunk';
+        chunk: string;
+      }
+    | {
+        type: 'worker_stderr_chunk';
+        chunk: string;
+      }
+    | {
+        type: 'hmr_client_error';
+        error: Error;
+      }
+    | {
+        type: 'client_log';
+        level:
+          | 'trace'
+          | 'info'
+          | 'warn'
+          | 'log'
+          | 'group'
+          | 'groupCollapsed'
+          | 'groupEnd'
+          | 'debug';
+        data: unknown[];
+      };
+
+  /**
+   * Code across the application takes a reporter as an option and calls the
+   * update whenever one of the ReportableEvent happens. Code does not directly
+   * write to the standard output, because a build would be:
+   *
+   *   1. ad-hoc, embedded into another tool, in which case we do not want to
+   *   pollute that tool's own output. The tool is free to present the
+   *   warnings/progress we generate any way they want, by specifing a custom
+   *   reporter.
+   *   2. run as a background process from another tool, in which case we want
+   *   to expose updates in a way that is easily machine-readable, for example
+   *   a JSON-stream. We don't want to pollute it with textual messages.
+   *
+   * We centralize terminal reporting into a single place because we want the
+   * output to be robust and consistent. The most common reporter is
+   * TerminalReporter, that should be the only place in the application should
+   * access the `terminal` module (nor the `console`).
+   */
+  export interface Reporter {
+    update(event: ReportableEvent): void;
+  }
+
+  //#endregion
+  //#region metro/src/ModuleGraph/types.flow.js
+
+  export type TransformVariants = {
+    readonly [name: string]: object;
+  };
+
+  //#endregion
+  //#region metro/src/Server.js
+
+  type ServerOptions = Readonly<{
+    watch?: boolean;
+  }>;
+
+  //#endregion
+  //#region metro/src/Server/index.js
+
+  type IncrementalBundler = unknown;
+
+  export class Server {
+    constructor(config: ConfigT, options?: ServerOptions);
+
+    end(): void;
+
+    getBundler(): IncrementalBundler;
+
+    getCreateModuleId(): (path: string) => number;
+
+    build(options: BundleOptions): Promise<{
+      code: string;
+      map: string;
+    }>;
+
+    getRamBundleInfo(options: BundleOptions): Promise<RamBundleInfo>;
+
+    getAssets(options: BundleOptions): Promise<readonly AssetData[]>;
+
+    getOrderedDependencyPaths(options: {
+      readonly dev: boolean;
+      readonly entryFile: string;
+      readonly minify: boolean;
+      readonly platform: string;
+    }): Promise<string[]>;
+
+    processRequest(
+      req: IncomingMessage,
+      res: ServerResponse,
+      next: (arg0: Error | null | undefined) => unknown
+    ): void;
+
+    getNewBuildID(): string;
+
+    getPlatforms(): readonly string[];
+
+    getWatchFolders(): readonly string[];
+
+    static DEFAULT_GRAPH_OPTIONS: {
+      customTransformOptions: any;
+      dev: boolean;
+      hot: boolean;
+      minify: boolean;
+    };
+
+    static DEFAULT_BUNDLE_OPTIONS: typeof Server.DEFAULT_GRAPH_OPTIONS & {
+      excludeSource: false;
+      inlineSourceMap: false;
+      modulesOnly: false;
+      onProgress: null;
+      runModule: true;
+      shallow: false;
+      sourceMapUrl: null;
+      sourceUrl: null;
+    };
+  }
+
+  //#endregion
+  //#region metro/src/shared/types.flow.js
+
+  type BundleType = 'bundle' | 'delta' | 'meta' | 'map' | 'ram' | 'cli' | 'hmr' | 'todo' | 'graph';
+
+  type MetroSourceMapOrMappings = MixedSourceMap | MetroSourceMapSegmentTuple[];
+
+  export interface BundleOptions {
+    bundleType: BundleType;
+    customTransformOptions: CustomTransformOptions;
+    dev: boolean;
+    entryFile: string;
+    readonly excludeSource: boolean;
+    readonly hot: boolean;
+    readonly inlineSourceMap: boolean;
+    minify: boolean;
+    readonly modulesOnly: boolean;
+    onProgress: (doneCont: number, totalCount: number) => unknown | null | undefined;
+    readonly platform: string | null | undefined;
+    readonly runModule: boolean;
+    readonly shallow: boolean;
+    sourceMapUrl: string | null | undefined;
+    sourceUrl: string | null | undefined;
+    createModuleIdFactory?: () => (path: string) => number;
+  }
+
+  type ModuleTransportLike = {
+    readonly code: string;
+    readonly id: number;
+    readonly map: MetroSourceMapOrMappings | null | undefined;
+    readonly name?: string;
+    readonly sourcePath: string;
+  };
+
+  export interface OutputOptions {
+    bundleOutput: string;
+    bundleEncoding?: 'utf8' | 'utf16le' | 'ascii';
+    dev?: boolean;
+    indexedRamBundle?: boolean;
+    platform: string;
+    sourcemapOutput?: string;
+    sourcemapSourcesRoot?: string;
+    sourcemapUseAbsolutePath?: boolean;
+  }
+
+  export interface RequestOptions {
+    entryFile: string;
+    inlineSourceMap?: boolean;
+    sourceMapUrl?: string;
+    dev?: boolean;
+    minify: boolean;
+    platform: string;
+    createModuleIdFactory?: () => (path: string) => number;
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
+  }
+
+  //#endregion
+}


### PR DESCRIPTION
# Why
Stuff can really go wrong if you don't extend the Expo metro config, in non-obvious ways

# How
Basically stuck the eas-cli metro config check into Doctor:
https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/project/metroConfig.ts

# Test Plan
<img width="850" alt="image" src="https://github.com/expo/expo/assets/8053974/771e3f2e-f149-4ddc-9fde-0f26bfa29110">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
