### PR TITLE
[docs] Update Reanimated babel plugin step for SDK 50 in Drawer guide

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -1,7 +1,6 @@
 ---
 title: Drawer
 description: Learn how to use the Drawer layout in Expo Router.
-hideTOC: true
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -9,13 +8,25 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some extra dependencies.
 
+## Installation
+
 <Terminal
   cmd={[
     '$ npx expo install @react-navigation/drawer react-native-gesture-handler react-native-reanimated',
   ]}
 />
 
-Next, you'll need to update your **babel.config.js** to include the reanimated plugin:
+<Tabs>
+
+<Tab label="SDK 50 and higher">
+
+No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
+
+</Tab>
+
+<Tab label="SDK 49 and lower">
+
+Update your **babel.config.js** to include the Reanimated babel plugin:
 
 {/* prettier-ignore */}
 ```js babel.config.js
@@ -30,51 +41,21 @@ module.exports = {
 };
 ```
 
-> After changing your **babel.config.js**, run `npx expo start --clear` once to start the development server and clear the babel cache.
+After you add the Babel plugin, restart your development server and clear the bundler cache using the command:
 
-<Tabs>
-<Tab label="SDK 49 and lower">
+<Terminal cmd={['$ npx expo start --clear']} />
 
-Now you can use the `Drawer` layout to create a drawer navigator.
-
-```jsx app/_layout.js
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return <Drawer />;
-}
-```
-
-To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
-
-```jsx app/_layout.js
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return (
-    <Drawer>
-      <Drawer.Screen
-        name="index" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'Home',
-          title: 'overview',
-        }}
-      />
-      <Drawer.Screen
-        name="user/[id]" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'User',
-          title: 'overview',
-        }}
-      />
-    </Drawer>
-  );
-}
-```
+> If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 
 </Tab>
 
-<Tab label="SDK 50 and greater">
+</Tabs>
+
+## Usage
+
+<Tabs>
+
+<Tab label="SDK 50 and higher">
 
 Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. It is required as of Expo Router v3 and greater. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
 
@@ -122,6 +103,47 @@ export default function Layout() {
 ```
 
 > **Note:** Be careful when using `react-native-gesture-handler` on the web. It can increase the JavaScript bundle size significantly. Learn more about using [platform-specific modules](/router/advanced/platform-specific-modules/).
+
+</Tab>
+
+<Tab label="SDK 49 and lower">
+
+Now you can use the `Drawer` layout to create a drawer navigator.
+
+```jsx app/_layout.js
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return <Drawer />;
+}
+```
+
+To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
+
+```jsx app/_layout.js
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return (
+    <Drawer>
+      <Drawer.Screen
+        name="index" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'Home',
+          title: 'overview',
+        }}
+      />
+      <Drawer.Screen
+        name="user/[id]" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'User',
+          title: 'overview',
+        }}
+      />
+    </Drawer>
+  );
+}
+```
 
 </Tab>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #27258

This PR:
- Update Reanimated babel plugin step for SDK 50 in Drawer guide
- Also, update the order of tabs (SDK 50 > SDK 49).
- Add "Installation" and "Usage" section and remove `hideTOC` 


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/advanced/drawer/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
