### PR TITLE
drop extraneous babel configs

### DIFF
--- a/templates/expo-template-bare-minimum/babel.config.js
+++ b/templates/expo-template-bare-minimum/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo']
-  };
-};

--- a/templates/expo-template-blank-typescript/babel.config.js
+++ b/templates/expo-template-blank-typescript/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/templates/expo-template-blank/babel.config.js
+++ b/templates/expo-template-blank/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/templates/expo-template-tabs/babel.config.js
+++ b/templates/expo-template-tabs/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo']
-  };
-};


### PR DESCRIPTION
# Why

- With SDK 48/49/50 we removed the need for babel.config.js by making Expo CLI the only CLI you need, and by making expo/metro-config a required package for using Expo CLI.
- It's very common in web frameworks (back when all web frameworks used Babel) to ship without a babel config as they all required the project to use the default babel preset. Expo is no different, you must use `babel-preset-expo`.
- Our metro config (and webpack config) defaults to using babel-preset-expo when no config is defined.
- With the last few releases, we've rewritten `babel-preset-expo` to account for the majority of basic config changes that users need. This includes support for tsconfig path aliases, environment variables, and react-native-reanimated. Along with many new innovations like removing a dozen or so babel plugins when the runtime app is targeting Hermes, and adding support for React component stacks.
  - Often, the expo version of these features is more performant and is less likely to invalidate the Metro cache. For example, tsconfig paths, vector icons alias, and environment variables (in dev) are implemented outside the babel transformer. Meaning they're cached on more flexible values such as file paths and resolution criteria.
- Going forward, users will have to run `npx expo customize babel.config.js` (or `npx expo customize` -> select `babel.config.js`) to generate a template babel preset in their app.

# Test Plan

- In any project, all Expo CLI features and commands work without the babel config.
  - Any command that uses React Native Community CLI will require a physical `metro.config.js` file that uses `expo/metro-config` in order to get the babel config (amongst other features).