### PR TITLE
[expo-updates][cli] Add --version top-level flag and also add handler for missing command

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix fingerprint runtime version policy. Calculate fingerprint at build time. ([#26901](https://github.com/expo/expo/pull/26901) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli fingerprint:generate command. ([#27119](https://github.com/expo/expo/pull/27119) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli runtimeversion:resolve command. ([#27263](https://github.com/expo/expo/pull/27263) by [@wschurman](https://github.com/wschurman))
+- Add --version top-level flag and also add handler for missing command in expo-update cli. ([#27296](https://github.com/expo/expo/pull/27296) by [@wschurman](https://github.com/wschurman))
 - Added React Native New Architecture support. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/cli/build/cli.js
+++ b/packages/expo-updates/cli/build/cli.js
@@ -49,12 +49,19 @@ const commands = {
 };
 const args = (0, arg_1.default)({
     // Types
+    '--version': Boolean,
     '--help': Boolean,
     // Aliases
     '-h': '--help',
 }, {
     permissive: true,
 });
+if (args['--version']) {
+    // Version is added in the build script.
+    const packageJSON = require('../../package.json');
+    console.log(packageJSON.version);
+    process.exit(0);
+}
 const command = args._[0];
 const commandArgs = args._.slice(1);
 // Handle `--help` flag
@@ -80,4 +87,8 @@ if (args['--help']) {
 // Install exit hooks
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
+if (!(command in commands)) {
+    console.error(`Invalid command: ${command}`);
+    process.exit(1);
+}
 commands[command]().then((exec) => exec(commandArgs));

--- a/packages/expo-updates/cli/src/cli.ts
+++ b/packages/expo-updates/cli/src/cli.ts
@@ -31,6 +31,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
 const args = arg(
   {
     // Types
+    '--version': Boolean,
     '--help': Boolean,
 
     // Aliases
@@ -40,6 +41,13 @@ const args = arg(
     permissive: true,
   }
 );
+
+if (args['--version']) {
+  // Version is added in the build script.
+  const packageJSON = require('../../package.json');
+  console.log(packageJSON.version);
+  process.exit(0);
+}
 
 const command = args._[0];
 const commandArgs = args._.slice(1);
@@ -72,5 +80,10 @@ if (args['--help']) {
 // Install exit hooks
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
+
+if (!(command in commands)) {
+  console.error(`Invalid command: ${command}`);
+  process.exit(1);
+}
 
 commands[command]().then((exec) => exec(commandArgs));


### PR DESCRIPTION
# Why

As we add more stuff to this CLI, we need to improve the DX a bit. This also better supports calling it from eas-cli and not needing to hardcode versions to detect if a command is supported (can just try running the command and detect the "invalid command" error).

# How

Add `--version` handler and also add invalid command handler. 

# Test Plan

I'd like to start adding tests for the CLI similar to the e2e tests in the `@expo/cli` package, but it seemed a bit tough to do, especially in the scope of this PR. I've created a task to add more tests: https://linear.app/expo/issue/ENG-11507/add-more-tests-for-expo-updates-cli-and-utils

For now, the test plan is just to run:
```
$ npx expo-updates wat
Invalid command: wat
$ npx expo-updates --version
0.24.3
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
