### PR TITLE
[docs] remove "development mode" qualifier from navigation devtools plugin

### DIFF
--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -67,6 +67,8 @@ After installing the dev tools plugin and adding the connecting required code to
 
 Expo provides some dev tools plugins for common debugging tasks. Follow the instructions below to start using them in your app.
 
+> Each of these dev tools plugin hooks will only enable the plugin in development mode, so you don't need to worry about this code affecting your production builds.
+
 ### React Navigation
 
 Inspired by [`@react-navigation/devtools`](https://github.com/react-navigation/react-navigation/tree/main/packages/devtools) and [`flipper-plugin-react-navigation`](https://github.com/react-navigation/react-navigation/tree/main/packages/flipper-plugin-react-navigation), the React Navigation dev tools plugin allows seeing history of [React Navigation](https://reactnavigation.org/) actions and state. You can also rewind to previous points in your navigation history and send deep links to your app. Since Expo Router is built upon React Navigation, this plugin is fully compatible with [Expo Router](/router/introduction).

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -67,7 +67,7 @@ After installing the dev tools plugin and adding the connecting required code to
 
 Expo provides some dev tools plugins for common debugging tasks. Follow the instructions below to start using them in your app.
 
-> Each of these dev tools plugin hooks will only enable the plugin in development mode, so you don't need to worry about this code affecting your production bundle.
+> **Note**: Each of the following dev tools plugin hooks will only enable the plugin in development mode. It doesn't affect your production bundle.
 
 ### React Navigation
 

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -67,7 +67,7 @@ After installing the dev tools plugin and adding the connecting required code to
 
 Expo provides some dev tools plugins for common debugging tasks. Follow the instructions below to start using them in your app.
 
-> Each of these dev tools plugin hooks will only enable the plugin in development mode, so you don't need to worry about this code affecting your production builds.
+> Each of these dev tools plugin hooks will only enable the plugin in development mode, so you don't need to worry about this code affecting your production bundle.
 
 ### React Navigation
 

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -75,7 +75,7 @@ To use the plugin, start by installing the package:
 
 <Terminal cmd={['$ npx expo install @dev-plugins/react-navigation']} />
 
-Pass the navigation root to the plugin in your app's entry point when running in development mode:
+Pass the navigation root to the plugin in your app's entry point:
 
 <Tabs tabs={["Expo Router", "React Navigation"]}>
 <Tab>


### PR DESCRIPTION
# Why
Thanks to @RRaideRR for the feedback that we noted earlier in the doc that the plugins take care of turning on/off based on whether or not the app is in development mode, but we left this unnecessary step in there for the React Navigation plugin. 

# How
Removed the reference - just passing nav root is enough; the plugin will turn off in production code.
