### PR TITLE
[docs] Notifications: remove legacy notifications system hint

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -19,8 +19,6 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? See [the migration guide](https://expo.fyi/legacy-notifications-to-expo-notifications).
-
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
 <PlatformsSection

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -18,8 +18,6 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? See [the migration guide](https://expo.fyi/legacy-notifications-to-expo-notifications).
-
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
 <PlatformsSection

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -19,8 +19,6 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? See [the migration guide](https://expo.fyi/legacy-notifications-to-expo-notifications).
-
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 
 <PlatformsSection

--- a/docs/pages/versions/v50.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/notifications.mdx
@@ -19,7 +19,6 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 `expo-notifications` provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 
-> Migrating from Expo's `LegacyNotifications` module? See [the migration guide](https://expo.fyi/legacy-notifications-to-expo-notifications).
 
 <PlatformsSection title="Push notifications Platform Compatibility" android ios />
 


### PR DESCRIPTION
# Why

Refs https://exponent-internal.slack.com/archives/C03H8T98KNH/p1709684665330859

# How

Remove legacy notifications system hint form the `expo-notifcation` API Reference. Legacy system has not been supported for around 3 year now.

# Test Plan

Docs changes have been reviewed locally. Lint checks and tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
