### PR TITLE
fix(cli): filter ADB trace logs from the device list

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Keep typed routes in-sync with current Expo Router version ([#26578](https://github.com/expo/expo/pull/26578) by [@marklawlor](https://github.com/marklawlor))
 - Fix development codesigning certificate validity checks. ([#27361](https://github.com/expo/expo/pull/27361) by [@wschurman](https://github.com/wschurman))
 - Included groups in Expo Router typed routes generation ([#27690](https://github.com/expo/expo/pull/27690) by [@marklawlor](https://github.com/marklawlor))
+- Filter ADB trace logs when resolving Android devices. ([#27473](https://github.com/expo/expo/pull/27473) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -209,7 +209,40 @@ describe(getAttachedDevicesAsync, () => {
         isAuthorized: true,
         isBooted: true,
         name: 'Pixel_4_XL_API_30',
+        pid: 'emulator-5554',
+        type: 'emulator',
+      },
+    ]);
+  });
 
+  it(`gets devices when ADB_TRACE is set`, async () => {
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce(
+        [
+          'List of devices attached',
+          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:393] adb_query: host:devices-l',
+          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:351] adb_connect: service: host:devices-l',
+          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:160] _adb_connect: host:devices-l',
+          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:194] _adb_connect: return fd 3',
+          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:369] adb_connect: return fd 3',
+          // Emulator
+          'emulator-5554          offline transport_id:1',
+          '',
+        ].join('\n')
+      )
+      .mockResolvedValueOnce(
+        // Return the emulator name
+        ['Pixel_4_XL_API_30', 'OK'].join('\n')
+      );
+
+    const devices = await getAttachedDevicesAsync();
+
+    expect(devices).toEqual([
+      {
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_4_XL_API_30',
         pid: 'emulator-5554',
         type: 'emulator',
       },

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -229,7 +229,16 @@ export function adbArgs(pid: Device['pid'], ...options: string[]): string[] {
 export async function getAttachedDevicesAsync(): Promise<Device[]> {
   const output = await getServer().runAsync(['devices', '-l']);
 
-  const splitItems = output.trim().replace(/\n$/, '').split(os.EOL);
+  const splitItems = output
+    .trim()
+    .replace(/\n$/, '')
+    .split(os.EOL)
+    // Filter ADB trace logs from the output, e.g.
+    // adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:393] adb_query: host:devices-l
+    // 03-04 12:29:44.557 16415 16415 D adb     : commandline.cpp:1646 Using server socket: tcp:172.27.192.1:5037
+    // 03-04 12:29:44.557 16415 16415 D adb     : adb_client.cpp:160 _adb_connect: host:version
+    .filter((line) => !line.match(/\.cpp:[0-9]+/));
+
   // First line is `"List of devices attached"`, remove it
   // @ts-ignore: todo
   const attachedDevices: {


### PR DESCRIPTION
# Why

Fixes #27421

# How

Filter logs based on mentions of `adb_trace.cpp:<line>`, `adb_client.cpp:<line>`, or `commandline.cpp:<line>`.

# Test Plan

See issue #27421

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
