### PR TITLE
[expotools] Fix check-package uniformity check for plugin, cli, utils subpackages

### DIFF
--- a/tools/src/check-packages/checkPackageAsync.ts
+++ b/tools/src/check-packages/checkPackageAsync.ts
@@ -40,7 +40,11 @@ export default async function checkPackageAsync(
       }
 
       if (options.uniformityCheck) {
-        await checkUniformityAsync(pkg, './build');
+        if (options.checkPackageType === 'package') {
+          await checkUniformityAsync(pkg, './build');
+        } else {
+          await checkUniformityAsync(pkg, `./${options.checkPackageType}/build`);
+        }
         if (pkg.scripts.bundle) {
           await checkUniformityAsync(pkg, '*bundle');
         }


### PR DESCRIPTION
# Why

The uniformity check (checking that the built files were committed) was only ever run for the main package. This PR fixes this so that it checks plugin, cli, and utils subpackages.

Closes ENG-11459.

# How

Update et cp script.

# Test Plan

1. Make a change to a ts file in expo-updates/cli
2. run `et cp expo-updates`
3. see that it now warns that the build files differ (previously it didn't)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
