### PR TITLE
[docs] add image Lightbox with ability to pop up and zoom assets

### DIFF
--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -30,7 +30,7 @@ module.exports = {
         "node_modules/@expo/styleguide/dist/global.css"
       ],
       callees: ["mergeClasses"],
-      classRegex: "^(confirmation)?(c|C)lass(Name)?$",
+      classRegex: "^(confirmation|container)?(c|C)lass(Name)?$",
       config: "tailwind.config.cjs",
     }
   }

--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -1,39 +1,22 @@
-import { theme } from '@expo/styleguide';
-import { CSSProperties } from 'react';
+import { mergeClasses } from '@expo/styleguide';
+import { type CSSProperties } from 'react';
+
+import { LightboxImage } from '~/ui/components/LightboxImage';
 
 type Props = {
   alt: string;
   style?: CSSProperties;
-  containerStyle?: CSSProperties;
+  containerClassName?: string;
   src: string;
   caption?: string;
 };
 
-export default function ImageSpotlight({ alt, src, style, containerStyle, caption }: Props) {
+export default function ImageSpotlight({ alt, src, style, containerClassName, caption }: Props) {
   return (
-    <figure
-      style={{
-        textAlign: 'center',
-        backgroundColor: theme.background.subtle,
-        paddingTop: 10,
-        paddingBottom: 10,
-        marginTop: 20,
-        marginBottom: 20,
-        ...containerStyle,
-      }}>
-      <img src={src} alt={alt} style={style} className="inline" />
+    <figure className={mergeClasses('text-center bg-subtle py-2.5 my-5', containerClassName)}>
+      <LightboxImage src={src} alt={alt} style={style} className="inline" />
       {caption && (
-        <figcaption
-          style={{
-            fontSize: 14,
-            paddingLeft: 20,
-            paddingRight: 20,
-            paddingTop: 25,
-            paddingBottom: 5,
-            lineHeight: 1.5,
-            color: theme.text.secondary,
-            textAlign: 'center',
-          }}>
+        <figcaption className="mt-[14px] text-secondary text-center text-xs px-8 py-2">
           {caption}
         </figcaption>
       )}

--- a/docs/package.json
+++ b/docs/package.json
@@ -58,7 +58,8 @@
     "remark-mdx": "^2.2.1",
     "remark-mdx-disable-explicit-jsx": "^0.1.0",
     "remark-mdx-frontmatter": "^2.1.1",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "yet-another-react-lightbox": "^3.17.0"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.1.0",

--- a/docs/pages/build-reference/build-configuration.mdx
+++ b/docs/pages/build-reference/build-configuration.mdx
@@ -19,7 +19,6 @@ If you only want to use EAS Build for a single platform, that's fine. If you cha
 <ImageSpotlight
   alt="Terminal running eas build command with platform Android and iOS options available"
   src="/static/images/eas-build/configure/01-configure-platform.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>
@@ -66,7 +65,6 @@ If you haven't configured your **app.json** with `android.package` and/or `ios.b
 <ImageSpotlight
   alt="Application identifier prompts in eas build:configure"
   src="/static/images/eas-build/configure/02-configure-app-ids.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 In the example above, we defined exactly the same Android application id and iOS bundle identifier. However, they don't need to match.
@@ -91,7 +89,6 @@ There is one final step if you set `cli.requireCommit` to `true` in your **eas.j
 <ImageSpotlight
   alt="Application identifier prompts in eas build:configure"
   src="/static/images/eas-build/configure/03-next-steps.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>

--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -14,7 +14,7 @@ The [`expo-notifications`](/versions/latest/sdk/notifications) library provides 
 <ImageSpotlight
   alt="Diagram explaining sending a push from your server to device"
   src="/static/images/sending-notification.png"
-  containerStyle={{ backgroundColor: '#fff' }}
+  containerClassName="bg-white"
 />
 
 ## Send push notifications using a server

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -17,7 +17,6 @@ In this chapter, we will create the first screen of the StickerSmash app.
   alt="Initial layout."
   src="/static/images/tutorial/initial-layout.jpg"
   style={{ maxWidth: 300 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 The screen above displays an image and two buttons. The app user can select an image using one of the two buttons. The first button allows the user to select an image from their device. The second button allows the user to continue with a default image provided by the app.
@@ -34,7 +33,6 @@ Before we build this screen by writing code, let's break it down into some essen
   alt="Break down of initial layout."
   src="/static/images/tutorial/breakdown-of-layout.jpg"
   style={{ maxWidth: 300 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 There are three essential elements:
@@ -49,7 +47,6 @@ The first button is composed of multiple components. The parent element provides
   alt="Break down of the button component with row."
   src="/static/images/tutorial/breakdown-of-buttons.png"
   style={{ maxWidth: 400 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 In React Native, styling (such as the yellow border) is done using JavaScript as compared to the web, where CSS is used. Most of the React Native core components accept a `style` prop that accepts a JavaScript object as its value. For detailed information on styling, see [Styling in React Native](https://reactnative.dev/docs/style).
@@ -148,7 +145,6 @@ We can use React Native's `<Image>` component to display the image in the app. T
   alt="Background image that we are going to use as a placeholder for the tutorial."
   src="/static/images/tutorial/background-image.png"
   style={{ maxWidth: 250 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 Next, import and use the `<Image>` component from React Native and `background-image.png` in the **App.js**. Let's also add styles to display the image.
@@ -386,7 +382,6 @@ Let's take a look at our app on Android, iOS and the web:
   alt="Initial layout."
   src="/static/images/tutorial/buttons-created.jpg"
   style={{ maxWidth: 720 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 The second button with the label "Use this photo" resembles the actual button from the design. However, the first button needs more styling to match the design.

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -63,7 +63,6 @@ We already have **splash.png** in the **assets** directory. It looks as shown be
 <ImageSpotlight
   src="/static/images/tutorial/splash.png"
   style={{ maxWidth: 250 }}
-  containerStyle={{ marginBottom: 20 }}
 />
 
 Let's take a look at our app now on Android, and iOS:

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -107,7 +107,6 @@ Let's break down the layout of the option buttons we will implement in this chap
   alt="Break down of the layout of the buttons row."
   src="/static/images/tutorial/buttons-layout.jpg"
   style={{ maxWidth: 480 }}
-  containerStyle={{ marginBottom: 10 }}
 />
 
 It contains a parent `<View>` with three buttons aligned in a row. The button in the middle with the plus icon (+) will open the modal and is styled differently than the other two buttons.
@@ -263,7 +262,6 @@ Let's take a look at our app on Android, iOS and the web:
   alt="Button options displayed after a image is selected."
   src="/static/images/tutorial/button-options.jpg"
   style={{ maxWidth: 720 }}
-  containerStyle={{ marginBottom: 0 }}
 />
 
 </Step>

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerStyle={{ backgroundColor: '#fff' }}
+  containerClassName="bg-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerStyle={{ backgroundColor: '#fff' }}
+  containerClassName="bg-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerStyle={{ backgroundColor: '#fff' }}
+  containerClassName="bg-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerStyle={{ backgroundColor: '#fff' }}
+  containerClassName="bg-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -210,7 +210,6 @@ On the Android Studio main screen, click **More Actions**, then **Virtual Device
 <ImageSpotlight
   alt="Android Studio configure."
   src="/static/images/android-studio/virtual-device.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>
@@ -222,7 +221,6 @@ Click the **Create device** button.
 <ImageSpotlight
   alt="Android Studio create virtual device."
   src="/static/images/android-studio/create-device.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>
@@ -234,7 +232,6 @@ Under **Select Hardware**, choose the type of hardware you'd like to emulate. We
 <ImageSpotlight
   alt="Android Studio create virtual device hardware selection."
   src="/static/images/android-studio/select-hardware.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>
@@ -246,7 +243,6 @@ Select an OS version to load on the emulator (probably one of the system images 
 <ImageSpotlight
   alt="Android Studio create virtual device os selection."
   src="/static/images/android-studio/select-os.png"
-  containerStyle={{ paddingBottom: 0 }}
 />
 
 </Step>

--- a/docs/ui/components/LightboxImage/index.tsx
+++ b/docs/ui/components/LightboxImage/index.tsx
@@ -1,0 +1,36 @@
+import { ImgHTMLAttributes, useState } from 'react';
+import Lightbox from 'yet-another-react-lightbox';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+
+import 'yet-another-react-lightbox/styles.css';
+
+type Props = ImgHTMLAttributes<HTMLImageElement> & {
+  src: string;
+};
+
+export function LightboxImage({ src, alt, ...rest }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        <img src={src} alt={alt} {...rest} />
+      </button>
+      <Lightbox
+        open={open}
+        close={() => setOpen(false)}
+        slides={[{ src }]}
+        styles={{ container: { backgroundColor: 'rgba(0, 0, 0, .8)' } }}
+        controller={{
+          aria: true,
+          closeOnBackdropClick: true,
+        }}
+        render={{
+          buttonPrev: () => null,
+          buttonNext: () => null,
+        }}
+        plugins={[Zoom]}
+      />
+    </>
+  );
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -10088,6 +10088,11 @@ yauzl@^2.10.0, yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
+yet-another-react-lightbox@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/yet-another-react-lightbox/-/yet-another-react-lightbox-3.17.0.tgz#806d0141dc9a71489ba6e9b441a146ac43399e6d"
+  integrity sha512-xtVFmYaMOsqEDitx0ju6wTLVjCIUdS1TLeY2bwwUHapj3coh1uQxEwDAGg8aZiKs+Qd5AcpLOoCfH/T3TKeLTA==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
# Why

Fixes ENG-9341

# How

Add a basic image Lightbox with ability to pop up and zoom assets. It has been hooked up as a default for all `ImageSpotlight` usages.

In the process I have also partially rewrite component to use TailWind, leaving `style` as is for now, to avoid blowing up the changeset.

# Test Plan

The new feature has been reviewed locally. All lint checks and tests are passing.

# Preview

https://github.com/expo/expo/assets/719641/84c076af-120f-4ff4-9bab-996820d861fd

