### PR TITLE
[docs] Clearer CTA for additional WSL configuration

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -65,4 +65,4 @@ The Expo CLI is compatible with the following terminals on Windows 10 and higher
 - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/overview) (the default terminal)
 - WSL 2 (Windows Subsystem for Linux) using a Bash shell
 
-WSL 2 typically requires additional configuration to set up your development environment for testing code on a device using a [development build](/develop/development-builds/introduction/) or Expo Go. [Learn more about configuring WSL 2 for Expo development](https://expo.fyi/wsl).
+WSL 2 typically requires additional configuration to set up your development environment for testing code on a device using a [development build](/develop/development-builds/introduction/) or Expo Go. Learn more about [configuring WSL 2 for Expo development](https://expo.fyi/wsl).

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -65,4 +65,4 @@ The Expo CLI is compatible with the following terminals on Windows 10 and higher
 - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/overview) (the default terminal)
 - WSL 2 (Windows Subsystem for Linux) using a Bash shell
 
-WSL 2 may require additional configuration to [set up your development environment](https://expo.fyi/wsl) and testing code on a [development build](/develop/development-builds/introduction/).
+WSL 2 typically requires additional configuration to set up your development environment for testing code on a device using a [development build](/develop/development-builds/introduction/) or Expo Go. [Learn more about configuring WSL 2 for Expo development](https://expo.fyi/wsl).


### PR DESCRIPTION
# Why
Reference to the WSL guide had a grammar bug, and it wasn't really clear where to go next. Adopted the "Learn more..." common to other docs to make a clearer call to action. Also referenced Expo Go in there; even though we want folks to proceed quickly to development builds, this doc is likely to be hit early in someone's learning experience, before they might understand development builds, so this seems a little more beginner-friendly.