### PR TITLE
fix(cli): Prevent `console.log` statements from colliding with Metro logs.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent `console.log` statements from colliding with Metro logs.
+- Prevent `console.log` statements from colliding with Metro logs. ([#27217](https://github.com/expo/expo/pull/27217) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix using dev server URL in development. ([#27213](https://github.com/expo/expo/pull/27213) by [@EvanBacon](https://github.com/EvanBacon))
 - Always reset production bundler cache in run command. ([#27114](https://github.com/expo/expo/pull/27114) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix expo router src log memo. ([#27013](https://github.com/expo/expo/pull/27013) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent `console.log` statements from colliding with Metro logs.
 - Fix using dev server URL in development. ([#27213](https://github.com/expo/expo/pull/27213) by [@EvanBacon](https://github.com/EvanBacon))
 - Always reset production bundler cache in run command. ([#27114](https://github.com/expo/expo/pull/27114) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix expo router src log memo. ([#27013](https://github.com/expo/expo/pull/27013) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -63,6 +63,9 @@ class LogRespectingTerminal extends Terminal {
       );
       // @ts-expect-error
       this._scheduleUpdate();
+
+      // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
+      this.flush();
     };
 
     console.log = sendLog;


### PR DESCRIPTION
# Why

This is a minor fix to prevent `console.log` statements (not `console.error` or `console.warn`) from breaking the Metro loading indicator. It's very fragile but the alternative has been bugging me. Whenever console.log is called (after metro has been loaded) the log will be added to the Metro queue to ensure it doesn't disrupt the loading bar behavior.

## Before

<img width="1160" alt="Screenshot 2024-02-21 at 2 16 40 PM" src="https://github.com/expo/expo/assets/9664363/0a80f690-620a-4862-a592-0af09a4c3bde">

## After

<img width="720" alt="Screenshot 2024-02-21 at 2 15 30 PM" src="https://github.com/expo/expo/assets/9664363/6edb3fb5-0c71-4bab-a8d7-ec35d2765f7a">


