### PR TITLE
[dev-menu][dev-launcher] fix jsc support

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Android] Fixed to not return DevLauncherDevSupportManagerFactory in host handler when `enableAutoSetup` is false. ([#27068](https://github.com/expo/expo/pull/27068) by [@jayshah123](https://github.com/jayshah123))
 - Fixed missing `runtimeVersion` error when loading app with `expo-updates` and `expo-dev-client`. ([#27180](https://github.com/expo/expo/pull/27180) by [@kudo](https://github.com/kudo))
 - Remove legacy flag from command line hint. ([#27225](https://github.com/expo/expo/pull/27225) by [@simek](https://github.com/simek))
+- Fixed libhermes.so loading error when the app running on JSC jsEngine. ([#27507](https://github.com/expo/expo/pull/27507) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -152,6 +152,7 @@ dependencies {
   }
 
   implementation 'com.facebook.react:react-android'
+  implementation 'com.facebook.soloader:soloader:0.11.0'
 
   implementation 'commons-io:commons-io:2.6'
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
 - Fix runtime version overflow ([#27172](https://github.com/expo/expo/pull/27172) by [@kadikraman](https://github.com/kadikraman))
 - Fixed registerDevMenuItems duplicating items rather than replacing. ([#27356](https://github.com/expo/expo/pull/27356) by [@lukmccall](https://github.com/lukmccall))
+- Fixed libhermes.so loading error when the app running on JSC jsEngine. ([#27507](https://github.com/expo/expo/pull/27507) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -170,6 +170,7 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.8.6'
 
   implementation 'com.facebook.react:react-android'
+  implementation 'com.facebook.soloader:soloader:0.11.0'
   implementation "androidx.transition:transition:1.1.0" // use by react-native-reanimated
 
   // Fixes


### PR DESCRIPTION
# Why

fixes #27357
close ENG-11541

# How

since expo 50 with android minSdkVersion 23, native libs are lived inside apk. the current react-native's soloader does not support this flow for `SoLoader.getLibraryPath()`. we use this method in [jsc detection](https://github.com/expo/expo/blob/3d2157c5d9a351cd692fe245a1134a6d9540b0b8/packages/expo-dev-launcher/android/src/react-native-72/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt#L38). the newer soloader 0.11.0 added the support.

one risky concern is that react-native currently only has soloader 0.10.5. when bumping the soloader, the dependency is affected to the whole app. but i believe meta internally used the latest soloader already. it's good to try out and see how it goes.

# Test Plan

update jsEngine=jsc in bare-expo and launch dev-launcher/dev-menu on bare-expo

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
