### PR TITLE
[docs] New expo-updates assets:verify CLI command

### DIFF
--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -37,9 +37,9 @@ When using this feature, assets that do not match any file patterns will resolve
 
 If you are building your app locally or have access to the correct build for publishing updates (with the same [runtime version](/eas-update/runtime-versions/)), then you can use the `npx expo-updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
 
-> **info** This new command is part of the `expo-updates` CLI, which also supports [EAS Update code signing](/eas-update/code-signing/). It is not part of the [Expo CLI](/more/expo-cli/). It is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
-
 <Terminal cmd={['$ npx expo-updates assets:verify <dir>']} />
+> **info** This new command is part of the `expo-updates` CLI, which also supports [EAS Update code signing](/eas-update/code-signing/). It is not part of the [Expo CLI](/more/expo-cli/) or the [EAS CLI](https://github.com/expo/eas-cli). It is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
+
 
 You can also use `--help` with the command to see the available options:
 

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -6,6 +6,7 @@ hideTOC: true
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
@@ -30,11 +31,13 @@ In this case, all **.png** files in all subdirectories of **app/images** will be
 
 If this new property is not in your app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
 
-## Verifying an update includes all required app assets
+## Verifying that an update includes all required app assets
 
 When using this feature, assets that do not match any file patterns will resolve in the Metro bundler. However, these assets will not be uploaded to the updates server. You have to be certain that assets not included in updates are built into the native build of the app.
 
-If you are building your app locally or have access to the correct build for publishing updates (with the same **runtimeVersion**), then you can use the `npx expo updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
+If you are building your app locally or have access to the correct build for publishing updates (with the same [runtime version](/eas-update/runtime-versions/)), then you can use the `npx expo-updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
+
+> **info** This new command is part of the `expo-updates` CLI, which also supports [EAS Update code signing](/eas-update/code-signing/). It is not part of the [Expo CLI](/more/expo-cli/). It is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
 
 <Terminal cmd={['$ npx expo-updates assets:verify <dir>']} />
 
@@ -49,8 +52,6 @@ Options
   -p, --platform <platform>              Options: ["android","ios"]
   -h, --help                             Usage info
 ```
-
-> **info** The CLI command is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
 
 ## Example
 

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -28,15 +28,40 @@ To use this feature, include the new property `extra.updates.assetPatternsToBeBu
 
 In this case, all **.png** files in all subdirectories of **app/images** will be included in updates.
 
-Assets that do not match any of the file patterns will still resolve in the Metro bundler, but will not be uploaded to the updates server. If making use of this feature, a developer needs to be certain that assets not included in updates are built into the native build of the app.
-
 If this new property is not in your app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
+
+### Ensuring that an update contains all assets needed by your application
+
+When using this feature, assets that do not match any of the file patterns will still resolve in the Metro bundler, but will not be uploaded to the updates server. A developer needs to be certain that assets not included in updates are built into the native build of the app.
+
+If you are building your app locally, or have access to the correct build that you are publishing updates for (with the same **runtimeVersion**), then the **expo-updates** CLI contains a command, **assets:verify**, that will allow you to check whether all required assets will be included when you publish an update:
+
+```bash assets:verify help
+$ npx expo-updates assets:verify --help
+
+Description
+Verify that all static files in an exported bundle are in either the export or an embedded bundle
+
+Usage
+  $ npx expo-updates assets:verify <dir>
+
+  Options
+  <dir>                                  Directory of the Expo project. Default: Current working directory
+  -a, --asset-map-path <path>            Path to the `assetmap.json` in an export produced by the command `npx expo export --dump-assetmap`
+  -e, --exported-manifest-path <path>    Path to the `metadata.json` in an export produced by the command `npx expo export --dump-assetmap`
+  -b, --build-manifest-path <path>       Path to the `app.manifest` file created by expo-updates in an Expo application build (either ios or android)
+  -p, --platform <platform>              Options: ["android","ios"]
+  -h, --help                             Usage info
+
+```
+
+> **info** The CLI command is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
 
 ## Example
 
 <BoxLink
   title="Working example"
-  description="See a working example on using asset selection and other EAS update features."
+  description="See a working example on using asset selection, the assets:verify CLI command, and other EAS update features."
   Icon={GithubIcon}
   href="https://github.com/expo/UpdatesAPIDemo"
 />

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -30,29 +30,24 @@ In this case, all **.png** files in all subdirectories of **app/images** will be
 
 If this new property is not in your app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
 
-### Ensuring that an update contains all assets needed by your application
+## Verifying an update includes all required app assets
 
-When using this feature, assets that do not match any of the file patterns will still resolve in the Metro bundler, but will not be uploaded to the updates server. A developer needs to be certain that assets not included in updates are built into the native build of the app.
+When using this feature, assets that do not match any file patterns will resolve in the Metro bundler. However, these assets will not be uploaded to the updates server. You have to be certain that assets not included in updates are built into the native build of the app.
 
-If you are building your app locally, or have access to the correct build that you are publishing updates for (with the same **runtimeVersion**), then the **expo-updates** CLI contains a command, **assets:verify**, that will allow you to check whether all required assets will be included when you publish an update:
+If you are building your app locally or have access to the correct build for publishing updates (with the same **runtimeVersion**), then you can use the `npx expo updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
 
-```bash assets:verify help
-$ npx expo-updates assets:verify --help
+<Terminal cmd={['$ npx expo-updates assets:verify <dir>']} />
 
-Description
-Verify that all static files in an exported bundle are in either the export or an embedded bundle
+You can also use `--help` with the command to see the available options:
 
-Usage
-  $ npx expo-updates assets:verify <dir>
-
-  Options
+```sh
+Options
   <dir>                                  Directory of the Expo project. Default: Current working directory
   -a, --asset-map-path <path>            Path to the `assetmap.json` in an export produced by the command `npx expo export --dump-assetmap`
   -e, --exported-manifest-path <path>    Path to the `metadata.json` in an export produced by the command `npx expo export --dump-assetmap`
   -b, --build-manifest-path <path>       Path to the `app.manifest` file created by expo-updates in an Expo application build (either ios or android)
   -p, --platform <platform>              Options: ["android","ios"]
   -h, --help                             Usage info
-
 ```
 
 > **info** The CLI command is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).


### PR DESCRIPTION
# Why

Document the new command `npx expo-updates assets:verify` for checking correct usage of asset selection.

# How

- Update existing doc
- UpdatesAPIDemo now has working example of command usage

# Test Plan

- Docs CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
