### PR TITLE
[docs] Remove deprecated dependency

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -67,7 +67,7 @@ Now, let's open the project directory in our favorite code editor or IDE. Throug
 
 To run the project on the web, we need to install the following dependencies that will help to run the project on the web:
 
-<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']} />
+<Terminal cmd={['$ npx expo install react-dom react-native-web']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

The previously recommended `@expo/webpack-config` package is deprecated and breaks web build since SDK 50

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
