### PR TITLE
[Doc]: fix typo, JSX element 'Stack.Screen' has no corresponding closing tag

### DIFF
--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -40,7 +40,7 @@ import { Stack } from 'expo-router/stack';
 export default function AppLayout() {
  return (
    <Stack>
-     <Stack.Screen name="(tabs)" options={{ headerShown: false }}>
+     <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
    </Stack>
  );
 }


### PR DESCRIPTION
# Why
The change was necessary because the previous syntax was incorrect. The self-closing tag was missing which caused an error in the code.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
The fix was implemented by adding a forward slash (/).
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
No test plan, just a typo.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
