### PR TITLE
[docs] add missing `PackagerAsset` type link

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -183,6 +183,7 @@ const hardcodedTypeLinks: Record<string, string> = {
   MediaTrackSettings: 'https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings',
   MessageEvent: 'https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent',
   Omit: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys',
+  PackagerAsset: 'https://github.com/facebook/react-native/blob/main/packages/assets/registry.js',
   Pick: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys',
   Partial: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype',
   Platform: 'https://reactnative.dev/docs/platform',


### PR DESCRIPTION
# Why

We use that type in our internal type definition in `expo-asset`:
* https://docs.expo.dev/versions/latest/sdk/asset/#assetmetadata

# How

Add link to the RN core repo, since there is no docs talking about this package or its properties.

# Test Plan

`PackagerAsset` is a not dead link anymore.
