### PR TITLE
fix ci: Disable color in snapshot tests in CI.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Disable color in snapshot tests in CI.
+- Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade `babel-plugin-react-native-web` for latest `react-native-web` aliases. ([#27214](https://github.com/expo/expo/pull/27214) by [@EvanBacon](https://github.com/EvanBacon))
 - Directly resolve plugins. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- Disable color in snapshot tests in CI.
 - Upgrade `babel-plugin-react-native-web` for latest `react-native-web` aliases. ([#27214](https://github.com/expo/expo/pull/27214) by [@EvanBacon](https://github.com/EvanBacon))
 - Directly resolve plugins. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/client-module-proxy-plugin.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/client-module-proxy-plugin.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`asserts that use client and use server cannot be used together 1`] = `
 "/unknown: It's not possible to have both \`use client\` and \`use server\` directives in the same file.
-[0m[31m[1m>[22m[39m[90m 1 |[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[0m
-[0m [90m 2 |[39m     [32m'use server'[39m[33m;[39m[0m
-[0m [90m 3 |[39m     [32m'use client'[39m[33m;[39m[0m
-[0m [90m 4 |[39m     [0m"
+> 1 |
+    | ^
+  2 |     'use server';
+  3 |     'use client';
+  4 |     "
 `;
 
 exports[`use client does nothing without use client directive 1`] = `"export var foo = 'bar';"`;

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/environment-restricted-imports.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/environment-restricted-imports.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`forbidden server imports client mode (default) asserts importing server-side modules in client components 1`] = `
 "/unknown: Importing 'server-only' module is not allowed in a client component.
-[0m[31m[1m>[22m[39m[90m 1 |[39m [36mimport[39m { [33mA[39m } [36mfrom[39m [32m'server-only'[39m[33m;[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m"
+> 1 | import { A } from 'server-only';
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 `;
 
 exports[`forbidden server imports react server mode asserts importing client-side modules in server components 1`] = `
 "/unknown: Importing 'client-only' module is not allowed in a React server bundle. Add the "use client" directive to this file or one of the parent modules to allow importing this module.
-[0m[31m[1m>[22m[39m[90m 1 |[39m [36mimport[39m { [33mA[39m } [36mfrom[39m [32m'client-only'[39m[33m;[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m"
+> 1 | import { A } from 'client-only';
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 `;

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/restricted-react-api-plugin.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/restricted-react-api-plugin.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`forbidden React server APIs asserts importing client-side React APIs in server components 1`] = `
 "/unknown: Client-only "react" API "useState" cannot be imported in a React server component. Add the "use client" directive to the top of this file or one of the parent files to enable running this stateful code on a user's device.
-[0m[31m[1m>[22m[39m[90m 1 |[39m [36mimport[39m { useState } [36mfrom[39m [32m'react'[39m[33m;[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m"
+> 1 | import { useState } from 'react';
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 `;
 
 exports[`forbidden React server APIs asserts importing client-side react-dom APIs in server components 1`] = `
 "/unknown: Client-only "react-dom" API "findDOMNode" cannot be imported in a React server component. Add the "use client" directive to the top of this file or one of the parent files to enable running this stateful code on a user's device.
-[0m[31m[1m>[22m[39m[90m 1 |[39m [36mimport[39m { findDOMNode } [36mfrom[39m [32m'react-dom'[39m[33m;[39m[0m
-[0m [90m   |[39m [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m"
+> 1 | import { findDOMNode } from 'react-dom';
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 `;

--- a/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
@@ -34,7 +34,7 @@ const DEF_OPTIONS = {
 const originalEnv = process.env;
 
 beforeEach(() => {
-  process.env = { ...originalEnv };
+  process.env = { ...originalEnv, FORCE_COLOR: '0' };
 });
 
 afterAll(() => {

--- a/packages/babel-preset-expo/src/__tests__/environment-restricted-imports.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/environment-restricted-imports.test.ts
@@ -34,7 +34,7 @@ const DEF_OPTIONS = {
 const originalEnv = process.env;
 
 beforeEach(() => {
-  process.env = { ...originalEnv };
+  process.env = { ...originalEnv, FORCE_COLOR: '0' };
 });
 
 afterAll(() => {

--- a/packages/babel-preset-expo/src/__tests__/restricted-react-api-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/restricted-react-api-plugin.test.ts
@@ -34,7 +34,7 @@ const DEF_OPTIONS = {
 const originalEnv = process.env;
 
 beforeEach(() => {
-  process.env = { ...originalEnv };
+  process.env = { ...originalEnv, FORCE_COLOR: '0' };
 });
 
 afterAll(() => {


### PR DESCRIPTION
# Why

CI is failing because it disables color in the snapshots.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
