### PR TITLE
[updates] try to fix updates e2e test error

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Fix case where launch wait ms timeout is greater than okhttp default timeout. ([#26731](https://github.com/expo/expo/pull/26731) by [@wschurman](https://github.com/wschurman))
 - Fix assets:verify command for images with multiple scales. ([#26940](https://github.com/expo/expo/pull/26940) by [@douglowder](https://github.com/douglowder))
 - Make error messages consistent across platforms for dev client and disabled controllers. ([#26988](https://github.com/expo/expo/pull/26988) by [@wschurman](https://github.com/wschurman))
+- Fixed ANR issue from Detox testing on Android. ([#27031](https://github.com/expo/expo/pull/27031) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -64,7 +64,7 @@ class RemoteLoaderTest {
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
     every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(3)
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,
@@ -76,7 +76,7 @@ class RemoteLoaderTest {
 
     every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(4)
+      val callback = arg<AssetDownloadCallback>(3)
       callback.onSuccess(asset, true)
     }
 
@@ -103,7 +103,7 @@ class RemoteLoaderTest {
   fun testRemoteLoader_FailureToDownloadAssets() {
     every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(4)
+      val callback = arg<AssetDownloadCallback>(3)
       callback.onFailure(IOException("mock failed to download asset"), asset)
     }
 
@@ -257,7 +257,7 @@ class RemoteLoaderTest {
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
     every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(3)
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,
@@ -282,7 +282,7 @@ class RemoteLoaderTest {
   fun testRemoteLoader_RollBackDirective() {
     val updateDirective = UpdateDirective.RollBackToEmbeddedUpdateDirective(commitTime = Date(), signingInfo = null)
     every { mockFileDownloader.downloadRemoteUpdate(any(), any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(3)
+      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(2)
       callback.onSuccess(
         UpdateResponse(
           responseHeaderData = null,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -99,8 +99,9 @@ class UpdatesPackage : Package {
     val handler = object : ApplicationLifecycleListener {
       override fun onCreate(application: Application) {
         super.onCreate(application)
-        if (isRunningAndroidTest()) {
+        if (shouldAutoSetup(context) && isRunningAndroidTest()) {
           // Preload updates to prevent Detox ANR
+          UpdatesController.initialize(context)
           UpdatesController.instance.launchAssetFile
         }
       }


### PR DESCRIPTION
# Why

updates e2e tests are broken https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/ee1a090b-f346-443e-a067-875fa95cb7db because of detox ANR detector

```
05:26:47.483 detox[8585] i Application nonresponsiveness detected!
On Android, this could imply an ANR alert, which evidently causes tests to fail.
Here's the native main-thread stacktrace from the device, to help you out (refer to device logs for the complete thread dump):
com.github.anrwatchdog.ANRError: Application Not Responding for at least 5000 ms.
Caused by: com.github.anrwatchdog.ANRError$$$_Thread: main (state = WAITING)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:442)
	at java.lang.Object.wait(Object.java:568)
	at expo.modules.updates.EnabledUpdatesController.getLaunchAssetFile(EnabledUpdatesController.kt:126)
	at expo.modules.updates.UpdatesPackage$createReactNativeHostHandlers$handler$1.getJSBundleFile(UpdatesPackage.kt:32)
	at expo.modules.ReactNativeHostWrapperBase$getJSBundleFile$1.invoke(ReactNativeHostWrapperBase.kt:52)
	at expo.modules.ReactNativeHostWrapperBase$getJSBundleFile$1.invoke(ReactNativeHostWrapperBase.kt:52)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.SequencesKt___SequencesKt.firstOrNull(_Sequences.kt:168)
	at expo.modules.ReactNativeHostWrapperBase.getJSBundleFile(ReactNativeHostWrapperBase.kt:53)
	at com.facebook.react.ReactNativeHost.createReactInstanceManager(ReactNativeHost.java:92)
	at expo.modules.ReactNativeHostWrapperBase.createReactInstanceManager(ReactNativeHostWrapperBase.kt:29)
	at com.facebook.react.ReactNativeHost.getReactInstanceManager(ReactNativeHost.java:43)
	at com.wix.detox.reactnative.ReactNativeLoadingMonitor.subscribeToNewRNContextUpdates$lambda-0(ReactNativeLoadingMonitor.kt:35)
	at com.wix.detox.reactnative.ReactNativeLoadingMonitor.$r8$lambda$dGZ4tWaX8OR4qbOQsrnU2hX6Axo(Unknown Source:0)
	at com.wix.detox.reactnative.ReactNativeLoadingMonitor$$ExternalSyntheticLambda0.run(Unknown Source:2)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at android.app.Instrumentation$SyncRunnable.run(Instrumentation.java:2266)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7839)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

# How

- i don't like the intrusive code from detox that to initialize react instance by its own and that would break our assumption from #20273. this pr as a workaround tries to initialize expo-updates even before detox setup ANR detector, that would be on main thread and only for e2e testing.
- following up #26994 to fix android instrumentation tests

# Test Plan

ci passed

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
