### PR TITLE
[cli] Fix development codesigning certificate validity checks

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [Android] correct drawable types in updates embedded manifest. ([#26676](https://github.com/expo/expo/pull/26676) by [@douglowder](https://github.com/douglowder))
 - Fix progress bar locking in at `100%` when bundling app. ([#26775](https://github.com/expo/expo/pull/26775) by [@byCedric](https://github.com/byCedric))
 - Keep typed routes in-sync with current Expo Router version ([#26578](https://github.com/expo/expo/pull/26578) by [@marklawlor](https://github.com/marklawlor))
+- Fix development codesigning certificate validity checks. ([#27361](https://github.com/expo/expo/pull/27361) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -349,7 +349,7 @@ function validateStoredDevelopmentExpoRootCertificateCodeSigningInfo(
 
   // TODO(wschurman): maybe move to @expo/code-signing-certificates
 
-  // ensure all intermediate certificates are valid (in case we forget to rotate)
+  // ensure all intermediate certificates are valid
   for (const certificate of certificateChain) {
     const now = new Date();
     if (certificate.validity.notBefore > now || certificate.validity.notAfter < now) {

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -348,10 +348,13 @@ function validateStoredDevelopmentExpoRootCertificateCodeSigningInfo(
   );
 
   // TODO(wschurman): maybe move to @expo/code-signing-certificates
-  const leafCertificate = certificateChain[0];
-  const now = new Date();
-  if (leafCertificate.validity.notBefore > now || leafCertificate.validity.notAfter < now) {
-    return null;
+
+  // ensure all intermediate certificates are valid (in case we forget to rotate)
+  for (const certificate of certificateChain) {
+    const now = new Date();
+    if (certificate.validity.notBefore > now || certificate.validity.notAfter < now) {
+      return null;
+    }
   }
 
   // TODO(wschurman): maybe do more validation, like validation of projectID and scopeKey within eas certificate extension


### PR DESCRIPTION
# Why

We need to validate that all certificates in the chain are valid instead of just the leaf (development) certificate. What we're seeing is that we forgot to rotate the Expo Go intermediate certificate at the required cadence of 1 year, so the intermediate cert being served is not valid. https://github.com/expo/universe/pull/14632 and https://github.com/expo/code-signing-certificates/pull/1 rotate the cert, but since the CLI caches the cert it'll continue to try to use the cached development (only if offline) and intermediate cert for up to 30 days (if the user had just generated one).

This will need to be cherry-picked and released. In the meantime, the recommendation is just to go online once and then go back offline if the user so desires.

# How

Check that all certificates in the cached chain are valid, otherwise report cache as null and re-fetch current from server.

# Test Plan

1. create expo project
2. `npx expo start`
3. open in store version of Expo Go
4. see "Certificate not valid" error
5. Open codesigning cache file for project (`~/.expo/codesigning/<project_id>/development-code-signing-settings-2.json`)
6. start in offline mode
7. reload the app in Expo Go
8. see "Offline and no cached development certificate found, unable to sign manifest" since cached stuff is invalidated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
