### PR TITLE
[expo-updates] Add native sync CLI for eas-cli

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix fingerprint runtime version policy. Calculate fingerprint at build time. ([#26901](https://github.com/expo/expo/pull/26901) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli fingerprint:generate command. ([#27119](https://github.com/expo/expo/pull/27119) by [@wschurman](https://github.com/wschurman))
 - Add expo-updates cli runtimeversion:resolve command. ([#27263](https://github.com/expo/expo/pull/27263) by [@wschurman](https://github.com/wschurman))
+- Add expo-updates cli configuration:syncnative command. ([#27511](https://github.com/expo/expo/pull/27511) by [@wschurman](https://github.com/wschurman))
 - Add --version top-level flag and also add handler for missing command in expo-update cli. ([#27296](https://github.com/expo/expo/pull/27296) by [@wschurman](https://github.com/wschurman))
 - Add more debug information to runtimeversion:resolve CLI output. ([#27323](https://github.com/expo/expo/pull/27323), [#27387](https://github.com/expo/expo/pull/27387) by [@wschurman](https://github.com/wschurman))
 - Added React Native New Architecture support. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))

--- a/packages/expo-updates/cli/build/cli.js
+++ b/packages/expo-updates/cli/build/cli.js
@@ -46,6 +46,7 @@ const commands = {
     'assets:verify': () => import('./assetsVerify.js').then((i) => i.expoAssetsVerify),
     'fingerprint:generate': () => import('./generateFingerprint.js').then((i) => i.generateFingerprint),
     'runtimeversion:resolve': () => import('./resolveRuntimeVersion.js').then((i) => i.resolveRuntimeVersion),
+    'configuration:syncnative': () => import('./syncConfigurationToNative.js').then((i) => i.syncConfigurationToNative),
 };
 const args = (0, arg_1.default)({
     // Types

--- a/packages/expo-updates/cli/build/syncConfigurationToNative.d.ts
+++ b/packages/expo-updates/cli/build/syncConfigurationToNative.d.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { Command } from './cli';
+export declare const syncConfigurationToNative: Command;

--- a/packages/expo-updates/cli/build/syncConfigurationToNative.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNative.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.syncConfigurationToNative = void 0;
+const chalk_1 = __importDefault(require("chalk"));
+const syncConfigurationToNativeAsync_1 = require("./syncConfigurationToNativeAsync");
+const args_1 = require("./utils/args");
+const Log = __importStar(require("./utils/log"));
+const syncConfigurationToNative = async (argv) => {
+    const args = (0, args_1.assertArgs)({
+        // Types
+        '--help': Boolean,
+        '--platform': String,
+        // Aliases
+        '-h': '--help',
+    }, argv ?? []);
+    if (args['--help']) {
+        Log.exit((0, chalk_1.default) `
+{bold Description}
+Sync configuration from Expo config to native project files if applicable. Note that this really
+only needs to be used by the EAS CLI for generic projects that do't use continuous native generation.
+
+{bold Usage}
+  {dim $} npx expo-updates configuration:syncnative --platform <platform>
+
+  Options
+  --platform <string>                  Platform to sync
+  -h, --help                           Output usage information
+    `, 0);
+    }
+    const platform = (0, args_1.requireArg)(args, '--platform');
+    if (!['ios', 'android'].includes(platform)) {
+        throw new Error(`Invalid platform argument: ${platform}`);
+    }
+    await (0, syncConfigurationToNativeAsync_1.syncConfigurationToNativeAsync)({
+        projectRoot: (0, args_1.getProjectRoot)(args),
+        platform,
+    });
+};
+exports.syncConfigurationToNative = syncConfigurationToNative;

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.d.ts
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.d.ts
@@ -1,0 +1,9 @@
+type SyncConfigurationToNativeOptions = {
+    projectRoot: string;
+    platform: 'ios' | 'android';
+};
+/**
+ * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
+ */
+export declare function syncConfigurationToNativeAsync(options: SyncConfigurationToNativeOptions): Promise<void>;
+export {};

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
@@ -1,0 +1,88 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.syncConfigurationToNativeAsync = void 0;
+const config_1 = require("@expo/config");
+const config_plugins_1 = require("@expo/config-plugins");
+const plist_1 = __importDefault(require("@expo/plist"));
+const fs_extra_1 = __importDefault(require("fs-extra"));
+const path_1 = __importDefault(require("path"));
+const workflow_1 = require("../../utils/build/workflow");
+/**
+ * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
+ */
+async function syncConfigurationToNativeAsync(options) {
+    const workflow = await (0, workflow_1.resolveWorkflowAsync)(options.projectRoot, options.platform);
+    if (workflow !== 'generic') {
+        // not applicable to managed workflow
+    }
+    switch (options.platform) {
+        case 'android':
+            await syncConfigurationToNativeAndroidAsync(options);
+            break;
+        case 'ios':
+            await syncConfigurationToNativeIosAsync(options);
+            break;
+    }
+}
+exports.syncConfigurationToNativeAsync = syncConfigurationToNativeAsync;
+async function syncConfigurationToNativeAndroidAsync(options) {
+    const { exp } = (0, config_1.getConfig)(options.projectRoot, {
+        isPublicConfig: true,
+        skipSDKVersionRequirement: true,
+    });
+    // sync AndroidManifest.xml
+    const androidManifestPath = await config_plugins_1.AndroidConfig.Paths.getAndroidManifestAsync(options.projectRoot);
+    if (!androidManifestPath) {
+        throw new Error(`Could not find AndroidManifest.xml in project directory: "${options.projectRoot}"`);
+    }
+    const androidManifest = await config_plugins_1.AndroidConfig.Manifest.readAndroidManifestAsync(androidManifestPath);
+    const updatedAndroidManifest = await config_plugins_1.AndroidConfig.Updates.setUpdatesConfigAsync(options.projectRoot, exp, androidManifest);
+    await config_plugins_1.AndroidConfig.Manifest.writeAndroidManifestAsync(androidManifestPath, updatedAndroidManifest);
+    // sync strings.xml
+    const stringsJSONPath = await config_plugins_1.AndroidConfig.Strings.getProjectStringsXMLPathAsync(options.projectRoot);
+    const stringsResourceXML = await config_plugins_1.AndroidConfig.Resources.readResourcesXMLAsync({
+        path: stringsJSONPath,
+    });
+    const updatedStringsResourceXML = await config_plugins_1.AndroidConfig.Updates.applyRuntimeVersionFromConfigForProjectRootAsync(options.projectRoot, exp, stringsResourceXML);
+    await config_plugins_1.XML.writeXMLAsync({ path: stringsJSONPath, xml: updatedStringsResourceXML });
+}
+async function syncConfigurationToNativeIosAsync(options) {
+    const { exp } = (0, config_1.getConfig)(options.projectRoot, {
+        isPublicConfig: true,
+        skipSDKVersionRequirement: true,
+    });
+    const expoPlist = await readExpoPlistAsync(options.projectRoot);
+    const updatedExpoPlist = await config_plugins_1.IOSConfig.Updates.setUpdatesConfigAsync(options.projectRoot, exp, expoPlist);
+    await writeExpoPlistAsync(options.projectRoot, updatedExpoPlist);
+}
+async function readExpoPlistAsync(projectDir) {
+    const expoPlistPath = config_plugins_1.IOSConfig.Paths.getExpoPlistPath(projectDir);
+    return ((await readPlistAsync(expoPlistPath)) ?? {});
+}
+async function writeExpoPlistAsync(projectDir, expoPlist) {
+    const expoPlistPath = config_plugins_1.IOSConfig.Paths.getExpoPlistPath(projectDir);
+    await writePlistAsync(expoPlistPath, expoPlist);
+}
+async function readPlistAsync(plistPath) {
+    if (await fs_extra_1.default.pathExists(plistPath)) {
+        const expoPlistContent = await fs_extra_1.default.readFile(plistPath, 'utf8');
+        try {
+            return plist_1.default.parse(expoPlistContent);
+        }
+        catch (err) {
+            err.message = `Failed to parse ${plistPath}. ${err.message}`;
+            throw err;
+        }
+    }
+    else {
+        return null;
+    }
+}
+async function writePlistAsync(plistPath, plistObject) {
+    const contents = plist_1.default.build(plistObject);
+    await fs_extra_1.default.mkdirp(path_1.default.dirname(plistPath));
+    await fs_extra_1.default.writeFile(plistPath, contents);
+}

--- a/packages/expo-updates/cli/src/cli.ts
+++ b/packages/expo-updates/cli/src/cli.ts
@@ -26,6 +26,8 @@ const commands: { [command: string]: () => Promise<Command> } = {
     import('./generateFingerprint.js').then((i) => i.generateFingerprint),
   'runtimeversion:resolve': () =>
     import('./resolveRuntimeVersion.js').then((i) => i.resolveRuntimeVersion),
+  'configuration:syncnative': () =>
+    import('./syncConfigurationToNative.js').then((i) => i.syncConfigurationToNative),
 };
 
 const args = arg(

--- a/packages/expo-updates/cli/src/syncConfigurationToNative.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNative.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from './cli';
+import { syncConfigurationToNativeAsync } from './syncConfigurationToNativeAsync';
+import { requireArg, assertArgs, getProjectRoot } from './utils/args';
+import * as Log from './utils/log';
+
+export const syncConfigurationToNative: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--platform': String,
+      // Aliases
+      '-h': '--help',
+    },
+    argv ?? []
+  );
+
+  if (args['--help']) {
+    Log.exit(
+      chalk`
+{bold Description}
+Sync configuration from Expo config to native project files if applicable. Note that this really
+only needs to be used by the EAS CLI for generic projects that do't use continuous native generation.
+
+{bold Usage}
+  {dim $} npx expo-updates configuration:syncnative --platform <platform>
+
+  Options
+  --platform <string>                  Platform to sync
+  -h, --help                           Output usage information
+    `,
+      0
+    );
+  }
+
+  const platform = requireArg(args, '--platform');
+  if (!['ios', 'android'].includes(platform)) {
+    throw new Error(`Invalid platform argument: ${platform}`);
+  }
+
+  await syncConfigurationToNativeAsync({
+    projectRoot: getProjectRoot(args),
+    platform,
+  });
+};

--- a/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
@@ -1,0 +1,133 @@
+import { getConfig } from '@expo/config';
+import { XML, AndroidConfig, IOSConfig } from '@expo/config-plugins';
+import plist from '@expo/plist';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { resolveWorkflowAsync } from '../../utils/build/workflow';
+
+type SyncConfigurationToNativeOptions = {
+  projectRoot: string;
+  platform: 'ios' | 'android';
+};
+
+/**
+ * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
+ */
+export async function syncConfigurationToNativeAsync(
+  options: SyncConfigurationToNativeOptions
+): Promise<void> {
+  const workflow = await resolveWorkflowAsync(options.projectRoot, options.platform);
+  if (workflow !== 'generic') {
+    // not applicable to managed workflow
+  }
+
+  switch (options.platform) {
+    case 'android':
+      await syncConfigurationToNativeAndroidAsync(options);
+      break;
+    case 'ios':
+      await syncConfigurationToNativeIosAsync(options);
+      break;
+  }
+}
+
+async function syncConfigurationToNativeAndroidAsync(
+  options: SyncConfigurationToNativeOptions
+): Promise<void> {
+  const { exp } = getConfig(options.projectRoot, {
+    isPublicConfig: true,
+    skipSDKVersionRequirement: true,
+  });
+
+  // sync AndroidManifest.xml
+  const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(
+    options.projectRoot
+  );
+  if (!androidManifestPath) {
+    throw new Error(
+      `Could not find AndroidManifest.xml in project directory: "${options.projectRoot}"`
+    );
+  }
+  const androidManifest =
+    await AndroidConfig.Manifest.readAndroidManifestAsync(androidManifestPath);
+
+  const updatedAndroidManifest = await AndroidConfig.Updates.setUpdatesConfigAsync(
+    options.projectRoot,
+    exp,
+    androidManifest
+  );
+  await AndroidConfig.Manifest.writeAndroidManifestAsync(
+    androidManifestPath,
+    updatedAndroidManifest
+  );
+
+  // sync strings.xml
+  const stringsJSONPath = await AndroidConfig.Strings.getProjectStringsXMLPathAsync(
+    options.projectRoot
+  );
+  const stringsResourceXML = await AndroidConfig.Resources.readResourcesXMLAsync({
+    path: stringsJSONPath,
+  });
+
+  const updatedStringsResourceXML =
+    await AndroidConfig.Updates.applyRuntimeVersionFromConfigForProjectRootAsync(
+      options.projectRoot,
+      exp,
+      stringsResourceXML
+    );
+  await XML.writeXMLAsync({ path: stringsJSONPath, xml: updatedStringsResourceXML });
+}
+
+async function syncConfigurationToNativeIosAsync(
+  options: SyncConfigurationToNativeOptions
+): Promise<void> {
+  const { exp } = getConfig(options.projectRoot, {
+    isPublicConfig: true,
+    skipSDKVersionRequirement: true,
+  });
+
+  const expoPlist = await readExpoPlistAsync(options.projectRoot);
+  const updatedExpoPlist = await IOSConfig.Updates.setUpdatesConfigAsync(
+    options.projectRoot,
+    exp,
+    expoPlist
+  );
+  await writeExpoPlistAsync(options.projectRoot, updatedExpoPlist);
+}
+
+async function readExpoPlistAsync(projectDir: string): Promise<IOSConfig.ExpoPlist> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(projectDir);
+  return ((await readPlistAsync(expoPlistPath)) ?? {}) as IOSConfig.ExpoPlist;
+}
+
+async function writeExpoPlistAsync(
+  projectDir: string,
+  expoPlist: IOSConfig.ExpoPlist
+): Promise<void> {
+  const expoPlistPath = IOSConfig.Paths.getExpoPlistPath(projectDir);
+  await writePlistAsync(expoPlistPath, expoPlist);
+}
+
+async function readPlistAsync(plistPath: string): Promise<object | null> {
+  if (await fs.pathExists(plistPath)) {
+    const expoPlistContent = await fs.readFile(plistPath, 'utf8');
+    try {
+      return plist.parse(expoPlistContent);
+    } catch (err: any) {
+      err.message = `Failed to parse ${plistPath}. ${err.message}`;
+      throw err;
+    }
+  } else {
+    return null;
+  }
+}
+
+async function writePlistAsync(
+  plistPath: string,
+  plistObject: IOSConfig.ExpoPlist | IOSConfig.InfoPlist
+): Promise<void> {
+  const contents = plist.build(plistObject);
+  await fs.mkdirp(path.dirname(plistPath));
+  await fs.writeFile(plistPath, contents);
+}


### PR DESCRIPTION
# Why

EAS CLI currently does native synchronization for generic projects (which includes projects that use continuous native generation / prebuild). Although unnecessary for CNG projects, it doesn't discriminate.

The issue is that the code it runs is a locked version of the runtime version evaluation, while it needs to be the version that matches the project.

# How

The solution is the same as runtime version resolution: create a expo-updates CLI command that does the synchronization.

# Test Plan

In a project that uses fingerprintExperimental runtime version:
```
yarn link expo-updates
npx expo-updates configuration:syncnative --platform android
npx expo-updates configuration:syncnative --platform ios
```

See consistent results.

For automatic testing, there isn't much to test here since it's mostly just calls to config plugins (where it is also mostly untested unfortunately as well as untested in eas-cli). What we'll do is add an end-to-end test for this stuff eventually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
