### PR TITLE
[dev-menu][dev-launcher] fix nightlies build errors

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740) by [@kudo](https://github.com/kudo))
+- Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))
 - [Android] Fixed unable to load dev client bundle on device. ([#26630](https://github.com/expo/expo/pull/26630) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
@@ -7,7 +7,7 @@ import expo.modules.devlauncher.react.DevLauncherPackagerConnectionSettings
 internal class DevLauncherInternalSettings(
   context: Context,
   debugServerHost: String
-) : DevInternalSettings(context, null) {
+) : DevInternalSettings(context, Listener{}) {
   private var packagerConnectionSettings = DevLauncherPackagerConnectionSettings(context, debugServerHost)
 
   override fun getPackagerConnectionSettings() = packagerConnectionSettings

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740) by [@kudo](https://github.com/kudo))
+- Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))
 - Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
@@ -36,15 +36,11 @@ internal class DevMenuReactInternalSettings(
 
   override fun setFpsDebugEnabled(enabled: Boolean) = Unit
 
-  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) = Unit
-
   override fun isRemoteJSDebugEnabled() = false
 
   override fun isHotModuleReplacementEnabled() = true
 
   override fun setHotModuleReplacementEnabled(enabled: Boolean) = Unit
-
-  override fun addMenuItem(title: String?) = Unit
 
   override fun isFpsDebugEnabled() = false
 

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -39,13 +39,14 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
 
   override func sourceURL(for bridge: RCTBridge) -> URL {
     #if DEBUG
-    if let packagerHost = jsPackagerHost() {
-      return RCTBundleURLProvider.jsBundleURL(
+    if let packagerHost = jsPackagerHost(),
+      let url = RCTBundleURLProvider.jsBundleURL(
         forBundleRoot: "index",
         packagerHost: packagerHost,
         enableDev: true,
         enableMinification: false,
-        inlineSourceMap: false)
+        inlineSourceMap: false) {
+      return url
     }
     #endif
     return jsSourceUrl()


### PR DESCRIPTION
# Why

fix nightlies build error: https://github.com/expo/expo/actions/runs/7910535856

# How

relevant changes:
- https://github.com/facebook/react-native/commit/12e4a5745d54a7be86c005e4ed954c42171541b2
- https://github.com/facebook/react-native/commit/239f9bf7eba6122ffacab2e1cdc3525bcb4174e4

# Test Plan

- ci passed
- nightlies testing: https://github.com/expo/expo/actions/runs/7921484497

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
