### PR TITLE
docs: fix missing bracket in fonts.mdx

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -211,7 +211,7 @@ An example of the path provided to the `fonts` option in the config plugin:
     [
       "expo-font",
       {
-        "fonts": "node_modules/@expo-google-fonts/inter/Inter_100Thin.ttf"
+        "fonts": ["node_modules/@expo-google-fonts/inter/Inter_100Thin.ttf"]
       }
     ]
   ]


### PR DESCRIPTION
# Why

I read the docs on using `expo-font` and follow installing a google font. Then I encounter an error `fonts.map is not a function`. So I read the docs again and found missing bracket in google fonts section.

# How

Just add a bracket

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
