### PR TITLE
[expo-updates] Add more debug information to runtimeversion:resolve CLI output

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add expo-updates cli fingerprint:generate command. ([#27119](https://github.com/expo/expo/pull/27119) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli runtimeversion:resolve command. ([#27263](https://github.com/expo/expo/pull/27263) by [@wschurman](https://github.com/wschurman))
 - Add --version top-level flag and also add handler for missing command in expo-update cli. ([#27296](https://github.com/expo/expo/pull/27296) by [@wschurman](https://github.com/wschurman))
+- Add more debug information to runtimeversion:resolve CLI output. ([#27323](https://github.com/expo/expo/pull/27323) by [@wschurman](https://github.com/wschurman))
 - Added React Native New Architecture support. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/cli/build/resolveRuntimeVersion.js
+++ b/packages/expo-updates/cli/build/resolveRuntimeVersion.js
@@ -57,7 +57,7 @@ Resolve expo-updates runtime version
     if (!['ios', 'android'].includes(platform)) {
         throw new Error(`Invalid platform argument: ${platform}`);
     }
-    const runtimeVersion = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform);
-    console.log(JSON.stringify({ runtimeVersion }));
+    const runtimeVersionInfo = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform);
+    console.log(JSON.stringify(runtimeVersionInfo));
 };
 exports.resolveRuntimeVersion = resolveRuntimeVersion;

--- a/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
+++ b/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
@@ -43,6 +43,6 @@ Resolve expo-updates runtime version
     throw new Error(`Invalid platform argument: ${platform}`);
   }
 
-  const runtimeVersion = await resolveRuntimeVersionAsync(getProjectRoot(args), platform);
-  console.log(JSON.stringify({ runtimeVersion }));
+  const runtimeVersionInfo = await resolveRuntimeVersionAsync(getProjectRoot(args), platform);
+  console.log(JSON.stringify(runtimeVersionInfo));
 };

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
@@ -28,6 +28,7 @@ async function createFingerprintForBuildAsync(platform, possibleProjectRoot, des
     });
     const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
     if (!runtimeVersion || typeof runtimeVersion === 'string') {
+        // normal runtime versions don't need fingerprinting
         return;
     }
     if (runtimeVersion.policy !== 'fingerprintExperimental') {

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
@@ -1,1 +1,5 @@
-export declare function resolveRuntimeVersionAsync(projectRoot: string, platform: 'ios' | 'android'): Promise<string | null>;
+import { FingerprintSource } from '@expo/fingerprint';
+export declare function resolveRuntimeVersionAsync(projectRoot: string, platform: 'ios' | 'android'): Promise<{
+    runtimeVersion: string | null;
+    fingerprintSources: FingerprintSource[] | null;
+}>;

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
@@ -12,16 +12,20 @@ async function resolveRuntimeVersionAsync(projectRoot, platform) {
     });
     const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
     if (!runtimeVersion || typeof runtimeVersion === 'string') {
-        return runtimeVersion ?? null;
+        return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null };
     }
     const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
     const policy = runtimeVersion.policy;
     if (policy === 'fingerprintExperimental') {
-        return (await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow)).hash;
+        const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow);
+        return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources };
     }
     if (workflow !== 'managed') {
         throw new Error(`You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions`);
     }
-    return await config_plugins_1.Updates.resolveRuntimeVersionPolicyAsync(policy, config, platform);
+    return {
+        runtimeVersion: await config_plugins_1.Updates.resolveRuntimeVersionPolicyAsync(policy, config, platform),
+        fingerprintSources: null,
+    };
 }
 exports.resolveRuntimeVersionAsync = resolveRuntimeVersionAsync;

--- a/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
+++ b/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
@@ -20,14 +20,20 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(getConfig).mockReturnValue({
       exp: { name: 'test', slug: 'test', runtimeVersion: '3' },
     } as any);
-    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual('3');
+    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual({
+      runtimeVersion: '3',
+      fingerprintSources: null,
+    });
   });
 
   it('uses platform precedence for constant string', async () => {
     jest.mocked(getConfig).mockReturnValue({
       exp: { name: 'test', slug: 'test', runtimeVersion: '3', ios: { runtimeVersion: '4' } },
     } as any);
-    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual('4');
+    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual({
+      runtimeVersion: '4',
+      fingerprintSources: null,
+    });
   });
 
   it('throws for bare when not fingerprint policy or constant string', async () => {
@@ -47,7 +53,10 @@ describe(resolveRuntimeVersionAsync, () => {
     } as any);
     jest.mocked(createFingerprintAsync).mockResolvedValue({ hash: 'hello', sources: [] });
 
-    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual('hello');
+    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual({
+      runtimeVersion: 'hello',
+      fingerprintSources: [],
+    });
   });
 
   it('returns the config plugins evaluated when other policy', async () => {
@@ -58,6 +67,9 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     jest.mocked(Updates.resolveRuntimeVersionPolicyAsync).mockResolvedValue('what');
 
-    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual('what');
+    await expect(resolveRuntimeVersionAsync('.', 'ios')).resolves.toEqual({
+      runtimeVersion: 'what',
+      fingerprintSources: null,
+    });
   });
 });

--- a/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
@@ -29,6 +29,7 @@ export async function createFingerprintForBuildAsync(
 
   const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
   if (!runtimeVersion || typeof runtimeVersion === 'string') {
+    // normal runtime versions don't need fingerprinting
     return;
   }
 


### PR DESCRIPTION
# Why

One thing with fingerprint is that when something differs it can be very hard to debug why. This PR adds debug information to the output of the CLI command so that in eas-cli we can log that information in DEBUG mode.

# How

Add fingerprint output info for debugging.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
