### PR TITLE
[core][Android] Thrown an exception when nested types can't be converted instead of crashing

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event. ([#26944](https://github.com/expo/expo/pull/26944) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Thrown an exception when nested types can't be converted instead of crashing the app.
+- [Android] Thrown an exception when nested types can't be converted instead of crashing the app. ([#27449](https://github.com/expo/expo/pull/27449) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event. ([#26944](https://github.com/expo/expo/pull/26944) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Thrown an exception when nested types can't be converted instead of crashing the app.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -197,12 +197,12 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
   ) -> const jsi::Value & {
     if (!takesOwner) {
       return args[index];
-    } else {
-      if (index != 0) {
-        return args[index - 1];
-      }
-      return thisValue;
     }
+
+    if (index != 0) {
+      return args[index - 1];
+    }
+    return thisValue;
   };
 
   for (size_t argIndex = 0; argIndex < count; argIndex++) {

--- a/packages/expo-modules-core/common/cpp/TypedArray.cpp
+++ b/packages/expo-modules-core/common/cpp/TypedArray.cpp
@@ -64,7 +64,6 @@ bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
     .getPropertyAsFunction(runtime, "isView")
     .callWithThis(runtime, ArrayBuffer, {jsi::Value(runtime, jsObj)});
 
-  assert(isViewResult.isBool());
   return isViewResult.getBool();
 }
 


### PR DESCRIPTION
# Why

When the nested type can't be converted the app will crash. It's not an expected behavior. The exception should be thrown in that case.

# How

Replace `get...` with `as...`. The second function is checking the type, and if it's not correct, it will throw a JS exception.

# Test Plan

- bare-expo ✅