### PR TITLE
[jest-expo] Mock event emitter

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Mock `EventEmitter` from `expo-modules-core`.
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 
 ## 50.0.1 — 2023-12-13

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Mock `EventEmitter` from `expo-modules-core`.
+- Mock `EventEmitter` from `expo-modules-core`. ([#26945](https://github.com/expo/expo/pull/26945) by [@aleqsio](https://github.com/aleqsio))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 
 ## 50.0.1 — 2023-12-13

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -213,6 +213,8 @@ try {
     }
     return {
       ...ExpoModulesCore,
+      // Mock EventEmitter since it's commonly constructed in modules and causing warnings.
+      EventEmitter: jest.fn(),
       requireNativeModule: (name) => {
         // Support auto-mocking of expo-modules that:
         // 1. have a mock in the `mocks` directory

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -214,7 +214,14 @@ try {
     return {
       ...ExpoModulesCore,
       // Mock EventEmitter since it's commonly constructed in modules and causing warnings.
-      EventEmitter: jest.fn(),
+      EventEmitter: jest.fn().mockImplementation(() => {
+        return {
+          addListener: jest.fn(),
+          removeAllListeners: jest.fn(),
+          removeSubscription: jest.fn(),
+          emit: jest.fn(),
+        };
+      }),
       requireNativeModule: (name) => {
         // Support auto-mocking of expo-modules that:
         // 1. have a mock in the `mocks` directory


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/26877
Warnings being thrown due to EventEmitter not being mocked out.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
