### PR TITLE
[cli] detect missing `adb`, add fix suggestion and docs hint

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,11 +10,13 @@
 
 ### 💡 Others
 
+- Detect missing `adb`, add fix suggestion and docs hint. ([#27419](https://github.com/expo/expo/pull/27419) by [@Simek](https://github.com/Simek))
+
 ## 0.24.7 — 2025-04-28
 
 ### 🎉 New features
 
-- Add support for custom remote build cache providers ([#36314](https://github.com/expo/expo/pull/36314) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for custom remote build cache providers. ([#36314](https://github.com/expo/expo/pull/36314) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.24.6 — 2025-04-28
 

--- a/packages/@expo/cli/src/start/doctor/android/AndroidPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/android/AndroidPrerequisite.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import open from 'open';
+
+import { AbortCommandError } from '../../../utils/errors';
+import { confirmAsync } from '../../../utils/prompts';
+import { Prerequisite } from '../Prerequisite';
+
+export async function isADBInstalledAsync() {
+  try {
+    execSync('adb --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    console.error(chalk.red`Cannot find {bold adb} setup on this machine.`);
+    return false;
+  }
+}
+
+export class AndroidPrerequisite extends Prerequisite {
+  static instance = new AndroidPrerequisite();
+
+  async assertImplementation(): Promise<void> {
+    if (await isADBInstalledAsync()) {
+      return;
+    }
+
+    const confirm = await confirmAsync({
+      initial: true,
+      message: chalk`The {bold Android SDK} needs to be installed before you can continue. Would you like to open Expo docs to learn more?`,
+    });
+
+    if (confirm) {
+      try {
+        await open('https://docs.expo.dev/workflow/android-studio-emulator/');
+      } catch {}
+    }
+
+    throw new AbortCommandError();
+  }
+}

--- a/packages/@expo/cli/src/start/doctor/android/__tests__/AndroidPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/android/__tests__/AndroidPrerequisite-test.ts
@@ -1,0 +1,45 @@
+import spawnAsync from '@expo/spawn-async';
+import { execSync } from 'child_process';
+
+import { confirmAsync } from '../../../../utils/prompts';
+import { AndroidPrerequisite } from '../AndroidPrerequisite';
+
+jest.mock(`../../../../log`);
+jest.mock('../../../../utils/prompts');
+
+it(`detects that adb is installed correctly`, async () => {
+  jest.mocked(execSync).mockReset().mockReturnValueOnce(`Android Debug Bridge version 1.0.41`);
+
+  jest
+    .mocked(confirmAsync)
+    .mockReset()
+    .mockImplementation(() => {
+      throw new Error("shouldn't happen");
+    });
+
+  await AndroidPrerequisite.instance.assertImplementation();
+});
+
+it(`asserts hints are shown when adb is not installed`, async () => {
+  jest.mocked(spawnAsync).mockReset();
+
+  jest
+    .mocked(execSync)
+    .mockReset()
+    .mockImplementationOnce(() => {
+      throw new Error('foobar');
+    })
+    .mockReturnValueOnce(`Android Debug Bridge version 1.0.41`);
+
+  jest
+    .mocked(confirmAsync)
+    .mockReset()
+    // Invoke the confirmation
+    .mockResolvedValueOnce(false)
+    .mockImplementation(() => {
+      throw new Error("shouldn't happen");
+    });
+
+  await expect(AndroidPrerequisite.instance.assertImplementation()).rejects.toThrowError();
+  expect(spawnAsync).not.toBeCalled();
+});

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { activateWindowAsync } from './activateWindow';
 import * as AndroidDebugBridge from './adb';
+import { assertSystemRequirementsAsync } from './assertSystemRequirements';
 import { startDeviceAsync } from './emulator';
 import { getDevicesAsync } from './getDevices';
 import { promptForDeviceAsync } from './promptAndroidDevice';
@@ -16,6 +17,8 @@ import { BaseResolveDeviceProps } from '../PlatformManager';
 const EXPO_GO_APPLICATION_IDENTIFIER = 'host.exp.exponent';
 
 export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Device> {
+  static assertSystemRequirementsAsync = assertSystemRequirementsAsync;
+
   static async resolveFromNameAsync(name: string): Promise<AndroidDeviceManager> {
     const devices = await getDevicesAsync();
     const device = devices.find((device) => device.name === name);

--- a/packages/@expo/cli/src/start/platforms/android/assertSystemRequirements.ts
+++ b/packages/@expo/cli/src/start/platforms/android/assertSystemRequirements.ts
@@ -1,0 +1,9 @@
+import { profile } from '../../../utils/profile';
+import { AndroidPrerequisite } from '../../doctor/android/AndroidPrerequisite';
+
+export async function assertSystemRequirementsAsync() {
+  await profile(
+    AndroidPrerequisite.instance.assertAsync.bind(AndroidPrerequisite.instance),
+    'AndroidPrerequisite'
+  )();
+}

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
+import { AndroidPrerequisite } from './doctor/android/AndroidPrerequisite';
 import { SimulatorAppPrerequisite } from './doctor/apple/SimulatorAppPrerequisite';
 import { getXcodeVersionAsync } from './doctor/apple/XcodePrerequisite';
 import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
@@ -72,10 +73,14 @@ export async function startAsync(
   if (exp.platforms?.includes('ios') && process.platform !== 'win32') {
     // If Xcode could potentially be used, then we should eagerly perform the
     // assertions since they can take a while on cold boots.
-    getXcodeVersionAsync({ silent: true });
+    await getXcodeVersionAsync({ silent: true });
     SimulatorAppPrerequisite.instance.assertAsync().catch(() => {
       // noop -- this will be thrown again when the user attempts to open the project.
     });
+  }
+
+  if (exp.platforms?.includes('android')) {
+    await AndroidPrerequisite.instance.assertAsync();
   }
 
   const platformBundlers = getPlatformBundlers(projectRoot, exp);


### PR DESCRIPTION
# Why

Hopefully fixes ENG-10014

# How

Add `AndroidPrerequisite` check for ADB, and provide basic information and hints how to solve the problem.

Any wording tweaks are appreciated! 😉 

# Test Plan

All lint checks and tests are passing. Local CLI after the changes behaves as expected. 

# Preview

https://github.com/expo/expo/assets/719641/f0f9fb46-c265-4c1a-ad31-1684ca5213a2


