### PR TITLE
[ci] try to fix unstable test-suite ios

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -140,6 +140,7 @@ jobs:
     steps:
       - name: Rerun failed ios-test job in the current workflow
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: gh run rerun ${{ github.run_id }} --failed
 

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -136,7 +136,7 @@ jobs:
   rerun-failed-ios-test:
     runs-on: ubuntu-latest
     needs: [ios-test]
-    if: failure()
+    if: failure() && fromJSON(github.run_attempt) <= 3
     steps:
       - name: Rerun failed ios-test job in the current workflow
         env:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -133,17 +133,6 @@ jobs:
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
 
-  rerun-failed-ios-test:
-    runs-on: ubuntu-latest
-    needs: [ios-test]
-    if: failure() && fromJSON(github.run_attempt) <= 3
-    env:
-      GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Rerun failed ios-test job in the current workflow
-        run: gh run rerun ${{ github.run_id }} --failed
-
   android-build:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -137,11 +137,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ios-test]
     if: failure() && fromJSON(github.run_attempt) <= 3
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Rerun failed ios-test job in the current workflow
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
         run: gh run rerun ${{ github.run_id }} --failed
 
   android-build:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -79,12 +79,14 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 15.2
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -133,6 +133,16 @@ jobs:
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
 
+  rerun-failed-ios-test:
+    runs-on: ubuntu-latest
+    needs: [ios-test]
+    if: failure()
+    steps:
+      - name: Rerun failed ios-test job in the current workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run rerun ${{ github.run_id }} --failed
+
   android-build:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -79,14 +79,12 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-14
+    runs-on: macos-12
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 15.2
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -156,6 +156,7 @@ jobs:
     steps:
       - name: Rerun failed ios-test job in the current workflow
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: gh run rerun ${{ github.run_id }} --failed
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -100,6 +100,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 15.2
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
@@ -146,6 +148,16 @@ jobs:
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite (iOS)
+
+  rerun-failed-ios-test:
+    runs-on: ubuntu-latest
+    needs: [ios-test]
+    if: failure()
+    steps:
+      - name: Rerun failed ios-test job in the current workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run rerun ${{ github.run_id }} --failed
 
   android-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -94,7 +94,7 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-14
+    runs-on: macos-12
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -94,7 +94,7 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -149,17 +149,6 @@ jobs:
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite (iOS)
 
-  rerun-failed-ios-test:
-    runs-on: ubuntu-latest
-    needs: [ios-test]
-    if: failure() && fromJSON(github.run_attempt) <= 3
-    env:
-      GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Rerun failed ios-test job in the current workflow
-        run: gh run rerun ${{ github.run_id }} --failed
-
   android-build:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -153,11 +153,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ios-test]
     if: failure() && fromJSON(github.run_attempt) <= 3
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Rerun failed ios-test job in the current workflow
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
         run: gh run rerun ${{ github.run_id }} --failed
 
   android-build:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -152,7 +152,7 @@ jobs:
   rerun-failed-ios-test:
     runs-on: ubuntu-latest
     needs: [ios-test]
-    if: failure()
+    if: failure() && fromJSON(github.run_attempt) <= 3
     steps:
       - name: Rerun failed ios-test job in the current workflow
         env:

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -34,7 +34,7 @@ enum StartMode {
       await fs.cp(binaryPath, appBinaryPath, { recursive: true });
     }
     if (startMode === StartMode.TEST || startMode === StartMode.BUILD_AND_TEST) {
-      await retryAsync(() => testAsync(projectRoot, deviceId, appBinaryPath), 3);
+      await retryAsync(() => testAsync(projectRoot, deviceId, appBinaryPath), 6);
     }
   } catch (e) {
     console.error('Uncaught Error', e);


### PR DESCRIPTION
# Why

test-suite ios testing is not stable.

# How

~partially revert #27029 that still run testing on macos-12 runner~
increase retries to six times

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
