### PR TITLE
[docs] Update @babel/plugin-proposal-export-namespace-from in gestures.mdx

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -29,9 +29,9 @@ To install them, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>
 
 <Terminal cmd={['$ npx expo install react-native-gesture-handler react-native-reanimated']} />
 
-Next, also install `@babel/plugin-proposal-export-namespace-from`, which is required to configure the Reanimated library:
+Next, also install `@babel/plugin-transform-export-namespace-from`, which is required to configure the Reanimated library:
 
-<Terminal cmd={['$ npm install -D @babel/plugin-proposal-export-namespace-from ']} />
+<Terminal cmd={['$ npm install -D @babel/plugin-transform-export-namespace-from ']} />
 
 Then, add Reanimated's Babel plugin to **babel.config.js**:
 
@@ -43,7 +43,7 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     /* @info Add the plugins array and inside it, add the plugins.*/
     plugins: [
-      "@babel/plugin-proposal-export-namespace-from",
+      "@babel/plugin-transform-export-namespace-from",
       "react-native-reanimated/plugin",
     ],
     /* @end */


### PR DESCRIPTION
Web bundling failed with @babel/plugin-proposal-export-namespace-from plugin.
```
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
```
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
