### PR TITLE
Add `config` to schema docs

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -69,4 +69,13 @@ export default [
       'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm library for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
     ],
   },
+  {
+    name: 'config',
+    type: 'string',
+    description: [
+      'Custom workflow file name that will be used to run this Android build. You can also specify this property on profile level for platform-agnostic workflows. [Learn more](/custom-builds/get-started/).',
+      '',
+      'Example: `"config": "production-android.yml"` will use workflow from `.eas/build/production-android.yml`.'
+    ],
+  },
 ]

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -155,4 +155,13 @@ export default [
       },
     ],
   },
+  {
+    name: 'config',
+    type: 'string',
+    description: [
+      'Custom workflow file name that will be used to run this build. You can also specify this property on platform level for platform-specific workflows. [Learn more](/custom-builds/get-started/).',
+      '',
+      'Example: `"config": "production.yml"` will use workflow from `.eas/build/production.yml`.'
+    ],
+  },
 ];

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -95,4 +95,13 @@ export default [
       'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom **Gymfile**. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
     ],
   },
+  {
+    name: 'config',
+    type: 'string',
+    description: [
+      'Custom workflow file name that will be used to run this iOS build. You can also specify this property on profile level for platform-agnostic workflows. [Learn more](/custom-builds/get-started/).',
+      '',
+      'Example: `"config": "production-ios.yml"` will use workflow from `.eas/build/production-ios.yml`.'
+    ],
+  },
 ]


### PR DESCRIPTION
# Why

It's missing.

# How
<img width="824" alt="Zrzut ekranu 2024-02-27 o 12 29 32" src="https://github.com/expo/expo/assets/1151041/7cb5b3c7-4711-4126-88c5-ee5ca97f6425">
<img width="809" alt="Zrzut ekranu 2024-02-27 o 12 29 42" src="https://github.com/expo/expo/assets/1151041/618f6f03-7dee-40c0-a0db-58ed2f82f708">
<img width="804" alt="Zrzut ekranu 2024-02-27 o 12 29 53" src="https://github.com/expo/expo/assets/1151041/65857077-678a-408f-95b0-9937e3cc9424">

