### PR TITLE
[core][Android] Remove redundant `args count` parameter

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -244,7 +244,6 @@ void JavaScriptModuleObject::exportConstants(
 void JavaScriptModuleObject::registerSyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
-  jint args,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
@@ -254,7 +253,6 @@ void JavaScriptModuleObject::registerSyncFunction(
     cName,
     cName,
     takesOwner,
-    args,
     false,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
@@ -264,7 +262,6 @@ void JavaScriptModuleObject::registerSyncFunction(
 void JavaScriptModuleObject::registerAsyncFunction(
   jni::alias_ref<jstring> name,
   jboolean takesOwner,
-  jint args,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
 ) {
@@ -274,7 +271,6 @@ void JavaScriptModuleObject::registerAsyncFunction(
     cName,
     cName,
     takesOwner,
-    args,
     true,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
@@ -286,7 +282,6 @@ void JavaScriptModuleObject::registerClass(
   jni::alias_ref<JavaScriptModuleObject::javaobject> classObject,
   jboolean takesOwner,
   jni::alias_ref<jclass> ownerClass,
-  jint args,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
@@ -294,7 +289,6 @@ void JavaScriptModuleObject::registerClass(
   MethodMetadata constructor(
     "constructor",
     takesOwner,
-    args,
     false,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
@@ -332,7 +326,6 @@ void JavaScriptModuleObject::registerProperty(
   auto getterMetadata = MethodMetadata(
     cName,
     getterTakesOwner,
-    getterExpectedArgsTypes->size(),
     false,
     jni::make_local(getterExpectedArgsTypes),
     jni::make_global(getter)
@@ -341,7 +334,6 @@ void JavaScriptModuleObject::registerProperty(
   auto setterMetadata = MethodMetadata(
     cName,
     setterTakesOwner,
-    setterExpectedArgsTypes->size(),
     false,
     jni::make_local(setterExpectedArgsTypes),
     jni::make_global(setter)

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -83,7 +83,6 @@ public:
   void registerSyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
-    jint args,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
@@ -95,7 +94,6 @@ public:
   void registerAsyncFunction(
     jni::alias_ref<jstring> name,
     jboolean takesOwner,
-    jint args,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
   );
@@ -105,7 +103,6 @@ public:
     jni::alias_ref<JavaScriptModuleObject::javaobject> classObject,
     jboolean takesOwner,
     jni::alias_ref<jclass> ownerClass,
-    jint args,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -36,10 +36,6 @@ public:
    */
   bool takesOwner;
   /**
-   * Number of arguments
-   */
-  int args;
-  /**
    * Whether this function is async
    */
   bool isAsync;
@@ -51,7 +47,6 @@ public:
   MethodMetadata(
     std::string name,
     bool takesOwner,
-    int args,
     bool isAsync,
     jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::global_ref<jobject> &&jBodyReference
@@ -60,7 +55,6 @@ public:
   MethodMetadata(
     std::string name,
     bool takesOwner,
-    int args,
     bool isAsync,
     std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
     jni::global_ref<jobject> &&jBodyReference

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -58,7 +58,6 @@ class ModuleHolder<T : Module>(val module: T) {
               clazzModuleObject,
               constructor.takesOwner,
               ownerClass,
-              constructor.argsCount,
               constructor.getCppRequiredTypes().toTypedArray(),
               constructor.getJNIFunctionBody(clazz.name, appContext)
             )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -59,7 +59,6 @@ abstract class AsyncFunction(
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
-      argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, promiseImpl ->
       if (BuildConfig.DEBUG) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -53,7 +53,6 @@ class SuspendFunctionComponent(
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
-      argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, promiseImpl ->
       if (BuildConfig.DEBUG) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -39,7 +39,6 @@ class SyncFunctionComponent(
     jsObject.registerSyncFunction(
       name,
       takesOwner,
-      argsCount,
       getCppRequiredTypes().toTypedArray(),
       getJNIFunctionBody(jsObject.name, appContext)
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -64,13 +64,13 @@ class JavaScriptModuleObject(
    * Register a promise-less function on the CPP module representation.
    * After calling this function, user can access the exported function in the JS code.
    */
-  external fun registerSyncFunction(name: String, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
+  external fun registerSyncFunction(name: String, takesOwner: Boolean, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   /**
    * Register a promise function on the CPP module representation.
    * After calling this function, user can access the exported function in the JS code.
    */
-  external fun registerAsyncFunction(name: String, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
+  external fun registerAsyncFunction(name: String, takesOwner: Boolean, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
 
   external fun registerProperty(
     name: String,
@@ -82,7 +82,7 @@ class JavaScriptModuleObject(
     setter: JNIFunctionBody?
   )
 
-  external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, ownerClass: Class<*>?, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
+  external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, ownerClass: Class<*>?, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
 


### PR DESCRIPTION
# Why

Removes redundant args count parameter pass to cpp during function initialization. 
That value can be obtained based on the number of converters passed to native. 

# Test Plan

- bare-expo ✅
- native tests ✅