### PR TITLE
[docs] Add prerelease notice to `next` packages

### DIFF
--- a/docs/components/PrereleaseNotice.tsx
+++ b/docs/components/PrereleaseNotice.tsx
@@ -1,0 +1,15 @@
+import ReactMarkdown from 'react-markdown';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { mdComponents } from './plugins/api/APISectionUtils';
+
+const PrereleaseNotice = () => {
+  return (
+    <Collapsible summary={`What is a (Next) package?`}>
+      <ReactMarkdown components={mdComponents}>
+        {`\`/next\` packages are pre-release versions of SDK libraries. We provide them to get feedback from the community and test new features before their stable release. If you encounter any issue, we encourage reporting on the [Expo](https://github.com/expo/expo/issues/new?assignees=&labels=needs+validation&projects=&template=bug_report.yml) GitHub repository.`}
+      </ReactMarkdown>
+    </Collapsible>
+  );
+};
+
+export default PrereleaseNotice;

--- a/docs/components/PrereleaseNotice.tsx
+++ b/docs/components/PrereleaseNotice.tsx
@@ -1,10 +1,12 @@
 import ReactMarkdown from 'react-markdown';
-import { Collapsible } from '~/ui/components/Collapsible';
+
 import { mdComponents } from './plugins/api/APISectionUtils';
