### PR TITLE
[docs] change github feature preview notice theme to info

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -8,7 +8,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
-> **warning** This feature is in early access and may change significantly. Its performance might not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
+> **info** This feature is in early access and may change significantly. Its performance might not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
 
 ## Prerequisites
 


### PR DESCRIPTION
# Why/How

The warning theme seems a little heavy-handed and could ward off potential users, so I wanted to change the style of the notice to "info".

# Test Plan

![Screenshot 2024-02-02 at 17 17 52](https://github.com/expo/expo/assets/12488826/bda112c8-3860-4635-b40d-60fdb96990c1)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
