### PR TITLE
[core] Add AppContext initializer to ExpoBridgeModule

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Introduced a base class for all shared objects (`expo.SharedObject`) with a simple mechanism to release native pointer from JS. ([#27038](https://github.com/expo/expo/pull/27038) by [@tsapeta](https://github.com/tsapeta) & [#27331](https://github.com/expo/expo/pull/27331) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added native implementation of the JS EventEmitter. ([#27092](https://github.com/expo/expo/pull/27092) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Allow for the export of views that conform to `AnyExpoView` ([#27284](https://github.com/expo/expo/pull/27284) by [@dominicstop](https://github.com/dominicstop))
-- [iOS] Added support for bridgeless mode in React Native 0.74 ([#27242](https://github.com/expo/expo/pull/27242), [#27289](https://github.com/expo/expo/pull/27289) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added support for bridgeless mode in React Native 0.74 ([#27242](https://github.com/expo/expo/pull/27242), [#27289](https://github.com/expo/expo/pull/27289), [#27531](https://github.com/expo/expo/pull/27531) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Implemented sending events from native shared objects. ([#27333](https://github.com/expo/expo/pull/27333) by [@tsapeta](https://github.com/tsapeta))
 - Added support for `startObserving` and `stopObserving` in the new `EventEmitter` class. ([#27393](https://github.com/expo/expo/pull/27393) by [@tsapeta](https://github.com/tsapeta))
 

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
@@ -10,6 +10,8 @@
 
 @property (nonatomic, nullable, strong) EXAppContext *appContext;
 
+- (nonnull instancetype)initWithAppContext:(nonnull EXAppContext *) appContext; 
+
 - (void)legacyProxyDidSetBridge:(nonnull EXNativeModulesProxy *)moduleProxy
            legacyModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
 

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -23,6 +23,14 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   return self;
 }
 
+- (instancetype)initWithAppContext:(EXAppContext *) appContext
+{
+  if (self = [super init]) {
+    _appContext = appContext;
+  }
+  return self;
+}
+
 + (BOOL)requiresMainQueueSetup
 {
   // We do want to run the initialization (`setBridge`) on the JS thread.


### PR DESCRIPTION
# Why

Trying to build Expo Go on main results in the following error 
![image](https://github.com/expo/expo/assets/11707729/4663b589-e0e8-4e5d-b302-17f73b8e7a10)
 

When we rewrote `ExpoBridgeModule` module back to Objective-C++ we forgot to add the equivalent `AppContext` initializer used by expo go VersionManager

# How

Add `initWithAppContext` initializer to ExpoBridgeModule

# Test Plan

Run Expo Go locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
