### PR TITLE
Fix issue with es-419 locale

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix es-419 locale returning empty list.
+
 ### 💡 Others
 
 ## 14.8.3 - 2024-01-18

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix es-419 locale returning empty list.
+- [Android] Fix es-419 locale returning empty list. ([#27250](https://github.com/expo/expo/pull/27250) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -137,6 +137,20 @@ class LocalizationModule : Module() {
     }
   }
 
+  private fun getCurrencyProperties(locale: Locale): Map<String, Any?> {
+    return try {
+      mapOf(
+      "currencyCode" to Currency.getInstance(locale).currencyCode,
+      // currency symbol can be localized to display locale (1st on the list) or to the locale for the currency (as done here).
+      "currencySymbol" to Currency.getInstance(locale).getSymbol(locale))
+    } catch (e: Exception) {
+      mapOf(
+        "currencyCode" to null,
+        "currencySymbol" to null
+      )
+    }
+  }
+
   private fun getPreferredLocales(): List<Map<String, Any?>> {
     val locales = mutableListOf<Map<String, Any?>>()
     val localeList: LocaleListCompat = LocaleListCompat.getDefault()
@@ -156,12 +170,8 @@ class LocalizationModule : Module() {
             "digitGroupingSeparator" to decimalFormat.groupingSeparator.toString(),
 
             "measurementSystem" to getMeasurementSystem(locale),
-            "currencyCode" to decimalFormat.currency.currencyCode,
-
-            // currency symbol can be localized to display locale (1st on the list) or to the locale for the currency (as done here).
-            "currencySymbol" to Currency.getInstance(locale).getSymbol(locale),
             "temperatureUnit" to getTemperatureUnit(locale)
-          )
+          ) + getCurrencyProperties(locale)
         )
       } catch (e: Exception) {
         // warn about the problematic locale

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -140,9 +140,10 @@ class LocalizationModule : Module() {
   private fun getCurrencyProperties(locale: Locale): Map<String, Any?> {
     return try {
       mapOf(
-      "currencyCode" to Currency.getInstance(locale).currencyCode,
-      // currency symbol can be localized to display locale (1st on the list) or to the locale for the currency (as done here).
-      "currencySymbol" to Currency.getInstance(locale).getSymbol(locale))
+        "currencyCode" to Currency.getInstance(locale).currencyCode,
+        // currency symbol can be localized to display locale (1st on the list) or to the locale for the currency (as done here).
+        "currencySymbol" to Currency.getInstance(locale).getSymbol(locale)
+      )
     } catch (e: Exception) {
       mapOf(
         "currencyCode" to null,


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/21414

# How

Was able to narrow down the reproduction steps thanks to @newfylox.

# Test Plan

Tested to make sure it returns correct null values on the es-419 locale.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
