### PR TITLE
Add loader that fetches the latest commit and shows a status on refer…

### DIFF
--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
 import { breakpoints, spacing } from '@expo/styleguide-base';
 import { BuildIcon, GithubIcon } from '@expo/styleguide-icons';
+import { formatDistance, subDays } from 'date-fns';
+import { useEffect, useState } from 'react';
 
-import { A, CALLOUT, H1 } from '~/ui/components/Text';
+import { A, CALLOUT, FOOTNOTE, H1 } from '~/ui/components/Text';
 
 type Props = {
   title?: string;
@@ -11,43 +13,75 @@ type Props = {
   iconUrl?: string;
 };
 
-export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => (
-  <div className="flex my-2 items-center justify-between max-xl-gutters:flex-col max-xl-gutters:items-start">
-    <H1 className="!my-0">
-      {iconUrl && <img src={iconUrl} css={titleIconStyle} alt={`Expo ${title} icon`} />}
-      {packageName && packageName.startsWith('expo-') && 'Expo '}
-      {title}
-    </H1>
-    {packageName && (
-      <span css={linksContainerStyle}>
-        {sourceCodeUrl && (
-          <A
-            isStyled
-            openInNewTab
-            href={sourceCodeUrl}
-            css={linkStyle}
-            title={`View source code of ${packageName} on GitHub`}>
-            <GithubIcon className="text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
-              GitHub
-            </CALLOUT>
-          </A>
+export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => {
+  const [lastUpdated, setLastUpdated] = useState('');
+  const blah = formatDistance(subDays(new Date(), 3), new Date(), { addSuffix: true });
+
+  useEffect(() => {
+    if (sourceCodeUrl) {
+      fetch(`https://api.github.com/repos/${sourceCodeUrl.split('github.com/')[1]}/commits`)
+        .then(response => response.json())
+        .then(data => {
+          if (data.length) {
+            setLastUpdated(
+              formatDistance(new Date(data[0].commit.author.date), new Date(), { addSuffix: true })
+            );
+          }
+        });
+    }
+  }, []);
+  return (
+    <>
+      {sourceCodeUrl ? (
+        <div className="flex items-center justify-start max-xl-gutters:flex-col max-xl-gutters:items-start">
+          {lastUpdated !== '' ? (
+            <FOOTNOTE>Last updated: {lastUpdated}</FOOTNOTE>
+          ) : (
+            <>
+              <FOOTNOTE>Last updated:</FOOTNOTE>
+              <div className="ml-2 animate-pulse rounded-md bg-palette-gray4 w-32 h-3" />
+            </>
+          )}
+        </div>
+      ) : null}
+      <div className="flex my-2 items-center justify-between max-xl-gutters:flex-col max-xl-gutters:items-start">
+        <H1 className="!my-0">
+          {iconUrl && <img src={iconUrl} css={titleIconStyle} alt={`Expo ${title} icon`} />}
+          {packageName && packageName.startsWith('expo-') && 'Expo '}
+          {title}
+        </H1>
+        {packageName && (
+          <span css={linksContainerStyle}>
+            {sourceCodeUrl && (
+              <A
+                isStyled
+                openInNewTab
+                href={sourceCodeUrl}
+                css={linkStyle}
+                title={`View source code of ${packageName} on GitHub`}>
+                <GithubIcon className="text-icon-secondary" />
+                <CALLOUT crawlable={false} theme="secondary">
+                  GitHub
+                </CALLOUT>
+              </A>
+            )}
+            <A
+              isStyled
+              openInNewTab
+              href={`https://www.npmjs.com/package/${packageName}`}
+              css={linkStyle}
+              title="View package in npm Registry">
+              <BuildIcon className="text-icon-secondary" />
+              <CALLOUT crawlable={false} theme="secondary">
+                npm
+              </CALLOUT>
+            </A>
+          </span>
         )}
-        <A
-          isStyled
-          openInNewTab
-          href={`https://www.npmjs.com/package/${packageName}`}
-          css={linkStyle}
-          title="View package in npm Registry">
-          <BuildIcon className="text-icon-secondary" />
-          <CALLOUT crawlable={false} theme="secondary">
-            npm
-          </CALLOUT>
-        </A>
-      </span>
-    )}
-  </div>
-);
+      </div>
+    </>
+  );
+};
 
 const titleIconStyle = css({
   float: 'left',


### PR DESCRIPTION
…ences

# Why

It's very useful to see when packages were updated when looking through various Expo SDK items.

# How

I'm simply calling the Github public API to get the latest commits for external repos.

# Test Plan

* Going to any Expo SDK reference page will invoke this.
* Going to accelerator (first one) will endlessly spin
* Going to AsyncStorage works as expected

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
