### PR TITLE
[Docs] add expo-router/types/jest to document

### DIFF
--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -11,6 +11,8 @@ Expo Router relies on your file system, which can present challenges when settin
 
 Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
+If you use Typescript, please add `expo-router/types/jest` to tsconfig.json's `types`.
+
 ### Jest Native Matchers (optional)
 
 [`@testing-library/jest-native`](https://testing-library.com/docs/ecosystem-jest-native/) provides custom Jest matchers that can be used to extend the functionality of `@testing-library/react-native`. If installed, Expo Router will automatically perform the `@testing-library/jest-native` setup.


### PR DESCRIPTION
# Why

VS Code display errors for missing expo-router's types.

# How

Add expo-router/types/jest to tsconfig.json.

# Test Plan

No need to add testing cases.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
