### PR TITLE
[tools] Add SDK tag when publishing from the release branch

### DIFF
--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -11,6 +11,7 @@ import { TaskRunner, Task, TasksRunnerBackup } from '../TasksRunner';
 import { PackagesGraph } from '../packages-graph';
 import { BACKUP_PATH, BACKUP_EXPIRATION_TIME } from '../publish-packages/constants';
 import { pickBackupableOptions, shouldUseBackupAsync } from '../publish-packages/helpers';
+import { assignTagForSdkRelease } from '../publish-packages/tasks/assignTagForSdkRelease';
 import { checkPackagesIntegrity } from '../publish-packages/tasks/checkPackagesIntegrity';
 import { grantTeamAccessToPackages } from '../publish-packages/tasks/grantTeamAccessToPackages';
 import { listUnpublished } from '../publish-packages/tasks/listUnpublished';
@@ -63,6 +64,11 @@ export default (program: Command) => {
     .option(
       '-c, --check-integrity',
       'Checks integrity of packages. These checks must pass to clearly identify changes that have been made since previous publish.',
+      false
+    )
+    .option(
+      '--assign-sdk-tag',
+      'Assigns the SDK tag to packages when run on the release branch.',
       false
     )
     .option('-C, --canary', 'Whether to publish all packages as canary versions.', false)
@@ -207,6 +213,9 @@ function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
   }
   if (options.checkIntegrity) {
     return [checkPackagesIntegrity];
+  }
+  if (options.assignSdkTag) {
+    return [assignTagForSdkRelease];
   }
   if (options.canary) {
     return [publishCanaryPipeline];

--- a/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
+++ b/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
@@ -1,0 +1,70 @@
+import chalk from 'chalk';
+
+import { loadRequestedParcels } from './loadRequestedParcels';
+import Git from '../../Git';
+import logger from '../../Logger';
+import * as Npm from '../../Npm';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+
+const { green, yellow } = chalk;
+
+/**
+ * Assigns the SDK tag to packages when run on the release branch.
+ */
+export const assignTagForSdkRelease = new Task<TaskArgs>(
+  {
+    name: 'assignTagForSdkRelease',
+    dependsOn: [loadRequestedParcels],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    const sdkTag = await findSdkTag();
+
+    // Skip the task when not on the SDK branch.
+    if (!sdkTag) {
+      if (options.assignSdkTag) {
+        logger.warn('SDK tag can be assigned only from the release branch.');
+      }
+      return;
+    }
+
+    await runWithSpinner(
+      `Assigning ${yellow.bold(sdkTag)} tag to packages`,
+      async (step) => {
+        for (const { pkg, pkgView } of parcels) {
+          if (isPackageViewMatchingTag(pkgView, sdkTag)) {
+            // Current version of the package is already tagged.
+            continue;
+          }
+          step.start(`Assigning ${yellow.bold(sdkTag)} tag to ${green(pkg.packageName)}`);
+
+          if (!options.dry) {
+            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag);
+          }
+        }
+      },
+      `Successfully assigned ${yellow.bold(sdkTag)} tag`
+    );
+  }
+);
+
+/**
+ * Returns a boolean value whether the package view matches the given tag.
+ */
+function isPackageViewMatchingTag(pkgView: Npm.PackageViewType, tag: string): boolean {
+  const tags = pkgView?.['dist-tags'] ?? {};
+  return tags[tag] === pkgView?.version;
+}
+
+/**
+ * Returns the SDK tag (e.g. `sdk-50`) when run on the release branch or `null` otherwise.
+ */
+async function findSdkTag(): Promise<string | null> {
+  const branchName = await Git.getCurrentBranchNameAsync();
+
+  if (/^sdk-\d+$/.test(branchName)) {
+    return branchName;
+  }
+  return null;
+}

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -33,10 +33,15 @@ export const publishPackages = new Task<TaskArgs>(
 
     for (const { pkg, state } of parcels) {
       const packageJsonPath = path.join(pkg.path, 'package.json');
+      const releaseVersion = state.releaseVersion;
+
+      if (!releaseVersion) {
+        continue;
+      }
 
       logger.log(
         '  ',
-        `${green(pkg.packageName)} version ${cyan(state.releaseVersion!)} as ${yellow(options.tag)}`
+        `${green(pkg.packageName)} version ${cyan(releaseVersion)} as ${yellow(options.tag)}`
       );
 
       // If there is a tarball already built, use it instead of packing it again
@@ -58,6 +63,9 @@ export const publishPackages = new Task<TaskArgs>(
 
       // Delete `gitHead` from `package.json` – no need to clutter it.
       await JsonFile.deleteKeyAsync(packageJsonPath, 'gitHead');
+
+      // Update stored package.json
+      pkg.packageJson.version = releaseVersion;
 
       state.published = true;
     }

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -24,6 +24,7 @@ export type CommandOptions = {
   listUnpublished: boolean;
   grantAccess: boolean;
   checkIntegrity: boolean;
+  assignSdkTag: boolean;
 };
 
 /**


### PR DESCRIPTION
# Why

I found it useful to know from the npm page which version is dedicated for the specific SDK version. This is also needed for #26934 to work properly.

# How

Added another task in the publish script that assigns the `sdk-X` tag when publishing from the release branch.

There is also a new `--assign-sdk-tag` flag that runs only this task, without publishing – this is what I used for testing on `sdk-50` branch and I'll do the same on `sdk-49` after merging.

# Test Plan

I switched to `sdk-50` branch, cherry-picked this commit and ran `et publish --assign-sdk-tag` to add the `sdk-50` tag to versions on that branch.