### PR TITLE
[camera] Make audio permissions on android optional in plugin

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### 💡 Others
 
 - Make the casing of `Barcode` consistent. ([#26900](https://github.com/expo/expo/pull/26900) by [@alanjhughes](https://github.com/alanjhughes))
-- On `Android`, requesting audio permissions was meant to be optional in the config plugin.
+- On `Android`, requesting audio permissions was meant to be optional in the config plugin. ([#27365](https://github.com/expo/expo/pull/27365) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 14.0.1 - 2023-12-19
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### 💡 Others
 
 - Make the casing of `Barcode` consistent. ([#26900](https://github.com/expo/expo/pull/26900) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, requesting audio permissions was meant to be optional in the config plugin.
 
 ## 14.0.1 - 2023-12-19
 

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -4,5 +4,6 @@ export declare function addCameraImport(src: string): MergeResults;
 declare const _default: ConfigPlugin<void | {
     cameraPermission?: string | undefined;
     microphonePermission?: string | undefined;
+    recordAudioAndroid?: boolean | undefined;
 }>;
 export default _default;

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -55,7 +55,7 @@ function appendContents({ src, newSrc, tag, comment, }) {
     }
     return { contents: src, didClear: false, didMerge: false };
 }
-const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid } = {}) => {
+const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
     config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
         config.modResults.NSCameraUsageDescription =
             cameraPermission || config.modResults.NSCameraUsageDescription || CAMERA_USAGE;

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -55,7 +55,7 @@ function appendContents({ src, newSrc, tag, comment, }) {
     }
     return { contents: src, didClear: false, didMerge: false };
 }
-const withCamera = (config, { cameraPermission, microphonePermission } = {}) => {
+const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid } = {}) => {
     config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
         config.modResults.NSCameraUsageDescription =
             cameraPermission || config.modResults.NSCameraUsageDescription || CAMERA_USAGE;
@@ -66,8 +66,8 @@ const withCamera = (config, { cameraPermission, microphonePermission } = {}) => 
     config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.CAMERA',
         // Optional
-        'android.permission.RECORD_AUDIO',
-    ]);
+        recordAudioAndroid && 'android.permission.RECORD_AUDIO',
+    ].filter(Boolean));
     return withAndroidCameraGradle(config);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withCamera, pkg.name, pkg.version);

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -82,8 +82,9 @@ const withCamera: ConfigPlugin<
   {
     cameraPermission?: string;
     microphonePermission?: string;
+    recordAudioAndroid?: boolean;
   } | void
-> = (config, { cameraPermission, microphonePermission } = {}) => {
+> = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
   config = withInfoPlist(config, (config) => {
     config.modResults.NSCameraUsageDescription =
       cameraPermission || config.modResults.NSCameraUsageDescription || CAMERA_USAGE;
@@ -94,11 +95,14 @@ const withCamera: ConfigPlugin<
     return config;
   });
 
-  config = AndroidConfig.Permissions.withPermissions(config, [
-    'android.permission.CAMERA',
-    // Optional
-    'android.permission.RECORD_AUDIO',
-  ]);
+  config = AndroidConfig.Permissions.withPermissions(
+    config,
+    [
+      'android.permission.CAMERA',
+      // Optional
+      recordAudioAndroid && 'android.permission.RECORD_AUDIO',
+    ].filter(Boolean) as string[]
+  );
 
   return withAndroidCameraGradle(config);
 };


### PR DESCRIPTION
# Why
Closes #27211

# How
Add a new property `recordAudioAndroid` to the plugin props. Defaults to true to keep existing behaviour. 

# Test Plan
Tried in a test project.
