### PR TITLE
[dev-launcher] remove flipper workaround

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove classic updates SDK version. ([#26061](https://github.com/expo/expo/pull/26061) by [@wschurman](https://github.com/wschurman))
 - Fixed lint warning ([#26876](https://github.com/expo/expo/pull/26876) by [@GaelCO](https://github.com/GaelCO))
 - Decouple from "bridge" in `expo-updates`. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
+- Removed [Flipper workaround](https://github.com/expo/expo/pull/18105) on Android. ([#27508](https://github.com/expo/expo/pull/27508) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoader.kt
@@ -10,7 +10,6 @@ import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
-import java.lang.reflect.InvocationTargetException
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -55,7 +54,6 @@ abstract class DevLauncherAppLoader(
 
           controller.onAppLoaded(context)
           onReactContext(context)
-          maybeInitFlipper(context.applicationContext, appHost.reactInstanceManager)
           appHost.reactInstanceManager.removeReactInstanceEventListener(this)
           reactContextWasInitialized = true
           continuation!!.resume(true)
@@ -95,60 +93,5 @@ abstract class DevLauncherAppLoader(
 
   private fun launchIntent(intent: Intent) {
     context.applicationContext.startActivity(intent)
-  }
-
-  private fun maybeInitFlipper(appContext: Context, reactInstanceManager: ReactInstanceManager) {
-    try {
-      val wasRunning = tryToStopFlipper()
-
-      // Flipper wasn't initialized in the MainApplication so we don't want to start it.
-      if (!wasRunning) {
-        return
-      }
-
-      /*
-      We use reflection here to pick up the class that initializes Flipper,
-      since Flipper library is not available in release mode
-       */
-      val packageName = appContext.packageName
-      val aClass = Class.forName("$packageName.ReactNativeFlipper")
-      aClass
-        .getMethod("initializeFlipper", Context::class.java, ReactInstanceManager::class.java)
-        .invoke(null, context, reactInstanceManager)
-    } catch (e: ClassNotFoundException) {
-      e.printStackTrace()
-    } catch (e: NoSuchMethodException) {
-      e.printStackTrace()
-    } catch (e: IllegalAccessException) {
-      e.printStackTrace()
-    } catch (e: InvocationTargetException) {
-      e.printStackTrace()
-    }
-  }
-
-  private fun tryToStopFlipper(): Boolean {
-    val androidFlipperClientClass = Class.forName("com.facebook.flipper.android.AndroidFlipperClient")
-    val getInstanceMethod = androidFlipperClientClass.getMethod("getInstanceIfInitialized")
-
-    val flipperClient = getInstanceMethod.invoke(null) ?: return false
-    val flipperClientClass = flipperClient.javaClass
-
-    val stopMethod = flipperClientClass.getMethod("stop")
-    val getPluginMethod = flipperClientClass.getMethod("getPlugin", String::class.java)
-
-    stopMethod.invoke(flipperClient)
-    val mClassIdentifierMapField = flipperClientClass.getDeclaredField("mClassIdentifierMap")
-    mClassIdentifierMapField.isAccessible = true
-    val pluginsMap = mClassIdentifierMapField.get(flipperClient) as Map<Class<*>, String>
-    val flipperPlugins = pluginsMap.map { (_, id) -> getPluginMethod.invoke(flipperClient, id) }
-
-    val flipperPluginClass = Class.forName("com.facebook.flipper.core.FlipperPlugin")
-    val removePluginMethod = flipperClientClass.getMethod("removePlugin", flipperPluginClass)
-
-    flipperPlugins.forEach {
-      removePluginMethod.invoke(flipperClient, it)
-    }
-
-    return true
   }
 }


### PR DESCRIPTION
# Why

noticed some flipper stuff in adb log when running bare-expo on android because flipper classes not found. since flipper are removed now, we could also remove the previous workaround #18105

# How

remove flipper relevant code

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
