### PR TITLE
[docs] add `eas/build` function docs

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -573,10 +573,9 @@ EAS provides a set of built-in reusable functions that you can use in a workflow
 
 #### `eas/build`
 
-The all-in-one function that encapsulates the entire EAS Build build process. It will resolve the best build workflow configuration for you based on your build profile's settings from [**eas.json**](/eas/json/).
+The all-in-one function that encapsulates the entire EAS Build build process. It resolves the best build workflow configuration based on your build profile's settings from [**eas.json**](/eas/json/).
 
-It's ideal for people who just want to have the build done without worrying about altering and configuring the build process manually.
-It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
+It's ideal for people who just want to have the build done without worrying about altering and configuring the build process manually. It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
 
 ```yaml example.yml
 build:
@@ -585,7 +584,7 @@ build:
     - eas/build
 ```
 
-If you want to have more control over the build process and customize it for your needs you may be interested in what are the custom functions and steps that are executed behind the scenes by this function. This is what will be resolved as a build process for you based on your build profile's configuration:
+To have more control over the build process and customize it as per your requirements, see the following custom functions and steps that run in the background by `eas/build`. They are executed as a build process based on your build profile's configuration.
 
 1. for iOS build:
    - if your build doesn't use credentials ([simulator](/eas/json/#simulator) build or when using when using [`withoutCredentials`](/eas/json/withoutcredentials-0)):
@@ -656,10 +655,10 @@ You can replace the `eas/build` command call by using these steps in your YAML c
   href="https://github.com/expo/eas-custom-builds-example/blob/main/.eas/build/android-build-with-credentials.yml"
 />
 
-Known limitations:
+##### Known limitations
 
-- This function won't configure updates for you properly if you still use the legacy classic updates. You should use the EAS Update instead. Check our [migration guide](/eas-update/migrate-from-classic-updates/) for more information.
-- Currently it doesn't accept any inputs and the resolved build process will be configured based on your build profile from [**eas.json**](/eas/json/) settings.
+- This function doesn't configure legacy classic updates. If you are using classic updates, [migrate to EAS Update](/eas-update/migrate-from-classic-updates/) before using this function.
+- It doesn't accept any inputs, and the resolved build process will be configured based on your build profile from [**eas.json**](/eas/json/).
 - The build process produced by `eas/build` is not configurable and you can't customize it. If you need to customize the build process you should use the subset of functions and steps that are executed behind the scenes by this function and configure them manually in your YAML configuration file as shown in the examples above.
 
 #### `eas/maestro_test`

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -668,7 +668,7 @@ You can replace the `eas/build` command call by using these steps in your YAML c
 
 - This function doesn't configure legacy classic updates. If you are using classic updates, [migrate to EAS Update](/eas-update/migrate-from-classic-updates/) before using this function.
 - It doesn't accept any inputs, and the resolved build process will be configured based on your build profile from [**eas.json**](/eas/json/).
-- The build process produced by `eas/build` is not configurable and you can't customize it. If you need to customize the build process you should use the subset of functions and steps that are executed behind the scenes by this function and configure them manually in your YAML configuration file as shown in the examples above.
+- The build process produced by `eas/build` is not configurable and you can't customize it. If you need to customize the build process, use the subset of functions and steps that are executed behind the scenes by this function and configure them manually in the YAML configuration file, as shown in the examples above.
 
 #### `eas/maestro_test`
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -586,47 +586,56 @@ build:
 
 To have more control over the build process and customize it as per your requirements, see the following custom functions and steps that run in the background by `eas/build`. They are executed as a build process based on your build profile's configuration.
 
