### PR TITLE
fix[dev-launcher][android]: only enable DevLauncher HostHandler in case of auto setup enabled

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740) by [@kudo](https://github.com/kudo))
 - [Android] Fixed unable to load dev client bundle on device. ([#26630](https://github.com/expo/expo/pull/26630) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed to not add dev client host handler when `enableAutoSetup` is false. ([#27068](https://github.com/expo/expo/pull/27068) by [@jayshah123](https://github.com/jayshah123))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740) by [@kudo](https://github.com/kudo))
 - [Android] Fixed unable to load dev client bundle on device. ([#26630](https://github.com/expo/expo/pull/26630) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed to not add dev client host handler when `enableAutoSetup` is false. ([#27068](https://github.com/expo/expo/pull/27068) by [@jayshah123](https://github.com/jayshah123))
+- [Android] Fixed to not return DevLauncherDevSupportManagerFactory in host handler when `enableAutoSetup` is false. ([#27068](https://github.com/expo/expo/pull/27068) by [@jayshah123](https://github.com/jayshah123))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/expo-45/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/expo-45/expo/modules/devlauncher/DevLauncherPackageDelegate.kt
@@ -20,73 +20,71 @@ import expo.modules.devlauncher.modules.DevLauncherDevMenuExtension
 import expo.modules.devlauncher.rncompatibility.DevLauncherReactNativeHostHandler
 
 object DevLauncherPackageDelegate {
-    @JvmField
-    var enableAutoSetup: Boolean? = null
-    private val shouldEnableAutoSetup: Boolean by lazy {
-        if (enableAutoSetup != null) {
-            // if someone else has set this explicitly, use that value
-            return@lazy enableAutoSetup!!
-        }
-        if (DevLauncherController.wasInitialized()) {
-            // Backwards compatibility -- if the MainApplication has already set up expo-dev-launcher,
-            // we just skip auto-setup in this case.
-            return@lazy false
-        }
-        return@lazy true
+  @JvmField
+  var enableAutoSetup: Boolean? = null
+  private val shouldEnableAutoSetup: Boolean by lazy {
+    if (enableAutoSetup != null) {
+      // if someone else has set this explicitly, use that value
+      return@lazy enableAutoSetup!!
     }
+    if (DevLauncherController.wasInitialized()) {
+      // Backwards compatibility -- if the MainApplication has already set up expo-dev-launcher,
+      // we just skip auto-setup in this case.
+      return@lazy false
+    }
+    return@lazy true
+  }
 
-    fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
-            listOf(
-                    DevLauncherModule(reactContext),
-                    DevLauncherInternalModule(reactContext),
-                    DevLauncherDevMenuExtension(reactContext),
-                    DevLauncherAuth(reactContext)
-            )
+  fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(
+      DevLauncherModule(reactContext),
+      DevLauncherInternalModule(reactContext),
+      DevLauncherDevMenuExtension(reactContext),
+      DevLauncherAuth(reactContext)
+    )
 
-    fun createApplicationLifecycleListeners(context: Context?): List<ApplicationLifecycleListener> =
-            listOf(
-                    object : ApplicationLifecycleListener {
-                        override fun onCreate(application: Application?) {
-                            if (shouldEnableAutoSetup && application != null && application is ReactApplication) {
-                                DevLauncherController.initialize(application, application.reactNativeHost)
-                                DevLauncherUpdatesInterfaceDelegate.initializeUpdatesInterface(application)
-                            }
-                        }
-                    }
-            )
+  fun createApplicationLifecycleListeners(context: Context?): List<ApplicationLifecycleListener> =
+    listOf(
+      object : ApplicationLifecycleListener {
+        override fun onCreate(application: Application?) {
+          if (shouldEnableAutoSetup && application != null && application is ReactApplication) {
+            DevLauncherController.initialize(application, application.reactNativeHost)
+            DevLauncherUpdatesInterfaceDelegate.initializeUpdatesInterface(application)
+          }
+        }
+      }
+    )
 
-    fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> =
-            listOf(
-                    object : ReactActivityLifecycleListener {
-                        override fun onNewIntent(intent: Intent?): Boolean {
-                            if (!shouldEnableAutoSetup || intent == null || activityContext == null || activityContext !is ReactActivity) {
-                                return false
-                            }
-                            return DevLauncherController.tryToHandleIntent(activityContext, intent)
-                        }
-                    }
-            )
+  fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> =
+    listOf(
+      object : ReactActivityLifecycleListener {
+        override fun onNewIntent(intent: Intent?): Boolean {
+          if (!shouldEnableAutoSetup || intent == null || activityContext == null || activityContext !is ReactActivity) {
+            return false
+          }
+          return DevLauncherController.tryToHandleIntent(activityContext, intent)
+        }
+      }
+    )
 
-    fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> =
-            listOf(
-                    object : ReactActivityHandler {
-                        override fun onDidCreateReactActivityDelegate(activity: ReactActivity, delegate: ReactActivityDelegate): ReactActivityDelegate? {
-                            if (!shouldEnableAutoSetup) {
-                                return null
-                            }
-                            return DevLauncherController.wrapReactActivityDelegate(
-                                    activity,
-                                    object : DevLauncherReactActivityDelegateSupplier {
-                                        override fun get(): ReactActivityDelegate {
-                                            return delegate
-                                        }
-                                    }
-                            )
-                        }
-                    }
-            )
+  fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> =
+    listOf(
+      object : ReactActivityHandler {
+        override fun onDidCreateReactActivityDelegate(activity: ReactActivity, delegate: ReactActivityDelegate): ReactActivityDelegate? {
+          if (!shouldEnableAutoSetup) {
+            return null
+          }
+          return DevLauncherController.wrapReactActivityDelegate(
+            activity,
+            object : DevLauncherReactActivityDelegateSupplier {
+              override fun get(): ReactActivityDelegate {
+                return delegate
+              }
+            }
+          )
+        }
+      }
+    )
 
-    fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> =
-            if (shouldEnableAutoSetup) listOf(DevLauncherReactNativeHostHandler(context))
-            else emptyList()
+  fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> = listOf(DevLauncherReactNativeHostHandler(context))
 }

--- a/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -15,10 +15,10 @@ import java.lang.ref.WeakReference
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
-    if(DevLauncherPackageDelegate.enableAutoSetup == true) {
-      return DevLauncherDevSupportManagerFactory()
+    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+        return null
     }
-    return null
+    return DevLauncherDevSupportManagerFactory()
   }
 
   override fun getUseDeveloperSupport(): Boolean? {

--- a/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -15,8 +15,8 @@ import java.lang.ref.WeakReference
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
-    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
-        return null
+    if (DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+     return null
     }
     return DevLauncherDevSupportManagerFactory()
   }

--- a/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -9,12 +9,16 @@ import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.DevLauncherPackageDelegate
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
-  override fun getDevSupportManagerFactory(): DevSupportManagerFactory {
-    return DevLauncherDevSupportManagerFactory()
+  override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
+    if(DevLauncherPackageDelegate.enableAutoSetup == true) {
+      return DevLauncherDevSupportManagerFactory()
+    }
+    return null
   }
 
   override fun getUseDeveloperSupport(): Boolean? {

--- a/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -15,8 +15,8 @@ import java.lang.ref.WeakReference
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
-    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
-        return null
+    if (DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+      return null
     }
     return DevLauncherDevSupportManagerFactory()
   }

--- a/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -9,6 +9,7 @@ import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.DevLauncherPackageDelegate
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {

--- a/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -13,7 +13,10 @@ import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
-  override fun getDevSupportManagerFactory(): DevSupportManagerFactory {
+  override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
+    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+        return null
+    }
     return DevLauncherDevSupportManagerFactory()
   }
 

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -15,8 +15,8 @@ import java.lang.ref.WeakReference
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
-    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
-        return null
+    if (DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+      return null
     }
     return DevLauncherDevSupportManagerFactory()
   }

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -9,6 +9,7 @@ import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.DevLauncherPackageDelegate
 import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -13,7 +13,10 @@ import java.lang.ref.WeakReference
 
 class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandler {
   private val contextHolder = WeakReference(context)
-  override fun getDevSupportManagerFactory(): DevSupportManagerFactory {
+  override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
+    if(DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
+        return null
+    }
     return DevLauncherDevSupportManagerFactory()
   }
 


### PR DESCRIPTION
# Why

I see the following crash in a build that has dev client disabled via `enableAutoSetup = false` - https://github.com/expo/expo/issues/25520
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

I saw DevLauncherDevSupportManager being set via reactnativehosthandler, even though I have disabled dev client.

# Test Plan

Try out bare expo with `enableAutoSetup` false. Then edit a file to trigger HMR.
I should not see following crash: https://github.com/expo/expo/issues/25520
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
