### PR TITLE
[camera] Add fallbackStrategy to QualitySelector

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix barcode types casing errors. ([#26888](https://github.com/expo/expo/pull/26888) by [@byudaniel](https://github.com/byudaniel))
 - On `iOS`, fix `maxDuration` timescale on videos. ([#26882](https://github.com/expo/expo/pull/26882) by [@alanjhughes](https://github.com/alanjhughes))
 - On `Android`, fix the camera not being released when the view is destroyed. ([#27086](https://github.com/expo/expo/pull/27086) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, fix empty qualities being passed to QualitySelector ([#27126](https://github.com/expo/expo/pull/27126) by [@leonhh](https://github.com/leonhh))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -25,8 +25,10 @@ import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.FileOutputOptions
 import androidx.camera.video.QualitySelector
+import androidx.camera.video.Quality
 import androidx.camera.video.Recorder
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture
@@ -303,11 +305,10 @@ class ExpoCameraView(
       }
 
   private fun createVideoCapture(info: List<CameraInfo>): VideoCapture<Recorder> {
-    val supportedQualities = QualitySelector.getSupportedQualities(info[0])
-    val filteredQualities = arrayListOf(videoQuality.mapToQuality())
-      .filter { supportedQualities.contains(it) }
+    var preferredQuality = videoQuality.mapToQuality()
+    var fallbackStrategy = FallbackStrategy.lowerQualityOrHigherThan(preferredQuality)
 
-    val qualitySelector = QualitySelector.fromOrderedList(filteredQualities)
+    var qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
 
     val recorder = Recorder.Builder()
       .setExecutor(ContextCompat.getMainExecutor(context))

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -305,10 +305,10 @@ class ExpoCameraView(
       }
 
   private fun createVideoCapture(info: List<CameraInfo>): VideoCapture<Recorder> {
-    var preferredQuality = videoQuality.mapToQuality()
-    var fallbackStrategy = FallbackStrategy.lowerQualityOrHigherThan(preferredQuality)
+    val preferredQuality = videoQuality.mapToQuality()
+    val fallbackStrategy = FallbackStrategy.lowerQualityOrHigherThan(preferredQuality)
 
-    var qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
+    val qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
 
     val recorder = Recorder.Builder()
       .setExecutor(ContextCompat.getMainExecutor(context))

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -28,7 +28,6 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.FileOutputOptions
 import androidx.camera.video.QualitySelector
-import androidx.camera.video.Quality
 import androidx.camera.video.Recorder
 import androidx.camera.video.Recording
 import androidx.camera.video.VideoCapture


### PR DESCRIPTION
# Why

`QualitySelector.fromOrderedList` does not accept empty lists as a precondition. On lower end devices we were running into an issue that none of the defined qualities in the `VideoQuality` enum were supported.  

Previously the androidx camera module would throw this error:

```
java.lang.IllegalArgumentException: qualities cannot be empty
        at androidx.core.util.Preconditions.checkArgument(Preconditions.java:51)
        at androidx.camera.video.QualitySelector.fromOrderedList(QualitySelector.java:269)
        at androidx.camera.video.QualitySelector.fromOrderedList(QualitySelector.java:243)
        at expo.modules.camera.next.ExpoCameraView.createVideoCapture(ExpoCameraView.kt:301)
```

# How

I've added a `FallbackStrategy` to the QualitySelector. It will now by default fallback to a higher quality. If there's no lower quality supported we will fallback to a higher quality.

# Test Plan

The camera will still use 1080p as that's defined as a default value in `ExpoCameraView.kt`.

# Checklist

- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
