### PR TITLE
[docs] Fix typo in Camera API references

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-next.mdx
@@ -44,7 +44,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
         "expo-camera",
         {
           "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
-          "microphonePermission": "Allow $(PRODUCT_NAME) to access your mircophone",
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
           "recordAudioAndroid": true
         }
       ]

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -44,7 +44,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
         "expo-camera",
         {
           "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
-          "microphonePermission": "Allow $(PRODUCT_NAME) to access your mircophone",
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
           "recordAudioAndroid": true
         }
       ]

--- a/docs/pages/versions/v50.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera.mdx
@@ -41,7 +41,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
         "expo-camera",
         {
           "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
-          "microphonePermission": "Allow $(PRODUCT_NAME) to access your mircophone",
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
           "recordAudioAndroid": true
         }
       ]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #27368

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix typo in config plugin example

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
