### PR TITLE
fix: bump json5 dependency

### DIFF
--- a/packages/@expo/json-file/CHANGELOG.md
+++ b/packages/@expo/json-file/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump JSON5 dependency ([#27026](https://github.com/expo/expo/pull/27026)) to fix [CVE-2022-46175](https://github.com/advisories/GHSA-9c47-m6qq-7p4h) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 ## 8.3.3 — 2024-04-23

--- a/packages/@expo/json-file/package.json
+++ b/packages/@expo/json-file/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "@babel/code-frame": "~7.10.4",
-    "json5": "^2.2.2",
+    "json5": "^2.2.3",
     "write-file-atomic": "^2.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11269,7 +11269,7 @@ json-to-pretty-yaml@^1.2.2:
     remedial "^1.0.7"
     remove-trailing-spaces "^1.0.6"
 
-json5@*, json5@^2.1.1, json5@^2.2.2, json5@^2.2.3:
+json5@*, json5@^2.1.1, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
# Why

Fixes CVE-2022-46175

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
