### PR TITLE
Fix url param filter in link to reactnative directory using-libraries.mdx

### DIFF
--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -99,7 +99,7 @@ After the React Native Directory, the [npm registry](https://www.npmjs.com/) is 
 
 Use Expo [development builds](/workflow/overview/#development-builds) for building production-quality apps. It includes all of the native code that your project needs to run. This is a great way to test your app before you publish it to the App Store or Google Play. You can also include libraries that require native projects (**android** and **ios** directories) configuration.
 
-The Expo Go app is an optional stepping stone towards development builds. You can use it to quickly test your app while you are developing it, but it does not include all of the native code required to support every library. You can check **React Native Directory** to find a library compatible with Expo Go by visiting the website and verifying that it has a "✔️ Expo Go" tag. You can also enable the [filter by Expo Go](https://reactnative.directory/?expo=true).
+The Expo Go app is an optional stepping stone towards development builds. You can use it to quickly test your app while you are developing it, but it does not include all of the native code required to support every library. You can check **React Native Directory** to find a library compatible with Expo Go by visiting the website and verifying that it has a "✔️ Expo Go" tag. You can also enable the [filter by Expo Go](https://reactnative.directory/?expoGo=true).
 
 
 To determine if a new dependency changes native project directories, you can check the following:


### PR DESCRIPTION
# Why

The url parameter on the react native directory to filter packages by compatibility is `expoGo` not `expo`.

# How

Changed link

# Test Plan
N/A
# Checklist
N/A
