### PR TITLE
fix(cli): fix critical issue with web dev urls

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix using dev server URL in development.
+- Fix using dev server URL in development. ([#27213](https://github.com/expo/expo/pull/27213) by [@EvanBacon](https://github.com/EvanBacon))
 - Always reset production bundler cache in run command. ([#27114](https://github.com/expo/expo/pull/27114) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix expo router src log memo. ([#27013](https://github.com/expo/expo/pull/27013) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent run commands from hanging when the process completes. ([#26960](https://github.com/expo/expo/pull/26960) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix using dev server URL in development.
 - Always reset production bundler cache in run command. ([#27114](https://github.com/expo/expo/pull/27114) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix expo router src log memo. ([#27013](https://github.com/expo/expo/pull/27013) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent run commands from hanging when the process completes. ([#26960](https://github.com/expo/expo/pull/26960) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializes development static html 1`] = `
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/packages/expo-router/entry.bundle?platform=web" defer></script>
+</body></html>"
+`;
+
+exports[`serializes production static html for export 1`] = `
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/dist/entry.js" defer></script>
+</body></html>"
+`;

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -1,0 +1,41 @@
+import { serializeHtmlWithAssets } from '../serializeHtml';
+
+it('serializes development static html', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: '/Users/path/to/expo/packages/expo-router/entry.js',
+        originFilename: '../../packages/expo-router/entry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+    ],
+    baseUrl: '',
+    isExporting: false,
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    devBundleUrl: '/packages/expo-router/entry.bundle?platform=web',
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(/<script src="\/packages\/expo-router\/entry\.bundle\?platform=web" defer>/);
+});
+
+it('serializes production static html for export', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: 'dist/entry.js',
+        originFilename: '../../packages/expo-router/entry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+    ],
+    baseUrl: '',
+    isExporting: true,
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    devBundleUrl: '/packages/expo-router/entry.bundle?platform=web',
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(/<script src="\/dist\/entry\.js" defer>/);
+});

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -26,7 +26,7 @@ export function serializeHtmlWithAssets({
     isExporting,
     template,
     baseUrl,
-    bundleUrl: isExporting ? devBundleUrl : undefined,
+    bundleUrl: isExporting ? undefined : devBundleUrl,
     route,
   });
 }


### PR DESCRIPTION
# Why

The wrong URL was being used for development, we don't have any tests to cover this case so it wasn't flagged during the refactor.
