### PR TITLE
[docs] refreshed way of showing package platform compatibility

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -22,8 +22,8 @@ const STYLES_CONTAINER = css`
   flex-direction: column;
 
   @media screen and (max-width: 1440px) {
-    border-left: 0px;
-    border-right: 0px;
+    border-left: 0;
+    border-right: 0;
   }
 
   @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
@@ -183,7 +183,7 @@ class ScrollContainer extends React.Component<ScrollContainerProps> {
 type Props = React.PropsWithChildren<{
   onContentScroll?: (scrollTop: number) => void;
   isMobileMenuVisible: boolean;
-  tocVisible: boolean;
+  hideTOC: boolean;
   header: React.ReactNode;
   sidebarScrollPosition: number;
   sidebar: React.ReactNode;
@@ -216,7 +216,7 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
       sidebarRight,
       sidebarScrollPosition,
       isMobileMenuVisible,
-      tocVisible,
+      hideTOC,
       children,
     } = this.props;
 
@@ -239,7 +239,7 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
               <div css={STYLES_CENTER_WRAPPER}>{children}</div>
             </ScrollContainer>
           </div>
-          {tocVisible && (
+          {!hideTOC && (
             <div css={[STYLES_SIDEBAR, STYLES_RIGHT]}>
               <ScrollContainer ref={this.sidebarRightRef}>
                 {React.cloneElement(sidebarRight, {

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -27,13 +27,14 @@ export default function DocumentationElements(props: DocumentationElementsProps)
         <PageMetadataContext.Provider value={props.meta}>
           <PageApiVersionProvider>
             <DocumentationPage
-              title={props.meta.title || ''}
-              description={props.meta.description || ''}
+              title={props.meta.title ?? ''}
+              description={props.meta.description ?? ''}
               sourceCodeUrl={props.meta.sourceCodeUrl}
-              tocVisible={!props.meta.hideTOC}
+              hideTOC={props.meta.hideTOC}
               hideFromSearch={props.meta.hideFromSearch}
               packageName={props.meta.packageName}
-              iconUrl={props.meta.iconUrl}>
+              iconUrl={props.meta.iconUrl}
+              platforms={props.meta.platforms}>
               {props.children}
             </DocumentationPage>
           </PageApiVersionProvider>

--- a/docs/components/plugins/PlatformIcon.tsx
+++ b/docs/components/plugins/PlatformIcon.tsx
@@ -1,4 +1,4 @@
-import { ExpoGoLogo } from '@expo/styleguide';
+import { ExpoGoLogo, mergeClasses } from '@expo/styleguide';
 import { AndroidIcon, AppleIcon, AtSignIcon } from '@expo/styleguide-icons';
 
 import { PlatformName } from '~/types/common';
@@ -10,7 +10,17 @@ export type PlatformIconProps = {
 export const PlatformIcon = ({ platform }: PlatformIconProps) => {
   switch (platform) {
     case 'ios':
-      return <AppleIcon className="icon-xs text-palette-blue12" />;
+    case 'macos':
+    case 'tvos':
+      return (
+        <AppleIcon
+          className={mergeClasses(
+            'icon-xs text-palette-blue12',
+            platform === 'macos' && 'text-palette-purple12',
+            platform === 'tvos' && 'text-palette-pink12'
+          )}
+        />
+      );
     case 'android':
       return <AndroidIcon className="icon-xs text-palette-green12" />;
     case 'web':

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4734,7 +4734,7 @@ OAuth 2.0 protocol
            
         </span>
         <div
-          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 css-7sgr13-PlatformTag"
+          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-7sgr13-PlatformTag"
         >
           <svg
             class="icon-xs text-palette-blue12"
@@ -9763,7 +9763,7 @@ exports[`APISection expo-pedometer 1`] = `
          
       </span>
       <div
-        class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 css-7sgr13-PlatformTag"
+        class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-7sgr13-PlatformTag"
       >
         <svg
           class="icon-xs text-palette-blue12"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
        
     </span>
     <div
-      class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 css-7sgr13-PlatformTag"
+      class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-7sgr13-PlatformTag"
     >
       <svg
         class="icon-xs text-palette-green12"

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,7 @@
     "@mdx-js/loader": "^2.2.1",
     "@mdx-js/mdx": "^2.2.1",
     "@mdx-js/react": "^2.2.1",
+    "@radix-ui/react-tooltip": "^1.0.7",
     "@reach/tabs": "^0.18.0",
     "@sentry/react": "^7.80.1",
     "clipboard-copy": "^4.0.1",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -11,6 +11,7 @@ import DocumentationElements from '~/components/page-higher-order/DocumentationE
 import { AnalyticsProvider } from '~/providers/Analytics';
 import { CodeBlockSettingsProvider } from '~/providers/CodeBlockSettingsProvider';
 import { markdownComponents } from '~/ui/components/Markdown';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 import 'global-styles/global.css';
 import '@expo/styleguide/dist/expo-theme.css';
