### PR TITLE
[ios][camera] Fix crash when dev menu is presented

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fix incorrect prop name `flash` being passed to native. ([#27394](https://github.com/expo/expo/pull/27394) by [@alanjhughes](https://github.com/alanjhughes))
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix camera orientation on initial render. ([#27545](https://github.com/expo/expo/pull/27545) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix an issue where the configuration can be interuppted when the dev menu is presented on intial launch.
+- On `iOS`, fix an issue where the configuration can be interuppted when the dev menu is presented on intial launch. ([#27572](https://github.com/expo/expo/pull/27572) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix incorrect prop name `flash` being passed to native. ([#27394](https://github.com/expo/expo/pull/27394) by [@alanjhughes](https://github.com/alanjhughes))
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix camera orientation on initial render. ([#27545](https://github.com/expo/expo/pull/27545) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix an issue where the configuration can be interuppted when the dev menu is presented on intial launch.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -210,11 +210,11 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
 
       self.addErrorNotification()
       self.changePreviewOrientation()
+      self.session.commitConfiguration()
 
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
         self.barcodeScanner.maybeStartBarcodeScanning()
-        self.session.commitConfiguration()
         self.session.startRunning()
         self.onCameraReady()
       }
@@ -570,6 +570,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
   }
 
+  // Must be called on the sessionQueue
   func updateSessionAudioIsMuted() {
     sessionQueue.async {
       self.session.beginConfiguration()
@@ -601,6 +602,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
   }
 
+  // Must be called on the sessionQueue
   func setupMovieFileCapture() {
     let output = AVCaptureMovieFileOutput()
     if self.session.canAddOutput(output) {
@@ -611,6 +613,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
   }
 
+  // Must be called on the sessionQueue
   func cleanupMovieFileCapture() {
     if let videoFileOutput {
       if session.outputs.contains(videoFileOutput) {
@@ -668,14 +671,15 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
   }
 
-func updateSessionPreset(preset: AVCaptureSession.Preset) {
-    #if !targetEnvironment(simulator)
+  // Must be called on the sessionQueue
+  func updateSessionPreset(preset: AVCaptureSession.Preset) {
+#if !targetEnvironment(simulator)
     if self.session.canSetSessionPreset(preset) {
       self.session.beginConfiguration()
       self.session.sessionPreset = preset
       self.session.commitConfiguration()
     }
-    #endif
+#endif
   }
 
   func initializeCaptureSessionInput() {


### PR DESCRIPTION
# Why
Closes #27410
Issue is difficult to reproduce. It happens when the dev menu is presented on initial launch, interrupting the camera initialisation. Even then, it is not consistent. It does not seem to occur at any other time or at least I can't get it to happen except on first launch.

# How
Commit the configuration changes outside of the async block that starts the session so it isn't moved onto the sessionQueue and will always happen before `startSession` is called. This is safe because `maybeStartBarcodeScanning` opens it's own configuration blocks if it needs to run at all. 

Also add doc comments to some functions that need to be called on the sessionQueue

# Test Plan
Tested in the provided repro. The issue does not occur.