### PR TITLE
[expo-updates] Add expo-updates cli fingerprint:generate command

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add timer capability to Logger. ([#26454](https://github.com/expo/expo/pull/26454), [#26477](https://github.com/expo/expo/pull/26477) by [@wschurman](https://github.com/wschurman))
 - Add assets:verify command to CLI. ([#26756](https://github.com/expo/expo/pull/26756) by [@douglowder](https://github.com/douglowder))
 - Fix fingerprint runtime version policy. Calculate fingerprint at build time. ([#26901](https://github.com/expo/expo/pull/26901) by [@wschurman](https://github.com/wschurman))
+- Add expo-updates cli fingerprint:generate command. ([#27119](https://github.com/expo/expo/pull/27119) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/cli/build/cli.js
+++ b/packages/expo-updates/cli/build/cli.js
@@ -44,6 +44,7 @@ const commands = {
     'codesigning:generate': () => import('./generateCodeSigning.js').then((i) => i.generateCodeSigning),
     'codesigning:configure': () => import('./configureCodeSigning.js').then((i) => i.configureCodeSigning),
     'assets:verify': () => import('./assetsVerify.js').then((i) => i.expoAssetsVerify),
+    'fingerprint:generate': () => import('./generateFingerprint.js').then((i) => i.generateFingerprint),
 };
 const args = (0, arg_1.default)({
     // Types

--- a/packages/expo-updates/cli/build/generateFingerprint.d.ts
+++ b/packages/expo-updates/cli/build/generateFingerprint.d.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { Command } from './cli';
+export declare const generateFingerprint: Command;

--- a/packages/expo-updates/cli/build/generateFingerprint.js
+++ b/packages/expo-updates/cli/build/generateFingerprint.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateFingerprint = void 0;
+const chalk_1 = __importDefault(require("chalk"));
+const args_1 = require("./utils/args");
+const Log = __importStar(require("./utils/log"));
+const generateFingerprint = async (argv) => {
+    const args = (0, args_1.assertArgs)({
+        // Types
+        '--help': Boolean,
+        '--platform': String,
+        // Aliases
+        '-h': '--help',
+    }, argv ?? []);
+    if (args['--help']) {
+        Log.exit((0, chalk_1.default) `
+{bold Description}
+Generate fingerprint for use in expo-updates runtime version
+
+{bold Usage}
+  {dim $} npx expo-updates fingerprint:generate --platform <platform>
+
+  Options
+  --platform <string>                  Platform to generate a fingerprint for
+  -h, --help                           Output usage information
+    `, 0);
+    }
+    const { createFingerprintAsync } = await import('../../utils/build/createFingerprintAsync.js');
+    const platform = (0, args_1.requireArg)(args, '--platform');
+    if (!['ios', 'android'].includes(platform)) {
+        throw new Error(`Invalid platform argument: ${platform}`);
+    }
+    const result = await createFingerprintAsync((0, args_1.getProjectRoot)(args), platform);
+    console.log(JSON.stringify(result));
+};
+exports.generateFingerprint = generateFingerprint;

--- a/packages/expo-updates/cli/src/cli.ts
+++ b/packages/expo-updates/cli/src/cli.ts
@@ -22,6 +22,8 @@ const commands: { [command: string]: () => Promise<Command> } = {
   'codesigning:configure': () =>
     import('./configureCodeSigning.js').then((i) => i.configureCodeSigning),
   'assets:verify': () => import('./assetsVerify.js').then((i) => i.expoAssetsVerify),
+  'fingerprint:generate': () =>
+    import('./generateFingerprint.js').then((i) => i.generateFingerprint),
 };
 
 const args = arg(

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from './cli';
+import { requireArg, assertArgs, getProjectRoot } from './utils/args';
+import * as Log from './utils/log';
+
+export const generateFingerprint: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--platform': String,
+      // Aliases
+      '-h': '--help',
+    },
+    argv ?? []
+  );
+
+  if (args['--help']) {
+    Log.exit(
+      chalk`
+{bold Description}
+Generate fingerprint for use in expo-updates runtime version
+
+{bold Usage}
+  {dim $} npx expo-updates fingerprint:generate --platform <platform>
+
+  Options
+  --platform <string>                  Platform to generate a fingerprint for
+  -h, --help                           Output usage information
+    `,
+      0
+    );
+  }
+
+  const { createFingerprintAsync } = await import('../../utils/build/createFingerprintAsync.js');
+
+  const platform = requireArg(args, '--platform');
+  if (!['ios', 'android'].includes(platform)) {
+    throw new Error(`Invalid platform argument: ${platform}`);
+  }
+
+  const result = await createFingerprintAsync(getProjectRoot(args), platform);
+  console.log(JSON.stringify(result));
+};

--- a/packages/expo-updates/utils/build/createFingerprintAsync.d.ts
+++ b/packages/expo-updates/utils/build/createFingerprintAsync.d.ts
@@ -1,1 +1,2 @@
-export declare function createFingerprintAsync(platform: 'ios' | 'android', possibleProjectRoot: string, destinationDir: string): Promise<void>;
+import * as Fingerprint from '@expo/fingerprint';
+export declare function createFingerprintAsync(projectRoot: string, platform: 'ios' | 'android'): Promise<Fingerprint.Fingerprint>;

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.d.ts
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.d.ts
@@ -1,0 +1,1 @@
+export declare function createFingerprintForBuildAsync(platform: 'ios' | 'android', possibleProjectRoot: string, destinationDir: string): Promise<void>;

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
@@ -1,0 +1,40 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createFingerprintForBuildAsync = void 0;
+const config_1 = require("@expo/config");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const createFingerprintAsync_1 = require("./createFingerprintAsync");
+async function createFingerprintForBuildAsync(platform, possibleProjectRoot, destinationDir) {
+    // Remove projectRoot validation when we no longer support React Native <= 62
+    let projectRoot;
+    if (fs_1.default.existsSync(path_1.default.join(possibleProjectRoot, 'package.json'))) {
+        projectRoot = possibleProjectRoot;
+    }
+    else if (fs_1.default.existsSync(path_1.default.join(possibleProjectRoot, '..', 'package.json'))) {
+        projectRoot = path_1.default.resolve(possibleProjectRoot, '..');
+    }
+    else {
+        throw new Error('Error loading app package. Ensure there is a package.json in your app.');
+    }
+    process.chdir(projectRoot);
+    const { exp: config } = (0, config_1.getConfig)(projectRoot, {
+        isPublicConfig: true,
+        skipSDKVersionRequirement: true,
+    });
+    const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
+    if (!runtimeVersion || typeof runtimeVersion === 'string') {
+        return;
+    }
+    if (runtimeVersion.policy !== 'fingerprintExperimental') {
+        // not a policy that needs fingerprinting
+        return;
+    }
+    const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform);
+    console.log(JSON.stringify(fingerprint.sources));
+    fs_1.default.writeFileSync(path_1.default.join(destinationDir, 'fingerprint'), fingerprint.hash);
+}
+exports.createFingerprintForBuildAsync = createFingerprintForBuildAsync;

--- a/packages/expo-updates/utils/build/createManifestAsync.d.ts
+++ b/packages/expo-updates/utils/build/createManifestAsync.d.ts
@@ -1,1 +1,0 @@
-export declare function createManifestAsync(platform: 'ios' | 'android', possibleProjectRoot: string, destinationDir: string, entryFileArg?: string): Promise<void>;

--- a/packages/expo-updates/utils/build/createManifestForBuildAsync.d.ts
+++ b/packages/expo-updates/utils/build/createManifestForBuildAsync.d.ts
@@ -1,0 +1,1 @@
+export declare function createManifestForBuildAsync(platform: 'ios' | 'android', possibleProjectRoot: string, destinationDir: string, entryFileArg?: string): Promise<void>;

--- a/packages/expo-updates/utils/build/createManifestForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createManifestForBuildAsync.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createManifestAsync = void 0;
+exports.createManifestForBuildAsync = void 0;
 const exportEmbedAsync_1 = require("@expo/cli/build/src/export/embed/exportEmbedAsync");
 const metroAssetLocalPath_1 = require("@expo/cli/build/src/export/metroAssetLocalPath");
 const paths_1 = require("@expo/config/paths");
@@ -11,7 +11,7 @@ const crypto_1 = __importDefault(require("crypto"));
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const filterPlatformAssetScales_1 = require("./filterPlatformAssetScales");
-async function createManifestAsync(platform, possibleProjectRoot, destinationDir, entryFileArg) {
+async function createManifestForBuildAsync(platform, possibleProjectRoot, destinationDir, entryFileArg) {
     const entryFile = entryFileArg ||
         process.env.ENTRY_FILE ||
         getRelativeEntryPoint(possibleProjectRoot, platform) ||
@@ -83,7 +83,7 @@ async function createManifestAsync(platform, possibleProjectRoot, destinationDir
     });
     fs_1.default.writeFileSync(path_1.default.join(destinationDir, 'app.manifest'), JSON.stringify(manifest));
 }
-exports.createManifestAsync = createManifestAsync;
+exports.createManifestForBuildAsync = createManifestForBuildAsync;
 /**
  * Resolve the relative entry file using Expo's resolution method.
  */

--- a/packages/expo-updates/utils/build/createUpdatesResources.js
+++ b/packages/expo-updates/utils/build/createUpdatesResources.js
@@ -4,8 +4,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const assert_1 = __importDefault(require("assert"));
-const createFingerprintAsync_1 = require("./createFingerprintAsync");
-const createManifestAsync_1 = require("./createManifestAsync");
+const createFingerprintForBuildAsync_1 = require("./createFingerprintForBuildAsync");
+const createManifestForBuildAsync_1 = require("./createManifestForBuildAsync");
 const findUpProjectRoot_1 = require("./findUpProjectRoot");
 (async function () {
     const platform = process.argv[2];
@@ -25,9 +25,9 @@ const findUpProjectRoot_1 = require("./findUpProjectRoot");
     const entryFileArg = process.argv[6];
     await Promise.all([
         createUpdatesResourcesMode === 'all'
-            ? (0, createManifestAsync_1.createManifestAsync)(platform, possibleProjectRoot, destinationDir, entryFileArg)
+            ? (0, createManifestForBuildAsync_1.createManifestForBuildAsync)(platform, possibleProjectRoot, destinationDir, entryFileArg)
             : null,
-        (0, createFingerprintAsync_1.createFingerprintAsync)(platform, possibleProjectRoot, destinationDir),
+        (0, createFingerprintForBuildAsync_1.createFingerprintForBuildAsync)(platform, possibleProjectRoot, destinationDir),
     ]);
 })().catch((e) => {
     // Wrap in regex to make it easier for log parsers (like `@expo/xcpretty`) to find this error.

--- a/packages/expo-updates/utils/src/createFingerprintAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintAsync.ts
@@ -1,59 +1,23 @@
-import { getConfig } from '@expo/config';
 import * as Fingerprint from '@expo/fingerprint';
-import fs from 'fs';
-import path from 'path';
 
 import { resolveWorkflowAsync } from './workflow';
 
 export async function createFingerprintAsync(
-  platform: 'ios' | 'android',
-  possibleProjectRoot: string,
-  destinationDir: string
-): Promise<void> {
-  // Remove projectRoot validation when we no longer support React Native <= 62
-  let projectRoot;
-  if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
-    projectRoot = possibleProjectRoot;
-  } else if (fs.existsSync(path.join(possibleProjectRoot, '..', 'package.json'))) {
-    projectRoot = path.resolve(possibleProjectRoot, '..');
-  } else {
-    throw new Error('Error loading app package. Ensure there is a package.json in your app.');
-  }
-
-  process.chdir(projectRoot);
-
-  const { exp: config } = getConfig(projectRoot, {
-    isPublicConfig: true,
-    skipSDKVersionRequirement: true,
-  });
-
-  const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
-  if (!runtimeVersion || typeof runtimeVersion === 'string') {
-    return;
-  }
-
-  if (runtimeVersion.policy !== 'fingerprintExperimental') {
-    // not a policy that needs fingerprinting
-    return;
-  }
-
+  projectRoot: string,
+  platform: 'ios' | 'android'
+): Promise<Fingerprint.Fingerprint> {
   const workflow = await resolveWorkflowAsync(projectRoot, platform);
 
-  let fingerprint: Fingerprint.Fingerprint;
   if (workflow === 'generic') {
-    fingerprint = await Fingerprint.createFingerprintAsync(projectRoot, {
+    return await Fingerprint.createFingerprintAsync(projectRoot, {
       platforms: [platform],
     });
   } else {
     // ignore everything in native directories to ensure fingerprint is the same
     // no matter whether project has been prebuilt
-    fingerprint = await Fingerprint.createFingerprintAsync(projectRoot, {
+    return await Fingerprint.createFingerprintAsync(projectRoot, {
       platforms: [platform],
       ignorePaths: ['/android/**/*', '/ios/**/*'],
     });
   }
-
-  console.log(JSON.stringify(fingerprint.sources));
-
-  fs.writeFileSync(path.join(destinationDir, 'fingerprint'), fingerprint.hash);
 }

--- a/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
@@ -1,0 +1,44 @@
+import { getConfig } from '@expo/config';
+import fs from 'fs';
+import path from 'path';
+
+import { createFingerprintAsync } from './createFingerprintAsync';
+
+export async function createFingerprintForBuildAsync(
+  platform: 'ios' | 'android',
+  possibleProjectRoot: string,
+  destinationDir: string
+): Promise<void> {
+  // Remove projectRoot validation when we no longer support React Native <= 62
+  let projectRoot;
+  if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
+    projectRoot = possibleProjectRoot;
+  } else if (fs.existsSync(path.join(possibleProjectRoot, '..', 'package.json'))) {
+    projectRoot = path.resolve(possibleProjectRoot, '..');
+  } else {
+    throw new Error('Error loading app package. Ensure there is a package.json in your app.');
+  }
+
+  process.chdir(projectRoot);
+
+  const { exp: config } = getConfig(projectRoot, {
+    isPublicConfig: true,
+    skipSDKVersionRequirement: true,
+  });
+
+  const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
+  if (!runtimeVersion || typeof runtimeVersion === 'string') {
+    return;
+  }
+
+  if (runtimeVersion.policy !== 'fingerprintExperimental') {
+    // not a policy that needs fingerprinting
+    return;
+  }
+
+  const fingerprint = await createFingerprintAsync(projectRoot, platform);
+
+  console.log(JSON.stringify(fingerprint.sources));
+
+  fs.writeFileSync(path.join(destinationDir, 'fingerprint'), fingerprint.hash);
+}

--- a/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
@@ -14,7 +14,7 @@ import path from 'path';
 
 import { filterPlatformAssetScales } from './filterPlatformAssetScales';
 
-export async function createManifestAsync(
+export async function createManifestForBuildAsync(
   platform: 'ios' | 'android',
   possibleProjectRoot: string,
   destinationDir: string,

--- a/packages/expo-updates/utils/src/createUpdatesResources.ts
+++ b/packages/expo-updates/utils/src/createUpdatesResources.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
-import { createFingerprintAsync } from './createFingerprintAsync';
-import { createManifestAsync } from './createManifestAsync';
+import { createFingerprintForBuildAsync } from './createFingerprintForBuildAsync';
+import { createManifestForBuildAsync } from './createManifestForBuildAsync';
 import { findUpProjectRoot } from './findUpProjectRoot';
 
 (async function () {
@@ -28,9 +28,9 @@ import { findUpProjectRoot } from './findUpProjectRoot';
 
   await Promise.all([
     createUpdatesResourcesMode === 'all'
-      ? createManifestAsync(platform, possibleProjectRoot, destinationDir, entryFileArg)
+      ? createManifestForBuildAsync(platform, possibleProjectRoot, destinationDir, entryFileArg)
       : null,
-    createFingerprintAsync(platform, possibleProjectRoot, destinationDir),
+    createFingerprintForBuildAsync(platform, possibleProjectRoot, destinationDir),
   ]);
 })().catch((e) => {
   // Wrap in regex to make it easier for log parsers (like `@expo/xcpretty`) to find this error.


### PR DESCRIPTION
# Why

We need the `@expo/fingerprint` package version to match that of expo-updates (the fingerprint generated during the build from https://github.com/expo/expo/pull/26901) when we generate a fingerprint in `eas-cli` for the `eas update` command. The only way I can think to do this is make a command in `expo-updates` that `eas-cli` calls into to get the version of `@expo/fingerpring` being used by the project (and build process). This is similar to how we call `npx expo` from `eas-cli` to get the correct versioned CLI.

# How

Add new command, `yarn expo-updates fingerprint:generate --platform ios` that just runs fingerprint. This has the secondary benefit of consolidating the workflow detection code to one place as well so there aren't any inconsistencies.

# Test Plan

`yarn expo-updates fingerprint:generate --platform ios`
see JSON fingerprint output stringified

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
