### PR TITLE
[docs] Fix broken internal links

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -235,9 +235,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/routing/appearance/': '/router/appearance/',
   '/routing/error-handling/': '/router/error-handling/',
 
-  // Move overview to index
-  '/versions/v37.0.0/sdk/overview/': '/versions/v37.0.0/',
-
   // Errors and debugging is better suited for getting started than tutorial
   '/tutorial/errors/': '/debugging/errors-and-warnings/',
 

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -85,10 +85,6 @@ redirects[versions/latest/sdk/introduction/index.html]=versions/latest/sdk/overv
 # project-lifecycle is now covered by managed-vs-bare
 redirects[versions/latest/introduction/project-lifecycle]=archive/managed-vs-bare
 
-# exp-cli is now expo-cli
-# redirects[versions/latest/guides/exp-cli.html]=versions/latest/workflow/expo-cli/
-# redirects[versions/latest/guides/exp-cli]=versions/latest/workflow/expo-cli/
-
 # Migrated FAQ pages
 redirects[faq/image-background]=ui-programming/image-background
 redirects[faq/react-native-styling-buttons]=ui-programming/react-native-styling-buttons

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -53,7 +53,7 @@ export default App() {
 
 ### Compatibility with Expo Go and Development builds
 
-Dev tools plugins should only include JavaScript code. They are generally compatible with Expo Go and [Development builds](/development-builds/introduction/) and should not require creating a new development build to add the plugin. If a package's underlying module that the plugin inspects includes native code and is not part of Expo Go, create a new development build to use both the component and the plugin from that package.
+Dev tools plugins should only include JavaScript code. They are generally compatible with Expo Go and [Development builds](/develop/development-builds/introduction/) and should not require creating a new development build to add the plugin. If a package's underlying module that the plugin inspects includes native code and is not part of Expo Go, create a new development build to use both the component and the plugin from that package.
 
 For example, a dev tools plugin that inspects [React Native Firebase](/guides/using-firebase/#using-react-native-firebase) will not work with Expo Go. React Native Firebase includes native code that is not part of Expo Go. To use the dev tools plugin and React Native Firebase, create a development build.
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -70,6 +70,6 @@ When you're ready to ship your app, you can [build it with EAS Build](/build/int
 
 ## Create reusable native modules
 
-Apart from adding custom native code to a project, the [Expo Modules API](/modules/overview) enables developers to build reusable modules for Expo and React Native projects using Swift, Kotlin, and TypeScript. These modules are often published to npm. They can also be included as separate packages within a [monorepo](/guides/monorepo). We use the Expo Modules API for most modules in the [Expo SDK](/versions/latest).
+Apart from adding custom native code to a project, the [Expo Modules API](/modules/overview) enables developers to build reusable modules for Expo and React Native projects using Swift, Kotlin, and TypeScript. These modules are often published to npm. They can also be included as separate packages within a [monorepo](/guides/monorepos/). We use the Expo Modules API for most modules in the [Expo SDK](/versions/latest).
 
 Another option is to use [React Native's Core Native Modules API](https://reactnative.dev/docs/native-modules-intro), which may require some C++ knowledge in addition to Objective-C and Java. Most React Native modules in the ecosystem are built using this API because it is and always has been part of React Native. The Expo Module API is new and intends to solve many of the pain points of using the core API.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Looking into Algolia report, I found a couple of internal links are broken.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR, fixes the broken internal links and cleans up some old server side and client side redirects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
