### PR TITLE
[core][iOS] Native implementation of the EventEmitter in JS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `BarCodeScannerResult` interface now declares an additional `raw` field corresponding to the barcode value as it was encoded in the barcode without parsing. Will always be undefined on iOS. ([#25391](https://github.com/expo/expo/pull/25391) by [@ajacquierbret](https://github.com/ajacquierbret))
 - [Android] Added syntactic sugar for defining a prop group. ([#27004](https://github.com/expo/expo/pull/27004) by [@lukmccall](https://github.com/lukmccall))
 - Introduced a base class for all shared objects (`expo.SharedObject`) with a simple mechanism to release native pointer from JS. ([#27038](https://github.com/expo/expo/pull/27038) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added native implementation of the JS EventEmitter. ([#27092](https://github.com/expo/expo/pull/27092) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -6,7 +6,7 @@ namespace expo::EventEmitter {
 #pragma mark - Listeners
 
 void Listeners::add(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {
-  listenersMap[eventName].push_back(jsi::Value(runtime, listener));
+  listenersMap[eventName].emplace_back(runtime, listener);
 }
 
 void Listeners::remove(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -1,0 +1,140 @@
+#include "JSIUtils.h"
+#include "EventEmitter.h"
+
+namespace expo::EventEmitter {
+
+#pragma mark - Listeners
+
+void Listeners::add(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {
+  listenersMap[eventName].push_back(jsi::Value(runtime, listener));
+}
+
+void Listeners::remove(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept {
+  if (!listenersMap.contains(eventName)) {
+    return;
+  }
+  jsi::Value listenerValue(runtime, listener);
+
+  listenersMap[eventName].remove_if([&](const jsi::Value &item) {
+    return jsi::Value::strictEquals(runtime, listenerValue, item);
+  });
+}
+
+void Listeners::removeAll(std::string eventName) noexcept {
+  if (listenersMap.contains(eventName)) {
+    listenersMap[eventName].clear();
+  }
+}
+
+void Listeners::clear() noexcept {
+  listenersMap.clear();
+}
+
+void Listeners::call(jsi::Runtime &runtime, std::string eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept {
+  if (!listenersMap.contains(eventName)) {
+    return;
+  }
+  ListenersList &listenersList = listenersMap[eventName];
+
+  for (const jsi::Value &listener : listenersList) {
+    listener
+      .asObject(runtime)
+      .asFunction(runtime)
+      .callWithThis(runtime, thisObject, args, count);
+  }
+}
+
+#pragma mark - NativeState
+
+NativeState::NativeState() : jsi::NativeState() {}
+
+NativeState::~NativeState() {
+  listeners.clear();
+}
+
+NativeState::Shared NativeState::get(jsi::Runtime &runtime, jsi::Object &object, bool createIfMissing) {
+  if (object.hasNativeState<NativeState>(runtime)) {
+    return object.getNativeState<NativeState>(runtime);
+  }
+  if (createIfMissing) {
+    NativeState::Shared state = std::make_shared<NativeState>();
+    object.setNativeState(runtime, state);
+    return state;
+  }
+  return nullptr;
+}
+
+#pragma mark - Utils
+
+jsi::Function getClass(jsi::Runtime &runtime) {
+  return runtime
+    .global()
+    .getPropertyAsObject(runtime, "expo")
+    .getPropertyAsFunction(runtime, "EventEmitter");
+}
+
+void installClass(jsi::Runtime &runtime) {
+  jsi::Function eventEmitterClass = common::createClass(runtime, "EventEmitter");
+  jsi::Object prototype = eventEmitterClass.getPropertyAsObject(runtime, "prototype");
+
+  jsi::HostFunctionType addListener = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    if (NativeState::Shared state = NativeState::get(runtime, thisObject, true)) {
+      state->listeners.add(runtime, eventName, listener);
+    }
+    return jsi::Value::undefined();
+  };
+
+  jsi::HostFunctionType removeListener = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    if (NativeState::Shared state = NativeState::get(runtime, thisObject, false)) {
+      state->listeners.remove(runtime, eventName, listener);
+    }
+    return jsi::Value::undefined();
+  };
+
+  jsi::HostFunctionType removeAllListeners = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    if (NativeState::Shared state = NativeState::get(runtime, thisObject, false)) {
+      state->listeners.removeAll(eventName);
+    }
+    return jsi::Value::undefined();
+  };
+
+  jsi::HostFunctionType emit = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    if (NativeState::Shared state = NativeState::get(runtime, thisObject, false)) {
+      // Pass the arguments without the first that is the event name.
+      const jsi::Value *payloadArgs = count > 1 ? &args[1] : nullptr;
+      state->listeners.call(runtime, eventName, thisObject, payloadArgs, count - 1);
+    }
+    return jsi::Value::undefined();
+  };
+
+  jsi::PropNameID addListenerProp = jsi::PropNameID::forAscii(runtime, "addListener", 11);
+  jsi::PropNameID removeListenerProp = jsi::PropNameID::forAscii(runtime, "removeListener", 14);
+  jsi::PropNameID removeAllListenersProp = jsi::PropNameID::forAscii(runtime, "removeAllListeners", 18);
+  jsi::PropNameID emitProp = jsi::PropNameID::forAscii(runtime, "emit", 4);
+
+  prototype.setProperty(runtime, addListenerProp, jsi::Function::createFromHostFunction(runtime, addListenerProp, 2, addListener));
+  prototype.setProperty(runtime, removeListenerProp, jsi::Function::createFromHostFunction(runtime, removeListenerProp, 2, removeListener));
+  prototype.setProperty(runtime, removeAllListenersProp, jsi::Function::createFromHostFunction(runtime, removeAllListenersProp, 1, removeAllListeners));
+  prototype.setProperty(runtime, emitProp, jsi::Function::createFromHostFunction(runtime, emitProp, 2, emit));
+
+  runtime
+    .global()
+    .getPropertyAsObject(runtime, "expo")
+    .setProperty(runtime, "EventEmitter", eventEmitterClass);
+}
+
+} // namespace expo::EventEmitter

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#ifdef __cplusplus
+
+#include <unordered_map>
+#include <list>
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo::EventEmitter {
+
+/**
+ Class containing and managing listeners of the event emitter.
+ */
+class Listeners {
+private:
+  friend class NativeState;
+  friend void installClass(jsi::Runtime &runtime);
+
+  /**
+   Type of the list containing listeners for the specific event name.
+   */
+  using ListenersList = std::list<jsi::Value>;
+
+  /**
+   Type of the map where the keys are event names and the values are lists of listeners.
+   */
+  using ListenersMap = std::unordered_map<std::string, ListenersList>;
+
+  /**
+   Map with the events and listeners.
+   */
+  ListenersMap listenersMap;
+
+  /**
+   Adds a listener for the given event name.
+   */
+  void add(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept;
+
+  /**
+   Removes the listener for the given event name.
+   */
+  void remove(jsi::Runtime &runtime, std::string eventName, const jsi::Function &listener) noexcept;
+
+  /**
+   Removes all listeners for the given event name.
+   */
+  void removeAll(std::string eventName) noexcept;
+
+  /**
+   Clears the entire map of events and listeners.
+   */
+  void clear() noexcept;
+
+  /**
+   Calls listeners for the given event name, with the given `this` object and payload arguments.
+   */
+  void call(jsi::Runtime &runtime, std::string eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept;
+};
+
+/**
+ Class representing a native state of objects that emit events.
+ */
+class JSI_EXPORT NativeState : public jsi::NativeState {
+public:
+  using Shared = std::shared_ptr<NativeState>;
+
+  NativeState();
+  virtual ~NativeState();
+
+  /**
+   A structure containing event listeners.
+   */
+  Listeners listeners;
+
+  /**
+   Gets event emitter's native state from the given object.
+   If `createIfMissing` is set to `true`, the state will be automatically created.
+   */
+  static Shared get(jsi::Runtime &runtime, jsi::Object &object, bool createIfMissing = false);
+};
+
+/**
+ Gets `expo.EventEmitter` class from the given runtime.
+ */
+jsi::Function getClass(jsi::Runtime &runtime);
+
+/**
+ Installs `expo.EventEmitter` class in the given runtime.
+ */
+void installClass(jsi::Runtime &runtime);
+
+} // namespace expo::EventEmitter
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -398,6 +398,9 @@ public final class AppContext: NSObject {
     EXJavaScriptRuntimeManager.installSharedObjectClass(runtime) { [weak sharedObjectRegistry] objectId in
       sharedObjectRegistry?.delete(objectId)
     }
+
+    // Install `global.expo.EventEmitter`.
+    EXJavaScriptRuntimeManager.installEventEmitterClass(runtime)
   }
 
   /**

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -25,4 +25,9 @@
  */
 + (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser;
 
+/**
+ Installs the EventEmitter class in the given runtime as `global.expo.EventEmitter`.
+ */
++ (void)installEventEmitterClass:(nonnull EXRuntime *)runtime;
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -5,6 +5,7 @@
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/LazyObject.h>
 #import <ExpoModulesCore/SharedObject.h>
+#import <ExpoModulesCore/EventEmitter.h>
 #import <ExpoModulesCore/Swift.h>
 
 namespace jsi = facebook::jsi;
@@ -61,6 +62,11 @@ static NSString *modulesHostObjectPropertyName = @"modules";
   expo::SharedObject::installBaseClass(*[runtime get], [releaser](expo::SharedObject::ObjectId objectId) {
     releaser(objectId);
   });
+}
+
++ (void)installEventEmitterClass:(nonnull EXRuntime *)runtime
+{
+  expo::EventEmitter::installClass(*[runtime get]);
 }
 
 @end

--- a/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
@@ -2,7 +2,7 @@ import ExpoModulesTestCore
 
 @testable import ExpoModulesCore
 
-final class JSEventEmitterSpec: ExpoSpec {
+final class EventEmitterSpec: ExpoSpec {
   override class func spec() {
     let appContext = AppContext.create()
     let runtime = try! appContext.runtime

--- a/packages/expo-modules-core/ios/Tests/JSEventEmitterSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JSEventEmitterSpec.swift
@@ -1,0 +1,91 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class JSEventEmitterSpec: ExpoSpec {
+  override class func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    describe("JS class") {
+      it("exists") {
+        let eventEmitterClass = try runtime.eval("expo.EventEmitter")
+        expect(eventEmitterClass.kind) == .function
+      }
+
+      it("has functions in prototype") {
+        let prototype = try runtime.eval("expo.EventEmitter.prototype").asObject()
+        let addListener = prototype.getProperty("addListener")
+        let removeListener = prototype.getProperty("removeListener")
+        let removeAllListeners = prototype.getProperty("removeAllListeners")
+        let emit = prototype.getProperty("emit")
+
+        expect(addListener.kind) == .function
+        expect(removeListener.kind) == .function
+        expect(removeAllListeners.kind) == .function
+        expect(emit.kind) == .function
+      }
+
+      it("creates an instance") {
+        let eventEmitter = try runtime.eval("new expo.EventEmitter()")
+        expect(eventEmitter.kind) == .object
+      }
+
+      it("calls a listener") {
+        let result = try runtime.eval([
+          "emitter = new expo.EventEmitter()",
+          "result = null",
+          "emitter.addListener('test', payload => { result = payload })",
+          "emitter.emit('test', 'it\\'s a payload')",
+          "result"
+        ])
+        expect(result.kind) == .string
+        expect(try result.asString()) == "it's a payload"
+      }
+
+      it("removes a listener") {
+        let result = try runtime.eval([
+          "emitter = new expo.EventEmitter()",
+          "result = null",
+          "listener = () => { result = 1 }",
+          "emitter.addListener('test', listener)",
+          "emitter.removeListener('test', listener)",
+          "emitter.emit('test')",
+          "result"
+        ])
+        expect(result.kind) == .null
+      }
+
+      it("removes all listeners") {
+        let result = try runtime.eval([
+          "emitter = new expo.EventEmitter()",
+          "result = null",
+          "emitter.addListener('test', () => { result = 1 })",
+          "emitter.addListener('test', () => { result = 2 })",
+          "emitter.removeAllListeners('test')",
+          "emitter.emit('test')",
+          "result"
+        ])
+        expect(result.kind) == .null
+      }
+
+      it("emits with multiple arguments") {
+        let args = try runtime
+          .eval([
+            "emitter = new expo.EventEmitter()",
+            "result = null",
+            "emitter.addListener('test', (a, b, c) => { result = [a, b, c] })",
+            "emitter.emit('test', 14, 2, 24)",
+            "result"
+          ])
+          .asArray()
+          .compactMap({ try $0?.asInt() })
+
+        expect(args.count) == 3
+        expect(args[0]) == 14
+        expect(args[1]) == 2
+        expect(args[2]) == 24
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Right now if the module needs to emit events, it requires some additional setup on the JS side – creating an emitter using the `EventEmitter` class.
What if the module object already inherits from such class and no setup is needed? The same could be used by the `SharedObject` class introduced in #27038 – right now we don't have any way to emit events from the shared object.

# How

Created and installed `global.expo.EventEmitter` class that stores the events and listeners in its native state. It provides a few basic functions: `addListener`, `removeListener`, `removeAllListeners` and `emit` (as in https://github.com/expo/expo/blob/main/packages/expo-modules-core/src/EventEmitter.ts).
I was a bit reluctant to expose the last one, but I can imagine it might be useful in testing and we could just call the JS function from Swift to trigger the event.

The following are out of scope of this PR and will be addressed later:
- Inheritance in the module objects
- Inheritance in the SharedObject class
- Implementing sending events by shared objects
- Replacing the implementation of `sendEvent` on the module
- Replacing the class that is already defined in the JS code
- Returning a subscription object in `addListener`

# Test Plan

Added some new unit tests, all are passing.