### PR TITLE
[cli] Filter extra avd info when listing emulators

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Prevent run commands from hanging when the process completes. ([#26960](https://github.com/expo/expo/pull/26960) by [@EvanBacon](https://github.com/EvanBacon))
 - Keep typed routes in-sync with current Expo Router version ([#26578](https://github.com/expo/expo/pull/26578) by [@marklawlor](https://github.com/marklawlor))
 - Fix development codesigning certificate validity checks. ([#27361](https://github.com/expo/expo/pull/27361) by [@wschurman](https://github.com/wschurman))
+- Filter extra avd info when listing emulators. ([#27497](https://github.com/expo/expo/pull/27497) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -28,7 +28,7 @@ export async function listAvdsAsync(): Promise<Device[]> {
         .split(os.EOL)
         .filter(Boolean)
         /**
-         * AVD names cannot contain spaces. This removes extra info lines from the output. e.g.
+         * AVD IDs cannot contain spaces. This removes extra info lines from the output. e.g.
          * "INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db
          */
         .filter((name) => !name.trim().includes(' '))

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -23,16 +23,23 @@ export function whichEmulator(): string {
 export async function listAvdsAsync(): Promise<Device[]> {
   try {
     const { stdout } = await spawnAsync(whichEmulator(), ['-list-avds']);
-    return stdout
-      .split(os.EOL)
-      .filter(Boolean)
-      .map((name) => ({
-        name,
-        type: 'emulator',
-        // unsure from this
-        isBooted: false,
-        isAuthorized: true,
-      }));
+    return (
+      stdout
+        .split(os.EOL)
+        .filter(Boolean)
+        /**
+         * AVD names cannot contain spaces. This removes extra info lines from the output. e.g.
+         * "INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db
+         */
+        .filter((name) => !name.trim().includes(' '))
+        .map((name) => ({
+          name,
+          type: 'emulator',
+          // unsure from this
+          isBooted: false,
+          isAuthorized: true,
+        }))
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
# Why

Recently got a few reports from @brentvatne and @Simek regarding a non bootable device being listed in Orbit
<details>
<summary>Check image</summary>

![image](https://github.com/expo/expo/assets/11707729/12301bbe-5442-4e13-807f-26654349526a)

</details>

After doing some testing this same bug also applies to expo-cli 

```
yarn expo run:android
yarn run v1.22.21
$ /Users/brent/code/microfoam/node_modules/.bin/expo run:android
✔ Created native directory
✔ Updated package.json | no changes
✔ Finished prebuild
› Opening emulator INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92192
Error: The emulator (INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92192) quit before it finished opening. You can try starting the emulator manually from the terminal with: /Users/brent/Library/Android/sdk/emulator/emulator @INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92192
Error: The emulator (INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92192) quit before it finished opening. You can try starting the emulator manually from the terminal with: /Users/brent/Library/Android/sdk/emulator/emulator @INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92192
    at stopWaitingAndReject (/Users/brent/code/microfoam/node_modules/@expo/cli/build/src/start/platforms/android/emulator.js:110:20)
    at ChildProcess.<anonymous> (/Users/brent/code/microfoam/node_modules/@expo/cli/build/src/start/platforms/android/emulator.js:121:13)
    at ChildProcess.emit (node:events:517:28)
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
# How

AVD IDs cannot contain spaces,  so in order to remove all the extra info returned by `emulator -list-avds`, we can just filter out lines that contain spaces 

# Test Plan

Running `yarn expo run:android -d` should not list ` INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92342 (emulator)` as an option to launch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
