### PR TITLE
[docs] Add rn-text-editor as example of rich text editor built on top of React Native TextInput

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -81,7 +81,7 @@ Then, let's append a fifth letter `a` to the text input. The position of your cu
 
 There is an additional `onSelectionChange` prop that can be used to get that information. However, it makes the task significantly harder. Inserting additional characters (such as newlines for lists or bullet points) also desynchronizes the selection.
 
-There are some attempts to build such an editor, such as [`markdown-editor`](https://github.com/shakogegia/markdown-editor), but no widely used packages exist.
+There are some attempts to build such an editor, such as [`markdown-editor`](https://github.com/shakogegia/markdown-editor) (not actively maintained) and [`rn-text-editor`](https://github.com/amjadbouhouch/rn-text-editor) (in beta), but no widely used packages exist.
 
 ## Markdown editors with always visible styling markers
 


### PR DESCRIPTION
# Why

I found a new project which uses TextInput as the basis for a React Native text editor component. And given that the previous example hasn't been updated for years, even if this new effort is in beta, it might be useful to bring traffic to the project.

# How

This isn't my package. It's from @amjadbouhouch 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
