### PR TITLE
[docs] add basic code snippets auto-collapse function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -287,7 +287,7 @@ import Video from '~/components/plugins/Video';
 
 ### Add code block
 
-Code blocks are a great way to add code snippets to our docs. We leverage the usuall code block Markdown syntax, but it's expanded to support code block titles, and an additional params.
+Code blocks are a great way to add code snippets to our docs. We leverage the usual code block Markdown syntax, but it's expanded to support code block titles and additional params.
 
 <!-- prettier-ignore -->
 ```mdx
@@ -296,7 +296,7 @@ Code blocks are a great way to add code snippets to our docs. We leverage the us
     // Your code goes in here
     ```
 
-    {/* To add a title, just enter it right after language, in the code block starting line: */}
+    {/* To add a title, enter it right after the language, in the code block starting line: */}
     ```js myFile.js
     // Your code goes in here
     ```
@@ -317,7 +317,7 @@ Code blocks are a great way to add code snippets to our docs. We leverage the us
 
 | Param            | Type   | Description                                                                                                                                                            |
 | ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collapseHeight` | number | The custom height to which code block should be automatically collapsed, the default value is `408` and it's applied unless `collapseHeight` param has been specified. |
+| `collapseHeight` | number | The custom height that the code block uses to collapse automatically. The default value is `408` and is applied unless the `collapseHeight` param has been specified. |
 
 ### Add inline Snack examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -285,61 +285,96 @@ import Video from '~/components/plugins/Video';
 <Video file="guides/color-schemes.mp4" />;
 ```
 
-### Inline Snack examples
+### Add code block
+
+Code blocks are a great way to add code snippets to our docs. We leverage the usuall code block Markdown syntax, but it's expanded to support code block titles, and an additional params.
+
+<!-- prettier-ignore -->
+```mdx
+    {/* For plain code block the syntax is unchanged (but we recommend to always add a title to the snippet): */}
+    ```js
+    // Your code goes in here
+    ```
+
+    {/* To add a title, just enter it right after language, in the code block starting line: */}
+    ```js myFile.js
+    // Your code goes in here
+    ```
+    ```js Title for a code block
+    // Your code goes in here
+    ```
+
+    {/* Title and params can be separated by pipe ("|") characters, but they also work for block without a title: */}
+    ```js myFile.js|collapseHeight=600
+    // Your code goes in here
+    ```
+    ```js collapseHeight=200
+    // Your code goes in here
+    ```
+```
+
+#### Supported additional params
+
+| Param            | Type   | Description                                                                                                                                                            |
+| ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collapseHeight` | number | The custom height to which code block should be automatically collapsed, the default value is `408` and it's applied unless `collapseHeight` param has been specified. |
+
+### Add inline Snack examples
 
 Snacks are a great way to add instantly-runnable examples to our docs. The `SnackInline` component can be imported to any markdown file, and used like this:
 
 <!-- prettier-ignore -->
-```jsx
+```mdx
 import SnackInline from '~/components/plugins/SnackInline';
 
 <SnackInline label='My Example Label' dependencies={['array of', 'packages', 'this Snack relies on']}>
+    ```js
+    // All your code goes in here
 
-// All your JavaScript code goes in here
+    // You can use:
+    /* @info Some text goes here */
+    const myVariable = SomeCodeThatDoesStuff();
+    /* @end */
+    // to create hoverable-text, which reveals the text inside of `@info` onHover.
 
-// You can use:
-/* @info Some text goes here */
-  const myVariable = SomeCodeThatDoesStuff();
-/* @end */
-// to create hoverable-text, which reveals the text inside of `@info` onHover.
-
-// You can use:
-/* @hide Content that is still shown, like a preview. */
-  Everything in here is hidden in the example Snack until
-  you open it in snack.expo.dev
-/* @end */
-// to shorten the length of the Snack shown in our docs. Common example are hiding useless code in examples, like StyleSheets
-
+    // You can use:
+    /* @hide Content that is still shown, like a preview. */
+    Everything in here is hidden in the example Snack until
+    you open it in snack.expo.dev
+    /* @end */
+    // to shorten the length of code block shown in our docs.
+    // Hidden code will still be present when opening in Snack or using "Copy" action.
+    ```
 </SnackInline>
 ```
 
-### Embed multiple options of code
+### Add multiple code variants
 
 Sometimes it's useful to show multiple ways of doing something, for instance, maybe you'd like to have an example using a React class component, and also an example of a functional component.
 The `Tabs` plugin is really useful for this, and this is how you'd use it in a markdown file:
 
 <!-- prettier-ignore -->
-```jsx
+```mdx
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 <Tabs>
 <Tab label="Add 1 One Way">
-
+    ```js
     addOne = async x => {
-    /* @info This text will be shown onHover */
-    return x + 1;
-    /* @end */
+      /* @info This text will be shown onHover */
+      return x + 1;
+      /* @end */
     };
-
+    ```
 </Tab>
 <Tab label="Add 1 Another Way">
