### PR TITLE
[video][Android] Add borders support

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### 🎉 New features
 
-- [Android] Adds support for boarders. ([#27003](https://github.com/expo/expo/pull/27003) by [@lukmccall](https://github.com/lukmccall))
-
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Adds support for boarders. ([#27003](https://github.com/expo/expo/pull/27003) by [@lukmccall](https://github.com/lukmccall))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Android] Add fullscreen support. ([#26159](https://github.com/expo/expo/pull/26159) by [@behenate](https://github.com/behenate))
 - [web] Add volume ([#26137](https://github.com/expo/expo/pull/26137) by [@behenate](https://github.com/behenate))
 - Initial release for Android 🎉 ([#26033](https://github.com/expo/expo/pull/26033) by [@behenate](https://github.com/behenate))
+- [Android] Adds support for boarders. ([#27003](https://github.com/expo/expo/pull/27003) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -106,7 +106,9 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation project(path: ':expo-modules-core')
 
-  def exoPlayerVersion = "1.2.0"
+  implementation 'com.facebook.react:react-android'
+
+  def exoPlayerVersion = "1.2.1"
   implementation "androidx.media3:media3-exoplayer:${exoPlayerVersion}"
   implementation "androidx.media3:media3-exoplayer-dash:${exoPlayerVersion}"
   implementation "androidx.media3:media3-ui:${exoPlayerVersion}"

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -14,7 +14,10 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
 @UnstableApi
 class VideoPlayer(context: Context, private val mediaItem: MediaItem) : AutoCloseable, SharedObject() {
-  val player = ExoPlayer.Builder(context).setLooper(context.mainLooper).build()
+  val player = ExoPlayer
+    .Builder(context)
+    .setLooper(context.mainLooper)
+    .build()
 
   // We duplicate some properties of the player, because we don't want to always use the mainQueue to access them.
   var isPlaying = false

--- a/packages/expo-video/android/src/main/java/expo/modules/video/YogaUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/YogaUtils.kt
@@ -1,0 +1,20 @@
+package expo.modules.video
+
+import com.facebook.yoga.YogaConstants
+
+fun Float.ifYogaUndefinedUse(value: Float) =
+  if (YogaConstants.isUndefined(this)) {
+    value
+  } else {
+    this
+  }
+
+inline fun Float.ifYogaDefinedUse(transformFun: (current: Float) -> Float) =
+  if (YogaConstants.isUndefined(this)) {
+    this
+  } else {
+    transformFun(this)
+  }
+
+fun makeYogaUndefinedIfNegative(value: Float) =
+  if (!YogaConstants.isUndefined(value) && value < 0) YogaConstants.UNDEFINED else value

--- a/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
@@ -1,0 +1,212 @@
+package expo.modules.video.drawing
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Outline
+import android.graphics.Path
+import android.graphics.RectF
+import android.view.View
+import android.view.ViewOutlineProvider
+import com.facebook.react.modules.i18nmanager.I18nUtil
+import com.facebook.react.uimanager.FloatUtil
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.yoga.YogaConstants
+import expo.modules.video.ifYogaUndefinedUse
+
+class OutlineProvider(private val mContext: Context) : ViewOutlineProvider() {
+  enum class BorderRadiusConfig {
+    ALL,
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_RIGHT,
+    BOTTOM_LEFT,
+    TOP_START,
+    TOP_END,
+    BOTTOM_START,
+    BOTTOM_END
+  }
+
+  enum class CornerRadius {
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_RIGHT,
+    BOTTOM_LEFT
+  }
+
+  private var mLayoutDirection = View.LAYOUT_DIRECTION_LTR
+  private val mBounds = RectF()
+  val borderRadiiConfig = FloatArray(9) { YogaConstants.UNDEFINED }
+  private val mCornerRadii = FloatArray(4)
+  private var mCornerRadiiInvalidated = true
+  private val mConvexPath = Path()
+  private var mConvexPathInvalidated = true
+
+  init {
+    updateCornerRadiiIfNeeded()
+  }
+
+  private fun updateCornerRadiiIfNeeded() {
+    if (!mCornerRadiiInvalidated) {
+      return
+    }
+
+    val isRTL = mLayoutDirection == View.LAYOUT_DIRECTION_RTL
+    val isRTLSwap = I18nUtil.getInstance().doLeftAndRightSwapInRTL(mContext)
+    updateCornerRadius(
+      CornerRadius.TOP_LEFT,
+      BorderRadiusConfig.TOP_LEFT,
+      BorderRadiusConfig.TOP_RIGHT,
+      BorderRadiusConfig.TOP_START,
+      BorderRadiusConfig.TOP_END,
+      isRTL,
+      isRTLSwap
+    )
+    updateCornerRadius(
+      CornerRadius.TOP_RIGHT,
+      BorderRadiusConfig.TOP_RIGHT,
+      BorderRadiusConfig.TOP_LEFT,
+      BorderRadiusConfig.TOP_END,
+      BorderRadiusConfig.TOP_START,
+      isRTL,
+      isRTLSwap
+    )
+    updateCornerRadius(
+      CornerRadius.BOTTOM_LEFT,
+      BorderRadiusConfig.BOTTOM_LEFT,
+      BorderRadiusConfig.BOTTOM_RIGHT,
+      BorderRadiusConfig.BOTTOM_START,
+      BorderRadiusConfig.BOTTOM_END,
+      isRTL,
+      isRTLSwap
+    )
+    updateCornerRadius(
+      CornerRadius.BOTTOM_RIGHT,
+      BorderRadiusConfig.BOTTOM_RIGHT,
+      BorderRadiusConfig.BOTTOM_LEFT,
+      BorderRadiusConfig.BOTTOM_END,
+      BorderRadiusConfig.BOTTOM_START,
+      isRTL,
+      isRTLSwap
+    )
+    mCornerRadiiInvalidated = false
+    mConvexPathInvalidated = true
+  }
+
+  private fun updateCornerRadius(
+    outputPosition: CornerRadius,
+    inputPosition: BorderRadiusConfig,
+    oppositePosition: BorderRadiusConfig,
+    startPosition: BorderRadiusConfig,
+    endPosition: BorderRadiusConfig,
+    isRTL: Boolean,
+    isRTLSwap: Boolean
+  ) {
+    var radius = borderRadiiConfig[inputPosition.ordinal]
+    if (isRTL) {
+      if (isRTLSwap) {
+        radius = borderRadiiConfig[oppositePosition.ordinal]
+      }
+      if (YogaConstants.isUndefined(radius)) {
+        radius = borderRadiiConfig[endPosition.ordinal]
+      }
+    } else {
+      if (YogaConstants.isUndefined(radius)) {
+        radius = borderRadiiConfig[startPosition.ordinal]
+      }
+    }
+    radius = radius
+      .ifYogaUndefinedUse(borderRadiiConfig[BorderRadiusConfig.ALL.ordinal])
+      .ifYogaUndefinedUse(0f)
+    mCornerRadii[outputPosition.ordinal] = PixelUtil.toPixelFromDIP(radius)
+  }
+
+  private fun updateConvexPathIfNeeded() {
+    if (!mConvexPathInvalidated) {
+      return
+    }
+    mConvexPath.reset()
+    mConvexPath.addRoundRect(
+      mBounds,
+      floatArrayOf(
+        mCornerRadii[CornerRadius.TOP_LEFT.ordinal],
+        mCornerRadii[CornerRadius.TOP_LEFT.ordinal],
+        mCornerRadii[CornerRadius.TOP_RIGHT.ordinal],
+        mCornerRadii[CornerRadius.TOP_RIGHT.ordinal],
+        mCornerRadii[CornerRadius.BOTTOM_RIGHT.ordinal],
+        mCornerRadii[CornerRadius.BOTTOM_RIGHT.ordinal],
+        mCornerRadii[CornerRadius.BOTTOM_LEFT.ordinal],
+        mCornerRadii[CornerRadius.BOTTOM_LEFT.ordinal]
+      ),
+      Path.Direction.CW
+    )
+    mConvexPathInvalidated = false
+  }
+
+  fun hasEqualCorners(): Boolean {
+    updateCornerRadiiIfNeeded()
+    val initialCornerRadius = mCornerRadii[0]
+    return mCornerRadii.all { initialCornerRadius == it }
+  }
+
+  fun setBorderRadius(radius: Float, position: Int): Boolean {
+    if (!FloatUtil.floatsEqual(borderRadiiConfig[position], radius)) {
+      borderRadiiConfig[position] = radius
+      mCornerRadiiInvalidated = true
+      return true
+    }
+    return false
+  }
+
+  private fun updateBoundsAndLayoutDirection(view: View) {
+    // Update layout direction
+    val layoutDirection = view.layoutDirection
+    if (mLayoutDirection != layoutDirection) {
+      mLayoutDirection = layoutDirection
+      mCornerRadiiInvalidated = true
+    }
+
+    // Update size
+    val left = 0
+    val top = 0
+    val right = view.width
+    val bottom = view.height
+    if (mBounds.left != left.toFloat() ||
+      mBounds.top != top.toFloat() ||
+      mBounds.right != right.toFloat() ||
+      mBounds.bottom != bottom.toFloat()
+    ) {
+      mBounds[left.toFloat(), top.toFloat(), right.toFloat()] = bottom.toFloat()
+      mCornerRadiiInvalidated = true
+    }
+  }
+
+  override fun getOutline(view: View, outline: Outline) {
+    updateBoundsAndLayoutDirection(view)
+
+    // Calculate outline
+    updateCornerRadiiIfNeeded()
+    if (hasEqualCorners()) {
+      val cornerRadius = mCornerRadii[0]
+      if (cornerRadius > 0) {
+        outline.setRoundRect(0, 0, mBounds.width().toInt(), mBounds.height().toInt(), cornerRadius)
+      } else {
+        outline.setRect(0, 0, mBounds.width().toInt(), mBounds.height().toInt())
+      }
+    } else {
+      // Clipping is not supported when using a convex path, but drawing the elevation
+      // shadow is. For the particular case, we fallback to canvas clipping in the view
+      // which is supposed to call `clipCanvasIfNeeded` in its `draw` method.
+      updateConvexPathIfNeeded()
+      outline.setConvexPath(mConvexPath)
+    }
+  }
+
+  fun clipCanvasIfNeeded(canvas: Canvas, view: View) {
+    updateBoundsAndLayoutDirection(view)
+    updateCornerRadiiIfNeeded()
+    if (!hasEqualCorners()) {
+      updateConvexPathIfNeeded()
+      canvas.clipPath(mConvexPath)
+    }
+  }
+}


### PR DESCRIPTION
# Why

Adds support for border-related pros. Borders are supported on iOS out of the box, but they are not on Android.  

# How

Add a similar implementation to one from `expo-image`. There was one significant difference: we didn't have to turn off the view optimization in the' expo-image' case. GPU handles the video view, and it's not rendered in the `onDraw` function. So, for the operation system, our view is fully transparent and doesn't have to be redrawn. I've only turned off that option when borders were defined. 

# Test Plan

- NCL ✅