@@ -59,17 +60,19 @@ export default function App({ Component, pageProps }: AppProps) {
       <ThemeProvider>
         <CodeBlockSettingsProvider>
           <MDXProvider components={rootMarkdownComponents}>
-            <Global
-              styles={css({
-                'html, body, kbd, button, input, select': {
-                  fontFamily: regularFont.style.fontFamily,
-                },
-                'code, pre, table.diff': {
-                  fontFamily: monospaceFont.style.fontFamily,
-                },
-              })}
-            />
-            <Component {...pageProps} />
+            <Tooltip.Provider>
+              <Global
+                styles={css({
+                  'html, body, kbd, button, input, select': {
+                    fontFamily: regularFont.style.fontFamily,
+                  },
+                  'code, pre, table.diff': {
+                    fontFamily: monospaceFont.style.fontFamily,
+                  },
+                })}
+              />
+              <Component {...pageProps} />
+            </Tooltip.Provider>
           </MDXProvider>
         </CodeBlockSettingsProvider>
       </ThemeProvider>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -47,7 +47,7 @@ const Home = () => {
   const { palette, background } = theme;
   return (
     <ScreenClassProvider>
-      <DocumentationPage tocVisible={false} hideFromSearch>
+      <DocumentationPage hideTOC hideFromSearch>
         <div className="h-0">
           <DevicesImageMasks />
         </div>

--- a/docs/pages/versions/unversioned/sdk/accelerometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.mdx
@@ -4,17 +4,14 @@ description: A library that provides access to the device's accelerometer sensor
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-import PlatformsSection from '~/components/plugins/PlatformsSection';
-
 `Accelerometer` from `expo-sensors` provides access to the device accelerometer sensor(s) and associated listeners to respond to changes in acceleration in three-dimensional space, meaning any movement or vibration.
-
-<PlatformsSection android emulator ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -3,19 +3,17 @@ title: AppleAuthentication
 description: A library that provides Sign in with Apple capability for iOS 13 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
+platforms: ['ios 13+', 'tvos']
 ---
 
 import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
 Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
-
-<PlatformsSection ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/application.mdx
+++ b/docs/pages/versions/unversioned/sdk/application.mdx
@@ -3,6 +3,7 @@ title: Application
 description: A universal library that provides information native application's ID, app name and build version at runtime.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-application'
 packageName: 'expo-application'
+platforms: ['android', 'ios', 'web', 'tvos']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -10,8 +11,6 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -3,6 +3,7 @@ title: Asset
 description: A universal library that allows downloading assets and using them with other libraries.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-asset'
 packageName: 'expo-asset'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -10,8 +11,6 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-asset`** provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -3,14 +3,12 @@ title: AsyncStorage
 description: A library that provides an asynchronous, unencrypted, persistent, key-value storage API.
 sourceCodeUrl: 'https://github.com/react-native-async-storage/async-storage'
 packageName: '@react-native-async-storage/async-storage'
+platforms: ['android', 'ios', 'macos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 An asynchronous, unencrypted, persistent, key-value storage API.
-
-<PlatformsSection android emulator ios web simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -4,10 +4,10 @@ description: A library that provides an API to implement audio playback and reco
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import APISection from '~/components/plugins/APISection';
 import { PlatformTags } from '~/ui/components/Tag';
@@ -17,8 +17,6 @@ import { PlatformTags } from '~/ui/components/Tag';
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
 Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -3,17 +3,15 @@ title: AuthSession
 description: A universal library that provides an API to handle browser-based authentication.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-auth-session'
 packageName: 'expo-auth-session'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { Terminal } from '~/ui/components/Snippet';
 
 `AuthSession` enables web browser-based authentication (for example, browser-based OAuth flows) in your app by utilizing [WebBrowser](webbrowser.mdx) and [Crypto](crypto.mdx). For implementation details, refer to this reference, and for usage, see the [Authentication](/guides/authentication/) guide.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -4,11 +4,11 @@ description: A universal library that provides separate APIs for Audio and Video
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -21,8 +21,6 @@ The [`Audio.Sound`](audio.mdx) objects and [`Video`](video.mdx) components share
 Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
 Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -3,11 +3,11 @@ title: BackgroundFetch
 description: A universal library that provides API for performing background fetch tasks.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-background-fetch'
 packageName: 'expo-background-fetch'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
@@ -15,8 +15,6 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
 
 `expo-background-fetch` provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
-
-<PlatformsSection android emulator ios simulator />
 
 #### Known issues&ensp;<PlatformTags platforms={['ios']} />
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -4,11 +4,11 @@ description: A library that allows scanning a variety of supported barcodes. It 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-barcode-scanner'
 packageName: 'expo-barcode-scanner'
 iconUrl: '/static/images/packages/expo-barcode-scanner.png'
+platforms: ['android*', 'ios*']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import {
@@ -22,8 +22,6 @@ import { PlatformTags } from '~/ui/components/Tag';
 > **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend using [`expo-camera/next`](camera-next) which has barcode scanning built-in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
-
-<PlatformsSection android ios />
 
 #### Limitations
 

--- a/docs/pages/versions/unversioned/sdk/barometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/barometer.mdx
@@ -4,17 +4,15 @@ description: A library that provides access to device's barometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios*']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { NoIcon } from '~/ui/components/DocIcons';
 
 `Barometer` from **`expo-sensors`** provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
-
-<PlatformsSection android emulator ios />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/battery.mdx
+++ b/docs/pages/versions/unversioned/sdk/battery.mdx
@@ -4,16 +4,14 @@ description: A library that provides battery information for the physical device
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-battery'
 packageName: 'expo-battery'
 iconUrl: '/static/images/packages/expo-battery.png'
+platforms: ['android', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
-
-<PlatformsSection android emulator ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -4,18 +4,16 @@ description: A React component that blurs everything underneath the view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-blur'
 packageName: 'expo-blur'
 iconUrl: '/static/images/packages/expo-blur.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 A React component that blurs everything underneath the view. Common usage of this is for navigation bars, tab bars, and modals.
 
 > **info** `BlurView` on Android is an experimental feature. To enable it use the [`experimentalBlurMethod`](#experimentalblurmethod) prop.
-
-<PlatformsSection emulator android ios simulator web />
 
 #### Known issues
 

--- a/docs/pages/versions/unversioned/sdk/brightness.mdx
+++ b/docs/pages/versions/unversioned/sdk/brightness.mdx
@@ -4,11 +4,11 @@ description: A library that provides access to an API for getting and setting th
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-brightness'
 packageName: 'expo-brightness'
 iconUrl: '/static/images/packages/expo-brightness.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
@@ -16,8 +16,6 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 An API to get and set screen brightness.
 
 On Android, there is a global system-wide brightness setting, and each app has its own brightness setting that can optionally override the global setting. It is possible to set either of these values with this API. On iOS, the system brightness setting cannot be changed programmatically; instead, any changes to the screen brightness will persist until the device is locked or powered off.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -3,20 +3,18 @@ title: BuildProperties
 description: A config plugin that allows customizing native build properties during prebuild.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-build-properties'
 packageName: 'expo-build-properties'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
 
 > **info** This config plugin configures how [Prebuild command](/workflow/prebuild) generates the native **android** and **ios** folders
 > and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
-
-<PlatformsSection ios simulator android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -3,11 +3,11 @@ title: Calendar
 description: A library that provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-calendar'
 packageName: 'expo-calendar'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import {
   ConfigReactNative,
@@ -17,8 +17,6 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-calendar` provides an API for interacting with the device's system calendars, events, reminders, and associated records.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/camera-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-next.mdx
@@ -4,11 +4,11 @@ description: A React component that renders a preview for the device's front or 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-camera'
 packageName: 'expo-camera'
 iconUrl: '/static/images/packages/expo-camera.png'
+platforms: ['android*', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import PrereleaseNotice from '~/components/PrereleaseNotice';
 import {
   ConfigReactNative,
@@ -23,8 +23,6 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 </PrereleaseNotice>
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
-
-<PlatformsSection android ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -4,11 +4,11 @@ description: A React component that renders a preview for the device's front or 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-camera'
 packageName: 'expo-camera'
 iconUrl: '/static/images/packages/expo-camera.png'
+platforms: ['android*', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import {
   ConfigReactNative,
@@ -18,8 +18,6 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
-
-<PlatformsSection android ios web />
 
 > **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
 

--- a/docs/pages/versions/unversioned/sdk/captureRef.mdx
+++ b/docs/pages/versions/unversioned/sdk/captureRef.mdx
@@ -3,18 +3,16 @@ title: captureRef
 description: A library that allows you to capture a React Native view and save it as an image.
 sourceCodeUrl: 'https://github.com/gre/react-native-view-shot'
 packageName: 'react-native-view-shot'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.mdx#takesnapshotasyncoptions) instead.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/cellular.mdx
+++ b/docs/pages/versions/unversioned/sdk/cellular.mdx
@@ -4,17 +4,15 @@ description: An API that provides information about the user's cellular service 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-cellular'
 packageName: 'expo-cellular'
 iconUrl: '/static/images/packages/expo-cellular.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-cellular` provides information about the user's cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
-
-<PlatformsSection android emulator ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/checkbox.mdx
@@ -3,16 +3,14 @@ title: Checkbox
 description: A universal React component that provides basic checkbox functionality.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-checkbox'
 packageName: 'expo-checkbox'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
-
-<PlatformsSection android emulator web ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/clipboard.mdx
+++ b/docs/pages/versions/unversioned/sdk/clipboard.mdx
@@ -4,16 +4,14 @@ description: A universal library that allows getting and setting Clipboard conte
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-clipboard'
 packageName: 'expo-clipboard'
 iconUrl: '/static/images/packages/expo-clipboard.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/constants.mdx
+++ b/docs/pages/versions/unversioned/sdk/constants.mdx
@@ -3,15 +3,13 @@ title: Constants
 description: An API that provides system information that remains constant throughout the lifetime of your app's installation.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-constants'
 packageName: 'expo-constants'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -4,11 +4,11 @@ description: A library that provides access to the phone's system contacts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-contacts'
 packageName: 'expo-contacts'
 iconUrl: '/static/images/packages/expo-contacts.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import {
   ConfigReactNative,
@@ -20,8 +20,6 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 `expo-contacts` provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
 
 On iOS, contacts have a multi-layered grouping system that you can also access through this API.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/crypto.mdx
+++ b/docs/pages/versions/unversioned/sdk/crypto.mdx
@@ -4,16 +4,14 @@ description: A universal library for crypto operations.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-crypto'
 packageName: 'expo-crypto'
 iconUrl: '/static/images/packages/expo-crypto.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-crypto` enables you to hash data in an equivalent manner to the Node.js core `crypto` API.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -3,17 +3,15 @@ title: DateTimePicker
 description: A component that provides access to the system UI for date and time selection.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-datetimepicker'
 packageName: '@react-native-community/datetimepicker'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
 A component that provides access to the system UI for date and time selection.
 
 <Video file={'sdk/datetimepicker.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -4,6 +4,7 @@ description: 'A library that allows to create a development build.'
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-dev-client'
 packageName: 'expo-dev-client'
 iconUrl: '/static/images/packages/expo-dev-client.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -12,7 +13,6 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-dev-client` adds various useful development tools to your debug builds:
 
@@ -21,8 +21,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 - [a powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/device.mdx
+++ b/docs/pages/versions/unversioned/sdk/device.mdx
@@ -4,15 +4,13 @@ description: A universal library provides access to system information about the
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-device'
 packageName: 'expo-device'
 iconUrl: '/static/images/packages/expo-device.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/devicemotion.mdx
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.mdx
@@ -4,11 +4,11 @@ description: A library that provides access to a device's motion and orientation
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,8 +17,6 @@ import {
 import { IOSPermissions } from '~/components/plugins/permissions';
 
 `DeviceMotion` from `expo-sensors` provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -4,6 +4,7 @@ description: A library that provides access to the system's UI for selecting doc
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-document-picker'
 packageName: 'expo-document-picker'
 iconUrl: '/static/images/packages/expo-document-picker.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import {
@@ -13,14 +14,11 @@ import {
 } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
 `expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -3,19 +3,17 @@ title: FaceDetector
 description: A library that uses Google Mobile Vision to detect faces on images.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-face-detector'
 packageName: 'expo-face-detector'
+platforms: ['android*', 'ios*']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
 > **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend [`react-native-vision-camera`](https://github.com/mrousavy/react-native-vision-camera) if you require this functionality.
 
 `expo-face-detector` lets you use the power of the [Google's ML Kit](https://developers.google.com/ml-kit/vision/face-detection) framework to detect faces on images.
-
-<PlatformsSection android ios />
 
 #### Known issues&ensp;<PlatformTags platforms={['android']} />
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -4,6 +4,7 @@ description: A library that provides access to the local file system on the devi
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-file-system'
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
+platforms: ['android', 'ios', 'tvos']
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
@@ -11,7 +12,6 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-file-system` provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
@@ -24,8 +24,6 @@ import { SnackInline } from '~/ui/components/Snippet';
   style={{ maxWidth: 850, maxHeight: 600 }}
   containerClassName="bg-white"
 />
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -3,6 +3,7 @@ title: FlashList
 description: A React Native component that provides a fast and performant way to render lists.
 sourceCodeUrl: 'https://github.com/shopify/flash-list'
 packageName: '@shopify/flash-list'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -4,6 +4,7 @@ description: A library that allows loading fonts at runtime and using them in Re
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-font'
 packageName: 'expo-font'
 iconUrl: '/static/images/packages/expo-font.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import {
@@ -13,12 +14,9 @@ import {
 } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-font` allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Fonts](/develop/user-interface/fonts/) guide.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -3,6 +3,7 @@ title: GestureHandler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -4,16 +4,14 @@ description: A library that provides GLView that acts as an OpenGL ES render tar
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-gl'
 packageName: 'expo-gl'
 iconUrl: '/static/images/packages/expo-gl.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/gyroscope.mdx
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.mdx
@@ -4,16 +4,14 @@ description: A library that provides access to the device's gyroscope sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
-
-<PlatformsSection android emulator ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -4,11 +4,11 @@ description: A library that provides access to the system's vibration effects on
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-haptics'
 packageName: 'expo-haptics'
 iconUrl: '/static/images/packages/expo-haptics.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-haptics`** provides haptic (touch) feedback for
@@ -21,8 +21,6 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 - Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
 - User disabled the Taptic Engine in settings.
 - iOS Camera is active (in order prevent destabilization).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -4,11 +4,11 @@ description: A cross-platform and performant React component that loads and rend
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-image'
 packageName: 'expo-image'
 iconUrl: '/static/images/packages/expo-image.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
@@ -23,8 +23,6 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 - Transitioning between images when the source changes (no more flickering!)
 - Implements the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) and [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) properties (see [`contentFit`](#contentfit) and [`contentPosition`](#contentposition) props)
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
-
-<PlatformsSection android emulator ios simulator web />
 
 #### Supported image formats
 

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -4,16 +4,14 @@ description: A library that provides an API for image manipulation on the local 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-image-manipulator'
 packageName: 'expo-image-manipulator'
 iconUrl: '/static/images/packages/expo-image-manipulator.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-manipulator`** provides an API to modify images stored on the local file system.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -4,6 +4,7 @@ description: A library that provides access to the system's UI for selecting ima
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-image-picker'
 packageName: 'expo-image-picker'
 iconUrl: '/static/images/packages/expo-image-picker.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import {
@@ -14,7 +15,6 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -24,8 +24,6 @@ import { PlatformTags } from '~/ui/components/Tag';
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
 <Video file={'sdk/imagepicker.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.mdx
@@ -3,15 +3,13 @@ title: IntentLauncher
 description: A library that provides an API to launch Android intents.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-intent-launcher'
 packageName: 'expo-intent-launcher'
+platforms: ['android']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
-
-<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/keep-awake.mdx
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.mdx
@@ -4,16 +4,14 @@ description: A React component that prevents the screen from sleeping when rende
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-keep-awake'
 packageName: 'expo-keep-awake'
 iconUrl: '/static/images/packages/expo-keep-awake.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/light-sensor.mdx
+++ b/docs/pages/versions/unversioned/sdk/light-sensor.mdx
@@ -4,16 +4,14 @@ description: A library that provides access to the device's light sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `LightSensor` from `expo-sensors` provides access to the device's light sensor to respond to illuminance changes.
-
-<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
@@ -4,16 +4,14 @@ description: A universal React component that renders a gradient view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-linear-gradient'
 packageName: 'expo-linear-gradient'
 iconUrl: '/static/images/packages/expo-linear-gradient.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/linking.mdx
+++ b/docs/pages/versions/unversioned/sdk/linking.mdx
@@ -3,17 +3,15 @@ title: Linking
 description: An API that provides methods to create and open deep links universally.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-linking'
 packageName: 'expo-linking'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-linking` provides utilities for your app to interact with other installed apps using deep links. It also provides helper methods for constructing and parsing deep links into your app. This module is an extension of the React Native [Linking](https://reactnative.dev/docs/linking.html) module.
 
 For a more comprehensive explanation of how to use `expo-linking`, refer to the [Linking guide](/guides/linking).
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -4,11 +4,11 @@ description: A library that provides functionality for implementing the Fingerpr
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-local-authentication'
 packageName: 'expo-local-authentication'
 iconUrl: '/static/images/packages/expo-local-authentication.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,8 +17,6 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -4,16 +4,14 @@ description: A library that provides an interface for native user localization i
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-localization'
 packageName: 'expo-localization'
 iconUrl: '/static/images/packages/expo-localization.png'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device. Using a localization library such as [`lingui-js`](https://lingui.dev/introduction), [`react-i18next`](https://react.i18next.com/), [`react-intl`](https://formatjs.io/docs/getting-started/installation/) or [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -4,11 +4,11 @@ description: A library that provides access to reading geolocation information, 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-location'
 packageName: 'expo-location'
 iconUrl: '/static/images/packages/expo-location.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import {
@@ -19,8 +19,6 @@ import {
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -3,17 +3,15 @@ title: Lottie
 description: A library that allows rendering After Effects animations.
 sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
 packageName: 'lottie-react-native'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
@@ -25,9 +23,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 ## Usage
 
 <SnackInline
-label="Lottie"
-dependencies={['lottie-react-native']}
-files={{
+  label="Lottie"
+  dependencies={['lottie-react-native']}
+  files={{
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 

--- a/docs/pages/versions/unversioned/sdk/magnetometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.mdx
@@ -4,18 +4,16 @@ description: A library that provides access to the device's magnetometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 
 You can access the calibrated values with `Magnetometer` and uncalibrated raw values with `MagnetometerUncalibrated`.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/mail-composer.mdx
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.mdx
@@ -4,18 +4,16 @@ description: A library that provides functionality to compose and send emails wi
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-mail-composer'
 packageName: 'expo-mail-composer'
 iconUrl: '/static/images/packages/expo-mail-composer.png'
+platforms: ['android', 'ios*', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
 **`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <Video file={'sdk/mailcomposer.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -3,10 +3,10 @@ title: MapView
 description: A library that provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 sourceCodeUrl: 'https://github.com/react-native-maps/react-native-maps'
 packageName: 'react-native-maps'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -16,8 +16,6 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -3,6 +3,7 @@ title: MaskedView
 description: A library that provides a masked view.
 sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
 packageName: '@react-native-masked-view/masked-view'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -4,6 +4,7 @@ description: A library that provides access to the device's media library.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-media-library'
 packageName: 'expo-media-library'
 iconUrl: '/static/images/packages/expo-media-library.png'
+platforms: ['android', 'ios']
 ---
 
 import {
@@ -14,13 +15,10 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
 > **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and `expo-media-library` won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
@@ -3,19 +3,17 @@ title: NavigationBar
 description: A library that provides access to various interactions with the native navigation bar on Android.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-navigation-bar'
 packageName: 'expo-navigation-bar'
+platforms: ['android']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
 
 Properties are named after style properties; visibility, position, backgroundColor, borderColor, and so on.
 
 The APIs in this package have no impact when "Gesture Navigation" is enabled on the Android device. There is currently no native Android API to detect if "Gesture Navigation" is enabled or not.
-
-<PlatformsSection android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -3,14 +3,12 @@ title: NetInfo
 description: A cross-platform API that provides access to network information.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 packageName: '@react-native-community/netinfo'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `@react-native-community/netinfo` allows you to get information about connection type and connection quality.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/network.mdx
+++ b/docs/pages/versions/unversioned/sdk/network.mdx
@@ -4,15 +4,13 @@ description: A library that provides access to the device's network such as its 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-network'
 packageName: 'expo-network'
 iconUrl: '/static/images/packages/expo-network.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -4,6 +4,7 @@ description: A library that provides an API to fetch push notification tokens an
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-notifications'
 packageName: 'expo-notifications'
 iconUrl: '/static/images/packages/expo-notifications.png'
+platforms: ['android*', 'ios*', 'web']
 ---
 
 import { ConfigReactNative, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
@@ -11,7 +12,6 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 import { SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 import APISection from '~/components/plugins/APISection';
 import { PlatformTags } from '~/ui/components/Tag';
@@ -19,23 +19,13 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-<PlatformsSection title="Push notifications Platform Compatibility" android ios />
-
-<PlatformsSection
-  title="Local notifications Platform Compatibility"
-  android
-  emulator
-  ios
-  simulator
-/>
-
 ## Features
 
 - Schedule a one-off notification for a specific date or some time from now
 - Schedule a notification repeating in some time interval (or a calendar date match on iOS)
 - Get and set the application badge icon number
-- Fetch a native device push token so you can send push notifications with FCM and APNs
-- Fetch an Expo push token so you can send push notifications with Expo
+- Fetch a native device push token, so you can send push notifications with FCM and APNs
+- Fetch an Expo push token, so you can send push notifications with Expo
 - Listen to incoming notifications in the foreground and background
 - Listen to interactions with notifications
 - Handle notifications when the app is in the foreground

--- a/docs/pages/versions/unversioned/sdk/pedometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/pedometer.mdx
@@ -4,16 +4,14 @@ description: A library that provides access to the device's pedometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `Pedometer` from `expo-sensors` uses the system `hardware.Sensor` on Android and Core Motion on iOS to get the user's step count, and also allows you to subscribe to pedometer updates.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -3,6 +3,7 @@ title: Picker
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'
+platforms: ['android', 'ios', 'macos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -4,16 +4,14 @@ description: A library that provides printing functionality for Android and iOS 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-print'
 packageName: 'expo-print'
 iconUrl: '/static/images/packages/expo-print.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-print` provides an API for Android and iOS (AirPrint) printing functionality.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -3,10 +3,10 @@ title: Reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
@@ -14,8 +14,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. To use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -3,14 +3,12 @@ title: registerRootComponent
 description: A universal component that allows setting the initial React component to render natively in the app's root React Native view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo/src/launch'
 packageName: 'expo'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Sets the initial React component to render natively in the app's root React Native view on iOS, Android, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -3,11 +3,11 @@ title: SafeAreaContext
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { APIBox } from '~/components/plugins/APIBox';
 import { CALLOUT } from '~/ui/components/Text';
 import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
@@ -15,8 +15,6 @@ import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -3,11 +3,11 @@ title: ScreenCapture
 description: A library that allows you to protect screens in your app from being captured or recorded.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-screen-capture'
 packageName: 'expo-screen-capture'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-screen-capture` allows you to protect screens in your app from being captured or recorded, as well as be notified if a screenshot is taken while your app is foregrounded. The two most common reasons you may want to prevent screen capture are:
@@ -18,8 +18,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 This is especially important on Android since the [`android.media.projection`](https://developer.android.com/about/versions/android-5.0.html#ScreenCapture) API allows third-party apps to perform screen capture or screen sharing (even if the app is in the background).
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
@@ -4,6 +4,7 @@ description: A universal library for managing a device's screen orientation.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-screen-orientation'
 packageName: 'expo-screen-orientation'
 iconUrl: '/static/images/packages/expo-screen-orientation.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import {
@@ -11,11 +12,9 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
-import { palette } from '@expo/styleguide';
 import APISection from '~/components/plugins/APISection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Screen Orientation is defined as the orientation in which graphics are painted on the device. For example, the figure below has a device in a vertical and horizontal physical orientation, but a portrait screen orientation. For physical device orientation, see the orientation section of [Device Motion](devicemotion.mdx).
 
@@ -27,8 +26,6 @@ Screen Orientation is defined as the orientation in which graphics are painted o
 On both Android and iOS platforms, changes to the screen orientation will override any system settings or user preferences. On Android, it is possible to change the screen orientation while taking the user's preferred orientation into account. On iOS, user and system settings are not accessible by the application and any changes to the screen orientation will override existing settings.
 
 > Web has [limited support](https://caniuse.com/#feat=deviceorientation).
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/screens.mdx
+++ b/docs/pages/versions/unversioned/sdk/screens.mdx
@@ -3,16 +3,14 @@ title: Screens
 description: A library that provides native primitives to represent screens instead of plain React Native View components for better operating system behavior and screen optimizations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
 packageName: 'react-native-screens'
+platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`react-native-screens`** provides native primitives to represent screens instead of plain `<View>` components To better take advantage of operating system behavior and optimizations around screens. This capability is used by library authors and unlikely to be used directly by most app developers. It also provides the native components needed for React Navigation's [createNativeStackNavigator](https://reactnavigation.org/docs/native-stack-navigator).
 
 > Note: Please refer to [the issue tracker](https://github.com/software-mansion/react-native-screens/issues) if you encounter any problems.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -4,11 +4,11 @@ description: A library that provides a way to encrypt and securely store key-val
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-secure-store'
 packageName: 'expo-secure-store'
 iconUrl: '/static/images/packages/expo-secure-store.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import {
   ConfigPluginExample,
   ConfigReactNative,
@@ -21,8 +21,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 **Size limit for a value is 2048 bytes. An attempt to store larger values may fail. Currently, we print a warning when the limit is reached, however, in a future SDK version an error might be thrown.**
 
 **The `requireAuthentication` option is not supported in Expo Go when biometric authentication is available due to a missing `NSFaceIDUsageDescription` key.**
-
-<PlatformsSection android emulator ios simulator />
 
 > This API is not compatible with devices running Android 5 or lower.
 

--- a/docs/pages/versions/unversioned/sdk/segmented-control.mdx
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.mdx
@@ -3,14 +3,12 @@ title: SegmentedControl
 description: A React Native library that provides a component to render UISegmentedControl from iOS.
 sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
 packageName: '@react-native-segmented-control/segmented-control'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
-
-<PlatformsSection android emulator ios web simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -4,17 +4,15 @@ description: A library that provides access to a device's accelerometer, baromet
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-sensors` provides various APIs for accessing device sensors to measure motion, orientation, pressure, magnetic fields, ambient light, and step count.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sharing.mdx
+++ b/docs/pages/versions/unversioned/sdk/sharing.mdx
@@ -4,18 +4,16 @@ description: A library that provides implementing sharing files.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sharing'
 packageName: 'expo-sharing'
 iconUrl: '/static/images/packages/expo-sharing.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
 **`expo-sharing`** allows you to share files directly with other compatible applications.
 
 <Video file={'sdk/sharing.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios simulator web />
 
 #### Sharing limitations on web
 

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -3,6 +3,7 @@ title: Skia
 description: A React Native library for creating graphics using Skia.
 sourceCodeUrl: 'https://github.com/shopify/react-native-skia'
 packageName: '@shopify/react-native-skia'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
@@ -11,8 +12,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`@shopify/react-native-skia`** brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -3,19 +3,16 @@ title: Slider
 description: A React Native component library that provides access to the system UI for a slider control.
 sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
 packageName: '@react-native-community/slider'
+platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
-import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sms.mdx
+++ b/docs/pages/versions/unversioned/sdk/sms.mdx
@@ -4,15 +4,13 @@ description: A library that provides access to the system's UI/app for sending S
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sms'
 packageName: 'expo-sms'
 iconUrl: '/static/images/packages/expo-sms.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-sms`** provides access to the system's UI/app for sending SMS messages.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -4,16 +4,14 @@ description: A library that provides access to text-to-speech functionality.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-speech'
 packageName: 'expo-speech'
 iconUrl: '/static/images/packages/expo-speech.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -4,18 +4,16 @@ description: A library that provides access to controlling the visibility behavi
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-splash-screen'
 packageName: 'expo-splash-screen'
 iconUrl: '/static/images/packages/expo-splash-screen.png'
+platforms: ['android', 'ios', 'tvos']
 ---
 
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
 Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen/), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -5,11 +5,11 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sqlite'
 packageName: 'expo-sqlite'
 maxHeadingDepth: 3
 iconUrl: '/static/images/packages/expo-sqlite.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import PrereleaseNotice from '~/components/PrereleaseNotice';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -20,8 +20,6 @@ import { Step } from '~/ui/components/Step';
 </PrereleaseNotice>
 
 `expo-sqlite` gives your app access to a database that can be queried through a SQLite API. The database is persisted across restarts of your app.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -4,19 +4,17 @@ description: A library that provides access to a database that can be queried th
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sqlite'
 packageName: 'expo-sqlite'
 iconUrl: '/static/images/packages/expo-sqlite.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -5,16 +5,14 @@ description: A library that provides the same interface as the React Native Stat
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-status-bar'
 packageName: 'expo-status-bar'
 iconUrl: '/static/images/packages/expo-status-bar.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-status-bar`** gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
-
-<PlatformsSection android emulator ios simulator web />
 
 > **Web support**
 >

--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -4,12 +4,12 @@ description: A library that provides access to native APIs for in-app reviews.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-store-review'
 packageName: 'expo-store-review'
 iconUrl: '/static/images/packages/expo-store-review.png'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-store-review`** provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
 
@@ -17,8 +17,6 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
   src="/static/images/store-review.png"
   alt="Screenshots of the store review API in action on iOS"
 />
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -3,16 +3,14 @@ title: Stripe
 description: A library that provides access to native APIs for integrating Stripe payments.
 sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native and Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
 > Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to the new `@stripe/stripe-react-native` library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -3,17 +3,15 @@ title: Svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'
+platforms: ['android', 'ios', 'macos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/system-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/system-ui.mdx
@@ -3,15 +3,13 @@ title: SystemUI
 description: A library that allows interacting with system UI elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-system-ui'
 packageName: 'expo-system-ui'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
-
-<PlatformsSection ios simulator web android emulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -3,11 +3,11 @@ title: TaskManager
 description: A library that provides support for tasks that can run in the background.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-task-manager'
 packageName: 'expo-task-manager'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
@@ -17,8 +17,6 @@ Some features of this module are used by other modules under the hood. Here is a
 - [Location](location.mdx)
 - [BackgroundFetch](background-fetch.mdx)
 - [Notifications](notifications.mdx)
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -3,6 +3,7 @@ title: TrackingTransparency
 description: A library for requesting permission to track the users on devices using iOS 14 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-tracking-transparency'
 packageName: 'expo-tracking-transparency'
+platforms: ['android', 'ios']
 ---
 
 import {
@@ -13,14 +14,11 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, and more. This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked. Otherwise, your app will be rejected by Apple.
 
 For more information on Apple's new App Tracking Transparency framework, please refer to their [documentation](https://developer.apple.com/app-store/user-privacy-and-data-use/).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -4,19 +4,17 @@ description: A library that allows programmatically controlling and responding t
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-updates'
 packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
+platforms: ['android', 'ios', 'tvos']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
 The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -1,15 +1,12 @@
 ---
 title: URL
-description: Standard URL API available on all Expo-supported platforms. 
+description: Standard URL API available on all Expo-supported platforms.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo'
 packageName: 'expo'
+platforms: ['android', 'ios', 'web']
 ---
 
-import PlatformsSection from '~/components/plugins/PlatformsSection';
-
 The standard URL API is available on all Expo-supported platforms.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
@@ -25,9 +22,9 @@ const params = new URLSearchParams();
 
 ## Conformance
 
-Expo's built-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL). 
+Expo's built-in URL support attempts to be fully [spec compliant](https://developer.mozilla.org/en-US/docs/Web/API/URL).
 
-The only missing exception is that native platforms do not currently support [non-ASCII characters](https://unicode.org/reports/tr46/) in the hostname. 
+The only missing exception is that native platforms do not currently support [non-ASCII characters](https://unicode.org/reports/tr46/) in the hostname.
 
 Consider the following example:
 

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -3,16 +3,14 @@ title: VideoThumbnails
 description: A library that allows you to generate an image to serve as a thumbnail from a video file.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video-thumbnails'
 packageName: 'expo-video-thumbnails'
+platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -4,18 +4,16 @@ description: A library that provides an API to implement video playback and reco
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
 Much of Video and Audio have common APIs that are documented in [AV documentation](av.mdx). This page covers video-specific props and APIs. We encourage you to skim through this document to get basic video working, and then move on to [AV documentation](av.mdx) for more advanced functionality. The audio experience of video (such as whether to interrupt music already playing in another app, or whether to play sound while the phone is on silent mode) can be customized using the [Audio API](audio.mdx).
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -3,10 +3,10 @@ title: ViewPager
 description: A component library that provides a carousel-like view to swipe through pages of content.
 sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
 packageName: 'react-native-pager-view'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
@@ -14,8 +14,6 @@ import Video from '~/components/plugins/Video';
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={'sdk/viewpager.mp4'} loop={false} />
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/webbrowser.mdx
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.mdx
@@ -4,16 +4,14 @@ description: A library that provides access to the system's web browser and supp
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-web-browser'
 packageName: 'expo-web-browser'
 iconUrl: '/static/images/packages/expo-web-browser.png'
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-web-browser` provides access to the system's web browser and supports handling redirects. On Android, it uses `ChromeCustomTabs` and on iOS, it uses `SFSafariViewController` or `SFAuthenticationSession`, depending on the method you call. As of iOS 11, `SFSafariViewController` no longer shares cookies with Safari, so if you are using `WebBrowser` for authentication you will want to use `WebBrowser.openAuthSessionAsync`, and if you just want to open a webpage (such as your app privacy policy), then use `WebBrowser.openBrowserAsync`.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -3,15 +3,13 @@ title: WebView
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 packageName: 'react-native-webview'
+platforms: ['android', 'ios']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
 **`react-native-webview`** provides a `WebView` component that renders web content in a native view.
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -53,6 +53,46 @@ module.exports = {
           opacity: 0,
         },
       },
+      slideDownAndFade: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateY(8px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateY(0)',
+        },
+      },
+      slideRightAndFade: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateX(8px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateX(0)',
+        },
+      },
+      slideLeftAndFade: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateX(-8px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateX(0)',
+        },
+      },
+      slideUpAndFade: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateY(-8px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateY(0)',
+        },
+      },
       slideUpAndFadeIn: {
         '0%': {
           opacity: 0,
@@ -67,6 +107,10 @@ module.exports = {
     animation: {
       fadeIn: 'fadeIn 0.25s ease-out',
       fadeOut: 'fadeOut 0.15s ease-in',
+      slideDownAndFade: 'slideDownAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+      slideRightAndFade: 'slideRightAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+      slideLeftAndFade: 'slideLeftAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+      slideUpAndFade: 'slideUpAndFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
       slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
     },
   },

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -8,6 +8,7 @@ export type PageMetadata = {
   /* If the page should not show up in the Algolia Docsearch results */
   hideFromSearch?: boolean;
   hideTOC?: boolean;
+  platforms?: string[];
 };
 
 /**
@@ -49,4 +50,13 @@ export type NavigationRouteWithSection = NavigationRoute & { section?: string };
  * Available platforms supported by our APIs.
  * Temporarily it also accepts other strings for compatibility reasons.
  */
-export type PlatformName = 'ios' | 'android' | 'web' | 'expo' | string;
+export type PlatformName =
+  | 'ios'
+  | 'ios-nosim'
+  | 'android'
+  | 'android-noemu'
+  | 'web'
+  | 'expo'
+  | 'macos'
+  | 'tvos'
+  | string;

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -1,8 +1,7 @@
-import { css } from '@emotion/react';
-import { breakpoints, spacing } from '@expo/styleguide-base';
+import { Button, mergeClasses } from '@expo/styleguide';
 import { BuildIcon, GithubIcon } from '@expo/styleguide-icons';
 
-import { A, CALLOUT, H1 } from '~/ui/components/Text';
+import { CALLOUT, H1 } from '~/ui/components/Text';
 
 type Props = {
   title?: string;
@@ -14,69 +13,55 @@ type Props = {
 export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => (
   <div className="flex my-2 items-center justify-between max-xl-gutters:flex-col max-xl-gutters:items-start">
     <H1 className="!my-0">
-      {iconUrl && <img src={iconUrl} css={titleIconStyle} alt={`Expo ${title} icon`} />}
+      {iconUrl && (
+        <img
+          src={iconUrl}
+          className="float-left mr-3.5 relative -top-0.5 size-[42px]"
+          alt={`Expo ${title} icon`}
+        />
+      )}
       {packageName && packageName.startsWith('expo-') && 'Expo '}
       {title}
     </H1>
     {packageName && (
-      <span css={linksContainerStyle}>
+      <span className="flex gap-1 max-lg-gutters:mt-3 max-lg-gutters:mb-1">
         {sourceCodeUrl && (
-          <A
-            isStyled
+          <Button
+            theme="quaternary"
+            className="min-h-[48px] min-w-[60px] px-2 justify-center max-lg-gutters:min-h-[unset]"
             openInNewTab
             href={sourceCodeUrl}
-            css={linkStyle}
             title={`View source code of ${packageName} on GitHub`}>
-            <GithubIcon className="text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
-              GitHub
-            </CALLOUT>
-          </A>
+            <div
+              className={mergeClasses(
+                'flex flex-col items-center',
+                'max-lg-gutters:flex-row max-lg-gutters:gap-1.5'
+              )}>
+              <GithubIcon className="text-icon-secondary" />
+              <CALLOUT crawlable={false} theme="secondary">
+                GitHub
+              </CALLOUT>
+            </div>
+          </Button>
         )}
-        <A
-          isStyled
+        <Button
+          theme="quaternary"
           openInNewTab
+          className="min-h-[48px] min-w-[60px] px-2 justify-center max-lg-gutters:min-h-[unset]"
           href={`https://www.npmjs.com/package/${packageName}`}
-          css={linkStyle}
           title="View package in npm Registry">
-          <BuildIcon className="text-icon-secondary" />
-          <CALLOUT crawlable={false} theme="secondary">
-            npm
-          </CALLOUT>
-        </A>
+          <div
+            className={mergeClasses(
+              'flex flex-col items-center',
+              'max-lg-gutters:flex-row max-lg-gutters:gap-1.5'
+            )}>
+            <BuildIcon className="text-icon-secondary" />
+            <CALLOUT crawlable={false} theme="secondary">
+              npm
+            </CALLOUT>
+          </div>
+        </Button>
       </span>
     )}
   </div>
 );
-
-const titleIconStyle = css({
-  float: 'left',
-  marginRight: spacing[3.5],
-  position: 'relative',
-  top: -2,
-  width: 42,
-  height: 42,
-});
-
-const linksContainerStyle = css({
-  display: 'flex',
-  gap: spacing[6],
-
-  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
-    marginTop: spacing[3],
-    marginBottom: spacing[1],
-  },
-});
-
-const linkStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: spacing[0.5],
-  alignItems: 'center',
-  minWidth: 44,
-
-  [`@media screen and (max-width: ${breakpoints.large}px)`]: {
-    flexDirection: 'row',
-    gap: spacing[2],
-  },
-});

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -21,8 +21,10 @@ export const PlatformTag = ({ platform, type, className }: PlatformTagProps) => 
         (platformName === 'android' ||
           platformName === 'ios' ||
           platformName === 'web' ||
-          platformName === 'expo') &&
+          platformName === 'macos' ||
+          platformName === 'tvos') &&
           TAG_CLASSES[platformName],
+        'select-none',
         className
       )}>
       {type !== 'toc' && <PlatformIcon platform={platformName} />}

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -17,6 +17,7 @@ export const StatusTag = ({ status, type, note, className }: StatusTagProps) => 
       className={mergeClasses(
         status === 'deprecated' && TAG_CLASSES['deprecated'],
         status === 'experimental' && TAG_CLASSES['experimental'],
+        'select-none',
         className
       )}
       css={[tagStyle, type === 'toc' && tagToCStyle]}>

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -5,7 +5,8 @@ export const getPlatformName = (text: string): PlatformName => {
   if (text.toLowerCase().includes('ios')) return 'ios';
   if (text.toLowerCase().includes('android')) return 'android';
   if (text.toLowerCase().includes('web')) return 'web';
-  if (text.toLowerCase().includes('expo')) return 'expo';
+  if (text.toLowerCase().includes('macos')) return 'macos';
+  if (text.toLowerCase().includes('tvos')) return 'tvos';
   return '';
 };
 
@@ -13,7 +14,8 @@ export const TAG_CLASSES = {
   android: '!bg-palette-green4 !text-palette-green12 !border-palette-green5',
   ios: '!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5',
   web: '!bg-palette-orange4 !text-palette-orange12 !border-palette-orange5',
-  expo: '!bg-palette-purple4 !text-palette-purple12 !border-palette-purple5',
+  macos: '!bg-palette-purple4 !text-palette-purple12 !border-palette-purple5',
+  tvos: '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5',
   deprecated: '!bg-palette-yellow3 !text-palette-yellow12 !border-palette-yellow5',
   experimental: '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5',
 };
@@ -22,8 +24,10 @@ export const formatName = (name: PlatformName) => {
   const cleanName = name.toLowerCase().replace('\n', '');
   if (cleanName.includes('ios')) {
     return cleanName.replace('ios', 'iOS');
-  } else if (cleanName.includes('expo')) {
-    return cleanName.replace('expo', 'Expo Go');
+  } else if (cleanName.includes('macos')) {
+    return cleanName.replace('macos', 'macOS');
+  } else if (cleanName.includes('tvos')) {
+    return cleanName.replace('tvos', 'tvOS');
   } else {
     return capitalize(name);
   }

--- a/docs/ui/components/Tooltip/Content.tsx
+++ b/docs/ui/components/Tooltip/Content.tsx
@@ -1,0 +1,22 @@
+import { mergeClasses } from '@expo/styleguide';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { HTMLAttributes } from 'react';
+
+type TooltipContentProps = TooltipPrimitive.TooltipContentProps & HTMLAttributes<HTMLDivElement>;
+
+export function Content({ children, className, sideOffset = 4, ...rest }: TooltipContentProps) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        className={mergeClasses(
+          'dark-theme flex flex-col rounded-md bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
+          'data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade',
+          className
+        )}
+        {...rest}>
+        {children}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}

--- a/docs/ui/components/Tooltip/Provider.tsx
+++ b/docs/ui/components/Tooltip/Provider.tsx
@@ -1,0 +1,1 @@
+export { Provider } from '@radix-ui/react-tooltip';

--- a/docs/ui/components/Tooltip/Root.tsx
+++ b/docs/ui/components/Tooltip/Root.tsx
@@ -1,0 +1,9 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+export function Root({ children, delayDuration = 0, ...rest }: TooltipPrimitive.TooltipProps) {
+  return (
+    <TooltipPrimitive.Root delayDuration={delayDuration} {...rest}>
+      {children}
+    </TooltipPrimitive.Root>
+  );
+}

--- a/docs/ui/components/Tooltip/Trigger.tsx
+++ b/docs/ui/components/Tooltip/Trigger.tsx
@@ -1,0 +1,24 @@
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { Children, isValidElement, NamedExoticComponent } from 'react';
+
+export function Trigger({ children, asChild, ...rest }: TooltipPrimitive.TooltipTriggerProps) {
+  if (process.env.NODE_ENV === 'development' && !asChild) {
+    Children.forEach(children, child => {
+      if (
+        isValidElement(child) &&
+        !child.props?.href &&
+        typeof child.type === 'object' &&
+        (child.type as NamedExoticComponent)?.displayName === 'Button'
+      ) {
+        throw Error(
+          'If wrapping button with tooltip trigger use `asChild` prop to prevent hydration issues'
+        );
+      }
+    });
+  }
+  return (
+    <TooltipPrimitive.Trigger asChild={asChild} {...rest}>
+      {children}
+    </TooltipPrimitive.Trigger>
+  );
+}

--- a/docs/ui/components/Tooltip/index.tsx
+++ b/docs/ui/components/Tooltip/index.tsx
@@ -1,0 +1,4 @@
+export { Provider } from './Provider';
+export { Content } from './Content';
+export { Root } from './Root';
+export { Trigger } from './Trigger';

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -527,12 +527,27 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
   integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
 
+"@floating-ui/core@^1.0.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.0.tgz#fa41b87812a16bf123122bf945946bae3fdf7fc1"
+  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
+  dependencies:
+    "@floating-ui/utils" "^0.2.1"
+
 "@floating-ui/dom@^0.5.3":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
   integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
   dependencies:
     "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/dom@^1.6.1":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.3.tgz#954e46c1dd3ad48e49db9ada7218b0985cee75ef"
+  integrity sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==
+  dependencies:
+    "@floating-ui/core" "^1.0.0"
+    "@floating-ui/utils" "^0.2.0"
 
 "@floating-ui/react-dom@0.7.2":
   version "0.7.2"
@@ -541,6 +556,18 @@
   dependencies:
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.8.tgz#afc24f9756d1b433e1fe0d047c24bd4d9cefaa5d"
+  integrity sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+
+"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
 "@gitbeaker/core@^35.8.1":
   version "35.8.1"
@@ -1175,6 +1202,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.0"
 
+"@radix-ui/react-arrow@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
+  integrity sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-collection@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.0.tgz#0ec4c72fabd35a03b5787075ac799e3b17ca5710"
@@ -1392,6 +1427,23 @@
     "@radix-ui/react-use-size" "1.0.0"
     "@radix-ui/rect" "1.0.0"
 
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
 "@radix-ui/react-portal@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.0.tgz#7220b66743394fabb50c55cb32381395cc4a276b"
@@ -1474,6 +1526,25 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
 
+"@radix-ui/react-tooltip@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.0.7.tgz#8f55070f852e7e7450cc1d9210b793d2e5a7686e"
+  integrity sha512-lPh5iKNFVQ/jav/j6ZrWq3blfDJ0OH9R6FlNUHPMqdLuQ9vwDgFsRxvl8b7Asuy5c8xmoojHUxKHQSOAvMHxyw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+
 "@radix-ui/react-use-callback-ref@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
@@ -1542,6 +1613,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/rect" "1.0.0"
 
+"@radix-ui/react-use-rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz#fde50b3bb9fd08f4a1cd204572e5943c244fcec2"
+  integrity sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
 "@radix-ui/react-use-size@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz#a0b455ac826749419f6354dc733e2ca465054771"
@@ -1550,10 +1629,33 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
+"@radix-ui/react-use-size@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz#1c5f5fea940a7d7ade77694bb98116fb49f870b2"
+  integrity sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz#51aed9dd0fe5abcad7dee2a234ad36106a6984ac"
+  integrity sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/rect@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.0.tgz#0dc8e6a829ea2828d53cbc94b81793ba6383bf3c"
   integrity sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.1.tgz#bf8e7d947671996da2e30f4904ece343bc4a883f"
+  integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
 


### PR DESCRIPTION
# Why

We are supporting more platforms nowadays for Expo packages, and we plan to expand on that front in the future, that's why we decided to work on improvements when it comes to convening this information in our API Reference docs.

# How

Add the new platform compatibility tags to the header of package for packages, starting from `unversioned` only docs at this time. Nothing is rock solid in there, we still might want to iterate on the solution, and definitely there is also a room to expand when it comes to the ToC sidebar or in general list compatibility per API entry.

Within this change sI have also added a refreshed Tooltip component based on Radix, and plan to use it to replace the ToC tooltips for overflowing entities names in the future.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview 

Just an example, do not reflect actual package platforms supported! 😉 

![Screenshot 2024-03-05 at 16 20 22](https://github.com/expo/expo/assets/719641/64188383-d13a-4b1d-9962-e2d5e49ea7f3)
