### PR TITLE
[ci] add pr-labeler comment

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,6 +9,7 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
+      # Adding new paths should also update the following "Get the base commit" step's paths
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -37,7 +38,10 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.base_ref || 'main' }}:${{ github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request'
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
@@ -50,11 +54,23 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: Get the base commit
+        id: base-commit
+        run: |
+          # Since we limit this pr-labeler workflow only triggered from limited paths, we should use custom base commit
+          REF=${{ github.base_ref || 'main' }}
+          echo base-commit=$(git log -n 1 $REF --pretty=format:'%H' -- .github/workflows/pr-labeler.yml apps/bare-expo apps/test-suite packages yarn.lock) >> "$GITHUB_OUTPUT"
       - name: 📷 Check fingerprint
         id: fingerprint
         uses: expo/expo-github-action/fingerprint@main
         with:
           working-directory: apps/bare-expo
+          previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
+
+      - name: 👀 Debug fingerprint
+        run: |
+          echo "previousGitCommit=${{ steps.fingerprint.outputs.previous-git-commit }} currentGitCommit=${{ steps.fingerprint.outputs.current-git-commit }}"
+          echo "isPreviousFingerprintEmpty=${{ steps.fingerprint.outputs.previous-fingerprint == '' }}"
 
       - name: 🏷️ Labeling PR
         uses: actions/github-script@v6
@@ -102,3 +118,70 @@ jobs:
               repo: context.repo.repo,
               labels: ['bot: fingerprint changed']
             })
+
+      - name: 🔍 Find old comment if it exists
+        uses: peter-evans/find-comment@v2
+        id: old_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'expo-bot'
+          body-includes: <!-- pr-labeler comment -->
+      - name: 💬 Add comment with fingerprint
+        if: ${{ steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            const diff = JSON.stringify(${{ steps.fingerprint.outputs.fingerprint-diff}}, null, 2);
+            const body = `<!-- pr-labeler comment -->
+            The Pull Request introduced fingerprint changes against the base commit: ${{ steps.fingerprint.outputs.previous-git-commit }}
+            <details><summary>Fingerprint diff</summary>
+
+            \`\`\`json
+            ${diff}
+            \`\`\`
+
+            </details>`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });
+      - name: 💬 Update comment with fingerprint
+        if: ${{ steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id != '' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            const diff = JSON.stringify(${{ steps.fingerprint.outputs.fingerprint-diff}}, null, 2);
+            const body = `<!-- pr-labeler comment -->
+            The Pull Request introduced fingerprint changes against the base commit: ${{ steps.fingerprint.outputs.previous-git-commit }}
+            <details><summary>Fingerprint diff</summary>
+
+            \`\`\`json
+            ${diff}
+            \`\`\`
+
+            </details>`;
+
+            github.rest.issues.updateComment({
+              issue_number: context.issue.number,
+              comment_id: '${{ steps.old_comment.outputs.comment-id }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });
+      - name: 💬 Delete comment with fingerprint
+        if: ${{ steps.fingerprint.outputs.fingerprint-diff == '[]' && steps.old_comment.outputs.comment-id != '' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.deleteComment({
+              issue_number: context.issue.number,
+              comment_id: '${{ steps.old_comment.outputs.comment-id }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });


### PR DESCRIPTION
# Why

i noticed that the pr-labeler sometimes showing incorrect information. would be good to show more information

# How

- show a comment box with diff when fingerprint is changed, e.g. https://github.com/expo/expo/pull/27319#issuecomment-1967114059
- add debug log for previous and current commit
- one reason for incorrect fingerprint is that our workflow does not trigger from all push commit to main branch. some main commit in the database would have empty fingerprint. this pr fixes that by using correct base commit to calculate fingerprint diff.

# Test Plan

- ci passed
- test in https://github.com/expo/expo/pull/27319

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).