### PR TITLE
feat(cli): add number of transformed modules to bundle output

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add total files bundled to the bundling finished message.
 - Add better API Route error messages. ([#27024](https://github.com/expo/expo/pull/27024) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent bundling production react modules in development. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `--no-bytecode` flag to `expo export` to disable generating Hermes bytecode for use with debugging tools. ([#26985](https://github.com/expo/expo/pull/26985) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add total files bundled to the bundling finished message.
+- Add total files bundled to the bundling finished message. ([#27215](https://github.com/expo/expo/pull/27215) by [@EvanBacon](https://github.com/EvanBacon))
 - Add better API Route error messages. ([#27024](https://github.com/expo/expo/pull/27024) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent bundling production react modules in development. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `--no-bytecode` flag to `expo export` to disable generating Hermes bytecode for use with debugging tools. ([#26985](https://github.com/expo/expo/pull/26985) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -51,9 +51,14 @@ export class MetroTerminalReporter extends TerminalReporter {
       const color = phase === 'done' ? chalk.green : chalk.red;
 
       const startTime = this._bundleTimers.get(progress.bundleDetails.buildID!);
+
       const time = startTime != null ? chalk.dim(this._getElapsedTime(startTime) + 'ms') : '';
       // iOS Bundled 150ms
-      return color(platform + status) + time + chalk.reset.dim(' (' + localPath + ')');
+      return (
+        color(platform + status) +
+        time +
+        chalk.reset.dim(` ${localPath} (${progress.totalFileCount} modules)`)
+      );
     }
 
     const filledBar = Math.floor(progress.ratio * MAX_PROGRESS_BAR_CHAR_WIDTH);

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -54,10 +54,11 @@ export class MetroTerminalReporter extends TerminalReporter {
 
       const time = startTime != null ? chalk.dim(this._getElapsedTime(startTime) + 'ms') : '';
       // iOS Bundled 150ms
+      const plural = progress.totalFileCount === 1 ? '' : 's';
       return (
         color(platform + status) +
         time +
-        chalk.reset.dim(` ${localPath} (${progress.totalFileCount} modules)`)
+        chalk.reset.dim(` ${localPath} (${progress.totalFileCount} module${plural})`)
       );
     }
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -98,7 +98,7 @@ describe('_getBundleStatusMessage', () => {
           'done'
         )
       )
-    ).toMatchInlineSnapshot(`"Android Bundled 100ms (./index.js)"`);
+    ).toMatchInlineSnapshot(`"Android Bundled 100ms ./index.js (100 modules)"`);
   });
   it(`should format failed loading`, () => {
     expect(
@@ -117,7 +117,7 @@ describe('_getBundleStatusMessage', () => {
           'failed'
         )
       )
-    ).toMatchInlineSnapshot(`"Android Bundling failed 100ms (./index.js)"`);
+    ).toMatchInlineSnapshot(`"Android Bundling failed 100ms ./index.js (100 modules)"`);
   });
 });
 


### PR DESCRIPTION
# Why

This may be too verbose but I find it helpful for understanding why a particular bundle operation took so long.

This should help condition users to understand how fast/slow their bundling is by showing the main operation / time it took to complete.

<img width="500" alt="Screenshot 2024-02-21 at 1 24 05 PM" src="https://github.com/expo/expo/assets/9664363/433afe97-79f3-4850-a2af-fdc17edbc260">


