### PR TITLE
[docs] add TenTap Rich Text Editor to docs

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -47,7 +47,7 @@ There are a couple of existing React Native libraries to allow rich-text editing
 
 - [`react-native-rich-editor`](https://github.com/wxik/react-native-rich-editor)
 - [`react-native-cn-quill`](https://github.com/imnapo/react-native-cn-quill)
-- [`@10play/tentap-editor`](https://github.com/10play/10Tap-Editor) - TenTap also gives you a way to customize the editor with some additional steps.
+- [`@10play/tentap-editor`](https://github.com/10play/10Tap-Editor)
 
 ### Custom webview-based editor
 

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -47,6 +47,7 @@ There are a couple of existing React Native libraries to allow rich-text editing
 
 - [`react-native-rich-editor`](https://github.com/wxik/react-native-rich-editor)
 - [`react-native-cn-quill`](https://github.com/imnapo/react-native-cn-quill)
+- [`@10play/tentap-editor`](https://github.com/10play/10Tap-Editor) - TenTap also gives you a way to customize the editor with some additional steps.
 
 ### Custom webview-based editor
 


### PR DESCRIPTION
# Why

[TenTap](https://github.com/10play/10Tap-Editor) is an open source WebView based rich text editor I have been working on, and we just added expo support!


# How

I added it to the section where WebView based solutions are added, but TenTap also exposes a way to create custom "editor build" so I added a description for that too.