### PR TITLE
Update variants.mdx

### DIFF
--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -85,7 +85,7 @@ export default {
 
 In the above example, the environment variable `IS_DEV` is used to differentiate between the development and production environment. Based on its value, the different Application IDs or Bundle Identifiers are set for each variant.
 
-> **Note**: If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps, you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`. You can also swap this configuration using the same approach as above.
+> **Note**: If you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps or Firebase Cloud Messaging (FCM), you'll need to have a separate configuration for that API for the `android.package` and `ios.bundleIdentifier`. You can also swap this configuration using the same approach as above.
 
 ### Configuration for EAS Build
 


### PR DESCRIPTION
# Why

I wanted to build and install different versions of my app onto my physical devices and kept running into ambiguous build errors. Spent a lot of time on this before managing to land on [this answer](https://forums.expo.dev/t/eas-build-error-no-matching-client-found-for-package-name/67349/5). If I were someone going through the documentation in the future, who was using `expo-notifications`, reading this remark would definitely save me time.

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
