### PR TITLE
[docs] Fixes and improvements to Building for TV

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -47,6 +47,30 @@ You will need:
 
 > **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
 
+## Supported modules
+
+At this time, TV applications work with the following packages and APIs listed in our Expo API docs.
+
+- [AppleAuthentication](/versions/latest/sdk/apple-authentication/)
+- [Application](/versions/latest/sdk/application/)
+- [Asset](/versions/latest/sdk/asset/)
+- [AV](/versions/latest/sdk/av/)
+- [BlurView](/versions/latest/sdk/blur-view/)
+- [Crypto](/versions/latest/sdk/crypto/)
+- [Device](/versions/latest/sdk/device/)
+- [FileSystem](/versions/latest/sdk/filesystem/)
+- [FlashList](/versions/latest/sdk/flash-list/)
+- [Font](/versions/latest/sdk/font/)
+- [Image](/versions/latest/sdk/image)
+- [KeepAwake](/versions/latest/sdk/keep-awake/)
+- [LinearGradient](/versions/latest/sdk/linear-gradient/)
+- [Localization](/versions/latest/sdk/localization/)
+- [Reanimated](/versions/latest/sdk/reanimated/)
+- [SplashScreen](/versions/latest/sdk/splash-screen/)
+- [Updates](/versions/latest/sdk/updates/)
+
+TV also works with react-navigation, react-native-video, and many other commonly used 3rd party React Native libraries.
+
 ## Limitations
 
 Certain Expo modules are not supported at this time, most notably:
@@ -105,10 +129,10 @@ Verify that this plugin appears in **app.json**:
  To see additional information on the plugin's actions during prebuild, you can set [debug environment variables](https://github.com/debug-js/debug#conventions) before running prebuild. (See also our documentation on [Expo CLI environment variables](/more/expo-cli/#environment-variables).)
 
 <Terminal cmd={[
-  '# See all Expo CLI and config plugin debug information'
+  '# See all Expo CLI and config plugin debug information',
   'export DEBUG=expo:*',
   '',
-  '# See only debug information for the TV plugin'
+  '# See only debug information for the TV plugin',
   'export DEBUG=expo:react-native-tvos:config-tv']}
 />
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -92,7 +92,7 @@ When installed, the plugin will modify the project for TV when either:
 - The environment variable `EXPO_TV` is set to `1`
 - The plugin parameter `isTV` is set to `true`
 
-Make sure that this plugin appears in `app.json`:
+Verify that this plugin appears in **app.json**:
 
 ```json app.json
 {
@@ -105,8 +105,11 @@ Make sure that this plugin appears in `app.json`:
  To see additional information on the plugin's actions during prebuild, you can set [debug environment variables](https://github.com/debug-js/debug#conventions) before running prebuild. (See also our documentation on [Expo CLI environment variables](/more/expo-cli/#environment-variables).)
 
 <Terminal cmd={[
-  'export DEBUG=expo:* # see all Expo CLI and config plugin debug information',
-  'export DEBUG=expo:react-native-tvos:config-tv # see only debug information for the TV plugin']}
+  '# See all Expo CLI and config plugin debug information'
+  'export DEBUG=expo:*',
+  '',
+  '# See only debug information for the TV plugin'
+  'export DEBUG=expo:react-native-tvos:config-tv']}
 />
 
 </Step>

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -85,29 +85,29 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 ## Add the TV config plugin
 
-<Terminal cmd={['npx expo install @react-native-tvos/config-tv']} />
-
-Installing the library adds the `@react-native-tvos/config-tv` plugin to your project's **app.json**.
+<Terminal cmd={['npx expo install --dev @react-native-tvos/config-tv']} />
 
 When installed, the plugin will modify the project for TV when either:
 
 - The environment variable `EXPO_TV` is set to `1`
 - The plugin parameter `isTV` is set to `true`
 
-Make sure that this plugin appears in `app.json`. It is recommended to set the `showVerboseWarnings` property to `true` to see additional information during prebuild.
+Make sure that this plugin appears in `app.json`:
 
 ```json app.json
 {
   "plugins": [
-    [
-      "@react-native-tvos/config-tv",
-      {
-        "showVerboseWarnings": true
-      }
-    ]
+    "@react-native-tvos/config-tv"
   ]
 }
 ```
+
+ To see additional information on the plugin's actions during prebuild, you can set [debug environment variables](https://github.com/debug-js/debug#conventions) before running prebuild. (See also our documentation on [Expo CLI environment variables](/more/expo-cli/#environment-variables).)
+
+<Terminal cmd={[
+  'export DEBUG=expo:* # see all Expo CLI and config plugin debug information',
+  'export DEBUG=expo:react-native-tvos:config-tv # see only debug information for the TV plugin']}
+/>
 
 </Step>
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -69,7 +69,7 @@ At this time, TV applications work with the following packages and APIs listed i
 - [SplashScreen](/versions/latest/sdk/splash-screen/)
 - [Updates](/versions/latest/sdk/updates/)
 
-TV also works with react-navigation, react-native-video, and many other commonly used 3rd party React Native libraries.
+TV also works with `react-navigation`, `react-native-video,` and many other commonly used third-party React Native libraries.
 
 ## Limitations
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -69,14 +69,14 @@ At this time, TV applications work with the following packages and APIs listed i
 - [SplashScreen](/versions/latest/sdk/splash-screen/)
 - [Updates](/versions/latest/sdk/updates/)
 
-TV also works with `react-navigation`, `react-native-video,` and many other commonly used third-party React Native libraries.
+TV also works with [react-navigation](https://reactnavigation.org/), [react-native-video](https://github.com/react-native-video/react-native-video), and many other commonly used third-party React Native libraries.
 
 ## Limitations
 
-Certain Expo modules are not supported at this time, most notably:
+Certain Expo packages are not supported at this time, most notably:
 
-- `expo-dev-client`
-- `expo-router`
+- [Expo DevClient](/versions/latest/sdk/dev-client/)
+- [Expo Router](/router/introduction/)
 
 <Step label="1">
 


### PR DESCRIPTION
# Why

TV docs need some changes to reflect changes to the TV config plugin, and to ensure that the plugin is installed as a dev dependency.

# How

Update the doc.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
