### PR TITLE
[cli] Start script does not validate dependencies or display warning

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Change server log tag. ([#26834](https://github.com/expo/expo/pull/26834) by [@EvanBacon](https://github.com/EvanBacon))
 - Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
+- Display incompatible dependency warnings for `expo start` dev client. ([#26923](https://github.com/expo/expo/pull/26923))
 
 ## 0.17.1 - 2024-01-18
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Change server log tag. ([#26834](https://github.com/expo/expo/pull/26834) by [@EvanBacon](https://github.com/EvanBacon))
 - Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
-- Display incompatible dependency warnings for `expo start` dev client. ([#26923](https://github.com/expo/expo/pull/26923))
+- Display incompatible dependency warnings for `expo start` dev client. ([#26923](https://github.com/expo/expo/pull/26923) by [@ChromeQ](https://github.com/ChromeQ))
 
 ## 0.17.1 - 2024-01-18
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -108,9 +108,8 @@ export async function startAsync(
 
     // After the server starts, we can start attempting to bootstrap TypeScript.
     await devServerManager.bootstrapTypeScriptAsync();
-  }
 
-  if (!settings.webOnly && !options.devClient) {
+    // Check the dependencies are compatible with expo and show warning if not
     await profile(validateDependenciesVersionsAsync)(projectRoot, exp, pkg);
   }
 


### PR DESCRIPTION
# Why

When running `npx expo start` there are no warnings about incompatible dependencies, this warning is shown when running `npx expo-doctor` or `npx expo install --check`.

This would be useful even when running in a dev client so that I see potential problems before committing and running expo doctor on the CI server.

Before:
![image](https://github.com/expo/expo/assets/625203/a8d4dc71-6cd0-4181-838d-17008d692132)


After:
![image](https://github.com/expo/expo/assets/625203/c645fd3c-0c5c-4f61-b222-75b93b036203)


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Move the dependency validator to start script as there was a conditional preventing this running on dev client
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Update a dependency which is not compatible with expo (using `yarn install ...` rather than `expo install ...`)
Run `npx expo start` and observe the warning - will not show on master branch, will show on PR branch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
