### PR TITLE
[docs] Update localization.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-`expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device. Using a localization library such as [`lingui-js`](https://lingui.dev/introduction), [`react-intl`](https://formatjs.io/docs/getting-started/installation/) or [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
+`expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device. Using a localization library such as [`lingui-js`](https://lingui.dev/introduction), [`react-i18next`](https://react.i18next.com/), [`react-intl`](https://formatjs.io/docs/getting-started/installation/) or [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
 
 <PlatformsSection android emulator ios simulator web />
 


### PR DESCRIPTION
Added react-i18next library link in the docs that can also be used with expo-localization.

# Why
[react-i18next](https://react.i18next.com/) is a powerful internationalization framework that can also be used with expo-localization to add localization in the react native expo apps. I have used it in my apps. On expo documentation, I saw that there are many other libraries but this was missing in references.



# Checklist
- [*] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [*] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [*] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
