### PR TITLE
[docs] Update push notification server for Rust

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -23,20 +23,20 @@ After you setup your push notification credentials and add logic to get the `Exp
 
 The Expo team and community have taken care of creating back-ends for you in a few different languages:
 
-| SDKs                                                                                     | Back-end | Maintained by |
-| ---------------------------------------------------------------------------------------- | -------- | ------------- |
-| [expo-server-sdk-node](https://github.com/expo/expo-server-sdk-node)                     | Node.js  | Expo team     |
-| [expo-server-sdk-python](https://github.com/expo/expo-server-sdk-python)                 | Python   | Community     |
-| [expo-server-sdk-ruby](https://github.com/expo/expo-server-sdk-ruby)                     | Ruby     | Community     |
-| [expo-server-sdk-rust](https://github.com/expo/expo-server-sdk-rust)                     | Rust     | Community     |
-| [expo-notifier](https://github.com/symfony/expo-notifier)                                | Symfony  | Symfony       |
-| [exponent-server-sdk-php](https://github.com/Alymosul/exponent-server-sdk-php)           | PHP      | Community     |
-| [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php)                   | PHP      | Community     |
-| [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang) | Golang   | Community     |
-| [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir)        | Elixir   | Community     |
-| [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet)             | dotnet   | Community     |
-| [expo-server-sdk-java](https://github.com/jav/expo-server-sdk-java)                      | Java     | Community     |
-| [laravel-expo-notifier](https://github.com/YieldStudio/laravel-expo-notifier)            | Laravel  | Community     |
+| SDKs                                                                                                     | Back-end | Maintained by |
+| -------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| [expo-server-sdk-node](https://github.com/expo/expo-server-sdk-node)                                     | Node.js  | Expo team     |
+| [expo-server-sdk-python](https://github.com/expo/expo-server-sdk-python)                                 | Python   | Community     |
+| [expo-server-sdk-ruby](https://github.com/expo/expo-server-sdk-ruby)                                     | Ruby     | Community     |
+| [expo-push-notification-client-rust](https://github.com/katayama8000/expo-push-notification-client-rust) | Rust     | Community     |
+| [expo-notifier](https://github.com/symfony/expo-notifier)                                                | Symfony  | Symfony       |
+| [exponent-server-sdk-php](https://github.com/Alymosul/exponent-server-sdk-php)                           | PHP      | Community     |
+| [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php)                                   | PHP      | Community     |
+| [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang)                 | Golang   | Community     |
+| [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir)                        | Elixir   | Community     |
+| [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet)                             | dotnet   | Community     |
+| [expo-server-sdk-java](https://github.com/jav/expo-server-sdk-java)                                      | Java     | Community     |
+| [laravel-expo-notifier](https://github.com/YieldStudio/laravel-expo-notifier)                            | Laravel  | Community     |
 
 Each of the example servers above is a wrapper around Expo's Push API.
 
@@ -274,7 +274,7 @@ Each message must be a JSON object with the given fields (only the `to` field is
 | `sound`          | iOS Only        | <CODE>'default' \| null</CODE>               | Play a sound when the recipient receives this notification. Specify `"default"` to play the device's default notification sound, or omit this field to play no sound. Custom sounds are not supported.                                                                                                                                                            |
 | `badge`          | iOS Only        | `number`                                     | Number to display in the badge on the app icon. Specify zero to clear the badge.                                                                                                                                                                                                                                                                                  |
 | `channelId`      | Android Only    | `string`                                     | ID of the Notification Channel through which to display this notification. If an ID is specified but the corresponding channel does not exist on the device (that has not yet been created by your app), the notification will not be displayed to the user.                                                                                                      |
-| `categoryId`     | Android and iOS | `string`                                     | ID of the notification category that this notification is associated with. [Find out more about notification categories here](/versions/latest/sdk/notifications/#manage-notification-categories-interactive-notifications). Must be on at least SDK 41 or bare workflow.                                                                                    |
+| `categoryId`     | Android and iOS | `string`                                     | ID of the notification category that this notification is associated with. [Find out more about notification categories here](/versions/latest/sdk/notifications/#manage-notification-categories-interactive-notifications). Must be on at least SDK 41 or bare workflow.                                                                                         |
 | `mutableContent` | iOS Only        | `boolean`                                    | Specifies whether this notification can be [intercepted by the client app](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications?language=objc). In Expo Go, this defaults to `true`, and if you change that to false, you may experience issues. In standalone and bare apps, this defaults to `false`. |
 
 **Note on `ttl`**: On Android, we make our best effort to deliver messages with zero TTL immediately and do not throttle them. However, setting TTL to a low value (for example, zero) can prevent normal-priority notifications from ever reaching Android devices that are in doze mode. To guarantee that a notification will be delivered, TTL must be long enough for the device to wake from doze mode. This field takes precedence over `expiration` when both are specified.


### PR DESCRIPTION
# Why

A user named kataama8000 wrote this library: https://github.com/katayama8000/expo-push-notification-client-rust

They asked that we include it in our doc: https://docs.expo.dev/push-notifications/sending-notifications/

I asked Quin about our current Rust library, which she authored > 5 years ago. We haven't updated it since then, so she said we should recommend this library.

# Test Plan

Make sure that the link to the rust library on the /push-notifications/sending-notifications/#send-push-notifications-using-a-server doc goes to https://github.com/katayama8000/expo-push-notification-client-rust

Here's a screenshot: 
<img width="1211" alt="Screenshot 2024-02-15 at 12 58 39 PM" src="https://github.com/expo/expo/assets/6455018/51e94c8d-6348-4946-990c-0b08f7388c0f">