-
+    ```js
     addOne = async x => {
-    /* @info This text will be shown onHover */
-    return x++;
-    /* @end */
+      /* @info This text will be shown onHover */
+      return x++;
+      /* @end */
     };
-
+    ```
 </Tab>
 </Tabs>
 ```
@@ -363,13 +398,13 @@ If you just want to hide a single page from the sidebar, set `hideInSidebar: tru
 
 Whenever shell commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported into any markdown file.
 
-```jsx
+```mdx
 import { Terminal } from '~/ui/components/Snippet';
 
-// for single command and one prop
+{/* for single command and one prop: */}
 <Terminal cmd={["$ npx expo install package"]} />
 
-// for multiple commands
+{/* for multiple commands: */}
 
 <Terminal cmd={[
   "# Create a new native project",

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6954,7 +6954,7 @@ This uses both
     </p>
     <pre>
       <pre
-        class="last:mb-0 css-1r21cuo-Code"
+        class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
         data-text="true"
       >
         <code

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -81,7 +81,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </p>
   <pre>
     <pre
-      class="last:mb-0 css-1r21cuo-Code"
+      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
       data-text="true"
     >
       <code

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -608,7 +608,7 @@ export const withSimpleAppDelegateHeaderMod = config => {
 
 To use this new base mod, add it to the plugins array. The base mod **MUST** be added last after all other plugins that use the mod, this is because it must write the results to disk at the end of the process.
 
-```js app.config.js
+```js app.config.js|collapseHeight=420
 // Required for external files using TS
 require('ts-node/register');
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -148,7 +148,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -156,7 +155,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -260,12 +258,13 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      <Text style={{ fontFamily: 'Inter_900Black', fontSize: 40 }}>Inter Black</Text>
+      <Text style={{ fontFamily: 'Inter_900Black', fontSize: 40 }}>
+        Inter Black
+      </Text>
     </View>
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -273,7 +272,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -194,7 +194,7 @@ Next time you deploy your website, the banner should appear when you visit it on
 
 Implementing deep links on Android (without a custom URL scheme) is somewhat simpler than on iOS. You need to add `intentFilters` to the [`android`](/versions/latest/config/app/#android) section of your [app config](/workflow/configuration/). The following basic configuration will cause your app to be presented in the standard Android dialog as an option for handling any record links to `myapp.io`:
 
-```json app.json
+```json app.json|collapseHeight=454
 {
   "expo": {
     "android": {

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -21,9 +21,8 @@ module.exports = {
   ],
   ...getExpoTheme({
     backgroundImage: theme => ({
-      'default-fade': `linear-gradient(to bottom, ${theme(
-        'backgroundColor.default'
-      )}, transparent)`,
+      'default-fade': `linear-gradient(to bottom, ${theme('backgroundColor.default')}, transparent)`,
+      'default-fade-down': `linear-gradient(to bottom, transparent, ${theme('backgroundColor.default')})`,
       appjs: "url('/static/images/appjs.svg'), linear-gradient(#0033cc, #0033cc)",
     }),
     fontSize: {

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -19,7 +19,7 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
           wordWrap && '!whitespace-pre-wrap !break-words',
-          'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
+          'relative text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
           'prose-code:!px-0',
           alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
           hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from '@expo/styleguide';
 
-export const EXPAND_SNIPPET_BOUND = 410;
-export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[410px]';
+export const EXPAND_SNIPPET_BOUND = 408;
+export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[408px]';
 
 type Props = {
   onClick?: ButtonProps['onClick'];
@@ -11,7 +11,7 @@ export function SnippetExpandOverlay({ onClick }: Props) {
   return (
     <div className="flex absolute bottom-0 left-0 p-6 w-full bg-default-fade-down">
       <Button theme="secondary" onClick={onClick} className="mx-auto">
-        Expand snippet
+        Show more
       </Button>
     </div>
   );

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -1,0 +1,18 @@
+import { Button, ButtonProps } from '@expo/styleguide';
+
+export const EXPAND_SNIPPET_BOUND = 410;
+export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[410px]';
+
+type Props = {
+  onClick?: ButtonProps['onClick'];
+};
+
+export function SnippetExpandOverlay({ onClick }: Props) {
+  return (
+    <div className="flex absolute bottom-0 left-0 p-6 w-full bg-default-fade-down">
+      <Button theme="secondary" onClick={onClick} className="mx-auto">
+        Expand snippet
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Why

Hopefully fixes ENG-11219

# How

Add basic, and automated code snippets auto-collapse function.

It's purely based on the container height, initially I have went with different approach, involving counting lines, but the implementation were way more complex and was causing som side effect when manipulation "Word Wrap" preference.

To make it more customizable we would need to introduce or update our remark plugin to be able to provide this prop and value directly in MDX code block, since this is what we use at the end for most of the content. That's why I have opt-out ATM from more flexible approach. In the future, with a refactor of the code snippets with collapsible function in mind, it might be a bit more strength forward to implement that function with optional params.

# Test Plan

The changes have been tested running docs app locally.

# Preview

https://github.com/expo/expo/assets/719641/8e598e4e-ace4-47ac-a38a-83684d5cda18