+
+import { Collapsible } from '~/ui/components/Collapsible';
 
 const PrereleaseNotice = () => {
   return (
-    <Collapsible summary={`What is a (Next) package?`}>
+    <Collapsible summary="What is a (Next) package?">
       <ReactMarkdown components={mdComponents}>
         {`\`/next\` packages are pre-release versions of SDK libraries. We provide them to get feedback from the community and test new features before their stable release. If you encounter any issue, we encourage reporting on the [Expo](https://github.com/expo/expo/issues/new?assignees=&labels=needs+validation&projects=&template=bug_report.yml) GitHub repository.`}
       </ReactMarkdown>

--- a/docs/pages/versions/unversioned/sdk/camera-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-next.mdx
@@ -9,6 +9,7 @@ iconUrl: '/static/images/packages/expo-camera.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import PrereleaseNotice from '~/components/PrereleaseNotice';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,6 +18,8 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 > **info** This page documents an upcoming version of Camera library. To try it, switch to `expo-camera/next` imports in your code.
+
+<PrereleaseNotice />
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -74,13 +74,11 @@ for await (const row of db.getEachAsync('SELECT * FROM test')) {
 ### Prepared statements
 
 Prepared statement allows you compile your SQL query once and execute it multiple times with different parameters. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
-
 > **Note:** Remember to call [`finalizeAsync()`](#finalizeasync) or [`finalizeSync()`](#finalizesync) method to release the prepared statement after you finish using the statement. `try-finally` block is recommended to ensure the prepared statement is finalized.
 
 ```ts Prepared statements
-const statement = await db.prepareAsync(
-  'INSERT INTO test (value, intValue) VALUES ($value, $intValue)'
-);
+
+const statement = await db.prepareAsync('INSERT INTO test (value, intValue) VALUES ($value, $intValue)');
 try {
   let result = await statement.executeAsync({ $value: 'bbb', $intValue: 101 });
   console.log('bbb and 101:', result.lastInsertRowId, result.changes);
@@ -96,9 +94,7 @@ try {
 
 const statement2 = await db.prepareAsync('SELECT * FROM test WHERE intValue >= $intValue');
 try {
-  const result = await statement2.executeAsync<{ value: string; intValue: number }>({
-    $intValue: 100,
-  });
+  const result = await statement2.executeAsync<{ value: string, intValue: number }>({ $intValue: 100 });
 
   // `getFirstAsync()` is useful when you want to get a single row from the database.
   const firstRow = await result.getFirstAsync();
@@ -148,9 +144,7 @@ export function Header() {
   const [version, setVersion] = useState('');
   useEffect(() => {
     async function setup() {
-      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>(
-        'SELECT sqlite_version()'
-      );
+      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
       setVersion(result['sqlite_version()']);
     }
     setup();
@@ -276,8 +270,8 @@ Promise.all([
   //    This `UPDATE` query runs in the transaction even though its code is
   //    outside of it because the transaction happens to be active at the time
   //    this query runs.
-  sleep(1000).then(async () => db.execAsync('UPDATE test SET data = "second"')),
-]);
+  sleep(1000).then(async() => db.execAsync('UPDATE test SET data = "second"')),
+])
 ```
 
 The [`withExclusiveTransactionAsync()`](#withexclusivetransactionasynctask) function addresses this. Only queries that run within the scope function passed to `withExclusiveTransactionAsync()` will run within the actual SQL transaction.

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -9,10 +9,13 @@ maxHeadingDepth: 3
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import PrereleaseNotice from '~/components/PrereleaseNotice';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
 > **info** This page documents an upcoming version of SQLite library. To try it, switch to `expo-sqlite/next` imports in your code.
+
+<PrereleaseNotice />
 
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
 
@@ -71,11 +74,13 @@ for await (const row of db.getEachAsync('SELECT * FROM test')) {
 ### Prepared statements
 
 Prepared statement allows you compile your SQL query once and execute it multiple times with different parameters. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
+
 > **Note:** Remember to call [`finalizeAsync()`](#finalizeasync) or [`finalizeSync()`](#finalizesync) method to release the prepared statement after you finish using the statement. `try-finally` block is recommended to ensure the prepared statement is finalized.
 
 ```ts Prepared statements
-
-const statement = await db.prepareAsync('INSERT INTO test (value, intValue) VALUES ($value, $intValue)');
+const statement = await db.prepareAsync(
+  'INSERT INTO test (value, intValue) VALUES ($value, $intValue)'
+);
 try {
   let result = await statement.executeAsync({ $value: 'bbb', $intValue: 101 });
   console.log('bbb and 101:', result.lastInsertRowId, result.changes);
@@ -91,7 +96,9 @@ try {
 
 const statement2 = await db.prepareAsync('SELECT * FROM test WHERE intValue >= $intValue');
 try {
-  const result = await statement2.executeAsync<{ value: string, intValue: number }>({ $intValue: 100 });
+  const result = await statement2.executeAsync<{ value: string; intValue: number }>({
+    $intValue: 100,
+  });
 
   // `getFirstAsync()` is useful when you want to get a single row from the database.
   const firstRow = await result.getFirstAsync();
@@ -141,7 +148,9 @@ export function Header() {
   const [version, setVersion] = useState('');
   useEffect(() => {
     async function setup() {
-      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
+      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>(
+        'SELECT sqlite_version()'
+      );
       setVersion(result['sqlite_version()']);
     }
     setup();
@@ -267,8 +276,8 @@ Promise.all([
   //    This `UPDATE` query runs in the transaction even though its code is
   //    outside of it because the transaction happens to be active at the time
   //    this query runs.
-  sleep(1000).then(async() => db.execAsync('UPDATE test SET data = "second"')),
-])
+  sleep(1000).then(async () => db.execAsync('UPDATE test SET data = "second"')),
+]);
 ```
 
 The [`withExclusiveTransactionAsync()`](#withexclusivetransactionasynctask) function addresses this. Only queries that run within the scope function passed to `withExclusiveTransactionAsync()` will run within the actual SQL transaction.

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -9,6 +9,7 @@ iconUrl: '/static/images/packages/expo-camera.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import PrereleaseNotice from '~/components/PrereleaseNotice';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,6 +18,8 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 > **info** This page documents an upcoming version of Camera library. To try it, switch to `expo-camera/next` imports in your code.
+
+<PrereleaseNotice />
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -74,13 +74,11 @@ for await (const row of db.getEachAsync('SELECT * FROM test')) {
 ### Prepared statements
 
 Prepared statement allows you compile your SQL query once and execute it multiple times with different parameters. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
-
 > **Note:** Remember to call [`finalizeAsync()`](#finalizeasync) or [`finalizeSync()`](#finalizesync) method to release the prepared statement after you finish using the statement. `try-finally` block is recommended to ensure the prepared statement is finalized.
 
 ```ts Prepared statements
-const statement = await db.prepareAsync(
-  'INSERT INTO test (value, intValue) VALUES ($value, $intValue)'
-);
+
+const statement = await db.prepareAsync('INSERT INTO test (value, intValue) VALUES ($value, $intValue)');
 try {
   let result = await statement.executeAsync({ $value: 'bbb', $intValue: 101 });
   console.log('bbb and 101:', result.lastInsertRowId, result.changes);
@@ -96,9 +94,7 @@ try {
 
 const statement2 = await db.prepareAsync('SELECT * FROM test WHERE intValue >= $intValue');
 try {
-  const result = await statement2.executeAsync<{ value: string; intValue: number }>({
-    $intValue: 100,
-  });
+  const result = await statement2.executeAsync<{ value: string, intValue: number }>({ $intValue: 100 });
 
   // `getFirstAsync()` is useful when you want to get a single row from the database.
   const firstRow = await result.getFirstAsync();
@@ -148,9 +144,7 @@ export function Header() {
   const [version, setVersion] = useState('');
   useEffect(() => {
     async function setup() {
-      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>(
-        'SELECT sqlite_version()'
-      );
+      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
       setVersion(result['sqlite_version()']);
     }
     setup();
@@ -276,8 +270,8 @@ Promise.all([
   //    This `UPDATE` query runs in the transaction even though its code is
   //    outside of it because the transaction happens to be active at the time
   //    this query runs.
-  sleep(1000).then(async () => db.execAsync('UPDATE test SET data = "second"')),
-]);
+  sleep(1000).then(async() => db.execAsync('UPDATE test SET data = "second"')),
+])
 ```
 
 The [`withExclusiveTransactionAsync()`](#withexclusivetransactionasynctask) function addresses this. Only queries that run within the scope function passed to `withExclusiveTransactionAsync()` will run within the actual SQL transaction.

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -9,10 +9,13 @@ maxHeadingDepth: 3
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import PrereleaseNotice from '~/components/PrereleaseNotice';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
 > **info** This page documents an upcoming version of SQLite library. To try it, switch to `expo-sqlite/next` imports in your code.
+
+<PrereleaseNotice />
 
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
 
@@ -71,11 +74,13 @@ for await (const row of db.getEachAsync('SELECT * FROM test')) {
 ### Prepared statements
 
 Prepared statement allows you compile your SQL query once and execute it multiple times with different parameters. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
+
 > **Note:** Remember to call [`finalizeAsync()`](#finalizeasync) or [`finalizeSync()`](#finalizesync) method to release the prepared statement after you finish using the statement. `try-finally` block is recommended to ensure the prepared statement is finalized.
 
 ```ts Prepared statements
-
-const statement = await db.prepareAsync('INSERT INTO test (value, intValue) VALUES ($value, $intValue)');
+const statement = await db.prepareAsync(
+  'INSERT INTO test (value, intValue) VALUES ($value, $intValue)'
+);
 try {
   let result = await statement.executeAsync({ $value: 'bbb', $intValue: 101 });
   console.log('bbb and 101:', result.lastInsertRowId, result.changes);
@@ -91,7 +96,9 @@ try {
 
 const statement2 = await db.prepareAsync('SELECT * FROM test WHERE intValue >= $intValue');
 try {
-  const result = await statement2.executeAsync<{ value: string, intValue: number }>({ $intValue: 100 });
+  const result = await statement2.executeAsync<{ value: string; intValue: number }>({
+    $intValue: 100,
+  });
 
   // `getFirstAsync()` is useful when you want to get a single row from the database.
   const firstRow = await result.getFirstAsync();
@@ -141,7 +148,9 @@ export function Header() {
   const [version, setVersion] = useState('');
   useEffect(() => {
     async function setup() {
-      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
+      const result = await db.getFirstAsync<{ 'sqlite_version()': string }>(
+        'SELECT sqlite_version()'
+      );
       setVersion(result['sqlite_version()']);
     }
     setup();
@@ -267,8 +276,8 @@ Promise.all([
   //    This `UPDATE` query runs in the transaction even though its code is
   //    outside of it because the transaction happens to be active at the time
   //    this query runs.
-  sleep(1000).then(async() => db.execAsync('UPDATE test SET data = "second"')),
-])
+  sleep(1000).then(async () => db.execAsync('UPDATE test SET data = "second"')),
+]);
 ```
 
 The [`withExclusiveTransactionAsync()`](#withexclusivetransactionasynctask) function addresses this. Only queries that run within the scope function passed to `withExclusiveTransactionAsync()` will run within the actual SQL transaction.


### PR DESCRIPTION
# Why
Closes ENG-11454
We should provide users some context about how we think about `/next` versions of our packages

# How
Added a `PrereleaseNotice` component with some information that can be added to any of the `(Next)` pages. Added it to camera and sqlite.

# Test Plan
n/a