### PR TITLE
Fix splashscreen not autohiding on expo-go

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.m
@@ -310,7 +310,7 @@
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_handleReactContentEvent:)
                                                name:RCTContentDidAppearNotification
-                                             object:bridge];
+                                             object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_handleBridgeEvent:)
                                                name:RCTBridgeWillReloadNotification


### PR DESCRIPTION
# Why

A bug was preventing RCTContentDidAppearNotification from being received by ExReactAppManager and passed on to splashscreen.

# Test Plan

Tested in expo go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
