### PR TITLE
[core][Android] Add getter for `AppContext` to `SharedObject`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -7,14 +7,14 @@ import expo.modules.kotlin.logger
 import java.lang.ref.WeakReference
 
 @DoNotStrip
-open class SharedObject {
+open class SharedObject(appContext: AppContext? = null) {
   /**
    * An identifier of the native shared object that maps to the JavaScript object.
    * When the object is not linked with any JavaScript object, its value is 0.
    */
   internal var sharedObjectId: SharedObjectId = SharedObjectId(0)
 
-  internal var appContextHolder = WeakReference<AppContext>(null)
+  internal var appContextHolder = WeakReference<AppContext>(appContext)
 
   val appContext: AppContext?
     get() = appContextHolder.get()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -16,10 +16,13 @@ open class SharedObject {
 
   internal var appContextHolder = WeakReference<AppContext>(null)
 
+  val appContext: AppContext?
+    get() = appContextHolder.get()
+
   private fun getJavaScriptObject(): JavaScriptObject? {
     return SharedObjectId(sharedObjectId.value)
       .toJavaScriptObject(
-        appContextHolder.get() ?: return null
+        appContext ?: return null
       )
   }
 
@@ -33,7 +36,7 @@ open class SharedObject {
           eventName,
           *args,
           thisValue = jsThis,
-          appContext = appContextHolder.get()
+          appContext = appContext
         )
     } catch (e: Throwable) {
       logger.error("Unable to send event '$eventName' by shared object of type ${this::class.java.simpleName}", e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -56,7 +56,9 @@ class SharedObjectRegistry(appContext: AppContext) {
       pairs[id] = native to jsWeakObject
     }
 
-    native.appContextHolder = WeakReference(appContext)
+    if (native.appContextHolder.get() == null) {
+      native.appContextHolder = WeakReference(appContext)
+    }
 
     return id
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.sharedobjects
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.AppContext
 
 /**
  * Shared object (ref) that holds a strong reference to any native object. Allows passing references
@@ -9,7 +10,7 @@ import expo.modules.core.interfaces.DoNotStrip
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-open class SharedRef<RefType>(val ref: RefType) : SharedObject() {
+open class SharedRef<RefType>(val ref: RefType, appContext: AppContext? = null) : SharedObject(appContext) {
 
   @DoNotStrip
   private val mHybridData = initHybrid()

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -25,11 +25,12 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
 @UnstableApi
-class VideoPlayer(context: Context, private val appContext: AppContext, private val mediaItem: MediaItem) : AutoCloseable, SharedObject() {
-  private val currentActivity: Activity by lazy {
-    appContext.activityProvider?.currentActivity
-      ?: throw Exceptions.MissingActivity()
-  }
+class VideoPlayer(context: Context, appContext: AppContext, private val mediaItem: MediaItem) : AutoCloseable, SharedObject(appContext) {
+  private val currentActivity: Activity
+    get() {
+      return appContext?.activityProvider?.currentActivity
+        ?: throw Exceptions.MissingActivity()
+    }
 
   // This improves the performance of playing DRM-protected content
   private var renderersFactory = DefaultRenderersFactory(context)
@@ -128,8 +129,10 @@ class VideoPlayer(context: Context, private val appContext: AppContext, private 
       }
     }
     intent.action = MediaSessionService.SERVICE_INTERFACE
-    currentActivity.startService(intent)
-    currentActivity.bindService(intent, serviceConnection, BIND_AUTO_CREATE)
+    currentActivity.apply {
+      startService(intent)
+      bindService(intent, serviceConnection, BIND_AUTO_CREATE)
+    }
     player.addListener(playerListener)
     VideoManager.registerVideoPlayer(this)
   }


### PR DESCRIPTION
# Why

Adds a getter to receive `AppContext` from `SharedObject` 

# How

See https://github.com/expo/expo/pull/27523#discussion_r1518682470.


# Test Plan

- unit tests ✅