### PR TITLE
[prebuild-config] update test snapshot

### DIFF
--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -445,12 +445,6 @@ exports[`built-in plugins compiles mods 1`] = `
       "NSAppTransportSecurity": {
         "NSAllowsArbitraryLoads": false,
         "NSAllowsLocalNetworking": true,
-        "NSExceptionDomains": {
-          "exp.direct": {
-            "NSExceptionAllowsInsecureHTTPLoads": true,
-            "NSIncludesSubdomains": true,
-          },
-        },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
       "UILaunchStoryboardName": "SplashScreen",
@@ -1268,12 +1262,6 @@ exports[`built-in plugins introspects mods 1`] = `
           "NSAppTransportSecurity": {
             "NSAllowsArbitraryLoads": false,
             "NSAllowsLocalNetworking": true,
-            "NSExceptionDomains": {
-              "exp.direct": {
-                "NSExceptionAllowsInsecureHTTPLoads": true,
-                "NSIncludesSubdomains": true,
-              },
-            },
           },
           "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
           "UILaunchStoryboardName": "SplashScreen",
@@ -1740,12 +1728,6 @@ exports[`built-in plugins introspects mods 1`] = `
       "NSAppTransportSecurity": {
         "NSAllowsArbitraryLoads": false,
         "NSAllowsLocalNetworking": true,
-        "NSExceptionDomains": {
-          "exp.direct": {
-            "NSExceptionAllowsInsecureHTTPLoads": true,
-            "NSIncludesSubdomains": true,
-          },
-        },
       },
       "NSLocationWhenInUseUsageDescription": "Allow $(PRODUCT_NAME) to access your location",
       "UILaunchStoryboardName": "SplashScreen",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17505,14 +17505,7 @@ semver@7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@7.5.3:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
-  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@7.x, semver@^7.0.0, semver@^7.3.4, semver@^7.3.5, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3:
+semver@7.5.4, semver@7.x, semver@^7.0.0, semver@^7.3.4, semver@^7.3.5, semver@^7.5.0, semver@^7.5.2:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -17523,6 +17516,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semve
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.4:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~7.3.2:
   version "7.3.7"


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/runs/21365567334

# How

Update outdated `@expo/prebuild-config` test snapshot.

# Test Plan

No errors/warnings when running `et cp`.
