### PR TITLE
Stress life saving intelli sense of native editors for native modules

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -77,9 +77,9 @@ Congratulations! You have created a local Expo module. You can now start working
 
 #### Android
 
-If you have an **android** directory in your project that you created using `npx expo prebuild`, you can open the directory in Android Studio.
+Open `modules/my-module/android/src/main/java/expo/modules/mymodule/**` in your favorite text editor to edit. Preferably, open the **android** directory at the root of your project in Android Studio. This directory was created by `npx expo prebuild`. Android Studio will provide you helpful code completion and debugging. You will find a directory called "mymodule" in the "Project" view of Android Studio.
 
-You can always just edit the files in the `modules/my-module/android/src/main/java/expo/modules/mymodule/` directory directly in your favorite text editor.
+You can always just edit the files in the `modules/my-module/android/src/main/java/expo/modules/mymodule/` directory directly in your favorite text editor. 
 
 Change the `hello` method to return a different string. For example, you can change it to return "Hello world! 🌎🍎".
 
@@ -87,7 +87,7 @@ Rebuild the app or build a new development client and you should see your change
 
 #### iOS
 
-Open the files in **modules/my-module/ios/** directory in your favorite code editor to edit them. Alternatively, if you have an **ios** directory in your project that was created using `npx expo prebuild`, you can use Xcode to edit them.
+Open the files in **modules/my-module/ios/** directory in your favorite code editor to edit them. Preferrably, open the **ios** directory at the root of your project created by `npx expo prebuild` with Xcode for helpful code completion and debugging. You will find this new module in "Pods" / "Development Pods" on the left.
 
 Now, change the `hello` method to return a different string. For example, you can change it to return "Hello world! 🌎🍎".
 


### PR DESCRIPTION
# Why

I struggled for months when editing native modules. I had no idea that the project could be opened in native editors, which gives you the absolutely life saving critical intellisense and debugging abilities.

# How

This stresses the intellisense part.

# Test Plan

none

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