-1. for iOS build:
-   - if your build doesn't use credentials ([simulator](/eas/json/#simulator) build or when using when using [`withoutCredentials`](/eas/json/withoutcredentials-0)):
-     - [`eas/checkout`](#eascheckout)
-     - [`eas/install_node_modules`](#easinstall_node_modules)
-     - [`eas/prebuild`](#easprebuild)
-     - Install pods using the `pod install` command
-     - [`eas/configure_eas_update`](#easconfigure_eas_update)
-     - [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
-     - [`eas/run_fastlane`](#easrun_fastlane)
-     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
-   - if your build uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
-     - [`eas/checkout`](#eascheckout)
-     - [`eas/install_node_modules`](#easinstall_node_modules)
-     - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
-     - [`eas/resolve_apple_team_id_from_credentials`](#easresolve_apple_team_id_from_credentials)
-     - [`eas/prebuild`](#easprebuild)
-     - Install pods using the `pod install` command
-     - [`eas/configure_eas_update`](#easconfigure_eas_update)
-     - [`eas/configure_ios_credentials`](#easconfigure_ios_credentials)
-     - [`eas/configure_ios_version`](#easconfigure_ios_version)
-     - [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
-     - [`eas/run_fastlane`](#easrun_fastlane)
-     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
-2. for Android build:
-   - if your build doesn't use credentials (when using [`withoutCredentials`](/eas/json/withoutcredentials-1) option):
-     - [`eas/checkout`](#eascheckout)
-     - [`eas/install_node_modules`](#easinstall_node_modules)
-     - [`eas/prebuild`](#easprebuild)
-     - [`eas/configure_eas_update`](#easconfigure_eas_update)
-     - [`eas/run_gradle`](#easrun_gradle)
-     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
-   - if your build uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
-     - [`eas/checkout`](#eascheckout)
-     - [`eas/install_node_modules`](#easinstall_node_modules)
-     - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
-     - [`eas/prebuild`](#easprebuild)
-     - [`eas/configure_eas_update`](#easconfigure_eas_update)
-     - [`eas/inject_android_credentials`](#easinject_android_credentials)
-     - [`eas/configure_android_version`](#easconfigure_android_version)
-     - [`eas/run_gradle`](#easrun_gradle)
-     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+##### Android
+
+When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcredentials):
+
+- [`eas/checkout`](#eascheckout)
+- [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/prebuild`](#easprebuild)
+- [`eas/configure_eas_update`](#easconfigure_eas_update)
+- [`eas/run_gradle`](#easrun_gradle)
+- [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+
+When a build configuration uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
+
+- [`eas/checkout`](#eascheckout)
+- [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+- [`eas/prebuild`](#easprebuild)
+- [`eas/configure_eas_update`](#easconfigure_eas_update)
+- [`eas/inject_android_credentials`](#easinject_android_credentials)
+- [`eas/configure_android_version`](#easconfigure_android_version)
+- [`eas/run_gradle`](#easrun_gradle)
+- [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+
+##### iOS
+
+When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcredentials) or [`simulator`](/eas/json/#simulator):
+
+- [`eas/checkout`](#eascheckout)
+- [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/prebuild`](#easprebuild)
+- Install pods using the `pod install` command
+- [`eas/configure_eas_update`](#easconfigure_eas_update)
+- [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
+- [`eas/run_fastlane`](#easrun_fastlane)
+- [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+
+When a build configuration uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
+
+- [`eas/checkout`](#eascheckout)
+- [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+- [`eas/resolve_apple_team_id_from_credentials`](#easresolve_apple_team_id_from_credentials)
+- [`eas/prebuild`](#easprebuild)
+- Install pods using the `pod install` command
+- [`eas/configure_eas_update`](#easconfigure_eas_update)
+- [`eas/configure_ios_credentials`](#easconfigure_ios_credentials)
+- [`eas/configure_ios_version`](#easconfigure_ios_version)
+- [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
+- [`eas/run_fastlane`](#easrun_fastlane)
+- [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
 
 You can replace the `eas/build` command call by using these steps in your YAML configuration file:
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -571,6 +571,90 @@ EAS provides a set of built-in reusable functions that you can use in a workflow
 
 > **info** **Tip:** Any function that is built-in and provided by EAS must start with the `eas/` prefix.
 
+#### `eas/build`
+
+The all-in-one function that encapsulates the entire EAS Build build process. It will resolve the best build workflow configuration for you based on your build profile's settings from [**eas.json**](/eas/json/).
+
+It's ideal for people who just want to have the build done without worrying about altering and configuring the build process manually.
+It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
+
+If you want to have more control over the build process and customize it for your needs you may be interested in what are the custom functions and steps that are executed behind the scenes by this function. This is what will be resolved as a build process for you based on your build profile's configuration:
+
+1. for iOS build:
+   - if your build doesn't use credentials ([simulator](/eas/json/#simulator) build or when using when using [`withoutCredentials`](/eas/json/withoutcredentials-0)):
+     - [`eas/checkout`](#eascheckout)
+     - [`eas/install_node_modules`](#easinstall_node_modules)
+     - [`eas/prebuild`](#easprebuild)
+     - Install pods using the `pod install` command
+     - [`eas/configure_eas_update`](#easconfigure_eas_update)
+     - [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
+     - [`eas/run_fastlane`](#easrun_fastlane)
+     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+   - if your build uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
+     - [`eas/checkout`](#eascheckout)
+     - [`eas/install_node_modules`](#easinstall_node_modules)
+     - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+     - [`eas/resolve_apple_team_id_from_credentials`](#easresolve_apple_team_id_from_credentials)
+     - [`eas/prebuild`](#easprebuild)
+     - Install pods using the `pod install` command
+     - [`eas/configure_eas_update`](#easconfigure_eas_update)
+     - [`eas/configure_ios_credentials`](#easconfigure_ios_credentials)
+     - [`eas/configure_ios_version`](#easconfigure_ios_version)
+     - [`eas/generate_gymfile_from_template`](#easgenerate_gymfile_from_template)
+     - [`eas/run_fastlane`](#easrun_fastlane)
+     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+2. for Android build:
+   - if your build doesn't use credentials (when using [`withoutCredentials`](/eas/json/withoutcredentials-1) option):
+     - [`eas/checkout`](#eascheckout)
+     - [`eas/install_node_modules`](#easinstall_node_modules)
+     - [`eas/prebuild`](#easprebuild)
+     - [`eas/configure_eas_update`](#easconfigure_eas_update)
+     - [`eas/run_gradle`](#easrun_gradle)
+     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+   - if your build uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
+     - [`eas/checkout`](#eascheckout)
+     - [`eas/install_node_modules`](#easinstall_node_modules)
+     - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+     - [`eas/prebuild`](#easprebuild)
+     - [`eas/configure_eas_update`](#easconfigure_eas_update)
+     - [`eas/inject_android_credentials`](#easinject_android_credentials)
+     - [`eas/configure_android_version`](#easconfigure_android_version)
+     - [`eas/run_gradle`](#easrun_gradle)
+     - [`eas/find_and_upload_build_artifacts`](#easfind_and_upload_build_artifacts)
+
+You can replace the `eas/build` command call by using these steps in your YAML configuration file:
+
+<BoxLink
+  title="ios-simulator-build.yml"
+  description="View the steps executed behind the scenes by the `eas/build` function for an iOS simulator build in our example repository."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-custom-builds-example/blob/main/.eas/build/ios-simulator-build.yml"
+/>
+<BoxLink
+  title="ios-credentials-build.yml"
+  description="View the steps executed behind the scenes by the `eas/build` function for an iOS build with credentials in our example repository."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-custom-builds-example/blob/main/.eas/build/ios-build-with-credentials.yml"
+/>
+<BoxLink
+  title="android-build-without-credentials.yml"
+  description="View the steps executed behind the scenes by the `eas/build` function for an Android build without credentials in our example repository."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-custom-builds-example/blob/main/.eas/build/android-build-without-credentials.yml"
+/>
+<BoxLink
+  title="android-build-with-credentials.yml"
+  description="View the steps executed behind the scenes by the `eas/build` function for an Android build with credentials in our example repository."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-custom-builds-example/blob/main/.eas/build/android-build-with-credentials.yml"
+/>
+
+Known limitations:
+
+- This function won't configure updates for you properly if you still use the legacy classic updates. You should use the EAS Update instead. Check our [migration guide](/eas-update/migrate-from-classic-updates/) for more information.
+- Currently it doesn't accept any inputs and the resolved build process will be configured based on your build profile from [**eas.json**](/eas/json/) settings.
+- The build process produced by `eas/build` is not configurable and you can't customize it. If you need to customize the build process you should use the subset of functions and steps that are executed behind the scenes by this function and configure them manually in your YAML configuration file as shown in the examples above.
+
 #### `eas/maestro_test`
 
 All-in-one function that installs Maestro, prepares a testing environment (Android Emulator or iOS Simulator), and tests the app.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -591,6 +591,7 @@ To have more control over the build process and customize it as per your require
 When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcredentials):
 
 - [`eas/checkout`](#eascheckout)
+- [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
 - [`eas/prebuild`](#easprebuild)
 - [`eas/configure_eas_update`](#easconfigure_eas_update)
@@ -600,6 +601,7 @@ When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcre
 When a build configuration uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
 
 - [`eas/checkout`](#eascheckout)
+- [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
 - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
 - [`eas/prebuild`](#easprebuild)
@@ -614,6 +616,7 @@ When a build configuration uses credentials (for both `internal` and `store` [di
 When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcredentials) or [`simulator`](/eas/json/#simulator):
 
 - [`eas/checkout`](#eascheckout)
+- [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
 - [`eas/prebuild`](#easprebuild)
 - Install pods using the `pod install` command
@@ -625,6 +628,7 @@ When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcre
 When a build configuration uses credentials (for both `internal` and `store` [distribution](/eas/json/#distribution) builds):
 
 - [`eas/checkout`](#eascheckout)
+- [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
 - [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
 - [`eas/resolve_apple_team_id_from_credentials`](#easresolve_apple_team_id_from_credentials)

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -578,6 +578,13 @@ The all-in-one function that encapsulates the entire EAS Build build process. It
 It's ideal for people who just want to have the build done without worrying about altering and configuring the build process manually.
 It can be a great starting point for your custom build configuration if you are interested in using other custom steps before or after the build process and you don't want to change the build process itself.
 
+```yaml example.yml
+build:
+  name: Run a build using a single command
+  steps:
+    - eas/build
+```
+
 If you want to have more control over the build process and customize it for your needs you may be interested in what are the custom functions and steps that are executed behind the scenes by this function. This is what will be resolved as a build process for you based on your build profile's configuration:
 
 1. for iOS build:


### PR DESCRIPTION
# Why

Document the `eas/build` function

# How

Document the `eas/build` function

# Test Plan

Preview

# TODO

I still need to add the examples in example repo before it starts to link to them correctly 😅 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
