### PR TITLE
[core][Android] Add `getViewConfig` function

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -1,8 +1,10 @@
 package expo.modules.kotlin.defaultmodules
 
-import expo.modules.kotlin.uuidv5.*
+import expo.modules.kotlin.events.normalizeEventName
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.uuidv5.InvalidNamespaceException
+import expo.modules.kotlin.uuidv5.uuidv5
 import java.util.UUID
 
 class CoreModule : Module() {
@@ -19,6 +21,34 @@ class CoreModule : Module() {
         throw InvalidNamespaceException(namespace)
       }
       return@Function uuidv5(namespaceUUID, name).toString()
+    }
+
+    Function("getViewConfig") { viewName: String ->
+      val holder = appContext.registry.getModuleHolder(viewName)
+        ?: return@Function null
+
+      val viewManagerDefinition = holder.definition.viewManagerDefinition
+        ?: return@Function null
+
+      val validAttributes = viewManagerDefinition
+        .props
+        .keys
+        .associateWith { true }
+
+      val directEventTypes = viewManagerDefinition
+        .callbacksDefinition
+        ?.names
+        ?.associate {
+          val normalizedEventName = normalizeEventName(it)
+          normalizedEventName to mapOf(
+            "registrationName" to it
+          )
+        }
+
+      return@Function mapOf(
+        "validAttributes" to validAttributes,
+        "directEventTypes" to directEventTypes
+      )
     }
   }
 }


### PR DESCRIPTION
# Why

Adds the `getViewConfig` function to return the static configuration for our views. It's not used now, but it will be when https://github.com/expo/expo/pull/27289/files is ready.

# Test Plan

- manually ensures that the config is correct ✅  