### PR TITLE
[core] Set bridge on AppContext

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Moved away from `SharedObjectRegistry` being a singleton. ([#27032](https://github.com/expo/expo/pull/27032) by [@tsapeta](https://github.com/tsapeta))
 - Moved and added more JSI utils to the common C++ codebase. ([#27045](https://github.com/expo/expo/pull/27045) by [@tsapeta](https://github.com/tsapeta))
 - Introduce `EXCreateReactBindingRootView` to create correct React Native setup for New Architecture mode. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
+- Set bridge on `AppContext` in `ExpoBridgeModule`.
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Moved away from `SharedObjectRegistry` being a singleton. ([#27032](https://github.com/expo/expo/pull/27032) by [@tsapeta](https://github.com/tsapeta))
 - Moved and added more JSI utils to the common C++ codebase. ([#27045](https://github.com/expo/expo/pull/27045) by [@tsapeta](https://github.com/tsapeta))
 - Introduce `EXCreateReactBindingRootView` to create correct React Native setup for New Architecture mode. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
-- Set bridge on `AppContext` in `ExpoBridgeModule`.
+- Set bridge on `AppContext` in `ExpoBridgeModule`. ([#27378](https://github.com/expo/expo/pull/27378) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 1.11.7 - 2024-01-18
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -43,7 +43,7 @@ public final class AppContext: NSObject {
    or when the app context is "bridgeless" (for example in native unit tests).
    */
   @objc
-  public internal(set) weak var reactBridge: RCTBridge?
+  public weak var reactBridge: RCTBridge?
 
   /**
    Underlying JSI runtime of the running app.

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -35,6 +35,7 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   // it's actually an instance of `RCTBridgeProxy` that provides backwards compatibility.
   // Also, hold on with initializing the runtime until `setRuntimeExecutor` is called.
   _bridge = bridge;
+  _appContext.reactBridge = bridge;
 
 #if !__has_include(<ReactCommon/RCTRuntimeExecutor.h>)
   _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];


### PR DESCRIPTION
# Why
The bridge is not being set on the old architecture.

# How
Set the bridge on the `AppContext` in `ExpoBridgeModule`

# Test Plan

