### PR TITLE
[core] fix androidTest errors

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -11,7 +11,7 @@ internal class JSIPropertiesTest {
       .get { }
       .set { _: String -> }
   }) {
-    val keys = evaluateScript("Object.keys($moduleRef)").getArray()
+    val keys = evaluateScript("Object.keys($moduleRef).filter(key => ['p1', 'p2'].includes(key))").getArray()
 
     Truth.assertThat(keys).hasLength(2)
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptModuleObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptModuleObjectTest.kt
@@ -17,14 +17,6 @@ class JavaScriptModuleObjectTest {
   }
 
   @Test
-  fun hostObject_should_not_expose_addListener_by_default() = withSingleModule {
-    val addListenerFunction = property("addListener")
-    val removeListenersFunction = property("removeListeners")
-    Truth.assertThat(addListenerFunction.isUndefined()).isTrue()
-    Truth.assertThat(removeListenersFunction.isUndefined()).isTrue()
-  }
-
-  @Test
   fun hostObject_should_not_override_existing_addListener() = withSingleModule({
     Events("onFoo")
     Function("addListener") { name: String ->


### PR DESCRIPTION
# Why

fix invalid android instrumentation test since #27510

# How

EventEmitter properties are now default in a native module, the pr revises the tests

# Test Plan

android instrumentation test passed: https://github.com/expo/expo/actions/runs/8246683515

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
