### PR TITLE
[docs] Format Configure EAS Build with eas.json

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -383,7 +383,7 @@ The [Environment variables and secrets](/build-reference/variables) reference ex
 
 <BoxLink
   title="EAS Build schema reference"
-  description="See complete reference of available properties  for EAS Build."
+  description="See complete reference of available properties for EAS Build."
   href="/eas/json/#eas-build"
   Icon={BuildIcon}
 />

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -63,7 +63,25 @@ Developers using Expo tools usually end up having three different types of build
 
 By default, `eas build:configure` will create a `development` profile with `"developmentClient": true`. This indicates that this build depends on [`expo-dev-client`](/develop/development-builds/introduction/). These builds include developer tools, and they are never submitted to an app store.
 
-The `development` profile also defaults to [`"distribution": "internal"`](/build/internal-distribution). This will make it easy to distribute your app directly to physical Android and iOS devices. You can also configure your development builds to run on the [iOS Simulator](/build-reference/simulators).
+The `development` profile also defaults to [`"distribution": "internal"`](/build/internal-distribution). This will make it easy to distribute your app directly to physical Android and iOS devices.
+
+You can also configure your development builds to run on the [iOS Simulator](/build-reference/simulators). To do this, use the following configuration for the `development` profile:
+
+```json eas.json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
 
 > **Note:** For iOS, to create a build for internal distribution and another for the iOS Simulator, you can create a separate development profile for that build. You can give the profile a custom name. For example, `development-simulator`, and use the [iOS simulator specific configuration](/build-reference/simulators/#configuring-a-profile-to-build-for-simulators) on that profile instead of on `development`. No such configuration is required to run an [Android **.apk** on a device and an Android Emulator](/build-reference/apk) as the same **.apk** will run with both environments.
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -371,9 +371,9 @@ You can configure environment variables on your build profiles using the `"env"`
         "API_URL": "https://staging.company.com/api"
       }
     }
-    // ...
+    /* @hide ... */ /* @end */
   }
-  // ...
+  /* @hide ... */ /* @end */
 }
 ```
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -41,6 +41,7 @@ To run a build with a specific profile, use the command as shown below with a `<
     '# Replace the <profile-name> with a build profile from the eas.json',
     '$ eas build --profile <profile-name>',
   ]}
+  cmdCopy="eas build --profile"
 />
 
 If you omit the `--profile` flag, EAS CLI will default to using the profile with the name `production` (if it exists).

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -83,7 +83,7 @@ You can also configure your development builds to run on the [iOS Simulator](/bu
 }
 ```
 
