### PR TITLE
[docs] Add a note about non-expo modules autolinking

### DIFF
--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -143,6 +143,20 @@ The following config in **package.json** will exclude `expo-random` from autolin
 }
 ```
 
+Note that the above `excludes` option is specifically for excluding expo modules. For excluding the autolinking for any other packages, use the `react-native.config.js` at the root directory of your project:
+
+```js react-native.config.js
+module.exports = {
+  dependencies: {
+    'some-library': {
+      platforms: {
+        android: null,
+      },
+    },
+  },
+};
+```
+
 </APIBox>
 <APIBox platforms={['ios']}>
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -143,12 +143,12 @@ The following config in **package.json** will exclude `expo-random` from autolin
 }
 ```
 
-Note that the above `excludes` option is specifically for excluding expo modules. For excluding the autolinking for any other packages, use the `react-native.config.js` at the root directory of your project:
+Note that the `exclude` option is for excluding the autolinking of Expo packages. To exclude the autolinking for any other packages, create **react-native.config.js** at the root directory of your project and apply the configuration as shown in the example below:
 
 ```js react-native.config.js
 module.exports = {
   dependencies: {
-    'some-library': {
+    'library-name': {
       platforms: {
         android: null,
       },


### PR DESCRIPTION
# Why

From a discussion on [Discord](https://discord.com/channels/695411232856997968/1204711120003137536), a user asked about excluding libraries from autolinking and why the expo excludes config wasn't working.

Turns out, this `excludes` option is _specifically_ for excluding linking expo modules. You can still exclude any other libraries with `react-native.config.js` like normal, but this is not clear from the docs. Even though this docs page is about "expo modules", of you search for "autolinking" and land here, you'd think this is the way to stop autolinking in expo apps.

# How

Added a note about `react-native.config.js`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="762" alt="Screenshot 2024-02-08 at 13 23 53" src="https://github.com/expo/expo/assets/6534400/28b45056-244d-4e40-b6d9-d6bc488e51a4">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
