### PR TITLE
[docs] Fix outdated information in various docs

### DIFF
--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -11,7 +11,7 @@ You can grant other users access to the projects belonging to your Personal Acco
 
 You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.dev/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.dev/signup](https://expo.dev/signup) if they don't have an account yet. You may have up to 100 members and pending invitations combined for a single account.
 
-> When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../versions/latest/config/app.mdx#owner) property to your project's app config.
+> When adding new developers to your projects, who are publishing updates or creating new builds, make sure to add the [`owner`](../versions/latest/config/app.mdx#owner) property to your project's app config.
 
 ## Manage access
 
@@ -22,8 +22,12 @@ Access for members is managed through a role-based system. Users can have the _o
 | **Owner**     | Can take any action on an account or any projects, including deleting them. (Note: the Owner role is not available on your Personal Account)              |
 | **Admin**     | Can control most settings on your account, including signing up for paid services, changing permissions of other users, and managing programmatic access. |
 | **Developer** | Can create new projects, make new builds, release updates, and manage credentials.                                                                        |
-| **Viewer**    | Can only view your projects through Expo Go, but can't modify your projects in any way.                                                                   |
+| **Viewer**    | Can only view your projects through Expo Go or installed builds, but can't modify your projects in any way.                                               |
 
 ## Remove members
 
-To remove members, go to the [Members](https://expo.dev/settings/members) page and revoke access.
+To remove a member:
+
+- Navigate to [**Members**](https://expo.dev/settings/members) in Expo dashboard
+- Next to the member you want to remove, click on the three-dotted menu icon.
+- Click **Remove member**.

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -191,6 +191,7 @@ For Android and iOS, there are different requirements to set up your credentials
     For Android, you need to configure **Firebase Cloud Messaging (FCM) V1** to get credentials and set up your Expo project.
 
     Follow the steps in [Add Android FCM V1 credentials](/push-notifications/fcm-credentials) to set up your credentials.
+
   </Tab>
   <Tab>
     > **warning** A paid Apple Developer Account is required to generate credentials.
@@ -201,6 +202,7 @@ For Android and iOS, there are different requirements to set up your credentials
 
     - Setup Push Notifications for your project
     - Generating a new Apple Push Notifications service key
+
   </Tab>
 </Tabs>
 
@@ -217,7 +219,7 @@ After creating and installing the development build, you can use [Expo's push no
 
 1. Start the development server for your project:
 
-   <Terminal cmd={['$ npx expo start --dev-client']} />
+   <Terminal cmd={['$ npx expo start']} />
 
 2. Open the development build on your device.
 
@@ -225,17 +227,17 @@ After creating and installing the development build, you can use [Expo's push no
 
 4. Click on the **Send a Notification** button.
 
-    <ImageSpotlight
-      alt="Expo push notifications tool overview."
-      src="/static/images/notifications/push-notifications-tool-overview.png"
-      style={{ maxWidth: 1200 }}
-    />
+   <ImageSpotlight
+     alt="Expo push notifications tool overview."
+     src="/static/images/notifications/push-notifications-tool-overview.png"
+     style={{ maxWidth: 1200 }}
+   />
 
 After sending the notification from the tool, you should see the notification on your device. Below is an example of an Android device receiving a push notification.
 
   <ImageSpotlight
     alt="An Android device receiving a push notification."
     src="/static/images/notifications/notification-on-android.png"
-    style={{ maxWidth: 360 }}
+    style={{ maxWidth: 280 }}
   />
 </Step>

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -38,11 +38,11 @@ You can use the **app/\_layout.tsx** file to define your app's main navigator:
 import { Stack } from 'expo-router/stack';
 
 export default function AppLayout() {
- return (
-   <Stack>
-     <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-   </Stack>
- );
+  return (
+    <Stack>
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+    </Stack>
+  );
 }
 ```
 
@@ -79,14 +79,14 @@ export default function TabLayout() {
 
 The tabs layout wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. You can use the options presented in the React Navigation documentation to customize the tab bar.
 
-Finally, we have the two tab files which make up the content of the tabs: **app/(tabs)/index.tsx** and **app/(tabs)/settings.tsx**.
+Finally, we have the two tab files that make up the content of the tabs: **app/(tabs)/index.tsx** and **app/(tabs)/settings.tsx**.
 
 ```tsx app/(tabs)/index.tsx & app/(tabs)/settings.tsx
-import { View, Text } from "react-native";
+import { View, Text } from 'react-native';
 
 export default function Tab() {
   return (
-    <View style={{ justifyContent: "center", alignItems: "center", flex: 1 }}>
+    <View style={{ justifyContent: 'center', alignItems: 'center', flex: 1 }}>
       <Text>Tab [Home|Settings]</Text>
     </View>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This PR:
- Fixes minor issues (incorrect grammar usage, incorrect code formatting on a snippet) and update outdated (such as `--dev-client` flag in push notifications setup guide) info in various docs.
- Adds step to describe how to remove a member.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
