### PR TITLE
[docs] fix error while parsing Clipboard API data

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -171,7 +171,7 @@ const renderAPI = (
       entry =>
         isProp(entry) &&
         ([TypeDocKind.TypeAlias, TypeDocKind.TypeAlias_Legacy].includes(entry.kind)
-          ? !!(entry.type.types || entry.type.declaration?.children)
+          ? !!(entry.type?.types || entry.type?.declaration?.children)
           : true)
     );
     const defaultProps = filterDataByKind(


### PR DESCRIPTION
# Why

![image](https://github.com/expo/expo/assets/719641/36e318ab-3665-4faf-a164-a2d2971b8c90)

# How

Fix error in API render pipeline leading to lack od API reference data on the `expo-clipboard` package reference page.

# Test Plan

Tested locally that API data is present on the page.

# Preview

![Screenshot 2024-02-20 at 22 09 05](https://github.com/expo/expo/assets/719641/b3ab3e6e-a1c4-4e9c-b44f-c90780847793)

