### PR TITLE
[core][iOS] Make SharedObject inherit from EventEmitter

### DIFF
--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -24,7 +24,7 @@ jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstruc
 /**
  Creates a class (function) that inherits from the provided base class.
  */
-jsi::Function createInheritingClass(jsi::Runtime &runtime, const char *className, jsi::Function &baseClass, ClassConstructor constructor);
+jsi::Function createInheritingClass(jsi::Runtime &runtime, const char *className, jsi::Function &baseClass, ClassConstructor constructor = nullptr);
 
 /**
  Creates an object from the given prototype, without calling the constructor.

--- a/packages/expo-modules-core/common/cpp/SharedObject.cpp
+++ b/packages/expo-modules-core/common/cpp/SharedObject.cpp
@@ -8,7 +8,7 @@ namespace expo::SharedObject {
 #pragma mark - NativeState
 
 NativeState::NativeState(const ObjectId objectId, const ObjectReleaser releaser)
-: objectId(objectId), releaser(releaser), jsi::NativeState() {}
+: objectId(objectId), releaser(releaser), EventEmitter::NativeState() {}
 
 NativeState::~NativeState() {
   releaser(objectId);
@@ -17,7 +17,8 @@ NativeState::~NativeState() {
 #pragma mark - Utils
 
 void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser) {
-  jsi::Function klass = expo::common::createClass(runtime, "SharedObject");
+  jsi::Function baseClass = EventEmitter::getClass(runtime);
+  jsi::Function klass = expo::common::createInheritingClass(runtime, "SharedObject", baseClass);
   jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
 
   jsi::Function releaseFunction = jsi::Function::createFromHostFunction(

--- a/packages/expo-modules-core/common/cpp/SharedObject.h
+++ b/packages/expo-modules-core/common/cpp/SharedObject.h
@@ -7,6 +7,7 @@
 #include <jsi/jsi.h>
 #include "JSIUtils.h"
 #include "ObjectDeallocator.h"
+#include "EventEmitter.h"
 
 namespace jsi = facebook::jsi;
 
@@ -40,7 +41,7 @@ jsi::Function createClass(jsi::Runtime &runtime, const char *className, common::
 /**
  Class representing a native state of the shared object.
  */
-class JSI_EXPORT NativeState : public jsi::NativeState {
+class JSI_EXPORT NativeState : public EventEmitter::NativeState {
 public:
   const ObjectId objectId = 0;
   const ObjectReleaser releaser;

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -394,13 +394,13 @@ public final class AppContext: NSObject {
     // Install the modules host object as the `global.expo.modules`.
     EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
 
+    // Install `global.expo.EventEmitter`.
+    EXJavaScriptRuntimeManager.installEventEmitterClass(runtime)
+
     // Install `global.expo.SharedObject`.
     EXJavaScriptRuntimeManager.installSharedObjectClass(runtime) { [weak sharedObjectRegistry] objectId in
       sharedObjectRegistry?.delete(objectId)
     }
-
-    // Install `global.expo.EventEmitter`.
-    EXJavaScriptRuntimeManager.installEventEmitterClass(runtime)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
@@ -32,6 +32,12 @@ final class SharedObjectSpec: ExpoSpec {
         try runtime.eval("new expo.SharedObject()")
         expect(appContext.sharedObjectRegistry.size) == registrySizeBefore
       }
+
+      it("inherits from EventEmitter") {
+        let isEventEmitter = try runtime.eval("new expo.SharedObject() instanceof expo.EventEmitter")
+        expect(isEventEmitter.kind) == .bool
+        expect(try isEventEmitter.asBool()) == true
+      }
     }
 
     describe("Concrete JS class") {


### PR DESCRIPTION
# Why

Follow up on #27038 and #27092

# How

Made `expo.SharedObject` JS class inherit from `expo.EventEmitter` so that shared objects will be able to emit events

# Test Plan

Added a new unit test on iOS.

<!-- disable:changelog-checks -->