### PR TITLE
[ios][camera] Fix method call on optional

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,7 +20,7 @@
 - On `Android`, fix the camera not being released when the view is destroyed. ([#27086](https://github.com/expo/expo/pull/27086) by [@alanjhughes](https://github.com/alanjhughes))
 - On `Android`, fix empty qualities being passed to QualitySelector ([#27126](https://github.com/expo/expo/pull/27126) by [@leonhh](https://github.com/leonhh))
 - On `web`, prevent creating a webworker when rendering on the server ([#27222](https://github.com/expo/expo/pull/27222) by [@marklawlor](https://github.com/marklawlor))
-- On `iOS`, fix method call on an optional variable.
+- On `iOS`, fix method call on an optional variable. ([#27235](https://github.com/expo/expo/pull/27235) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,6 +20,7 @@
 - On `Android`, fix the camera not being released when the view is destroyed. ([#27086](https://github.com/expo/expo/pull/27086) by [@alanjhughes](https://github.com/alanjhughes))
 - On `Android`, fix empty qualities being passed to QualitySelector ([#27126](https://github.com/expo/expo/pull/27126) by [@leonhh](https://github.com/leonhh))
 - On `web`, prevent creating a webworker when rendering on the server ([#27222](https://github.com/expo/expo/pull/27222) by [@marklawlor](https://github.com/marklawlor))
+- On `iOS`, fix method call on an optional variable.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraView.swift
+++ b/packages/expo-camera/ios/CameraView.swift
@@ -130,7 +130,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     previewLayer = AVCaptureVideoPreviewLayer.init(session: session)
     previewLayer?.videoGravity = .resizeAspectFill
     previewLayer?.needsDisplayOnBoundsChange = true
-    barCodeScanner.setPreviewLayer(previewLayer)
+    barCodeScanner?.setPreviewLayer(previewLayer)
     #endif
     self.changePreviewOrientation(orientation: UIApplication.shared.statusBarOrientation)
     self.initializeCaptureSessionInput()


### PR DESCRIPTION
# Why
Fixes a regression from #27207

# How
`barCodeScanner` can be nil. Wouldn't be noticed until you try to run on a real device because of the compiler directive.

# Test Plan
bare-expo build when connected to a real device


