### PR TITLE
[ci] use ubuntu runner to launch android emulator

### DIFF
--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,12 +9,12 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
         echo 'Showing Android SDKs'
         ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
-        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall 'ndk;24.0.8215888' 'ndk;25.2.9519653'
+        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall 'ndk;24.0.8215888' 'ndk;25.2.9519653' 'ndk;26.2.11394342'
         echo 'Removing all Docker images'
         docker rmi -f $(docker images -aq)
         echo 'Disk space after cleanup'

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' '^llvm-.*' 'powershell' 'google-chrome-*' 'microsoft-edge-*' 'firefox' 'nginx' 'apache2'
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
         echo 'Showing Android SDKs'

--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -26,6 +26,12 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: ⚙️ Enable KVM for Android virtualization
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
     # NOTE: When updating any emulator settings, please make sure all the settings are also updated in each retry step.
     # Sorry that we can't use a loop here, because GitHub Actions doesn't support it yet.
     - name: '💿 Setup Android Emulator #1'
@@ -37,13 +43,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
-        emulator-build: 9536276
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-        emulator-boot-timeout: 900
-        profile: pixel_6
-        ram-size: 8192MB
-        disk-size: 8192MB
-        heap-size: 2048MB
         script: |
           # Wait for emulator to fully ready
           sleep 20
@@ -67,13 +67,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
-        emulator-build: 9536276
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-        emulator-boot-timeout: 900
-        profile: pixel_6
-        ram-size: 8192MB
-        disk-size: 8192MB
-        heap-size: 2048MB
         script: |
           # Wait for emulator to fully ready
           sleep 20
@@ -97,13 +91,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
-        emulator-build: 9536276
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-        emulator-boot-timeout: 900
-        profile: pixel_6
-        ram-size: 8192MB
-        disk-size: 8192MB
-        heap-size: 2048MB
         script: |
           # Wait for emulator to fully ready
           sleep 20

--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -27,6 +27,7 @@ runs:
   using: 'composite'
   steps:
     - name: ⚙️ Enable KVM for Android virtualization
+      shell: bash
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     timeout-minutes: 150
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
@@ -53,6 +53,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   detox_e2e:
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [33]

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   detox_latest_e2e:
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [33]

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -192,7 +192,7 @@ jobs:
 
   android-test:
     needs: android-build
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [33]

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -215,7 +215,7 @@ jobs:
 
   android-test:
     needs: android-build
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [33]


### PR DESCRIPTION
# Why

since the new github linux runner for open source repo supports nested virtualization, it's a good time to try out using ubuntu runner to launch android emulator without blocking macos runners.

# How

- use ubuntu runner to run android emulator.
- setup kvm according to [android-emulator-runner doc](https://github.com/ReactiveCircus/android-emulator-runner/blob/main/README.md#running-hardware-accelerated-emulators-on-linux-runners)
- clean up more disk space because i've seen running out disk space sometimes

# Test Plan

ci passed (nightly test is broken because 0.74 upgrade, will fix later)
reduce ci time:
- test-suite android-test: 19m -> 3m
- android-instrumentation-test: 51m -> 17m