### PR TITLE
[docs] PROVIDER_GOOGLE usage correction

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
 #### Add the API key to your project
 
 - Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/develop/development-builds/create-a-build/#create-a-development-build-for-emulatorsimulator).
 
 </Step>

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
 #### Add the API key to your project
 
 - Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/create-a-build/#create-a-development-build-for-emulatorsimulator).
 
 </Step>


### PR DESCRIPTION
Correcting usage of `provider={PROVIDER_GOOGLE}`

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Documentation is incorrect.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Usage in a project.

# Test Plan

n/a

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
