### PR TITLE
chore: Add additional tests for undefined platform minification behavior.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
+- Add additional tests for undefined platform minification behavior.
 - Upgrade `babel-plugin-react-native-web` for latest `react-native-web` aliases. ([#27214](https://github.com/expo/expo/pull/27214) by [@EvanBacon](https://github.com/EvanBacon))
 - Directly resolve plugins. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
-- Add additional tests for undefined platform minification behavior.
+- Add additional tests for undefined platform minification behavior. ([#27515](https://github.com/expo/expo/pull/27515) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade `babel-plugin-react-native-web` for latest `react-native-web` aliases. ([#27214](https://github.com/expo/expo/pull/27214) by [@EvanBacon](https://github.com/EvanBacon))
 - Directly resolve plugins. ([#27041](https://github.com/expo/expo/pull/27041) by [@EvanBacon](https://github.com/EvanBacon))
 


### PR DESCRIPTION
# Why

- Metro's platform minification plugin has undefined behavior where the Platform module doesn't need to come from the `react-native` import, this inadvertently resolves the need to add support for `expo-modules-core`.
- I'll add a follow up PR to fork the Metro plugin and remove the many additional passes used to support haste. Will also fix the extra case I found where `.native` is left as-is even when bundling for web.

# Test Plan

- Added tests only