### PR TITLE
[docs] layout fixes and Table of Content tweaks

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -92,3 +92,16 @@ export const isRouteActive = (
   const linkUrl = stripVersionFromPath(info?.as || info?.href);
   return linkUrl === stripVersionFromPath(pathname) || linkUrl === stripVersionFromPath(asPath);
 };
+
+export function appendSectionToRoute(route?: NavigationRouteWithSection) {
+  if (route?.children) {
+    return route.children.map((entry: NavigationRouteWithSection) =>
+      route.type !== 'page'
+        ? Object.assign(entry, {
+            section: route.section ? `${route.section} - ${route.name}` : route.name,
+          })
+        : route
+    );
+  }
+  return route;
+}

--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -1,3 +1,4 @@
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { render, RenderOptions } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
 import { PropsWithChildren, ReactElement } from 'react';
@@ -6,9 +7,11 @@ import { HeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
 const Wrapper = ({ children }: PropsWithChildren<object>) => (
-  <HeadingsContext.Provider value={new HeadingManager(new GithubSlugger(), { headings: [] })}>
-    {children}
-  </HeadingsContext.Provider>
+  <TooltipProvider>
+    <HeadingsContext.Provider value={new HeadingManager(new GithubSlugger(), { headings: [] })}>
+      {children}
+    </HeadingsContext.Provider>
+  </TooltipProvider>
 );
 
 export const renderWithHeadings = (

--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -1,204 +1,35 @@
-// NOTE(jim):
-// GETTING NESTED SCROLL RIGHT IS DELICATE BUSINESS. THEREFORE THIS COMPONENT
-// IS THE ONLY PLACE WHERE SCROLL CODE SHOULD BE HANDLED. THANKS.
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { breakpoints } from '@expo/styleguide-base';
-import * as React from 'react';
+import { mergeClasses } from '@expo/styleguide';
+import {
+  Component,
+  cloneElement,
+  createRef,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 
+import { ScrollContainer } from '~/components/ScrollContainer';
 import { SidebarHead, SidebarFooter } from '~/ui/components/Sidebar';
 
-const STYLES_CONTAINER = css`
-  width: 100%;
-  height: 100vh;
-  overflow: hidden;
-  margin: 0 auto 0 auto;
-  border-right: 1px solid ${theme.border.default};
-  background: ${theme.background.default};
-
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-direction: column;
-
-  @media screen and (max-width: 1440px) {
-    border-left: 0;
-    border-right: 0;
-  }
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    display: block;
-    height: auto;
-  }
-`;
-
-const STYLES_HEADER = css`
-  flex-shrink: 0;
-  width: 100%;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    position: sticky;
-    top: -57px;
-    z-index: 3;
-    max-height: 100vh;
-  }
-`;
-
-const STYLES_CONTENT = css`
-  display: flex;
-  align-items: flex-start;
-  margin: 0 auto;
-  justify-content: space-between;
-  width: 100%;
-  height: 100%;
-  min-height: 25%;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    height: auto;
-  }
-`;
-
-const STYLES_SIDEBAR = css`
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  max-width: 280px;
-  height: 100%;
-  overflow: hidden;
-  transition: 200ms ease max-width;
-  background: ${theme.background.default};
-
-  @media screen and (max-width: 1200px) {
-    max-width: 280px;
-  }
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    display: none;
-  }
-`;
-
-const STYLES_LEFT = css`
-  border-right: 1px solid ${theme.border.default};
-`;
-
-const STYLES_RIGHT = css`
-  border-left: 1px solid ${theme.border.default};
-  background-color: ${theme.background.default};
-`;
-
-const STYLES_CENTER = css`
-  background: ${theme.background.default};
-  min-width: 5%;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  display: flex;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    height: auto;
-    overflow: auto;
-  }
-`;
-
-// NOTE(jim):
-// All the other components tame the UI. this one allows a container to scroll.
-const STYLES_SCROLL_CONTAINER = css`
-  height: 100%;
-  width: 100%;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  -webkit-overflow-scrolling: touch;
-
-  /* width */
-  ::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  /* Track */
-  ::-webkit-scrollbar-track {
-    background: transparent;
-    cursor: pointer;
-  }
-
-  /* Handle */
-  ::-webkit-scrollbar-thumb {
-    background: ${theme.palette.gray5};
-  }
-
-  /* Handle on hover */
-  ::-webkit-scrollbar-thumb:hover {
-    background: ${theme.palette.gray6};
-  }
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    overflow-y: auto;
-  }
-`;
-
-const STYLES_CENTER_WRAPPER = css`
-  max-width: 1200px;
-  margin: auto;
-`;
-
-const STYLES_HIDDEN = css`
-  display: none;
-`;
-
-type ScrollContainerProps = React.PropsWithChildren<{
-  className?: string;
-  scrollPosition?: number;
-  scrollHandler?: () => void;
-}>;
-
-class ScrollContainer extends React.Component<ScrollContainerProps> {
-  scrollRef = React.createRef<HTMLDivElement>();
-
-  componentDidMount() {
-    if (this.props.scrollPosition && this.scrollRef.current) {
-      this.scrollRef.current.scrollTop = this.props.scrollPosition;
-    }
-  }
-
-  public getScrollTop = () => {
-    return this.scrollRef.current?.scrollTop ?? 0;
-  };
-
-  public getScrollRef = () => {
-    return this.scrollRef;
-  };
-
-  render() {
-    return (
-      <div
-        css={STYLES_SCROLL_CONTAINER}
-        className={this.props.className}
-        ref={this.scrollRef}
-        onScroll={this.props.scrollHandler}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
-
-type Props = React.PropsWithChildren<{
+type Props = PropsWithChildren<{
   onContentScroll?: (scrollTop: number) => void;
   isMobileMenuVisible: boolean;
   hideTOC: boolean;
   header: React.ReactNode;
   sidebarScrollPosition: number;
-  sidebar: React.ReactNode;
+  sidebar: ReactNode;
   sidebarActiveGroup: string;
-  sidebarRight: React.ReactElement;
+  sidebarRight: ReactElement;
 }>;
 
-export default class DocumentationNestedScrollLayout extends React.Component<Props> {
+export default class DocumentationNestedScrollLayout extends Component<Props> {
   static defaultProps = {
     sidebarScrollPosition: 0,
   };
 
-  sidebarRef = React.createRef<ScrollContainer>();
-  contentRef = React.createRef<ScrollContainer>();
-  sidebarRightRef = React.createRef<ScrollContainer>();
+  sidebarRef = createRef<ScrollContainer>();
+  contentRef = createRef<ScrollContainer>();
+  sidebarRightRef = createRef<ScrollContainer>();
 
   public getSidebarScrollTop = () => {
     return this.sidebarRef.current?.getScrollTop() ?? 0;
@@ -221,10 +52,14 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
     } = this.props;
 
     return (
-      <div css={STYLES_CONTAINER}>
-        <div css={STYLES_HEADER}>{header}</div>
-        <div css={STYLES_CONTENT}>
-          <div css={[STYLES_SIDEBAR, STYLES_LEFT]}>
+      <div className="w-full h-[100vh] overflow-hidden mx-auto flex flex-col">
+        <div className="max-lg-gutters:sticky">{header}</div>
+        <div className="flex mx-auto justify-between items-center w-full h-[calc(100vh-60px)]">
+          <div
+            className={mergeClasses(
+              'flex flex-col shrink-0 max-w-[280px] h-full overflow-hidden border-r border-r-default',
+              'max-lg-gutters:hidden'
+            )}>
             <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
             <ScrollContainer
               ref={this.sidebarRef}
@@ -234,15 +69,24 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
               <SidebarFooter />
             </ScrollContainer>
           </div>
-          <div css={[STYLES_CENTER, isMobileMenuVisible && STYLES_HIDDEN]}>
+          <div
+            className={mergeClasses(
+              'w-full h-[calc(100vh-60px)] flex overflow-hidden',
+              'max-lg-gutters:overflow-auto',
+              isMobileMenuVisible && 'hidden'
+            )}>
             <ScrollContainer ref={this.contentRef} scrollHandler={this.scrollHandler}>
-              <div css={STYLES_CENTER_WRAPPER}>{children}</div>
+              <div className="max-w-[1200px] mx-auto">{children}</div>
             </ScrollContainer>
           </div>
           {!hideTOC && (
-            <div css={[STYLES_SIDEBAR, STYLES_RIGHT]}>
+            <div
+              className={mergeClasses(
+                'flex flex-col shrink-0 max-w-[280px] h-full overflow-hidden border-l border-l-default',
+                'max-lg-gutters:hidden'
+              )}>
               <ScrollContainer ref={this.sidebarRightRef}>
-                {React.cloneElement(sidebarRight, {
+                {cloneElement(sidebarRight, {
                   selfRef: this.sidebarRightRef,
                   contentRef: this.contentRef,
                 })}

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,11 +1,10 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
+import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState, createRef, type PropsWithChildren } from 'react';
 
 import * as RoutesUtils from '~/common/routes';
-import { isRouteActive } from '~/common/routes';
+import { appendSectionToRoute, isRouteActive } from '~/common/routes';
 import * as WindowUtils from '~/common/window';
 import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
 import DocumentationSidebarRight, {
@@ -13,40 +12,16 @@ import DocumentationSidebarRight, {
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
-import { NavigationRouteWithSection, PageMetadata } from '~/types/common';
+import { PageMetadata } from '~/types/common';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
+import { PagePlatformTags } from '~/ui/components/PagePlatformTags';
 import { PageTitle } from '~/ui/components/PageTitle';
 import { Separator } from '~/ui/components/Separator';
 import { Sidebar } from '~/ui/components/Sidebar';
-import { Tag } from '~/ui/components/Tag';
-import { FOOTNOTE, P } from '~/ui/components/Text';
-import * as Tooltip from '~/ui/components/Tooltip';
-
-const STYLES_DOCUMENT = css`
-  background: ${theme.background.default};
-  margin: 0 auto;
-  padding: 40px 56px;
-
-  @media screen and (max-width: ${breakpoints.medium + 124}px) {
-    padding: 20px 16px 48px 16px;
-  }
-`;
+import { P } from '~/ui/components/Text';
 
 export type DocPageProps = PropsWithChildren<PageMetadata>;
-
-function appendSectionToRoute(route?: NavigationRouteWithSection) {
-  if (route?.children) {
-    return route.children.map((entry: NavigationRouteWithSection) =>
-      route.type !== 'page'
-        ? Object.assign(entry, {
-            section: route.section ? `${route.section} - ${route.name}` : route.name,
-          })
-        : route
-    );
-  }
-  return route;
-}
 
 export default function DocumentationPage({
   title,
@@ -154,7 +129,11 @@ export default function DocumentationPage({
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
       </Head>
-      <div css={STYLES_DOCUMENT}>
+      <div
+        className={mergeClasses(
+          'mx-auto py-10 px-14',
+          'max-lg-gutters:px-4 max-lg-gutters:pt-5 max-lg-gutters:pb-12'
+        )}>
         {title && (
           <PageTitle
             title={title}
@@ -168,32 +147,7 @@ export default function DocumentationPage({
             {description}
           </P>
         )}
-        {platforms && (
-          <div className="inline-flex mt-3 flex-wrap gap-y-1.5">
-            {platforms
-              .sort((a, b) => a.localeCompare(b))
-              .map(platform => {
-                if (platform.includes('*')) {
-                  return (
-                    <Tooltip.Root>
-                      <Tooltip.Trigger key={platform} className="cursor-default">
-                        <Tag name={platform} className="!rounded-full" />
-                      </Tooltip.Trigger>
-                      <Tooltip.Content side="bottom">
-                        {platform.startsWith('android') && (
-                          <FOOTNOTE>Android Emulator not supported</FOOTNOTE>
-                        )}
-                        {platform.startsWith('ios') && (
-                          <FOOTNOTE>iOS Simulator not supported</FOOTNOTE>
-                        )}
-                      </Tooltip.Content>
-                    </Tooltip.Root>
-                  );
-                }
-                return <Tag name={platform} key={platform} className="!rounded-full" />;
-              })}
-          </div>
-        )}
+        {platforms && <PagePlatformTags platforms={platforms} />}
         {title && <Separator />}
         {children}
         <Footer

--- a/docs/components/DocumentationSidebarRight.test.tsx
+++ b/docs/components/DocumentationSidebarRight.test.tsx
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
 
 import DocumentationSidebarRight from './DocumentationSidebarRight';
 
 import { HeadingManager, HeadingType } from '~/common/headingManager';
+import { renderWithHeadings } from '~/common/test-utilities';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
 const prepareHeadingManager = () => {
@@ -22,7 +22,7 @@ describe('DocumentationSidebarRight', () => {
   test('correctly matches snapshot', () => {
     const headingManager = prepareHeadingManager();
 
-    const { container } = render(
+    const { container } = renderWithHeadings(
       <HeadingsContext.Provider value={headingManager}>
         <DocumentationSidebarRight />
       </HeadingsContext.Provider>

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -150,7 +150,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
       top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR,
     });
 
-    if (!history?.replaceState) {
+    if (history?.replaceState) {
       history.replaceState(history.state, '', '#' + slug);
     }
   };
@@ -165,7 +165,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
       top: 0,
     });
 
-    if (!history?.replaceState) {
+    if (history?.replaceState) {
       history.replaceState(history.state, '', ' ');
     }
   };

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
 import { Button, mergeClasses } from '@expo/styleguide';
-import { breakpoints, spacing } from '@expo/styleguide-base';
 import { ArrowCircleUpIcon, LayoutAlt03Icon } from '@expo/styleguide-icons';
 import * as React from 'react';
 
@@ -12,32 +10,13 @@ import withHeadingManager, {
 } from '~/components/page-higher-order/withHeadingManager';
 import { CALLOUT } from '~/ui/components/Text';
 
-const sidebarStyle = css({
-  padding: spacing[6],
-  paddingTop: spacing[14],
-  paddingBottom: spacing[12],
-  width: 280,
-
-  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
-    width: '100%',
-  },
-});
-
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
 const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;
 
 const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 10;
 
 const isDynamicScrollAvailable = () => {
-  if (!history?.replaceState) {
-    return false;
-  }
-
-  if (window.matchMedia('(prefers-reduced-motion)').matches) {
-    return false;
-  }
-
-  return true;
+  return !window.matchMedia('(prefers-reduced-motion)').matches;
 };
 
 type Props = React.PropsWithChildren<{
@@ -102,7 +81,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     );
 
     return (
-      <nav css={sidebarStyle} data-sidebar>
+      <nav className="pt-14 pb-12 px-6 w-[280px]" data-sidebar>
         <CALLOUT
           weight="medium"
           className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none">
@@ -157,38 +136,38 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     }
   };
 
-  private handleLinkClick = (event: React.MouseEvent<HTMLAnchorElement>, heading: Heading) => {
-    if (!isDynamicScrollAvailable()) {
-      return;
-    }
-
+  private handleLinkClick = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    { slug, ref }: Heading
+  ) => {
     event.preventDefault();
-    const { slug, ref } = heading;
 
     // disable sidebar scrolling until we reach that slug
     this.slugScrollingTo = slug;
 
     this.props.contentRef?.current?.getScrollRef().current?.scrollTo({
-      behavior: 'smooth',
+      behavior: isDynamicScrollAvailable() ? 'smooth' : 'instant',
       top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR,
     });
-    history.replaceState(history.state, '', '#' + slug);
+
+    if (!history?.replaceState) {
+      history.replaceState(history.state, '', '#' + slug);
+    }
   };
 
   private handleTopClick = (
     event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>
   ) => {
-    if (!isDynamicScrollAvailable()) {
-      return;
-    }
-
     event.preventDefault();
 
     this.props.contentRef?.current?.getScrollRef().current?.scrollTo({
-      behavior: 'smooth',
+      behavior: isDynamicScrollAvailable() ? 'smooth' : 'instant',
       top: 0,
     });
-    history.replaceState(history.state, '', ' ');
+
+    if (!history?.replaceState) {
+      history.replaceState(history.state, '', ' ');
+    }
   };
 }
 

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -52,8 +52,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
             className={mergeClasses(
               'flex mb-1.5 truncate items-center justify-between !text-pretty',
               'focus-visible:relative focus-visible:z-10'
-            )}
-          >
+            )}>
             <TitleElement
               className={mergeClasses(
                 '!text-secondary hocus:!text-link',

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -1,78 +1,90 @@
-import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { mergeClasses } from '@expo/styleguide';
 import Link from 'next/link';
-import * as React from 'react';
+import { forwardRef, useState, type MouseEvent } from 'react';
 
 import { BASE_HEADING_LEVEL, Heading, HeadingType } from '~/common/headingManager';
 import { Tag } from '~/ui/components/Tag';
-import { MONOSPACE, CALLOUT } from '~/ui/components/Text';
-
-const STYLES_LINK = css`
-  transition: 50ms ease color;
-  display: flex;
-  text-decoration: none;
-  margin-bottom: 6px;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  align-items: center;
-  justify-content: space-between;
-
-  :focus-visible {
-    position: relative;
-    z-index: 10;
-  }
-`;
-
-const STYLES_LINK_LABEL = css`
-  color: ${theme.text.secondary};
-
-  :hover {
-    color: ${theme.text.link};
-  }
-`;
-
-const STYLES_LINK_MONOSPACE = css`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  ${typography.fontSizes[13]}
-`;
-
-const STYLES_LINK_ACTIVE = css`
-  color: ${theme.text.link};
-`;
-
-const STYLES_TOOLTIP = css`
-  border-radius: 3px;
-  position: absolute;
-  background-color: ${theme.background.subtle};
-  max-width: 400px;
-  border: 1px solid ${theme.border.default};
-  padding: 3px 6px;
-  display: inline-block;
-`;
-
-const STYLES_TOOLTIP_TEXT = css`
-  ${typography.fontSizes[13]}
-  color: ${theme.text.default};
-  word-break: break-word;
-  word-wrap: normal;
-`;
-
-const STYLES_TOOLTIP_CODE = css`
-  ${typography.fontSizes[12]}
-`;
-
-const STYLES_TAG_CONTAINER = css`
-  display: inline-flex;
-`;
+import { MONOSPACE, CALLOUT, FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 const NESTING_OFFSET = 12;
 
+type SidebarLinkProps = {
+  heading: Heading;
+  isActive: boolean;
+  shortenCode: boolean;
+  onClick: (event: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkProps>(
+  ({ heading, isActive, shortenCode, onClick }, ref) => {
+    const { slug, level, title, type, tags } = heading;
+
+    // preset for monospace, tail ellipsis, and removing extra bits like details of function signatures
+    const isCode = type === HeadingType.InlineCode;
+    // preset for monospace, tail ellipsis, don't touch the title otherwise
+    const isCodeOrFilePath = isCode || type === HeadingType.CodeFilePath;
+
+    const paddingLeft = NESTING_OFFSET * (level - BASE_HEADING_LEVEL);
+    const displayTitle = shortenCode && isCode ? trimCodedTitle(title) : title;
+
+    const [tooltipVisible, setTooltipVisible] = useState(false);
+    const onMouseOver = (event: MouseEvent<HTMLAnchorElement>) => {
+      setTooltipVisible(isOverflowing(event.currentTarget));
+    };
+
+    const onMouseOut = () => {
+      setTooltipVisible(false);
+    };
+
+    const TitleElement = isCodeOrFilePath ? MONOSPACE : CALLOUT;
+
+    return (
+      <Tooltip.Root open={tooltipVisible}>
+        <Tooltip.Trigger asChild>
+          <Link
+            ref={ref}
+            onMouseOver={isCode ? onMouseOver : undefined}
+            onMouseOut={isCode ? onMouseOut : undefined}
+            href={'#' + slug}
+            onClick={onClick}
+            style={paddingLeft ? { paddingLeft } : undefined}
+            className={mergeClasses(
+              'flex mb-1.5 truncate items-center justify-between !text-pretty',
+              'focus-visible:relative focus-visible:z-10'
+            )}
+          >
+            <TitleElement
+              className={mergeClasses(
+                '!text-secondary hocus:!text-link',
+                isCodeOrFilePath && 'truncate !text-2xs',
+                isActive && '!text-link'
+              )}>
+              {displayTitle}
+            </TitleElement>
+            {tags && tags.length ? (
+              <div className="inline-flex">
+                {tags.map(tag => (
+                  <Tag name={tag} type="toc" key={`${displayTitle}-${tag}`} />
+                ))}
+              </div>
+            ) : undefined}
+          </Link>
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="bottom"
+          collisionPadding={{
+            right: 22,
+          }}>
+          <FOOTNOTE tag="code">{displayTitle}</FOOTNOTE>
+        </Tooltip.Content>
+      </Tooltip.Root>
+    );
+  }
+);
+
 /**
- * Replaces `Module.someFunction(arguments: argType)`
- * with `someFunction()`
+ * Replaces `Module.someFunction(arguments: argType)` with `someFunction()`
  */
 const trimCodedTitle = (str: string) => {
   const dotIdx = str.indexOf('.');
@@ -85,9 +97,8 @@ const trimCodedTitle = (str: string) => {
 };
 
 /**
- * Determines if element is overflowing
- * (its children width exceeds container width)
- * @param {HTMLElement} el element to check
+ * Determines if element is overflowing (children width exceeds container width).
+ * @param {HTMLElement} el HTML element to check
  */
 const isOverflowing = (el: HTMLElement) => {
   if (!el || !el.children) {
@@ -98,89 +109,5 @@ const isOverflowing = (el: HTMLElement) => {
   const indent = parseInt(window.getComputedStyle(el).paddingLeft, 10);
   return childrenWidth >= el.scrollWidth - indent;
 };
-
-type TooltipProps = React.PropsWithChildren<{
-  isCode?: boolean;
-  topOffset: number;
-}>;
-
-const Tooltip = ({ children, isCode, topOffset }: TooltipProps) => {
-  const ContentWrapper = isCode ? MONOSPACE : CALLOUT;
-  return (
-    <div css={STYLES_TOOLTIP} style={{ right: 24, top: topOffset }}>
-      <ContentWrapper css={[STYLES_TOOLTIP_TEXT, isCode && STYLES_TOOLTIP_CODE]}>
-        {children}
-      </ContentWrapper>
-    </div>
-  );
-};
-
-type SidebarLinkProps = {
-  heading: Heading;
-  isActive: boolean;
-  shortenCode: boolean;
-  onClick: (event: React.MouseEvent<HTMLAnchorElement>) => void;
-};
-
-const DocumentationSidebarRightLink = React.forwardRef<HTMLAnchorElement, SidebarLinkProps>(
-  ({ heading, isActive, shortenCode, onClick }, ref) => {
-    const { slug, level, title, type, tags } = heading;
-
-    // preset for monospace, tail ellipsize, and removing extra bits like details of function signatures
-    const isCode = type === HeadingType.InlineCode;
-    // preset for monospace, tail ellipsize, don't touch the title otherwise
-    const isCodeOrFilePath = isCode || type === HeadingType.CodeFilePath;
-    const paddingLeft = NESTING_OFFSET * (level - BASE_HEADING_LEVEL);
-    const displayTitle = shortenCode && isCode ? trimCodedTitle(title) : title;
-
-    const [tooltipVisible, setTooltipVisible] = React.useState(false);
-    const [tooltipOffset, setTooltipOffset] = React.useState(-20);
-    const onMouseOver = (event: React.MouseEvent<HTMLAnchorElement>) => {
-      setTooltipVisible(isOverflowing(event.currentTarget));
-      setTooltipOffset(
-        event.currentTarget.getBoundingClientRect().top + event.currentTarget.offsetHeight
-      );
-    };
-
-    const onMouseOut = () => {
-      setTooltipVisible(false);
-    };
-
-    const TitleElement = isCodeOrFilePath ? MONOSPACE : CALLOUT;
-
-    return (
-      <>
-        {tooltipVisible && isCode && (
-          <Tooltip topOffset={tooltipOffset} isCode={isCode}>
-            {displayTitle}
-          </Tooltip>
-        )}
-        <Link
-          ref={ref}
-          onMouseOver={isCode ? onMouseOver : undefined}
-          onMouseOut={isCode ? onMouseOut : undefined}
-          href={'#' + slug}
-          onClick={onClick}
-          css={[STYLES_LINK, paddingLeft && { paddingLeft }]}>
-          <TitleElement
-            css={[
-              STYLES_LINK_LABEL,
-              isCodeOrFilePath && STYLES_LINK_MONOSPACE,
-              isActive && STYLES_LINK_ACTIVE,
-            ]}>
-            {displayTitle}
-          </TitleElement>
-          {tags && tags.length ? (
-            <div css={STYLES_TAG_CONTAINER}>
-              {tags.map(tag => (
-                <Tag name={tag} type="toc" key={`${displayTitle}-${tag}`} />
-              ))}
-            </div>
-          ) : undefined}
-        </Link>
-      </>
-    );
-  }
-);
 
 export default DocumentationSidebarRightLink;

--- a/docs/components/ScrollContainer.tsx
+++ b/docs/components/ScrollContainer.tsx
@@ -1,0 +1,40 @@
+import { mergeClasses } from '@expo/styleguide';
+import { Component, createRef, PropsWithChildren } from 'react';
+
+type ScrollContainerProps = PropsWithChildren<{
+  className?: string;
+  scrollPosition?: number;
+  scrollHandler?: () => void;
+}>;
+
+export class ScrollContainer extends Component<ScrollContainerProps> {
+  scrollRef = createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    if (this.props.scrollPosition && this.scrollRef.current) {
+      this.scrollRef.current.scrollTop = this.props.scrollPosition;
+    }
+  }
+
+  public getScrollTop = () => {
+    return this.scrollRef.current?.scrollTop ?? 0;
+  };
+
+  public getScrollRef = () => {
+    return this.scrollRef;
+  };
+
+  render() {
+    return (
+      <div
+        className={mergeClasses(
+          'size-full overflow-x-hidden overflow-y-auto',
+          this.props.className
+        )}
+        ref={this.scrollRef}
+        onScroll={this.props.scrollHandler}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="css-wc5n09"
+    class="pt-14 pb-12 px-6 w-[280px]"
     data-sidebar="true"
   >
     <p
@@ -62,33 +62,38 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </button>
     </p>
     <a
-      class="css-vmf6tj"
+      class="flex mb-1.5 truncate items-center justify-between !text-pretty focus-visible:relative focus-visible:z-10"
+      data-state="closed"
       href="#base-level-heading"
     >
       <p
-        class="css-dhipyq-TextComponent"
+        class="!text-secondary hocus:!text-link css-1yjys1n-TextComponent"
         data-text="true"
       >
         Base level heading
       </p>
     </a>
     <a
-      class="css-1p8gu4x"
+      class="flex mb-1.5 truncate items-center justify-between !text-pretty focus-visible:relative focus-visible:z-10"
+      data-state="closed"
       href="#level-3-subheading"
+      style="padding-left: 12px;"
     >
       <p
-        class="css-dhipyq-TextComponent"
+        class="!text-secondary hocus:!text-link css-1yjys1n-TextComponent"
         data-text="true"
       >
         Level 3 subheading
       </p>
     </a>
     <a
-      class="css-1p8gu4x"
+      class="flex mb-1.5 truncate items-center justify-between !text-pretty focus-visible:relative focus-visible:z-10"
+      data-state="closed"
       href="#code-heading-depth-1"
+      style="padding-left: 12px;"
     >
       <code
-        class="css-1jai1da-TextComponent"
+        class="!text-secondary hocus:!text-link truncate !text-2xs css-yszm2s-TextComponent"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -379,7 +379,6 @@ export default function Settings() {
     </View>
   );
 }
-
 ```
 
 ## More

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -1,0 +1,34 @@
+import { Tag } from '~/ui/components/Tag';
+import { FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
+
+type Props = {
+  platforms: string[];
+};
+
+export function PagePlatformTags({ platforms }: Props) {
+  return (
+    <div className="inline-flex mt-3 flex-wrap gap-y-1.5">
+      {platforms
+        .sort((a, b) => a.localeCompare(b))
+        .map(platform => {
+          if (platform.includes('*')) {
+            return (
+              <Tooltip.Root>
+                <Tooltip.Trigger key={platform} className="cursor-default">
+                  <Tag name={platform} className="!rounded-full" />
+                </Tooltip.Trigger>
+                <Tooltip.Content side="bottom">
+                  {platform.startsWith('android') && (
+                    <FOOTNOTE>Android Emulator not supported</FOOTNOTE>
+                  )}
+                  {platform.startsWith('ios') && <FOOTNOTE>iOS Simulator not supported</FOOTNOTE>}
+                </Tooltip.Content>
+              </Tooltip.Root>
+            );
+          }
+          return <Tag name={platform} key={platform} className="!rounded-full" />;
+        })}
+    </div>
+  );
+}

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -11,7 +11,11 @@ type Props = {
 };
 
 export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => (
-  <div className="flex my-2 items-center justify-between max-xl-gutters:flex-col max-xl-gutters:items-start">
+  <div
+    className={mergeClasses(
+      'flex my-2 items-center justify-between',
+      'max-xl-gutters:flex-col max-xl-gutters:items-start'
+    )}>
     <H1 className="!my-0">
       {iconUrl && (
         <img
@@ -24,20 +28,20 @@ export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props)
       {title}
     </H1>
     {packageName && (
-      <span className="flex gap-1 max-lg-gutters:mt-3 max-lg-gutters:mb-1">
+      <span className="flex gap-1 max-xl-gutters:mt-3 max-xl-gutters:mb-1">
         {sourceCodeUrl && (
           <Button
             theme="quaternary"
-            className="min-h-[48px] min-w-[60px] px-2 justify-center max-lg-gutters:min-h-[unset]"
+            className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
             openInNewTab
             href={sourceCodeUrl}
             title={`View source code of ${packageName} on GitHub`}>
             <div
               className={mergeClasses(
                 'flex flex-col items-center',
-                'max-lg-gutters:flex-row max-lg-gutters:gap-1.5'
+                'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
               )}>
-              <GithubIcon className="text-icon-secondary" />
+              <GithubIcon className="mt-0.5 text-icon-secondary" />
               <CALLOUT crawlable={false} theme="secondary">
                 GitHub
               </CALLOUT>
@@ -47,15 +51,15 @@ export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props)
         <Button
           theme="quaternary"
           openInNewTab
-          className="min-h-[48px] min-w-[60px] px-2 justify-center max-lg-gutters:min-h-[unset]"
+          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
           href={`https://www.npmjs.com/package/${packageName}`}
           title="View package in npm Registry">
           <div
             className={mergeClasses(
               'flex flex-col items-center',
-              'max-lg-gutters:flex-row max-lg-gutters:gap-1.5'
+              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
             )}>
-            <BuildIcon className="text-icon-secondary" />
+            <BuildIcon className="mt-0.5 text-icon-secondary" />
             <CALLOUT crawlable={false} theme="secondary">
               npm
             </CALLOUT>


### PR DESCRIPTION
# Why

Preparation to further Table of Content changes.

# How

This PR includes the following changes:
* most of the layout elements style rewritten to Tailwind,
* unify layout breakpoints,
* fix for non-working sticky header in mobile view,
* fix for not working "Scroll to top" button when OS setting to prefer reduced motion was enabled,
* use recently introduced Radix tooltip instead on custom on in Table of Content,
* extract API Reference platform tags to a separate component.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-03-08 at 12 37 13](https://github.com/expo/expo/assets/719641/0a1fadd0-6ee3-4410-a622-9f6b1254c5e6)
![Screenshot 2024-03-08 at 15 26 27](https://github.com/expo/expo/assets/719641/d9482cbc-a8d5-4f23-918e-216884cf9c91)

