### PR TITLE
[android][camera] Release camera on view destroy

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Set a higher resolution for barcode scans to allow scanning of high resolution barcodes. ([#26886](https://github.com/expo/expo/pull/26886)) by [@byudaniel](https://github.com/byudaniel))
 - Fix barcode types casing errors. ([#26888](https://github.com/expo/expo/pull/26888) by [@byudaniel](https://github.com/byudaniel))
 - On `iOS`, fix `maxDuration` timescale on videos. ([#26882](https://github.com/expo/expo/pull/26882) by [@alanjhughes](https://github.com/alanjhughes))
-- On `Android`, fix the camera not being released when the view is destroyed.
+- On `Android`, fix the camera not being released when the view is destroyed. ([#27086](https://github.com/expo/expo/pull/27086) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Set a higher resolution for barcode scans to allow scanning of high resolution barcodes. ([#26886](https://github.com/expo/expo/pull/26886)) by [@byudaniel](https://github.com/byudaniel))
 - Fix barcode types casing errors. ([#26888](https://github.com/expo/expo/pull/26888) by [@byudaniel](https://github.com/byudaniel))
 - On `iOS`, fix `maxDuration` timescale on videos. ([#26882](https://github.com/expo/expo/pull/26882) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, fix the camera not being released when the view is destroyed.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
@@ -151,6 +151,7 @@ class CameraViewNextModule : Module() {
 
       OnViewDestroys { view ->
         view.cancelCoroutineScope()
+        view.releaseCamera()
       }
     }
   }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -79,6 +79,7 @@ class ExpoCameraView(
   var camera: Camera? = null
   var activeRecording: Recording? = null
 
+  private var cameraProvider: ProcessCameraProvider? = null
   private val providerFuture = ProcessCameraProvider.getInstance(context)
   private var imageCaptureUseCase: ImageCapture? = null
   private var imageAnalysisUseCase: ImageAnalysis? = null
@@ -270,6 +271,7 @@ class ExpoCameraView(
           camera?.let {
             observeCameraState(it.cameraInfo)
           }
+          this.cameraProvider = cameraProvider
         } catch (e: Exception) {
           onMountError(
             CameraMountErrorEvent("Camera component could not be rendered - is there any other instance running?")
@@ -326,7 +328,6 @@ class ExpoCameraView(
         CameraState.Type.OPEN -> {
           onCameraReady(Unit)
         }
-
         else -> {}
       }
     }
@@ -343,6 +344,12 @@ class ExpoCameraView(
 
   private fun getDeviceOrientation() =
     (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
+
+  fun releaseCamera() {
+    appContext.mainQueue.launch {
+      cameraProvider?.unbindAll()
+    }
+  }
 
   private fun transformBarcodeScannerResultToViewCoordinates(barcode: BarCodeScannerResult) {
     val cornerPoints = barcode.cornerPoints


### PR DESCRIPTION
# Why
Closes #27074
Closes ENG-11423

# How
Add a function to release the camera when the view is destroyed

# Test Plan
bare-expo. When the component unmounts the surface is destroyed and the camera indicator is off in the status bar. This was always the case on my test device but this should ensure it is correctly destroyed on all devices.
 