### PR TITLE
[expo-updates] Make error messages consistent across platforms for dev client and disabled controllers

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] correct drawable types in updates embedded manifest. ([#26676](https://github.com/expo/expo/pull/26676) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix case where launch wait ms timeout is greater than okhttp default timeout. ([#26731](https://github.com/expo/expo/pull/26731) by [@wschurman](https://github.com/wschurman))
 - Fix assets:verify command for images with multiple scales. ([#26940](https://github.com/expo/expo/pull/26940) by [@douglowder](https://github.com/douglowder))
+- Make error messages consistent across platforms for dev client and disabled controllers. ([#26988](https://github.com/expo/expo/pull/26988) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -121,17 +121,17 @@ class DisabledUpdatesController(
   override fun checkForUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("Updates.checkForUpdateAsync() cannot be called when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.checkForUpdateAsync() is not supported when expo-updates is not enabled."))
   }
 
   override fun fetchUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("Updates.fetchUpdateAsync() cannot be called when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.fetchUpdateAsync() is not supported when expo-updates is not enabled."))
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(UpdatesDisabledException("Updates.getExtraParamsAsync() cannot be called when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.getExtraParamsAsync() is not supported when expo-updates is not enabled."))
   }
 
   override fun setExtraParam(
@@ -139,7 +139,7 @@ class DisabledUpdatesController(
     value: String?,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(UpdatesDisabledException("Updates.setExtraParamAsync() cannot be called when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.setExtraParamAsync() is not supported when expo-updates is not enabled."))
   }
 
   @Synchronized

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -121,17 +121,17 @@ class DisabledUpdatesController(
   override fun checkForUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("You cannot check for updates when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Cannot check for updates when expo-updates is not enabled."))
   }
 
   override fun fetchUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("You cannot fetch update when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Cannot fetch update when expo-updates is not enabled."))
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Cannot get extra params when expo-updates is not enabled."))
   }
 
   override fun setExtraParam(
@@ -139,7 +139,7 @@ class DisabledUpdatesController(
     value: String?,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(UpdatesDisabledException("You cannot use extra params when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Cannot set extra params when expo-updates is not enabled."))
   }
 
   @Synchronized

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -121,17 +121,17 @@ class DisabledUpdatesController(
   override fun checkForUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("Cannot check for updates when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.checkForUpdateAsync() cannot be called when expo-updates is not enabled."))
   }
 
   override fun fetchUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
