### PR TITLE
fix(cli): filter url stacks out of node logs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 💡 Others
 
-- Filter URL files out of stacks in Node logs.
+- Filter URL files out of stacks in Node logs. ([#26868](https://github.com/expo/expo/pull/26868) by [@EvanBacon](https://github.com/EvanBacon))
 - Change server log tag. ([#26834](https://github.com/expo/expo/pull/26834) by [@EvanBacon](https://github.com/EvanBacon))
 - Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 💡 Others
 
+- Filter URL files out of stacks in Node logs.
 - Change server log tag. ([#26834](https://github.com/expo/expo/pull/26834) by [@EvanBacon](https://github.com/EvanBacon))
 - Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -115,7 +115,13 @@ export function formatStackLikeMetro(projectRoot: string, stack: string) {
 
   const stackTrace = stackTraceParser.parse(stack);
   return stackTrace
-    .filter((line) => line.file && line.file !== '<anonymous>')
+    .filter(
+      (line) =>
+        line.file &&
+        line.file !== '<anonymous>' &&
+        // Ignore unsymbolicated stack frames. It's not clear how this is possible but it sometimes happens when the graph changes.
+        !/^https?:\/\//.test(line.file)
+    )
     .map((line) => {
       // Use the same regex we use in Metro config to filter out traces:
       const isCollapsed = INTERNAL_CALLSITES_REGEX.test(line.file!);


### PR DESCRIPTION
# Why

Unclear why, but sometimes URLs will be used as files in Node.js stacks on subsequent logs. I couldn't find a way to consistently reproduce this issue.
