### PR TITLE
feature(cli): allow raw gradle props pass-through in `expo run:android`

### DIFF
--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -8,7 +8,7 @@ import * as Log from '../../log';
 import { assertWithOptionsArgs } from '../../utils/args';
 import { logCmdError } from '../../utils/errors';
 
-export const expoRunAndroid: Command = async (argv) => {
+export const expoRunAndroid: Command = async (argv, passThroughArgs) => {
   const rawArgsMap: arg.Spec = {
     // Types
     '--help': Boolean,
@@ -72,6 +72,7 @@ export const expoRunAndroid: Command = async (argv) => {
     port: args['--port'],
     variant: args['--variant'],
     allArch: args['--all-arch'],
+    gradleArgs: passThroughArgs,
 
     // Custom parsed args
     device: parsed.args['--device'],

--- a/packages/@expo/cli/src/run/android/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/android/resolveOptions.ts
@@ -12,6 +12,7 @@ export type Options = {
   install?: boolean;
   buildCache?: boolean;
   allArch?: boolean;
+  gradleArgs?: string[];
 };
 
 export type ResolvedOptions = GradleProps &

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -33,6 +33,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     appName: props.appName,
     buildCache: props.buildCache,
     architectures: props.architectures,
+    gradleArgs: options.gradleArgs,
   });
 
   // Ensure the port hasn't become busy during the build.

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/gradle-test.ts
@@ -76,6 +76,30 @@ describe(assembleAsync, () => {
       { cwd: '/android', stdio: 'inherit' }
     );
   });
+  it('uses pass-through gradle properties instead of default ones', async () => {
+    await assembleAsync('/android', {
+      variant: 'debug',
+      appName: 'app',
+      port: 8081,
+      architectures: 'universal',
+      gradleArgs: ['-PreactNativeArchitectures=test', '-PreactNativeDevServerPort=6969'],
+    });
+
+    expect(spawnAsync).toHaveBeenCalledWith(
+      '/android/gradlew',
+      [
+        'app:assembleDebug',
+        '-x',
+        'lint',
+        '-x',
+        'test',
+        '--configure-on-demand',
+        '-PreactNativeArchitectures=test',
+        '-PreactNativeDevServerPort=6969',
+      ],
+      { cwd: '/android', stdio: 'inherit' }
+    );
+  });
 });
 
 describe(installAsync, () => {


### PR DESCRIPTION
# Why

Fixes ENG-11312

This adds two things to the CLI

1. The concept of "pass-through" properties, using `expo <command> [args] -- [pass-through]`
2. Use these pass-through properties as raw gradle props directly in `expo run:android`

The reason why we had to add the concept of pass-through properties is because the CLI is parsing the arguments twice, once in the entry binary (to determine what command needs to run), and once in the command itself.

Unfortunately, when using `arg()` on the `argv` object with pass-through properties, they get parsed as normal properties. Once the command itself runs, we lose the info that `-- -PreactNativeArchitectures` was passed as pass-through (we can only see the argument).

By splitting any pass-through props early on, we maintain that info separately from the normal `arg` object.

# How

1. The concept of "pass-through" properties, using `expo <command> [args] -- [pass-through]`
2. Use these pass-through properties as raw gradle props directly in `expo run:android`

# Test Plan

See added test.

```
DEBUG=expo:start:platforms:android:gradle expo run:android -- -PreactNativeDevServerPort=420
```

^ Should output the gradle command, with any pass-through props provided.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
