### PR TITLE
[expotools] Enable NPM 2FA on `et promote-packages`

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -156,15 +156,20 @@ export async function publishPackageAsync(
 export async function addTagAsync(
   packageName: string,
   version: string,
-  tagName: string
+  tagName: string,
+  spawnOptions?: SpawnOptions
 ): Promise<void> {
-  await spawnAsync('npm', ['dist-tag', 'add', `${packageName}@${version}`, tagName]);
+  await spawnAsync('npm', ['dist-tag', 'add', `${packageName}@${version}`, tagName], spawnOptions);
 }
 
 /**
  * Removes package's tag with given name.
  */
-export async function removeTagAsync(packageName: string, tagName: string): Promise<void> {
+export async function removeTagAsync(
+  packageName: string,
+  tagName: string,
+  spawnOptions?: SpawnOptions
+): Promise<void> {
   await spawnAsync('npm', ['dist-tag', 'rm', packageName, tagName]);
 }
 

--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -170,7 +170,7 @@ export async function removeTagAsync(
   tagName: string,
   spawnOptions?: SpawnOptions
 ): Promise<void> {
-  await spawnAsync('npm', ['dist-tag', 'rm', packageName, tagName]);
+  await spawnAsync('npm', ['dist-tag', 'rm', packageName, tagName], spawnOptions);
 }
 
 /**


### PR DESCRIPTION
# Why
I'm not sure why this hasn't come up before (maybe my account is setup differently), but, after publishing a package to `next`, I always get roadblocked on `et promote-packages` with this error:

<img width="925" alt="image" src="https://github.com/expo/expo/assets/8053974/eb41001c-fa75-4788-83c8-672784c612b4">

# How
I copied the 2FA logic from `et publish-packages`

# Test Plan
After I made this change locally, I was able to promote my package to latest. I don't have a great way to test when 2FA isn't enabled for this operation.

