### PR TITLE
[expo-calendar] fix build

### DIFF
--- a/packages/expo-calendar/plugin/build/withCalendar.js
+++ b/packages/expo-calendar/plugin/build/withCalendar.js
@@ -21,6 +21,14 @@ const withCalendar = (config, { calendarPermission, remindersPermission } = {}) 
         remindersPermission ||
             config.ios.infoPlist.NSRemindersFullAccessUsageDescription ||
             REMINDERS_USAGE;
+    config.ios.infoPlist.NSCalendarsFullAccessUsageDescription =
+        calendarPermission ||
+            config.ios.infoPlist.NSCalendarsFullAccessUsageDescription ||
+            CALENDARS_USAGE;
+    config.ios.infoPlist.NSRemindersFullAccessUsageDescription =
+        remindersPermission ||
+            config.ios.infoPlist.NSRemindersFullAccessUsageDescription ||
+            REMINDERS_USAGE;
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.READ_CALENDAR',
         'android.permission.WRITE_CALENDAR',


### PR DESCRIPTION
# Why

As of landing https://github.com/expo/expo/pull/27140 all subpackages are checked for uniformity.

`expo-calendar` wasn't built and committed since et cp wasn't set up to catch this issue at the time. This commits the built changes.

Blame: https://github.com/expo/expo/commit/957904e9987bf5590826954584e4b45330d42086
(not cherry-picked so we're good)

# How

`et cp --all`

# Test Plan

`et cp expo-calendar`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
