### PR TITLE
[go][iOS] Remove EXMediaLibraryImageLoader remaining references

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.m
@@ -35,7 +35,6 @@
 
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <ExpoModulesCore/EXModuleRegistryHolderReactModule.h>
-#import <EXMediaLibrary/EXMediaLibraryImageLoader.h>
 
 // When `use_frameworks!` is used, the generated Swift header is inside modules.
 // Otherwise, it's available only locally with double-quoted imports.
@@ -447,7 +446,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
   // Standard
   if (moduleClass == RCTImageLoader.class) {
     return [[moduleClass alloc] initWithRedirectDelegate:nil loadersProvider:^NSArray<id<RCTImageURLLoader>> *(RCTModuleRegistry *) {
-      return @[[RCTLocalAssetImageLoader new], [EXMediaLibraryImageLoader new]];
+      return @[[RCTLocalAssetImageLoader new]];
     } decodersProvider:^NSArray<id<RCTImageDataDecoder>> *(RCTModuleRegistry *) {
       return @[[RCTGIFImageDecoder new]];
     }];


### PR DESCRIPTION
# Why

When we migrated media-library to Expo Modules https://github.com/expo/expo/pull/25587, we deleted EXMediaLibraryImageLoader files but forgot to remove its references from Expo Go, causing builds to fail.


# How

Remove `EXMediaLibraryImageLoader` remaining references

# Test Plan

Run Expo Go locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
