### PR TITLE
[docs] Update blog link

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -14,7 +14,7 @@ The following resources are useful for learning about Expo tooling and services.
 
 ### Expo team communication
 
-- [Exposition](https://blog.expo.dev/) - Our official blog, where we post release notes every month and other Expo related content at random intervals.
+- [Blog](https://expo.dev/blog) - Our official blog, where we post release notes every month and other Expo related content at random intervals.
 - [Changelog](https://expo.dev/changelog) - Our official changelog, where we post information about EAS, web dashboard and other Expo services related changes at random intervals.
 
 ### GitHub

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -35,7 +35,7 @@ export const Header = ({
             openInNewTab
             theme="quaternary"
             className="px-2 text-secondary"
-            href="https://blog.expo.dev">
+            href="https://expo.dev/blog">
             Blog
           </Button>
           <Button


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C2XUELR8U/p1707324110896949)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the blog link in the menu bar and its individual reference on the additional resources page.

# Test Plan

Checked for the places where to update the Blog link and found only two. Kept the old blog references where we link to the individual posts.

On additional resources, also removed the name "Exposition". Wasn't sure if we still need to keep the name reference around as our new blog doesn't have name other than just "Blog".

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Run docs locally and click "Blog" in menu bar.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
