### PR TITLE
[docs] mention `image` requirement in GH build docs

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -14,14 +14,18 @@ This guide explains how to trigger builds directly from your GitHub repository u
 
 ### Set the `image` field in your eas.json
 
-For the build profiles you want to use with GitHub, you need to specify the image to use for the
-build. This is done in the **eas.json** file in your project's root directory. See [the eas.json reference](/eas/json/#image) to learn more.
+For the build profiles you want to use with GitHub, specify an [`image`](/eas/json/#image) to use for the native platform in **eas.json**.
+
+Use the `latest` image if your project's configuration does not rely on a specific [build image](/build-reference/infrastructure/). For example:
 
 ```json eas.json
 {
-  // ...
+  /* @hide ... */ /* @end */
   "build": {
     "production": {
+      "android": {
+        "image": "latest"
+      },
       "ios": {
         "image": "latest"
       }

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -12,6 +12,23 @@ This guide explains how to trigger builds directly from your GitHub repository u
 
 ## Prerequisites
 
+### Set the `image` field in your eas.json
+
+For the build profiles you want to use with GitHub, you need to specify the image to use for the
+build. This is done in the **eas.json** file in your project's root directory. See [the eas.json reference](/eas/json/#image) to learn more.
+
+```json eas.json
+{
+  // ...
+  "build": {
+    "production": {
+      "ios": {
+        "image": "latest"
+      }
+    }
+  }
+}
+```
 
 ### Run a successful build from your local machine
 


### PR DESCRIPTION
# Why

We require the "image" field when building from GitHub now.

# How

I updated the GitHub builds guide with the new requirements.

# Test Plan

http://localhost:3002/build/building-from-github/

![Screenshot 2024-02-14 at 20 25 13](https://github.com/expo/expo/assets/12488826/46b268c6-949c-4c92-afe8-06cd9131b7c5)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
