### PR TITLE
[dev-client] fix launching error when interop with expo-updates

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))
 - [Android] Fixed unable to load dev client bundle on device. ([#26630](https://github.com/expo/expo/pull/26630) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed to not return DevLauncherDevSupportManagerFactory in host handler when `enableAutoSetup` is false. ([#27068](https://github.com/expo/expo/pull/27068) by [@jayshah123](https://github.com/jayshah123))
+- Fixed missing `runtimeVersion` error when loading app with `expo-updates` and `expo-dev-client`. ([#27180](https://github.com/expo/expo/pull/27180) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -349,22 +349,8 @@ class DevLauncherController private constructor() :
     internal var sAdditionalPackages: List<ReactPackage>? = null
 
     @JvmStatic
-    fun getMetadataValue(context: Context, key: String, defaultValue: String = ""): String {
-      val packageManager = context.packageManager
-      val packageName = context.packageName
-      val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-      var metaDataValue = defaultValue
-
-      if (applicationInfo.metaData != null) {
-        val value = applicationInfo.metaData.get(key)
-
-        if (value != null) {
-          metaDataValue = value.toString()
-        }
-      }
-
-      return metaDataValue
-    }
+    fun getMetadataValue(context: Context, key: String, defaultValue: String = "") =
+      DevLauncherMetadataHelper.getMetadataValue(context, key, defaultValue)
 
     @JvmStatic
     fun wasInitialized() =

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.facebook.react.ReactNativeHost
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.modules.devlauncher.helpers.createUpdatesConfigurationWithUrl
+import expo.modules.devlauncher.helpers.getRuntimeVersion
 import expo.modules.devlauncher.helpers.loadUpdate
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.koin.optInject
@@ -45,7 +46,8 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
         }
         DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
       } else {
-        val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, installationIDHelper.getOrCreateInstallationID(context))
+        val runtimeVersion = getRuntimeVersion(context)
+        val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
         val update = updatesInterface!!.loadUpdate(configuration, context) {
           manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
           return@loadUpdate !manifest!!.isUsingDeveloperTool()

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherMetadataHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherMetadataHelper.kt
@@ -1,0 +1,19 @@
+package expo.modules.devlauncher.helpers
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+object DevLauncherMetadataHelper {
+  fun getMetadataValue(context: Context, key: String, defaultValue: String = ""): String {
+    val packageManager = context.packageManager
+    val packageName = context.packageName
+    val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+    var metaDataValue = if (applicationInfo.metaData != null) {
+      applicationInfo.metaData.getString(key, defaultValue)
+    } else {
+      defaultValue
+    }
+
+    return metaDataValue
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -46,7 +46,7 @@ suspend fun UpdatesInterface.loadUpdate(
     )
   }
 
-fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, installationID: String?): HashMap<String, Any> {
+fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, runtimeVersion: String, installationID: String?): HashMap<String, Any> {
   val requestHeaders = hashMapOf(
     "Expo-Updates-Environment" to "DEVELOPMENT"
   )
@@ -60,6 +60,11 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, installationID:
     "launchWaitMs" to 60000,
     "checkOnLaunch" to "ALWAYS",
     "enabled" to true,
-    "requestHeaders" to requestHeaders
+    "requestHeaders" to requestHeaders,
+    "runtimeVersion" to runtimeVersion,
   )
+}
+
+fun getRuntimeVersion(context: Context): String {
+  return DevLauncherMetadataHelper.getMetadataValue(context, "expo.modules.updates.EXPO_RUNTIME_VERSION")
 }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -19,7 +19,8 @@ internal class DevLauncherUpdatesHelperTest {
 
   private val context: Context = ApplicationProvider.getApplicationContext()
   private val url = Uri.parse("https://exp.host/@esamelson/sdk42updates")
-  private val configuration = createUpdatesConfigurationWithUrl(url, url, null)
+  private val runtimeVersion = "1.0.0"
+  private val configuration = createUpdatesConfigurationWithUrl(url, url, runtimeVersion, null)
   private val mockManifest = JSONObject("{\"icon\":\"./assets/icon.png\",\"name\":\"sdk42updates\",\"slug\":\"sdk42updates\",\"splash\":{\"image\":\"./assets/splash.png\",\"imageUrl\":\"https://classic-assets.eascdn.net/~assets/201a91bd1740bb1d6a1dbad049310724\",\"resizeMode\":\"contain\",\"backgroundColor\":\"#ffffff\"},\"iconUrl\":\"https://classic-assets.eascdn.net/~assets/4e3f888fc8475f69fd5fa32f1ad5216a\",\"version\":\"1.0.0\",\"sdkVersion\":\"42.0.0\",\"orientation\":\"portrait\",\"currentFullName\":\"@esamelson/sdk42updates\",\"originalFullName\":\"@esamelson/sdk42updates\",\"id\":\"@esamelson/sdk42updates\",\"projectId\":\"04e1e9f2-b297-44da-a11c-90a6a27859bc\",\"scopeKey\":\"@esamelson/sdk42updates\",\"releaseId\":\"a2b0a544-40f0-4fd6-9972-19f094380681\",\"publishedTime\":\"2021-07-13T22:29:24.170Z\",\"commitTime\":\"2021-07-13T22:29:24.209Z\",\"bundleUrl\":\"https://classic-assets.eascdn.net/%40esamelson%2Fsdk42updates%2F1.0.0%2F8c3e605420e77ba9fe35a0a7ef8459a9-42.0.0-ios.js\",\"bundleKey\":\"8c3e605420e77ba9fe35a0a7ef8459a9\",\"releaseChannel\":\"default\",\"hostUri\":\"exp.host/@esamelson/sdk42updates\"}")
   private val mockUpdate = object : UpdatesInterface.Update {
     override fun getManifest(): JSONObject = mockManifest
@@ -67,11 +68,11 @@ internal class DevLauncherUpdatesHelperTest {
   fun `createUpdatesConfiguration sets the correct value for scopeKey`() {
     val urlString1 = "https://exp.host/@test/first-app"
     val url1 = Uri.parse(urlString1)
-    val configuration1 = createUpdatesConfigurationWithUrl(url1, url1, null)
+    val configuration1 = createUpdatesConfigurationWithUrl(url1, url1, runtimeVersion, null)
 
     val urlString2 = "https://exp.host/@test/second-app"
     val url2 = Uri.parse(urlString2)
-    val configuration2 = createUpdatesConfigurationWithUrl(url2, url2, null)
+    val configuration2 = createUpdatesConfigurationWithUrl(url2, url2, runtimeVersion,null)
 
     val scopeKey1 = configuration1["scopeKey"]
     val scopeKey2 = configuration2["scopeKey"]
@@ -84,7 +85,7 @@ internal class DevLauncherUpdatesHelperTest {
   fun `createUpdatesConfiguration sets the correct scopeKey if projectUrl is different`() {
     val url = Uri.parse("https://u.expo.dev/update/421ba616-9145-4236-8fe8-7be9f2782a30")
     val projectUrlString = "https://u.expo.dev/2f662161-8616-4f16-9f88-911dfb2d3cd6?channel-name=production"
-    val configuration = createUpdatesConfigurationWithUrl(url, Uri.parse(projectUrlString), "test")
+    val configuration = createUpdatesConfigurationWithUrl(url, Uri.parse(projectUrlString), runtimeVersion, "test")
 
     val configuredUrl = configuration["updateUrl"]
     val configuredScopeKey = configuration["scopeKey"]
@@ -97,7 +98,7 @@ internal class DevLauncherUpdatesHelperTest {
   fun `createUpdatesConfiguration sets the correct header for installationID`() {
     val installationID = "test-installation-id"
     val url = Uri.parse("https://exp.host/@test/test")
-    val configuration = createUpdatesConfigurationWithUrl(url, url, installationID)
+    val configuration = createUpdatesConfigurationWithUrl(url, url, runtimeVersion, installationID)
 
     Truth.assertThat((configuration["requestHeaders"] as HashMap<*, *>)["Expo-Dev-Client-ID"]).isEqualTo(installationID)
   }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -425,7 +425,7 @@
   // an update url requires a matching projectUrl
   // if one isn't provided, default to the configured project url in Expo.plist
   if (isEASUpdate && projectUrl == nil) {
-    NSString *projectUrlString = [self getUpdatesConfigForKey:@"EXUpdatesURL"];
+    NSString *projectUrlString = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesURL"];
     projectUrl = [NSURL URLWithString:projectUrlString];
   }
 
@@ -437,10 +437,12 @@
   // Disable onboarding popup if "&disableOnboarding=1" is a param
   [EXDevLauncherURLHelper disableOnboardingPopupIfNeeded:expoUrl];
 
+  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
   NSString *installationID = [_installationIDHelper getOrCreateInstallationID];
 
   NSDictionary *updatesConfiguration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:expoUrl
                                                                                           projectURL:projectUrl
+                                                                                      runtimeVersion:runtimeVersion
                                                                                       installationID:installationID];
 
   void (^launchReactNativeApp)(void) = ^{
@@ -670,7 +672,7 @@
   NSMutableDictionary *buildInfo = [NSMutableDictionary new];
 
   NSString *appIcon = [self getAppIcon];
-  NSString *runtimeVersion = [self getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
   NSString *appVersion = [self getFormattedAppVersion];
   NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleDisplayName"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleExecutable"];
 
@@ -694,22 +696,6 @@
   }
 
   return appIcon;
-}
-
--(NSString *)getUpdatesConfigForKey:(NSString *)key
-{
-  NSString *value = @"";
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"Expo" ofType:@"plist"];
-
-  if (path != nil) {
-    NSDictionary *expoConfig = [NSDictionary dictionaryWithContentsOfFile:path];
-
-    if (expoConfig != nil) {
-      value = [expoConfig objectForKey:key] ?: @"";
-    }
-  }
-
-  return value;
 }
 
 -(NSString *)getFormattedAppVersion
@@ -748,12 +734,12 @@
 {
   NSMutableDictionary *updatesConfig = [NSMutableDictionary new];
 
-  NSString *runtimeVersion = [self getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
+  NSString *runtimeVersion = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesRuntimeVersion"];
 
   // url structure for EASUpdates: `http://u.expo.dev/{appId}`
   // this url field is added to app.json.updates when running `eas update:configure`
   // the `u.expo.dev` determines that it is the modern manifest protocol
-  NSString *projectUrl = [self getUpdatesConfigForKey:@"EXUpdatesURL"];
+  NSString *projectUrl = [EXDevLauncherUpdatesHelper getUpdatesConfigForKey:@"EXUpdatesURL"];
   NSURL *url = [NSURL URLWithString:projectUrl];
   NSString *appId = [[url pathComponents] lastObject];
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.h
@@ -8,7 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url
                                          projectURL:(NSURL *)projectURL
+                                     runtimeVersion:(NSString *)runtimeVersion
                                      installationID:(NSString *)installationID;
+
++ (NSString *)getUpdatesConfigForKey:(NSString *)key;
 
 @end
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDictionary *)createUpdatesConfigurationWithURL:(NSURL *)url
                                          projectURL:(NSURL *)projectURL
+                                     runtimeVersion:(NSString *)runtimeVersion
                                      installationID:(NSString *)installationID
 {
   NSMutableDictionary *requestHeaders = @{@"Expo-Updates-Environment": @"DEVELOPMENT"}.mutableCopy;
@@ -23,7 +24,24 @@ NS_ASSUME_NONNULL_BEGIN
     @"EXUpdatesHasEmbeddedUpdate": @(NO),
     @"EXUpdatesEnabled": @(YES),
     @"EXUpdatesRequestHeaders": requestHeaders,
+    @"EXUpdatesRuntimeVersion": runtimeVersion,
   };
+}
+
++ (NSString *)getUpdatesConfigForKey:(NSString *)key
+{
+  NSString *value = @"";
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"Expo" ofType:@"plist"];
+
+  if (path != nil) {
+    NSDictionary *expoConfig = [NSDictionary dictionaryWithContentsOfFile:path];
+
+    if (expoConfig != nil) {
+      value = [expoConfig objectForKey:key] ?: @"";
+    }
+  }
+
+  return value;
 }
 
 @end

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherUpdatesHelperTests.m
@@ -14,11 +14,17 @@
 {
   NSString *urlString1 = @"https://exp.host/@test/first-app";
   NSURL *url1 = [NSURL URLWithString:urlString1];
-  NSDictionary *configuration1 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url1 projectURL:url1 installationID:@"test-installation-id"];
+  NSDictionary *configuration1 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url1
+                                                                                    projectURL:url1
+                                                                                runtimeVersion:@"1.0.0"
+                                                                                installationID:@"test-installation-id"];
 
   NSString *urlString2 = @"https://exp.host/@test/second-app";
   NSURL *url2 = [NSURL URLWithString:urlString2];
-  NSDictionary *configuration2 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url2 projectURL:url2 installationID:@"test-installation-id"];
+  NSDictionary *configuration2 = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url2
+                                                                                    projectURL:url2
+                                                                                runtimeVersion:@"1.0.0"
+                                                                                installationID:@"test-installation-id"];
 
   NSString *scopeKey1 = configuration1[@"EXUpdatesScopeKey"];
   NSString *scopeKey2 = configuration2[@"EXUpdatesScopeKey"];
@@ -31,7 +37,10 @@
 {
   NSString *urlString = @"https://u.expo.dev/update/421ba616-9145-4236-8fe8-7be9f2782a30";
   NSString *projectURLString = @"https://u.expo.dev/2f662161-8616-4f16-9f88-911dfb2d3cd6?channel-name=production";
-  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString] projectURL:[NSURL URLWithString:projectURLString] installationID:@"test"];
+  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:[NSURL URLWithString:urlString]
+                                                                                   projectURL:[NSURL URLWithString:projectURLString]
+                                                                               runtimeVersion:@"1.0.0"
+                                                                               installationID:@"test"];
 
   NSString *updatesURL = configuration[@"EXUpdatesURL"];
   NSString *updatesScopeKey = configuration[@"EXUpdatesScopeKey"];
