### PR TITLE
Update <Slot /> consider safe area

### DIFF
--- a/packages/expo-router/src/views/Navigator.tsx
+++ b/packages/expo-router/src/views/Navigator.tsx
@@ -120,9 +120,11 @@ export function Slot(props: Omit<NavigatorProps, 'children'>) {
   if (context?.contextKey !== contextKey) {
     // Qualify the content and re-export.
     return (
-      <Navigator {...props}>
-        <QualifiedSlot />
-      </Navigator>
+      <SafeAreaView style={{ flex: 1 }}>
+        <Navigator {...props}>
+          <QualifiedSlot />
+        </Navigator>
+      </SafeAreaView>
     );
   }
 


### PR DESCRIPTION
When using layout with slot, manual safe area view is required to be added on screen.

# Why

When using layout with slot safe area is not considered and required to add <SafeAreaView> to screen.

# How

Simply added <SafeAreaView> to slot.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
