### PR TITLE
[core] Replace findNodeHandle for StrictMode compatibility

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the deprecated usage of findNodeHandle ([#27043](https://github.com/expo/expo/pull/27043) by [@chocoladisco](https://github.com/chocoladisco))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fix proguard rules so `Serializable` types are not obfuscated. ([#26545](https://github.com/expo/expo/pull/26545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
+++ b/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx
@@ -52,20 +52,8 @@ export function requireNativeViewManager<P>(viewName: string): React.ComponentTy
   const reactNativeViewName = `ViewManagerAdapter_${viewName}`;
   const ReactNativeComponent = requireCachedNativeComponent(reactNativeViewName);
 
-  class NativeComponent extends React.PureComponent<P> {
-    static displayName = viewName;
-
-    // This will be accessed from native when the prototype functions are called,
-    // in order to find the associated native view.
-    nativeTag: number | null = null;
-
-    componentDidMount(): void {
-      this.nativeTag = findNodeHandle(this);
-    }
-
-    render(): React.ReactNode {
-      return <ReactNativeComponent {...this.props} />;
-    }
+  const NativeComponent = React.forwardRef((props: P, ref: React.Ref<React.Component>) => {
+    return <ReactNativeComponent {...props} ref={ref} />;
   }
 
   try {


### PR DESCRIPTION
# Why

Using findNodeHandle is deprecated in Strict Mode.

# How

Replaced the usage of findNodeHandle with a ForwardRef

# Test Plan

Should be covered by the existing test cases, as it is only a refactor of a singular function

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