-    callback.onFailure(UpdatesDisabledException("Cannot fetch update when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.fetchUpdateAsync() cannot be called when expo-updates is not enabled."))
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(UpdatesDisabledException("Cannot get extra params when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.getExtraParamsAsync() cannot be called when expo-updates is not enabled."))
   }
 
   override fun setExtraParam(
@@ -139,7 +139,7 @@ class DisabledUpdatesController(
     value: String?,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(UpdatesDisabledException("Cannot set extra params when expo-updates is not enabled."))
+    callback.onFailure(UpdatesDisabledException("Updates.setExtraParamAsync() cannot be called when expo-updates is not enabled."))
   }
 
   @Synchronized

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -305,17 +305,17 @@ class UpdatesDevLauncherController(
   override fun checkForUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.checkForUpdateAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.checkForUpdateAsync() is not supported in development builds."))
   }
 
   override fun fetchUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.fetchUpdateAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.fetchUpdateAsync() is not supported in development builds."))
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.getExtraParamsAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.getExtraParamsAsync() is not supported in development builds."))
   }
 
   override fun setExtraParam(
@@ -323,6 +323,6 @@ class UpdatesDevLauncherController(
     value: String?,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.setExtraParamAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.setExtraParamAsync() is not supported in development builds."))
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -305,17 +305,17 @@ class UpdatesDevLauncherController(
   override fun checkForUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Cannot check for update in a development client. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.checkForUpdateAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
   }
 
   override fun fetchUpdate(
     callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Cannot fetch update in a development client. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.fetchUpdateAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
   }
 
   override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(NotAvailableInDevClientException("Cannot get extra params in a development client. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.getExtraParamsAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
   }
 
   override fun setExtraParam(
@@ -323,6 +323,6 @@ class UpdatesDevLauncherController(
     value: String?,
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Cannot set extra params in a development client. A non-development build should be used to test this functionality."))
+    callback.onFailure(NotAvailableInDevClientException("Updates.setExtraParamAsync() cannot be called from a development build. A non-development build should be used to test this functionality."))
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -318,19 +318,19 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   }
 
   public func checkForUpdate(success successBlockArg: @escaping (CheckForUpdateResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException("check for update"))
+    errorBlockArg(NotAvailableInDevClientException("Updates.checkForUpdateAsync()"))
   }
 
   public func fetchUpdate(success successBlockArg: @escaping (FetchUpdateResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException("fetch update"))
+    errorBlockArg(NotAvailableInDevClientException("Updates.fetchUpdateAsync()"))
   }
 
   public func getExtraParams(success successBlockArg: @escaping ([String: String]?) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException("get extra params"))
+    errorBlockArg(NotAvailableInDevClientException("Updates.getExtraParamsAsync()"))
   }
 
   public func setExtraParam(key: String, value: String?, success successBlockArg: @escaping () -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException("set extra params"))
+    errorBlockArg(NotAvailableInDevClientException("Updates.setExtraParamAsync()"))
   }
 
   public func getNativeStateMachineContext(success successBlockArg: @escaping (UpdatesStateContext) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -318,19 +318,19 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   }
 
   public func checkForUpdate(success successBlockArg: @escaping (CheckForUpdateResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException())
+    errorBlockArg(NotAvailableInDevClientException("check for update"))
   }
 
   public func fetchUpdate(success successBlockArg: @escaping (FetchUpdateResult) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException())
+    errorBlockArg(NotAvailableInDevClientException("fetch update"))
   }
 
   public func getExtraParams(success successBlockArg: @escaping ([String: String]?) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException())
+    errorBlockArg(NotAvailableInDevClientException("get extra params"))
   }
 
   public func setExtraParam(key: String, value: String?, success successBlockArg: @escaping () -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {
-    errorBlockArg(NotAvailableInDevClientException())
+    errorBlockArg(NotAvailableInDevClientException("set extra params"))
   }
 
   public func getNativeStateMachineContext(success successBlockArg: @escaping (UpdatesStateContext) -> Void, error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void) {

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -91,21 +91,21 @@ public class DisabledAppController: InternalAppControllerInterface {
     success successBlockArg: @escaping (CheckForUpdateResult) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException("check for update"))
+    errorBlockArg(UpdatesDisabledException("Updates.checkForUpdateAsync()"))
   }
 
   public func fetchUpdate(
     success successBlockArg: @escaping (FetchUpdateResult) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException("fetch update"))
+    errorBlockArg(UpdatesDisabledException("Updates.fetchUpdateAsync()"))
   }
 
   public func getExtraParams(
     success successBlockArg: @escaping ([String: String]?) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException("get extra params"))
+    errorBlockArg(UpdatesDisabledException("Updates.getExtraParamsAsync()"))
   }
 
   public func setExtraParam(
@@ -114,7 +114,7 @@ public class DisabledAppController: InternalAppControllerInterface {
     success successBlockArg: @escaping () -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException("set extra params"))
+    errorBlockArg(UpdatesDisabledException("Updates.setExtraParamAsync()"))
   }
 
   public func getNativeStateMachineContext(

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -91,21 +91,21 @@ public class DisabledAppController: InternalAppControllerInterface {
     success successBlockArg: @escaping (CheckForUpdateResult) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException())
+    errorBlockArg(UpdatesDisabledException("check for update"))
   }
 
   public func fetchUpdate(
     success successBlockArg: @escaping (FetchUpdateResult) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException())
+    errorBlockArg(UpdatesDisabledException("fetch update"))
   }
 
   public func getExtraParams(
     success successBlockArg: @escaping ([String: String]?) -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException())
