### PR TITLE
[core][Android] Ensure that `onCreate` before `OnActivityEntersForeground` event

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
 - Add iOS support for `PlatformColor` and `DynamicColorIOS` color props. ([#26724](https://github.com/expo/expo/pull/26724) by [@dlindenkreuz](https://github.com/dlindenkreuz))
-
 - `BarCodeScannerResult` interface now declares an additional `raw` field corresponding to the barcode value as it was encoded in the barcode without parsing. Will always be undefined on iOS. ([#25391](https://github.com/expo/expo/pull/25391) by [@ajacquierbret](https://github.com/ajacquierbret))
 
 ### 🐛 Bug fixes
@@ -19,6 +18,7 @@
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event.
+- [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event. ([#26944](https://github.com/expo/expo/pull/26944) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -138,10 +138,7 @@ class AppContext(
   }
 
   fun onCreate() = trace("AppContext.onCreate") {
-    registry.readyForPostingEvents()
-    registry.post(EventName.MODULE_CREATE)
-    registry.registerActivityContracts()
-    registry.flushTheEventQueue()
+    registry.postOnCreate()
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -71,6 +71,18 @@ class ModuleRegistry(
     }
   }
 
+  /**
+   * Post onCreate event to all modules. It has its own method to ensure that it’s called first.
+   */
+  fun postOnCreate() {
+    forEach {
+      it.post(EventName.MODULE_CREATE)
+    }
+    registerActivityContracts()
+    readyForPostingEvents()
+    flushTheEventQueue()
+  }
+
   fun post(eventName: EventName) {
     if (addToQueueIfNeeded(eventName)) {
       return
@@ -117,11 +129,11 @@ class ModuleRegistry(
   /**
    * Tell the modules registry it can handle events as they come, without adding them to the event queue.
    */
-  fun readyForPostingEvents() = synchronized(this) {
+  private fun readyForPostingEvents() = synchronized(this) {
     isReadyForPostingEvents = true
   }
 
-  fun flushTheEventQueue() = synchronized(this) {
+  private fun flushTheEventQueue() = synchronized(this) {
     eventQueue.forEach { event ->
       forEach {
         event.post(it)


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/26788.

# How

Currently, the `onCreate` method is not being called from the main queue. This can lead to a race condition that causes crashes in the `expo-clipboard` library.
```kotlin
fun onCreate() = trace("AppContext.onCreate") {
  registry.readyForPostingEvents() // here, we're allowing events to be posted
  registry.post(EventName.MODULE_CREATE) // before calling `onCreate` other events may be posted, which may lead to problems
  registry.registerActivityContracts() 
  registry.flushTheEventQueue()
}
```

# Test Plan

- I've checked if everything is working as intended. I wasn't able to reproduce the posted issue. However, the previous logic could certainly cause problems.