### PR TITLE
[sqlite] add `expo.sqlite.customBuildFlags` property

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Added `expo.sqlite.customBuildFlags` gradle property to support custom sqlite3 building flags. ([#27385](https://github.com/expo/expo/pull/27385) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-sqlite/android/CMakeLists.txt
+++ b/packages/expo-sqlite/android/CMakeLists.txt
@@ -10,6 +10,12 @@ set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 set(SRC_DIR "${CMAKE_SOURCE_DIR}/src/main/cpp")
 file(GLOB SOURCES "${SRC_DIR}/*.cpp")
 
+if (NOT "${SQLITE_CUSTOM_BUILDFLAGS}" STREQUAL "")
+  add_compile_options(
+    "${SQLITE_CUSTOM_BUILDFLAGS}"
+  )
+endif()
+
 add_library(
   ${PACKAGE_NAME}
   SHARED

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -122,7 +122,8 @@ android {
       cmake {
         abiFilters (*reactNativeArchitectures())
         arguments "-DANDROID_STL=c++_shared",
-          "-DSQLITE3_SRC_DIR=${toPlatformIndependentPath(SQLITE3_SRC_DIR)}"
+          "-DSQLITE3_SRC_DIR=${toPlatformIndependentPath(SQLITE3_SRC_DIR)}",
+          "-DSQLITE_CUSTOM_BUILDFLAGS=${findProperty('expo.sqlite.customBuildFlags') ?: ''}"
       }
     }
   }


### PR DESCRIPTION
# Why

to support 3rd party library integration that requires custom flags from building sqlite3

# How

add `expo.sqlite.customBuildFlags` build property that could add from static config plugin

# Test Plan

added `expo.sqlite.customBuildFlags=-DSQLITE_ENABLE_BYTECODE_VTAB=1` to **apps/bare-expo/android/gradle.properties** and verity sqlite by `SELECT * FROM tables_used('SELECT * FROM sqlite_schema')`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
