### PR TITLE
[et] Fix publish command failing with `git exited with non-zero code: 1`

### DIFF
--- a/tools/src/Workspace.ts
+++ b/tools/src/Workspace.ts
@@ -1,11 +1,11 @@
 import JsonFile from '@expo/json-file';
 import path from 'path';
 
-import { EXPO_DIR } from './Constants';
+import { EXPO_DIR, EXPO_GO_DIR } from './Constants';
 import { Package } from './Packages';
 import { spawnAsync, spawnJSONCommandAsync } from './Utils';
 
-const NATIVE_APPS_PATHS = [EXPO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
+const NATIVE_APPS_PATHS = [EXPO_GO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
 
 /**
  * Workspace info for the single project.

--- a/tools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/src/publish-packages/tasks/updateIosProjects.ts
@@ -18,7 +18,7 @@ export const updateIosProjects = new Task<TaskArgs>(
   {
     name: 'updateIosProjects',
     dependsOn: [selectPackagesToPublish],
-    filesToStage: ['ios', 'apps/*/ios/**'],
+    filesToStage: ['apps/*/ios/**'],
   },
   async (parcels: Parcel[]) => {
     logger.info('\n🍎 Updating iOS projects...');


### PR DESCRIPTION
# Why

Fixes publish command failing with `git exited with non-zero code: 1`
```
🍎 Updating iOS projects...
   @expo/home: Reinstalling pods...
   bare-expo: No pods to update.
   ios projects updated successfully!

💥 Error: git exited with non-zero code: 1
    at ChildProcess.completionListener (/Users/lukasz/work/expo/tools/node_modules/@expo/spawn-async/build/spawnAsync.js:41:23)
    at Object.onceWrapper (node:events:632:26)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at Socket.<anonymous> (node:internal/child_process:450:11)
    at Socket.emit (node:events:517:28)
    at Pipe.<anonymous> (node:net:350:12)
    ...
    at spawnAsync (/Users/lukasz/work/expo/tools/node_modules/@expo/spawn-async/build/spawnAsync.js:7:23)
    at spawnAsync (/Users/lukasz/work/expo/tools/build/Utils.js:76:36)
    at GitDirectory.runAsync (/Users/lukasz/work/expo/tools/build/Git.js:43:38)
    at GitDirectory.discardFilesAsync (/Users/lukasz/work/expo/tools/build/Git.js:250:20)
    at TaskRunner.runAsync (/Users/lukasz/work/expo/tools/build/TasksRunner.js:136:36)
    at async TaskRunner.runAndExitAsync (/Users/lukasz/work/expo/tools/build/TasksRunner.js:154:13)
    at async main (/Users/lukasz/work/expo/tools/build/commands/PublishPackages.js:152:5)
    at async Command.<anonymous> (/Users/lukasz/work/expo/tools/node_modules/@expo/commander/index.js:1125:9)
💥 stderr output:
```

# How

When we moved the expo to the `apps` folder, we didn't update all paths that refer to the project location in our tooling. 

# Test Plan

- run dry run on `expo-image` package ✅ 