### PR TITLE
[android][image-picker] fix inconsistent naming of filesize property (filesize vs fileSize) 

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android `fileSize` was named `filesize` which did not match the docs & typescript definition. ([#27293](https://github.com/expo/expo/pull/27293) by [@WookieFPV](https://github.com/wookieFPV))
+
 ### 💡 Others
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
@@ -12,7 +12,7 @@ internal class ImagePickerAsset(
   @Field val width: Int = 0,
   @Field val height: Int = 0,
   @Field val fileName: String? = null,
-  @Field val filesize: Long? = null,
+  @Field val fileSize: Long? = null,
   @Field val mimeType: String? = null,
   @Field val base64: String? = null,
   @Field val exif: Bundle? = null,

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
@@ -65,7 +65,7 @@ internal class MediaHandler(
       width = exportedImage.width,
       height = exportedImage.height,
       fileName = fileData?.fileName,
-      filesize = fileData?.filesize,
+      fileSize = fileData?.fileSize,
       mimeType = mimeType,
       base64 = base64,
       exif = exif,
@@ -107,7 +107,7 @@ internal class MediaHandler(
         width = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH),
         height = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT),
         fileName = fileData?.fileName,
-        filesize = fileData?.filesize,
+        fileSize = fileData?.fileSize,
         mimeType = mimeType,
         duration = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_DURATION),
         rotation = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION),
@@ -121,5 +121,5 @@ internal class MediaHandler(
 
 data class AdditionalFileData(
   val fileName: String?,
-  val filesize: Long?
+  val fileSize: Long?
 )


### PR DESCRIPTION
rename filesize to fileSize.
Android Implementation was different from iOS, ts definitions (ImagePicker.types.ts) & docu.
This was probably not intended and a bug


# Why

The naming of filesize was different on iOS (file**S**ize) and Android (file**s**ize).
This PR should unify the naming.
Support for fileSize in Android was added in #24524 but this improves the naming to make it the same on iOS & Android.

Naming:
file**s**ize: Android
file**S**ize: iOS, typescript, docs


# How

Replace in Files "filesize" -> "fileSize" in the whole packages/expo-image-picker/android folder.

# Test Plan

I did not test this feature.
This change is fairly simple.
But consumer that rely on the "wrong" field name might get a breaking change if this bug is fixed

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
