### PR TITLE
[docs] Add react-native-live-markdown example

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -91,10 +91,11 @@ This editing experience suits power users or programming/tech applications. You 
 
 ## Native editors
 
-You can use a native Android or iOS rich text editor wrapped into a React Native module. There are a couple of options:
+You can use a native Android or iOS rich text editor wrapped into a React Native module. There are a few options:
 
 - [`react-native-aztec`](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-aztec)
 - [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile)
+- [`react-native-live-markdown`](https://github.com/Expensify/react-native-live-markdown)
 
 You can also wrap any native rich text editor using [Expo Modules](/modules/overview/), but if you use different ones on each platform, you need to unify their APIs and input formats.
 


### PR DESCRIPTION
# Why

There is a new rich editing component https://github.com/Expensify/react-native-live-markdown which uses a native markdown view.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
