### PR TITLE
[docs] Remove UInt from list of Kotlin primitives

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -549,7 +549,7 @@ All functions and view prop setters accept all common primitive types in Swift a
 | Language | Supported primitive types                                                                                                      |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Swift    | `Bool`, `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Float32`, `Double`, `String` |
-| Kotlin   | `Boolean`, `Int`, `Long`, `UInt`, `Float`, `Double`, `String`, `Pair`                                                          |
+| Kotlin   | `Boolean`, `Int`, `Long`, `Float`, `Double`, `String`, `Pair`                                                          |
 
 </APIBox>
 <APIBox header="Convertibles">


### PR DESCRIPTION
# Why

Closes #27445 

Issue #27445 contains a reproduction case demonstrating that Kotlin Native Modules do not currently seem to support the UInt type. It'd be great to support this in the future, but for now, it'd be nice to remove UInt from the docs to avoid confusion.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

This PR removes `UInt` from the list of Kotlin primitives.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
