### PR TITLE
Lint react hooks exhaustive dependency array

### DIFF
--- a/packages/eslint-config-universe/shared/react.js
+++ b/packages/eslint-config-universe/shared/react.js
@@ -37,7 +37,7 @@ module.exports = {
     'react/self-closing-comp': 'warn',
 
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'off',
+    'react-hooks/exhaustive-deps': 'warn',
   },
   settings: {
     react: { version: 'detect' },


### PR DESCRIPTION
# Why

This is a very important rule that specifically prevents bugs, and should absolutely not be turned off in any react project. It has been mentioned that it should almost always be followed by the react team, and if it needs to be disabled in an edge case, it can do so with an ignore comment.

Seems much more important to be linting this rather than stylistic things like `import/order`, `prettier/prettier` or `react/jsx-boolean-value`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
