### PR TITLE
[docs] Update reanimated babel plugin configuration instructions depending on SDK

### DIFF
--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -132,7 +132,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    flexDirection: 'column',
   },
   box: {
     width: 100,

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -16,13 +16,13 @@ To install `react-native-reanimated`, run the following command:
 
 <Tabs>
 
-<Tab label="SDK 50 and above">
+<Tab label="SDK 50 and higher">
 
 No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
 
 </Tab>
 
-<Tab label="SDK 49 and below">
+<Tab label="SDK 49 and lower">
 
 After the installation completes, add the Babel plugin to **babel.config.js**:
 
@@ -52,7 +52,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 <Tabs>
 
-<Tab label="SDK 50 and above">
+<Tab label="SDK 50 and higher">
 
 No additional configuration is required for SDK 50 and above when using `react-native-reanimated`.
 
@@ -64,7 +64,7 @@ No additional configuration is required for web. Make sure that `react-native-re
 
 </Tab>
 
-<Tab label="SDK 48 and below">
+<Tab label="SDK 48 and lower">
 
 Install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
 

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -4,6 +4,7 @@ description: Learn how to integrate the react-native-reanimated library and use 
 ---
 
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Animations are a great way to enhance and provide a better user experience. In your Expo projects, you can use the [Animated API](https://reactnative.dev/docs/next/animations) from React Native. However, if you want to use more advanced animations with better performance, you can use the [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) library. It provides an API that simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -13,6 +14,16 @@ To install `react-native-reanimated`, run the following command:
 
 <Terminal cmd={['$ npx expo install react-native-reanimated']} />
 
+<Tabs>
+
+<Tab label="SDK 50 and above">
+
+No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
+
+</Tab>
+
+<Tab label="SDK 49 and below">
+
 After the installation completes, add the Babel plugin to **babel.config.js**:
 
 ```js babel.config.js
@@ -20,18 +31,42 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    /* @info Add the Reanimated Babel Plugin as the last item in the plugins array.*/
     plugins: ['react-native-reanimated/plugin'],
+    /* @end */
   };
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache using `npx expo start --clear`.
+After you add the Babel plugin, restart your development server and clear the bundler cache using the command:
+
+<Terminal cmd={['$ npx expo start --clear']} />
 
 > If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
+</Tab>
+
+</Tabs>
+
 ### Web support
 
