### PR TITLE
[docs] deprecate Classic Updates

### DIFF
--- a/docs/pages/eas-update/develop-faster.mdx
+++ b/docs/pages/eas-update/develop-faster.mdx
@@ -10,7 +10,7 @@ EAS Update can help us fix critical bugs in production. It can also help us iter
 
 ## Developing locally
 
-When developing locally, `npx expo start` will start a server that serves a manifest and assets to Expo Go and development builds. Locally, those builds look for a local manifest, and when there's an update, they'll download any missing local assets. To accomplish this, Expo Go/development builds use a protocol. That protocol is either a classic version of the updates protocol (used with Classic Updates), or the modern version of the [updates protocol](/technical-specs/expo-updates-1) (used with EAS Update).
+When developing locally, `npx expo start` will start a server that serves a manifest and assets to Expo Go and development builds. Locally, those builds look for a local manifest, and when there's an update, they'll download any missing local assets. To accomplish this, Expo Go/development builds use a protocol. That protocol is either a classic version of the updates protocol (used with Classic Updates, now deprecated), or the modern version of the [updates protocol](/technical-specs/expo-updates-1) (used with EAS Update).
 
 We want to make sure that our locally developed app is using the same protocol locally as it does when we build our app.
 

--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -18,6 +18,6 @@ EAS Update is a great way to quickly deliver improvements to the people who use 
 
 ### Are Classic Updates still supported
 
-Expo is committed to supporting projects that use Classic Updates, which is the updates service available before December 2021. Apps that receive updates from the Classic Updates service will continue to work. With that, we are not planning on adding new features to Classic Updates other than fixing general issues and implementing security fixes as they arise.
+The Classic Updates service, which has been available before December 2021, is now deprecated. Users can no longer run `expo publish`, but existing apps will continue to receive Classic Updates that have already been published and are actively used.
 
-In the future, we plan to scale down Classic Updates as we transition to EAS Update. We will ensure every developer still using the service will have ample notice to upgrade to the modern Expo Updates format so that they can use another update service like their own servers or EAS Update.
+We recommend users transition to EAS Update or use a [self-hosted update service](https://docs.expo.dev/eas-update/custom-updates-server).

--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -20,4 +20,4 @@ EAS Update is a great way to quickly deliver improvements to the people who use 
 
 The Classic Updates service, which has been available before December 2021, is now deprecated. Users can no longer run `expo publish`, but existing apps will continue to receive Classic Updates that have already been published and are actively used.
 
-We recommend users transition to EAS Update or use a [self-hosted update service](https://docs.expo.dev/eas-update/custom-updates-server).
+We recommend transitioning to EAS Update or using a [self-hosted update service](/eas-update/custom-updates-server).

--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -18,6 +18,6 @@ EAS Update is a great way to quickly deliver improvements to the people who use 
 
 ### Are Classic Updates still supported
 
-The Classic Updates service, which has been available before December 2021, is now deprecated. Users can no longer run `expo publish`, but existing apps will continue to receive Classic Updates that have already been published and are actively used.
+The Classic Updates service is now deprecated. It was available before December 2021, and `expo publish` cannot be run anymore. However, existing apps will continue to receive Classic Updates that have already been published and are actively used.
 
 We recommend transitioning to EAS Update or using a [self-hosted update service](/eas-update/custom-updates-server).

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -13,8 +13,6 @@ EAS Update makes fixing small bugs and pushing quick fixes a snap in between app
 
 All apps running the `expo-updates` library have the ability to receive updates. To start using EAS Update, continue to the [Getting Started](/eas-update/getting-started) guide.
 
-> Still, using Classic Updates? We moved those docs to [the archive](/archive/classic-updates/introduction).
-
 ## Pitch
 
 ### Improve user experience


### PR DESCRIPTION
# Why

Mark Classic Updates as deprecated in our docs or remove mentions of it completely. Aim to land this on Feb 12, since the amendments mention that Classic Updates is 'completely deprecated' and expo publish can no longer be done

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- [ ] manually inspected with `yarn run dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
