### PR TITLE
doc: update devtools-plugins.mdx

### DIFF
--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -168,7 +168,7 @@ const queryClient = new QueryClient({});
 export default function App() {
   useReactQueryDevTools(queryClient);
 
-  return <QueryClientProvider>{/* ... */}</QueryClientProvider>;
+  return <QueryClientProvider client={queryClient}>{/* ... */}</QueryClientProvider>;
 }
 ```
 


### PR DESCRIPTION
# Why
I just added client prop to `QueryClientProvider` because is required

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
