### PR TITLE
[doctor] Check for troublesome cocoapods versions / misc packages that shouldn't be installed

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Warn if using Cocoapods versions 1.15.1 or 1.15.2. ([#26966](https://github.com/expo/expo/pull/26966) by [@keith-kurak](https://github.com/keith-kurak))
+- Warn if using Cocoapods versions 1.15.0 or 1.15.1. ([#26966](https://github.com/expo/expo/pull/26966) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Warn if using Cocoapods versions 1.15.1 or 1.15.2. ([#26966](https://github.com/expo/expo/pull/26966) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
@@ -1,5 +1,6 @@
 import { DoctorMultiCheck, DoctorMultiCheckItemBase } from './DoctorMultiCheck';
 import { DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { learnMore } from '../utils/TerminalLink';
 
 export type DirectPackageInstallCheckItem = {
   packageName: string;
@@ -9,6 +10,14 @@ const baseCheckItem = {
   getMessage: (packageName: string) =>
     `The package "${packageName}" should not be installed directly in your project. It is a dependency of other Expo packages, which will install it automatically as needed.`,
   sdkVersionRange: '*',
+};
+
+const expoFirebaseCheckItem = {
+  getMessage: (packageName: string) =>
+    `The package "${packageName}" has been removed as of SDK 48. You should use the Firebase JS SDK or React Native Firebase directly. ${learnMore(
+      'https://expo.fyi/firebase-migration-guide'
+    )}`,
+  sdkVersionRange: '>=48.0.0',
 };
 
 const shouldBeInstalledGloballyItem = {
@@ -57,6 +66,27 @@ export const directPackageInstallCheckItems: DirectPackageInstallCheckItem[] = [
     getMessage: () =>
       `The package  "expo-permissions" was deprecated in SDK 41 and should be removed from your project because it may no longer compile on the latest SDK. It was replaced by permissions methods directly on modules, eg: MediaLibrary.requestPermissionsAsync().`,
     sdkVersionRange: '>=50.0.0',
+  },
+  {
+    packageName: 'expo-firebase-analytics',
+    ...expoFirebaseCheckItem,
+  },
+  {
+    packageName: 'expo-firebase-recaptcha',
+    ...expoFirebaseCheckItem,
+  },
+  // unlikely to be installed directly, but just in case
+  {
+    packageName: 'expo-firebase-core',
+    ...expoFirebaseCheckItem,
+  },
+  {
+    packageName: 'expo-app-loading',
+    getMessage: (packageName: string) =>
+      `The package "${packageName}" has been removed as of SDK 49. You should use expo-splash-screen instead. ${learnMore(
+        'https://docs.expo.dev/versions/latest/sdk/splash-screen/'
+      )}`,
+    sdkVersionRange: '>=49.0.0',
   },
 ];
 

--- a/packages/expo-doctor/src/checks/GlobalPackageInstalledLocallyCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPackageInstalledLocallyCheck.ts
@@ -1,7 +1,7 @@
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { getDeepDependenciesWarningAsync } from '../utils/explainDependencies';
 
-export class GlobalPackageInstalledCheck implements DoctorCheck {
+export class GlobalPackageInstalledLocallyCheck implements DoctorCheck {
   description = 'Check for legacy global CLI installed locally';
 
   sdkVersionRange = '>=46.0.0';

--- a/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
@@ -1,0 +1,48 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+async function checkCocoapodsVersionAsync(): Promise<string | null> {
+  try {
+    const cocoapodsVersionResponse = await spawnAsync('pod', ['--version']);
+    const cocoapodsVersion = cocoapodsVersionResponse.stdout.trim();
+    if (semver.satisfies(cocoapodsVersion, '1.15.0 || 1.15.1')) {
+      return `You are using Cocoapods version ${cocoapodsVersion}. There are known issues with this version and React Native projects. Upgrading to 1.15.2 or higher is recommended.`;
+    } else if (semver.validRange(cocoapodsVersion) === null) {
+      // the command works and does not fail but somehow doesn't report a valid version (is this possible?)
+      return `Cannot determine Cocoapods version. There may be an issue with your Cocoapods installation.`;
+    }
+  } catch {
+    // no install detected / command failed
+    return `Cocoapods version check failed. Cocoapods may not be installed or there may be an issue with your Cocoapods installation. Installing version 1.15.2 or higher is recommended.`;
+  }
+  return null;
+}
+
+export class NativeToolingVersionCheck implements DoctorCheck {
+  description = 'Check native tooling versions';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+
+    const hasPodfile = fs.existsSync(path.join(projectRoot, 'ios', 'Podfile'));
+
+    if (hasPodfile) {
+      const checkResult = await checkCocoapodsVersionAsync();
+      if (checkResult) {
+        issues.push(checkResult);
+      }
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+      // advice currently tightly coupled with issues in code copied from doctor
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/PackageManagerVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageManagerVersionCheck.ts
@@ -42,7 +42,7 @@ async function checkNpmVersionAsync(): Promise<string | null> {
   return null;
 }
 
-export class GlobalPrereqsVersionCheck implements DoctorCheck {
+export class PackageManagerVersionCheck implements DoctorCheck {
   description = 'Check npm/ yarn versions';
 
   sdkVersionRange = '*';

--- a/packages/expo-doctor/src/checks/__tests__/ExpoConfigCommonIssueCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/ExpoConfigCommonIssueCheck.test.ts
@@ -21,6 +21,10 @@ const additionalProjectProps = {
 };
 
 describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
   it('returns result with isSuccessful = true if Expo config SDK version matches installed version', async () => {
     vol.fromJSON({
       [projectRoot + '/node_modules/expo/package.json']: `{

--- a/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledLocallyCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/GlobalPackageInstalledLocallyCheck.test.ts
@@ -1,5 +1,5 @@
 import { getDeepDependenciesWarningAsync } from '../../utils/explainDependencies';
-import { GlobalPackageInstalledCheck } from '../GlobalPackageInstalledCheck';
+import { GlobalPackageInstalledLocallyCheck } from '../GlobalPackageInstalledLocallyCheck';
 
 jest.mock('../../utils/explainDependencies');
 
@@ -18,7 +18,7 @@ const additionalProjectProps = {
 describe('runAsync', () => {
   it('returns result with isSuccessful = true if check passes', async () => {
     jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce(null);
-    const check = new GlobalPackageInstalledCheck();
+    const check = new GlobalPackageInstalledLocallyCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,
@@ -28,7 +28,7 @@ describe('runAsync', () => {
 
   it('returns result with isSuccessful = false if check fails', async () => {
     jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
-    const check = new GlobalPackageInstalledCheck();
+    const check = new GlobalPackageInstalledLocallyCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,
@@ -38,7 +38,7 @@ describe('runAsync', () => {
 
   it('returns result with advice to remove expo-cli if check fails', async () => {
     jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
-    const check = new GlobalPackageInstalledCheck();
+    const check = new GlobalPackageInstalledLocallyCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,

--- a/packages/expo-doctor/src/checks/__tests__/NativeToolingVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/NativeToolingVersionCheck.test.ts
@@ -1,0 +1,112 @@
+import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
+
+import { mockSpawnPromise } from '../../__tests__/spawn-utils';
+import { NativeToolingVersionCheck } from '../NativeToolingVersionCheck';
+
+jest.mock('fs');
+
+const projectRoot = '/tmp/project';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  pkg: { name: 'name', version: '1.0.0' },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('returns result with isSuccessful = true if ios folder present, Cocoapods >= 1.15.2', async () => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() =>
+      mockSpawnPromise(
+        Promise.resolve({
+          status: 0,
+          stdout: '1.15.2',
+        })
+      )
+    );
+
+    vol.fromJSON({
+      [projectRoot + '/ios/Podfile']: 'test',
+    });
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync(additionalProjectProps);
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if ios folder present, Cocoapods = 1.15.1', async () => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() =>
+      mockSpawnPromise(
+        Promise.resolve({
+          status: 0,
+          stdout: '1.15.1',
+        })
+      )
+    );
+
+    vol.fromJSON({
+      [projectRoot + '/ios/Podfile']: 'test',
+    });
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync(additionalProjectProps);
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if ios folder present, Cocoapods version returns nonsense', async () => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() =>
+      mockSpawnPromise(
+        Promise.resolve({
+          status: 0,
+          stdout: 'slartibartfast',
+        })
+      )
+    );
+
+    vol.fromJSON({
+      [projectRoot + '/ios/Podfile']: 'test',
+    });
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync(additionalProjectProps);
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if ios folder present, Cocoapods version check fails', async () => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() => {
+      const error: any = new Error();
+      error.status = -1;
+      return mockSpawnPromise(Promise.reject(error));
+    });
+
+    vol.fromJSON({
+      [projectRoot + '/ios/Podfile']: 'test',
+    });
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync(additionalProjectProps);
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = true if no ios folder present, even if Cocoapods = 1.15.1', async () => {
+    jest.mocked(spawnAsync).mockImplementationOnce(() =>
+      mockSpawnPromise(
+        Promise.resolve({
+          status: 0,
+          stdout: '1.15.1',
+        })
+      )
+    );
+
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync(additionalProjectProps);
+    expect(result.isSuccessful).toBeTruthy();
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
@@ -25,6 +25,10 @@ describe('runAsync', () => {
     });
   });
 
+  afterEach(() => {
+    vol.reset();
+  });
+
   it('returns result with isSuccessful = true if empty dependencies, devDependencies, scripts', async () => {
     const check = new PackageJsonCheck();
     const result = await check.runAsync({

--- a/packages/expo-doctor/src/checks/__tests__/PackageManagerVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageManagerVersionCheck.test.ts
@@ -2,7 +2,7 @@ import spawnAsync from '@expo/spawn-async';
 import { execSync } from 'child_process';
 
 import { mockSpawnPromise } from '../../__tests__/spawn-utils';
-import { GlobalPrereqsVersionCheck } from '../GlobalPrereqsVersionCheck';
+import { PackageManagerVersionCheck } from '../PackageManagerVersionCheck';
 
 jest.mock('child_process');
 
@@ -27,7 +27,7 @@ describe('runAsync', () => {
         })
       )
     );
-    const check = new GlobalPrereqsVersionCheck();
+    const check = new PackageManagerVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,
@@ -45,7 +45,7 @@ describe('runAsync', () => {
     );
 
     jest.mocked(execSync).mockReturnValueOnce('8.19.3');
-    const check = new GlobalPrereqsVersionCheck();
+    const check = new PackageManagerVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,
@@ -63,7 +63,7 @@ describe('runAsync', () => {
     );
 
     jest.mocked(execSync).mockReturnValueOnce('5.0.0');
-    const check = new GlobalPrereqsVersionCheck();
+    const check = new PackageManagerVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
       ...additionalProjectProps,

--- a/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
@@ -21,6 +21,9 @@ const additionalProjectProps = {
 };
 
 describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+  });
   // unintentionally bare check
   it('returns result with isSuccessful = true if no ios/ android folders and no config plugins', async () => {
     const check = new ProjectSetupCheck();

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -5,12 +5,13 @@ import semver from 'semver';
 import { DirectPackageInstallCheck } from './checks/DirectPackageInstallCheck';
 import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
-import { GlobalPackageInstalledCheck } from './checks/GlobalPackageInstalledCheck';
-import { GlobalPrereqsVersionCheck } from './checks/GlobalPrereqsVersionCheck';
+import { GlobalPackageInstalledLocallyCheck } from './checks/GlobalPackageInstalledLocallyCheck';
 import { IllegalPackageCheck } from './checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from './checks/InstalledDependencyVersionCheck';
 import { MetroConfigCheck } from './checks/MetroConfigCheck';
+import { NativeToolingVersionCheck } from './checks/NativeToolingVersionCheck';
 import { PackageJsonCheck } from './checks/PackageJsonCheck';
+import { PackageManagerVersionCheck } from './checks/PackageManagerVersionCheck';
 import { ProjectSetupCheck } from './checks/ProjectSetupCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
@@ -119,9 +120,9 @@ export async function runChecksAsync(
 export function getChecksInScopeForProject(exp: ExpoConfig) {
   // add additional checks here
   const checks = [
-    new GlobalPrereqsVersionCheck(),
+    new PackageManagerVersionCheck(),
     new IllegalPackageCheck(),
-    new GlobalPackageInstalledCheck(),
+    new GlobalPackageInstalledLocallyCheck(),
     new SupportPackageVersionCheck(),
     new ExpoConfigSchemaCheck(),
     new ExpoConfigCommonIssueCheck(),
@@ -129,6 +130,7 @@ export function getChecksInScopeForProject(exp: ExpoConfig) {
     new PackageJsonCheck(),
     new ProjectSetupCheck(),
     new MetroConfigCheck(),
+    new NativeToolingVersionCheck(),
   ];
   if (env.EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK) {
     Log.log(


### PR DESCRIPTION
# Why
Cocoapods versions 1.15.0 and 1.15.1 cause problems that are hard to troubleshoot. It appears all is well with 1.15.2.

# How
Check the cocoapods version if a Podfile is present. Error if we can't affirm that it's a good version. Since this only checks when a podfile is present, it'll only present to those who has run `prebuild` or `run:ios`; it shouldn't show for anyone who doesn't have cocoapods because they don't interact with native ios projects.

Some test file renaming since some of the old names sounded like a good place for this test, even though they really weren't.

Also slipped in @wodin 's recommendations for additional package checks here: https://github.com/expo/expo/pull/26929#issuecomment-1929456702

# Test Plan
<img width="1109" alt="image" src="https://github.com/expo/expo/assets/8053974/2e3094b9-61a6-4244-aaed-e8ca0845db52">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
