### PR TITLE
[modules] Make ObjectDeallocator a native state instead of a host object

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))
+- `ObjectDeallocator` is now a native state instead of a host object.
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))
-- `ObjectDeallocator` is now a native state instead of a host object.
+- `ObjectDeallocator` is now a native state instead of a host object. ([#26906](https://github.com/expo/expo/pull/26906) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -156,8 +156,6 @@ class JavaScriptClassTest {
       val jsObject = callClass("MySharedObject").getObject()
       id = SharedObjectId(jsObject.getProperty(sharedObjectIdPropertyName).getInt())
       registry = jsiInterop.appContextHolder.get()?.sharedObjectRegistry
-
-      Truth.assertThat(jsObject.hasProperty("__expo_shared_object_deallocator__")).isTrue()
     }
 
     Truth.assertThat(registry!!.pairs[id!!]).isNull()

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -184,8 +184,7 @@ void JavaScriptObject::defineNativeDeallocator(
       );
       globalRef->invoke(args);
       globalRef.reset();
-    },
-    "__expo_shared_object_deallocator__"
+    }
   );
 }
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/ObjectDeallocator.cpp
+++ b/packages/expo-modules-core/common/cpp/ObjectDeallocator.cpp
@@ -8,14 +8,12 @@ namespace expo::common {
 void setDeallocator(
   jsi::Runtime &runtime,
   const std::shared_ptr<jsi::Object> &jsThis,
-  ObjectDeallocator::Block deallocatorBlock,
-  const std::string &key
+  ObjectDeallocator::Block deallocatorBlock
 ) {
-  std::shared_ptr<ObjectDeallocator> hostObjectPtr = std::make_shared<ObjectDeallocator>(
+  std::shared_ptr<ObjectDeallocator> objectDeallocator = std::make_shared<ObjectDeallocator>(
     deallocatorBlock
   );
-  jsi::Object jsDeallocator = jsi::Object::createFromHostObject(runtime, hostObjectPtr);
-  jsThis->setProperty(runtime, key.c_str(), jsi::Value(runtime, jsDeallocator));
+  jsThis->setNativeState(runtime, objectDeallocator);
 }
 
 } // namespace expo::common

--- a/packages/expo-modules-core/common/cpp/ObjectDeallocator.h
+++ b/packages/expo-modules-core/common/cpp/ObjectDeallocator.h
@@ -8,7 +8,7 @@ namespace jsi = facebook::jsi;
 
 namespace expo::common {
 
-class JSI_EXPORT ObjectDeallocator : public jsi::HostObject {
+class JSI_EXPORT ObjectDeallocator : public jsi::NativeState {
 public:
   typedef std::function<void()> Block;
 
@@ -28,8 +28,7 @@ public:
 void setDeallocator(
   jsi::Runtime &runtime,
   const std::shared_ptr<jsi::Object> &jsThis,
-  ObjectDeallocator::Block deallocatorBlock,
-  const std::string &key = "__expo_object_deallocator__"
+  ObjectDeallocator::Block deallocatorBlock
 );
 
 } // namespace expo::common


### PR DESCRIPTION
# Why

We use the `ObjectDeallocator` class to listen to shared objects deallocation. It's a host object that we install to the JS object under an internal property. Native state seems to be a better choice for this use case and is recommended by people working on Hermes. This also prevents users from misusing the deallocator, by calling it or deleting.

Using `NativeState` is also a bit more extensible and aligns with our plan to have a custom native state dedicated for shared objects.

# How

- Changed `ObjectDeallocator` to inherit from `NativeState` instead of `HostObject`
- Updated the function that sets the deallocator on the given JS object
- Removed an unnecessary assert from tests on Android

# Test Plan

I created thousands of shared objects in a few batches and used the memory debugger to confirm that the number of native shared objects is smaller, thus the deallocators were called and are not causing memory leaks. Also added a breakpoint in the deallocator to check whether it's called on the JS thread (same as in the host object).