### PR TITLE
feat(@expo/config-types): add android intent filters data introduced in API 31

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added new `AndroidIntentFiltersData` introduced in API 31, `pathSuffix` and `pathAdvancedPattern`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added new `AndroidIntentFiltersData` introduced in API 31, `pathSuffix` and `pathAdvancedPattern`.
+- Added new `AndroidIntentFiltersData` introduced in API 31, `pathSuffix` and `pathAdvancedPattern`. ([#26989](https://github.com/expo/expo/pull/26989) by [@NoZiL](https://github.com/NoZiL))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -730,6 +730,15 @@ export interface AndroidIntentFiltersData {
      */
     pathPrefix?: string;
     /**
+     * Suffix for paths that should be matched by the filter, e.g. `/123` will match `/records/123`
+     */
+    pathSuffix?: string;
+    /**
+     * Advanced pattern for paths that should be matched by the filter and supports the following
+     * regex-like patterns, e.g. /records/[0-9] will match `/records/123` but not `/records/new`
+     */
+    pathAdvancedPattern?: string;
+    /**
      * MIME type for URLs that should be matched by the filter
      */
     mimeType?: string;

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -734,6 +734,15 @@ export interface AndroidIntentFiltersData {
    */
   pathPrefix?: string;
   /**
+   * Suffix for paths that should be matched by the filter, e.g. `/123` will match `/records/123`
+   */
+  pathSuffix?: string;
+  /**
+   * Advanced pattern for paths that should be matched by the filter and supports the following
+   * regex-like patterns, e.g. /records/[0-9] will match `/records/123` but not `/records/new`
+   */
+  pathAdvancedPattern?: string;
+  /**
    * MIME type for URLs that should be matched by the filter
    */
   mimeType?: string;


### PR DESCRIPTION
# Why

New `IntentFilters.Data` attributes were introduced in API 31, they are documented [here](https://developer.android.com/guide/topics/manifest/data-element).
It introduces:
- `pathSuffix`
- `pathAdvancedPattern`: a new Regex like way to manage path patterns

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->
I added the types according to the android documentation [here](https://developer.android.com/guide/topics/manifest/data-element).

# Test Plan

I did use this in a build on my personal projects, I don't see how to test it within the expo project, if someone could give me some hints on how to test it 🙏 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
