### PR TITLE
[core][Android] Remove usage of `CatalystInstance` in the bridgeless mode

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactExtensions.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin
+
+import com.facebook.react.bridge.ReactContext
+import expo.modules.adapters.react.NativeModulesProxy
+
+internal fun ReactContext.getUnimoduleProxy(): NativeModulesProxy? {
+  @Suppress("DEPRECATION")
+  return if (!isBridgeless) {
+    catalystInstance?.getNativeModule("NativeUnimoduleProxy") as? NativeModulesProxy
+  } else {
+    nativeModules?.find { it is NativeModulesProxy } as? NativeModulesProxy
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -3,8 +3,8 @@ package expo.modules.kotlin.viewevent
 import android.view.View
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
-import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.core.utilities.ifNull
+import expo.modules.kotlin.getUnimoduleProxy
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.putGeneric
@@ -22,10 +22,7 @@ open class ViewEvent<T>(
 
   override operator fun invoke(arg: T) {
     val reactContext = view.context as ReactContext
-    val nativeModulesProxy = reactContext
-      .catalystInstance
-      ?.getNativeModule("NativeUnimoduleProxy") as? NativeModulesProxy
-      ?: return
+    val nativeModulesProxy = reactContext.getUnimoduleProxy() ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
     if (!isValidated) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.bridge.ReactContext
-import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.functions.BaseAsyncFunctionComponent
+import expo.modules.kotlin.getUnimoduleProxy
 
 class ViewManagerDefinition(
   private val viewFactory: (Context, AppContext) -> View,
@@ -34,10 +34,7 @@ class ViewManagerDefinition(
 
   fun handleException(view: View, exception: CodedException) {
     val reactContext = (view.context as? ReactContext) ?: return
-    val nativeModulesProxy = reactContext
-      .catalystInstance
-      ?.getNativeModule("NativeUnimoduleProxy") as? NativeModulesProxy
-      ?: return
+    val nativeModulesProxy = reactContext.getUnimoduleProxy() ?: return
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
     appContext.errorManager?.reportExceptionToLogBox(exception)


### PR DESCRIPTION
# Why

We want to prepare ourselves to support bridgeless mode on Android. I've decided to search for usage of `CatalystInstance` and see if I can replace it with something else. I replaced all places except the init function, which will be reworked later. So when the init logic is ready, we should support the bridgeless mode in the core. 

# Test Plan

- bare-expo ✅ and simple project with bridgeless enable ✅
