### PR TITLE
[core][iOS] Add a function to schedule work on the runtime scheduler

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added support for `startObserving` and `stopObserving` in the new `EventEmitter` class. ([#27393](https://github.com/expo/expo/pull/27393) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Implemented sending events from native shared objects. ([#27523](https://github.com/expo/expo/pull/27523) by [@lukmccall](https://github.com/lukmccall))
 - JS object of the native module is now an instance of the `NativeModule` class that inherits from `EventEmitter`. ([#27510](https://github.com/expo/expo/pull/27510) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Exposed a function on the runtime to schedule some work with synchronized access to JS. ([#27567](https://github.com/expo/expo/pull/27567) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -16,6 +16,8 @@ namespace react = facebook::react;
 @class EXJavaScriptObject;
 @class EXJavaScriptSharedObject;
 
+typedef void (^JSRuntimeExecutionBlock)();
+
 typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
                                      NSArray<EXJavaScriptValue *> * _Nonnull arguments,
                                      RCTPromiseResolveBlock _Nonnull resolve,
@@ -114,5 +116,12 @@ typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, N
  Evaluates given JavaScript source code.
  */
 - (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource NS_REFINED_FOR_SWIFT;
+
+#pragma mark - Runtime execution
+
+/**
+ Schedules a block to be executed with granted synchronized access to the JS runtime.
+ */
+- (void)schedule:(nonnull JSRuntimeExecutionBlock)block priority:(int)priority NS_REFINED_FOR_SWIFT;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -228,6 +228,13 @@ public:
   return [[EXJavaScriptValue alloc] initWithRuntime:self value:result];
 }
 
+#pragma mark - Runtime execution
+
+- (void)schedule:(nonnull JSRuntimeExecutionBlock)block priority:(int)priority
+{
+  _jsCallInvoker->invokeAsync(SchedulerPriority(priority), block);
+}
+
 #pragma mark - Private
 
 - (nonnull EXJavaScriptObject *)createHostFunction:(nonnull NSString *)name

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -60,6 +60,22 @@ public extension JavaScriptRuntime {
       }
     }
   }
+
+  /**
+   Schedules a block to be executed with granted synchronized access to the JS runtime.
+   */
+  public func schedule(priority: SchedulerPriority = .normal, _ closure: @escaping () -> Void) {
+    __schedule(closure, priority: priority.rawValue)
+  }
+}
+
+// Keep it in sync with the equivalent C++ enum from React Native (see SchedulerPriority.h from React-callinvoker).
+public enum SchedulerPriority: Int32 {
+  case immediate = 1
+  case userBlocking = 2
+  case normal = 3
+  case low = 4
+  case idle = 5
 }
 
 internal final class JavaScriptEvalException: GenericException<NSError> {


### PR DESCRIPTION
# Why

There are places where we need to be sure that we're running on the JS thread (i.e. have a safe access to the runtime). For example, sending events to shared objects should be scheduled for execution on the JS thread.

# How

- Exposed a function that schedules a block to be executed with granted synchronized access to the JS runtime. Under the hood, it uses the `invokeAsync` from the JS call invoker.
- Used the new function in SharedObject's `sendEvent` function so it's safe to send events from non-JS threads

Initially I was planning to expose call invoker's `invokeSync` as well, but it's not supported in the old architecture so it doesn't seem to be worth it right now.

# Test Plan

1. Added async function to the VideoPlayer class in expo-video that sends an event (from non-JS thread)
2. Called that async function from JS
3. Confirmed that the block is executed, is run on the queue dedicated for JS and the JS listener is invoked without crashes

iOS unit tests are passing locally