### PR TITLE
Gracefully handle unsupported languages

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix es-419 locale returning empty list. ([#27250](https://github.com/expo/expo/pull/27250) by [@aleqsio](https://github.com/aleqsio))
+- [Web] Gracefully handle unsupported language tags. ([#27403](https://github.com/expo/expo/pull/27403) by [@mary-ext](https://github.com/mary-ext))
 
 ### 💡 Others
 

--- a/packages/expo-localization/src/ExpoLocalization.ts
+++ b/packages/expo-localization/src/ExpoLocalization.ts
@@ -131,23 +131,31 @@ export default {
       // We might want to consider using a locale lookup table instead.
 
       let locale = {} as ExtendedLocale;
-      
+
+      // Properties added only for compatibility with native, use `toLocaleString` instead.
+      let digitGroupingSeparator: string | null = null;
+      let decimalSeparator: string | null = null;
+      let temperatureUnit: "fahrenheit" | "celsius" | null = null;
+
       if (typeof Intl !== 'undefined') {
         // Gracefully handle language codes like `en-GB-oed` which is unsupported
         // but is otherwise a valid language tag (grandfathered)
         try {
           locale = new Intl.Locale(languageTag) as unknown as ExtendedLocale
+
+          digitGroupingSeparator =
+            Array.from((10000).toLocaleString(languageTag)).filter((c) => c > '9' || c < '0')[0] ||
+            null; // using 1e5 instead of 1e4 since for some locales (like pl-PL) 1e4 does not use digit grouping
+
+          decimalSeparator = (1.1).toLocaleString(languageTag).substring(1, 2);
         } catch {}
       }
 
       const { region, textInfo, language } = locale;
 
-      // Properties added only for compatibility with native, use `toLocaleString` instead.
-      const digitGroupingSeparator =
-        Array.from((10000).toLocaleString(languageTag)).filter((c) => c > '9' || c < '0')[0] ||
-        null; // using 1e5 instead of 1e4 since for some locales (like pl-PL) 1e4 does not use digit grouping
-      const decimalSeparator = (1.1).toLocaleString(languageTag).substring(1, 2);
-      const temperatureUnit = region ? regionToTemperatureUnit(region) : null;
+      if (region) {
+        temperatureUnit = regionToTemperatureUnit(region)
+      }
 
       return {
         languageTag,

--- a/packages/expo-localization/src/ExpoLocalization.ts
+++ b/packages/expo-localization/src/ExpoLocalization.ts
@@ -135,7 +135,7 @@ export default {
       // Properties added only for compatibility with native, use `toLocaleString` instead.
       let digitGroupingSeparator: string | null = null;
       let decimalSeparator: string | null = null;
-      let temperatureUnit: "fahrenheit" | "celsius" | null = null;
+      let temperatureUnit: 'fahrenheit' | 'celsius' | null = null;
 
       // Gracefully handle language codes like `en-GB-oed` which is unsupported
       // but is otherwise a valid language tag (grandfathered)

--- a/packages/expo-localization/src/ExpoLocalization.ts
+++ b/packages/expo-localization/src/ExpoLocalization.ts
@@ -137,19 +137,19 @@ export default {
       let decimalSeparator: string | null = null;
       let temperatureUnit: "fahrenheit" | "celsius" | null = null;
 
-      if (typeof Intl !== 'undefined') {
-        // Gracefully handle language codes like `en-GB-oed` which is unsupported
-        // but is otherwise a valid language tag (grandfathered)
-        try {
+      // Gracefully handle language codes like `en-GB-oed` which is unsupported
+      // but is otherwise a valid language tag (grandfathered)
+      try {
+        digitGroupingSeparator =
+          Array.from((10000).toLocaleString(languageTag)).filter((c) => c > '9' || c < '0')[0] ||
+          null; // using 1e5 instead of 1e4 since for some locales (like pl-PL) 1e4 does not use digit grouping
+
+        decimalSeparator = (1.1).toLocaleString(languageTag).substring(1, 2);
+
+        if (typeof Intl !== 'undefined') {
           locale = new Intl.Locale(languageTag) as unknown as ExtendedLocale
-
-          digitGroupingSeparator =
-            Array.from((10000).toLocaleString(languageTag)).filter((c) => c > '9' || c < '0')[0] ||
-            null; // using 1e5 instead of 1e4 since for some locales (like pl-PL) 1e4 does not use digit grouping
-
-          decimalSeparator = (1.1).toLocaleString(languageTag).substring(1, 2);
-        } catch {}
-      }
+        }
+      } catch {}
 
       const { region, textInfo, language } = locale;
 

--- a/packages/expo-localization/src/ExpoLocalization.ts
+++ b/packages/expo-localization/src/ExpoLocalization.ts
@@ -129,10 +129,17 @@ export default {
     return locales?.map((languageTag) => {
       // TextInfo is an experimental API that is not available in all browsers.
       // We might want to consider using a locale lookup table instead.
-      const locale =
-        typeof Intl !== 'undefined'
-          ? (new Intl.Locale(languageTag) as unknown as ExtendedLocale)
-          : { region: null, textInfo: null, language: null };
+
+      let locale = {} as ExtendedLocale;
+      
+      if (typeof Intl !== 'undefined') {
+        // Gracefully handle language codes like `en-GB-oed` which is unsupported
+        // but is otherwise a valid language tag (grandfathered)
+        try {
+          locale = new Intl.Locale(languageTag) as unknown as ExtendedLocale
+        } catch {}
+      }
+
       const { region, textInfo, language } = locale;
 
       // Properties added only for compatibility with native, use `toLocaleString` instead.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Gracefully handle language tags like `en-GB-oed` which is a valid language tag but is otherwise unsupported by `Intl.Locale` API and/or `.toLocaleString`

Closes https://github.com/expo/expo/issues/25694
Ref https://github.com/bluesky-social/social-app/issues/2381

# How

<!--
How did you build this feature or fix this bug and why?
-->
Adds a try-catch when calling out to `.toLocaleString` for retrieving digit grouping separator, decimal separator, and `Intl.Locale` for actual locale information.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I wanted to add tests but it seems like we have no tests whatsoever for `getLocales` at the moment, this was what I wanted to add:

```
it(`can resolve an unsupported locale`, async () => {
  jest.spyOn(navigator, 'languages', 'get').mockReturnValue(['en-GB-oed']);

  const Localization = require('../ExpoLocalization').default;
  const locales = Localization.getLocales();

  expect(locales).tohaveLength(1);
  expect(locales[0].languageTag).toBe('en-GB-oed');
  expect(locales[0].languageCode).tobe('en');
  expect(locales[0].regionCode).toBe(null);
});
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
