### PR TITLE
[CI] Downgrade Maestro to 1.33.1 to fix timeouts

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -98,6 +98,8 @@ jobs:
           brew tap facebook/fb
           brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+        env:
+          MAESTRO_VERSION: '1.33.1'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -113,6 +113,8 @@ jobs:
           brew tap facebook/fb
           brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
+        env:
+          MAESTRO_VERSION: '1.33.1'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches


### PR DESCRIPTION
# Why

test-suite/ios-test job was hitting this issue: https://github.com/mobile-dev-inc/maestro/issues/1585

We always used the latest version of Maestro, which is probably not a good idea. Let's pin to a specific version.

# How

Since the issue refers to version `1.34.1`, I tried `1.34.0` first, but it seems to be broken too. When I downgraded to `1.33.1`, the job passed twice.

# Test Plan

The job passed twice
- https://github.com/expo/expo/actions/runs/7855583322/job/21437565324?pr=27034
- https://github.com/expo/expo/actions/runs/7855583322/job/21437768703?pr=27034

Nightly tests are still failing, but this is different and unrelated issue.