### PR TITLE
[expo-updates][cli] Add resolved workflow to debug info

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Add expo-updates cli fingerprint:generate command. ([#27119](https://github.com/expo/expo/pull/27119) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli runtimeversion:resolve command. ([#27263](https://github.com/expo/expo/pull/27263) by [@wschurman](https://github.com/wschurman))
 - Add --version top-level flag and also add handler for missing command in expo-update cli. ([#27296](https://github.com/expo/expo/pull/27296) by [@wschurman](https://github.com/wschurman))
-- Add more debug information to runtimeversion:resolve CLI output. ([#27323](https://github.com/expo/expo/pull/27323) by [@wschurman](https://github.com/wschurman))
+- Add more debug information to runtimeversion:resolve CLI output. ([#27323](https://github.com/expo/expo/pull/27323), [#27387](https://github.com/expo/expo/pull/27387) by [@wschurman](https://github.com/wschurman))
 - Added React Native New Architecture support. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
@@ -2,4 +2,5 @@ import * as Fingerprint from '@expo/fingerprint';
 export declare function resolveRuntimeVersionAsync(projectRoot: string, platform: 'ios' | 'android', options: Fingerprint.Options): Promise<{
     runtimeVersion: string | null;
     fingerprintSources: Fingerprint.FingerprintSource[] | null;
+    workflow: 'managed' | 'generic';
 }>;

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
@@ -10,15 +10,15 @@ async function resolveRuntimeVersionAsync(projectRoot, platform, options) {
         isPublicConfig: true,
         skipSDKVersionRequirement: true,
     });
+    const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
     const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
     if (!runtimeVersion || typeof runtimeVersion === 'string') {
-        return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null };
+        return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null, workflow };
     }
-    const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
     const policy = runtimeVersion.policy;
     if (policy === 'fingerprintExperimental') {
         const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, options);
-        return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources };
+        return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources, workflow };
     }
     if (workflow !== 'managed') {
         throw new Error(`You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions`);
@@ -26,6 +26,7 @@ async function resolveRuntimeVersionAsync(projectRoot, platform, options) {
     return {
         runtimeVersion: await config_plugins_1.Updates.resolveRuntimeVersionPolicyAsync(policy, config, platform),
         fingerprintSources: null,
+        workflow,
     };
 }
 exports.resolveRuntimeVersionAsync = resolveRuntimeVersionAsync;

--- a/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
+++ b/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
@@ -20,9 +20,11 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(getConfig).mockReturnValue({
       exp: { name: 'test', slug: 'test', runtimeVersion: '3' },
     } as any);
+    jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
       runtimeVersion: '3',
       fingerprintSources: null,
+      workflow: 'managed',
     });
   });
 
@@ -30,9 +32,11 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(getConfig).mockReturnValue({
       exp: { name: 'test', slug: 'test', runtimeVersion: '3', ios: { runtimeVersion: '4' } },
     } as any);
+    jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
       runtimeVersion: '4',
       fingerprintSources: null,
+      workflow: 'managed',
     });
   });
 
@@ -51,11 +55,13 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(getConfig).mockReturnValue({
       exp: { name: 'test', slug: 'test', runtimeVersion: { policy: 'fingerprintExperimental' } },
     } as any);
+    jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     jest.mocked(createFingerprintAsync).mockResolvedValue({ hash: 'hello', sources: [] });
 
     await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
       runtimeVersion: 'hello',
       fingerprintSources: [],
+      workflow: 'managed',
     });
   });
 
@@ -70,6 +76,7 @@ describe(resolveRuntimeVersionAsync, () => {
     await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
       runtimeVersion: 'what',
       fingerprintSources: null,
+      workflow: 'managed',
     });
   });
 });

--- a/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
+++ b/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
@@ -12,24 +12,25 @@ export async function resolveRuntimeVersionAsync(
 ): Promise<{
   runtimeVersion: string | null;
   fingerprintSources: Fingerprint.FingerprintSource[] | null;
+  workflow: 'managed' | 'generic';
 }> {
   const { exp: config } = getConfig(projectRoot, {
     isPublicConfig: true,
     skipSDKVersionRequirement: true,
   });
 
+  const workflow = await resolveWorkflowAsync(projectRoot, platform);
+
   const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
   if (!runtimeVersion || typeof runtimeVersion === 'string') {
-    return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null };
+    return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null, workflow };
   }
-
-  const workflow = await resolveWorkflowAsync(projectRoot, platform);
 
   const policy = runtimeVersion.policy;
 
   if (policy === 'fingerprintExperimental') {
     const fingerprint = await createFingerprintAsync(projectRoot, platform, workflow, options);
-    return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources };
+    return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources, workflow };
   }
 
   if (workflow !== 'managed') {
@@ -41,5 +42,6 @@ export async function resolveRuntimeVersionAsync(
   return {
     runtimeVersion: await Updates.resolveRuntimeVersionPolicyAsync(policy, config, platform),
     fingerprintSources: null,
+    workflow,
   };
 }


### PR DESCRIPTION
# Why

For debugging, it's helpful to know what the resolved workflow was during runtime version resolution.

Closes ENG-11538.

# How

Add resolved workflow to output.

# Test Plan

Run test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
