### PR TITLE
[core] Fix test for Date convertible to use GMT timezone

### DIFF
--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -408,7 +408,12 @@ class ConvertiblesSpec: ExpoSpec {
       
       it("converts from `Date.now()` to Date") {
         let date = try Date.convert(from: 1703718341639, appContext: appContext)
-        let components = Calendar.current.dateComponents([.day, .month], from: date)
+        var components = Calendar.current.dateComponents([.day, .month], from: date)
+
+        // The current calendar uses the local timezone, so basically the `day` component
+        // could differ depending on the current timezone. Set it to GMT for correctness.
+        components.timeZone = TimeZone(abbreviation: "GMT")
+
         expect(components.month) == 12
         expect(components.day) == 27
       }


### PR DESCRIPTION
# Why

I ran native unit tests on iOS, surprisingly test for the Date convertible failed. The current Calendar instance uses the local timezone (GMT+1 in my case). Since the timestamp points to 11pm GMT, for me the `day` of the date was 28 instead of 27 🙂 

# How

Set the timezone of the date components to GMT

# Test Plan

Tests are passing now

<!-- disable:changelog-checks -->