### PR TITLE
[font] Only include supported font files

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Only include supported font files when using the plugin.
+- Only include supported font files when using the plugin. ([#27002](https://github.com/expo/expo/pull/27002) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Only include supported font files when using the plugin.
+
 ### 💡 Others
 
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-font/plugin/build/utils.js
+++ b/packages/expo-font/plugin/build/utils.js
@@ -16,6 +16,8 @@ async function resolveFontPaths(fonts, projectRoot) {
         }
         return [resolvedPath];
     });
-    return (await Promise.all(promises)).flat();
+    return (await Promise.all(promises))
+        .flat()
+        .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf'));
 }
 exports.resolveFontPaths = resolveFontPaths;

--- a/packages/expo-font/plugin/build/withFontsAndroid.js
+++ b/packages/expo-font/plugin/build/withFontsAndroid.js
@@ -17,7 +17,9 @@ const withFontsAndroid = (config, fonts) => {
                 const fontsDir = path_1.default.join(config.modRequest.platformProjectRoot, 'app/src/main/assets/fonts');
                 await promises_1.default.mkdir(fontsDir, { recursive: true });
                 const output = path_1.default.join(fontsDir, path_1.default.basename(asset));
-                await promises_1.default.copyFile(asset, output);
+                if (output.endsWith('.ttf') || output.endsWith('.otf')) {
+                    await promises_1.default.copyFile(asset, output);
+                }
             }));
             return config;
         },

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -12,5 +12,7 @@ export async function resolveFontPaths(fonts: string[], projectRoot: string) {
     }
     return [resolvedPath];
   });
-  return (await Promise.all(promises)).flat();
+  return (await Promise.all(promises))
+    .flat()
+    .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf'));
 }

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -17,7 +17,9 @@ export const withFontsAndroid: ConfigPlugin<string[]> = (config, fonts) => {
           );
           await fs.mkdir(fontsDir, { recursive: true });
           const output = path.join(fontsDir, path.basename(asset));
-          await fs.copyFile(asset, output);
+          if (output.endsWith('.ttf') || output.endsWith('.otf')) {
+            await fs.copyFile(asset, output);
+          }
         })
       );
       return config;


### PR DESCRIPTION
# Why
When using a directory path the font plugin would add every file in the directory to the native project. It should only add supported font files.

# How
Filter the file paths to only include files ending in `.ttf` and `.otf` extensions.

# Test Plan
Tested in local project. 
