### PR TITLE
[docs] Update ImageSpotlight to disable slide mode when an image is in full screen mode

### DIFF
--- a/docs/ui/components/LightboxImage/index.tsx
+++ b/docs/ui/components/LightboxImage/index.tsx
@@ -25,6 +25,7 @@ export function LightboxImage({ src, alt, ...rest }: Props) {
           aria: true,
           closeOnBackdropClick: true,
         }}
+        carousel={{ finite: true }}
         render={{
           buttonPrev: () => null,
           buttonNext: () => null,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, ImageSpotlight allows sliding left and right when an image is open in full screen mode due to the underlying `LightboxImage` component.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `carousel={{ finite: true }}` on the `LightboxImage` component so that the sliding is automatically disabled. We already setting next and previous buttons to `null` in the `render` prop. 

References:
- Discussion post in Lightbox GitHub: https://github.com/igordanchenko/yet-another-react-lightbox/discussions/116
- Documentation: https://yet-another-react-lightbox.com/customization#HidingNavigationButtons

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, go to page where `ImageSpotlight` is used, open the image in full screen mode and then press right or left arrow keys (they won't work). See demo below:

## Preview


https://github.com/expo/expo/assets/10234615/5ba069a6-e042-4241-9527-d9ee52cccd00



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
