### PR TITLE
[iOS] Move away from SharedObjectRegistry being a singleton

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))
 - `ObjectDeallocator` is now a native state instead of a host object. ([#26906](https://github.com/expo/expo/pull/26906) by [@tsapeta](https://github.com/tsapeta))
+- Moved away from `SharedObjectRegistry` being a singleton. ([#27032](https://github.com/expo/expo/pull/27032) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -134,6 +134,8 @@ public final class AppContext: NSObject {
 
   // MARK: - Classes
 
+  internal lazy var sharedObjectRegistry = SharedObjectRegistry()
+
   /**
    A registry containing references to JavaScript classes.
    - ToDo: Make one registry per module, not the entire app context.
@@ -397,9 +399,7 @@ public final class AppContext: NSObject {
    Unsets runtime objects that we hold for each module.
    */
   private func releaseRuntimeObjects() {
-    // FIXME: Release objects only from the current context.
-    // Making the registry non-global (similarly to the class registry) would fix it.
-    SharedObjectRegistry.clear()
+    sharedObjectRegistry.clear()
     classRegistry.clear()
 
     for module in moduleRegistry {

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -49,7 +49,7 @@ public final class ClassDefinition: ObjectDefinition {
 
       // Register the shared object if returned by the constructor.
       if let result = result as? SharedObject {
-        SharedObjectRegistry.add(native: result, javaScript: this)
+        appContext.sharedObjectRegistry.add(native: result, javaScript: this)
       }
     }
 

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -173,7 +173,7 @@ internal final class Conversions {
           log.warn("Unable to create a JS object for \(dynamicType.description)")
           return Optional<Any>.none
         }
-        SharedObjectRegistry.add(native: value, javaScript: object)
+        appContext.sharedObjectRegistry.add(native: value, javaScript: object)
         return object
       }
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -36,7 +36,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
 
     // If the given value is a shared object id, search the registry for its native representation
     if let sharedObjectId = value as? SharedObjectId,
-       let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native {
+      let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native {
       return nativeSharedObject
     }
     throw NativeSharedObjectNotFoundException()
@@ -52,7 +52,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
       return nativeSharedObject
     }
     if let jsObject = try? jsValue.asObject(),
-       let nativeSharedObject = appContext.sharedObjectRegistry.toNativeObject(jsObject) {
+      let nativeSharedObject = appContext.sharedObjectRegistry.toNativeObject(jsObject) {
       return nativeSharedObject
     }
     throw NativeSharedObjectNotFoundException()

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -36,7 +36,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
 
     // If the given value is a shared object id, search the registry for its native representation
     if let sharedObjectId = value as? SharedObjectId,
-       let nativeSharedObject = SharedObjectRegistry.get(sharedObjectId)?.native {
+       let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native {
       return nativeSharedObject
     }
     throw NativeSharedObjectNotFoundException()
@@ -46,13 +46,13 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
     if jsValue.kind == .number {
       let sharedObjectId = jsValue.getInt() as SharedObjectId
 
-      guard let nativeSharedObject = SharedObjectRegistry.get(sharedObjectId)?.native else {
+      guard let nativeSharedObject = appContext.sharedObjectRegistry.get(sharedObjectId)?.native else {
         throw NativeSharedObjectNotFoundException()
       }
       return nativeSharedObject
     }
     if let jsObject = try? jsValue.asObject(),
-       let nativeSharedObject = SharedObjectRegistry.toNativeObject(jsObject) {
+       let nativeSharedObject = appContext.sharedObjectRegistry.toNativeObject(jsObject) {
       return nativeSharedObject
     }
     throw NativeSharedObjectNotFoundException()

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -76,7 +76,7 @@ public final class ModuleHolder {
       let result = try function.call(by: self, withArguments: arguments, appContext: appContext)
 
       if let result = result as? SharedObject {
-        let jsObject = SharedObjectRegistry.ensureSharedJavaScriptObject(runtime: try appContext.runtime, nativeObject: result)
+        let jsObject = appContext.sharedObjectRegistry.ensureSharedJavaScriptObject(runtime: try appContext.runtime, nativeObject: result)
         return jsObject
       }
       return result

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -76,8 +76,7 @@ public final class ModuleHolder {
       let result = try function.call(by: self, withArguments: arguments, appContext: appContext)
 
       if let result = result as? SharedObject {
-        let jsObject = appContext.sharedObjectRegistry.ensureSharedJavaScriptObject(runtime: try appContext.runtime, nativeObject: result)
-        return jsObject
+        return appContext.sharedObjectRegistry.ensureSharedJavaScriptObject(runtime: try appContext.runtime, nativeObject: result)
       }
       return result
     } catch {

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -21,11 +21,4 @@ open class SharedObject: AnySharedObject {
    The default public initializer of the shared object.
    */
   public init() {}
-
-  /**
-   Returns the JavaScript shared object associated with the native shared object.
-   */
-  public func getJavaScriptObject() -> JavaScriptObject? {
-    return SharedObjectRegistry.toJavaScriptObject(self)
-  }
 }

--- a/packages/expo-modules-core/ios/Tests/ClassDefinitionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassDefinitionSpec.swift
@@ -121,15 +121,15 @@ class ClassDefinitionSpec: ExpoSpec {
       }
       it("creates shared object") {
         let jsObject = try runtime.eval("new expo.modules.TestModule.Counter(0)").getObject()
-        let nativeObject = SharedObjectRegistry.toNativeObject(jsObject)
+        let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
 
         expect(nativeObject).notTo(beNil())
       }
       it("registers shared object") {
-        let oldSize = SharedObjectRegistry.size
+        let oldSize = appContext.sharedObjectRegistry.size
         try runtime.eval("object = new expo.modules.TestModule.Counter(0)")
 
-        expect(SharedObjectRegistry.size) == oldSize + 1
+        expect(appContext.sharedObjectRegistry.size) == oldSize + 1
       }
       it("calls function with owner") {
         try runtime.eval([

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -300,7 +300,7 @@ final class DynamicTypeSpec: ExpoSpec {
           let nativeObject = TestSharedObject()
           let jsObjectValue = try appContext.runtime.eval("({})")
 
-          SharedObjectRegistry.add(native: nativeObject, javaScript: try jsObjectValue.asObject())
+          appContext.sharedObjectRegistry.add(native: nativeObject, javaScript: try jsObjectValue.asObject())
 
           // `DynamicSharedObjectType` only supports casting
           // from `JavaScriptValue`, but not from `JavaScriptObject`.

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -8,51 +8,52 @@ final class SharedObjectRegistrySpec: ExpoSpec {
   override class func spec() {
     let appContext = AppContext.create()
     let runtime = try! appContext.runtime
+    let sharedObjectRegistry = appContext.sharedObjectRegistry
 
     describe("pullNextId") {
       it("returns nextId") {
-        let id = SharedObjectRegistry.nextId
-        expect(SharedObjectRegistry.pullNextId()) == id
+        let id = sharedObjectRegistry.nextId
+        expect(sharedObjectRegistry.pullNextId()) == id
       }
       it("increments nextId") {
-        let id = SharedObjectRegistry.nextId
-        SharedObjectRegistry.pullNextId()
-        expect(SharedObjectRegistry.nextId) == id + 1
+        let id = sharedObjectRegistry.nextId
+        sharedObjectRegistry.pullNextId()
+        expect(sharedObjectRegistry.nextId) == id + 1
       }
       it("is not increasing size") {
-        let size = SharedObjectRegistry.size
-        SharedObjectRegistry.pullNextId()
-        expect(SharedObjectRegistry.size) == size
+        let size = sharedObjectRegistry.size
+        sharedObjectRegistry.pullNextId()
+        expect(sharedObjectRegistry.size) == size
       }
     }
 
     describe("add") {
       it("adds using nextId") {
-        let nextId = SharedObjectRegistry.nextId
-        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
+        let nextId = sharedObjectRegistry.nextId
+        let id = sharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
         expect(nextId) == id
       }
       it("is increasing size") {
-        let size = SharedObjectRegistry.size
-        SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
-        expect(SharedObjectRegistry.size) == size + 1
+        let size = sharedObjectRegistry.size
+        sharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
+        expect(sharedObjectRegistry.size) == size + 1
       }
       it("assigns id on native object") {
         let nativeObject = TestSharedObject()
-        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
+        let id = sharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
         expect(nativeObject.sharedObjectId) == id
       }
       it("assigns id on JS object") {
         let jsObject = runtime.createObject()
-        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
+        let id = sharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
         expect(jsObject.hasProperty(sharedObjectIdPropertyName)) == true
         expect(try! jsObject.getProperty(sharedObjectIdPropertyName).asInt()) == id
       }
       it("saves objects pair") {
         let nativeObject = TestSharedObject()
         let jsObject = runtime.createObject()
-        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
-        let pair = SharedObjectRegistry.get(id)
+        let id = sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        let pair = sharedObjectRegistry.get(id)
         expect(pair?.native) === nativeObject
         expect(pair?.javaScript.lock()) == jsObject
       }
@@ -60,14 +61,14 @@ final class SharedObjectRegistrySpec: ExpoSpec {
 
     describe("delete") {
       it("deletes objects pair") {
-        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
-        SharedObjectRegistry.delete(id)
-        expect(SharedObjectRegistry.get(id)).to(beNil())
+        let id = sharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
+        sharedObjectRegistry.delete(id)
+        expect(sharedObjectRegistry.get(id)).to(beNil())
       }
       it("resets id on native object") {
         let nativeObject = TestSharedObject()
-        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
-        SharedObjectRegistry.delete(id)
+        let id = sharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
+        sharedObjectRegistry.delete(id)
         expect(nativeObject.sharedObjectId).toEventually(equal(0))
       }
     }
@@ -76,12 +77,12 @@ final class SharedObjectRegistrySpec: ExpoSpec {
       it("returns native object") {
         let nativeObject = TestSharedObject()
         let jsObject = runtime.createObject()
-        SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
-        expect(SharedObjectRegistry.toNativeObject(jsObject)) === nativeObject
+        sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        expect(sharedObjectRegistry.toNativeObject(jsObject)) === nativeObject
       }
       it("returns nil") {
         let jsObject = runtime.createObject()
-        expect(SharedObjectRegistry.toNativeObject(jsObject)).to(beNil())
+        expect(sharedObjectRegistry.toNativeObject(jsObject)).to(beNil())
       }
     }
 
@@ -89,12 +90,12 @@ final class SharedObjectRegistrySpec: ExpoSpec {
       it("returns JS object") {
         let nativeObject = TestSharedObject()
         let jsObject = runtime.createObject()
-        SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
-        expect(SharedObjectRegistry.toJavaScriptObject(nativeObject)) == jsObject
+        sharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
+        expect(sharedObjectRegistry.toJavaScriptObject(nativeObject)) == jsObject
       }
       it("returns nil") {
         let nativeObject = TestSharedObject()
-        expect(SharedObjectRegistry.toJavaScriptObject(nativeObject)).to(beNil())
+        expect(sharedObjectRegistry.toJavaScriptObject(nativeObject)).to(beNil())
       }
     }
   }


### PR DESCRIPTION
# Why

`SharedObjectRegistry` was basically a singleton, so it's been shared across different JS runtimes. This was not good for a few reasons. Most importantly it's been clearing the entire registry on AppContext deallocation, which may cause deallocations of objects from the other context.

# How

- Made shared object registry an instance of the AppContext.
- Updated tests.

# Test Plan

- CI passes
- Native unit tests passed locally
- Tested SQLiteNext and VideoPlayer in NCL and checked in the memory graph whether they get deallocated after reload