### PR TITLE
[cli] Fix 'Tunnel URL not found' warning when starting bundler

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -19,7 +19,7 @@ export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
 
   const { middleware, websocketEndpoints } = createDevMiddleware({
     projectRoot: metroBundler.projectRoot,
-    serverBaseUrl: metroBundler.getJsInspectorBaseUrl(),
+    serverBaseUrl: metroBundler.getUrlCreator().constructUrl({ scheme: 'http', hostType: 'lan' }),
     logger: createLogger(chalk.bold('Debug:')),
     unstable_InspectorProxy: ExpoInspectorProxy,
     unstable_experiments: {


### PR DESCRIPTION
# Why

Running `npx expo start --tunnel` in SDK 50 always results in a warning being thrown about the tunnel URL not being ready

<img width="643" alt="image" src="https://github.com/expo/expo/assets/11707729/a338dac1-c044-4f21-833d-8d2900f03c48">


The problem in this case is the order which things get executed.  The `debugMiddleware` has to be created before we initialize the metro server,  given that we need to know the `debugWebsocketEndpoints` beforehand, and ngrok is only 
initialized inside `postStartAsync`. 

# How

This warning happens because we were calling `metroBundler.getJsInspectorBaseUrl()` before Metro was fully initiated. This PR fixes this by using the `.getUrlCreator().constructUrl` function directly.


# Test Plan

Run  `npx expo start --tunnel` and see no warning 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
