### PR TITLE
[core][iOS] Introduce base JS class for shared objects

### DIFF
--- a/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
@@ -1003,11 +1003,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1059,11 +1055,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add iOS support for `PlatformColor` and `DynamicColorIOS` color props. ([#26724](https://github.com/expo/expo/pull/26724) by [@dlindenkreuz](https://github.com/dlindenkreuz))
 - `BarCodeScannerResult` interface now declares an additional `raw` field corresponding to the barcode value as it was encoded in the barcode without parsing. Will always be undefined on iOS. ([#25391](https://github.com/expo/expo/pull/25391) by [@ajacquierbret](https://github.com/ajacquierbret))
 - [Android] Added syntactic sugar for defining a prop group. ([#27004](https://github.com/expo/expo/pull/27004) by [@lukmccall](https://github.com/lukmccall))
+- Introduced a base class for all shared objects (`expo.SharedObject`) with a simple mechanism to release native pointer from JS. ([#27038](https://github.com/expo/expo/pull/27038) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -103,8 +103,8 @@ void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name
       runtime,
       getPropName,
       0,
-      [&descriptor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
-        return descriptor.get(runtime, thisValue.asObject(runtime));
+      [getter = descriptor.get](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+        return getter(runtime, thisValue.asObject(runtime));
       });
 
     jsDescriptor.setProperty(runtime, getPropName, get);
@@ -115,8 +115,8 @@ void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name
       runtime,
       setPropName,
       1,
-      [&descriptor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
-        descriptor.set(runtime, thisValue.asObject(runtime), jsi::Value(runtime, args[0]));
+      [setter = descriptor.set](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+        setter(runtime, thisValue.asObject(runtime), jsi::Value(runtime, args[0]));
         return jsi::Value::undefined();
       });
 

--- a/packages/expo-modules-core/common/cpp/SharedObject.cpp
+++ b/packages/expo-modules-core/common/cpp/SharedObject.cpp
@@ -1,0 +1,72 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#include "SharedObject.h"
+#include "JSIUtils.h"
+
+namespace expo::SharedObject {
+
+#pragma mark - NativeState
+
+NativeState::NativeState(const ObjectId objectId, const ObjectReleaser releaser)
+: objectId(objectId), releaser(releaser), jsi::NativeState() {}
+
+NativeState::~NativeState() {
+  releaser(objectId);
+}
+
+#pragma mark - Utils
+
+void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser) {
+  jsi::Function klass = expo::common::createClass(runtime, "SharedObject");
+  jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
+
+  jsi::Function releaseFunction = jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "release"),
+    1,
+    [releaser](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+      jsi::Object thisObject = args[0].asObject(runtime);
+
+      if (thisObject.hasNativeState<NativeState>(runtime)) {
+        auto nativeState = thisObject.getNativeState<NativeState>(runtime);
+
+        releaser(nativeState->objectId);
+
+        // Should we reset the native state?
+        thisObject.setNativeState(runtime, nullptr);
+      }
+      return jsi::Value::undefined();
+    });
+
+  prototype.setProperty(runtime, "release", releaseFunction);
+
+  // This property should be deprecated, but it's still used when passing as a view prop.
+  defineProperty(runtime, &prototype, "__expo_shared_object_id__", common::PropertyDescriptor {
+    .get = [](jsi::Runtime &runtime, jsi::Object thisObject) {
+      if (thisObject.hasNativeState<NativeState>(runtime)) {
+        auto nativeState = thisObject.getNativeState<NativeState>(runtime);
+        return jsi::Value((int)nativeState->objectId);
+      }
+      return jsi::Value(0);
+    }
+  });
+
+  runtime
+    .global()
+    .getPropertyAsObject(runtime, "expo")
+    .setProperty(runtime, "SharedObject", klass);
+}
+
+jsi::Function getBaseClass(jsi::Runtime &runtime) {
+  return runtime
+    .global()
+    .getPropertyAsObject(runtime, "expo")
+    .getPropertyAsFunction(runtime, "SharedObject");
+}
+
+jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::ClassConstructor constructor) {
+  jsi::Function baseSharedObjectClass = getBaseClass(runtime);
+  return common::createInheritingClass(runtime, className, baseSharedObjectClass, constructor);
+}
+
+} // namespace expo::SharedObject

--- a/packages/expo-modules-core/common/cpp/SharedObject.h
+++ b/packages/expo-modules-core/common/cpp/SharedObject.h
@@ -1,0 +1,58 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+#include "JSIUtils.h"
+#include "ObjectDeallocator.h"
+
+namespace jsi = facebook::jsi;
+
+namespace expo::SharedObject {
+
+/**
+ Type of the shared object IDs.
+ */
+typedef long ObjectId;
+
+/**
+ Defines an object releaser block of the shared object.
+ */
+typedef std::function<void(const ObjectId)> ObjectReleaser;
+
+/**
+ Installs a base JavaScript class for all shared object with a shared release block.
+ */
+void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser);
+
+/**
+ Returns the base JavaScript class for all shared objects, i.e. `global.expo.SharedObject`.
+ */
+jsi::Function getBaseClass(jsi::Runtime &runtime);
+
+/**
+ Creates a concrete shared object class with the given name and constructor.
+ */
+jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::ClassConstructor constructor);
+
+/**
+ Class representing a native state of the shared object.
+ */
+class JSI_EXPORT NativeState : public jsi::NativeState {
+public:
+  const ObjectId objectId = 0;
+  const ObjectReleaser releaser;
+
+  /**
+   The default constructor that initializes a native state for the shared object with given ID.
+   */
+  NativeState(const ObjectId objectId, const ObjectReleaser releaser);
+
+  virtual ~NativeState();
+}; // class NativeState
+
+} // namespace expo::SharedObject
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -134,7 +134,7 @@ public final class AppContext: NSObject {
 
   // MARK: - Classes
 
-  internal lazy var sharedObjectRegistry = SharedObjectRegistry()
+  internal lazy var sharedObjectRegistry = SharedObjectRegistry(appContext: self)
 
   /**
    A registry containing references to JavaScript classes.
@@ -393,6 +393,11 @@ public final class AppContext: NSObject {
 
     // Install the modules host object as the `global.expo.modules`.
     EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
+
+    // Install `global.expo.SharedObject`.
+    EXJavaScriptRuntimeManager.installSharedObjectClass(runtime) { [weak sharedObjectRegistry] objectId in
+      sharedObjectRegistry?.delete(objectId)
+    }
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -38,7 +38,7 @@ public final class ClassDefinition: ObjectDefinition {
   // MARK: - JavaScriptObjectBuilder
 
   public override func build(appContext: AppContext) throws -> JavaScriptObject {
-    let klass = try appContext.runtime.createClass(name) { [weak self, weak appContext] this, arguments in
+    let klass = try appContext.runtime.createSharedObjectClass(name) { [weak self, weak appContext] this, arguments in
       guard let self = self, let appContext else {
         // TODO: Throw an exception? (@tsapeta)
         return

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -20,4 +20,9 @@
  */
 + (BOOL)installExpoModulesHostObject:(nonnull EXAppContext *)appContext;
 
+/**
+ Installs the base class for shared objects, i.e. `global.expo.SharedObject`.
+ */
++ (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser;
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -4,6 +4,7 @@
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/LazyObject.h>
+#import <ExpoModulesCore/SharedObject.h>
 #import <ExpoModulesCore/Swift.h>
 
 namespace jsi = facebook::jsi;
@@ -53,6 +54,13 @@ static NSString *modulesHostObjectPropertyName = @"modules";
                      options:EXJavaScriptObjectPropertyDescriptorEnumerable];
 
   return true;
+}
+
++ (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser
+{
+  expo::SharedObject::installBaseClass(*[runtime get], [releaser](expo::SharedObject::ObjectId objectId) {
+    releaser(objectId);
+  });
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -14,6 +14,7 @@ namespace react = facebook::react;
 
 @class EXJavaScriptValue;
 @class EXJavaScriptObject;
+@class EXJavaScriptSharedObject;
 
 typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
                                      NSArray<EXJavaScriptValue *> * _Nonnull arguments,
@@ -101,6 +102,11 @@ typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, N
  Creates a new object, using the provided object as the prototype.
  */
 - (nullable EXJavaScriptObject *)createObjectWithPrototype:(nonnull EXJavaScriptObject *)prototype;
+
+#pragma mark - Shared objects
+
+- (nonnull EXJavaScriptObject *)createSharedObjectClass:(nonnull NSString *)name
+                                            constructor:(nonnull ClassConstructorBlock)constructor;
 
 #pragma mark - Script evaluation
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -18,6 +18,7 @@
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/EXJSIUtils.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/SharedObject.h>
 #import <ExpoModulesCore/Swift.h>
 
 namespace {
@@ -182,6 +183,22 @@ public:
 {
   std::shared_ptr<jsi::Object> object = std::make_shared<jsi::Object>(expo::common::createObjectWithPrototype(*_runtime, [prototype getShared].get()));
   return object ? [[EXJavaScriptObject alloc] initWith:object runtime:self] : nil;
+}
+
+#pragma mark - Shared objects
+
+- (nonnull EXJavaScriptObject *)createSharedObjectClass:(nonnull NSString *)name
+                                            constructor:(nonnull ClassConstructorBlock)constructor
+{
+  expo::common::ClassConstructor jsConstructor = [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
+    std::shared_ptr<jsi::Object> thisPtr = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
+    EXJavaScriptObject *caller = [[EXJavaScriptObject alloc] initWith:thisPtr runtime:self];
+    NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
+
+    constructor(caller, arguments);
+  };
+  std::shared_ptr<jsi::Function> klass = std::make_shared<jsi::Function>(expo::SharedObject::createClass(*_runtime, [name UTF8String], jsConstructor));
+  return [[EXJavaScriptObject alloc] initWith:klass runtime:self];
 }
 
 #pragma mark - Script evaluation

--- a/packages/expo-modules-core/ios/JSI/EXSharedObjectUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXSharedObjectUtils.h
@@ -1,0 +1,15 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJavaScriptObject.h>
+
+typedef void (^ObjectReleaser)(long objectId);
+
+NS_SWIFT_NAME(SharedObjectUtils)
+@interface EXSharedObjectUtils : NSObject
+
++ (void)setNativeState:(nonnull EXJavaScriptObject *)object
+               runtime:(nonnull EXJavaScriptRuntime *)runtime
+              objectId:(long)objectId
+              releaser:(nonnull ObjectReleaser)releaser;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXSharedObjectUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXSharedObjectUtils.mm
@@ -1,0 +1,18 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+#import <ExpoModulesCore/EXSharedObjectUtils.h>
+#import <ExpoModulesCore/SharedObject.h>
+
+@implementation EXSharedObjectUtils
+
++ (void)setNativeState:(nonnull EXJavaScriptObject *)object
+               runtime:(nonnull EXJavaScriptRuntime *)runtime
+              objectId:(long)objectId
+              releaser:(nonnull ObjectReleaser)releaser
+{
+  auto nativeState = std::make_shared<expo::SharedObject::NativeState>(objectId, releaser);
+  [object get]->setNativeState(*[runtime get], nativeState);
+}
+
+@end

--- a/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
@@ -1,0 +1,99 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class SharedObjectSpec: ExpoSpec {
+  override class func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    beforeSuite {
+      appContext.moduleRegistry.register(moduleType: SharedObjectModule.self)
+    }
+
+    describe("Base JS class") {
+      it("exists") {
+        let baseSharedObjectClass = try runtime.eval("expo.SharedObject")
+        expect(baseSharedObjectClass.kind) == .function
+      }
+
+      it("has release function in prototype") {
+        let releaseFunction = try runtime.eval("expo.SharedObject.prototype.release")
+        expect(releaseFunction.kind) == .function
+      }
+
+      it("initializes") {
+        let sharedObject = try runtime.eval("new expo.SharedObject()")
+        expect(sharedObject.kind) == .object
+      }
+
+      it("does not register") {
+        let registrySizeBefore = appContext.sharedObjectRegistry.size
+        try runtime.eval("new expo.SharedObject()")
+        expect(appContext.sharedObjectRegistry.size) == registrySizeBefore
+      }
+    }
+
+    describe("Concrete JS class") {
+      it("exists") {
+        let sharedObjectClass = try runtime.eval("expo.modules.SharedObjectModule.SharedObjectExample")
+        expect(sharedObjectClass.kind) == .function
+      }
+
+      it("has base class prototype") {
+        let hasBaseClassPrototype = try runtime.eval("expo.modules.SharedObjectModule.SharedObjectExample.prototype instanceof expo.SharedObject")
+        expect(hasBaseClassPrototype.kind) == .bool
+        expect(try hasBaseClassPrototype.asBool()) == true
+      }
+
+      it("creates new instance") {
+        let sharedObject = try runtime.eval("new expo.modules.SharedObjectModule.SharedObjectExample()")
+        expect(sharedObject.kind) == .object
+      }
+
+      it("registers") {
+        let registrySizeBefore = appContext.sharedObjectRegistry.size
+        try runtime.eval("new expo.modules.SharedObjectModule.SharedObjectExample()")
+        expect(appContext.sharedObjectRegistry.size) == registrySizeBefore + 1
+      }
+
+      it("is instance of") {
+        let isInstanceOf = try runtime.eval([
+          "sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()",
+          "sharedObject instanceof expo.modules.SharedObjectModule.SharedObjectExample"
+        ])
+        expect(isInstanceOf.kind) == .bool
+        expect(try isInstanceOf.asBool()) == true
+      }
+
+      it("is instance of base class") {
+        let isInstanceOfBaseClass = try runtime.eval([
+          "sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()",
+          "sharedObject instanceof expo.SharedObject"
+        ])
+        expect(isInstanceOfBaseClass.kind) == .bool
+        expect(try isInstanceOfBaseClass.asBool()) == true
+      }
+
+      it("has function from base class") {
+        let releaseFunction = try runtime.eval([
+          "sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()",
+          "sharedObject.release"
+        ])
+        expect(releaseFunction.kind) == .function
+      }
+    }
+  }
+}
+
+private class SharedObjectModule: Module {
+  public func definition() -> ModuleDefinition {
+    Class(SharedObjectExample.self) {
+      Constructor {
+        return SharedObjectExample()
+      }
+    }
+  }
+}
+
+private final class SharedObjectExample: SharedObject {}


### PR DESCRIPTION
# Why

Currently, on the JS side, shared objects inherit only from `Object`. To provide some common functionalities, we're introducing a `SharedObject` class in JS (`global.expo.SharedObject`).

# How

Made a new `SharedObject` class, installed it in the runtime as `global.expo.SharedObject` and made other shared object classes inherit from it.

# Test Plan

Added some new unit tests that are passing