### PR TITLE
[CLI] Mute require cycle warnings from node_modules

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Mute require cycle warnings triggered from node_modules in API routes. [#27039](https://github.com/expo/expo/pull/27039) by [@hdwatts](https://github.com/hdwatts)
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -78,7 +78,7 @@ export function logLikeMetro(
 }
 
 // TODO: Remove this once API routes properly read from metro config
-function filterRequireCycle(...data: any[]): boolean {
+function filterRequireCycle(data: any[]): boolean {
   return data.some((d) =>
     Array.isArray(d)
       ? filterRequireCycle(d)

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -30,6 +30,11 @@ export function logLikeMetro(
         ? chalk.inverse.yellow
         : chalk.inverse.white;
 
+  // TODO: Remove this once API routes properly read from metro config
+  if (filterRequireCycle(data)) {
+    return;
+  }
+
   if (level === 'group') {
     groupStack.push(level);
   } else if (level === 'groupCollapsed') {
@@ -70,6 +75,15 @@ export function logLikeMetro(
       ...data
     );
   }
+}
+
+// TODO: Remove this once API routes properly read from metro config
+function filterRequireCycle(...data: any[]): boolean {
+  return data.some((d) =>
+    Array.isArray(d)
+      ? filterRequireCycle(d)
+      : d.includes('Require cycle') && d.includes('node_modules')
+  );
 }
 
 const escapedPathSep = path.sep === '\\' ? '\\\\' : path.sep;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes: https://github.com/expo/expo/issues/26613

# How

<!--
How did you build this feature or fix this bug and why?
-->

Ideally, I would be intelligent enough to find where these metro warnings are coming from and have it properly use the default metro value or read from the config. Unfortunately, I am too unfamiliar with metro and this codebase to do that. Therefore, I looked for the area where we log this message in the CLI and short circuited that method instead.

**I will defer to the expo router team on if this is worth merging in or not, as it is not the proper fix and more of a bandaid.**

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested against a build with a circular reference in both `node_modules` and in the app router itself. The app router messages were output as expected, while the `node_modules` library was not.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