+    errorBlockArg(UpdatesDisabledException("get extra params"))
   }
 
   public func setExtraParam(
@@ -114,7 +114,7 @@ public class DisabledAppController: InternalAppControllerInterface {
     success successBlockArg: @escaping () -> Void,
     error errorBlockArg: @escaping (ExpoModulesCore.Exception) -> Void
   ) {
-    errorBlockArg(UpdatesDisabledException())
+    errorBlockArg(UpdatesDisabledException("set extra params"))
   }
 
   public func getNativeStateMachineContext(

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -54,7 +54,7 @@ internal final class UpdatesUnsupportedDirectiveException: Exception {
 internal final class NotAvailableInDevClientException: Exception {
   private let actionBeingPerformed: String
 
-  public init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+  internal init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
     self.actionBeingPerformed = actionBeingPerformed
     super.init(file: file, line: line, function: function)
   }

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -5,10 +5,10 @@
 import ExpoModulesCore
 
 public final class UpdatesDisabledException: Exception {
-  private let actionBeingPerformed: String
+  private let jsMethodName: String
 
-  public init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
-    self.actionBeingPerformed = actionBeingPerformed
+  public init(_ jsMethodName: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.jsMethodName = jsMethodName
     super.init(file: file, line: line, function: function)
   }
 
@@ -17,7 +17,7 @@ public final class UpdatesDisabledException: Exception {
   }
 
   public override var reason: String {
-    "Cannot \(actionBeingPerformed) when expo-updates is not enabled."
+    "\(jsMethodName) cannot be called when expo-updates is not enabled."
   }
 }
 
@@ -52,10 +52,10 @@ internal final class UpdatesUnsupportedDirectiveException: Exception {
 }
 
 internal final class NotAvailableInDevClientException: Exception {
-  private let actionBeingPerformed: String
+  private let jsMethodName: String
 
-  internal init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
-    self.actionBeingPerformed = actionBeingPerformed
+  internal init(_ jsMethodName: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.jsMethodName = jsMethodName
     super.init(file: file, line: line, function: function)
   }
 
@@ -64,6 +64,6 @@ internal final class NotAvailableInDevClientException: Exception {
   }
 
   override var reason: String {
-    "Cannot \(actionBeingPerformed) in a development client. A non-development build should be used to test this functionality."
+    "\(jsMethodName) cannot be called from a development build. A non-development build should be used to test this functionality."
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -17,7 +17,7 @@ public final class UpdatesDisabledException: Exception {
   }
 
   public override var reason: String {
-    "\(jsMethodName) cannot be called when expo-updates is not enabled."
+    "\(jsMethodName) is not supported when expo-updates is not enabled."
   }
 }
 
@@ -64,6 +64,6 @@ internal final class NotAvailableInDevClientException: Exception {
   }
 
   override var reason: String {
-    "\(jsMethodName) cannot be called from a development build. A non-development build should be used to test this functionality."
+    "\(jsMethodName) is not supported in development builds."
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -5,12 +5,19 @@
 import ExpoModulesCore
 
 public final class UpdatesDisabledException: Exception {
+  private let actionBeingPerformed: String
+
+  public init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.actionBeingPerformed = actionBeingPerformed
+    super.init(file: file, line: line, function: function)
+  }
+
   public override var code: String {
     "ERR_UPDATES_DISABLED"
   }
 
   public override var reason: String {
-    "Cannot call module method when expo-updates is disabled"
+    "Cannot \(actionBeingPerformed) when expo-updates is not enabled."
   }
 }
 
@@ -45,11 +52,18 @@ internal final class UpdatesUnsupportedDirectiveException: Exception {
 }
 
 internal final class NotAvailableInDevClientException: Exception {
+  private let actionBeingPerformed: String
+
+  public init(_ actionBeingPerformed: String, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.actionBeingPerformed = actionBeingPerformed
+    super.init(file: file, line: line, function: function)
+  }
+
   override var code: String {
     "ERR_NOT_AVAILABLE_IN_DEV_CLIENT"
   }
 
   override var reason: String {
-    "This method is not supported in development client builds. A non-development build should be used to test this functionality."
+    "Cannot \(actionBeingPerformed) in a development client. A non-development build should be used to test this functionality."
   }
 }


### PR DESCRIPTION
# Why

These messages should be more descriptive on iOS. They were already better on android since android exceptions are easier to use, but we can do some string interpolation on iOS to achieve the same set of error messages without needing to create a separate exception subclass for each error.

# How

Update messages.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
