### PR TITLE
[docs] Remove outdated warning in dev client expo-updates doc

### DIFF
--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -9,8 +9,6 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-> **warning** This guide is likely to change as we continue to work on EAS Update.
-
 The [`expo-dev-client`](/develop/development-builds/introduction/) library allows launching different versions of a project. One of the most popular use cases is to preview a published update inside a development build using the `expo-dev-client` library.
 
 It supports loading published EAS Updates through channels. In this guide, you'll learn how to load a specific channel to preview an update in a development build.


### PR DESCRIPTION
# Why

This warning is no longer necessary.

# How

Remove

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
