### PR TITLE
[ios][camera] Fix initial orientation

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -415,6 +415,7 @@ export default class CameraScreen extends React.Component<object, State> {
         ratio={this.state.ratio}
         pictureSize={this.state.pictureSize}
         onMountError={this.handleMountError}
+        responsiveOrientationWhenOrientationLocked
         onFacesDetected={this.state.faceDetecting ? this.onFacesDetected : undefined}
         faceDetectorSettings={{
           tracking: true,

--- a/apps/native-component-list/src/screens/Camera/CameraScreenNext.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenNext.tsx
@@ -293,6 +293,7 @@ export default class CameraScreen extends React.Component<object, State> {
         onCameraReady={() => {
           console.log('ready');
         }}
+        responsiveOrientationWhenOrientationLocked
         enableTorch={this.state.torchEnabled}
         facing={this.state.facing}
         flash={this.state.flash}

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fix scanned frame bounds when scanning a barcode. ([#27207](https://github.com/expo/expo/pull/27207) by [@tamagokun](https://github.com/tamagokun))
 - Fix incorrect prop name `flash` being passed to native. ([#27394](https://github.com/expo/expo/pull/27394) by [@alanjhughes](https://github.com/alanjhughes))
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix camera orientation on initial render.
+- On `iOS`, fix camera orientation on initial render. ([#27545](https://github.com/expo/expo/pull/27545) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix scanned frame bounds when scanning a barcode. ([#27207](https://github.com/expo/expo/pull/27207) by [@tamagokun](https://github.com/tamagokun))
 - Fix incorrect prop name `flash` being passed to native. ([#27394](https://github.com/expo/expo/pull/27394) by [@alanjhughes](https://github.com/alanjhughes))
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix camera orientation on initial render.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraView.swift
+++ b/packages/expo-camera/ios/CameraView.swift
@@ -132,7 +132,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     previewLayer?.needsDisplayOnBoundsChange = true
     barCodeScanner?.setPreviewLayer(previewLayer)
     #endif
-    self.changePreviewOrientation(orientation: UIApplication.shared.statusBarOrientation)
     self.initializeCaptureSessionInput()
     self.startSession()
     NotificationCenter.default.addObserver(
@@ -237,6 +236,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       }
 
       self.addErrorNotification()
+      self.changePreviewOrientation()
 
       self.sessionQueue.asyncAfter(deadline: .now() + round(50 / 1_000_000)) {
         self.maybeStartFaceDetection(self.presetCamera != .back)
@@ -413,11 +413,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       let connection = photoOutput.connection(with: .video)
       let orientation = self.responsiveWhenOrientationLocked ? self.physicalOrientation : UIDevice.current.orientation
       connection?.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
-      let photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecJPEG])
+      let photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
 
-      if photoOutput.isHighResolutionCaptureEnabled {
-        photoSettings.isHighResolutionPhotoEnabled = true
-      }
       var requestedFlashMode = AVCaptureDevice.FlashMode.off
 
       switch self.flashMode {
@@ -911,13 +908,12 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   @objc func orientationChanged(notification: Notification) {
-    changePreviewOrientation(orientation: deviceOrientation)
+    changePreviewOrientation()
   }
 
-  func changePreviewOrientation(orientation: UIInterfaceOrientation) {
-    let videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
-
+  func changePreviewOrientation() {
     EXUtilities.performSynchronously {
+      let videoOrientation = ExpoCameraUtils.videoOrientation(for: self.deviceOrientation)
       if (self.previewLayer?.connection?.isVideoOrientationSupported) == true {
         self.previewLayer?.connection?.videoOrientation = videoOrientation
       }

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -207,10 +207,10 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
         photoOutput.isLivePhotoCaptureEnabled = false
         self.photoOutput = photoOutput
       }
-      
+
       self.addErrorNotification()
       self.changePreviewOrientation()
-      
+
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
         self.barcodeScanner.maybeStartBarcodeScanning()
@@ -308,7 +308,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       let orientation = self.responsiveWhenOrientationLocked ? self.physicalOrientation : UIDevice.current.orientation
       connection?.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
       let photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
-      
+
       var requestedFlashMode = AVCaptureDevice.FlashMode.off
 
       switch self.flashMode {

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -115,9 +115,9 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     #if !targetEnvironment(simulator)
     setupPreview()
     #endif
-    self.changePreviewOrientation(orientation: UIApplication.shared.statusBarOrientation)
-    self.initializeCaptureSessionInput()
-    self.startSession()
+    UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+    initializeCaptureSessionInput()
+    startSession()
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(orientationChanged(notification:)),
@@ -199,10 +199,6 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
 
     sessionQueue.async {
-      if self.presetCamera == .unspecified {
-        return
-      }
-
       self.session.beginConfiguration()
 
       let photoOutput = AVCapturePhotoOutput()
@@ -211,7 +207,10 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
         photoOutput.isLivePhotoCaptureEnabled = false
         self.photoOutput = photoOutput
       }
-
+      
+      self.addErrorNotification()
+      self.changePreviewOrientation()
+      
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
         self.barcodeScanner.maybeStartBarcodeScanning()
@@ -239,7 +238,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
 
   private func addErrorNotification() {
     if self.errorNotification != nil {
-      NotificationCenter.default.removeObserver(self.errorNotification)
+      NotificationCenter.default.removeObserver(self.errorNotification as Any)
     }
 
     self.errorNotification = NotificationCenter.default.addObserver(
@@ -308,11 +307,8 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       let connection = photoOutput.connection(with: .video)
       let orientation = self.responsiveWhenOrientationLocked ? self.physicalOrientation : UIDevice.current.orientation
       connection?.videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
-      let photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecJPEG])
-
-      if photoOutput.isHighResolutionCaptureEnabled {
-        photoSettings.isHighResolutionPhotoEnabled = true
-      }
+      let photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+      
       var requestedFlashMode = AVCaptureDevice.FlashMode.off
 
       switch self.flashMode {
@@ -438,7 +434,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       guard let exifDict = metadata[kCGImagePropertyExifDictionary as String] as? NSDictionary else {
         return
       }
-      var updatedExif = ExpoCameraUtils.updateExif(
+      let updatedExif = ExpoCameraUtils.updateExif(
         metadata: exifDict,
         with: ["Orientation": ExpoCameraUtils.export(orientation: takenImage.imageOrientation)]
       )
@@ -610,7 +606,6 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     if self.session.canAddOutput(output) {
       self.session.beginConfiguration()
       self.session.addOutput(output)
-      self.session.sessionPreset = .high
       self.videoFileOutput = output
       self.session.commitConfiguration()
     }
@@ -636,13 +631,12 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
   public override func removeFromSuperview() {
     lifecycleManager?.unregisterAppLifecycleListener(self)
     super.removeFromSuperview()
+    UIDevice.current.endGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
   }
 
   func ensureSessionConfiguration() {
-    sessionQueue.async {
-      self.updateSessionAudioIsMuted()
-    }
+    self.updateSessionAudioIsMuted()
   }
 
   public func fileOutput(
@@ -691,16 +685,6 @@ func updateSessionPreset(preset: AVCaptureSession.Preset) {
   func initializeCaptureSessionInput() {
     if captureDeviceInput?.device.position == presetCamera {
       return
-    }
-
-    EXUtilities.performSynchronously {
-      var orientation: AVCaptureVideoOrientation = .portrait
-      if self.deviceOrientation != .unknown {
-        if let videoOrientation = AVCaptureVideoOrientation(rawValue: self.deviceOrientation.rawValue) {
-          orientation = videoOrientation
-        }
-      }
-      self.previewLayer.videoPreviewLayer.connection?.videoOrientation = orientation
     }
 
     sessionQueue.async {
@@ -753,13 +737,13 @@ func updateSessionPreset(preset: AVCaptureSession.Preset) {
   }
 
   @objc func orientationChanged(notification: Notification) {
-    changePreviewOrientation(orientation: deviceOrientation)
+    changePreviewOrientation()
   }
 
-  func changePreviewOrientation(orientation: UIInterfaceOrientation) {
-    let videoOrientation = ExpoCameraUtils.videoOrientation(for: orientation)
-
+  func changePreviewOrientation() {
     EXUtilities.performSynchronously {
+      // We shouldn't access the device orientation anywhere but on the main thread
+      let videoOrientation = ExpoCameraUtils.videoOrientation(for: self.deviceOrientation)
       if (self.previewLayer.videoPreviewLayer.connection?.isVideoOrientationSupported) == true {
         self.previewLayer.videoPreviewLayer.connection?.videoOrientation = videoOrientation
       }

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -253,9 +253,9 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       }
 
       if error.code == .mediaServicesWereReset {
-        if self.session.isRunning {
+        if !self.session.isRunning {
           self.session.startRunning()
-          self.ensureSessionConfiguration()
+          self.updateSessionAudioIsMuted()
           self.onCameraReady()
         }
       }
@@ -633,10 +633,6 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     super.removeFromSuperview()
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
-  }
-
-  func ensureSessionConfiguration() {
-    self.updateSessionAudioIsMuted()
   }
 
   public func fileOutput(


### PR DESCRIPTION
# Why
Closes #27218
In both versions of the package we were checking for the initial orientation too early. At a time when the video buffers were not yet connected. 

# How
Moved the call to correct the orientation after we have connected the inputs. Also fixed a number of other small warnings and removed dead code. I've backported the fix to old camera.

# Test Plan
Bare-expo and provided repro. 

