### PR TITLE
[core][Android] Unit converter now ignores nullability

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event. ([#26944](https://github.com/expo/expo/pull/26944) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Thrown an exception when nested types can't be converted instead of crashing the app. ([#27449](https://github.com/expo/expo/pull/27449) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Unit converter now ignores nullability. It will always return unit regardless of whether the input value is null or not.
+- [Android] Unit converter now ignores nullability. It will always return unit regardless of whether the input value is null or not. ([#27591](https://github.com/expo/expo/pull/27591) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [Android] Fixed activity contract registration after host destruction. ([#26881](https://github.com/expo/expo/pull/26881) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Ensured that `onCreate` before `OnActivityEntersForeground` event. ([#26944](https://github.com/expo/expo/pull/26944) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Thrown an exception when nested types can't be converted instead of crashing the app. ([#27449](https://github.com/expo/expo/pull/27449) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Unit converter now ignores nullability. It will always return unit regardless of whether the input value is null or not.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -295,7 +295,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       Any::class to AnyTypeConverter(isOptional),
 
-      Unit::class to UnitTypeConverter(isOptional),
+      // Unit converter doesn't care about nullability.
+      // It will always return Unit
+      Unit::class to UnitTypeConverter(),
 
       ReadableArguments::class to ReadableArgumentsTypeConverter(isOptional)
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
-class UnitTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
+class UnitTypeConverter : DynamicAwareTypeConverters<Any>(true) {
   override fun convertFromDynamic(value: Dynamic): Any {
     return Unit
   }


### PR DESCRIPTION
# Why

Unit converter now ignores nullability.

# How

The unit converter should always return `Unit,` no matter what it's trying to convert. 

# Test Plan

- bare-expo ✅ (tested with `expo-video` and new event emitter)