### PR TITLE
[docs] Fix formatting issues and links in EAS JSON reference

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -5,14 +5,14 @@ export default [
     name: 'withoutCredentials',
     type: 'boolean',
     description: [
-      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. The default is `false`.",
+      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when you want to build debug binaries and the debug keystore is checked in to the repository. Defaults to `false`.",
     ],
   },
   {
     name: 'image',
     type: 'string',
     description: [
-      'Image with build environment. [Learn more about it here](../../build-reference/infrastructure).',
+      '[Image with build environment](/build-reference/infrastructure/).',
     ],
   },
   {
@@ -21,7 +21,7 @@ export default [
     description: [
       `The Android-specific resource class that will be used to run this build. Defaults to \`${ResourceClasses.android[0]}\`.`,
       '',
-      'To learn more about what build resources are available to each resource class, check out [Android build server configurations](../../build-reference/infrastructure#android-build-server-configurations).',
+      'For information on available build resources for each resource class, see [Android build server configurations](/build-reference/infrastructure/#android-build-server-configurations).',
       '',
       'The `large` resource class is not available on the free plan.',
     ],
@@ -38,18 +38,18 @@ export default [
       'Controls how EAS CLI bumps your application build version. Defaults to `false`.',
       '',
       'Allowed values:',
-      ' - `"version"` - bumps the patch of `expo.version` (e.g. `1.2.3` -> `1.2.4`).',
-      ' - `"versionCode"` (or `true`) - bumps `expo.android.versionCode` (e.g. `3` -> `4`).',
-      ' - `false` - versions won\'t be bumped automatically (default)',
+      ' - `"version"` - bumps the patch of `expo.version` (for example, `1.2.3` to `1.2.4`).',
+      ' - `"versionCode"` (or `true`) - bumps `expo.android.versionCode` (for example, `3` to `4`).',
+      ' - `false` - versions won\'t be bumped automatically (default).',
       '',
-      `Based on the value of "cli.appVersionSource" option in **eas.json**, the values will be updated locally in your project or on EAS servers. [Learn more](../build-reference/app-versions)`,
+      'Based on the value of [`cli.appVersionSource` in **eas.json**](/build-reference/app-versions/), the values will be updated locally in your project or on EAS servers.',
     ],
   },
   {
     name: 'buildType',
     enum: ['app-bundle', 'apk'],
     description: [
-      'Type of the artifact you want to build. It controls what Gradle task will be used, can be overridden by `gradleCommand` or `developmentClient: true` option.',
+      'Type of the artifact you want to build. It controls which Gradle task will be used to build the project. It can be overridden by `gradleCommand` or `developmentClient: true` option.',
       ' - `app-bundle` - `:app:bundleRelease`',
       ' - `apk` - `:app:assembleRelease`',
     ],
@@ -58,15 +58,15 @@ export default [
     name: 'gradleCommand',
     type: 'string',
     description: [
-      'Gradle task that will be used to build your project, e.g. `:app:assembleDebug` to build a debug binary.',
-      "It's not recommended unless you need to run a task that `buildType` does not support, it takes priority over `buildType` and `developmentClient`.",
+      'Gradle task that will be used to build your project. For example, `:app:assembleDebug` to build a debug binary.',
+      "It's not recommended unless you need to run a task that `buildType` does not support, it takes priority over [`buildType`](#buildtype) and [`developmentClient`](#developmentclient).",
     ],
   },
   {
     name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm library for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
     ],
   },
 ]

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -3,7 +3,7 @@ export default [
     name: 'withoutCredentials',
     type: 'boolean',
     description: [
-      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when using EAS Build [custom builds](/custom-builds/get-started/).",
+      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when using EAS Build [custom builds](/custom-builds/get-started/). Defaults to `false`.",
     ],
   },
   {
@@ -18,8 +18,8 @@ export default [
     enum: ['local', 'remote'],
     description: [
       'The source of credentials used to sign the application archive.',
-      ' - `local` - if you want to provide your own `credentials.json` file. ([Learn more on this here](/app-signing/local-credentials).)',
-      ' - `remote` - if you want to use the credentials managed by EAS (this is the default option).',
+      ' - `local` - if you want to provide your own [**credentials.json**](/app-signing/local-credentials).',
+      ' - `remote` - if you want to use the credentials managed by EAS (default option).',
     ],
   },
   {
@@ -28,7 +28,7 @@ export default [
     description: [
       '**Deprecated**: Name of the release channel for the Classic Updates service, which is only supported in SDK 49 and lower. If you do not specify a channel, your binary will pull releases from the `default` channel.',
       '',
-      'EAS Update uses the [channel](#channel) field, so you can remove [releaseChannel](#releasechannel) after migrating to EAS Update. [Learn more about migrating from Classic Updates to EAS Update](/eas-update/migrate-from-classic-updates/).',
+      'EAS Update uses the [channel](#channel) field, so you can remove [`releaseChannel`](#releasechannel) after [migrating to EAS Update](/eas-update/migrate-from-classic-updates/).',
     ],
   },
   {
@@ -39,7 +39,7 @@ export default [
       '',
       'This field has no effect when [developmentClient](#developmentclient) is set to `true`, as development builds can run updates from any channnel.',
       '',
-      'If you have not yet migrated from Classic Updates to EAS Update, then continue to use the [releaseChannel](#releasechannel) field instead.',
+      'If you have not yet migrated from Classic Updates to EAS Update, then continue to use the [`releaseChannel`](#releasechannel) field instead.',
     ],
   },
   {
@@ -47,7 +47,7 @@ export default [
     enum: ['store', 'internal'],
     description: [
       'The method of distributing your app.',
-      "- `internal` - with this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces an APK or IPA file. Otherwise, the shareable URL will be useless. [Learn more about internal distribution](../../build/internal-distribution).",
+      "- `internal` - with this option you'll be able to share your build URLs with anyone, and they will be able to install the builds to their devices straight from the Expo website. When using `internal`, make sure the build produces a **.apk** or **ipa** file. Otherwise, the shareable URL will be not work. See [internal distribution](/build/internal-distribution) for more information.",
       " - `store` - produces builds for store uploads, your build URLs won't be shareable.",
     ],
   },
@@ -55,10 +55,10 @@ export default [
     name: 'developmentClient',
     type: 'boolean',
     description: [
-      'If set to true (defaults to false), this field expresses the intent to produce a development client build.',
-      'For the build to be successful, the project must have expo-dev-client installed and configured.',
-      'Note: this field is sugar for setting the iOS `buildConfiguration` to `Debug` and Android `gradleCommand` to `:app:assembleDebug`. Those fields, if provided for the same build profile, will take precedence.',
-      '[Learn more about custom development clients](../../clients/introduction).',
+      'If set to `true` (defaults to `false`), this field will produce a [development build](/workflow/overview/#development-builds).',
+      'For the build to be successful, the project must have [`expo-dev-client`](/versions/latest/sdk/dev-client/) installed and configured.',
+      '',
+      '**Note**: this field is for setting the `gradleCommand` to `:app:assembleDebug` for Android and `buildConfiguration` to `Debug` for iOS . If these fields are provided for the same build profile, will take precedence over `developmentClient`.',
     ],
   },
   {
@@ -66,7 +66,7 @@ export default [
     enum: ['default', 'medium', 'large'],
     description: [
       'The resource class that will be used to run this build.',
-      'To see mapping for each platform, see [Android-specific resource class field](#resourceclass-1) and [iOS-specific resource class field](#resourceclass-2) documentation.',
+      'To see mapping for each platform, see [Android-specific resource class field](#resourceclass-1) and [iOS-specific resource class field](#resourceclass-2).',
       '',
       'The `large` resource class is not available on the free plan.',
     ],
@@ -75,17 +75,18 @@ export default [
     name: 'prebuildCommand',
     type: 'string',
     description: [
-      'Optional override of the prebuild command used by EAS.',
+      'Optional override of the [prebuild](/more/expo-cli/#prebuild) command used by EAS.',
+      '',
       'For example, you can specify `prebuild --template example-template` to use a custom template.',
-      'Note: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
-      '[Learn more about prebuild options](../../workflow/expo-cli/#expo-prebuild).',
+      '',
+      '**Note**: `--platform` and `--non-interactive` will be added automatically by the build engine, so you do not need to specify them manually.',
     ],
   },
   {
     name: 'buildArtifactPaths',
     type: 'string[]',
     description: [
-      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)).',
+      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm library for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax).',
     ],
   },
   {
@@ -107,14 +108,16 @@ export default [
     name: 'expoCli',
     type: 'string',
     description: [
-      '**Deprecated**: Version of [expo-cli](https://www.npmjs.com/package/expo-cli) used to [prebuild](../../workflow/expo-cli/#expo-prebuild) your app. It only affects managed projects on Expo SDK 45 and lower. For newer SDKs, EAS Build will use the versioned Expo CLI. It comes with the `expo` package installed in your project ([learn more](/workflow/expo-cli)). You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_LOCAL_CLI=0` env variable in the build profile.',
+      '**Deprecated**: Version of [`expo-cli`](https://www.npmjs.com/package/expo-cli) used to [prebuild](/more/expo-cli/#prebuild) your app. It only affects managed projects on Expo SDK 45 and lower.',
+      '',
+      'For newer SDKs, EAS Build will use the versioned [Expo CLI](/more/expo-cli/). It is included with `expo` library. You can opt out of using the versioned Expo CLI by setting the `EXPO_USE_LOCAL_CLI=0` environment variable in the build profile.',
     ],
   },
   {
     name: 'env',
     type: 'object',
     description: [
-      'Environment variables that should be set during the build process (should only be used for values that you would commit to your git repository, i.e. not passwords or secrets).',
+      '[Environment variables](/guides/environment-variables/) that should be set during the build process. It should only be used for values that you would commit to your git repository and not for passwords or [secrets](/build-reference/variables/).',
     ],
   },
   {
@@ -123,20 +126,20 @@ export default [
     description: [
       'Controls how EAS CLI bumps your application build version. Defaults to `false`.',
       '',
-      'When enabled, for iOS, bumps the last component of `expo.ios.buildNumber` (e.g. `1.2.3.39` -> `1.2.3.40`) and for Android, bumps `expo.android.versionCode` (e.g. `3` -> `4`).',
+      'When enabled, for Android, bumps `expo.android.versionCode` (for example, `3`to `4`). For iOS, bumps the last component of `expo.ios.buildNumber` (for example, `1.2.3.39` to `1.2.3.40`).',
     ],
   },
   {
     name: 'cache',
     type: 'object',
     description: [
-      "Cache configuration. This feature is intended for caching values that require a lot of computation, e.g. compilation results (both final binaries and any intermediate files), but it wouldn't work well for `node_modules` because the cache is not local to the machine, so the download speed is similar to downloading from the npm registry. ",
+      "Cache configuration. This feature is intended for caching values that require a lot of computation. For example, compilation results (both final binaries and any intermediate files). However, it doesn't work well for **node_modules** because the cache is not local to the machine, so the download speed is similar to downloading from the npm registry. ",
     ],
     properties: [
       {
         name: 'disabled',
         type: 'boolean',
-        description: ['Disables caching. Defaults to false.'],
+        description: ['Disables caching. Defaults to `false`.'],
       },
       {
         name: 'key',
@@ -147,7 +150,7 @@ export default [
         name: 'paths',
         type: 'array',
         description: [
-          'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
+          'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with **eas.json**.',
         ],
       },
     ],

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -5,13 +5,13 @@ export default [
     name: 'withoutCredentials',
     type: 'boolean',
     description: [
-      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when using EAS Build [custom builds](/custom-builds/get-started/).",
+      "When set to `true`, EAS CLI won't require you to configure credentials when building the app. This comes in handy when using EAS Build [custom builds](/custom-builds/get-started/). Defaults to `false`",
     ],
   },
   {
     name: 'simulator',
     type: 'boolean',
-    description: [ 'If set to true, creates build for simulator. Defaults to false' ],
+    description: [ 'If set to true, creates build for iOS Simulator. Defaults to `false`.' ],
   },
   {
     name: 'enterpriseProvisioning',
@@ -26,18 +26,18 @@ export default [
       'Controls how EAS CLI bumps your application build version. Defaults to `false`.',
       '',
       'Allowed values:',
-      ' - `"version"` - bumps the patch of `expo.version` (e.g. `1.2.3` -> `1.2.4`).',
-      ' - `"buildNumber"` (or `true`) - bumps the last component of `expo.ios.buildNumber` (e.g. `1.2.3.39` -> `1.2.3.40`).',
+      ' - `"version"` - bumps the patch of `expo.version` (for example, `1.2.3` to `1.2.4`).',
+      ' - `"buildNumber"` (or `true`) - bumps the last component of `expo.ios.buildNumber` (for example, `1.2.3.39` to `1.2.3.40`).',
       ' - `false` - versions won\'t be bumped automatically (default)',
       '',
-      `Based on the value of "cli.appVersionSource" option in **eas.json**, the values will be updated locally in your project or on EAS servers. [Learn more](../build-reference/app-versions)`,
+      'Based on the value of [`cli.appVersionSource` in **eas.json**](/build-reference/app-versions/), the values will be updated locally in your project or on EAS servers.',
     ],
   },
   {
     name: 'image',
     type: 'string',
     description: [
-      'Image with build environment. [Learn more about it here](../../build-reference/infrastructure).',
+      '[Image with build environment](/build-reference/infrastructure).',
     ],
   },
   {
@@ -46,7 +46,7 @@ export default [
     description: [
       `The iOS-specific resource class that will be used to run this build. Defaults to \`${ResourceClasses.ios[0]}\`.`,
       '',
-      'To learn more about what build resources are available to each resource class, check out [iOS build server configurations](../../build-reference/infrastructure#ios-build-server-configurations).',
+      'For information on available build resources for each resource class, see [iOS build server configurations](/build-reference/infrastructure/#ios-build-server-configurations).',
       '',
       'The `large` resource class is not available on the free plan.',
     ],
@@ -70,12 +70,10 @@ export default [
     name: 'scheme',
     type: 'string',
     description: [
-      'Xcode project\'s scheme.',
-      ' - managed project: does not have any effect',
-      ' - bare project',
-      '   - If your project has multiple schemes, you should set this value.',
-      '   - If the project has only one scheme, it will be detected automatically.',
-      '   - If multiple schemes exist and this value is **not** set, EAS CLI will prompt you to select one of them.',
+      "Xcode project's scheme. If a project:",
+      '   - Has multiple schemes, you should set this value.',
+      '   - Has only one scheme, it will be detected automatically.',
+      '   - Have multiple schemes schemes and if this value is **not** set, EAS CLI will prompt you to select one of them.',
 
     ]
   },
@@ -84,17 +82,17 @@ export default [
     type: 'string',
     description: [
       'Xcode project\'s Build Configuration.',
-      ' - managed project: "Release" or "Debug", defaults to "Release"',
-      ' - bare project: defaults to the value specified in the scheme',
+      ' - For an Expo project, the value is `"Release"` or `"Debug"`. Defaults to `"Release"`.',
+      ' - For a [bare React Native](/bare/overview/) project, defaults to the value specified in the scheme.',
       '',
-      'It takes priority over `developmentClient` field.',
+      'It takes priority over [`developmentClient`](#developmentclient).',
     ],
   },
   {
     name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for pattern matching ([see their README to learn more about the syntax you can use](https://github.com/mrmlnc/fast-glob#pattern-syntax)). You should modify that path only if you are using a custom `Gymfile`. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom **Gymfile**. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
     ],
   },
 ]

--- a/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
@@ -2,7 +2,7 @@ export default [
   {
     name: 'serviceAccountKeyPath',
     type: 'string',
-    description: ['Path to the JSON file with service account key used to authenticate with Google Play. [See how to create one](https://expo.fyi/creating-google-service-account).'],
+    description: ['Path to the JSON file with [Google Service Account Key](https://expo.fyi/creating-google-service-account) used to authenticate with Google Play.'],
   },
   {
     name: 'track',
@@ -12,23 +12,23 @@ export default [
   {
     name: 'releaseStatus',
     enum: ['completed', 'draft', 'halted', 'inProgress'],
-    description: ['The status of a release. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks).'],
+    description: ['The [status of a release](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).'],
   },
   {
     name: 'rollout',
     type: 'number',
-    description: ['The initial fraction of users who are eligible to receive the release. Should be a value from 0 (no users) to 1 (all users). Works only with `inProgress` release status. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)'],
+    description: ['The initial fraction of users who are eligible to receive the release. Should be a value from 0 (no users) to 1 (all users). Works only with `inProgress` [release status](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).'],
   },
   {
     name: 'changesNotSentForReview',
     type: 'boolean',
-    description: ['Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to false.'],
+    description: ['Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to `false`.'],
   },
   {
     name: 'applicationId',
     type: 'string',
     description: [
-      'The application id that will be used when accessing Service Account Keys managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple product flavors, this value might be necessary.',
+      'The application ID that is used when accessing Service Account Key managed by Expo. It does not have any effect if you are using local credentials. In most cases this value will be autodetected. However, if you have multiple product flavors, this value might be necessary.',
     ],
   },
 ];

--- a/docs/public/static/schemas/unversioned/eas-json-submit-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-submit-ios-schema.js
@@ -8,8 +8,7 @@ export default [
     name: 'ascAppId',
     type: 'string',
     description: [
-      'App Store Connect unique application Apple ID number. When set, results in skipping the app creation step.',
-      '[Learn more on this](https://expo.fyi/asc-app-id).',
+      '[App Store Connect unique application Apple ID number](https://expo.fyi/asc-app-id). When set, results in skipping the app creation step.',
     ],
   },
   {
@@ -40,42 +39,42 @@ export default [
     name: 'appName',
     type: 'string',
     description: [
-      'The name of your app as it will appear on the App Store. Defaults to `expo.name` from the app config.',
+      'The name of your app as it will appear on the App Store. Defaults to `expo.name` from the [app config](/workflow/configuration/).',
     ],
   },
   {
     name: 'ascApiKeyPath',
     type: 'string',
     description: [
-      'The path to your App Store Connect Api Key .p8 file. [Learn more](https://expo.fyi/creating-asc-api-key).',
+      'The path to your [App Store Connect Api Key **.p8** file](https://expo.fyi/creating-asc-api-key).',
     ],
   },
   {
     name: 'ascApiKeyIssuerId',
     type: 'string',
     description: [
-      'The Issuer ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key).',
+      'The Issuer ID of your [App Store Connect Api Key](https://expo.fyi/creating-asc-api-key).',
     ],
   },
   {
     name: 'ascApiKeyId',
     type: 'string',
     description: [
-      'The Key ID of your App Store Connect Api Key. [Learn more](https://expo.fyi/creating-asc-api-key).',
+      'The Key ID of your [App Store Connect Api Key](https://expo.fyi/creating-asc-api-key).',
     ],
   },
   {
     name: 'bundleIdentifier',
     type: 'string',
     description: [
-      'The Bundle identifier that will be used when accessing submit credentials managed by Expo, it does not have any effect if you are using local credentials. In most cases this value will be autodetected, but if you have multiple Xcode schemes and targets, this value might be necessary.',
+      'The bundle identifier that will be used when accessing submit credentials managed by Expo. It does not have any effect if you are using local credentials. In most cases, this value will be autodetected. However, if you have multiple Xcode schemes and targets, this value might be necessary.',
     ],
   },
   {
     name: 'metadataPath',
     type: 'string',
     description: [
-      'The path to your store configuration file. [Learn more](https://docs.expo.dev/eas/metadata/).'
+      'The path to your [store configuration file](/eas/metadata/).'
     ],
   }
 ];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the **eas.json** reference does not follow formatting as per our writing style guide and has some broken internal links. Came across these issues while working on EAS Tutorial.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes aforementioned issues and also adds some new internal links to support the concept/reference in all schema table files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/eas/json or see **Preview**.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
