### PR TITLE
[media-library] Fix guard condition causing rejections

### DIFF
--- a/packages/expo-media-library/ios/MediaLibraryModule.swift
+++ b/packages/expo-media-library/ios/MediaLibraryModule.swift
@@ -132,7 +132,7 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
           return
         }
         self.delegates.remove(delegate)
-        guard error != nil else {
+        guard error == nil else {
           promise.reject(SaveAssetException())
           return
         }


### PR DESCRIPTION
# Why

I was poking around `expo-media-library` to implement some custom behaviors on a personal fork, and I kept running into an issue where `saveToLibraryAsync` was throwing when I expected it to work and resolving when I expected it to throw. Apologies in advance for the sparse reproducibility and test plan, but I think this is a case in which the code's intended behavior and bugs speak for itself. 

# How

Fixed guard statement to correctly pass when the `error` is `nil` and to reject when an `error` value exists. 

# Test Plan

N/A (I'm happy to put together a minimal repository to reproduce the issue if necessary)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
