### PR TITLE
[docs] Fix config plugin example snippet

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -78,7 +78,6 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
       [
         "@sentry/react-native/expo",
         {
-          "url": "https://sentry.io/",
           "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
           "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable"
         }
@@ -91,6 +90,29 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
 Next, in an environment where you want to create releases and upload sourcemaps to Sentry, you will need to set the `SENTRY_AUTH_TOKEN` environment variable to your [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). If you are using EAS Build, you can set the environment variable by [creating a secret named SENTRY_AUTH_TOKEN](/build-reference/variables/#using-secrets-in-environment-variables).
 
 > **warning** The Sentry auth token should be stored securely. Do not commit it to a public repository, and treat it as you would any other sensitive API key.
+
+<Collapsible summary={<>When to add <CODE>url</CODE> to <CODE>@sentry/react-native/expo</CODE> config plugin?</>}>
+
+If you are using a self-hosted instance, you need to add the `url` property to the `@sentry/react-native/expo` config plugin.
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@sentry/react-native/expo",
+        {
+          "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
+          "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable",
+          "url": "https://self-hosted.example.com"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
 
 <ConfigReactNative>
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -95,6 +95,7 @@ Next, in an environment where you want to create releases and upload sourcemaps 
 
 If you are using a self-hosted instance, you need to add the `url` property to the `@sentry/react-native/expo` config plugin.
 
+{/* prettier-ignore */}
 ```json app.json
 {
   "expo": {
@@ -102,8 +103,7 @@ If you are using a self-hosted instance, you need to add the `url` property to t
       [
         "@sentry/react-native/expo",
         {
-          "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
-          "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable",
+          /*@hide ...*/ /*@end*/
           "url": "https://self-hosted.example.com"
         }
       ]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the `url` property is shown as part of the main config plugin example which is incorrect.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the config plugin example by removing the `url` property
- Add a collapsible describing the use case for `url` property and how to use it by providing a code snippet example for config plugin

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/using-sentry/#app-configuration

## Preview

![CleanShot 2024-02-27 at 23 54 10](https://github.com/expo/expo/assets/10234615/58dee40f-cff8-4850-9012-6074d588bb27)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
