### PR TITLE
[tools] fix nightlies patch errors

### DIFF
--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -24,6 +24,8 @@ export default (program: Command) => {
 async function main() {
   const nightlyVersion = await queryNpmDistTagVersionAsync('react-native', 'nightly');
 
+  await removePostinstallPatchAsync();
+
   logger.info('Adding bare-expo optional packages:');
   await addBareExpoOptionalPackagesAsync();
 
@@ -73,6 +75,17 @@ async function main() {
 
   logger.info('Setting up project files for bare-expo.');
   await updateBareExpoAsync(nightlyVersion);
+}
+
+async function removePostinstallPatchAsync() {
+  const packageJsonPath = path.join(EXPO_DIR, 'package.json');
+  const packageJson = await JsonFile.readAsync(packageJsonPath);
+  packageJson.scripts = {
+    ...((packageJson.scripts as Record<string, string> | undefined) ?? {}),
+    postinstall:
+      'yarn-deduplicate && yarn workspace @expo/cli prepare && node ./tools/bin/expotools.js validate-workspace-dependencies',
+  };
+  await JsonFile.writeAsync(packageJsonPath, packageJson);
 }
 
 /**


### PR DESCRIPTION
# Why

fix nightlies error: https://github.com/expo/expo/runs/22327640108

# How

the nightlies patches will conflict with postinstall patches. this pr just remove the postinstall patches

# Test Plan

ci passed
