### PR TITLE
[expo-module-template] Module template should support TV by default

### DIFF
--- a/packages/expo-module-template-local/expo-module.config.json
+++ b/packages/expo-module-template-local/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "tvos", "android", "web"],
   "ios": {
     "modules": ["<%- project.moduleName %>"]
   },

--- a/packages/expo-module-template-local/ios/{%- project.name %}.podspec
+++ b/packages/expo-module-template-local/ios/{%- project.name %}.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.description    = 'A sample project description'
   s.author         = ''
   s.homepage       = 'https://docs.expo.dev/modules/'
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.source         = { git: '' }
   s.static_framework = true
 

--- a/packages/expo-module-template/expo-module.config.json
+++ b/packages/expo-module-template/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "tvos", "android", "web"],
   "ios": {
     "modules": ["<%- project.moduleName %>"]
   },

--- a/packages/expo-module-template/ios/{%- project.name %}.podspec
+++ b/packages/expo-module-template/ios/{%- project.name %}.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.swift_version  = '5.4'
   s.source         = { git: '<%- repo %>' }
   s.static_framework = true


### PR DESCRIPTION
# Why

For the convenience of TV customers, our module template should be able to build on Apple TV by default.

# How

Added the required changes to `expo-module.config.json` and the `*.podspec` files in the templates.

These changes will have no effect on non-TV projects.

# Test Plan

Copy the new `expo-module-template-local` into a TV project and execute

```
npx create-expo-module@latest --local --source expo-module-template-local
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
