### PR TITLE
[core] Fix defining property with a value

### DIFF
--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -122,6 +122,10 @@ void defineProperty(jsi::Runtime &runtime, jsi::Object *object, const char *name
 
     jsDescriptor.setProperty(runtime, setPropName, set);
   }
+  if (!descriptor.value.isUndefined()) {
+    jsi::PropNameID valuePropName = jsi::PropNameID::forAscii(runtime, "value", 5);
+    jsDescriptor.setProperty(runtime, valuePropName, descriptor.value);
+  }
 
   defineProperty(runtime, object, name, std::move(jsDescriptor));
 }

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -47,7 +47,7 @@ struct PropertyDescriptor {
   const bool configurable = false;
   const bool enumerable = false;
   const bool writable = false;
-  const jsi::Value value = 0;
+  const jsi::Value value = jsi::Value::undefined();
   const std::function<jsi::Value(jsi::Runtime &runtime, jsi::Object thisObject)> get = 0;
   const std::function<void(jsi::Runtime &runtime, jsi::Object thisObject, jsi::Value newValue)> set = 0;
 }; // PropertyDescriptor


### PR DESCRIPTION
# Why

Looks like I forgot about handling the `value` of the property descriptor 😅 

# How

Change its default value to `undefined` and properly set it on the JS property descriptor.
I'm not adding any changelog entries because the entire util function wasn't published yet.

# Test Plan

Tested in #27510 

<!-- disable:changelog-checks -->
