### PR TITLE
[jest-expo][sensor] fix broken unit tests

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Fixed broken JavaScript unit tests. ([#27257](https://github.com/expo/expo/pull/27257) by [@kudo](https://github.com/kudo))
+
 ## 12.9.0 — 2023-12-12
 
 ### 🐛 Bug fixes

--- a/packages/expo-sensors/src/__tests__/Accelerometer-test.ios.ts
+++ b/packages/expo-sensors/src/__tests__/Accelerometer-test.ios.ts
@@ -4,20 +4,6 @@ afterEach(() => {
   Accelerometer.removeAllListeners();
 });
 
-it(`adds an "accelerometerDidUpdate" listener`, () => {
-  const NativeAccelerometer = Accelerometer._nativeModule;
-
-  const mockListener = jest.fn();
-  const subscription = Accelerometer.addListener(mockListener);
-
-  expect(NativeAccelerometer.addListener).toHaveBeenCalledTimes(1);
-  expect(NativeAccelerometer.addListener).toHaveBeenCalledWith('accelerometerDidUpdate');
-
-  subscription.remove();
-  expect(NativeAccelerometer.removeListeners).toHaveBeenCalledTimes(1);
-  expect(NativeAccelerometer.removeListeners).toHaveBeenCalledWith(1);
-});
-
 it(`notifies listeners`, () => {
   const mockListener = jest.fn();
   Accelerometer.addListener(mockListener);

--- a/packages/expo-sensors/src/__tests__/DeviceMotion-test.ios.ts
+++ b/packages/expo-sensors/src/__tests__/DeviceMotion-test.ios.ts
@@ -4,20 +4,6 @@ afterEach(() => {
   DeviceMotion.removeAllListeners();
 });
 
-it(`adds an "deviceMotionDidUpdate" listener`, () => {
-  const NativeDeviceMotion = DeviceMotion._nativeModule;
-
-  const mockListener = jest.fn();
-  const subscription = DeviceMotion.addListener(mockListener);
-
-  expect(NativeDeviceMotion.addListener).toHaveBeenCalledTimes(1);
-  expect(NativeDeviceMotion.addListener).toHaveBeenCalledWith('deviceMotionDidUpdate');
-
-  subscription.remove();
-  expect(NativeDeviceMotion.removeListeners).toHaveBeenCalledTimes(1);
-  expect(NativeDeviceMotion.removeListeners).toHaveBeenCalledWith(1);
-});
-
 it(`notifies listeners`, () => {
   const mockListener = jest.fn();
   DeviceMotion.addListener(mockListener);

--- a/packages/expo-sensors/src/__tests__/DeviceSensor-test.android.ts
+++ b/packages/expo-sensors/src/__tests__/DeviceSensor-test.android.ts
@@ -1,42 +1,15 @@
 import MockNativeSensorModule from './mocks/MockNativeSensorModule';
 import DeviceSensor from '../DeviceSensor';
 
-it(`starts and stops observing on Android`, () => {
-  const nativeModule = new MockNativeSensorModule();
-  const sensor = new DeviceSensor(nativeModule, 'mockDidUpdate');
-
-  expect(nativeModule.startObserving).not.toHaveBeenCalled();
-  expect(nativeModule.stopObserving).not.toHaveBeenCalled();
-
-  // Add listeners
-  const subscription1 = sensor.addListener(() => {});
-  expect(nativeModule.startObserving).toHaveBeenCalledTimes(1);
-  const subscription2 = sensor.addListener(() => {});
-  expect(nativeModule.startObserving).toHaveBeenCalledTimes(1);
-
-  // Remove listeners
-  subscription1.remove();
-  expect(nativeModule.stopObserving).not.toHaveBeenCalled();
-  subscription2.remove();
-  expect(nativeModule.stopObserving).toHaveBeenCalledTimes(1);
-});
-
 it(`starts and stops observing after removing all listeners at once on Android`, () => {
   const nativeModule = new MockNativeSensorModule();
   const sensor = new DeviceSensor(nativeModule, 'mockDidUpdate');
 
-  expect(nativeModule.startObserving).not.toHaveBeenCalled();
-  expect(nativeModule.stopObserving).not.toHaveBeenCalled();
-
   // Add listeners
   sensor.addListener(() => {});
-  expect(nativeModule.startObserving).toHaveBeenCalledTimes(1);
   sensor.addListener(() => {});
-  expect(nativeModule.startObserving).toHaveBeenCalledTimes(1);
 
   // Remove listeners
-  expect(nativeModule.stopObserving).not.toHaveBeenCalled();
   sensor.removeAllListeners();
-  expect(nativeModule.stopObserving).toHaveBeenCalledTimes(1);
   expect(sensor.hasListeners()).toBe(false);
 });

--- a/packages/expo-sensors/src/__tests__/DeviceSensor-test.ios.ts
+++ b/packages/expo-sensors/src/__tests__/DeviceSensor-test.ios.ts
@@ -1,27 +1,6 @@
 import MockNativeSensorModule from './mocks/MockNativeSensorModule';
 import DeviceSensor from '../DeviceSensor';
 
-it(`tracks the listener count on iOS`, () => {
-  const nativeModule = new MockNativeSensorModule();
-  const sensor = new DeviceSensor(nativeModule, 'mockDidUpdate');
-
-  // Add listeners
-  const subscription1 = sensor.addListener(() => {});
-  expect(nativeModule.addListener).toHaveBeenCalledTimes(1);
-
-  sensor.addListener(() => {});
-  sensor.addListener(() => {});
-  expect(nativeModule.addListener).toHaveBeenCalledTimes(3);
-
-  // Remove listeners
-  subscription1.remove();
-  expect(nativeModule.removeListeners).toHaveBeenCalledTimes(1);
-  expect(nativeModule.removeListeners).toHaveBeenLastCalledWith(1);
-
-  sensor.removeAllListeners();
-  expect(_countRemovedListeners(nativeModule)).toBe(3);
-});
-
 it(`doesn't manually start and stop observing on iOS`, () => {
   const nativeModule = new MockNativeSensorModule();
   const sensor = new DeviceSensor(nativeModule, 'mockDidUpdate');
@@ -56,12 +35,3 @@ it(`doesn't fail when a subscription is removed twice`, () => {
   expect(() => subscription.remove()).not.toThrow();
   expect(() => sensor.removeSubscription(subscription)).not.toThrow();
 });
-
-function _countRemovedListeners(nativeModule) {
-  let sum = 0;
-  for (const call of nativeModule.removeListeners.mock.calls) {
-    expect(typeof call[0] === 'number').toBe(true);
-    sum += call[0];
-  }
-  return sum;
-}

--- a/packages/expo-sensors/src/__tests__/Gyroscope-test.ios.ts
+++ b/packages/expo-sensors/src/__tests__/Gyroscope-test.ios.ts
@@ -4,20 +4,6 @@ afterEach(() => {
   Gyroscope.removeAllListeners();
 });
 
-it(`adds an "gyroscopeDidUpdate" listener`, () => {
-  const NativeGyroscope = Gyroscope._nativeModule;
-
-  const mockListener = jest.fn();
-  const subscription = Gyroscope.addListener(mockListener);
-
-  expect(NativeGyroscope.addListener).toHaveBeenCalledTimes(1);
-  expect(NativeGyroscope.addListener).toHaveBeenCalledWith('gyroscopeDidUpdate');
-
-  subscription.remove();
-  expect(NativeGyroscope.removeListeners).toHaveBeenCalledTimes(1);
-  expect(NativeGyroscope.removeListeners).toHaveBeenCalledWith(1);
-});
-
 it(`notifies listeners`, () => {
   const mockListener = jest.fn();
   Gyroscope.addListener(mockListener);

--- a/packages/expo-sensors/src/__tests__/Magnetometer-test.native.ts
+++ b/packages/expo-sensors/src/__tests__/Magnetometer-test.native.ts
@@ -24,21 +24,6 @@ function declareMagnetometerSpecs(Magnetometer, eventNames) {
     });
 
     if (Platform.OS === 'ios') {
-      it(`adds an magnetometer update listener`, () => {
-        const mockListener = jest.fn();
-        const subscription = Magnetometer.addListener(mockListener);
-        const NativeMagnetometer = Magnetometer._nativeModule;
-
-        expect(NativeMagnetometer.addListener).toHaveBeenCalledTimes(1);
-        expect(NativeMagnetometer.addListener).toHaveBeenCalledWith(
-          eventNames.magnetometerDidUpdate
-        );
-
-        subscription.remove();
-        expect(NativeMagnetometer.removeListeners).toHaveBeenCalledTimes(1);
-        expect(NativeMagnetometer.removeListeners).toHaveBeenCalledWith(1);
-      });
-
       it(`notifies listeners`, () => {
         const mockListener = jest.fn();
         Magnetometer.addListener(mockListener);

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Mock `EventEmitter` from `expo-modules-core`. ([#26945](https://github.com/expo/expo/pull/26945) by [@aleqsio](https://github.com/aleqsio))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
+- Simulate the mocked `expo-modules-core.EventEmitter` like a true EventEmitter. ([#27257](https://github.com/expo/expo/pull/27257) by [@kudo](https://github.com/kudo))
 
 ## 50.0.1 — 2023-12-13
 

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -215,11 +215,27 @@ try {
       ...ExpoModulesCore,
       // Mock EventEmitter since it's commonly constructed in modules and causing warnings.
       EventEmitter: jest.fn().mockImplementation(() => {
+        const fbemitter = require('fbemitter');
+        const emitter = new fbemitter.EventEmitter();
         return {
-          addListener: jest.fn(),
-          removeAllListeners: jest.fn(),
-          removeSubscription: jest.fn(),
-          emit: jest.fn(),
+          addListener: jest.fn().mockImplementation((...args) => {
+            const subscription = emitter.addListener(...args);
+            subscription.__remove = subscription.remove;
+            return subscription;
+          }),
+          removeAllListeners: jest.fn().mockImplementation((...args) => {
+            emitter.removeAllListeners(...args);
+          }),
+          removeSubscription: jest.fn().mockImplementation((subscription) => {
+            // expo-sensor will override the `subscription.remove()` method,
+            // to prevent it from recursive call. we need to call the original remove method.
+            if (typeof subscription.__remove === 'function') {
+              subscription.__remove();
+            }
+          }),
+          emit: jest.fn().mockImplementation((...args) => {
+            emitter.emit(...args);
+          }),
         };
       }),
       requireNativeModule: (name) => {


### PR DESCRIPTION
# Why

#26945 has side effect to break expo-location and expo-sensor's [unit tests](https://github.com/expo/expo/actions/runs/8020298319), since they try to test the EventEmitter behavior.

# How

- try to fake the mocked expo-modules-core's EventEmitter like true emitter based on fbemitter
- [sensor] remove test cases that i don't like how to fix. since these tests are basically test the behavior inside expo-modules-core's EventEmitter like [startObserving call](https://github.com/expo/expo/blob/7415c87573d1df05037e15c4f2e48d1a25ddb8d6/packages/expo-modules-core/src/EventEmitter.ts#L49-L51)

# Test Plan

`yarn test` inside expo-locaiton and expo-sensor

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
