### PR TITLE
[core] Implement startObserving and stopObserving in the new EventEmitter class

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Added native implementation of the JS EventEmitter. ([#27092](https://github.com/expo/expo/pull/27092) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Allow for the export of views that conform to `AnyExpoView` ([#27284](https://github.com/expo/expo/pull/27284) by [@dominicstop](https://github.com/dominicstop))
 - [iOS] Added support for native modules in bridgeless mode in React Native 0.74 ([#27242](https://github.com/expo/expo/pull/27242) by [@tsapeta](https://github.com/tsapeta))
+- Added support for `startObserving` and `stopObserving` in the new `EventEmitter` class. ([#27393](https://github.com/expo/expo/pull/27393) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -54,6 +54,11 @@ private:
   void clear() noexcept;
 
   /**
+   Returns a number of listeners added for the given event name.
+   */
+  size_t listenersCount(std::string eventName) noexcept;
+
+  /**
    Calls listeners for the given event name, with the given `this` object and payload arguments.
    */
   void call(jsi::Runtime &runtime, std::string eventName, const jsi::Object &thisObject, const jsi::Value *args, size_t count) noexcept;

--- a/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
@@ -86,6 +86,82 @@ final class EventEmitterSpec: ExpoSpec {
         expect(args[1]) == 2
         expect(args[2]) == 24
       }
+
+      it("calls startObserving on addListener") {
+        var calls: Int = 0
+        let eventName = "testEvent"
+        let listenerA = runtime.createSyncFunction("listenerA") { _, _ in }
+        let listenerB = runtime.createSyncFunction("listenerB") { _, _ in }
+        let observer = try setupEventObserver(runtime: runtime, functionName: "startObserving") { arguments in
+          expect(try arguments.first?.asString()) == eventName
+          calls = calls + 1
+        }
+
+        observer.addListener.call(withArguments: [eventName, listenerA], thisObject: observer.emitter, asConstructor: false)
+        observer.addListener.call(withArguments: [eventName, listenerB], thisObject: observer.emitter, asConstructor: false)
+
+        expect(calls) == 1
+      }
+
+      it("calls stopObserving on removeListener") {
+        var calls: Int = 0
+        let eventName = "testEvent"
+        let listener = runtime.createSyncFunction("listener") { _, _ in }
+        let observer = try setupEventObserver(runtime: runtime, functionName: "stopObserving") { arguments in
+          expect(try arguments.first?.asString()) == eventName
+          calls = calls + 1
+        }
+
+        observer.addListener.call(withArguments: [eventName, listener], thisObject: observer.emitter, asConstructor: false)
+        observer.removeListener.call(withArguments: [eventName, listener], thisObject: observer.emitter, asConstructor: false)
+        observer.removeListener.call(withArguments: [eventName, listener], thisObject: observer.emitter, asConstructor: false)
+
+        expect(calls) == 1
+      }
+
+      it("calls stopObserving on removeAllListeners") {
+        var calls: Int = 0
+        let eventName = "testEvent"
+        let listener = runtime.createSyncFunction("listener") { _, _ in }
+        let observer = try setupEventObserver(runtime: runtime, functionName: "stopObserving") { arguments in
+          expect(try arguments.first?.asString()) == eventName
+          calls = calls + 1
+        }
+
+        observer.addListener.call(withArguments: [eventName, listener], thisObject: observer.emitter, asConstructor: false)
+        observer.removeAllListeners.call(withArguments: [eventName], thisObject: observer.emitter, asConstructor: false)
+        observer.removeAllListeners.call(withArguments: [eventName], thisObject: observer.emitter, asConstructor: false)
+
+        expect(calls) == 1
+      }
     }
   }
+}
+
+private typealias EventObserver = (
+  emitter: JavaScriptObject,
+  addListener: RawJavaScriptFunction,
+  removeListener: RawJavaScriptFunction,
+  removeAllListeners: RawJavaScriptFunction
+)
+
+private func setupEventObserver(
+  runtime: ExpoRuntime,
+  functionName: String,
+  callback: @escaping (_ arguments: [JavaScriptValue]) throws -> Void
+) throws -> EventObserver {
+  let emitter = try! runtime.eval("new expo.EventEmitter()").asObject()
+  let observingFunction = runtime.createSyncFunction(functionName) { [callback] this, arguments in
+    try callback(arguments)
+    return Optional<Any>.none as Any
+  }
+
+  emitter.setProperty(functionName, value: observingFunction)
+
+  return (
+    emitter,
+    addListener: try emitter.getProperty("addListener").asFunction(),
+    removeListener: try emitter.getProperty("removeListener").asFunction(),
+    removeAllListeners: try emitter.getProperty("removeAllListeners").asFunction()
+  )
 }


### PR DESCRIPTION
# Why

The old `EventEmitter` calls `startObserving` when the first event listener is added and `stopObserving` when the last event listener is removed. This needs to be backported, but with slightly improved behavior: they will be given the event name as the argument and called per-event instead of just once.

# How

Automatically calling `startObserving` and `stopObserving` on the event emitting object.

# Test Plan

Added some native unit tests, but in general covering all the use cases would be a bit complicated in native tests so I'm leaning towards extending them in the future on the JS side.
