### PR TITLE
[asset] Add config plugin to link assets to native project

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added config plugin to allow assets to be linked at build time.
+- Added config plugin to allow assets to be linked at build time. ([#27052](https://github.com/expo/expo/pull/27052) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added config plugin to allow assets to be linked at build time.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-asset/app.plugin.js
+++ b/packages/expo-asset/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withAssets');

--- a/packages/expo-asset/plugin/build/utils.d.ts
+++ b/packages/expo-asset/plugin/build/utils.d.ts
@@ -1,6 +1,6 @@
-export declare const imageTypes: string[];
-export declare const fontTypes: string[];
-export declare const mediaTypes: string[];
+export declare const IMAGE_TYPES: string[];
+export declare const FONT_TYPES: string[];
+export declare const MEDIA_TYPES: string[];
 export declare const ACCEPTED_TYPES: string[];
 export declare function resolveAssetPaths(assets: string[], projectRoot: string): Promise<string[]>;
 export declare function validateAssets(assets: string[]): string[];

--- a/packages/expo-asset/plugin/build/utils.d.ts
+++ b/packages/expo-asset/plugin/build/utils.d.ts
@@ -1,0 +1,6 @@
+export declare const imageTypes: string[];
+export declare const fontTypes: string[];
+export declare const mediaTypes: string[];
+export declare const ACCEPTED_TYPES: string[];
+export declare function resolveAssetPaths(assets: string[], projectRoot: string): Promise<string[]>;
+export declare function validateAssets(assets: string[]): string[];

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -8,7 +8,7 @@ const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 exports.IMAGE_TYPES = ['.png', '.jpg', '.gif'];
 exports.FONT_TYPES = ['.otf', '.ttf'];
-exports.MEDIA_TYPES = ['.mp4', '.mp3'];
+exports.MEDIA_TYPES = ['.mp4', '.mp3', '.lottie'];
 exports.ACCEPTED_TYPES = ['.json', '.db', ...exports.IMAGE_TYPES, ...exports.MEDIA_TYPES, ...exports.FONT_TYPES];
 async function resolveAssetPaths(assets, projectRoot) {
     const promises = assets.map(async (p) => {

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -1,0 +1,37 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validateAssets = exports.resolveAssetPaths = exports.ACCEPTED_TYPES = exports.mediaTypes = exports.fontTypes = exports.imageTypes = void 0;
+const promises_1 = __importDefault(require("fs/promises"));
+const path_1 = __importDefault(require("path"));
+exports.imageTypes = ['.png', '.jpg', '.gif'];
+exports.fontTypes = ['.otf', '.ttf'];
+exports.mediaTypes = ['.mp4', '.mp3'];
+exports.ACCEPTED_TYPES = ['.json', '.db', ...exports.imageTypes, ...exports.mediaTypes, ...exports.fontTypes];
+async function resolveAssetPaths(assets, projectRoot) {
+    const promises = assets.map(async (p) => {
+        const resolvedPath = path_1.default.resolve(projectRoot, p);
+        const stat = await promises_1.default.stat(resolvedPath);
+        if (stat.isDirectory()) {
+            const dir = await promises_1.default.readdir(resolvedPath);
+            return dir.map((file) => path_1.default.join(resolvedPath, file));
+        }
+        return [resolvedPath];
+    });
+    return (await Promise.all(promises)).flat();
+}
+exports.resolveAssetPaths = resolveAssetPaths;
+function validateAssets(assets) {
+    return assets?.filter((asset) => {
+        const ext = path_1.default.extname(asset);
+        const accepted = exports.ACCEPTED_TYPES.includes(ext);
+        if (!accepted) {
+            console.warn(`\`${ext}\` is not a supported asset type`);
+            return;
+        }
+        return asset;
+    });
+}
+exports.validateAssets = validateAssets;

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -3,13 +3,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateAssets = exports.resolveAssetPaths = exports.ACCEPTED_TYPES = exports.mediaTypes = exports.fontTypes = exports.imageTypes = void 0;
+exports.validateAssets = exports.resolveAssetPaths = exports.ACCEPTED_TYPES = exports.MEDIA_TYPES = exports.FONT_TYPES = exports.IMAGE_TYPES = void 0;
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
-exports.imageTypes = ['.png', '.jpg', '.gif'];
-exports.fontTypes = ['.otf', '.ttf'];
-exports.mediaTypes = ['.mp4', '.mp3'];
-exports.ACCEPTED_TYPES = ['.json', '.db', ...exports.imageTypes, ...exports.mediaTypes, ...exports.fontTypes];
+exports.IMAGE_TYPES = ['.png', '.jpg', '.gif'];
+exports.FONT_TYPES = ['.otf', '.ttf'];
+exports.MEDIA_TYPES = ['.mp4', '.mp3'];
+exports.ACCEPTED_TYPES = ['.json', '.db', ...exports.IMAGE_TYPES, ...exports.MEDIA_TYPES, ...exports.FONT_TYPES];
 async function resolveAssetPaths(assets, projectRoot) {
     const promises = assets.map(async (p) => {
         const resolvedPath = path_1.default.resolve(projectRoot, p);
@@ -24,11 +24,16 @@ async function resolveAssetPaths(assets, projectRoot) {
 }
 exports.resolveAssetPaths = resolveAssetPaths;
 function validateAssets(assets) {
-    return assets?.filter((asset) => {
+    return assets.filter((asset) => {
         const ext = path_1.default.extname(asset);
         const accepted = exports.ACCEPTED_TYPES.includes(ext);
+        const isFont = exports.FONT_TYPES.includes(ext);
         if (!accepted) {
             console.warn(`\`${ext}\` is not a supported asset type`);
+            return;
+        }
+        if (isFont) {
+            console.warn(`Fonts are not supported with the \`expo-asset\` plugin. Please use \`expo-font\` for this functionality. Ignoring ${asset}`);
             return;
         }
         return asset;

--- a/packages/expo-asset/plugin/build/withAssets.d.ts
+++ b/packages/expo-asset/plugin/build/withAssets.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+export type AssetProps = {
+    assets?: string[];
+};
+declare const _default: ConfigPlugin<AssetProps>;
+export default _default;

--- a/packages/expo-asset/plugin/build/withAssets.d.ts
+++ b/packages/expo-asset/plugin/build/withAssets.d.ts
@@ -2,5 +2,5 @@ import { ConfigPlugin } from 'expo/config-plugins';
 export type AssetProps = {
     assets?: string[];
 };
-declare const _default: ConfigPlugin<AssetProps>;
+declare const _default: ConfigPlugin<AssetProps | null>;
 export default _default;

--- a/packages/expo-asset/plugin/build/withAssets.js
+++ b/packages/expo-asset/plugin/build/withAssets.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const withAssetsAndroid_1 = require("./withAssetsAndroid");
+const withAssetsIos_1 = require("./withAssetsIos");
+const pkg = require('expo-asset/package.json');
+const withAssets = (config, props) => {
+    if (!props) {
+        return config;
+    }
+    if (props.assets && props.assets.length === 0) {
+        return config;
+    }
+    config = (0, withAssetsIos_1.withAssetsIos)(config, props.assets ?? []);
+    config = (0, withAssetsAndroid_1.withAssetsAndroid)(config, props.assets ?? []);
+    return config;
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withAssets, pkg.name, pkg.version);

--- a/packages/expo-asset/plugin/build/withAssetsAndroid.d.ts
+++ b/packages/expo-asset/plugin/build/withAssetsAndroid.d.ts
@@ -1,0 +1,2 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+export declare const withAssetsAndroid: ConfigPlugin<string[]>;

--- a/packages/expo-asset/plugin/build/withAssetsAndroid.js
+++ b/packages/expo-asset/plugin/build/withAssetsAndroid.js
@@ -1,0 +1,44 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAssetsAndroid = void 0;
+const config_plugins_1 = require("expo/config-plugins");
+const promises_1 = __importDefault(require("fs/promises"));
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("./utils");
+const withAssetsAndroid = (config, assets) => {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'android',
+        async (config) => {
+            const resolvedAssets = await (0, utils_1.resolveAssetPaths)(assets, config.modRequest.projectRoot);
+            const validAssets = (0, utils_1.validateAssets)(resolvedAssets);
+            await Promise.all(validAssets.map(async (asset) => {
+                const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
+                await promises_1.default.mkdir(assetsDir, { recursive: true });
+                const output = path_1.default.join(assetsDir, path_1.default.basename(asset));
+                await promises_1.default.copyFile(asset, output);
+            }));
+            return config;
+        },
+    ]);
+};
+exports.withAssetsAndroid = withAssetsAndroid;
+function getAssetDir(asset, root) {
+    const assetPath = ['app', 'src', 'main', 'assets'];
+    const resPath = ['app', 'src', 'main', 'res'];
+    const ext = path_1.default.extname(asset);
+    if (utils_1.imageTypes.includes(ext)) {
+        return path_1.default.join(root, ...resPath, 'drawable');
+    }
+    else if (utils_1.fontTypes.includes(ext)) {
+        return path_1.default.join(root, ...assetPath, 'fonts');
+    }
+    else if (utils_1.mediaTypes.includes(ext)) {
+        return path_1.default.join(root, ...resPath, 'raw');
+    }
+    else {
+        return path_1.default.join(root, ...assetPath);
+    }
+}

--- a/packages/expo-asset/plugin/build/withAssetsAndroid.js
+++ b/packages/expo-asset/plugin/build/withAssetsAndroid.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withAssetsAndroid = void 0;
 const config_plugins_1 = require("expo/config-plugins");
+const fs_1 = __importDefault(require("fs"));
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
@@ -14,9 +15,12 @@ const withAssetsAndroid = (config, assets) => {
         async (config) => {
             const resolvedAssets = await (0, utils_1.resolveAssetPaths)(assets, config.modRequest.projectRoot);
             const validAssets = (0, utils_1.validateAssets)(resolvedAssets);
+            validAssets.forEach((asset) => {
+                const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
+                fs_1.default.mkdirSync(assetsDir, { recursive: true });
+            });
             await Promise.all(validAssets.map(async (asset) => {
                 const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
-                await promises_1.default.mkdir(assetsDir, { recursive: true });
                 const output = path_1.default.join(assetsDir, path_1.default.basename(asset));
                 await promises_1.default.copyFile(asset, output);
             }));
@@ -29,13 +33,13 @@ function getAssetDir(asset, root) {
     const assetPath = ['app', 'src', 'main', 'assets'];
     const resPath = ['app', 'src', 'main', 'res'];
     const ext = path_1.default.extname(asset);
-    if (utils_1.imageTypes.includes(ext)) {
+    if (utils_1.IMAGE_TYPES.includes(ext)) {
         return path_1.default.join(root, ...resPath, 'drawable');
     }
-    else if (utils_1.fontTypes.includes(ext)) {
+    else if (utils_1.FONT_TYPES.includes(ext)) {
         return path_1.default.join(root, ...assetPath, 'fonts');
     }
-    else if (utils_1.mediaTypes.includes(ext)) {
+    else if (utils_1.MEDIA_TYPES.includes(ext)) {
         return path_1.default.join(root, ...resPath, 'raw');
     }
     else {

--- a/packages/expo-asset/plugin/build/withAssetsIos.d.ts
+++ b/packages/expo-asset/plugin/build/withAssetsIos.d.ts
@@ -1,0 +1,2 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+export declare const withAssetsIos: ConfigPlugin<string[]>;

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -1,0 +1,102 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAssetsIos = void 0;
+const image_utils_1 = require("@expo/image-utils");
+const AssetContents_1 = require("@expo/prebuild-config/build/plugins/icons/AssetContents");
+const config_plugins_1 = require("expo/config-plugins");
+const fs_extra_1 = require("fs-extra");
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("./utils");
+const IMAGE_DIR = 'Images.xcassets';
+const withAssetsIos = (config, assets) => {
+    config = addAssetsToTarget(config, assets);
+    config = addFontsToPlist(config, assets);
+    return config;
+};
+exports.withAssetsIos = withAssetsIos;
+function addAssetsToTarget(config, assets) {
+    return (0, config_plugins_1.withXcodeProject)(config, async (config) => {
+        const resolvedAssets = await (0, utils_1.resolveAssetPaths)(assets, config.modRequest.projectRoot);
+        const validAssets = (0, utils_1.validateAssets)(resolvedAssets);
+        const project = config.modResults;
+        const platformProjectRoot = config.modRequest.platformProjectRoot;
+        config_plugins_1.IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');
+        const images = validAssets.filter((asset) => utils_1.imageTypes.includes(path_1.default.extname(asset)));
+        const assetsForResourcesDir = validAssets.filter((asset) => !utils_1.imageTypes.includes(path_1.default.extname(asset)));
+        await addImageAssets(images, config.modRequest.projectRoot);
+        addResourceFiles(project, platformProjectRoot, assetsForResourcesDir);
+        return config;
+    });
+}
+function addResourceFiles(project, platformRoot, assets) {
+    for (const asset of assets) {
+        const assetPath = path_1.default.relative(platformRoot, asset);
+        config_plugins_1.IOSConfig.XcodeUtils.addResourceFileToGroup({
+            filepath: assetPath,
+            groupName: 'Resources',
+            project,
+            isBuildFile: true,
+            verbose: true,
+        });
+    }
+}
+async function addImageAssets(assets, root) {
+    const iosNamedProjectRoot = config_plugins_1.IOSConfig.Paths.getSourceRoot(root);
+    for (const asset of assets) {
+        const name = path_1.default.basename(asset, path_1.default.extname(asset));
+        const image = path_1.default.basename(asset);
+        const assetPath = path_1.default.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
+        await (0, fs_extra_1.ensureDir)(assetPath);
+        const buffer = await (0, image_utils_1.generateImageAsync)({ projectRoot: root }, { src: asset });
+        await (0, fs_extra_1.writeFile)(path_1.default.resolve(assetPath, image), buffer.source);
+        await writeContentsJsonFileAsync({
+            assetPath,
+            image,
+        });
+    }
+}
+async function writeContentsJsonFileAsync({ assetPath, image, }) {
+    const images = buildContentsJsonImages({ image });
+    await (0, AssetContents_1.writeContentsJsonAsync)(assetPath, { images });
+}
+function buildContentsJsonImages({ image }) {
+    return [
+        (0, AssetContents_1.createContentsJsonItem)({
+            idiom: 'universal',
+            filename: image,
+            scale: '1x',
+        }),
+        (0, AssetContents_1.createContentsJsonItem)({
+            idiom: 'universal',
+            scale: '2x',
+        }),
+        (0, AssetContents_1.createContentsJsonItem)({
+            idiom: 'universal',
+            scale: '3x',
+        }),
+    ].filter(Boolean);
+}
+function addFontsToPlist(config, fonts) {
+    return (0, config_plugins_1.withInfoPlist)(config, async (config) => {
+        const resolvedAssets = await (0, utils_1.resolveAssetPaths)(fonts, config.modRequest.projectRoot);
+        const resolvedFonts = resolvedAssets.filter((asset) => utils_1.fontTypes.includes(path_1.default.extname(asset)));
+        if (!resolvedFonts) {
+            return config;
+        }
+        const existingFonts = getUIAppFonts(config.modResults);
+        const fontList = resolvedFonts.map((font) => path_1.default.basename(font)) ?? [];
+        const allFonts = [...existingFonts, ...fontList];
+        config.modResults.UIAppFonts = Array.from(new Set(allFonts));
+        return config;
+    });
+}
+function getUIAppFonts(infoPlist) {
+    const fonts = infoPlist['UIAppFonts'];
+    if (fonts != null && Array.isArray(fonts) && fonts.every((font) => typeof font === 'string')) {
+        return fonts;
+    }
+    return [];
+}

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -13,7 +13,6 @@ const utils_1 = require("./utils");
 const IMAGE_DIR = 'Images.xcassets';
 const withAssetsIos = (config, assets) => {
     config = addAssetsToTarget(config, assets);
-    config = addFontsToPlist(config, assets);
     return config;
 };
 exports.withAssetsIos = withAssetsIos;
@@ -24,8 +23,8 @@ function addAssetsToTarget(config, assets) {
         const project = config.modResults;
         const platformProjectRoot = config.modRequest.platformProjectRoot;
         config_plugins_1.IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');
-        const images = validAssets.filter((asset) => utils_1.imageTypes.includes(path_1.default.extname(asset)));
-        const assetsForResourcesDir = validAssets.filter((asset) => !utils_1.imageTypes.includes(path_1.default.extname(asset)));
+        const images = validAssets.filter((asset) => utils_1.IMAGE_TYPES.includes(path_1.default.extname(asset)));
+        const assetsForResourcesDir = validAssets.filter((asset) => !utils_1.IMAGE_TYPES.includes(path_1.default.extname(asset)));
         await addImageAssets(images, config.modRequest.projectRoot);
         addResourceFiles(project, platformProjectRoot, assetsForResourcesDir);
         return config;
@@ -77,26 +76,5 @@ function buildContentsJsonImages({ image }) {
             idiom: 'universal',
             scale: '3x',
         }),
-    ].filter(Boolean);
-}
-function addFontsToPlist(config, fonts) {
-    return (0, config_plugins_1.withInfoPlist)(config, async (config) => {
-        const resolvedAssets = await (0, utils_1.resolveAssetPaths)(fonts, config.modRequest.projectRoot);
-        const resolvedFonts = resolvedAssets.filter((asset) => utils_1.fontTypes.includes(path_1.default.extname(asset)));
-        if (!resolvedFonts) {
-            return config;
-        }
-        const existingFonts = getUIAppFonts(config.modResults);
-        const fontList = resolvedFonts.map((font) => path_1.default.basename(font)) ?? [];
-        const allFonts = [...existingFonts, ...fontList];
-        config.modResults.UIAppFonts = Array.from(new Set(allFonts));
-        return config;
-    });
-}
-function getUIAppFonts(infoPlist) {
-    const fonts = infoPlist['UIAppFonts'];
-    if (fonts != null && Array.isArray(fonts) && fonts.every((font) => typeof font === 'string')) {
-        return fonts;
-    }
-    return [];
+    ];
 }

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -49,7 +49,9 @@ async function addImageAssets(assets, root) {
         const image = path_1.default.basename(asset);
         const assetPath = path_1.default.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
         await (0, fs_extra_1.ensureDir)(assetPath);
-        const buffer = await (0, image_utils_1.generateImageAsync)({ projectRoot: root }, { src: asset });
+        const buffer = await (0, image_utils_1.generateImageAsync)({ projectRoot: root }, {
+            src: asset,
+        });
         await (0, fs_extra_1.writeFile)(path_1.default.resolve(assetPath, image), buffer.source);
         await writeContentsJsonFileAsync({
             assetPath,

--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 export const IMAGE_TYPES = ['.png', '.jpg', '.gif'];
 export const FONT_TYPES = ['.otf', '.ttf'];
-export const MEDIA_TYPES = ['.mp4', '.mp3'];
+export const MEDIA_TYPES = ['.mp4', '.mp3', '.lottie'];
 export const ACCEPTED_TYPES = ['.json', '.db', ...IMAGE_TYPES, ...MEDIA_TYPES, ...FONT_TYPES];
 
 export async function resolveAssetPaths(assets: string[], projectRoot: string) {

--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -1,0 +1,33 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export const imageTypes = ['.png', '.jpg', '.gif'];
+export const fontTypes = ['.otf', '.ttf'];
+export const mediaTypes = ['.mp4', '.mp3'];
+export const ACCEPTED_TYPES = ['.json', '.db', ...imageTypes, ...mediaTypes, ...fontTypes];
+
+export async function resolveAssetPaths(assets: string[], projectRoot: string) {
+  const promises = assets.map(async (p) => {
+    const resolvedPath = path.resolve(projectRoot, p);
+    const stat = await fs.stat(resolvedPath);
+    if (stat.isDirectory()) {
+      const dir = await fs.readdir(resolvedPath);
+      return dir.map((file) => path.join(resolvedPath, file));
+    }
+    return [resolvedPath];
+  });
+  return (await Promise.all(promises)).flat();
+}
+
+export function validateAssets(assets: string[]) {
+  return assets?.filter((asset) => {
+    const ext = path.extname(asset);
+    const accepted = ACCEPTED_TYPES.includes(ext);
+
+    if (!accepted) {
+      console.warn(`\`${ext}\` is not a supported asset type`);
+      return;
+    }
+    return asset;
+  });
+}

--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -1,10 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-export const imageTypes = ['.png', '.jpg', '.gif'];
-export const fontTypes = ['.otf', '.ttf'];
-export const mediaTypes = ['.mp4', '.mp3'];
-export const ACCEPTED_TYPES = ['.json', '.db', ...imageTypes, ...mediaTypes, ...fontTypes];
+export const IMAGE_TYPES = ['.png', '.jpg', '.gif'];
+export const FONT_TYPES = ['.otf', '.ttf'];
+export const MEDIA_TYPES = ['.mp4', '.mp3'];
+export const ACCEPTED_TYPES = ['.json', '.db', ...IMAGE_TYPES, ...MEDIA_TYPES, ...FONT_TYPES];
 
 export async function resolveAssetPaths(assets: string[], projectRoot: string) {
   const promises = assets.map(async (p) => {
@@ -20,12 +20,20 @@ export async function resolveAssetPaths(assets: string[], projectRoot: string) {
 }
 
 export function validateAssets(assets: string[]) {
-  return assets?.filter((asset) => {
+  return assets.filter((asset) => {
     const ext = path.extname(asset);
     const accepted = ACCEPTED_TYPES.includes(ext);
+    const isFont = FONT_TYPES.includes(ext);
 
     if (!accepted) {
       console.warn(`\`${ext}\` is not a supported asset type`);
+      return;
+    }
+
+    if (isFont) {
+      console.warn(
+        `Fonts are not supported with the \`expo-asset\` plugin. Please use \`expo-font\` for this functionality. Ignoring ${asset}`
+      );
       return;
     }
     return asset;

--- a/packages/expo-asset/plugin/src/withAssets.ts
+++ b/packages/expo-asset/plugin/src/withAssets.ts
@@ -9,7 +9,7 @@ export type AssetProps = {
   assets?: string[];
 };
 
-const withAssets: ConfigPlugin<AssetProps> = (config, props) => {
+const withAssets: ConfigPlugin<AssetProps | null> = (config, props) => {
   if (!props) {
     return config;
   }

--- a/packages/expo-asset/plugin/src/withAssets.ts
+++ b/packages/expo-asset/plugin/src/withAssets.ts
@@ -1,0 +1,27 @@
+import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
+
+import { withAssetsAndroid } from './withAssetsAndroid';
+import { withAssetsIos } from './withAssetsIos';
+
+const pkg = require('expo-asset/package.json');
+
+export type AssetProps = {
+  assets?: string[];
+};
+
+const withAssets: ConfigPlugin<AssetProps> = (config, props) => {
+  if (!props) {
+    return config;
+  }
+
+  if (props.assets && props.assets.length === 0) {
+    return config;
+  }
+
+  config = withAssetsIos(config, props.assets ?? []);
+  config = withAssetsAndroid(config, props.assets ?? []);
+
+  return config;
+};
+
+export default createRunOncePlugin(withAssets, pkg.name, pkg.version);

--- a/packages/expo-asset/plugin/src/withAssetsAndroid.ts
+++ b/packages/expo-asset/plugin/src/withAssetsAndroid.ts
@@ -1,8 +1,9 @@
 import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
-import fs from 'fs/promises';
+import fs from 'fs';
+import fsp from 'fs/promises';
 import path from 'path';
 
-import { fontTypes, imageTypes, mediaTypes, resolveAssetPaths, validateAssets } from './utils';
+import { FONT_TYPES, IMAGE_TYPES, MEDIA_TYPES, resolveAssetPaths, validateAssets } from './utils';
 
 export const withAssetsAndroid: ConfigPlugin<string[]> = (config, assets) => {
   return withDangerousMod(config, [
@@ -10,12 +11,17 @@ export const withAssetsAndroid: ConfigPlugin<string[]> = (config, assets) => {
     async (config) => {
       const resolvedAssets = await resolveAssetPaths(assets, config.modRequest.projectRoot);
       const validAssets = validateAssets(resolvedAssets);
+
+      validAssets.forEach((asset) => {
+        const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
+        fs.mkdirSync(assetsDir, { recursive: true });
+      });
+
       await Promise.all(
         validAssets.map(async (asset) => {
           const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
-          await fs.mkdir(assetsDir, { recursive: true });
           const output = path.join(assetsDir, path.basename(asset));
-          await fs.copyFile(asset, output);
+          await fsp.copyFile(asset, output);
         })
       );
       return config;
@@ -28,11 +34,11 @@ function getAssetDir(asset: string, root: string) {
   const resPath = ['app', 'src', 'main', 'res'];
   const ext = path.extname(asset);
 
-  if (imageTypes.includes(ext)) {
+  if (IMAGE_TYPES.includes(ext)) {
     return path.join(root, ...resPath, 'drawable');
-  } else if (fontTypes.includes(ext)) {
+  } else if (FONT_TYPES.includes(ext)) {
     return path.join(root, ...assetPath, 'fonts');
-  } else if (mediaTypes.includes(ext)) {
+  } else if (MEDIA_TYPES.includes(ext)) {
     return path.join(root, ...resPath, 'raw');
   } else {
     return path.join(root, ...assetPath);

--- a/packages/expo-asset/plugin/src/withAssetsAndroid.ts
+++ b/packages/expo-asset/plugin/src/withAssetsAndroid.ts
@@ -1,0 +1,40 @@
+import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { fontTypes, imageTypes, mediaTypes, resolveAssetPaths, validateAssets } from './utils';
+
+export const withAssetsAndroid: ConfigPlugin<string[]> = (config, assets) => {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const resolvedAssets = await resolveAssetPaths(assets, config.modRequest.projectRoot);
+      const validAssets = validateAssets(resolvedAssets);
+      await Promise.all(
+        validAssets.map(async (asset) => {
+          const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
+          await fs.mkdir(assetsDir, { recursive: true });
+          const output = path.join(assetsDir, path.basename(asset));
+          await fs.copyFile(asset, output);
+        })
+      );
+      return config;
+    },
+  ]);
+};
+
+function getAssetDir(asset: string, root: string) {
+  const assetPath = ['app', 'src', 'main', 'assets'];
+  const resPath = ['app', 'src', 'main', 'res'];
+  const ext = path.extname(asset);
+
+  if (imageTypes.includes(ext)) {
+    return path.join(root, ...resPath, 'drawable');
+  } else if (fontTypes.includes(ext)) {
+    return path.join(root, ...assetPath, 'fonts');
+  } else if (mediaTypes.includes(ext)) {
+    return path.join(root, ...resPath, 'raw');
+  } else {
+    return path.join(root, ...assetPath);
+  }
+}

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,0 +1,134 @@
+import { ExpoConfig } from '@expo/config-types';
+import { generateImageAsync } from '@expo/image-utils';
+import {
+  ContentsJsonImage,
+  createContentsJsonItem,
+  writeContentsJsonAsync,
+} from '@expo/prebuild-config/build/plugins/icons/AssetContents';
+import {
+  ConfigPlugin,
+  IOSConfig,
+  InfoPlist,
+  XcodeProject,
+  withInfoPlist,
+  withXcodeProject,
+} from 'expo/config-plugins';
+import { ensureDir, writeFile } from 'fs-extra';
+import path from 'path';
+
+import { fontTypes, imageTypes, resolveAssetPaths, validateAssets } from './utils';
+
+const IMAGE_DIR = 'Images.xcassets';
+
+export const withAssetsIos: ConfigPlugin<string[]> = (config, assets) => {
+  config = addAssetsToTarget(config, assets);
+  config = addFontsToPlist(config, assets);
+  return config;
+};
+
+function addAssetsToTarget(config: ExpoConfig, assets: string[]) {
+  return withXcodeProject(config, async (config) => {
+    const resolvedAssets = await resolveAssetPaths(assets, config.modRequest.projectRoot);
+    const validAssets = validateAssets(resolvedAssets);
+    const project = config.modResults;
+    const platformProjectRoot = config.modRequest.platformProjectRoot;
+    IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');
+
+    const images = validAssets.filter((asset) => imageTypes.includes(path.extname(asset)));
+    const assetsForResourcesDir = validAssets.filter(
+      (asset) => !imageTypes.includes(path.extname(asset))
+    );
+
+    await addImageAssets(images, config.modRequest.projectRoot);
+    addResourceFiles(project, platformProjectRoot, assetsForResourcesDir);
+
+    return config;
+  });
+}
+
+function addResourceFiles(project: XcodeProject, platformRoot: string, assets: string[]) {
+  for (const asset of assets) {
+    const assetPath = path.relative(platformRoot, asset);
+    IOSConfig.XcodeUtils.addResourceFileToGroup({
+      filepath: assetPath,
+      groupName: 'Resources',
+      project,
+      isBuildFile: true,
+      verbose: true,
+    });
+  }
+}
+
+async function addImageAssets(assets: string[], root: string) {
+  const iosNamedProjectRoot = IOSConfig.Paths.getSourceRoot(root);
+  for (const asset of assets) {
+    const name = path.basename(asset, path.extname(asset));
+    const image = path.basename(asset);
+
+    const assetPath = path.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
+    await ensureDir(assetPath);
+
+    const buffer = await generateImageAsync({ projectRoot: root }, { src: asset } as any);
+    await writeFile(path.resolve(assetPath, image), buffer.source);
+
+    await writeContentsJsonFileAsync({
+      assetPath,
+      image,
+    });
+  }
+}
+
+async function writeContentsJsonFileAsync({
+  assetPath,
+  image,
+}: {
+  assetPath: string;
+  image: string;
+}) {
+  const images = buildContentsJsonImages({ image });
+  await writeContentsJsonAsync(assetPath, { images });
+}
+
+function buildContentsJsonImages({ image }: { image: string }): ContentsJsonImage[] {
+  return [
+    createContentsJsonItem({
+      idiom: 'universal',
+      filename: image,
+      scale: '1x',
+    }),
+    createContentsJsonItem({
+      idiom: 'universal',
+      scale: '2x',
+    }),
+    createContentsJsonItem({
+      idiom: 'universal',
+      scale: '3x',
+    }),
+  ].filter(Boolean) as ContentsJsonImage[];
+}
+
+function addFontsToPlist(config: ExpoConfig, fonts: string[]) {
+  return withInfoPlist(config, async (config) => {
+    const resolvedAssets = await resolveAssetPaths(fonts, config.modRequest.projectRoot);
+    const resolvedFonts = resolvedAssets.filter((asset) => fontTypes.includes(path.extname(asset)));
+
+    if (!resolvedFonts) {
+      return config;
+    }
+
+    const existingFonts = getUIAppFonts(config.modResults);
+    const fontList = resolvedFonts.map((font) => path.basename(font)) ?? [];
+    const allFonts = [...existingFonts, ...fontList];
+    config.modResults.UIAppFonts = Array.from(new Set(allFonts));
+
+    return config;
+  });
+}
+
+function getUIAppFonts(infoPlist: InfoPlist): string[] {
+  const fonts = infoPlist['UIAppFonts'];
+  if (fonts != null && Array.isArray(fonts) && fonts.every((font) => typeof font === 'string')) {
+    return fonts as string[];
+  }
+  return [];
+}

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -5,24 +5,16 @@ import {
   createContentsJsonItem,
   writeContentsJsonAsync,
 } from '@expo/prebuild-config/build/plugins/icons/AssetContents';
-import {
-  ConfigPlugin,
-  IOSConfig,
-  InfoPlist,
-  XcodeProject,
-  withInfoPlist,
-  withXcodeProject,
-} from 'expo/config-plugins';
+import { ConfigPlugin, IOSConfig, XcodeProject, withXcodeProject } from 'expo/config-plugins';
 import { ensureDir, writeFile } from 'fs-extra';
 import path from 'path';
 
-import { fontTypes, imageTypes, resolveAssetPaths, validateAssets } from './utils';
+import { IMAGE_TYPES, resolveAssetPaths, validateAssets } from './utils';
 
 const IMAGE_DIR = 'Images.xcassets';
 
 export const withAssetsIos: ConfigPlugin<string[]> = (config, assets) => {
   config = addAssetsToTarget(config, assets);
-  config = addFontsToPlist(config, assets);
   return config;
 };
 
@@ -34,9 +26,9 @@ function addAssetsToTarget(config: ExpoConfig, assets: string[]) {
     const platformProjectRoot = config.modRequest.platformProjectRoot;
     IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');
 
-    const images = validAssets.filter((asset) => imageTypes.includes(path.extname(asset)));
+    const images = validAssets.filter((asset) => IMAGE_TYPES.includes(path.extname(asset)));
     const assetsForResourcesDir = validAssets.filter(
-      (asset) => !imageTypes.includes(path.extname(asset))
+      (asset) => !IMAGE_TYPES.includes(path.extname(asset))
     );
 
     await addImageAssets(images, config.modRequest.projectRoot);
@@ -104,31 +96,5 @@ function buildContentsJsonImages({ image }: { image: string }): ContentsJsonImag
       idiom: 'universal',
       scale: '3x',
     }),
-  ].filter(Boolean) as ContentsJsonImage[];
-}
-
-function addFontsToPlist(config: ExpoConfig, fonts: string[]) {
-  return withInfoPlist(config, async (config) => {
-    const resolvedAssets = await resolveAssetPaths(fonts, config.modRequest.projectRoot);
-    const resolvedFonts = resolvedAssets.filter((asset) => fontTypes.includes(path.extname(asset)));
-
-    if (!resolvedFonts) {
-      return config;
-    }
-
-    const existingFonts = getUIAppFonts(config.modResults);
-    const fontList = resolvedFonts.map((font) => path.basename(font)) ?? [];
-    const allFonts = [...existingFonts, ...fontList];
-    config.modResults.UIAppFonts = Array.from(new Set(allFonts));
-
-    return config;
-  });
-}
-
-function getUIAppFonts(infoPlist: InfoPlist): string[] {
-  const fonts = infoPlist['UIAppFonts'];
-  if (fonts != null && Array.isArray(fonts) && fonts.every((font) => typeof font === 'string')) {
-    return fonts as string[];
-  }
-  return [];
+  ] as ContentsJsonImage[];
 }

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
-import { generateImageAsync } from '@expo/image-utils';
+import { ImageOptions, generateImageAsync } from '@expo/image-utils';
 import {
   ContentsJsonImage,
   createContentsJsonItem,
@@ -60,7 +60,9 @@ async function addImageAssets(assets: string[], root: string) {
     const assetPath = path.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
     await ensureDir(assetPath);
 
-    const buffer = await generateImageAsync({ projectRoot: root }, { src: asset } as any);
+    const buffer = await generateImageAsync({ projectRoot: root }, {
+      src: asset,
+    } as unknown as ImageOptions);
     await writeFile(path.resolve(assetPath, image), buffer.source);
 
     await writeContentsJsonFileAsync({

--- a/packages/expo-asset/plugin/tsconfig.json
+++ b/packages/expo-asset/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why
Closes ENG-11315

# How
Added a config plugin to `expo-asset` that allows adding assets to the native project. 
Supports `json, png, jpg, mp3, mp4, off, ttf, db, gif, lottie`.

# Test Plan
Created a test project and added various asset types. Some of our libraries currently don't support reading from the native project.
`expo-av`: iOS only
`expo-image`: iOS only
`expo-sqlite`: iOS and android
I'll work on these in separate PRs

<img width="600" alt="Screenshot 2024-02-12 at 12 10 15" src="https://github.com/expo/expo/assets/30924086/83d0777c-752c-476e-8dad-4a3893b979b0">

