### PR TITLE
[docs] update native embedding fonts instructions to specify using `PostScript` font name

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -69,7 +69,7 @@ Install [`expo-font`](/versions/latest/sdk/font/#installation) library and add t
 
 The `fonts` option takes an array of one or more font files to link to the native project. The path to each font file is relative to the project's root.
 
-After [creating a new native build](/develop/development-builds/create-a-build/), you can use the font in your project with the `fontFamily` style prop. On Android, the font family name will be the name of the font file without the extension. On iOS, the font family name will be read from the font file itself. We recommend naming the font file the same as the font family so the family name is consistent on both platforms. For example, if you have a font family named "Inter-Black" and the name of the file **Inter-Black.otf**, then the font family name will be **Inter-Black** on both Android and iOS.
+After [creating a new native build](/develop/development-builds/create-a-build/), you can use the font in your project with the `fontFamily` style prop. On Android, the font family name will be the name of the font file without the extension. On iOS, the font family name will be read from the font file itself. We recommend naming the font file the same as the **PostScript name** so the family name is consistent on both platforms. For example, if you have a font family named "Inter-Black" and the name of the file **Inter-Black.otf**, then the font family name will be **Inter-Black** on both Android and iOS.
 
 If you want to try a font without creating a new native build, you can load it at runtime. See the next section for details.
 


### PR DESCRIPTION
# Why

It is important that the *Postscript* font name is used on IOS instead of the full font name. This needs to be explicitly listed in the docs or it will subtly break font rendering in apps with no error message.

See #27386 for example of confusing behavior.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Explicitly mention that you need to use the `PostScript` name for fonts to work on IOS.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run docs locally and visit: http://localhost:3002/develop/user-interface/fonts/#embed-font-in-a-native-project

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
