### PR TITLE
refactor(cli): enable lazy swc bundling

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Change server log tag. ([#26834](https://github.com/expo/expo/pull/26834) by [@EvanBacon](https://github.com/EvanBacon))
 - Eagerly perform iOS system checks to speed up iOS simulator launches. ([#26746](https://github.com/expo/expo/pull/26746) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve warning for favicon missing during web export. ([#26733](https://github.com/expo/expo/pull/26733) by [@EvanBacon](https://github.com/EvanBacon))
+- Enable lazy modules with swc when building `@expo/cli`. ([#27061](https://github.com/expo/expo/pull/27061) by [@byCedric](https://github.com/byCedric))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -19,12 +19,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/config').expoConfig`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/config/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -36,12 +36,6 @@ afterAll(async () => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/customize').expoCustomize`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/customize/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -27,12 +27,6 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/export/embed').expoExportEmbed`
   );
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/export/embed/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/export-web-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-web-test.ts
@@ -27,12 +27,6 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/export/web').expoExportWeb`
   );
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/export/web/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -34,12 +34,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/export').expoExport`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/export/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -29,12 +29,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/install').expoInstall`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/install/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -19,12 +19,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/login');`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/login/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/logout-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/logout-test.ts
@@ -17,12 +17,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/logout');`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/logout/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -55,12 +55,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/prebuild').expoPrebuild`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/prebuild/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/register-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/register-test.ts
@@ -19,12 +19,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/register');`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/register/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/run-android-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-android-test.ts
@@ -22,12 +22,6 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/run/android').expoRunAndroid`
   );
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/android/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
@@ -20,12 +20,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/run/ios').expoRunIos`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/ios/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -19,13 +19,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/run').expoRun`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/getenv/index.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/hints.js',
     '@expo/cli/build/src/run/index.js',

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -35,12 +35,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/start').expoStart`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/start/index.js',
     '@expo/cli/build/src/utils/args.js',

--- a/packages/@expo/cli/e2e/__tests__/whoami-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/whoami-test.ts
@@ -17,12 +17,6 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/whoami');`);
   expect(modules).toStrictEqual([
-    '../node_modules/ansi-styles/index.js',
-    '../node_modules/arg/index.js',
-    '../node_modules/chalk/source/index.js',
-    '../node_modules/chalk/source/util.js',
-    '../node_modules/has-flag/index.js',
-    '../node_modules/supports-color/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
     '@expo/cli/build/src/utils/errors.js',

--- a/packages/@expo/cli/taskfile-swc.js
+++ b/packages/@expo/cli/taskfile-swc.js
@@ -14,6 +14,7 @@ module.exports = function (task) {
       options: {
         module: {
           type: 'commonjs',
+          lazy: true,
         },
         env: {
           targets: {


### PR DESCRIPTION
# Why

This should boost startup performance a bit. Tested with `bun create expo ./test --template tabs`.

<details><summary>1: <code>expo export --platform web</code><em>(75-100ms improvement)</em></summary>

![image](https://github.com/expo/expo/assets/1203991/5b4150c5-7e33-4011-be6e-f90778bf886f)

> Top test is with `lazy: true`, bottom with `lazy: undefined` (false)

</details>

<details><summary>2: <code>expo export -p ios --no-bytecode --no-minify --max-workers=0 --clear --dev</code><em>(±300ms improvement)</em></summary>

![image](https://github.com/expo/expo/assets/1203991/ed23e034-5cd0-41d3-9505-94731a7fb728)

> Top test is with `lazy: true`, bottom with `lazy: undefined` (false)

</details>

# How

See hyperfine screenshots above

# Other tests

- Changing Node target to `18+`, adds back `100ms` to export performance to test 2
- Disabling module interop, not possible as we use both CJS and ESM mixed

<details><summary><code>Node target 18+</code></summary>

![image](https://github.com/expo/expo/assets/1203991/4d66ab61-6202-4020-98b2-e88cf91e7840)

</details>

# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
