### PR TITLE
feat(cli): skip bundling production react modules in development

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Prevent bundling production react modules in development.
 - Add `--no-bytecode` flag to `expo export` to disable generating Hermes bytecode for use with debugging tools. ([#26985](https://github.com/expo/expo/pull/26985) by [@EvanBacon](https://github.com/EvanBacon))
 - Add stack traces for warnings and errors that originate from API routes or server rendering. ([#26812](https://github.com/expo/expo/pull/26812) by [@EvanBacon](https://github.com/EvanBacon))
 - Add better error when `metro.config.js` does not extend `expo/metro-config`. ([#26726](https://github.com/expo/expo/pull/26726) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Prevent bundling production react modules in development.
+- Prevent bundling production react modules in development. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `--no-bytecode` flag to `expo export` to disable generating Hermes bytecode for use with debugging tools. ([#26985](https://github.com/expo/expo/pull/26985) by [@EvanBacon](https://github.com/EvanBacon))
 - Add stack traces for warnings and errors that originate from API routes or server rendering. ([#26812](https://github.com/expo/expo/pull/26812) by [@EvanBacon](https://github.com/EvanBacon))
 - Add better error when `metro.config.js` does not extend `expo/metro-config`. ([#26726](https://github.com/expo/expo/pull/26726) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -22,4 +22,7 @@ export async function exportAsync(projectRoot: string, options: Options) {
 
   // Final notes
   Log.log(`App exported to: ${options.outputDir}`);
+
+  // Force exit because various threading and analytics processes could be hanging, this command needs to run as fast as possible.
+  process.exit(0);
 }

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -29,6 +29,7 @@ jest.mock('metro-resolver', () => {
 
 function getDefaultRequestContext(): CustomResolutionContext {
   return {
+    dev: true,
     extraNodeModules: {},
     mainFields: ['react-native', 'browser', 'main'],
     nodeModulesPaths: ['/node_modules'],
@@ -180,6 +181,40 @@ describe(withExtendedResolver, () => {
       'react-native-web',
       platform
     );
+  });
+
+  it(`resolves production react files to empty when bundling for development`, async () => {
+    mockMinFs();
+
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+      tsconfig: {},
+      isTsconfigPathsEnabled: false,
+    });
+
+    modified.resolver.resolveRequest!({
+      ...getDefaultRequestContext(),
+      dev: true,
+      originModulePath: '/Users/path/to/expo/node_modules/react/index.js'
+    }, './cjs/react.production.min.js', 'web')
+    
+    expect(getResolveFunc()).not.toBeCalled();
+  });
+ 
+  it(`resolves production react files normally when bundling for production`, async () => {
+    mockMinFs();
+
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/' }), {
+      tsconfig: {},
+      isTsconfigPathsEnabled: false,
+    });
+
+    modified.resolver.resolveRequest!({
+      ...getDefaultRequestContext(),
+      dev: false,
+      originModulePath: '/Users/path/to/expo/node_modules/react/index.js'
+    }, './cjs/react.production.min.js', 'web')
+    
+    expect(getResolveFunc()).toBeCalled();
   });
 
   it(`resolves to @expo/vector-icons on any platform`, async () => {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -191,15 +191,19 @@ describe(withExtendedResolver, () => {
       isTsconfigPathsEnabled: false,
     });
 
-    modified.resolver.resolveRequest!({
-      ...getDefaultRequestContext(),
-      dev: true,
-      originModulePath: '/Users/path/to/expo/node_modules/react/index.js'
-    }, './cjs/react.production.min.js', 'web')
-    
+    modified.resolver.resolveRequest!(
+      {
+        ...getDefaultRequestContext(),
+        dev: true,
+        originModulePath: '/Users/path/to/expo/node_modules/react/index.js',
+      },
+      './cjs/react.production.min.js',
+      'web'
+    );
+
     expect(getResolveFunc()).not.toBeCalled();
   });
- 
+
   it(`resolves production react files normally when bundling for production`, async () => {
     mockMinFs();
 
@@ -208,12 +212,16 @@ describe(withExtendedResolver, () => {
       isTsconfigPathsEnabled: false,
     });
 
-    modified.resolver.resolveRequest!({
-      ...getDefaultRequestContext(),
-      dev: false,
-      originModulePath: '/Users/path/to/expo/node_modules/react/index.js'
-    }, './cjs/react.production.min.js', 'web')
-    
+    modified.resolver.resolveRequest!(
+      {
+        ...getDefaultRequestContext(),
+        dev: false,
+        originModulePath: '/Users/path/to/expo/node_modules/react/index.js',
+      },
+      './cjs/react.production.min.js',
+      'web'
+    );
+
     expect(getResolveFunc()).toBeCalled();
   });
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -235,11 +235,16 @@ export function withExtendedResolver(
       if (!context.dev) return null;
 
       if (
-        // Match production imports.
-        moduleName.includes('.production.') &&
-        // Match if the import originated from a react package.
-        context.originModulePath.match(/[\\/]node_modules[\\/](react[-\\/]|scheduler[\\/])/)
+        // Match react-native renderers.
+        (platform !== 'web' &&
+          context.originModulePath.match(/[\\/]node_modules[\\/]react-native[\\/]/) &&
+          moduleName.match(/([\\/]ReactFabric|ReactNativeRenderer)-prod/)) ||
+        // Match react production imports.
+        (moduleName.match(/\.production(\.min)?\.js$/) &&
+          // Match if the import originated from a react package.
+          context.originModulePath.match(/[\\/]node_modules[\\/](react[-\\/]|scheduler[\\/])/))
       ) {
+        debug(`Skipping production module: ${moduleName}`);
         // /Users/path/to/expo/node_modules/react/index.js ./cjs/react.production.min.js
         // /Users/path/to/expo/node_modules/react/jsx-dev-runtime.js ./cjs/react-jsx-dev-runtime.production.min.js
         // /Users/path/to/expo/node_modules/react-is/index.js ./cjs/react-is.production.min.js

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -228,6 +228,31 @@ export function withExtendedResolver(
   }
 
   const metroConfigWithCustomResolver = withMetroResolvers(config, [
+    // Mock out production react imports in development.
+    (context: ResolutionContext, moduleName: string, platform: string | null) => {
+      
+      // This resolution is dev-only to prevent bundling the production React packages in development.
+      // @ts-expect-error: dev is not on type.
+      if (!context.dev) return null;
+
+      if (
+        // Match production imports.
+        moduleName.includes('.production.') &&
+        // Match if the import originated from a react package.
+        context.originModulePath.match(/[\\/]node_modules[\\/](react[-\\/]|scheduler[\\/])/)
+      ) {
+        // /Users/path/to/expo/node_modules/react/index.js ./cjs/react.production.min.js
+        // /Users/path/to/expo/node_modules/react/jsx-dev-runtime.js ./cjs/react-jsx-dev-runtime.production.min.js
+        // /Users/path/to/expo/node_modules/react-is/index.js ./cjs/react-is.production.min.js
+        // /Users/path/to/expo/node_modules/react-refresh/runtime.js ./cjs/react-refresh-runtime.production.min.js
+        // /Users/path/to/expo/node_modules/react-native/node_modules/scheduler/index.native.js ./cjs/scheduler.native.production.min.js
+        // /Users/path/to/expo/node_modules/react-native/node_modules/react-is/index.js ./cjs/react-is.production.min.js
+        return {
+          type: 'empty',
+        };
+      }
+      return null;
+    },
     // tsconfig paths
     (context: ResolutionContext, moduleName: string, platform: string | null) => {
       return (

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -230,7 +230,6 @@ export function withExtendedResolver(
   const metroConfigWithCustomResolver = withMetroResolvers(config, [
     // Mock out production react imports in development.
     (context: ResolutionContext, moduleName: string, platform: string | null) => {
-      
       // This resolution is dev-only to prevent bundling the production React packages in development.
       // @ts-expect-error: dev is not on type.
       if (!context.dev) return null;

--- a/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
+++ b/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 /// <reference types="metro" />
+/// <reference types="node" />
 import type { TransformResultDependency } from 'metro/src/DeltaBundler';
 import { JsOutput, JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker';
 export { JsTransformOptions };

--- a/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
+++ b/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="metro" />
 /// <reference types="node" />
+/// <reference types="metro" />
 import type { TransformResultDependency } from 'metro/src/DeltaBundler';
 import { JsOutput, JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker';
 export { JsTransformOptions };

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Directly resolve plugins.
+
 ## 10.0.1 - 2023-12-19
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Directly resolve plugins.
+- Directly resolve plugins. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 10.0.1 - 2023-12-19
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -53,7 +53,7 @@ function babelPresetExpo(api, options = {}) {
         // getters and setters in spread objects. We need to add this plugin ourself without that option.
         // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
         extraPlugins.push([
-            require.resolve('@babel/plugin-transform-object-rest-spread'),
+            require('@babel/plugin-transform-object-rest-spread'),
             { loose: false },
         ]);
     }
@@ -100,7 +100,7 @@ function babelPresetExpo(api, options = {}) {
         extraPlugins.push(inline_env_vars_1.expoInlineEnvVars);
     }
     if (platform === 'web') {
-        extraPlugins.push(require.resolve('babel-plugin-react-native-web'));
+        extraPlugins.push(require('babel-plugin-react-native-web'));
         // Webpack uses the DefinePlugin to provide the manifest to `expo-constants`.
         if (bundler !== 'webpack') {
             extraPlugins.push(expo_inline_manifest_plugin_1.expoInlineManifestPlugin);
@@ -184,12 +184,12 @@ function babelPresetExpo(api, options = {}) {
         plugins: [
             ...extraPlugins,
             // TODO: Remove
-            [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-            require.resolve('@babel/plugin-transform-export-namespace-from'),
+            [require('@babel/plugin-proposal-decorators'), { legacy: true }],
+            require('@babel/plugin-transform-export-namespace-from'),
             // Automatically add `react-native-reanimated/plugin` when the package is installed.
             // TODO: Move to be a customTransformOption.
             (0, common_1.hasModule)('react-native-reanimated') &&
-                platformOptions.reanimated !== false && [require.resolve('react-native-reanimated/plugin')],
+                platformOptions.reanimated !== false && [require('react-native-reanimated/plugin')],
         ].filter(Boolean),
     };
 }

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -52,10 +52,7 @@ function babelPresetExpo(api, options = {}) {
         // `@react-native/babel-preset` configures this plugin with `{ loose: true }`, which breaks all
         // getters and setters in spread objects. We need to add this plugin ourself without that option.
         // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
-        extraPlugins.push([
-            require('@babel/plugin-transform-object-rest-spread'),
-            { loose: false },
-        ]);
+        extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
     }
     else {
         // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -104,10 +104,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // `@react-native/babel-preset` configures this plugin with `{ loose: true }`, which breaks all
     // getters and setters in spread objects. We need to add this plugin ourself without that option.
     // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
-    extraPlugins.push([
-      require('@babel/plugin-transform-object-rest-spread'),
-      { loose: false },
-    ]);
+    extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
   } else {
     // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
     // JSX is used in a function body. This is technically not required in production, but we

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -105,7 +105,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // getters and setters in spread objects. We need to add this plugin ourself without that option.
     // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
     extraPlugins.push([
-      require.resolve('@babel/plugin-transform-object-rest-spread'),
+      require('@babel/plugin-transform-object-rest-spread'),
       { loose: false },
     ]);
   } else {
@@ -158,7 +158,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   }
 
   if (platform === 'web') {
-    extraPlugins.push(require.resolve('babel-plugin-react-native-web'));
+    extraPlugins.push(require('babel-plugin-react-native-web'));
 
     // Webpack uses the DefinePlugin to provide the manifest to `expo-constants`.
     if (bundler !== 'webpack') {
@@ -255,12 +255,12 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     plugins: [
       ...extraPlugins,
       // TODO: Remove
-      [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-      require.resolve('@babel/plugin-transform-export-namespace-from'),
+      [require('@babel/plugin-proposal-decorators'), { legacy: true }],
+      require('@babel/plugin-transform-export-namespace-from'),
       // Automatically add `react-native-reanimated/plugin` when the package is installed.
       // TODO: Move to be a customTransformOption.
       hasModule('react-native-reanimated') &&
-        platformOptions.reanimated !== false && [require.resolve('react-native-reanimated/plugin')],
+        platformOptions.reanimated !== false && [require('react-native-reanimated/plugin')],
     ].filter(Boolean) as PluginItem[],
   };
 }


### PR DESCRIPTION
# Why

- Production react modules take seconds to bundle and in development they go unused. This change uses the upstream support for detecting if a resolver is resolving for development to mock production modules to an empty file.
- I've also added a force close to the end of export to speed up the testing since some lingering threads and timers keep it open for an extra 300ms.
- Finally, I've resolved the babel plugins directly to speed up babel config creation (which is currently performed on every transformation).

# Test Plan

- Added tests for the new behavior.
- Manually running a development export `npx expo export --dev` is now ~200ms faster.
