### PR TITLE
[go] Add metadata field to Feedback form

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -34,6 +34,7 @@
     "dedent": "^0.7.0",
     "es6-error": "^4.1.1",
     "expo": "~50.0.0-alpha.0",
+    "expo-application": "~5.8.0",
     "expo-asset": "~9.0.0",
     "expo-barcode-scanner": "~12.9.0",
     "expo-blur": "~12.9.0",

--- a/apps/expo-go/src/screens/FeedbackFormScreen/index.tsx
+++ b/apps/expo-go/src/screens/FeedbackFormScreen/index.tsx
@@ -1,5 +1,6 @@
 import { CheckIcon, spacing } from '@expo/styleguide-native';
 import { useNavigation } from '@react-navigation/native';
+import * as Application from 'expo-application';
 import {
   Text,
   View,
@@ -9,6 +10,7 @@ import {
   Spacer,
   useExpoTheme,
 } from 'expo-dev-client-components';
+import * as Device from 'expo-device';
 import * as React from 'react';
 import { useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet } from 'react-native';
@@ -35,8 +37,14 @@ export function FeedbackFormScreen() {
     setError(undefined);
     setSubmitting(true);
     try {
-      const body: { feedback: string; email?: string } = {
+      const body = {
         feedback,
+        email: undefined as string | undefined,
+        metadata: {
+          os: `${Device.osName} ${Device.osVersion}`,
+          model: Device.modelName,
+          expoGoVersion: Application.nativeApplicationVersion,
+        },
       };
       if (email.trim().length > 0) {
         if (!EMAIL_REGEX.test(email)) {


### PR DESCRIPTION
# Why

The addition of an Expo Go feedback form is giving us some good insights about issues that users are facing, but this feedback would be even more useful if we had more additional information about the app+device  

# How

Update the Feedback form to send  device os, mode and Expo Go version 

# Test Plan

Run Expo Go locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
