### PR TITLE
[docs] Update monorepos.mdx

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -110,7 +110,7 @@ const path = require('path');
 const projectRoot = __dirname;
 const monorepoRoot = path.resolve(projectRoot, '../..');
 
-const config = getDefaultConfig(workspaceRoot);
+const config = getDefaultConfig(monorepoRoot);
 
 // Only list the packages within your monorepo that your app uses. No need to add anything else.
 // If your monorepo tooling can give you the list of monorepo workspaces linked
@@ -121,7 +121,7 @@ const monorepoPackages = {
 };
 
 // 1. Watch the local app folder, and only the shared packages (limiting the scope and speeding it up)
-// Note how we change this from `workspaceRoot` to `projectRoot`. This is part of the optimization!
+// Note how we change this from `monorepoRoot` to `projectRoot`. This is part of the optimization!
 config.watchFolders = [projectRoot, ...Object.values(monorepoPackages)];
 
 // Add the monorepo workspaces as `extraNodeModules` to Metro.


### PR DESCRIPTION
# Why

Undeclared variable (workspaceRoot) in documentation.

```js metro.config.js
const config = getDefaultConfig(workspaceRoot);

// ...

// Note how we change this from `workspaceRoot` to `projectRoot`. This is part of the optimization!
```

# How

Replaced the variable with a more appropriate one.

```js metro.config.js
const config = getDefaultConfig(monorepoRoot);

// ...

// Note how we change this from `monorepoRoot` to `projectRoot`. This is part of the optimization!
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
