### PR TITLE
[expo-updates][wip] Add fingerprint normalization for EAS build mutations

### DIFF
--- a/packages/@expo/fingerprint/src/Options.ts
+++ b/packages/@expo/fingerprint/src/Options.ts
@@ -11,17 +11,24 @@ export const DEFAULT_IGNORE_PATHS = [
   // Android
   '**/android/build/**/*',
   '**/android/.cxx/**/*',
+  '**/android/.gradle/**/*',
   '**/android/app/build/**/*',
   '**/android/app/.cxx/**/*',
+  '**/android/app/.gradle/**/*',
   '**/android-annotation/build/**/*',
   '**/android-annotation/.cxx/**/*',
+  '**/android-annotation/.gradle/**/*',
   '**/android-annotation-processor/build/**/*',
   '**/android-annotation-processor/.cxx/**/*',
+  '**/android-annotation-processor/.gradle/**/*',
+
+  // Often has different line endings, rarely changes TODO need to be a source
+  '**/android/gradlew.bat',
 
   // Android gradle plugins
   '**/*-gradle-plugin/build/**/*',
-  '**/*-gradle-plugin/.gradle/**/*',
   '**/*-gradle-plugin/.cxx/**/*',
+  '**/*-gradle-plugin/.gradle/**/*',
 
   // iOS
   '**/ios/Pods/**/*',

--- a/packages/expo-updates/utils/src/createFingerprintAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintAsync.ts
@@ -1,4 +1,7 @@
+import { AndroidConfig, XML } from '@expo/config-plugins';
 import * as Fingerprint from '@expo/fingerprint';
+import fs from 'fs/promises';
+import path from 'path';
 
 export async function createFingerprintAsync(
   projectRoot: string,
@@ -10,6 +13,17 @@ export async function createFingerprintAsync(
     return await Fingerprint.createFingerprintAsync(projectRoot, {
       ...options,
       platforms: [platform],
+      extraSources: await getBareConfigurationEASBuildSourcesAsync(projectRoot, platform),
+      ignorePaths: [
+        // EAS Build injects this file at build time, can safely be ignored
+        '**/android/app/eas-build.gradle',
+
+        // EAS Build modifies this file at build time, handled by getAppBuildGradleSourceAsync
+        '**/android/app/build.gradle',
+
+        // EAS Build modifies this file at build time, handled by getAndroidManifestSourceAsync
+        '**/android/app/src/main/AndroidManifest.xml',
+      ],
     });
   } else {
     // ignore everything in native directories to ensure fingerprint is the same
@@ -20,4 +34,79 @@ export async function createFingerprintAsync(
       ignorePaths: ['android/**/*', 'ios/**/*'],
     });
   }
+}
+
+async function getBareConfigurationEASBuildSourcesAsync(
+  projectRoot: string,
+  platform: 'ios' | 'android'
+): Promise<Fingerprint.HashSource[]> {
+  switch (platform) {
+    case 'android':
+      return await Promise.all([
+        getAppBuildGradleSourceAsync(projectRoot),
+        getAndroidManifestSourceAsync(projectRoot),
+      ]);
+    case 'ios':
+      return await Promise.all([
+        getAppBuildGradleSourceAsync(projectRoot),
+        getAndroidManifestSourceAsync(projectRoot),
+      ]);
+  }
+}
+
+/**
+ * "Inverts" the configureBuildGradle step of eas-build for hashing when used in combination with ignore of eas-build.gradle above.
+ */
+async function getAppBuildGradleSourceAsync(projectRoot: string): Promise<Fingerprint.HashSource> {
+  const APPLY_EAS_BUILD_GRADLE_LINE = 'apply from: "./eas-build.gradle"';
+
+  const buildGradlePath = AndroidConfig.Paths.getAppBuildGradleFilePath(projectRoot);
+  const buildGradleContents = await fs.readFile(path.join(buildGradlePath), 'utf8');
+
+  const normalizedBuildGradleContents = buildGradleContents
+    .replace(APPLY_EAS_BUILD_GRADLE_LINE, '')
+    .trim();
+
+  const id = 'android:buildgradle:contents';
+  return {
+    type: 'contents',
+    id,
+    contents: normalizedBuildGradleContents,
+    reasons: [id],
+  };
+}
+
+/**
+ * "Inverts" the non-hashable portion of configureExpoUpdatesIfInstalledAsync step of eas-build for hashing when used in combination with ignores above.
+ */
+async function getAndroidManifestSourceAsync(projectRoot: string): Promise<Fingerprint.HashSource> {
+  const UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY =
+    'expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY';
+
+  const manifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
+  const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(manifestPath);
+  const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+  const stringifiedUpdatesRequestHeaders = AndroidConfig.Manifest.getMainApplicationMetaDataValue(
+    androidManifest,
+    UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY
+  );
+  // normalize the values set by eas-build. in this case, expo-channel-name
+  AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+    mainApp,
+    UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY,
+    JSON.stringify({
+      ...JSON.parse(stringifiedUpdatesRequestHeaders ?? '{}'),
+      'expo-channel-name': undefined,
+    }),
+    'value'
+  );
+  const normalizedManifestXml = XML.format(androidManifest);
+
+  const id = 'android:appmanifest:contents';
+  return {
+    type: 'contents',
+    id,
+    contents: normalizedManifestXml,
+    reasons: [id],
+  };
 }


### PR DESCRIPTION
# Why

Generic projects (including those that do continuous native generation, CNG) are having some issues with fingerprint when built on EAS build. This is because EAS build does mutations of the native files just before build, thus generating a different logical runtime from the fingerprint perspective. (https://github.com/expo/eas-build/blob/main/packages/build-tools/src/android/expoUpdates.ts#L55 for example)

# How

One solution to this problem is to normalize away these mutations.

IMO this is a bit fragile for a couple reasons: 
- it will break if we add more mutations and catching the breakage ahead of time would be unlikely
- the normalization code itself needs to do very specific things with specific files, and that's fragile.
- the code that does the normalization is not collocated with the code that does the mutation (at least in this PR). it needs to be in the same place.

# Test Plan

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
