### PR TITLE
[CI] Update runners and Xcode for testing nightlies

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -22,12 +22,12 @@ jobs:
       fail-fast: true
       matrix:
         build-type: [debug, release]
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
-      - name: 🔨 Switch to Xcode 14.3
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.app
+      - name: 🔨 Switch to Xcode 15.2
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -20,14 +20,14 @@ concurrency:
 
 jobs:
   ios-build:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 14.3
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.app
+      - name: 🔨 Switch to Xcode 15.2
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -79,12 +79,14 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 15.2
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds


### PR DESCRIPTION
# Why

Checks for RN nightlies are failing for a few reasons (I guess). I'm not sure if I can fix them all because they kinda accumulated over time. This PR aims to solve two:

In this job run: https://github.com/expo/expo/actions/runs/7854131101/job/21434553353
> Uncaught Error Error: Device not found: iPhone 15

In this job run: https://github.com/expo/expo/actions/runs/7852202962/job/21430293067
> ❌  /Users/runner/work/expo/expo/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift:38:11: type 'EKAuthorizationStatus' has no member 'fullAccess'

# How

Upgrading macOS and Xcode solves both

# Test Plan

Jobs running on RN nightlies are still failing, but at least they go further than before 😅 