### PR TITLE
[docs] silence expected error in test suite

### DIFF
--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { createRequire } from 'node:module';
 
@@ -9,7 +10,11 @@ const require = createRequire(import.meta.url);
 
 describe('APISection', () => {
   test('no data', () => {
+    console.error = jest.fn();
+
     const { container } = render(<APISection packageName="expo-none" testRequire={require} />);
+
+    expect(console.error).toHaveBeenCalled();
 
     expect(screen.getAllByText('No API data file found, sorry!')).toHaveLength(1);
 


### PR DESCRIPTION
# Why

To avoid confusion.

# How

Mock `console.error` in the test case, check if it was called.

# Test Plan

All tests are passing, there is no error logged in tests results.

# Preview

![Screenshot 2024-02-05 at 11 53 16](https://github.com/expo/expo/assets/719641/6ec4cd6a-80c4-4c7b-983b-cbd521d09033)

