### PR TITLE
[ios][file-system] Resolve promise manually after copying PHAsset

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - [iOS] Fix downloadAsync for local files. ([#27187](https://github.com/expo/expo/pull/27187) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - On `iOS`, fix an issue with `copyAsync` where the copy fails if it is a photo library asset. ([#27208](https://github.com/expo/expo/pull/27208) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, resolve the promise manually after copying a PHAsset file.
+- On `iOS`, resolve the promise manually after copying a PHAsset file. ([#27381](https://github.com/expo/expo/pull/27381) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.0.6 - 2024-02-06
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [iOS] Fix downloadAsync for local files. ([#27187](https://github.com/expo/expo/pull/27187) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - On `iOS`, fix an issue with `copyAsync` where the copy fails if it is a photo library asset. ([#27208](https://github.com/expo/expo/pull/27208) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, resolve the promise manually after copying a PHAsset file.
 
 ## 16.0.6 - 2024-02-06
 

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -92,6 +92,7 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
         if let error {
           promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
         }
+        promise.resolve()
       }
     } else {
       promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))


### PR DESCRIPTION
# Why
The promise needs to be resolved after successfully copying a PHAsset from the camera roll

# How
Resolve it in the completion handler of `resourceManager.writeData`

# Test Plan
We don't have any tests to cover accessing the camera roll. Created a repro and tested the fix there.

