### PR TITLE
Update configuration.mdx

### DIFF
--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -85,6 +85,7 @@ And in your **app.config.js**, you are provided with that configuration in the a
 
 ```js app.config.js
 module.exports = ({ config }) => {
+  // In order for EAS build to work properly, remeber to remove all console.logs.
   console.log(config.name); // prints 'My App'
   return {
     ...config,


### PR DESCRIPTION
Misleading code. EAS build does NOT work if you leave any console.log statement inside of the function. More accurately: Pod install breaks.

# Why

The code sample in the docs does not work with EAS.

# How

Remove console.log statements

# Test Plan

Rebuild without console.logs
