### PR TITLE
[core] Move some JSI utils to common code

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))
 - `ObjectDeallocator` is now a native state instead of a host object. ([#26906](https://github.com/expo/expo/pull/26906) by [@tsapeta](https://github.com/tsapeta))
 - Moved away from `SharedObjectRegistry` being a singleton. ([#27032](https://github.com/expo/expo/pull/27032) by [@tsapeta](https://github.com/tsapeta))
+- Moved and added more JSI utils to the common C++ codebase. ([#27045](https://github.com/expo/expo/pull/27045) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -61,7 +61,7 @@ void decorateObjectWithProperties(
       jsi::Value(runtime, *setter.toJSFunction(runtime,
                                                jsiInteropModuleRegistry))
     );
-    common::definePropertyOnJSIObject(runtime, jsObject, name.c_str(), std::move(descriptor));
+    common::defineProperty(runtime, jsObject, name.c_str(), std::move(descriptor));
   }
 }
 
@@ -226,8 +226,7 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
     auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime, 0);
     descriptor.setProperty(runtime, "value", jsi::Value(runtime, nativeConstructor));
 
-    common::definePropertyOnJSIObject(runtime, &prototype, nativeConstructorKey.c_str(),
-                                      std::move(descriptor));
+    common::defineProperty(runtime, &prototype, nativeConstructorKey.c_str(), std::move(descriptor));
 
     moduleObject->setProperty(
       runtime,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -137,7 +137,7 @@ private:
     auto cName = name->toStdString();
     jsi::Object descriptor = preparePropertyDescriptor(jsRuntime, options);
     descriptor.setProperty(jsRuntime, "value", jsi_type_converter<T>::convert(jsRuntime, value));
-    common::definePropertyOnJSIObject(jsRuntime, jsObject.get(), cName.c_str(), std::move(descriptor));
+    common::defineProperty(jsRuntime, jsObject.get(), cName.c_str(), std::move(descriptor));
   }
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -177,7 +177,7 @@ void JavaScriptRuntime::installMainObject() {
 
   descriptor.setProperty(*runtime, "value", jsi::Value(*runtime, *mainObject));
 
-  common::definePropertyOnJSIObject(
+  common::defineProperty(
     *runtime,
     &global,
     "expo",

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -1,8 +1,74 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
+#include <sstream>
 #include "JSIUtils.h"
 
 namespace expo::common {
+
+jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor) {
+  std::string nativeConstructorKey("__native_constructor__");
+
+  // Create a string buffer of the source code to evaluate.
+  std::stringstream source;
+  source << "(function " << name << "(...args) { this." << nativeConstructorKey << "(...args); return this; })";
+  std::shared_ptr<jsi::StringBuffer> sourceBuffer = std::make_shared<jsi::StringBuffer>(source.str());
+
+  // Evaluate the code and obtain returned value (the constructor function).
+  jsi::Object klass = runtime.evaluateJavaScript(sourceBuffer, "").asObject(runtime);
+
+  // Set the native constructor in the prototype.
+  jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
+  jsi::PropNameID nativeConstructorPropId = jsi::PropNameID::forAscii(runtime, nativeConstructorKey);
+  jsi::Function nativeConstructor = jsi::Function::createFromHostFunction(
+    runtime,
+    nativeConstructorPropId,
+    // The paramCount is not obligatory to match, it only affects the `length` property of the function.
+    0,
+    [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+      if (constructor) {
+        constructor(runtime, thisValue, args, count);
+      }
+      return jsi::Value::undefined();
+    });
+
+  jsi::Object descriptor(runtime);
+  descriptor.setProperty(runtime, "value", jsi::Value(runtime, nativeConstructor));
+
+  defineProperty(runtime, &prototype, nativeConstructorKey.c_str(), std::move(descriptor));
+
+  return klass.asFunction(runtime);
+}
+
+jsi::Function createInheritingClass(jsi::Runtime &runtime, const char *className, jsi::Function &baseClass, ClassConstructor constructor) {
+  jsi::PropNameID prototypePropNameId = jsi::PropNameID::forAscii(runtime, "prototype", 9);
+  jsi::Object baseClassPrototype = baseClass
+    .getProperty(runtime, prototypePropNameId)
+    .asObject(runtime);
+
+  jsi::Function klass = createClass(runtime, className, constructor);
+  jsi::Object klassPrototype = klass.getProperty(runtime, prototypePropNameId).asObject(runtime);
+
+  klassPrototype.setProperty(runtime, "__proto__", baseClassPrototype);
+
+  return klass;
+}
+
+jsi::Object createObjectWithPrototype(jsi::Runtime &runtime, jsi::Object *prototype) {
+  // Get the "Object" class.
+  jsi::Object objectClass = runtime
+    .global()
+    .getPropertyAsObject(runtime, "Object");
+
+  // Call "Object.create(prototype)" to create an object with the given prototype without calling the constructor.
+  jsi::Object object = objectClass
+    .getPropertyAsFunction(runtime, "create")
+    .callWithThis(runtime, objectClass, {
+      jsi::Value(runtime, *prototype)
+    })
+    .asObject(runtime);
+
+  return object;
+}
 
 std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, const jsi::Array &array) {
   size_t size = array.size(runtime);
@@ -17,22 +83,56 @@ std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, 
   return vector;
 }
 
-void definePropertyOnJSIObject(
-  jsi::Runtime &runtime,
-  jsi::Object *jsthis,
-  const char *name,
-  jsi::Object descriptor
-) {
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor descriptor) {
+  jsi::Object jsDescriptor(runtime);
+
+  // These three flags are all `false` by default, so set the property only when `true`.
+  if (descriptor.configurable) {
+    jsDescriptor.setProperty(runtime, "configurable", jsi::Value(true));
+  }
+  if (descriptor.enumerable) {
+    jsDescriptor.setProperty(runtime, "enumerable", jsi::Value(true));
+  }
+  if (descriptor.writable) {
+    jsDescriptor.setProperty(runtime, "writable", jsi::Value(true));
+  }
+
+  if (descriptor.get) {
+    jsi::PropNameID getPropName = jsi::PropNameID::forAscii(runtime, "get", 3);
+    jsi::Function get = jsi::Function::createFromHostFunction(
+      runtime,
+      getPropName,
+      0,
+      [&descriptor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+        return descriptor.get(runtime, thisValue.asObject(runtime));
+      });
+
+    jsDescriptor.setProperty(runtime, getPropName, get);
+  }
+  if (descriptor.set) {
+    jsi::PropNameID setPropName = jsi::PropNameID::forAscii(runtime, "set", 3);
+    jsi::Function set = jsi::Function::createFromHostFunction(
+      runtime,
+      setPropName,
+      1,
+      [&descriptor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+        descriptor.set(runtime, thisValue.asObject(runtime), jsi::Value(runtime, args[0]));
+      });
+
+    jsDescriptor.setProperty(runtime, setPropName, set);
+  }
+
+  defineProperty(runtime, object, name, std::move(jsDescriptor));
+}
+
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, jsi::Object descriptor) {
   jsi::Object global = runtime.global();
   jsi::Object objectClass = global.getPropertyAsObject(runtime, "Object");
-  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(
-    runtime,
-    "defineProperty"
-  );
+  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(runtime, "defineProperty");
 
   // This call is basically the same as `Object.defineProperty(object, name, descriptor)` in JS
   definePropertyFunction.callWithThis(runtime, objectClass, {
-    jsi::Value(runtime, *jsthis),
+    jsi::Value(runtime, *object),
     jsi::String::createFromUtf8(runtime, name),
     std::move(descriptor),
   });

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -117,6 +117,7 @@ void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name
       1,
       [&descriptor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
         descriptor.set(runtime, thisValue.asObject(runtime), jsi::Value(runtime, args[0]));
+        return jsi::Value::undefined();
       });
 
     jsDescriptor.setProperty(runtime, setPropName, set);

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -9,20 +9,58 @@ namespace jsi = facebook::jsi;
 
 namespace expo::common {
 
+#pragma mark - Classes
+
+/**
+ Type of the native constructor of the JS classes.
+ */
+typedef std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count)> ClassConstructor;
+
+/**
+ Creates a class with the given name and native constructor.
+ */
+jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor = nullptr);
+
+/**
+ Creates a class (function) that inherits from the provided base class.
+ */
+jsi::Function createInheritingClass(jsi::Runtime &runtime, const char *className, jsi::Function &baseClass, ClassConstructor constructor);
+
+/**
+ Creates an object from the given prototype, without calling the constructor.
+ */
+jsi::Object createObjectWithPrototype(jsi::Runtime &runtime, jsi::Object *prototype);
+
+#pragma mark - Conversions
+
 /**
  Converts `jsi::Array` to a vector with prop name ids (`std::vector<jsi::PropNameID>`).
  */
 std::vector<jsi::PropNameID> jsiArrayToPropNameIdsVector(jsi::Runtime &runtime, const jsi::Array &array);
 
+#pragma mark - Properties
+
 /**
- Calls Object.defineProperty(jsThis, name, descriptor)`.
+ Represents a JS property descriptor used in the `Object.defineProperty` function.
  */
-void definePropertyOnJSIObject(
-  jsi::Runtime &runtime,
-  jsi::Object *jsthis,
-  const char *name,
-  jsi::Object descriptor
-);
+struct PropertyDescriptor {
+  const bool configurable = false;
+  const bool enumerable = false;
+  const bool writable = false;
+  const jsi::Value value = 0;
+  const std::function<jsi::Value(jsi::Runtime &runtime, jsi::Object thisObject)> get = 0;
+  const std::function<void(jsi::Runtime &runtime, jsi::Object thisObject, jsi::Value newValue)> set = 0;
+}; // PropertyDescriptor
+
+/**
+ Defines the property on the object with the provided descriptor options.
+ */
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, const PropertyDescriptor descriptor);
+
+/**
+ Calls `Object.defineProperty(object, name, descriptor)`.
+ */
+void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name, jsi::Object descriptor);
 
 } // namespace expo::common
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -20,17 +20,6 @@ using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, R
 
 void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> jsInvoker, std::shared_ptr<react::Promise> promise, PromiseInvocationBlock setupBlock);
 
