### PR TITLE
[menu] `registerDevMenuItems` duplicating items rather than replacing

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))
 - Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
 - Fix runtime version overflow ([#27172](https://github.com/expo/expo/pull/27172) by [@kadikraman](https://github.com/kadikraman))
-- Fixed registerDevMenuItems duplicating items rather than replacing.
+- Fixed registerDevMenuItems duplicating items rather than replacing. ([#27356](https://github.com/expo/expo/pull/27356) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))
 - Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
-- Fix runtime version overflow  ([#27172](https://github.com/expo/expo/pull/27172) by [@kadikraman](https://github.com/kadikraman))
+- Fix runtime version overflow ([#27172](https://github.com/expo/expo/pull/27172) by [@kadikraman](https://github.com/kadikraman))
+- Fixed registerDevMenuItems duplicating items rather than replacing.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -26,6 +26,8 @@ class DevMenuModule : Module() {
     }
 
     AsyncFunction("addDevMenuCallbacks") { callbacks: ReadableArray ->
+      DevMenuManager.registeredCallbacks.clear()
+
       val size = callbacks.size()
       for (i in 0 until size) {
         val callback = callbacks.getMap(i)

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -20,7 +20,7 @@ open class DevMenuModule: Module {
 
     AsyncFunction("addDevMenuCallbacks") { (callbacks: [[String: Any]]) in
       DevMenuManager.shared.registeredCallbacks.removeAll()
-      
+
       callbacks.forEach { callback in
         guard let name = callback["name"] as? String else {
           return

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -19,6 +19,8 @@ open class DevMenuModule: Module {
     }
 
     AsyncFunction("addDevMenuCallbacks") { (callbacks: [[String: Any]]) in
+      DevMenuManager.shared.registeredCallbacks.removeAll()
+      
       callbacks.forEach { callback in
         guard let name = callback["name"] as? String else {
           return


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/25663.

# How

Ensures that `registerDevMenuItems` clears the extension before registering the new one. 

# Test Plan

- bare-expo ✅
