### PR TITLE
[location] Enable foreground service by default when background location is enabled

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -89,8 +89,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location).',
-      default: 'false',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
   ]}
 />

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -89,8 +89,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location).',
-      default: 'false',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
   ]}
 />

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Make foreground service permission opt-in with `isAndroidForegroundServiceEnabled` config plugin option [#27265](https://github.com/expo/expo/pull/27265) by [@brentvatne](https://github.com/brentvatne))
+- [Android] Enable foreground service by default when background location is enabled [#27359](https://github.com/expo/expo/pull/27359) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-location/plugin/build/withLocation.js
+++ b/packages/expo-location/plugin/build/withLocation.js
@@ -33,6 +33,12 @@ const withLocation = (config, { locationAlwaysAndWhenInUsePermission, locationAl
                 LOCATION_USAGE;
         return config;
     });
+    // If the user has not specified a value for isAndroidForegroundServiceEnabled,
+    // we default to the value of isAndroidBackgroundLocationEnabled because we want
+    // to enable foreground by default if background location is enabled.
+    const enableAndroidForegroundService = typeof isAndroidForegroundServiceEnabled === 'undefined'
+        ? isAndroidBackgroundLocationEnabled
+        : isAndroidForegroundServiceEnabled;
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         // Note: these are already added in the library AndroidManifest.xml and so
         // are not required here, we may want to remove them in the future.
@@ -40,8 +46,8 @@ const withLocation = (config, { locationAlwaysAndWhenInUsePermission, locationAl
         'android.permission.ACCESS_FINE_LOCATION',
         // These permissions are optional, and not listed in the library AndroidManifest.xml
         isAndroidBackgroundLocationEnabled && 'android.permission.ACCESS_BACKGROUND_LOCATION',
-        isAndroidForegroundServiceEnabled && 'android.permission.FOREGROUND_SERVICE',
-        isAndroidForegroundServiceEnabled && 'android.permission.FOREGROUND_SERVICE_LOCATION',
+        enableAndroidForegroundService && 'android.permission.FOREGROUND_SERVICE',
+        enableAndroidForegroundService && 'android.permission.FOREGROUND_SERVICE_LOCATION',
     ].filter(Boolean));
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withLocation, pkg.name, pkg.version);

--- a/packages/expo-location/plugin/src/withLocation.ts
+++ b/packages/expo-location/plugin/src/withLocation.ts
@@ -61,6 +61,14 @@ const withLocation: ConfigPlugin<
     return config;
   });
 
+  // If the user has not specified a value for isAndroidForegroundServiceEnabled,
+  // we default to the value of isAndroidBackgroundLocationEnabled because we want
+  // to enable foreground by default if background location is enabled.
+  const enableAndroidForegroundService =
+    typeof isAndroidForegroundServiceEnabled === 'undefined'
+      ? isAndroidBackgroundLocationEnabled
+      : isAndroidForegroundServiceEnabled;
+
   return AndroidConfig.Permissions.withPermissions(
     config,
     [
@@ -70,8 +78,8 @@ const withLocation: ConfigPlugin<
       'android.permission.ACCESS_FINE_LOCATION',
       // These permissions are optional, and not listed in the library AndroidManifest.xml
       isAndroidBackgroundLocationEnabled && 'android.permission.ACCESS_BACKGROUND_LOCATION',
-      isAndroidForegroundServiceEnabled && 'android.permission.FOREGROUND_SERVICE',
-      isAndroidForegroundServiceEnabled && 'android.permission.FOREGROUND_SERVICE_LOCATION',
+      enableAndroidForegroundService && 'android.permission.FOREGROUND_SERVICE',
+      enableAndroidForegroundService && 'android.permission.FOREGROUND_SERVICE_LOCATION',
     ].filter(Boolean) as string[]
   );
 };


### PR DESCRIPTION
# Why

Foreground service permissions are required in this case, so we should default to a working state when folks enable background location.

# How

- Update the plugin
- Update docs

# Test Plan

CI

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