-**For web**, install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
+<Tabs>
+
+<Tab label="SDK 50 and above">
+
+No additional configuration is required for SDK 50 and above when using `react-native-reanimated`.
+
+</Tab>
+
+<Tab label="SDK 49">
+
+No additional configuration is required for web. Make sure that `react-native-reanimated/plugin` is added to **babel.config.js** as mentioned in [SDK 49 and below installation step](/#installation).
+
+</Tab>
+
+<Tab label="SDK 48 and below">
+
+Install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
 
 {/* prettier-ignore */}
 ```js babel.config.js
@@ -41,11 +76,17 @@ plugins: [
 ],
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache using `npx expo start --clear`.
+Next, restart your development server and clear the bundler cache using the command:
+
+<Terminal cmd={['$ npx expo start --clear']} />
+
+</Tab>
+
+</Tabs>
 
 ## Minimal example
 
-The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [**`react-native-reanimated` documentation**](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
 <SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
 
@@ -104,6 +145,6 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-### Other animation libraries
+## Other animation libraries
 
-Other animation packages are available, such as Moti, that you also use in your Expo project and work on Android, iOS, and the web. For more information on its API and usage, see [Moti's documentation](https://moti.fyi/).
+Other animation packages are available, such as [Moti](https://moti.fyi/), that you can use in your Expo project and work on Android, iOS, and web.

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -7,6 +7,7 @@ packageName: 'react-native-reanimated'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -20,34 +21,27 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-### Web support
+<br />
 
-**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
-
-{/* prettier-ignore */}
-```js babel.config.js
-plugins: [
-  '@babel/plugin-proposal-export-namespace-from',
-  'react-native-reanimated/plugin',
-],
-```
-
-After you add the Babel plugin, restart your development server and clear the bundler cache using `npx expo start --clear`.
+No additional configuration is required. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
 
 ## Usage
 
-The following example is a quick way to get started. For more information about the library and the underlying API, see [React Native Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
-```js
+<SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
+
+{/* prettier-ignore */}
+```jsx
 import Animated, {
   useSharedValue,
   withTiming,
   useAnimatedStyle,
   Easing,
 } from 'react-native-reanimated';
-import { View, Button } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
 
-export default function AnimatedStyleUpdateExample(props) {
+export default function AnimatedStyleUpdateExample() {
   const randomWidth = useSharedValue(10);
 
   const config = {
@@ -62,16 +56,8 @@ export default function AnimatedStyleUpdateExample(props) {
   });
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'column',
-      }}>
-      <Animated.View
-        style={[{ width: 100, height: 80, backgroundColor: 'black', margin: 30 }, style]}
-      />
+    <View style={styles.container}>
+      <Animated.View style={[styles.box, style]} />
       <Button
         title="toggle"
         onPress={() => {
@@ -81,4 +67,23 @@ export default function AnimatedStyleUpdateExample(props) {
     </View>
   );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  box: {
+    width: 100,
+    height: 80,
+    backgroundColor: 'black',
+    margin: 30,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    flexDirection: 'column',
   },
   box: {
     width: 100,

--- a/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
@@ -7,6 +7,7 @@ packageName: 'react-native-reanimated'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal, SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -32,7 +33,9 @@ module.exports = function (api) {
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+Next, restart your development server and clear the bundler cache using the command:
+
+<Terminal cmd={['$ npx expo start --clear']} />
 
 > If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
@@ -52,19 +55,21 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Usage
 
-The following example is a quick way to get started. For more information about the library and the underlying API, see [React Native Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
-```js
+<SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
+
+{/* prettier-ignore */}
+```jsx
 import Animated, {
   useSharedValue,
   withTiming,
   useAnimatedStyle,
   Easing,
 } from 'react-native-reanimated';
-import { View, Button } from 'react-native';
-import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
 
-export default function AnimatedStyleUpdateExample(props) {
+export default function AnimatedStyleUpdateExample() {
   const randomWidth = useSharedValue(10);
 
   const config = {
@@ -79,16 +84,8 @@ export default function AnimatedStyleUpdateExample(props) {
   });
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'column',
-      }}>
-      <Animated.View
-        style={[{ width: 100, height: 80, backgroundColor: 'black', margin: 30 }, style]}
-      />
+    <View style={styles.container}>
+      <Animated.View style={[styles.box, style]} />
       <Button
         title="toggle"
         onPress={() => {
@@ -98,4 +95,22 @@ export default function AnimatedStyleUpdateExample(props) {
     </View>
   );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  box: {
+    width: 100,
+    height: 80,
+    backgroundColor: 'black',
+    margin: 30,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -43,7 +43,7 @@ Next, restart your development server and clear the bundler cache using the comm
 
 No additional configuration is required for web.
 
-## Minimal example
+## Usage
 
 The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
@@ -91,7 +91,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    flexDirection: 'column',
   },
   box: {
     width: 100,

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -7,6 +7,7 @@ packageName: 'react-native-reanimated'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Terminal, SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -20,7 +21,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-After the installation completes, you must also add the Babel plugin to **babel.config.js**:
+After the installation completes, add the [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) to **babel.config.js**:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -32,38 +33,33 @@ module.exports = function (api) {
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+Next, restart your development server and clear the bundler cache using the command:
+
+<Terminal cmd={['$ npx expo start --clear']} />
 
 > If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
 ### Web support
 
-**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
+No additional configuration is required for web.
+
+## Minimal example
+
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+
+<SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
 
 {/* prettier-ignore */}
-```js babel.config.js
-plugins: [
-  '@babel/plugin-proposal-export-namespace-from',
-  'react-native-reanimated/plugin',
-],
-```
-
-After you add the Babel plugin, restart your development server and clear the bundler cache using `npx expo start --clear`.
-
-## Usage
-
-The following example is a quick way to get started. For more information about the library and the underlying API, see [React Native Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
-
-```js
+```jsx
 import Animated, {
   useSharedValue,
   withTiming,
   useAnimatedStyle,
   Easing,
 } from 'react-native-reanimated';
-import { View, Button } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
 
-export default function AnimatedStyleUpdateExample(props) {
+export default function AnimatedStyleUpdateExample() {
   const randomWidth = useSharedValue(10);
 
   const config = {
@@ -78,16 +74,8 @@ export default function AnimatedStyleUpdateExample(props) {
   });
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'column',
-      }}>
-      <Animated.View
-        style={[{ width: 100, height: 80, backgroundColor: 'black', margin: 30 }, style]}
-      />
+    <View style={styles.container}>
+      <Animated.View style={[styles.box, style]} />
       <Button
         title="toggle"
         onPress={() => {
@@ -97,4 +85,21 @@ export default function AnimatedStyleUpdateExample(props) {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  box: {
+    width: 100,
+    height: 80,
+    backgroundColor: 'black',
+    margin: 30,
+  },
+});
 ```
+
+</SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -7,6 +7,7 @@ packageName: 'react-native-reanimated'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -20,34 +21,27 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-### Web support
+<br />
 
-**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
-
-{/* prettier-ignore */}
-```js babel.config.js
-plugins: [
-  '@babel/plugin-proposal-export-namespace-from',
-  'react-native-reanimated/plugin',
-],
-```
-
-After you add the Babel plugin, restart your development server and clear the bundler cache using `npx expo start --clear`.
+No additional configuration is required. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
 
 ## Usage
 
-The following example is a quick way to get started. For more information about the library and the underlying API, see [React Native Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
-```js
+<SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
+
+{/* prettier-ignore */}
+```jsx
 import Animated, {
   useSharedValue,
   withTiming,
   useAnimatedStyle,
   Easing,
 } from 'react-native-reanimated';
-import { View, Button } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
 
-export default function AnimatedStyleUpdateExample(props) {
+export default function AnimatedStyleUpdateExample() {
   const randomWidth = useSharedValue(10);
 
   const config = {
@@ -62,16 +56,8 @@ export default function AnimatedStyleUpdateExample(props) {
   });
 
   return (
-    <View
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'column',
-      }}>
-      <Animated.View
-        style={[{ width: 100, height: 80, backgroundColor: 'black', margin: 30 }, style]}
-      />
+    <View style={styles.container}>
+      <Animated.View style={[styles.box, style]} />
       <Button
         title="toggle"
         onPress={() => {
@@ -81,4 +67,23 @@ export default function AnimatedStyleUpdateExample(props) {
     </View>
   );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  box: {
+    width: 100,
+    height: 80,
+    backgroundColor: 'black',
+    margin: 30,
+  },
+});
+/* @end */
 ```
+
+</SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -74,7 +74,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    flexDirection: 'column',
   },
   box: {
     width: 100,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #27258

Update Reanimated babel plugin and web support info in Animation guide and Reanimated SDK references. Changes from `unversioned` are backported to SDK 50. However, changes in SDK 49 and SDK 48 reference differ.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v48.0.0/sdk/reanimated/, http://localhost:3002/versions/unversioned/sdk/reanimated/ & http://localhost:3002/develop/user-interface/animation/.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
