### PR TITLE
Fix linking `expo` package when Expo autolinking is not used

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- Fixed React Native Community CLI not being able to autolink the `expo` package when Expo autolinking is not used. ([#26932](https://github.com/expo/expo/pull/26932) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -1,6 +1,12 @@
 require 'json'
+require 'colored2' # dependency of CocoaPods
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+# Use a global flag to check whether the warning about missing autolinking
+# scripts has already been printed. The podspec may be read multiple times
+# during `pod install` and we don't want to make the warning more obtrusive.
+$expo_warned_about_missing_autolinking |= false
 
 Pod::Spec.new do |s|
   s.name           = 'Expo'
@@ -19,7 +25,22 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.header_dir     = 'Expo'
 
-  s.dependency 'ExpoModulesCore'
+  # Don't require the `ExpoModulesCore` dependency if the autolinking hasn't been imported.
+  # Otherwise, `pod install` would fail because it's not linkable by the community CLI.
+  if defined?(use_expo_modules!)
+    s.dependency 'ExpoModulesCore'
+  elsif !$expo_warned_about_missing_autolinking
+    puts <<~EOS
+
+    Looks like your project uses Expo, but React Native Community CLI is unable to install Expo packages.
+    Make sure to require autolinking scripts from Expo and call `use_expo_modules!` in your target.
+    See https://docs.expo.dev/bare/installing-expo-modules for more information.
+    EOS
+    .yellow
+
+    # Suppress the warning next time.
+    $expo_warned_about_missing_autolinking = true
+  end
 
   s.source_files = 'ios/**/*.{h,m,swift}'
 end

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -32,9 +32,9 @@ Pod::Spec.new do |s|
   elsif !$expo_warned_about_missing_autolinking
     puts <<~EOS
 
-    Looks like your project uses Expo, but React Native Community CLI is unable to install Expo packages.
+    Your project includes the Expo package, but React Native Community CLI is unable to install the related Pods.
     Make sure to require autolinking scripts from Expo and call `use_expo_modules!` in your target.
-    See https://docs.expo.dev/bare/installing-expo-modules for more information.
+    Learn more: https://docs.expo.dev/bare/installing-expo-modules
     EOS
     .yellow
 


### PR DESCRIPTION
# Why

This [`react-native.config.js`](https://github.com/expo/expo/blob/main/packages/expo/react-native.config.js) is a nice way to prevent `expo` package being linked when Expo modules are not set. However, this is not perfect, especially that we now support out of tree platforms (i.e. the config doesn't handle macOS right now).

Currently, running `pod install` in a `react-native-macos` project that has `expo` in dependencies but doesn't have the setup for Expo autolinking would fail because it's unable to find pod specification for `ExpoModulesCore` (which cannot be linked by React Native Community CLI).

# How

When `use_expo_modules!` is not defined, don't include the dependency on `ExpoModulesCore` and print appropriate warning instead.

Sadly, this doesn't fix the problem when autolinking **is imported** but `use_expo_modules!` **is not used**. I'm not sure if we can do something with that, but this solution seems to be better than nothing.

# Test Plan

- `npx react-native init`
- `npm install expo`
- `npx react-native-macos-init` doesn't fail on `pod install` step and shows the warning that instructs me to set up Expo modules
