### PR TITLE
[router]: disable <Drawer /> tests due to RN gesture handler failing in Fabric

### DIFF
--- a/packages/expo-router/src/__tests__/smoke.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.ios.tsx
@@ -169,7 +169,11 @@ it('deep linking nested groups', async () => {
   expect(OtherTabsIndex).toHaveBeenCalledTimes(1);
 });
 
-it('can navigate across the drawer navigator', () => {
+// Skipped due to 0.74.0-rc.2 regression.
+// react-native-gesture-handler is failing in Fabric.
+// https://exponent-internal.slack.com/archives/C0447EFTS74/p1709588600921339?thread_ts=1709578927.565339&cid=C0447EFTS74
+// Please enable once `react-native-gesture-handler` is updated
+it.skip('can navigate across the drawer navigator', () => {
   renderRouter({
     _layout: () => <Stack />,
     index: () => <Text testID="index" />,


### PR DESCRIPTION
# Why

The `<Drawer />` tests are failing due #27342

`react-native-gesture-handler` is incorrectly mocked when rendering in Fabric and causes the tests to fail

https://exponent-internal.slack.com/archives/C0447EFTS74/p1709588600921339?thread_ts=1709578927.565339&cid=C0447EFTS74

The `<Drawer />` navigator is a extension of the `<Tabs />` navigator, so we rarely test directly against the `<Drawer />`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
