### PR TITLE
[go][iOS] Use monospaced digit font on app loading progress view

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -57,7 +57,7 @@
 
       self.textLabel = [UILabel new];
       self.textLabel.frame = CGRectMake(10, 0, screenSize.width - 20, 36);
-      self.textLabel.font = [UIFont systemFontOfSize:12];
+      self.textLabel.font = [UIFont monospacedDigitSystemFontOfSize:12 weight:(UIFontWeightRegular)];
       self.textLabel.textAlignment = NSTextAlignmentLeft;
       self.textLabel.textColor = [EXUtil colorWithRGB:0xa7a7a7];
       [containerView addSubview:self.textLabel];


### PR DESCRIPTION
# Why

on iOS when loading a bundle through Expo Go the app loading progress view text "jiggles" when updating the progress % because of the different widths of each number

# How

Use `monospacedDigitSystemFontOfSize` instead of `systemFontOfSize`

# Test Plan

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<td>
<video src="https://github.com/expo/expo/assets/11707729/cc86fd9b-4e96-4a28-a455-d16ff356af76" />
</td>
<td>
<video src="https://github.com/expo/expo/assets/11707729/ae43a11e-269a-4ce9-beba-267c5c8bacc0" /> 
</td>
<tr>
</tr>
</table>


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
