### PR TITLE
[expo-updates] Fix assets:verify command for images with multiple scales

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
 - [Android] correct drawable types in updates embedded manifest. ([#26676](https://github.com/expo/expo/pull/26676) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix case where launch wait ms timeout is greater than okhttp default timeout. ([#26731](https://github.com/expo/expo/pull/26731) by [@wschurman](https://github.com/wschurman))
+- Fix assets:verify command for images with multiple scales. ([#26940](https://github.com/expo/expo/pull/26940) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/cli/__tests__/assetsVerify-test.ts
+++ b/packages/expo-updates/cli/__tests__/assetsVerify-test.ts
@@ -245,6 +245,10 @@ describe(getMissingAssetsAsync, () => {
       'android'
     );
     expect(result.length).toBe(3);
+    expect(result[1].hash).toEqual('5c37045d0f36217bdee17959fc10986a');
+    expect(result[1].path).toEqual(
+      '/Users/dlowder/iosProjects/UpdatesAPIDemo/assets/icons/bell@2x.png'
+    );
   });
   it('Detects no missing assets', async () => {
     // Add the missing assets to the build manifest

--- a/packages/expo-updates/cli/__tests__/assetsVerify-test.ts
+++ b/packages/expo-updates/cli/__tests__/assetsVerify-test.ts
@@ -7,6 +7,7 @@ import {
   getExportedMetadataHashSet,
   getFullAssetDumpAsync,
   getFullAssetDumpHashSet,
+  getMissingAssetsAsync,
 } from '../assetsVerifyAsync';
 import { BuildManifest, ExportedMetadata, FullAssetDump } from '../assetsVerifyTypes';
 
@@ -66,6 +67,27 @@ const assetMap: FullAssetDump = new Map(
       type: 'jpg',
       fileHashes: ['a7643581b54e5c60b852c5d827e629dc'],
     },
+    '3fe96d5975601486c98c48b5dec0f777': {
+      __packager_asset: true,
+      fileSystemLocation: '/Users/dlowder/iosProjects/UpdatesAPIDemo/assets/icons',
+      httpServerLocation: '/assets/assets/icons',
+      width: 24,
+      height: 24,
+      scales: [1, 2, 3],
+      files: [
+        '/Users/dlowder/iosProjects/UpdatesAPIDemo/assets/icons/bell.png',
+        '/Users/dlowder/iosProjects/UpdatesAPIDemo/assets/icons/bell@2x.png',
+        '/Users/dlowder/iosProjects/UpdatesAPIDemo/assets/icons/bell@3x.png',
+      ],
+      hash: '3fe96d5975601486c98c48b5dec0f777',
+      name: 'bell',
+      type: 'png',
+      fileHashes: [
+        '0d38747965d80a1a453de5a07b05de55',
+        '5c37045d0f36217bdee17959fc10986a',
+        '55761b0bdbfd9d4c94c1b1f690954e37',
+      ],
+    },
   })
 );
 const buildManifest: BuildManifest = {
@@ -118,7 +140,7 @@ describe(getFullAssetDumpAsync, () => {
 describe(getFullAssetDumpHashSet, () => {
   it('Converts full asset map to set', () => {
     const result = getFullAssetDumpHashSet(assetMap);
-    expect(result.size).toEqual(4);
+    expect(result.fullAssetHashSet.size).toEqual(7); // Set should contain all hashes for an image with multiple scales
   });
 });
 describe(getBuildManifestAsync, () => {
@@ -201,5 +223,81 @@ describe(getExportedMetadataHashSet, () => {
       },
     };
     expect(() => getExportedMetadataHashSet(metadataWithoutAndroid, 'android')).toThrow();
+  });
+});
+describe(getMissingAssetsAsync, () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+  it('Detects missing assets', async () => {
+    vol.fromJSON(
+      {
+        'dist/assetmap.json': JSON.stringify(Object.fromEntries(assetMap)),
+        'dist/metadata.json': JSON.stringify(metadata),
+        'android/app/build/app.manifest': JSON.stringify(buildManifest),
+      },
+      projectRoot
+    );
+    const result = await getMissingAssetsAsync(
+      `${projectRoot}/android/app/build/app.manifest`,
+      `${projectRoot}/dist/metadata.json`,
+      `${projectRoot}/dist/assetmap.json`,
+      'android'
+    );
+    expect(result.length).toBe(3);
+  });
+  it('Detects no missing assets', async () => {
+    // Add the missing assets to the build manifest
+    const expandedBuildManifest = {
+      ...buildManifest,
+      assets: [
+        ...buildManifest.assets,
+        {
+          name: 'bell',
+          type: 'png',
+          scale: 1,
+          packagerHash: '0d38747965d80a1a453de5a07b05de55',
+          subdirectory: '/assets/assets/icons',
+          scales: [1, 2, 3],
+          resourcesFilename: 'assets_icons_bell',
+          resourcesFolder: 'drawable',
+        },
+        {
+          name: 'bell',
+          type: 'png',
+          scale: 2,
+          packagerHash: '5c37045d0f36217bdee17959fc10986a',
+          subdirectory: '/assets/assets/icons',
+          scales: [1, 2, 3],
+          resourcesFilename: 'assets_icons_bell',
+          resourcesFolder: 'drawable',
+        },
+        {
+          name: 'bell',
+          type: 'png',
+          scale: 3,
+          packagerHash: '55761b0bdbfd9d4c94c1b1f690954e37',
+          subdirectory: '/assets/assets/icons',
+          scales: [1, 2, 3],
+          resourcesFilename: 'assets_icons_bell',
+          resourcesFolder: 'drawable',
+        },
+      ],
+    };
+    vol.fromJSON(
+      {
+        'dist/assetmap.json': JSON.stringify(Object.fromEntries(assetMap)),
+        'dist/metadata.json': JSON.stringify(metadata),
+        'android/app/build/app.manifest': JSON.stringify(expandedBuildManifest),
+      },
+      projectRoot
+    );
+    const result = await getMissingAssetsAsync(
+      `${projectRoot}/android/app/build/app.manifest`,
+      `${projectRoot}/dist/metadata.json`,
+      `${projectRoot}/dist/assetmap.json`,
+      'android'
+    );
+    expect(result.length).toBe(0);
   });
 });

--- a/packages/expo-updates/cli/assetsVerify.ts
+++ b/packages/expo-updates/cli/assetsVerify.ts
@@ -76,10 +76,7 @@ Verify that all static files in an exported bundle are in either the export or a
         `${
           missingAssets.length
         } assets not found in either embedded manifest or in exported bundle:${JSON.stringify(
-          missingAssets.map((asset) => ({
-            hash: asset.hash,
-            path: asset.files?.length ? asset.files[0] : '',
-          })),
+          missingAssets,
           null,
           2
         )}`

--- a/packages/expo-updates/cli/assetsVerifyAsync.ts
+++ b/packages/expo-updates/cli/assetsVerifyAsync.ts
@@ -6,6 +6,7 @@ import {
   ExportedMetadataAsset,
   FullAssetDump,
   FullAssetDumpEntry,
+  MissingAsset,
   Platform,
 } from './assetsVerifyTypes';
 
@@ -45,12 +46,19 @@ export async function getMissingAssetsAsync(
   const buildAssetsPlusExportedAssets = new Set(buildManifestHashSet);
   exportedAssetSet.forEach((hash) => buildAssetsPlusExportedAssets.add(hash));
 
-  const missingAssets: FullAssetDumpEntry[] = [];
+  const missingAssets: MissingAsset[] = [];
 
   fullAssetHashSet.forEach((hash) => {
     if (!buildAssetsPlusExportedAssets.has(hash)) {
       const asset = fullAssetHashMap.get(hash);
-      asset && missingAssets.push(asset);
+      asset?.fileHashes.forEach((fileHash, index) => {
+        if (asset?.fileHashes[index] === hash) {
+          missingAssets.push({
+            hash,
+            path: asset?.files[index],
+          });
+        }
+      });
     }
   });
 

--- a/packages/expo-updates/cli/assetsVerifyAsync.ts
+++ b/packages/expo-updates/cli/assetsVerifyAsync.ts
@@ -30,8 +30,8 @@ export async function getMissingAssetsAsync(
     await getBuildManifestAsync(buildManifestPath)
   );
 
-  const fullAssetMap = await getFullAssetDumpAsync(assetMapPath);
-  const fullAssetSet = getFullAssetDumpHashSet(fullAssetMap);
+  const fullAssetDump = await getFullAssetDumpAsync(assetMapPath);
+  const { fullAssetHashSet, fullAssetHashMap } = getFullAssetDumpHashSet(fullAssetDump);
 
   const exportedAssetSet = getExportedMetadataHashSet(
     await getExportedMetadataAsync(exportMetadataPath),
@@ -40,16 +40,16 @@ export async function getMissingAssetsAsync(
 
   debug(`Assets in build: ${JSON.stringify([...buildManifestHashSet], null, 2)}`);
   debug(`Assets in exported bundle: ${JSON.stringify([...exportedAssetSet], null, 2)}`);
-  debug(`All assets resolved by Metro: ${JSON.stringify([...fullAssetSet], null, 2)}`);
+  debug(`All assets resolved by Metro: ${JSON.stringify([...fullAssetHashSet], null, 2)}`);
 
   const buildAssetsPlusExportedAssets = new Set(buildManifestHashSet);
   exportedAssetSet.forEach((hash) => buildAssetsPlusExportedAssets.add(hash));
 
   const missingAssets: FullAssetDumpEntry[] = [];
 
-  fullAssetSet.forEach((hash) => {
+  fullAssetHashSet.forEach((hash) => {
     if (!buildAssetsPlusExportedAssets.has(hash)) {
-      const asset = fullAssetMap.get(hash);
+      const asset = fullAssetHashMap.get(hash);
       asset && missingAssets.push(asset);
     }
   });
@@ -97,10 +97,21 @@ export async function getFullAssetDumpAsync(assetMapPath: string) {
  * Extracts the set of asset hashes from an asset dump.
  *
  * @param assetDump
- * @returns The set of asset hashes in the asset dump
+ * @returns The set of asset hashes in the asset dump, and a map of hash to asset
  */
 export function getFullAssetDumpHashSet(assetDump: FullAssetDump) {
-  return new Set(assetDump.keys());
+  const fullAssetHashSet = new Set<string>();
+  const fullAssetHashMap = new Map<string, FullAssetDumpEntry>();
+  assetDump.forEach((asset) =>
+    asset.fileHashes.forEach((hash) => {
+      fullAssetHashSet.add(hash);
+      fullAssetHashMap.set(hash, asset);
+    })
+  );
+  return {
+    fullAssetHashSet,
+    fullAssetHashMap,
+  };
 }
 
 /**

--- a/packages/expo-updates/cli/assetsVerifyTypes.ts
+++ b/packages/expo-updates/cli/assetsVerifyTypes.ts
@@ -55,3 +55,10 @@ export type ExportedMetadata = {
     android?: FileMetadata;
   };
 };
+
+// Type for the missing asset array returned by getMissingAssetsAsync
+
+export type MissingAsset = {
+  hash: string;
+  path: string;
+};


### PR DESCRIPTION
# Why

Testing in an SDK 50 project found that the new `assets:verify` command did not work correctly if the project contains assets at multiple scales, e.g. `bell.png`, `bell@2x.png`, etc.

# How

Modified the code to ensure that hashes for all image scales are included in the verification check.

# Test Plan

- Tested in a local project
- Additional unit tests to verify correct behavior

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
