### PR TITLE
[ios][camera] Fix orientation when exif is true

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -300,7 +300,8 @@ PODS:
     - ReachabilitySwift
     - React-Core
     - sqlite3 (~> 3.42.0)
-  - EXUpdatesInterface (0.15.0)
+  - EXUpdatesInterface (0.15.0):
+    - ExpoModulesCore
   - FBLazyVector (0.73.4)
   - FBReactNativeSpec (0.73.4):
     - RCT-Folly (= 2022.05.16.00)
@@ -2033,7 +2034,7 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
   EXTaskManager: 81b2dfaaba6d9f9a4bc3e3e2a786a98004eb9e98
   EXUpdates: e2cff3892ee9025c433082bb6e721d213c1a6f5b
-  EXUpdatesInterface: 4f787eeabc62c258f978ea4865c67adfb6b2f19f
+  EXUpdatesInterface: 431fbb833aefbc9b7252b24a6a563209ff94f87d
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: f40d49b222e5ff964f98c8aa4f08baa6c1e15e2d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9

--- a/apps/native-component-list/src/screens/Camera/CameraScreenNext.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenNext.tsx
@@ -31,8 +31,8 @@ const flashIcons: Record<string, string> = {
 };
 
 const volumeIcons: Record<string, string> = {
-  on: 'ios-volume-high',
-  off: 'ios-volume-mute',
+  on: 'volume-high',
+  off: 'volume-mute',
 };
 
 const photos: CameraCapturedPicture[] = [];

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -21,6 +21,7 @@
 - On `Android`, fix empty qualities being passed to QualitySelector ([#27126](https://github.com/expo/expo/pull/27126) by [@leonhh](https://github.com/leonhh))
 - On `web`, prevent creating a webworker when rendering on the server ([#27222](https://github.com/expo/expo/pull/27222) by [@marklawlor](https://github.com/marklawlor))
 - On `iOS`, fix method call on an optional variable. ([#27235](https://github.com/expo/expo/pull/27235) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix the orientation value in `onResponsiveOrientationChanged` when `exif` is set to true.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -21,7 +21,7 @@
 - On `Android`, fix empty qualities being passed to QualitySelector ([#27126](https://github.com/expo/expo/pull/27126) by [@leonhh](https://github.com/leonhh))
 - On `web`, prevent creating a webworker when rendering on the server ([#27222](https://github.com/expo/expo/pull/27222) by [@marklawlor](https://github.com/marklawlor))
 - On `iOS`, fix method call on an optional variable. ([#27235](https://github.com/expo/expo/pull/27235) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix the orientation value in `onResponsiveOrientationChanged` when `exif` is set to true.
+- On `iOS`, fix the orientation value in `onResponsiveOrientationChanged` when `exif` is set to true. ([#27314](https://github.com/expo/expo/pull/27314) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/ExpoCameraUtils.swift
@@ -48,9 +48,9 @@ struct ExpoCameraUtils {
     case .portraitUpsideDown:
       return .portraitUpsideDown
     case .landscapeLeft:
-      return .landscapeLeft
-    case .landscapeRight:
       return .landscapeRight
+    case .landscapeRight:
+      return .landscapeLeft
     default:
       return .portrait
     }

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -282,7 +282,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
           default: physicalOrientation)
         if deviceOrientation != self.physicalOrientation {
           self.physicalOrientation = deviceOrientation
-          onResponsiveOrientationChanged(["orientation": deviceOrientation.rawValue])
+          onResponsiveOrientationChanged(["orientation": ExpoCameraUtilsNext.toOrientationString(orientation: deviceOrientation)])
         }
       }
     } else {

--- a/packages/expo-camera/ios/Next/ExpoCameraUtilsNext.swift
+++ b/packages/expo-camera/ios/Next/ExpoCameraUtilsNext.swift
@@ -56,6 +56,27 @@ struct ExpoCameraUtilsNext {
     }
   }
 
+  static func toOrientationString(orientation: UIDeviceOrientation) -> String {
+    switch orientation {
+    case .portrait:
+      return "portrait"
+    case .landscapeLeft:
+      return "landscapeLeft"
+    case .landscapeRight:
+      return "landscapeRight"
+    case .portraitUpsideDown:
+      return "portraitUpsideDown"
+    case .faceDown:
+      return "faceDown"
+    case .faceUp:
+      return "faceUp"
+    case .unknown:
+      return "unknown"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
   static func export(orientation: UIImage.Orientation) -> Int {
     switch orientation {
     case .left:


### PR DESCRIPTION
# Why
Closes #27304

# How
Fix the orientation value when `onResponsiveOrientationChanged` is called and make the value a `String` instead of a number. 

# Test Plan
bare-expo and NCL