### PR TITLE
docs(create-expo): add basic usage and rules for placeholder values

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Document basic assumptions about the templating system.
+- Document basic assumptions about the templating system. ([#27071](https://github.com/expo/expo/pull/27071) by [@byCedric](https://github.com/byCedric))
 
 ## 2.1.4 - 2024-02-06
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Document basic assumptions about the templating system.
+
 ## 2.1.4 - 2024-02-06
 
 ### 🐛 Bug fixes

--- a/packages/create-expo/README.md
+++ b/packages/create-expo/README.md
@@ -32,17 +32,14 @@
 <!-- Body -->
 
 ```sh
-# With NPM
+# Usage for bun, npm, pnpm, and yarn
 npx create-expo
-
-# With Yarn
+bun create expo
+pnpm create expo
 yarn create expo
 
-# With pnpm
-pnpm create expo
-
-# With Bun
-bunx create-expo
+# Output help information with all available options
+npx create-expo --help
 ```
 
 Once you're up and running with Create Expo App, visit [this tutorial](https://docs.expo.dev/tutorial/planning/) for more information on building mobile apps with React.
@@ -52,7 +49,11 @@ Once you're up and running with Create Expo App, visit [this tutorial](https://d
 Create Expo App prepares an empty Expo project by default. You can choose to use a project with more prepared functionality. For that, you can start Create Expo App with the `--template` flag.
 
 ```sh
+# Pick from Expo's templates
 npx create-expo --template
+
+# Pick the expo-template-tabs template
+npx create-expo --template tabs
 ```
 
 ### npm templates
@@ -71,6 +72,10 @@ npx create-expo --template expo-template-blank@50
 npx create-expo --template ./path/to/template.tgz
 ```
 
+#### Private npm registry
+
+Create Expo App does not support private registries. In order to use a private template, use the local tarball option.
+
 ### GitHub templates
 
 Besides the templates provided by Expo, you can also create your own or use a 3rd party template directly from GitHub. The `--template` flag supports GitHub URLs, including branch, tag, or even specific commit.
@@ -79,8 +84,8 @@ Besides the templates provided by Expo, you can also create your own or use a 3r
 # Create from repository
 npx create-expo --template https://github.com/:owner/:repo
 
-# Create from repository using the `test` branch or tag
-npx create-expo --template https://github.com/:owner/:repo/tree/test
+# Create from repository using the `:ref` branch or tag
+npx create-expo --template https://github.com/:owner/:repo/tree/:ref
 
 # Create from repository using the `sdk-50` branch, and "templates/expo-template-bare-minimum" subdirectory
 npx create-expo --template https://github.com/expo/expo/tree/sdk-50/templates/expo-template-bare-minimum
@@ -102,8 +107,12 @@ Some characters aren't allowed in certain places, that's why Create Expo App app
 - Normalize the string using Unicode's normalization form "canonical composition" or `NFD`.
 - Remove all accent characters `u0300-u036f`.
 
-## Special files
+### Special files
 
 Due to some limitations with `npm pack`, some files are handled differently.
 
 - `gitignore` → Renamed to `.gitignore` due to `npm pack` skipping `.gitignore` files, see [npm/npm#1862](https://github.com/npm/npm/issues/1862)
+
+### Binary files
+
+Placeholder replacements only apply to non-binary files and folder names during unpacking. [These extensions](./src/createFileTransform.ts#L57) are left as-is without any modifications due to possible corrupting binary files.

--- a/packages/create-expo/README.md
+++ b/packages/create-expo/README.md
@@ -46,3 +46,64 @@ bunx create-expo
 ```
 
 Once you're up and running with Create Expo App, visit [this tutorial](https://docs.expo.dev/tutorial/planning/) for more information on building mobile apps with React.
+
+## Templates
+
+Create Expo App prepares an empty Expo project by default. You can choose to use a project with more prepared functionality. For that, you can start Create Expo App with the `--template` flag.
+
+```sh
+npx create-expo --template
+```
+
+### npm templates
+
+Expo publishes all [templates](../../templates/) through npm packages, versioned by Expo SDK. You can create your own npm templates with `npm pack`, or by publishing to npm.
+
+```sh
+# Create from npm
+npx create-expo --template tabs # Short for expo-template-tabs
+npx create-expo --template expo-template-tabs
+
+# Create from npm using a semver of the template
+npx create-expo --template expo-template-blank@50
+
+# Create from local tarball created with `npm pack`
+npx create-expo --template ./path/to/template.tgz
+```
+
+### GitHub templates
+
+Besides the templates provided by Expo, you can also create your own or use a 3rd party template directly from GitHub. The `--template` flag supports GitHub URLs, including branch, tag, or even specific commit.
+
+```sh
+# Create from repository
+npx create-expo --template https://github.com/:owner/:repo
+
+# Create from repository using the `test` branch or tag
+npx create-expo --template https://github.com/:owner/:repo/tree/test
+
+# Create from repository using the `sdk-50` branch, and "templates/expo-template-bare-minimum" subdirectory
+npx create-expo --template https://github.com/expo/expo/tree/sdk-50/templates/expo-template-bare-minimum
+```
+
+## Placeholders
+
+Create Expo App uses various placeholder values to customize the name of the projects. These placeholders are replaced with their actual value when unpacking the template, and applies to folder names and file contents.
+
+- `Hello App Display Name` → The name of the project, without modifications (example [Android](../../templates//expo-template-bare-minimum/android/app/src/main/res/values/strings.xml#L2))
+- `HelloWorld` → The name of the project with sanitization as described below (example [Android](../../templates/expo-template-bare-minimum//android/settings.gradle#L1), [iOS](../../templates/expo-template-bare-minimum/ios/Podfile#L16))
+- `helloworld` → The _lower-cased_ name of the project with sanitization as described below (example [Android](../../templates/expo-template-bare-minimum/android/app/build.gradle#L86))
+
+### Sanitization
+
+Some characters aren't allowed in certain places, that's why Create Expo App applies sanitization to the project name.
+
+- Remove all non-word `\W` and underscore `_` characters.
+- Normalize the string using Unicode's normalization form "canonical composition" or `NFD`.
+- Remove all accent characters `u0300-u036f`.
+
+## Special files
+
+Due to some limitations with `npm pack`, some files are handled differently.
+
+- `gitignore` → Renamed to `.gitignore` due to `npm pack` skipping `.gitignore` files, see [npm/npm#1862](https://github.com/npm/npm/issues/1862)


### PR DESCRIPTION
# Why

Fixes ENG-11313

This documents some of the basic assumptions we make in the templating system of `create-expo`.

# How

- Updated readme

# Test Plan

Docs only change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