@@ -45,7 +54,10 @@
 {
   NSString *installationID = @"test-installation-id";
   NSURL *url = [NSURL URLWithString:@"https://exp.host/@test/test"];
-  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url projectURL:url installationID:installationID];
+  NSDictionary *configuration = [EXDevLauncherUpdatesHelper createUpdatesConfigurationWithURL:url
+                                                                                   projectURL:url
+                                                                               runtimeVersion:@"1.0.0"
+                                                                               installationID:installationID];
 
   NSDictionary *requestHeaders = configuration[@"EXUpdatesRequestHeaders"];
   XCTAssertNotNil(requestHeaders);


### PR DESCRIPTION
# Why

supersede #26524 to fix the error when running an app with both expo-dev-client and expo-updates (on latest main branch).

# How

add runtimeVersion from Expo.plist and strings.xml.

# Test Plan

1. remove expo-updates from bare-expo's autolinking exclusion
2. add **Expo.plist** to bare-expo
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>EXUpdatesCheckOnLaunch</key>
    <string>ALWAYS</string>
    <key>EXUpdatesEnabled</key>
    <true/>
    <key>EXUpdatesLaunchWaitMs</key>
    <integer>0</integer>
  </dict>
</plist>
```
3. enable dev-launcher from bare-expo, by commenting out this line: https://github.com/expo/expo/blob/b8fa00e4f5d5fec2dc57e2752d1e6b6583cd3dc6/apps/bare-expo/ios/BareExpo/AppDelegate.mm#L25

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
