### PR TITLE
[expo-updates] remove use of legacy sdkVersion runtimeVersion policy

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Remove unsafe internal mutation capability. ([#26229](https://github.com/expo/expo/pull/26229) by [@wschurman](https://github.com/wschurman))
 - Rename manifest classes. ([#26234](https://github.com/expo/expo/pull/26234), [#26235](https://github.com/expo/expo/pull/26235), [#26257](https://github.com/expo/expo/pull/26257) by [@wschurman](https://github.com/wschurman))
+- Remove use of legacy sdkVersion runtimeVersion policy. ([#26957](https://github.com/expo/expo/pull/26957) by [@wschurman](https://github.com/wschurman))
 
 ## 0.13.2 - 2024-01-18
 

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/ExpoUpdatesManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/ExpoUpdatesManifest.kt
@@ -33,23 +33,8 @@ class ExpoUpdatesManifest(json: JSONObject) : Manifest(json) {
   @Throws(JSONException::class)
   override fun getBundleURL(): String = getLaunchAsset().require("url")
 
-  @Deprecated(message = "exposdk:... runtime version is deprecated")
-  private fun getSDKVersionFromRuntimeVersion(): String? {
-    val runtimeVersion = getRuntimeVersion()
-    if (runtimeVersion == "exposdk:UNVERSIONED") {
-      return "UNVERSIONED"
-    }
-
-    val expoSDKRuntimeVersionRegex: Pattern = Pattern.compile("^exposdk:(\\d+\\.\\d+\\.\\d+)$")
-    val expoSDKRuntimeVersionMatch: Matcher = expoSDKRuntimeVersionRegex.matcher(runtimeVersion)
-    if (expoSDKRuntimeVersionMatch.find()) {
-      return expoSDKRuntimeVersionMatch.group(1)!!
-    }
-    return null
-  }
-
   override fun getExpoGoSDKVersion(): String? {
-    return getExpoClientConfigRootObject()?.getString("sdkVersion") ?: getSDKVersionFromRuntimeVersion()
+    return getExpoClientConfigRootObject()?.getString("sdkVersion")
   }
 
   @Throws(JSONException::class)

--- a/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/ExpoUpdatesManifestTest.kt
+++ b/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/ExpoUpdatesManifestTest.kt
@@ -8,9 +8,8 @@ class ExpoUpdatesManifestTest {
   @Test
   @Throws(Exception::class)
   fun testGetSDKVersionNullable_ValidCases() {
-    val runtimeVersion = "exposdk:39.0.0"
     val manifestJson =
-      "{\"runtimeVersion\":\"$runtimeVersion\"}"
+      "{\"extra\":{\"expoClient\":{\"sdkVersion\":\"39.0.0\"}}}"
     val manifest = ExpoUpdatesManifest(JSONObject(manifestJson))
     Assert.assertEquals(manifest.getExpoGoSDKVersion(), "39.0.0")
   }
@@ -18,29 +17,9 @@ class ExpoUpdatesManifestTest {
   @Test
   @Throws(Exception::class)
   fun testGetSDKVersionNullable_ValidCaseUnversioned() {
-    val runtimeVersion = "exposdk:UNVERSIONED"
     val manifestJson =
-      "{\"runtimeVersion\":\"$runtimeVersion\"}"
+      "{\"extra\":{\"expoClient\":{\"sdkVersion\":\"UNVERSIONED\"}}}"
     val manifest = ExpoUpdatesManifest(JSONObject(manifestJson))
     Assert.assertEquals(manifest.getExpoGoSDKVersion(), "UNVERSIONED")
-  }
-
-  @Test
-  @Throws(Exception::class)
-  fun testGetSDKVersionNullable_NotSDKRuntimeVersionCases() {
-    val runtimeVersions = listOf(
-      "exposdk:123",
-      "exposdkd:39.0.0",
-      "exposdk:hello",
-      "bexposdk:39.0.0",
-      "exposdk:39.0.0-beta.0",
-      "exposdk:39.0.0-alpha.256"
-    )
-    runtimeVersions.forEach { runtimeVersion ->
-      val manifestJson =
-        "{\"runtimeVersion\":\"$runtimeVersion\"}"
-      val manifest = ExpoUpdatesManifest(JSONObject(manifestJson))
-      Assert.assertNull(manifest.getExpoGoSDKVersion())
-    }
   }
 }

--- a/packages/expo-manifests/ios/EXManifests/ExpoUpdatesManifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/ExpoUpdatesManifest.swift
@@ -37,28 +37,8 @@ public class ExpoUpdatesManifest: Manifest {
     return rawManifestJSON().requiredValue(forKey: "runtimeVersion")
   }
 
-  private func getSDKVersionFromRuntimeVersion() -> String? {
-    let runtimeVersion = runtimeVersion()
-    if runtimeVersion == "exposdk:UNVERSIONED" {
-      return "UNVERSIONED"
-    }
-
-    // The pattern is valid, so it'll never throw
-    // swiftlint:disable:next force_try
-    let regex = try! NSRegularExpression(pattern: "^exposdk:(\\d+\\.\\d+\\.\\d+)$", options: [])
-    guard let match = regex.firstMatch(
-      in: runtimeVersion,
-      options: [],
-      range: NSRange(runtimeVersion.startIndex..<runtimeVersion.endIndex, in: runtimeVersion)
-    ),
-    let range = Range(match.range(at: 1), in: runtimeVersion) else {
-      return nil
-    }
-    return String(runtimeVersion[range])
-  }
-
   public override func expoGoSDKVersion() -> String? {
-    return expoClientConfigRootObject()?.optionalValue(forKey: "sdkVersion") ?? getSDKVersionFromRuntimeVersion()
+    return expoClientConfigRootObject()?.optionalValue(forKey: "sdkVersion")
   }
 
   public func launchAsset() -> [String: Any] {

--- a/packages/expo-manifests/ios/Tests/ExpoUpdatesManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/ExpoUpdatesManifestSpec.swift
@@ -62,34 +62,27 @@ class ExpoUpdatesManifestSpec : ExpoSpec {
 
     describe("SDK Version") {
       it("is correct with valid numeric case") {
-        let runtimeVersion = "exposdk:39.0.0"
-        let manifestJson = ["runtimeVersion": runtimeVersion]
+        let manifestJson = [
+          "extra": [
+            "expoClient": [
+              "sdkVersion": "39.0.0"
+            ]
+          ]
+        ]
         let manifest = ExpoUpdatesManifest(rawManifestJSON: manifestJson)
         expect(manifest.expoGoSDKVersion()) == "39.0.0"
       }
 
       it("is UNVERSIONED with valid unversioned case") {
-        let runtimeVersion = "exposdk:UNVERSIONED"
-        let manifestJson = ["runtimeVersion": runtimeVersion]
+        let manifestJson = [
+          "extra": [
+            "expoClient": [
+              "sdkVersion": "UNVERSIONED"
+            ]
+          ]
+        ]
         let manifest = ExpoUpdatesManifest(rawManifestJSON: manifestJson)
         expect(manifest.expoGoSDKVersion()) == "UNVERSIONED"
-      }
-
-      it("is nil with non-sdk runtime version cases") {
-        let runtimeVersions = [
-          "exposdk:123",
-          "exposdkd:39.0.0",
-          "exposdk:hello",
-          "bexposdk:39.0.0",
-          "exposdk:39.0.0-beta.0",
-          "exposdk:39.0.0-alpha.256"
-        ]
-
-        for runtimeVersion in runtimeVersions {
-          let manifestJson = ["runtimeVersion": runtimeVersion]
-          let manifest = ExpoUpdatesManifest(rawManifestJSON: manifestJson)
-          expect(manifest.expoGoSDKVersion()).to(beNil())
-        }
       }
     }
   }


### PR DESCRIPTION
# Why

Determining Expo Go compatibility via the special `exposdk:...` runtime version was deprecated and now can be removed.

Now Expo Go solely uses the sdkversion field.

Closes ENG-8617.

# How

Remove code, generate schema from https://github.com/expo/universe/pull/14470 (though not completely sure we can actually remove the policy enum option).

# Test Plan

Inspect, CI builds.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
