### PR TITLE
[expo go] show app icon in for local development

### DIFF
--- a/apps/expo-go/src/menu/DevMenuTaskInfo.tsx
+++ b/apps/expo-go/src/menu/DevMenuTaskInfo.tsx
@@ -28,7 +28,8 @@ function getInfoFromManifest(
   if ('metadata' in manifest) {
     // modern manifest
     return {
-      iconUrl: undefined, // no icon for modern manifests
+      // @ts-expect-error iconUrl exists only for local development
+      iconUrl: manifest?.extra?.expoClient?.iconUrl,
       taskName: manifest.extra?.expoClient?.name,
       sdkVersion: manifest.extra?.expoClient?.sdkVersion,
       runtimeVersion: stringOrUndefined(manifest.runtimeVersion),

--- a/apps/expo-go/src/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, spacing } from '@expo/styleguide-native';
 import { Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
-import { View as RNView, StyleSheet, ViewStyle, Share } from 'react-native';
+import { View as RNView, StyleSheet, ViewStyle, Share, Image } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import * as UrlUtils from '../../../utils/UrlUtils';
@@ -12,9 +12,10 @@ type Props = {
   title?: string;
   url: string;
   onPress?: () => void;
+  iconUrl?: string;
 };
 
-export function RecentlyOpenedListItem({ title, url, disabled, style, onPress }: Props) {
+export function RecentlyOpenedListItem({ title, url, disabled, style, onPress, iconUrl }: Props) {
   const theme = useExpoTheme();
 
   const handleLongPress = () => {
@@ -34,7 +35,8 @@ export function RecentlyOpenedListItem({ title, url, disabled, style, onPress }:
       style={[styles.container, style, disabled && styles.disabled]}
       disabled={disabled}>
       <RNView style={[styles.contentContainer]}>
-        <View>
+        <View style={styles.row}>
+          {iconUrl ? <Image source={{ uri: iconUrl }} style={styles.icon} /> : null}
           <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
             {title}
           </Text>
@@ -81,5 +83,17 @@ const styles = StyleSheet.create({
   chevronRightContainer: {
     alignSelf: 'center',
     marginStart: spacing[2],
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    marginRight: 8,
+    borderRadius: 8,
+    alignSelf: 'center',
+    backgroundColor: 'transparent',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
   },
 });

--- a/apps/expo-go/src/screens/HomeScreen/RecentlyOpenedSection.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/RecentlyOpenedSection.tsx
@@ -24,10 +24,17 @@ export function RecentlyOpenedSection({ recentHistory }: Props) {
             ? String(project.manifest.name)
             : undefined);
 
+        const iconUrl =
+          project.manifest && 'extra' in project.manifest
+            ? // @ts-expect-error iconUrl exists only for local development
+              project.manifest?.extra?.expoClient?.iconUrl
+            : undefined;
+
         return (
           <Fragment key={project.manifestUrl}>
             <RecentlyOpenedListItem
               url={project.manifestUrl}
+              iconUrl={iconUrl}
               title={title}
               onPress={() => {
                 Linking.openURL(project.url);


### PR DESCRIPTION
# Why

In SDK 48, the app icon was displayed in Expo Go when developing locally, but it is not shown in SDK 49 or 50.

# How

Show the icon from `manifest?.extra?.expoClient?.iconUrl` if it exists.

# Test Plan

- run Expo Go locally
- create a new app with `npx create-expo-app`
- change the `icon.png` with a custom one
- load it in Expo Go
- verify the icon is displayed

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 14 50 40](https://github.com/expo/expo/assets/6534400/bcdac9fe-e74b-4bb4-84bb-526b3568d034)    | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 14 57 10](https://github.com/expo/expo/assets/6534400/090a4b4e-f0ad-443a-916a-9fa216c2c962)       |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 14 49 49](https://github.com/expo/expo/assets/6534400/c13e2a25-e3f6-4876-a0cb-f541f9d0d5f8)  | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 05 22](https://github.com/expo/expo/assets/6534400/c56d996d-835f-4de0-91a6-f2cab1072fcc)        |


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
