### PR TITLE
replacing webpack with metro

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -67,7 +67,7 @@ Now, let's open the project directory in our favorite code editor or IDE. Throug
 
 To run the project on the web, we need to install the following dependencies that will help to run the project on the web:
 
-<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']} />
+<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/metro-runtime']} />
 
 </Step>
 


### PR DESCRIPTION
Docs seem to be referencing webpack which is throwing an error. More: https://github.com/expo/expo/issues/26706#issuecomment-1937044034