### PR TITLE
[docs] Update installation.mdx

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -24,7 +24,7 @@ To use Expo, you need to have the following tools installed on your machine:
 
 After installing Node.js, you can use `npx` to create a new app.
 
-<Terminal cmd={['$ npx create-expo-app --template']} />
+<Terminal cmd={['$ npx create-expo-app my-app']} />
 
 <BoxLink
   title="Create a new project"


### PR DESCRIPTION
# Why

Running it with the `--template` argument used an old template project instead of the latest expo project template.
