### PR TITLE
[ncl][test-suite] Replace http urls with https

### DIFF
--- a/apps/native-component-list/src/screens/AV/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoScreen.tsx
@@ -10,9 +10,9 @@ export default function VideoScreen() {
       <HeadingText>HTTP player</HeadingText>
       <VideoPlayer
         sources={[
-          { uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
-          { uri: 'http://techslides.com/demos/sample-videos/small.mp4' },
-          { uri: 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8' },
+          { uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' },
+          { uri: 'https://techslides.com/demos/sample-videos/small.mp4' },
+          { uri: 'https://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8' },
         ]}
       />
       <HeadingText>Local asset player</HeadingText>

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -167,7 +167,7 @@ function ContactDetailView({
               transform = {
                 value: item.url,
                 onPress: () => {
-                  const webUrl = item.url.indexOf('://') === -1 ? 'http://' + item.url : item.url;
+                  const webUrl = item.url.indexOf('://') === -1 ? 'https://' + item.url : item.url;
                   console.log('open', item.url, webUrl);
                   Linking.openURL(webUrl);
                 },
@@ -193,8 +193,8 @@ function ContactDetailView({
                   onPress: () =>
                     Linking.openURL(
                       Platform.select<string>({
-                        ios: `http://maps.apple.com/maps?daddr=${targetUriAdress}`,
-                        default: `http://maps.google.com/maps?daddr=${targetUriAdress}`,
+                        ios: `https://maps.apple.com/maps?daddr=${targetUriAdress}`,
+                        default: `https://maps.google.com/maps?daddr=${targetUriAdress}`,
                       })
                     ),
                 };

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -41,14 +41,14 @@ export default class FileSystemScreen extends React.Component<object, State> {
   upload?: UploadTask;
 
   _download = async () => {
-    const url = 'http://ipv4.download.thinkbroadband.com/256KB.zip';
-    await FileSystem.downloadAsync(url, FileSystem.documentDirectory + '256KB.zip');
+    const url = 'https://getsamplefiles.com/download/zip/sample-1.zip';
+    await FileSystem.downloadAsync(url, FileSystem.documentDirectory + 'sample-1.zip');
     alert('Download complete!');
   };
 
   _startDownloading = async () => {
-    const url = 'http://ipv4.download.thinkbroadband.com/5MB.zip';
-    const fileUri = FileSystem.documentDirectory + '5MB.zip';
+    const url = 'https://getsamplefiles.com/download/zip/sample-5.zip';
+    const fileUri = FileSystem.documentDirectory + 'sample-5.zip';
     const callback: FileSystemNetworkTaskProgressCallback<DownloadProgressData> = (
       downloadProgress
     ) => {
@@ -162,8 +162,8 @@ export default class FileSystemScreen extends React.Component<object, State> {
 
   _upload = async () => {
     try {
-      const fileUri = FileSystem.documentDirectory + '5MB.zip';
-      const downloadUrl = 'https://xcal1.vodafone.co.uk/5MB.zip';
+      const fileUri = FileSystem.documentDirectory + 'sample-4.zip';
+      const downloadUrl = 'https://getsamplefiles.com/download/zip/sample-4.zip';
       await FileSystem.downloadAsync(downloadUrl, fileUri);
 
       const callback: FileSystemNetworkTaskProgressCallback<UploadProgressData> = (
@@ -174,7 +174,7 @@ export default class FileSystemScreen extends React.Component<object, State> {
           uploadProgress: progress,
         });
       };
-      const uploadUrl = 'http://httpbin.org/post';
+      const uploadUrl = 'https://httpbin.org/post';
       this.upload = FileSystem.createUploadTask(uploadUrl, fileUri, {}, callback);
 
       await this.upload.uploadAsync();
@@ -311,8 +311,8 @@ export default class FileSystemScreen extends React.Component<object, State> {
   render() {
     return (
       <ScrollView style={{ padding: 10 }}>
-        <ListButton onPress={this._download} title="Download file (512KB)" />
-        <ListButton onPress={this._startDownloading} title="Start Downloading file (5MB)" />
+        <ListButton onPress={this._download} title="Download file (1.1MB)" />
+        <ListButton onPress={this._startDownloading} title="Start Downloading file (8.4MB)" />
         {this.state.downloadProgress ? (
           <Text style={{ paddingVertical: 15 }}>
             Download progress: {this.state.downloadProgress * 100}%
@@ -323,7 +323,7 @@ export default class FileSystemScreen extends React.Component<object, State> {
         <ListButton onPress={this._pause} title="Pause Download" />
         <ListButton onPress={this._resume} title="Resume Download" />
         <ListButton onPress={this._cancel} title="Cancel Download" />
-        <ListButton onPress={this._upload} title="Download & Upload file (5MB)" />
+        <ListButton onPress={this._upload} title="Download & Upload file (2.8MB)" />
         {this.state.uploadProgress ? (
           <Text style={{ paddingVertical: 15 }}>
             Upload progress: {this.state.uploadProgress * 100}%

--- a/apps/native-component-list/src/screens/GL/WebGL2TransformFeedbackScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/WebGL2TransformFeedbackScreen.tsx
@@ -1,6 +1,6 @@
 import GLWrap from './GLWrap';
 
-// WebGL 2.0 sample - http://webglsamples.org/WebGL2Samples/#transform_feedback_separated_2
+// WebGL 2.0 sample - https://webglsamples.org/WebGL2Samples/#transform_feedback_separated_2
 export default GLWrap('WebGL2 - Transform feedback', async (gl) => {
   const POSITION_LOCATION = 0;
   const VELOCITY_LOCATION = 1;

--- a/apps/native-component-list/src/screens/GifScreen.tsx
+++ b/apps/native-component-list/src/screens/GifScreen.tsx
@@ -11,7 +11,7 @@ export default function GifScreen() {
         justifyContent: 'center',
       }}>
       <Image
-        source={{ uri: 'http://d23dyxeqlo5psv.cloudfront.net/cat.gif' }}
+        source={{ uri: 'https://d23dyxeqlo5psv.cloudfront.net/cat.gif' }}
         style={{ height: 140, width: 200 }}
       />
     </View>

--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -19,7 +19,7 @@ export default function VideoScreen() {
   }, [ref]);
 
   const player = useVideoPlayer(
-    'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
+    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
   );
 
   const togglePlayer = useCallback(() => {
@@ -32,7 +32,7 @@ export default function VideoScreen() {
 
   const replaceItem = useCallback(() => {
     player.replace(
-      'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4'
+      'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4'
     );
   }, []);
 

--- a/apps/test-suite/tests/Audio.js
+++ b/apps/test-suite/tests/Audio.js
@@ -8,10 +8,11 @@ import { retryForStatus, waitFor } from './helpers';
 
 export const name = 'Audio';
 const mainTestingSource = require('../assets/LLizard.mp3');
-const soundUri = 'http://www.noiseaddicts.com/samples_1w72b820/280.mp3';
-const hlsStreamUri = 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8';
-const hlsStreamUriWithRedirect = 'http://bit.ly/1iy90bn';
-const redirectingSoundUri = 'http://bit.ly/2qBMx80';
+const soundUri = 'https://file-examples.com/index.php/sample-audio-files/sample-mp3-download/';
+const hlsStreamUri =
+  'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
+const hlsStreamUriWithRedirect = 'https://bit.ly/1iy90bn';
+const redirectingSoundUri = 'https://bit.ly/2qBMx80';
 const authenticatedStaticFilesBackend = 'https://authenticated-static-files.vercel.app';
 
 export function test(t) {

--- a/apps/test-suite/tests/AuthSession.js
+++ b/apps/test-suite/tests/AuthSession.js
@@ -3,7 +3,7 @@ import * as PKCE from 'expo-auth-session/build/PKCE';
 
 export const name = 'AuthSession';
 
-// Open ID RP cert testing server http://openid.net/certification/rp_testing
+// Open ID RP cert testing server https://openid.net/certification/rp_testing
 // TODO(Bacon): Test exchanges
 // const testUri = "https://rp.certification.openid.net:8080/expo-auth-session/";
 

--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -35,9 +35,9 @@ export async function test({ describe, expect, it, ...t }) {
           await throws(() => FS.copyAsync({ from: 'c', to: p + '../a/b' }));
           await throws(() => FS.makeDirectoryAsync(p + '../hello/world'));
           await throws(() => FS.readDirectoryAsync(p + '../hello/world'));
-          await throws(() => FS.downloadAsync('http://www.google.com', p + '../hello/world'));
+          await throws(() => FS.downloadAsync('https://www.google.com', p + '../hello/world'));
           await throws(() => FS.readDirectoryAsync(p + '../'));
-          await throws(() => FS.downloadAsync('http://www.google.com', p + '../hello/world'));
+          await throws(() => FS.downloadAsync('https://www.google.com', p + '../hello/world'));
         });
       });
     }

--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -304,7 +304,7 @@ export async function test(t) {
 
       t.it('presents a notification with attachments', async () => {
         const fileUri = FileSystem.documentDirectory + 'expo-notifications-test-image.jpg';
-        await FileSystem.downloadAsync('http://placekitten.com/200/300', fileUri);
+        await FileSystem.downloadAsync('https://placekitten.com/200/300', fileUri);
         await Notifications.presentNotificationAsync({
           title: 'Look at that kitten! ➡️',
           body: 'What a cutie!',

--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -9,12 +9,13 @@ import { Platform } from 'react-native';
 import { waitFor, retryForStatus, mountAndWaitFor as originalMountAndWaitFor } from './helpers';
 
 export const name = 'Video';
-const imageRemoteSource = { uri: 'http://via.placeholder.com/350x150' };
-const videoRemoteSource = { uri: 'http://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' };
-const redirectingVideoRemoteSource = { uri: 'http://bit.ly/2mcW40Q' };
+const imageRemoteSource = { uri: 'https://via.placeholder.com/350x150' };
+const videoRemoteSource = { uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' };
+const redirectingVideoRemoteSource = { uri: 'https://bit.ly/2mcW40Q' };
 const mp4Source = require('../assets/big_buck_bunny.mp4');
-const hlsStreamUri = 'http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8';
-const hlsStreamUriWithRedirect = 'http://bit.ly/1iy90bn';
+const hlsStreamUri =
+  'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
+const hlsStreamUriWithRedirect = 'https://t.ly/fg37A';
 let source = null; // Local URI of the downloaded default source is set in a beforeAll callback.
 let portraitVideoSource = null;
 let imageSource = null;


### PR DESCRIPTION
# Why

In #24971 we changed `NSAllowsArbitraryLoads` to false (as imposed by RN) which caused errors when requesting resources with non-secure connection (http). In native-component-list and test-suite, we're using many media assets without https so they simply stopped loading.

# How

I went through http urls in native-component-list and test-suite and replaced them with https if possible. For domains that don't support secure connection, I replaced them with some alternative urls.

# Test Plan

Examples in NCL seem to work as expected (these are mostly videos, images and audio). 
