### PR TITLE
fix: [expo-device] `Device.productName` should return `Build.PRODUCT`

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- `Device.productName` now returns `Build.PRODUCT` instead of `Build.DEVICE`. ([#27230](https://github.com/expo/expo/pull/27230) by [@alex-fournier](https://github.com/alex-fournier))
+
 ### 💡 Others
 
 ## 5.9.3 - 2024-01-18

--- a/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+++ b/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
@@ -41,7 +41,7 @@ class DeviceModule : Module() {
         "manufacturer" to Build.MANUFACTURER,
         "modelName" to Build.MODEL,
         "designName" to Build.DEVICE,
-        "productName" to Build.DEVICE,
+        "productName" to Build.PRODUCT,
         "deviceYearClass" to deviceYearClass,
         "totalMemory" to run {
           val memoryInfo = ActivityManager.MemoryInfo()


### PR DESCRIPTION
# Why

Fixes #27229

`Device.productName` should return `Build.PRODUCT` instead of `Build.DEVICE` as mentioned in the [doc](https://docs.expo.dev/versions/latest/sdk/device/#deviceproductname).

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
