### PR TITLE
Deprecate old promise in core

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### 💡 Others
 
-- Deprecated `expo.modules.core.Promise`.
+- Deprecated `expo.modules.core.Promise`. ([#27471](https://github.com/expo/expo/pull/27471) by [@aleqsio](https://github.com/aleqsio))
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### 💡 Others
 
+- Deprecated `expo.modules.core.Promise`.
 - Removed deprecated `global.ExpoModules`. ([#26027](https://github.com/expo/expo/pull/26027) by [@tsapeta](https://github.com/tsapeta))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Added an alternative way of installing the JSI bindings. ([#26691](https://github.com/expo/expo/pull/26691) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/Promise.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/Promise.java
@@ -1,7 +1,9 @@
 package expo.modules.core;
 
 import expo.modules.core.interfaces.CodedThrowable;
+import kotlin.Deprecated;
 
+@Deprecated(message = "AsyncFunction will crash when called. Use expo.modules.kotlin.Promise instead")
 public interface Promise {
   String UNKNOWN_ERROR = "E_UNKNOWN_ERROR";
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -245,5 +245,5 @@ internal class UnsupportedClass(
 ) : CodedException(message = "Unsupported type: '$clazz'")
 
 internal class PromiseAlreadySettledException(functionName: String) : CodedException(
-  message = "Promised pass to '$functionName' was already settled. It will lead to a crash in the production environment!"
+  message = "Promise passed to '$functionName' was already settled. It will lead to a crash in the production environment!"
 )


### PR DESCRIPTION
# Why

It's easy to use the old promise import when writing your own module, and there's no easy way to identify the mistake.

# How

Deprecate old promise.

# Test Plan

Tested the DX manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