-#pragma mark - Classes
-
-using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count)>;
-
-std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor);
-
-/**
- Creates a new object, using the provided object as the prototype.
- */
-std::shared_ptr<jsi::Object> createObjectWithPrototype(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> prototype);
-
 #pragma mark - Weak objects
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObject.mm
@@ -76,7 +76,7 @@
   jsi::Runtime *runtime = [_runtime get];
   jsi::Object *jsThis = _jsObjectPtr.get();
 
-  expo::common::definePropertyOnJSIObject(*runtime, jsThis, [name UTF8String], std::move(*[descriptor get]));
+  expo::common::defineProperty(*runtime, jsThis, [name UTF8String], std::move(*[descriptor get]));
 }
 
 - (void)defineProperty:(nonnull NSString *)name value:(nullable id)value options:(EXJavaScriptObjectPropertyDescriptor)options
@@ -87,7 +87,7 @@
   jsi::Object descriptor = [self preparePropertyDescriptorWithOptions:options];
   descriptor.setProperty(*runtime, "value", expo::convertObjCObjectToJSIValue(*runtime, value));
 
-  expo::common::definePropertyOnJSIObject(*runtime, jsThis, [name UTF8String], std::move(descriptor));
+  expo::common::defineProperty(*runtime, jsThis, [name UTF8String], std::move(descriptor));
 }
 
 #pragma mark - WeakObject

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -167,20 +167,20 @@ public:
 - (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
                                 constructor:(nonnull ClassConstructorBlock)constructor
 {
-  expo::ClassConstructor jsConstructor = [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
+  expo::common::ClassConstructor jsConstructor = [self, constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) {
     std::shared_ptr<jsi::Object> thisPtr = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
     EXJavaScriptObject *caller = [[EXJavaScriptObject alloc] initWith:thisPtr runtime:self];
     NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
 
     constructor(caller, arguments);
   };
-  std::shared_ptr<jsi::Function> klass = expo::createClass(*_runtime, [name UTF8String], jsConstructor);
+  std::shared_ptr<jsi::Function> klass = std::make_shared<jsi::Function>(expo::common::createClass(*_runtime, [name UTF8String], jsConstructor));
   return [[EXJavaScriptObject alloc] initWith:klass runtime:self];
 }
 
 - (nullable EXJavaScriptObject *)createObjectWithPrototype:(nonnull EXJavaScriptObject *)prototype
 {
-  std::shared_ptr<jsi::Object> object = expo::createObjectWithPrototype(*_runtime, [prototype getShared]);
+  std::shared_ptr<jsi::Object> object = std::make_shared<jsi::Object>(expo::common::createObjectWithPrototype(*_runtime, [prototype getShared].get()));
   return object ? [[EXJavaScriptObject alloc] initWith:object runtime:self] : nil;
 }
 


### PR DESCRIPTION
# Why

Preparing the ground for #27038 by moving and adding some more C++ utils to the common codebase.

# How

- Moved creating classes and objects with prototypes from iOS to the common code
- Moved and made more convenient to use `defineProperty` (with a convenient struct to describe property descriptor)
- Added a function to create a class that inherits from another

# Test Plan

Unit tests are passing, bare-expo builds successfully