### PR TITLE
[camera][ios] Make sure barcode bounds match barcode scanner

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Fix scanned frame bounds when scanning a barcode. ([#27207](https://github.com/expo/expo/pull/27207) by [@tamagokun](https://github.com/tamagokun))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-camera/ios/CameraView.swift
+++ b/packages/expo-camera/ios/CameraView.swift
@@ -130,6 +130,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     previewLayer = AVCaptureVideoPreviewLayer.init(session: session)
     previewLayer?.videoGravity = .resizeAspectFill
     previewLayer?.needsDisplayOnBoundsChange = true
+    barCodeScanner.setPreviewLayer(previewLayer)
     #endif
     self.changePreviewOrientation(orientation: UIApplication.shared.statusBarOrientation)
     self.initializeCaptureSessionInput()


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/24540.

Set the preview layer for the barcode scanner so the bounds of the scanned frame are correct

Currently expo-camera gives you different bounds and corners data after scanning a barcode. The bug is outlined in this issue: https://github.com/expo/expo/issues/24540

> Note: this is an update from #24663 which provided this fix for the old expo-camera module.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