-> **Note:** For iOS, to create a build for internal distribution and another for the iOS Simulator, you can create a separate development profile for that build. You can give the profile a custom name. For example, `development-simulator`, and use the [iOS simulator specific configuration](/build-reference/simulators/#configuring-a-profile-to-build-for-simulators) on that profile instead of on `development`. No such configuration is required to run an [Android **.apk** on a device and an Android Emulator](/build-reference/apk) as the same **.apk** will run with both environments.
+> **Note:** For iOS, to create a build for internal distribution and another for the iOS Simulator, you can create a separate development profile for that build. You can give the profile a custom name. For example, `development-simulator`, and use the [iOS Simulator specific configuration](/build-reference/simulators/#configuring-a-profile-to-build-for-simulators) on that profile instead of on `development`. No such configuration is required to run an [Android **.apk** on a device and an Android Emulator](/build-reference/apk) as the same **.apk** will run with both environments.
 
 ### Preview builds
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -7,8 +7,11 @@ description: Learn how a project using EAS services is configured with eas.json.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon } from '@expo/styleguide-icons';
+import { Terminal } from '~/ui/components/Snippet';
 
-**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to your **package.json**. Configuration for EAS Build all belongs under the `build` key. A minimal **eas.json** is shown below:
+**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**. Configuration for EAS Build all belongs under the `build` key.
+
+The default configuration for **eas.json** in a new project is shown below:
 
 ```json eas.json
 {
@@ -29,17 +32,28 @@ import { BuildIcon } from '@expo/styleguide-icons';
 
 A build profile is a named group of configurations that describes the necessary parameters to perform a certain type of build.
 
-The JSON object under the `build` key can contain multiple build profiles, and you can name these build profiles whatever you like. In the previous example, there are three build profiles: `development`, `preview`, and `production`. However, these could have been named `foo`, `bar`, and `baz` if that is your preference.
+The JSON object under the `build` key can contain multiple build profiles, and you can have custom build profile names. In the default configuration, there are three build profiles: `development`, `preview`, and `production`. However, these could have been named `foo`, `bar`, and `baz`.
 
-To run a build with a specific profile, execute `eas build --profile <profile-name>`. If you omit the `--profile` flag, EAS CLI will default to using the profile with the name **production**, if it exists.
+To run a build with a specific profile, use the command as shown below with a `<profile-name>`:
+
+<Terminal
+  cmd={[
+    '# Replace the <profile-name> with a build profile from the eas.json',
+    '$ eas build --profile <profile-name>',
+  ]}
+/>
+
+If you omit the `--profile` flag, EAS CLI will default to using the profile with the name `production` (if it exists).
 
 ### Platform-specific and common options
 
-Inside each build profile, you can specify `android` and `ios` fields that contain platform-specific configuration for the build. Fields that are available to both platforms can be provided on the platform-specific configuration object or on the root of the profile.
+Inside each build profile, you can specify [`android`](/eas/json/#android-specific-options) and [`ios`](/eas/json/#ios-specific-options) fields that contain platform-specific configuration for the build. [Options that are available to both platforms](/eas/json/#common-properties-for-native-platforms) can be provided on the platform-specific configuration object or the root of a profile.
 
 ### Sharing configuration between profiles
 
-Build profiles can extend another build profile using the `extends` key. For example, in the `preview` profile you may have `"extends": "production"`. This will make the `preview` profile inherit the configuration of the `production` profile.
+Build profiles can be extended to other build profile properties using the `extends` option.
+
+For example, in the `preview` profile you might have `"extends": "production"`. This will make the `preview` profile inherit the configuration of the `production` profile.
 
 ## Common use cases
 
@@ -47,134 +61,23 @@ Developers using Expo tools usually end up having three different types of build
 
 ### Development builds
 
-These builds include developer tools, and they are never submitted to an app store.
+By default, `eas build:configure` will create a `development` profile with `"developmentClient": true`. This indicates that this build depends on [`expo-dev-client`](/develop/development-builds/introduction/). These builds include developer tools, and they are never submitted to an app store.
 
-By default, `eas build:configure` will create a `development` profile with `"developmentClient": true`. This indicates that this build depends on [`expo-dev-client`](/develop/development-builds/introduction/).
+The `development` profile also defaults to [`"distribution": "internal"`](/build/internal-distribution). This will make it easy to distribute your app directly to physical Android and iOS devices. You can also configure your development builds to run on the [iOS Simulator](/build-reference/simulators).
 
-The `development` profile also defaults to `"distribution": "internal"`. This will make it easy to distribute your app directly to physical Android and iOS devices. See [Internal distribution](/build/internal-distribution) for more information.
-
-You may alternatively prefer for your development build to [run on an iOS Simulator](/build-reference/simulators). To do this, use the following configuration for the `development` profile:
-
-```json eas.json
-{
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal",
-      "ios": {
-        "simulator": true
-      }
-    }
-    // ...
-  }
-  // ...
-}
-```
-
-If you'd like to create a build for internal distribution and another for the iOS Simulator then you can create another development profile for that build. You might call the profile something like `development-simulator` and use the above configuration on that profile instead of on `development`. [No such configuration is required to run an Android APK on your device and in an emulator](/build-reference/apk). The same APK will work in both circumstances.
+> **Note:** For iOS, to create a build for internal distribution and another for the iOS Simulator, you can create a separate development profile for that build. You can give the profile a custom name. For example, `development-simulator`, and use the [iOS simulator specific configuration](/build-reference/simulators/#configuring-a-profile-to-build-for-simulators) on that profile instead of on `development`. No such configuration is required to run an [Android **.apk** on a device and an Android Emulator](/build-reference/apk) as the same **.apk** will run with both environments.
 
 ### Preview builds
 
-These builds don't include developer tools, they are intended to be installed by your team and other stakeholders, to test out the app in production-like circumstances. In this way, they are similar to [production builds](#production-builds); the difference arises in that they are either not signed for distribution on stores (ad hoc or enterprise provisioning on iOS), or are packaged in a way that is not optimal for store deployment (Android APK is best for preview, AAB is best for stores).
+These builds don't include developer tools. They are intended to be installed by your team and other stakeholders, to test out the app in production-like circumstances. In this way, they are similar to [production builds](#production-builds). However, they are different from production builds because they are either not signed for distribution on app stores (ad hoc or enterprise provisioning on iOS), or are packaged in a way that is not optimal for store deployment (Android **.apk** is recommended for preview, **.aab** is recommended for Google Play Store).
 
-A minimal `preview` profile looks like this:
+A minimal `preview` profile example:
 
 ```json eas.json
 {
   "build": {
     "preview": {
       "distribution": "internal"
-    }
-    // ...
-  }
-  // ...
-}
-```
-
-Similar to [development builds](#development-builds), you can configure your preview build to run on the [iOS Simulator](/build-reference/simulators) or create a variant of your preview profile for that purpose. [No such configuration is required to run an Android APK on your device and in an emulator](/build-reference/apk); the same APK will work in both circumstances.
-
-### Production builds
-
-These builds are submitted to an app store, for release to the general public or as part of a store-facilitated testing process such as TestFlight.
-
-Production builds must be installed through their respective app stores; they cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile; however, it is recommended to use AAB when submitting to stores, and this is the default configuration.
-
-A minimal `production` profile looks like this:
-
-```json eas.json
-{
-  "build": {
-    "production": {}
-    // ...
-  }
-  // ...
-}
-```
-
-### Installing multiple builds of the same app on a single device
-
-It's common to have development and production builds installed simultaneously on the same device. See [Install app variants on the same device](/build-reference/variants/).
-
-## Configuring your build tools
-
-Every build depends either implicitly or explicitly on a specific set of versions of related tools that are needed to carry out the build process. These include but are not limited to: Node.js, npm, Yarn, Ruby, Bundler, CocoaPods, Fastlane, Xcode, and Android NDK.
-
-### Selecting build tool versions
-
-Versions for the most common build tools can be set on build profiles with fields corresponding to the names of the tools. For example `"node"`:
-
-```json eas.json
-{
-  "build": {
-    "production": {
-      "node": "16.18.0"
-    }
-    // ...
-  }
-  // ...
-}
-```
-
-It's common to want to share build tool configuration between profiles, and we can use `extends` for that:
-
-```json eas.json
-{
-  "build": {
-    "production": {
-      "node": "16.13.0"
-    },
-    "preview": {
-      "extends": "production",
-      "distribution": "internal"
-    },
-    "development": {
-      "extends": "production",
-      "developmentClient": true,
-      "distribution": "internal"
-    }
-    // ...
-  }
-  // ...
-}
-```
-
-### Selecting resource class
-
-Resource class is the virtual machine resources configuration (CPU cores, RAM size) EAS Build provides to your jobs. By default, the resource class is set to `medium`, which is usually sufficient for both small and bigger projects. However, if your project requires a more powerful CPU or bigger memory, or if you want your builds to finish faster, you can switch to `large` workers.
-
-For more details on resources provided to each class, see [`android.resourceClass`](/eas/json/#resourceclass-1) and [`ios.resourceClass`](/eas/json/#resourceclass-2) property documentations. To run your build on a worker of a specific resource class, configure this property in your build profile:
-
-{/* prettier-ignore */}
-```json eas.json
-{
-  "build": {
-    "production": {
-      "ios": {
-        "resourceClass": "large"
-      },
-      "android": {
-        "resourceClass": "medium"
-      }
     }
     /* @hide ... */ /* @end */
   }
@@ -182,13 +85,104 @@ For more details on resources provided to each class, see [`android.resourceClas
 }
 ```
 
-> **Note**: Running jobs on a `large` worker requires a paid EAS plan. [Subscribe here](https://expo.dev/accounts/[account]/settings/billing).
+Similar to [development builds](#development-builds), you can configure a preview build to run on the [iOS Simulator](/build-reference/simulators) or create a variant of your preview profile for that purpose. No such configuration is required to run an [Android **.apk** on a device and an Android Emulator](/build-reference/apk) as the same **.apk** will run with both environments.
+
+### Production builds
+
+These builds are submitted to an app store, for release to the general public or as part of a store-facilitated testing process such as TestFlight.
+
+Production builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **.aab** when submitting to stores, as this is the default configuration.
+
+A minimal `production` profile example:
+
+```json eas.json
+{
+  "build": {
+    "production": {}
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+### Installing multiple builds of the same app on a single device
+
+It's common to have development and production builds installed simultaneously on the same device. See [Install app variants on the same device](/build-reference/variants/).
+
+## Configuring build tools
+
+Every build depends either implicitly or explicitly on a specific set of versions of related tools that are needed to carry out the build process. These include but are not limited to: Node.js, npm, Yarn, Ruby, Bundler, CocoaPods, Fastlane, Xcode, and Android NDK.
+
+### Selecting build tool versions
+
+Versions for the most common build tools can be set on build profiles with fields corresponding to the names of the tools. For example [`node`](/eas/json/#node):
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "node": "18.18.0"
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+It's common to share build tool configurations between profiles. Use `extends` for that:
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "node": "18.18.0"
+    },
+    "preview": {
+      "extends": "production",
+      "distribution": "internal"
+    },
+    "development": {
+      "extends": "production",
+      "developmentClient": true,
+      "distribution": "internal"
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+### Selecting resource class
+
+A resource class is the virtual machine resources configuration (CPU cores, RAM size) EAS Build provides to your jobs. By default, the resource class is set to `medium`, which is usually sufficient for both small and bigger projects. However, if your project requires a more powerful CPU or bigger memory, or if you want your builds to finish faster, you can switch to `large` workers.
+
+For more details on resources provided to each class, see [`android.resourceClass`](/eas/json/#resourceclass-1) and [`ios.resourceClass`](/eas/json/#resourceclass-2) properties. To run your build on a worker of a specific resource class, configure this property in your build profile:
+
+{/* prettier-ignore */}
+```json eas.json
+{
+  "build": {
+    "production": {
+      "android": {
+        "resourceClass": "medium"
+      },
+      "ios": {
+        "resourceClass": "large"
+      },
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+> **Note**: Running jobs on a `large` worker requires a [paid EAS plan](https://expo.dev/accounts/[account]/settings/billing).
 
 ### Selecting a base image
 
-The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and CocoaPods. You can override them using the specific named fields as described in the previous section. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
+The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and CocoaPods. You can override them using the [specific named fields] as described in the previous section using `resourceClass`. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
 
-If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to read about the available images on [Build server infrastructure](/build-reference/infrastructure).
+If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to see the list of available images on [Build server infrastructure](/build-reference/infrastructure).
 
 ### Examples
 
@@ -204,7 +198,7 @@ If you are using the Expo managed workflow, EAS Build will pick the appropriate 
     "promptToConfigurePushNotifications": /* @info If set to false, skips Push Notifications credentials setup for EAS Build. Defaults to true. */boolean/* @end */,
   },
   "build": {
-    /* @info any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: {
+    /* @info Any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_1"/* @end */: {
       /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */,
       "android": {
         /* @info Options common to both platforms*/...COMMON_OPTIONS/* @end */,
@@ -216,7 +210,7 @@ If you are using the Expo managed workflow, EAS Build will pick the appropriate 
       }
     },
     /* @info Any arbitrary name - used as an identifier */"BUILD_PROFILE_NAME_2"/* @end */: {},
-	...
+	/* @hide ... */ /* @end */
   }
 }
 ```
@@ -365,9 +359,9 @@ You can configure environment variables on your build profiles using the `"env"`
 }
 ```
 
-The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [updates guide](/build/updates) provides guidance on considerations when using this feature alongside `expo-updates`.
+The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [Use EAS Update](/build/updates) guides considerations when using this feature alongside `expo-updates`.
 
-## Next step
+## More
 
 <BoxLink
   title="EAS Build schema reference"

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -359,7 +359,7 @@ You can configure environment variables on your build profiles using the `"env"`
 }
 ```
 
-The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [Use EAS Update](/build/updates) guides considerations when using this feature alongside `expo-updates`.
+The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [Use EAS Update](/build/updates) guide provides considerations when using this feature alongside `expo-updates`.
 
 ## More
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -198,7 +198,7 @@ For more details on resources provided to each class, see [`android.resourceClas
 
 ### Selecting a base image
 
-The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and CocoaPods. You can override them using the [specific named fields] as described in the previous section using `resourceClass`. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
+The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and CocoaPods. You can override them using the specific named fields as described in the previous section using `resourceClass`. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
 
 If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to see the list of available images on [Build server infrastructure](/build-reference/infrastructure).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, there formatting issue with this guide. Discovered these issues while working on EAS Tutorial.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR attempts to fix the formatting issues and remove duplicating iOS Simulator build profile info (as we have dedicated page for that). Also add links to EAS JSON schema properties where necessary.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/build/eas-json or see **Preview**.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
