### PR TITLE
[ios][file-system] Fix uploads

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix upload task requests.
+- On `iOS`, fix upload task requests. ([#26880](https://github.com/expo/expo/pull/26880) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix upload task requests.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemExceptions.swift
+++ b/packages/expo-file-system/ios/FileSystemExceptions.swift
@@ -67,3 +67,15 @@ final class CannotDetermineDiskCapacity: Exception {
     "Unable to determine free disk storage capacity"
   }
 }
+
+final class FailedToCreateBodyException: Exception {
+  override var reason: String {
+    "Unable to create multipart body"
+  }
+}
+
+final class FailedToAccessDirectoryException: Exception {
+  override var reason: String {
+    "Failed to access `Caches` directory"
+  }
+}

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -156,7 +156,7 @@ public final class FileSystemModule: Module {
         throw FileNotExistsException(localUrl.path)
       }
       let session = options.sessionType == .background ? backgroundSession : foregroundSession
-      let task = createUploadTask(session: session, targetUrl: targetUrl, sourceUrl: localUrl, options: options)
+      let task = try createUploadTask(session: session, targetUrl: targetUrl, sourceUrl: localUrl, options: options)
       let taskDelegate = EXSessionUploadTaskDelegate(resolve: promise.resolver, reject: promise.legacyRejecter)
 
       sessionTaskDispatcher.register(taskDelegate, for: task)
@@ -165,7 +165,7 @@ public final class FileSystemModule: Module {
 
     AsyncFunction("uploadTaskStartAsync") { (targetUrl: URL, localUrl: URL, uuid: String, options: UploadOptions, promise: Promise) in
       let session = options.sessionType == .background ? backgroundSession : foregroundSession
-      let task = createUploadTask(session: session, targetUrl: targetUrl, sourceUrl: localUrl, options: options)
+      let task = try createUploadTask(session: session, targetUrl: targetUrl, sourceUrl: localUrl, options: options)
       let onSend: EXUploadDelegateOnSendCallback = { [weak self] _, _, totalBytesSent, totalBytesExpectedToSend in
         self?.sendEvent(EVENT_UPLOAD_PROGRESS, [
           "uuid": uuid,

--- a/packages/expo-file-system/ios/Tests/EXFileSystemSpec.swift
+++ b/packages/expo-file-system/ios/Tests/EXFileSystemSpec.swift
@@ -20,7 +20,7 @@ class EXFileSystemSpec: ExpoSpec {
       it("should handle UTF-8 characters") {
         let utf8UriInput = "file:///var/mobile/中文"
         let utf8UriExpectedOutput = "file:///var/mobile/%E4%B8%AD%E6%96%87"
-        let utf8Uri = fileSystem.percentEncodedURL(fromURIString:utf8UriInput)
+        let utf8Uri = fileSystem.percentEncodedURL(fromURIString: utf8UriInput)
 
         expect(utf8Uri?.absoluteString) == utf8UriExpectedOutput
         expect(utf8Uri?.scheme) == "file"
@@ -29,7 +29,7 @@ class EXFileSystemSpec: ExpoSpec {
       it("should handle URI with percent, numbers and UTF-8 characters") {
         let input = "file:///document/directory/%40%2F中文"
         let expectedOutput = "file:///document/directory/%40%2F%E4%B8%AD%E6%96%87"
-        let uri = fileSystem.percentEncodedURL(fromURIString:input)
+        let uri = fileSystem.percentEncodedURL(fromURIString: input)
 
         expect(uri?.absoluteString) == expectedOutput
       }
@@ -37,7 +37,7 @@ class EXFileSystemSpec: ExpoSpec {
       it("should not decode percentages in URI") {
         let input = "file:///document/hello%2Fworld.txt"
         let unexpectedOutput = "file:///document/hello/world.txt"
-        let uri = fileSystem.percentEncodedURL(fromURIString:input)
+        let uri = fileSystem.percentEncodedURL(fromURIString: input)
 
         // Should not create a directory named "hello"
         expect(uri?.absoluteString) != unexpectedOutput
@@ -45,7 +45,7 @@ class EXFileSystemSpec: ExpoSpec {
 
       it("should handle assets-library URIs") {
         let assetsLibraryUriInput = "assets-library://asset/asset.JPG?id=3C1D9C54-9521-488F-BB27-AA1EA0F8AF04/L0/001&ext=JPG"
-        let assetsLibraryUri = fileSystem.percentEncodedURL(fromURIString:assetsLibraryUriInput)
+        let assetsLibraryUri = fileSystem.percentEncodedURL(fromURIString: assetsLibraryUriInput)
 
         expect(assetsLibraryUri?.absoluteString) == assetsLibraryUriInput
         expect(assetsLibraryUri?.scheme) == "assets-library"


### PR DESCRIPTION
# Why
Closes #26789
Closes #26750
Closes ENG-11304
Closes ENG-11287

Fixes a number of issues with file uploads

# How
- Use the correct initializer when converting the file to `Data`
- Format the multipart request body correctly. The multiline string resulted in malformed data
- We need to write the request data temporarily to the `Caches` directory and then upload that file as background tasks only support uploads from a file.

# Test Plan
- Tested in the provided repros
- Wrote a small express server that accepts file uploads. Working correctly.
- All file system tests are passing in bare-expo
