### PR TITLE
[ios][file-system] Fix copy async

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,6 +11,7 @@
 - On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix upload task requests. ([#26880](https://github.com/expo/expo/pull/26880) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix downloadAsync for local files. ([#27187](https://github.com/expo/expo/pull/27187) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- On `iOS`, fix an issue with `copyAsync` where the copy fails if it is a photo library asset.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,7 +11,7 @@
 - On `iOS`, set `httpMethod` on upload requests. ([#26516](https://github.com/expo/expo/pull/26516) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix upload task requests. ([#26880](https://github.com/expo/expo/pull/26880) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix downloadAsync for local files. ([#27187](https://github.com/expo/expo/pull/27187) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- On `iOS`, fix an issue with `copyAsync` where the copy fails if it is a photo library asset.
+- On `iOS`, fix an issue with `copyAsync` where the copy fails if it is a photo library asset. ([#27208](https://github.com/expo/expo/pull/27208) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemExceptions.swift
+++ b/packages/expo-file-system/ios/FileSystemExceptions.swift
@@ -79,3 +79,15 @@ final class FailedToAccessDirectoryException: Exception {
     "Failed to access `Caches` directory"
   }
 }
+
+final class FailedToCopyAssetException: GenericException<String> {
+  override var reason: String {
+    "Failed to copy photo library asset: \(param)"
+  }
+}
+
+final class FailedToFindAssetException: GenericException<String> {
+  override var reason: String {
+    "Failed to find photo library asset: \(param)"
+  }
+}

--- a/packages/expo-file-system/ios/FileSystemExceptions.swift
+++ b/packages/expo-file-system/ios/FileSystemExceptions.swift
@@ -8,6 +8,12 @@ final class FileNotExistsException: GenericException<String> {
   }
 }
 
+final class FileAlreadyExistsException: GenericException<String> {
+  override var reason: String {
+    "File '\(param)' already exists"
+  }
+}
+
 final class DirectoryNotExistsException: GenericException<String> {
   override var reason: String {
     "Directory '\(param)' does not exist"

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -4,7 +4,6 @@ import ExpoModulesCore
 import Photos
 
 private let assetIdentifier = "ph://"
-private let resourceManager = PHAssetResourceManager()
 
 internal func ensureFileDirectoryExists(_ fileUrl: URL) throws {
   let directoryPath = fileUrl.deletingLastPathComponent()
@@ -73,7 +72,7 @@ internal func isPHAsset(path: String) -> Bool {
   return path.contains(assetIdentifier)
 }
 
-internal func copyPHAsset(fromUrl: URL, toUrl: URL, promise: Promise) {
+internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAssetResourceManager, promise: Promise) {
   if isPhotoLibraryStatusAuthorized() {
     if FileManager.default.fileExists(atPath: toUrl.path) {
       promise.reject(FileAlreadyExistsException(toUrl.path))

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -1,6 +1,9 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import Photos
+
+private let assetIdentifier = "ph://"
 
 internal func ensureFileDirectoryExists(_ fileUrl: URL) throws {
   let directoryPath = fileUrl.deletingLastPathComponent()
@@ -63,4 +66,39 @@ internal func ensurePathPermission(_ appContext: AppContext?, path: String, flag
   guard permissionsManager.getPathPermissions(path).contains(flag) else {
     throw flag == .read ? FileNotReadableException(path) : FileNotWritableException(path)
   }
+}
+
+internal func isPHAsset(path: String) -> Bool {
+  return path.contains(assetIdentifier)
+}
+
+internal func copyPHAsset(fromUrl: URL, toUrl: URL, promise: Promise) {
+  if isPhotoLibraryStatusAuthorized() {
+    let identifier = fromUrl.absoluteString.replacingOccurrences(of: assetIdentifier, with: "")
+    let resourceManager = PHAssetResourceManager()
+
+    guard let asset = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil).firstObject else {
+      promise.reject(FailedToFindAssetException(fromUrl.absoluteString))
+      return
+    }
+
+    let firstResource = PHAssetResource.assetResources(for: asset).first
+    if let firstResource {
+      resourceManager.writeData(for: firstResource, toFile: toUrl, options: nil) { error in
+        if let error {
+          promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
+        }
+      }
+    } else {
+      promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
+    }
+  }
+}
+
+internal func isPhotoLibraryStatusAuthorized() -> Bool {
+  if #available(iOS 14, tvOS 14, *) {
+    let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    return status == .authorized || status == .limited
+  }
+  return PHPhotoLibrary.authorizationStatus() == .authorized
 }

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -4,6 +4,7 @@ import ExpoModulesCore
 import Photos
 
 private let assetIdentifier = "ph://"
+private let resourceManager = PHAssetResourceManager()
 
 internal func ensureFileDirectoryExists(_ fileUrl: URL) throws {
   let directoryPath = fileUrl.deletingLastPathComponent()
@@ -74,8 +75,12 @@ internal func isPHAsset(path: String) -> Bool {
 
 internal func copyPHAsset(fromUrl: URL, toUrl: URL, promise: Promise) {
   if isPhotoLibraryStatusAuthorized() {
+    if FileManager.default.fileExists(atPath: toUrl.path) {
+      promise.reject(FileAlreadyExistsException(toUrl.path))
+      return
+    }
+
     let identifier = fromUrl.absoluteString.replacingOccurrences(of: assetIdentifier, with: "")
-    let resourceManager = PHAssetResourceManager()
 
     guard let asset = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil).firstObject else {
       promise.reject(FailedToFindAssetException(fromUrl.absoluteString))

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -100,6 +100,11 @@ public final class FileSystemModule: Module {
     AsyncFunction("copyAsync") { (options: RelocatingOptions, promise: Promise) in
       let (fromUrl, toUrl) = try options.asTuple()
 
+      if isPHAsset(path: fromUrl.absoluteString) {
+        copyPHAsset(fromUrl: fromUrl, toUrl: toUrl, promise: promise)
+        return
+      }
+
       try ensurePathPermission(appContext, path: fromUrl.path, flag: .read)
       try ensurePathPermission(appContext, path: toUrl.path, flag: .write)
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -1,6 +1,7 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import Photos
 
 private let EVENT_DOWNLOAD_PROGRESS = "expo-file-system.downloadProgress"
 private let EVENT_UPLOAD_PROGRESS = "expo-file-system.uploadProgress"
@@ -8,6 +9,7 @@ private let EVENT_UPLOAD_PROGRESS = "expo-file-system.uploadProgress"
 public final class FileSystemModule: Module {
   private lazy var sessionTaskDispatcher = EXSessionTaskDispatcher(sessionHandler: ExpoAppDelegate.getSubscriberOfType(FileSystemBackgroundSessionHandler.self))
   private lazy var taskHandlersManager = EXTaskHandlersManager()
+  private lazy var resourceManager = PHAssetResourceManager()
 
   private lazy var backgroundSession = createUrlSession(type: .background, delegate: sessionTaskDispatcher)
   private lazy var foregroundSession = createUrlSession(type: .foreground, delegate: sessionTaskDispatcher)
@@ -101,7 +103,7 @@ public final class FileSystemModule: Module {
       let (fromUrl, toUrl) = try options.asTuple()
 
       if isPHAsset(path: fromUrl.absoluteString) {
-        copyPHAsset(fromUrl: fromUrl, toUrl: toUrl, promise: promise)
+        copyPHAsset(fromUrl: fromUrl, toUrl: toUrl, with: resourceManager, promise: promise)
         return
       }
 


### PR DESCRIPTION
# Why
Closes #27021
When an image is selected from the photo library it will have a url like `ph://***`. Our `URL` conversion will accept this but when we access `url.path` it will be blank, causing the copy to fail.

# How
Check if we are dealing with a photo library asset and handle the copy using the `PHAssetResourceManager` instead of the `FileManager`.

# Test Plan
All tests still passing in bare-expo
Tested using the provided repro.