### PR TITLE
[core] Add helper in C++ to get the core JS object

### DIFF
--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -90,9 +90,7 @@ void callObservingFunction(jsi::Runtime &runtime, jsi::Object &object, const cha
 }
 
 jsi::Function getClass(jsi::Runtime &runtime) {
-  return runtime
-    .global()
-    .getPropertyAsObject(runtime, "expo")
+  return common::getCoreObject(runtime)
     .getPropertyAsFunction(runtime, "EventEmitter");
 }
 
@@ -170,9 +168,7 @@ void installClass(jsi::Runtime &runtime) {
   prototype.setProperty(runtime, removeAllListenersProp, jsi::Function::createFromHostFunction(runtime, removeAllListenersProp, 1, removeAllListeners));
   prototype.setProperty(runtime, emitProp, jsi::Function::createFromHostFunction(runtime, emitProp, 2, emit));
 
-  runtime
-    .global()
-    .getPropertyAsObject(runtime, "expo")
+  common::getCoreObject(runtime)
     .setProperty(runtime, "EventEmitter", eventEmitterClass);
 }
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -5,6 +5,10 @@
 
 namespace expo::common {
 
+jsi::Object getCoreObject(jsi::Runtime &runtime) {
+  return runtime.global().getPropertyAsObject(runtime, "expo");
+}
+
 jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor) {
   std::string nativeConstructorKey("__native_constructor__");
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -5,10 +5,6 @@
 
 namespace expo::common {
 
-jsi::Object getCoreObject(jsi::Runtime &runtime) {
-  return runtime.global().getPropertyAsObject(runtime, "expo");
-}
-
 jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor) {
   std::string nativeConstructorKey("__native_constructor__");
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -14,7 +14,9 @@ namespace expo::common {
 /**
  Gets the core Expo object, i.e. `global.expo`.
  */
-jsi::Object getCoreObject(jsi::Runtime &runtime);
+inline jsi::Object getCoreObject(jsi::Runtime &runtime) {
+  return runtime.global().getPropertyAsObject(runtime, "expo");
+}
 
 #pragma mark - Classes
 

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -9,6 +9,13 @@ namespace jsi = facebook::jsi;
 
 namespace expo::common {
 
+#pragma mark - Helpers
+
+/**
+ Gets the core Expo object, i.e. `global.expo`.
+ */
+jsi::Object getCoreObject(jsi::Runtime &runtime);
+
 #pragma mark - Classes
 
 /**

--- a/packages/expo-modules-core/common/cpp/SharedObject.cpp
+++ b/packages/expo-modules-core/common/cpp/SharedObject.cpp
@@ -52,16 +52,12 @@ void installBaseClass(jsi::Runtime &runtime, const ObjectReleaser releaser) {
     }
   });
 
-  runtime
-    .global()
-    .getPropertyAsObject(runtime, "expo")
+  common::getCoreObject(runtime)
     .setProperty(runtime, "SharedObject", klass);
 }
 
 jsi::Function getBaseClass(jsi::Runtime &runtime) {
-  return runtime
-    .global()
-    .getPropertyAsObject(runtime, "expo")
+  return common::getCoreObject(runtime)
     .getPropertyAsFunction(runtime, "SharedObject");
 }
 


### PR DESCRIPTION
# Why

We're doing `runtime.global().getPropertyAsObject(runtime, "expo")` in a few places now, so it seems worthwhile to make a helper function.

# How

Added `common::getCoreObject(runtime)` to the common C++ codebase and used it in places where we are currently getting the core object.

# Test Plan

It's just a subtle change and the tests are passing.

<!-- disable:changelog-checks -->