### PR TITLE
[file-system][ios] Fix downloadAsync for local files

### DIFF
--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -308,6 +308,18 @@ export default class FileSystemScreen extends React.Component<object, State> {
     });
   };
 
+  _downloadAndReadLocalAsset = async () => {
+    const asset = Asset.fromModule(require('../../assets/index.html')).uri;
+    const tmpFile = FileSystem.cacheDirectory + 'test.html';
+    try {
+      await FileSystem.downloadAsync(asset, tmpFile);
+      const result = await FileSystem.readAsStringAsync(tmpFile);
+      Alert.alert('Result', result);
+    } catch (e) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
   render() {
     return (
       <ScrollView style={{ padding: 10 }}>
@@ -334,6 +346,7 @@ export default class FileSystemScreen extends React.Component<object, State> {
         <ListButton onPress={this._getInfoAsset} title="Get Info Asset" />
         <ListButton onPress={this._copyAndReadAsset} title="Copy and Read Asset" />
         <ListButton onPress={this._alertFreeSpace} title="Alert free space" />
+        <ListButton onPress={this._downloadAndReadLocalAsset} title="Download & local asset" />
         {Platform.OS === 'android' && (
           <>
             <HeadingText>Storage Access Framework</HeadingText>

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -346,7 +346,10 @@ export default class FileSystemScreen extends React.Component<object, State> {
         <ListButton onPress={this._getInfoAsset} title="Get Info Asset" />
         <ListButton onPress={this._copyAndReadAsset} title="Copy and Read Asset" />
         <ListButton onPress={this._alertFreeSpace} title="Alert free space" />
-        <ListButton onPress={this._downloadAndReadLocalAsset} title="Download and read local asset" />
+        <ListButton
+          onPress={this._downloadAndReadLocalAsset}
+          title="Download and read local asset"
+        />
         {Platform.OS === 'android' && (
           <>
             <HeadingText>Storage Access Framework</HeadingText>

--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -346,7 +346,7 @@ export default class FileSystemScreen extends React.Component<object, State> {
         <ListButton onPress={this._getInfoAsset} title="Get Info Asset" />
         <ListButton onPress={this._copyAndReadAsset} title="Copy and Read Asset" />
         <ListButton onPress={this._alertFreeSpace} title="Alert free space" />
-        <ListButton onPress={this._downloadAndReadLocalAsset} title="Download & local asset" />
+        <ListButton onPress={this._downloadAndReadLocalAsset} title="Download and read local asset" />
         {Platform.OS === 'android' && (
           <>
             <HeadingText>Storage Access Framework</HeadingText>

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix upload task requests. ([#26880](https://github.com/expo/expo/pull/26880) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix downloadAsync for local files. ([#27187](https://github.com/expo/expo/pull/27187) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -137,20 +137,20 @@ public final class FileSystemModule: Module {
       if sourceUrl.isFileURL {
         try ensurePathPermission(appContext, path: sourceUrl.path, flag: .read)
         EXFileSystemLocalFileHandler.copy(from: sourceUrl, to: localUrl, resolver: promise.resolver, rejecter: promise.legacyRejecter)
-      } else {
-        let session = options.sessionType == .background ? backgroundSession : foregroundSession
-        let request = createUrlRequest(url: sourceUrl, headers: options.headers)
-        let downloadTask = session.downloadTask(with: request)
-        let taskDelegate = EXSessionDownloadTaskDelegate(
-          resolve: promise.resolver,
-          reject: promise.legacyRejecter,
-          localUrl: localUrl,
-          shouldCalculateMd5: options.md5
-        )
-
-        sessionTaskDispatcher.register(taskDelegate, for: downloadTask)
-        downloadTask.resume()
+        return
       }
+      let session = options.sessionType == .background ? backgroundSession : foregroundSession
+      let request = createUrlRequest(url: sourceUrl, headers: options.headers)
+      let downloadTask = session.downloadTask(with: request)
+      let taskDelegate = EXSessionDownloadTaskDelegate(
+        resolve: promise.resolver,
+        reject: promise.legacyRejecter,
+        localUrl: localUrl,
+        shouldCalculateMd5: options.md5
+      )
+
+      sessionTaskDispatcher.register(taskDelegate, for: downloadTask)
+      downloadTask.resume()
     }
 
     AsyncFunction("uploadAsync") { (targetUrl: URL, localUrl: URL, options: UploadOptions, promise: Promise) in

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -134,18 +134,23 @@ public final class FileSystemModule: Module {
       try ensureFileDirectoryExists(localUrl)
       try ensurePathPermission(appContext, path: localUrl.path, flag: .write)
 
-      let session = options.sessionType == .background ? backgroundSession : foregroundSession
-      let request = createUrlRequest(url: sourceUrl, headers: options.headers)
-      let downloadTask = session.downloadTask(with: request)
-      let taskDelegate = EXSessionDownloadTaskDelegate(
-        resolve: promise.resolver,
-        reject: promise.legacyRejecter,
-        localUrl: localUrl,
-        shouldCalculateMd5: options.md5
-      )
+      if sourceUrl.isFileURL {
+        try ensurePathPermission(appContext, path: sourceUrl.path, flag: .read)
+        EXFileSystemLocalFileHandler.copy(from: sourceUrl, to: localUrl, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+      } else {
+        let session = options.sessionType == .background ? backgroundSession : foregroundSession
+        let request = createUrlRequest(url: sourceUrl, headers: options.headers)
+        let downloadTask = session.downloadTask(with: request)
+        let taskDelegate = EXSessionDownloadTaskDelegate(
+          resolve: promise.resolver,
+          reject: promise.legacyRejecter,
+          localUrl: localUrl,
+          shouldCalculateMd5: options.md5
+        )
 
-      sessionTaskDispatcher.register(taskDelegate, for: downloadTask)
-      downloadTask.resume()
+        sessionTaskDispatcher.register(taskDelegate, for: downloadTask)
+        downloadTask.resume()
+      }
     }
 
     AsyncFunction("uploadAsync") { (targetUrl: URL, localUrl: URL, options: UploadOptions, promise: Promise) in


### PR DESCRIPTION
# Why

Currently `FileSystem.downloadAsync` does not support "downloading" local files.  In most cases, users should just use `FileSystem.copyAsync`  instead, but the problem is that if you're using `Asset.fromModule(require("")).url` in dev mode you will get a remote URL (pointing to the bundler) and in prod that same call resolver to a local file path, causing this method to work differently in prod vs debug

Closes https://github.com/expo/expo/issues/26502

# How

Update `downloadAsync` method to check if source URL is a local file and then copy it to the destination instead of trying to download it with URLSession.downloadTask

# Test Plan

Run NCL through BareExpo on dev and release and ensure `downloadAsync` works as expected 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
