### PR TITLE
[android] Add application to Home activity modules

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -12,6 +12,7 @@ import com.facebook.react.ReactRootView
 import com.facebook.soloader.SoLoader
 import com.squareup.leakcanary.LeakCanary
 import de.greenrobot.event.EventBus
+import expo.modules.application.ApplicationModule
 import expo.modules.barcodescanner.BarCodeScannerModule
 import expo.modules.barcodescanner.BarCodeScannerPackage
 import expo.modules.blur.BlurModule
@@ -176,7 +177,8 @@ open class HomeActivity : BaseExperienceActivity() {
         SplashScreenModule::class.java,
         TrackingTransparencyModule::class.java,
         StoreReviewModule::class.java,
-        WebBrowserModule::class.java
+        WebBrowserModule::class.java,
+        ApplicationModule::class.java
       )
     }
   }


### PR DESCRIPTION
# Why

Expo Go is intacrasing with the following error 

> Caused by: com.facebook.react.common.JavascriptException: Error: Cannot find native module 'ExpoApplication'

# How

Add Application module to Home activity modules list

# Test Plan

Run Expo Go locally on android, ensure that home works as expected and that it can load apps

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
