### PR TITLE
[core][Android] Fix activity contract registration after host destruction

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
-- [Android] Fixed activity contract registration after host destruction.
+- [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
+- [Android] Fixed activity contract registration after host destruction.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -63,7 +63,7 @@ class AppContext(
   val registry = ModuleRegistry(WeakReference(this))
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
 
-  private var hostWereDestroyed = false
+  private var hostWasDestroyed = false
 
   // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
   internal lateinit var jsiInterop: JSIInteropModuleRegistry
@@ -333,8 +333,8 @@ class AppContext(
     }
 
     // We need to re-register activity contracts when reusing AppContext with new Activity after host destruction.
-    if (hostWereDestroyed) {
-      hostWereDestroyed = false
+    if (hostWasDestroyed) {
+      hostWasDestroyed = false
       registry.registerActivityContracts()
     }
 
@@ -357,7 +357,7 @@ class AppContext(
     registry.post(EventName.ACTIVITY_DESTROYS)
     // The host (Activity) was destroyed, but it doesn't mean that modules will be destroyed too.
     // So we save that information, and we will re-register activity contracts when the host will be resumed with new Activity.
-    hostWereDestroyed = true
+    hostWasDestroyed = true
   }
 
   internal fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -33,10 +33,6 @@ class ModuleRegistry(
       )
     }
 
-    holder.apply {
-      registerContracts()
-    }
-
     registry[holder.name] = holder
   }
 
@@ -110,6 +106,12 @@ class ModuleRegistry(
   fun cleanUp() {
     registry.clear()
     logger.info("✅ ModuleRegistry was destroyed")
+  }
+
+  internal fun registerActivityContracts() {
+    forEach { holder ->
+      holder.registerContracts()
+    }
   }
 
   /**


### PR DESCRIPTION
# Why

Fixed https://github.com/expo/expo/issues/19512.

# How

When the host is destroyed and the app isn't killed, contracts are not registered with the new Activity instance after the system recreates the main Activity. I've changed the order of initialization, and now, it should re-register all contracts correctly. 

# Test Plan

- NCL (expo-image-picker example) with `don't keep activity` option ✅