### PR TITLE
Enhance file search performance using fast-glob

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -66,6 +66,7 @@
     "connect": "^3.7.0",
     "debug": "^4.3.4",
     "env-editor": "^0.4.1",
+    "fast-glob": "^3.3.2",
     "find-yarn-workspace-root": "~2.0.0",
     "form-data": "^3.0.1",
     "freeport-async": "2.0.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -72,7 +72,6 @@
     "freeport-async": "2.0.0",
     "fs-extra": "~8.1.0",
     "getenv": "^1.0.0",
-    "glob": "^7.1.7",
     "graphql": "15.8.0",
     "graphql-tag": "^2.10.1",
     "https-proxy-agent": "^5.0.1",

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -7,7 +7,7 @@ import * as Log from '../../../log';
 import { fileExistsAsync } from '../../../utils/dir';
 import { env } from '../../../utils/env';
 import { memoize } from '../../../utils/fn';
-import { everyMatchAsync, wrapGlobWithTimeout } from '../../../utils/glob';
+import { anyMatchAsync, wrapGlobWithTimeout } from '../../../utils/glob';
 import { ProjectPrerequisite } from '../Prerequisite';
 import { ensureDependenciesAsync } from '../dependencies/ensureDependenciesAsync';
 
@@ -129,7 +129,7 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite<boolean> 
     const results = await wrapGlobWithTimeout(
       () =>
         // TODO(Bacon): Use `everyMatch` since a bug causes `anyMatch` to return inaccurate results when used multiple times.
-        everyMatchAsync('**/*.@(ts|tsx)', {
+        anyMatchAsync('**/*.@(ts|tsx)', {
           cwd: this.projectRoot,
           ignore: [
             '**/@(Carthage|Pods|node_modules)/**',

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -128,7 +128,6 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite<boolean> 
   async _queryFirstTypeScriptFileAsync(): Promise<null | string> {
     const results = await wrapGlobWithTimeout(
       () =>
-        // TODO(Bacon): Use `everyMatch` since a bug causes `anyMatch` to return inaccurate results when used multiple times.
         anyMatchAsync('**/*.@(ts|tsx)', {
           cwd: this.projectRoot,
           ignore: [

--- a/packages/@expo/cli/src/utils/glob.ts
+++ b/packages/@expo/cli/src/utils/glob.ts
@@ -1,42 +1,12 @@
-import G, { Glob } from 'glob';
-
-/** Finds all matching files. */
-export function everyMatchAsync(pattern: string, options: G.IOptions) {
-  return new Promise<string[]>((resolve, reject) => {
-    const g = new Glob(pattern, options);
-    let called = false;
-    const callback = (er: Error | null, matched: string[]) => {
-      if (called) return;
-      called = true;
-      if (er) reject(er);
-      else resolve(matched);
-    };
-    g.on('error', callback);
-    g.on('end', (matches) => callback(null, matches));
-  });
-}
+import glob, { Options } from 'fast-glob';
 
 /** Bails out early after finding the first matching file. */
-export function anyMatchAsync(pattern: string, options: G.IOptions) {
-  return new Promise<string[]>((resolve, reject) => {
-    const g = new Glob(pattern, options);
-    let called = false;
-    const callback = (er: Error | null, matched: string[]) => {
-      if (called) return;
-      called = true;
-      if (er) reject(er);
-      else resolve(matched);
-    };
-    g.on('error', callback);
-    g.on('match', (matched) => {
-      // We've disabled using abort as it breaks the entire glob package across all instances.
-      // https://github.com/isaacs/node-glob/issues/279 & https://github.com/isaacs/node-glob/issues/342
-      // For now, just collect every match.
-      // g.abort();
-      callback(null, [matched]);
-    });
-    g.on('end', (matches) => callback(null, matches));
-  });
+export async function anyMatchAsync(pattern: string, options: Options) {
+  const stream = glob.stream(pattern, options);
+  for await (const file of stream) {
+    return [file.toString('utf8')];
+  }
+  return [];
 }
 
 /**


### PR DESCRIPTION
# Why

This PR implements anyMatchAsync with fast-glob to leverage its lighter, faster capabilities as a replacement for glob. The expected outcome is improved time efficiency in file searching.

Previously, the reliance on everyMatchAsync was due to glob's lack of support for an abort controller, resulting in prolonged search times for files matching a pattern. fast-glob introduces a stream() method enabling early return upon finding the first matched file, thereby optimizing the search process.


# How

The transition to fast-glob was motivated by the need for a more efficient file search mechanism. By replacing glob with fast-glob, we utilize its streamlined file pattern matching and early return capabilities, significantly improving search performance and code maintainability.


This is my first pull request 🙇🏻‍♂️. I intend to add a performance comparison between the before and after states. Could you offer some guidance on how to proceed?

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
There is a test, and manual test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
