### PR TITLE
[module-template] Replace babel module resolver with extraNodeModules in Metro config

### DIFF
--- a/packages/expo-module-template/example/babel.config.js
+++ b/packages/expo-module-template/example/babel.config.js
@@ -1,19 +1,6 @@
-const path = require('path');
 module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [
-      [
-        'module-resolver',
-        {
-          extensions: ['.tsx', '.ts', '.js', '.json'],
-          alias: {
-            // For development, we want to alias the library to the source
-            '<%- project.slug %>': path.join(__dirname, '..', 'src', 'index.ts'),
-          },
-        },
-      ],
-    ],
   };
 };

--- a/packages/expo-module-template/example/metro.config.js
+++ b/packages/expo-module-template/example/metro.config.js
@@ -18,6 +18,10 @@ config.resolver.nodeModulesPaths = [
   path.resolve(__dirname, '../node_modules'),
 ];
 
+config.resolver.extraNodeModules = {
+  '<%- project.slug %>': '..',
+};
+
 config.watchFolders = [path.resolve(__dirname, '..')];
 
 config.transformer.getTransformOptions = async () => ({


### PR DESCRIPTION
# Why

Our current approach to replace imports to the module from the example app uses `babel-plugin-module-resolver`. Currently it fails because the module resolver cannot be found (not sure what broke that).

# How

I think a better approach would be to use `resolver.extraNodeModules` in the Metro config instead. Then we don't need any additional dependency.

# Test Plan

Used the script locally using this template, the example app works as expected.