### PR TITLE
[dev-launcher][android] Replace DevLoadingModule with custom implementation

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix react-native hot reload causing app to crash on Android. ([#27010](https://github.com/expo/expo/pull/27010) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ### 📚 3rd party library updates

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevLoadingModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevLoadingModule.kt
@@ -1,0 +1,35 @@
+package expo.modules.devlauncher.modules
+
+import com.facebook.fbreact.specs.NativeDevLoadingViewSpec
+import com.facebook.react.bridge.JSExceptionHandler
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation
+import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
+import com.facebook.react.module.annotations.ReactModule
+import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
+
+
+// Based on https://github.com/facebook/react-native/blob/0.72-stable/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
+@ReactModule(name = NativeDevLoadingViewSpec.NAME)
+class DevLauncherDevLoadingModule(reactContext: ReactApplicationContext) : NativeDevLoadingViewSpec(reactContext) {
+  private val mJSExceptionHandler: JSExceptionHandler?
+  private var mDevLoadingViewManager: DevLoadingViewManager? = null
+
+  init {
+    mJSExceptionHandler = reactContext.jsExceptionHandler
+    if (mJSExceptionHandler != null && mJSExceptionHandler is DevLauncherDevSupportManager) {
+      mDevLoadingViewManager = DefaultDevLoadingViewImplementation((mJSExceptionHandler as DevLauncherDevSupportManager).reactInstanceManagerHelper)
+    }
+  }
+
+  override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
+    UiThreadUtil.runOnUiThread { mDevLoadingViewManager?.showMessage(message) }
+  }
+
+  override fun hide() {
+    UiThreadUtil.runOnUiThread {
+      mDevLoadingViewManager?.hide()
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevLoadingModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherDevLoadingModule.kt
@@ -3,16 +3,16 @@ package expo.modules.devlauncher.modules
 import com.facebook.fbreact.specs.NativeDevLoadingViewSpec
 import com.facebook.react.bridge.JSExceptionHandler
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.modules.devloading.DevLoadingModule
 import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
 
 
 // Based on https://github.com/facebook/react-native/blob/0.72-stable/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.java
 @ReactModule(name = NativeDevLoadingViewSpec.NAME)
-class DevLauncherDevLoadingModule(reactContext: ReactApplicationContext) : NativeDevLoadingViewSpec(reactContext) {
+class DevLauncherDevLoadingModule(reactContext: ReactApplicationContext) : DevLoadingModule(reactContext) {
   private val mJSExceptionHandler: JSExceptionHandler?
   private var mDevLoadingViewManager: DevLoadingViewManager? = null
 
@@ -20,16 +20,6 @@ class DevLauncherDevLoadingModule(reactContext: ReactApplicationContext) : Nativ
     mJSExceptionHandler = reactContext.jsExceptionHandler
     if (mJSExceptionHandler != null && mJSExceptionHandler is DevLauncherDevSupportManager) {
       mDevLoadingViewManager = DefaultDevLoadingViewImplementation((mJSExceptionHandler as DevLauncherDevSupportManager).reactInstanceManagerHelper)
-    }
-  }
-
-  override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
-    UiThreadUtil.runOnUiThread { mDevLoadingViewManager?.showMessage(message) }
-  }
-
-  override fun hide() {
-    UiThreadUtil.runOnUiThread {
-      mDevLoadingViewManager?.hide()
     }
   }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/25520
Closes ENG-11348

In react-native 0.72.7 the `DevLoadingModule` module was enabled but the logic used in its constructor checks specifically for an instance of `BridgeDevSupportManager` to initialize `mDevLoadingViewManager` and given that DevLauncher uses a custom bridge support manager this check fails and `mDevLoadingViewManager` is never initialized, causing a crash when the HMR client invokes it from the JS side.

# How

Swap out react-native DevLoadingModule with a custom implementation that uses the correct checks for initializing 
`mDevLoadingViewManager` 

# Test Plan

Run dev-client through BareExpo and ensure hot reloading works 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
