### PR TITLE
[sqlite] Support import `expo-sqlite/next` from ESM project

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `expo-sqlite/next` cannot be imported from an ESM project. ([#27423](https://github.com/expo/expo/pull/27423) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 13.2.2 - 2024-01-25

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -5,6 +5,16 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "default": "./build/index.js",
+      "types": "./build/index.d.ts"
+    },
+    "./next": {
+      "default": "./build/next/index.js",
+      "types": "./build/next/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",


### PR DESCRIPTION
# Why

when importing `expo-sqlite/next` from an ESM project, it cannot resolve the import.

# How

add `exports` to support `./next`

# Test Plan

tested the import from an ESM project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---------

Co-authored-by: Johannes Schickling <schickling.j@gmail.com>