### PR TITLE
[blur][linear-gradient] Add Apple TV support

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for Apple tvOS. ([#26965](https://github.com/expo/expo/pull/26965) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-blur/expo-module.config.json
+++ b/packages/expo-blur/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-blur",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "tvos", "android"],
   "ios": {
     "modules": ["BlurViewModule"]
   },

--- a/packages/expo-blur/ios/ExpoBlur.podspec
+++ b/packages/expo-blur/ios/ExpoBlur.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-blur/ios/TintStyle.swift
+++ b/packages/expo-blur/ios/TintStyle.swift
@@ -24,6 +24,52 @@ public enum TintStyle: String, Enumerable {
   case systemChromeMaterialDark
 
   func toBlurEffect() -> UIBlurEffect.Style {
+#if os(tvOS)
+    switch self {
+    case .default:
+      return .regular
+    case .extraLight:
+      return .extraLight
+    case .light:
+      return .light
+    case .regular:
+      return .regular
+    case .dark:
+      return .dark
+    case .prominent:
+      return .prominent
+    case .systemUltraThinMaterial:
+      return .regular
+    case .systemThinMaterial:
+      return .regular
+    case .systemMaterial:
+      return .regular
+    case .systemThickMaterial:
+      return .regular
+    case .systemChromeMaterial:
+      return .regular
+    case .systemUltraThinMaterialLight:
+      return .light
+    case .systemThinMaterialLight:
+      return .light
+    case .systemMaterialLight:
+      return .light
+    case .systemThickMaterialLight:
+      return .light
+    case .systemChromeMaterialLight:
+      return .light
+    case .systemUltraThinMaterialDark:
+      return .dark
+    case .systemThinMaterialDark:
+      return .dark
+    case .systemMaterialDark:
+      return .dark
+    case .systemThickMaterialDark:
+      return .dark
+    case .systemChromeMaterialDark:
+      return .dark
+    }
+#else
     switch self {
     case .default:
       return .regular
@@ -68,5 +114,6 @@ public enum TintStyle: String, Enumerable {
     case .systemChromeMaterialDark:
       return .systemChromeMaterialDark
     }
+#endif
   }
 }

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for Apple tvOS. ([#26965](https://github.com/expo/expo/pull/26965) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-linear-gradient/expo-module.config.json
+++ b/packages/expo-linear-gradient/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-linear-gradient",
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "tvos", "android"],
   "ios": {
     "modulesClassNames": ["LinearGradientModule"]
   },

--- a/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -48,7 +48,7 @@ function getExpoDependencyChunks({
     ...(includeDevClient
       ? [['expo-dev-menu-interface'], ['expo-dev-menu'], ['expo-dev-launcher'], ['expo-dev-client']]
       : []),
-    ...(includeTV ? [['expo-av', 'expo-image', 'expo-localization']] : []),
+    ...(includeTV ? [['expo-av', 'expo-blur', 'expo-image', 'expo-linear-gradient', 'expo-localization']] : []),
   ];
 }
 


### PR DESCRIPTION
# Why

Customer has requested that TV support be added for `expo-blur` and `expo-linear-gradient`.

# How

- Enabled TV in podspecs and expo-module files
- Fix compile issue in `expo-blur`, replacing unavailable `UIBlurEffect` styles with the closest TV equivalents
- Added the modules to the TV compile test CI

# Test Plan

- Checked that the visual effects worked with our sample code
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
