### PR TITLE
[android][location] Fix exception when service is missing on api 34

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed: `NullPointerException: it must not be null`. ([#26688](https://github.com/expo/expo/pull/26688) by [@lukmccall](https://github.com/lukmccall))
-- On `Android`, prevent location service from starting when permission is not in the manifest.
+- On `Android`, prevent location service from starting when permission is not in the manifest. ([#27355](https://github.com/expo/expo/pull/27355) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed: `NullPointerException: it must not be null`. ([#26688](https://github.com/expo/expo/pull/26688) by [@lukmccall](https://github.com/lukmccall))
+- On `Android`, prevent location service from starting when permission is not in the manifest.
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationExceptions.kt
@@ -57,4 +57,7 @@ internal class ConversionException(fromClass: Class<*>, toClass: Class<*>, messa
   CodedException("Couldn't cast from ${fromClass::class.simpleName} to ${toClass::class.java.simpleName}: $message")
 
 internal class ForegroundServiceStartNotAllowedException :
-  CodedException("Couldn't start the foreground service. Foreground service cannot be started when the application is in the background.")
+  CodedException("Couldn't start the foreground service. Foreground service cannot be started when the application is in the background")
+
+internal class ForegroundServicePermissionsException :
+  CodedException("Couldn't start the foreground service. Foreground service permissions were not found in the manifest")


### PR DESCRIPTION
# Why
Closes #27336

# How
Only repros when full background permissions are granted (Always allow). Added a check for the required permissions and prevent the service from starting if they are missing. 

# Test Plan
bare-expo
