### PR TITLE
[docs] add basic code highlight for Terminal snippets

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -21,7 +21,7 @@ const { default: testTippy } = tippy;
 // Read more: https://github.com/FormidableLabs/prism-react-renderer#custom-language-support
 async function initPrism() {
   (typeof global !== 'undefined' ? global : window).Prism = Prism;
-  await import('prismjs/components/prism-bash' as Language);
+  await import('~/ui/components/Snippet/prism-bash' as Language);
   await import('prismjs/components/prism-diff' as Language);
   await import('prismjs/components/prism-groovy' as Language);
   await import('prismjs/components/prism-ini' as Language);
@@ -176,6 +176,8 @@ export function Code({ className, children }: React.PropsWithChildren<Props>) {
       lang = remapLanguages[lang];
     }
 
+    // const grammar =
+    //   lang === 'bash' ? EXPO_BASH_LANG : Prism.languages[lang as keyof typeof Prism.languages];
     const grammar = Prism.languages[lang as keyof typeof Prism.languages];
     if (!grammar) {
       throw new Error(`docs currently do not support language: ${lang}`);

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -171,13 +171,10 @@ export function Code({ className, children }: React.PropsWithChildren<Props>) {
 
   // Allow for code blocks without a language.
   if (lang) {
-    // sh isn't supported, use sh to match js, and ts
     if (lang in remapLanguages) {
       lang = remapLanguages[lang];
     }
 
-    // const grammar =
-    //   lang === 'bash' ? EXPO_BASH_LANG : Prism.languages[lang as keyof typeof Prism.languages];
     const grammar = Prism.languages[lang as keyof typeof Prism.languages];
     if (!grammar) {
       throw new Error(`docs currently do not support language: ${lang}`);

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -39,7 +39,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 The following instructions apply to installing the latest version of Expo modules in React Native 0.73.
 
-<InstallSection packageName="expo" cmd={['npm install expo']} hideBareInstructions />
+<InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 
 Once installation is complete, apply the changes from the following diffs to configure Expo modules in your project. This is expected to take about five minutes, and you may need to adapt it slightly depending on how customized your project is.
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -14,7 +14,7 @@ To migrate from `npx react-native init` to Expo CLI, you'll need to install the 
 
 In most cases, executing the following command in a project directory to install the package is all you need to do:
 
-<Terminal cmd={['npx install-expo-modules@latest']} />
+<Terminal cmd={['$ npx install-expo-modules@latest']} />
 
 For a detailed installation guide, see [Install Expo modules](/bare/installing-expo-modules).
 
@@ -51,7 +51,7 @@ Windows and macOS. If building for these platforms, you can utilize Expo CLI for
 
 After installing the `expo` package, you can use the following commands which are alternatives to `npx react-native run-android` and `npx react-native run-ios`:
 
-<Terminal cmd={['# for Android', 'npx expo run:android', '', '# for iOS', 'npx expo run:ios']} />
+<Terminal cmd={['# for Android', '$ npx expo run:android', '', '# for iOS', '$ npx expo run:ios']} />
 
 When building your project, you can choose a device or simulator by using the `--device` flag. This also applies to any iOS device that is connected to your computer.
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -8,7 +8,11 @@ import { Terminal } from '~/ui/components/Snippet';
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag.
 
 <Terminal
-  cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
+  cmd={[
+    '$ eas build --platform android --local',
+    '# or',
+    '$ eas build --platform ios --local'
+  ]}
 />
 
 > **Note:** If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project. It's not necessary to run `eas build --local`. However, it handles more of the build process for you &mdash; see [Use cases for local builds](#use-cases-for-local-builds).

--- a/docs/pages/deploy/instant-updates.mdx
+++ b/docs/pages/deploy/instant-updates.mdx
@@ -66,7 +66,7 @@ To publish an update to the build, run the following command:
 
 <Terminal
   cmd={[
-    '$ eas update --branch [branch] --message [message]',
+    '# eas update --branch [branch] --message [message]',
     '',
     '# Example',
     '$ eas update --branch preview --message "Updating the app"',

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -35,7 +35,7 @@ The app will default to the light style if this property is absent. Here is an e
 
 In development builds, you'll need to install the native package [`expo-system-ui`](/versions/latest/sdk/system-ui/#installation). Otherwise, the `userInterfaceStyle` property is ignored. You can also use the following command to check if the project is misconfigured:
 
-<Terminal cmd={['npx expo config --type introspect']} />
+<Terminal cmd={['$ npx expo config --type introspect']} />
 
 If the project is misconfigured, you'll see a warning as shown below:
 

--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -21,7 +21,7 @@ Generate a private key and corresponding code signing certificate for your app:
 
 <Terminal
   cmd={[
-    'npx expo-updates codesigning:generate \\',
+    '$ npx expo-updates codesigning:generate \\',
     '  --key-output-directory keys \\',
     '  --certificate-output-directory certs \\',
     '  --certificate-validity-duration-years 10 \\',
@@ -42,14 +42,9 @@ Generate a private key and corresponding code signing certificate for your app:
 
 Configure your app's builds to use code signing:
 
-<Terminal
-  cmd={[
-    'npx expo-updates codesigning:configure \\',
-    '  --certificate-input-directory certs \\',
-    '  --key-input-directory keys',
-  ]}
-  cmdCopy="npx expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys"
-/>
+<Terminal cmd={[
+  '$ npx expo-updates codesigning:configure --certificate-input-directory certs --key-input-directory keys',
+]} />
 
 After this step, create a new build with a new runtime version. The code signing certificate will be embedded in this new build.
 
@@ -59,7 +54,7 @@ After this step, create a new build with a new runtime version. The code signing
 
 Publish a signed update for your app:
 
-<Terminal cmd={['eas update --private-key-path keys/private-key.pem']} />
+<Terminal cmd={['$ eas update --private-key-path keys/private-key.pem']} />
 
 During `eas update`, the EAS CLI automatically detects that code signing is configured for your app. It then verifies the integrity of the update and creates a digital signature using your private key. This process is performed locally so that your private key never leaves your machine. The generated signature is automatically sent to EAS to store alongside the update.
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -52,7 +52,7 @@ Ensure that your project has an `app.json` file with an `expo` object. If you do
 
 Install the `expo` package by running the command:
 
-<Terminal cmd={['npx install-expo-modules@latest']} />
+<Terminal cmd={['$ npx install-expo-modules@latest']} />
 
 If the command fails, refer to the ["Installing Expo modules" guide](/bare/installing-expo-modules/#manual-installation).
 

--- a/docs/pages/eas-update/debug-advanced.mdx
+++ b/docs/pages/eas-update/debug-advanced.mdx
@@ -92,7 +92,7 @@ We'd expect the page to display the same channel name that our build has. If it'
     '# eas channel:create [channel-name]',
     '',
     '# Example',
-    'eas channel:create production',
+    '$ eas channel:create production',
   ]}
 />
 
@@ -115,7 +115,7 @@ If the channel is not linked to the branch we expect, we can change the link wit
     '# eas channel:edit [channel-name] --branch [branch-name]',
     '',
     '# Example',
-    'eas channel:edit production --branch release-1.0',
+    '$ eas channel:edit production --branch release-1.0',
   ]}
 />
 

--- a/docs/pages/eas-update/debug-advanced.mdx
+++ b/docs/pages/eas-update/debug-advanced.mdx
@@ -53,24 +53,20 @@ If our project does not have **android** or **ios** directories, we can make com
 
 In each, we expect to see configuration for the EAS Update URL and the runtime version. Here are the properties we'd expect to see in each file:
 
-**AndroidManifest.xml**
-
-```xml
-...
+```xml AndroidManifest.xml
+<!-- @hide ... --><!-- @end -->
 <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="your-runtime-version-here"/>
 <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/your-project-id-here"/>
-...
+<!-- @hide ... --><!-- @end -->
 ```
 
-**Expo.plist**
-
-```xml
-...
+```xml Expo.plist
+<!-- @hide ... --><!-- @end -->
 <key>EXUpdatesRuntimeVersion</key>
 <string>your-runtime-version-here</string>
 <key>EXUpdatesURL</key>
 <string>https://u.expo.dev/your-project-id-here</string>
-...
+<!-- @hide ... --><!-- @end -->
 ```
 
 ### Configuration without EAS Build
@@ -95,7 +91,6 @@ We'd expect the page to display the same channel name that our build has. If it'
   cmd={[
     '# eas channel:create [channel-name]',
     '',
-    '',
     '# Example',
     'eas channel:create production',
   ]}
@@ -118,7 +113,6 @@ If the channel is not linked to the branch we expect, we can change the link wit
 <Terminal
   cmd={[
     '# eas channel:edit [channel-name] --branch [branch-name]',
-    '',
     '',
     '# Example',
     'eas channel:edit production --branch release-1.0',
@@ -184,7 +178,7 @@ Here are the steps for inspecting an iOS Simulator build on macOS:
 Inside the **Expo.plist** file, we expect to see the following configurations:
 
 ```xml
-...
+<!-- @hide ... --><!-- @end -->
 <key>EXUpdatesRequestHeaders</key>
 <dict>
   <key>expo-channel-name</key>
@@ -194,7 +188,7 @@ Inside the **Expo.plist** file, we expect to see the following configurations:
 <string>your-runtime-version</string>
 <key>EXUpdatesURL</key>
 <string>https://u.expo.dev/your-project-id</string>
-...
+<!-- @hide ... --><!-- @end -->
 ```
 
 ### Inspecting manifests manually
@@ -250,11 +244,9 @@ We also provide a [step-by-step guide to try out EAS Update quickly](/eas-update
 - Reinstall pods with `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
 - [Ensure the desired channel is set in our **Expo.plist**](/eas-update/updating-your-app/#configuring-the-channel-manually)
 - Modify the application Xcode project file to force bundling of the application JavaScript for both release and debug builds:
-
-```
-sed -i '' 's/SKIP_BUNDLING/FORCE_BUNDLING/g;' ios/&lt;project name&gt;.xcodeproj/project.pbxproj
-```
-
+  ```sh
+  sed -i '' 's/SKIP_BUNDLING/FORCE_BUNDLING/g;' ios/&lt;project name&gt;.xcodeproj/project.pbxproj
+  ```
 - Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Xcode or from the command line.
 
 #### Android local builds
@@ -326,9 +318,7 @@ If "update 2" turned out to be a bad update, we can re-publish "update 1" with a
 <Terminal
   cmd={[
     '# eas update:republish --group [update-group-id]',
-    '',
     '# eas update:republish --branch [branch-name]',
-    '',
     '',
     '# Example',
     '$ eas update:republish --group abc1',
@@ -338,14 +328,15 @@ If "update 2" turned out to be a bad update, we can re-publish "update 1" with a
 
 The example command above would result in a branch that now appears like this:
 
-```bash
-branch: "production"
-updates: [
-  update 3 (id: def3) "updates color"  // re-publish of update 1 (id: abc1)
-  update 2 (id: xyz2) "fixes typo"     // bad update
-  update 1 (id: abc1) "updates color"  // good update
-]
-```
+<Terminal cmd={[
+  'branch: "production"',
+  'updates: [',
+  '  update 3 (id: def3) "updates color"  // re-publish of update 1 (id: abc1)',
+  '  update 2 (id: xyz2) "fixes typo"     // bad update',
+  '  update 1 (id: abc1) "updates color"  // good update',
+  ']'
+]} />
+
 
 Since "update 3" is now the most recent update on the "production" branch, all users who query for an update in the future will receive "update 3" instead of the bad update, "update 2".
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -128,9 +128,8 @@ If the channel is not mapped to the branch we expect, we can change the link wit
   cmd={[
     '# eas channel:edit [channel-name] --branch [branch-name]',
     '',
-    '',
     '# Example',
-    'eas channel:edit production --branch release-1.0',
+    '$ eas channel:edit production --branch release-1.0',
   ]}
 />
 

--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -94,7 +94,7 @@ export default () => ({
 
 Then, to set the `API_URL` environment variable during development, you can prepend the variables before running `npx expo start` as shown below:
 
-<Terminal cmd={['API_URL="http://localhost:3000" expo start']} />
+<Terminal cmd={['$ API_URL="http://localhost:3000" expo start']} />
 
 The command sets the `API_URL` to `"http://localhost:3000"`. Then, the [`expo-constants`](/versions/latest/sdk/constants/#installation) library provides the `Constants.expoConfig.extra.API_URL` property to access it inside a project.
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -111,7 +111,7 @@ To publish an update to the build, run the following command:
 
 <Terminal
   cmd={[
-    '$ eas update --branch [branch] --message [message]',
+    '# eas update --branch [branch] --message [message]',
     '',
     '# Example',
     '$ eas update --branch preview --message "Updating the app"',

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -98,7 +98,6 @@ After making a change to your project locally, you're ready to publish an update
     '$ eas update --channel [channel-name] --message [message]',
     '',
     '# Example',
-    '',
     '$ eas update --channel production --message "Fixes typo"',
   ]}
   cmdCopy="eas update --channel [channel-name] --message [message]"

--- a/docs/pages/eas-update/rollbacks.mdx
+++ b/docs/pages/eas-update/rollbacks.mdx
@@ -16,7 +16,7 @@ There are two types of rollbacks supported by EAS Update:
 
 To start a rollback, ensure you have EAS CLI version `5.9.0` or above installed. Then, run the following command:
 
-<Terminal cmd={['eas update:rollback']} />
+<Terminal cmd={['$ eas update:rollback']} />
 
 In the terminal, an interactive guide will assist you in selecting the type of rollback and doing the rollback.
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -13,7 +13,7 @@ Rollouts incrementally deploy updates on a new branch to a specific channel. Wit
 
 To start a rollout, ensure you have EAS CLI version `4.0.0` or above installed. Then, run the following command:
 
-<Terminal cmd={['eas channel:rollout']} />
+<Terminal cmd={['$ eas channel:rollout']} />
 
 In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 

--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -78,7 +78,7 @@ To run it on an emulator or a simulator, see [Android emulators](/workflow/andro
 <Step label="1">If installed, remove Expo Go from your device or simulator.</Step>
 <Step label="2">
   Start the development server:
-  <Terminal cmd={['npx expo start']} />
+  <Terminal cmd={['$ npx expo start']} />
 </Step>
 <Step label="3">
   Press <kbd>a</kbd> or <kbd>i</kbd> to run your app on Android or iOS. This will download and

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -109,7 +109,7 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 ## Add the TV config plugin
 
-<Terminal cmd={['npx expo install --dev @react-native-tvos/config-tv']} />
+<Terminal cmd={['$ npx expo install --dev @react-native-tvos/config-tv']} />
 
 When installed, the plugin will modify the project for TV when either:
 
@@ -130,10 +130,10 @@ Verify that this plugin appears in **app.json**:
 
 <Terminal cmd={[
   '# See all Expo CLI and config plugin debug information',
-  'export DEBUG=expo:*',
+  '$ export DEBUG=expo:*',
   '',
   '# See only debug information for the TV plugin',
-  'export DEBUG=expo:react-native-tvos:config-tv']}
+  '$ export DEBUG=expo:react-native-tvos:config-tv']}
 />
 
 </Step>
@@ -144,7 +144,7 @@ Verify that this plugin appears in **app.json**:
 
 Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifications to the project.
 
-<Terminal cmd={['export EXPO_TV=1', 'npx expo prebuild --clean']} />
+<Terminal cmd={['$ export EXPO_TV=1', '$ npx expo prebuild --clean']} />
 
 > **Note**: The `--clean` argument is recommended, and is required if you have existing Android and iOS directories in the project.
 
@@ -156,7 +156,7 @@ Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifica
 
 Start an Android TV emulator and use the following command to start the app on the emulator:
 
-<Terminal cmd={['npx expo run:android']} />
+<Terminal cmd={['$ npx expo run:android']} />
 
 </Step>
 <Step label="5">
@@ -165,7 +165,7 @@ Start an Android TV emulator and use the following command to start the app on t
 
 Run the following command to build and run the app on an Apple TV simulator:
 
-<Terminal cmd={['npx expo run:ios']} />
+<Terminal cmd={['$ npx expo run:ios']} />
 
 </Step>
 <Step label="6">
@@ -174,7 +174,7 @@ Run the following command to build and run the app on an Apple TV simulator:
 
 You can revert the changes for TV and go back to phone development by unsetting `EXPO_TV` and running prebuild again:
 
-<Terminal cmd={['unset EXPO_TV', 'npx expo prebuild --clean']} />
+<Terminal cmd={['$ unset EXPO_TV', '$ npx expo prebuild --clean']} />
 
 </Step>
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -8,6 +8,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 The New Architecture is a name that we use to describe a complete refactoring of the internals of React Native. It is also used to solve limitations of the original React Native architecture discovered over years of usage in production at Meta and other companies.
 
@@ -95,7 +96,22 @@ Set `newArchEnabled` on target platforms:
 
 Run prebuild command and compile your project:
 
-<Terminal cmd={['$ npx expo prebuild --clean', '$ npx expo run:android # or ios', '$ eas build -p android # or ios']} />
+<Tabs tabs={['Android', 'iOS']}>
+  <Tab>
+    <Terminal cmd={[
+      '$ npx expo prebuild --clean',
+      '$ npx expo run:android',
+      '$ eas build -p android',
+    ]} />
+  </Tab>
+  <Tab>
+    <Terminal cmd={[
+      '$ npx expo prebuild --clean',
+      '$ npx expo run:ios',
+      '$ eas build -p ios'
+    ]} />
+  </Tab>
+</Tabs>
 
 </Step>
 

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -21,7 +21,7 @@ Expo CLI automatically generates the **favicon.ico** file based on the `web.favi
 {
   "web": {
     "favicon": "./assets/favicon.png"
-  } 
+  }
 }
 ```
 
@@ -272,11 +272,11 @@ Run the wizard command, selecting `dist` as the root of the app, and the default
   cmd={[
     '$ npx workbox-cli wizard',
     '',
-    '$ ? What is the root of your web app (that is which directory do you deploy)? dist/',
-    '$ ? Which file types would you like to precache? js, html, ttf, ico, json',
-    '$ ? Where would you like your service worker file to be saved? dist/sw.js',
-    '$ ? Where would you like to save these configuration options? workbox-config.js',
-    "$ ? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    '? What is the root of your web app (that is which directory do you deploy)? dist/',
+    '? Which file types would you like to precache? js, html, ttf, ico, json',
+    '? Where would you like your service worker file to be saved? dist/sw.js',
+    '? Where would you like to save these configuration options? workbox-config.js',
+    "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
   ]}
 />
 
@@ -284,7 +284,7 @@ Run the wizard command, selecting `dist` as the root of the app, and the default
 
 <Step label="5">
 
-Finally, run `npx workbox-cli generateSW workbox-config.js` to generate the service worker config. 
+Finally, run `npx workbox-cli generateSW workbox-config.js` to generate the service worker config.
 
 Going forward, you can add a build script in **package.json** to run both scripts in the correct order:
 

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -15,15 +15,15 @@ To create a new app using Bun, [install Bun on your local machine](https://bun.s
 
 Now, create your new Expo project:
 
-<Terminal cmd={['bun create expo my-app']} />
+<Terminal cmd={['$ bun create expo my-app']} />
 
 You can also run any **package.json** script with `bun run`:
 
-<Terminal cmd={['bun run ios']} />
+<Terminal cmd={['$ bun run ios']} />
 
 To install any Expo library, you can use `bun expo install`:
 
-<Terminal cmd={['bun expo install expo-av']} />
+<Terminal cmd={['$ bun expo install expo-av']} />
 
 ## Use Bun for EAS builds
 

--- a/docs/pages/preview/dev-process-overview.mdx
+++ b/docs/pages/preview/dev-process-overview.mdx
@@ -105,11 +105,11 @@ The following three commands result in more or less the same project:
 
 <Terminal
   cmd={[
-    'npx create-expo-app MyApp && cd MyApp && npx expo prebuild',
+    '$ npx create-expo-app MyApp && cd MyApp && npx expo prebuild',
     '',
-    'npx create-expo-app --template bare-minimum',
+    '$ npx create-expo-app --template bare-minimum',
     '',
-    'npx react-native init MyApp && cd MyApp && npx install-expo-modules',
+    '$ npx react-native init MyApp && cd MyApp && npx install-expo-modules',
   ]}
 />
 

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -66,9 +66,9 @@ Add the following lines to your **/.zprofile** or **~/.zshrc** (if you are using
 
 <Terminal
   cmd={[
-    'export ANDROID_HOME=$HOME/Library/Android/sdk',
-    'export PATH=$PATH:$ANDROID_HOME/emulator',
-    'export PATH=$PATH:$ANDROID_HOME/platform-tools',
+    '$ export ANDROID_HOME=$HOME/Library/Android/sdk',
+    '$ export PATH=$PATH:$ANDROID_HOME/emulator',
+    '$ export PATH=$PATH:$ANDROID_HOME/platform-tools',
   ]}
   cmdCopy="export ANDROID_HOME=$HOME/Library/Android/sdk && export PATH=$PATH:$ANDROID_HOME/emulator && export PATH=$PATH:$ANDROID_HOME/platform-tools"
 />
@@ -79,7 +79,13 @@ Add the following lines to your **/.zprofile** or **~/.zshrc** (if you are using
 
 Reload the path environment variables in your current shell:
 
-<Terminal cmd={['# for bash', 'source $HOME/.bashrc', '', '# for zsh', 'source $HOME/.zshrc']} />
+<Terminal cmd={[
+  '# for zsh',
+  '$ source $HOME/.zshrc',
+  '',
+  '# for bash',
+  '$ source $HOME/.bashrc',
+]} />
 
 </Step>
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -105,11 +105,11 @@ The following three commands result in more or less the same project:
 
 <Terminal
   cmd={[
-    'npx create-expo-app MyApp && cd MyApp && npx expo prebuild',
+    '$ npx create-expo-app MyApp && cd MyApp && npx expo prebuild',
     '',
-    'npx create-expo-app --template bare-minimum',
+    '$ npx create-expo-app --template bare-minimum',
     '',
-    'npx react-native init MyApp && cd MyApp && npx install-expo-modules',
+    '$ npx react-native init MyApp && cd MyApp && npx install-expo-modules',
   ]}
 />
 

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,6 +1,5 @@
-import { css } from '@emotion/react';
-import { spacing } from '@expo/styleguide-base';
 import { TerminalSquareIcon } from '@expo/styleguide-icons';
+import { Language, Prism } from 'prism-react-renderer';
 
 import { Snippet } from '../Snippet';
 import { SnippetContent } from '../SnippetContent';
@@ -17,7 +16,7 @@ type TerminalProps = {
 };
 
 export const Terminal = ({ cmd, cmdCopy, hideOverflow, title = 'Terminal' }: TerminalProps) => (
-  <Snippet css={wrapperStyle}>
+  <Snippet className="[li_&]:mt-4">
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
@@ -75,9 +74,16 @@ function cmdMapper(line: string, index: number) {
         <CODE className="whitespace-pre !bg-[transparent] !border-none select-none !text-secondary">
           -&nbsp;
         </CODE>
-        <CODE className="whitespace-pre !bg-[transparent] !border-none text-default">
-          {line.substring(1).trim()}
-        </CODE>
+        <CODE
+          className="whitespace-pre !bg-[transparent] !border-none text-default"
+          dangerouslySetInnerHTML={{
+            __html: Prism.highlight(
+              line.substring(1).trim(),
+              Prism.languages['bash'],
+              'bash' as Language
+            ),
+          }}
+        />
       </div>
     );
   }
@@ -88,10 +94,3 @@ function cmdMapper(line: string, index: number) {
     </CODE>
   );
 }
-
-const wrapperStyle = css`
-  li & {
-    margin-top: ${spacing[4]}px;
-    display: flex;
-  }
-`;

--- a/docs/ui/components/Snippet/prism-bash.js
+++ b/docs/ui/components/Snippet/prism-bash.js
@@ -1,0 +1,242 @@
+// Base code has been copied over from `prismjs/components/prism-bash`
+
+import { Prism } from 'prism-react-renderer';
+
+(function (Prism) {
+  // $ set | grep '^[A-Z][^[:space:]]*=' | cut -d= -f1 | tr '\n' '|'
+  // + LC_ALL, RANDOM, REPLY, SECONDS.
+  // + make sure PS1..4 are here as they are not always set,
+  // - some useless things.
+  const envVars =
+    '\\b(?:BASH|BASHOPTS|BASH_ALIASES|BASH_ARGC|BASH_ARGV|BASH_CMDS|BASH_COMPLETION_COMPAT_DIR|BASH_LINENO|BASH_REMATCH|BASH_SOURCE|BASH_VERSINFO|BASH_VERSION|COLORTERM|COLUMNS|COMP_WORDBREAKS|DBUS_SESSION_BUS_ADDRESS|DEFAULTS_PATH|DESKTOP_SESSION|DIRSTACK|DISPLAY|EUID|GDMSESSION|GDM_LANG|GNOME_KEYRING_CONTROL|GNOME_KEYRING_PID|GPG_AGENT_INFO|GROUPS|HISTCONTROL|HISTFILE|HISTFILESIZE|HISTSIZE|HOME|HOSTNAME|HOSTTYPE|IFS|INSTANCE|JOB|LANG|LANGUAGE|LC_ADDRESS|LC_ALL|LC_IDENTIFICATION|LC_MEASUREMENT|LC_MONETARY|LC_NAME|LC_NUMERIC|LC_PAPER|LC_TELEPHONE|LC_TIME|LESSCLOSE|LESSOPEN|LINES|LOGNAME|LS_COLORS|MACHTYPE|MAILCHECK|MANDATORY_PATH|NO_AT_BRIDGE|OLDPWD|OPTERR|OPTIND|ORBIT_SOCKETDIR|OSTYPE|PAPERSIZE|PATH|PIPESTATUS|PPID|PS1|PS2|PS3|PS4|PWD|RANDOM|REPLY|SECONDS|SELINUX_INIT|SESSION|SESSIONTYPE|SESSION_MANAGER|SHELL|SHELLOPTS|SHLVL|SSH_AUTH_SOCK|TERM|UID|UPSTART_EVENTS|UPSTART_INSTANCE|UPSTART_JOB|UPSTART_SESSION|USER|WINDOWID|XAUTHORITY|XDG_CONFIG_DIRS|XDG_CURRENT_DESKTOP|XDG_DATA_DIRS|XDG_GREETER_DATA_DIR|XDG_MENU_PREFIX|XDG_RUNTIME_DIR|XDG_SEAT|XDG_SEAT_PATH|XDG_SESSION_DESKTOP|XDG_SESSION_ID|XDG_SESSION_PATH|XDG_SESSION_TYPE|XDG_VTNR|XMODIFIERS)\\b';
+
+  const commandAfterHeredoc = {
+    pattern: /(^(["']?)\w+\2)[ \t]+\S.*/,
+    lookbehind: true,
+    alias: 'punctuation', // this looks reasonably well in all themes
+    inside: null, // see below
+  };
+
+  const insideString = {
+    bash: commandAfterHeredoc,
+    environment: {
+      pattern: RegExp('\\$' + envVars),
+      alias: 'constant',
+    },
+    variable: [
+      // [0]: Arithmetic Environment
+      {
+        pattern: /\$?\(\([\s\S]+?\)\)/,
+        greedy: true,
+        inside: {
+          // If there is a $ sign at the beginning highlight $(( and )) as variable
+          variable: [
+            {
+              pattern: /(^\$\(\([\s\S]+)\)\)/,
+              lookbehind: true,
+            },
+            /^\$\(\(/,
+          ],
+          number: /\b0x[\dA-Fa-f]+\b|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:[Ee]-?\d+)?/,
+          // Operators according to https://www.gnu.org/software/bash/manual/bashref.html#Shell-Arithmetic
+          operator: /--|\+\+|\*\*=?|<<=?|>>=?|&&|\|\||[=!+\-*/%<>^&|]=?|[?~:]/,
+          // If there is no $ sign at the beginning highlight (( and )) as punctuation
+          punctuation: /\(\(?|\)\)?|,|;/,
+        },
+      },
+      // [1]: Command Substitution
+      {
+        pattern: /\$\((?:\([^)]+\)|[^()])+\)|`[^`]+`/,
+        greedy: true,
+        inside: {
+          variable: /^\$\(|^`|\)$|`$/,
+        },
+      },
+      // [2]: Brace expansion
+      {
+        pattern: /\$\{[^}]+\}/,
+        greedy: true,
+        inside: {
+          operator: /:[-=?+]?|[!/]|##?|%%?|\^\^?|,,?/,
+          punctuation: /[[\]]/,
+          environment: {
+            pattern: RegExp('(\\{)' + envVars),
+            lookbehind: true,
+            alias: 'constant',
+          },
+        },
+      },
+      /\$(?:\w+|[#?*!@$])/,
+    ],
+    // Escape sequences from echo and printf's manuals, and escaped quotes.
+    entity: /\\(?:[abceEfnrtv\\"]|O?[0-7]{1,3}|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{1,2})/,
+  };
+
+  Prism.languages.bash = {
+    shebang: {
+      pattern: /^#!\s*\/.*/,
+      alias: 'important',
+    },
+    comment: {
+      pattern: /(^|[^"{\\$])#.*/,
+      lookbehind: true,
+    },
+    'function-name': [
+      // a) function foo {
+      // b) foo() {
+      // c) function foo() {
+      // but not “foo {”
+      {
+        // a) and c)
+        pattern: /(\bfunction\s+)[\w-]+(?=(?:\s*\(?:\s*\))?\s*\{)/,
+        lookbehind: true,
+        alias: 'function',
+      },
+      {
+        // b)
+        pattern: /\b[\w-]+(?=\s*\(\s*\)\s*\{)/,
+        alias: 'function',
+      },
+    ],
+    // Highlight variable names as variables in for and select beginnings.
+    'for-or-select': {
+      pattern: /(\b(?:for|select)\s+)\w+(?=\s+in\s)/,
+      alias: 'variable',
+      lookbehind: true,
+    },
+    // Highlight variable names as variables in the left-hand part
+    // of assignments (“=” and “+=”).
+    'assign-left': {
+      pattern: /(^|[\s;|&]|[<>]\()\w+(?:\.\w+)*(?=\+?=)/,
+      inside: {
+        environment: {
+          pattern: RegExp('(^|[\\s;|&]|[<>]\\()' + envVars),
+          lookbehind: true,
+          alias: 'constant',
+        },
+      },
+      alias: 'variable',
+      lookbehind: true,
+    },
+    // Highlight parameter names as variables
+    parameter: {
+      pattern: /(^|\s)-{1,2}(?:\w+:[+-]?)?\w+(?:\.\w+)*(?=[=\s]|$)/,
+      alias: 'variable',
+      lookbehind: true,
+    },
+    string: [
+      // Support for Here-documents https://en.wikipedia.org/wiki/Here_document
+      {
+        pattern: /((?:^|[^<])<<-?\s*)(\w+)\s[\s\S]*?(?:\r?\n|\r)\2/,
+        lookbehind: true,
+        greedy: true,
+        inside: insideString,
+      },
+      // Here-document with quotes around the tag
+      // → No expansion (so no “inside”).
+      {
+        pattern: /((?:^|[^<])<<-?\s*)(["'])(\w+)\2\s[\s\S]*?(?:\r?\n|\r)\3/,
+        lookbehind: true,
+        greedy: true,
+        inside: {
+          bash: commandAfterHeredoc,
+        },
+      },
+      // “Normal” string
+      {
+        // https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
+        pattern: /(^|[^\\](?:\\\\)*)"(?:\\[\s\S]|\$\([^)]+\)|\$(?!\()|`[^`]+`|[^"\\`$])*"/,
+        lookbehind: true,
+        greedy: true,
+        inside: insideString,
+      },
+      {
+        // https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html
+        pattern: /(^|[^$\\])'[^']*'/,
+        lookbehind: true,
+        greedy: true,
+      },
+      {
+        // https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
+        pattern: /\$'(?:[^'\\]|\\[\s\S])*'/,
+        greedy: true,
+        inside: {
+          entity: insideString.entity,
+        },
+      },
+    ],
+    environment: {
+      pattern: RegExp('\\$?' + envVars),
+      alias: 'constant',
+    },
+    variable: insideString.variable,
+    function: {
+      pattern:
+        /(^|[\s;|&]|[<>]\()(?:apropos|apt|apt-cache|apt-get|aptitude|aspell|awk|basename|bash|bc|bconsole|bg|bzip2|cal|cargo|cat|cfdisk|chgrp|chkconfig|chmod|chown|chroot|cksum|clear|cmp|column|comm|composer|cp|cron|crontab|csplit|curl|cut|date|dc|dd|ddrescue|debootstrap|df|diff|diff3|dig|dir|dircolors|dirname|dirs|dmesg|docker|docker-compose|du|egrep|eject|env|ethtool|expand|expect|expr|fdformat|fdisk|fg|fgrep|file|find|fmt|fold|format|free|fsck|ftp|fuser|gawk|git|gparted|grep|groupadd|groupdel|groupmod|groups|grub-mkconfig|gzip|halt|head|hg|history|host|hostname|htop|iconv|id|ifconfig|ifdown|ifup|import|ip|java|jobs|join|kill|killall|less|link|ln|locate|logname|logrotate|look|lpc|lpr|lprint|lprintd|lprintq|lprm|ls|lsof|lynx|make|man|mc|mdadm|mkconfig|mkdir|mke2fs|mkfifo|mkfs|mkisofs|mknod|mkswap|mmv|more|most|mount|mtools|mtr|mutt|mv|nano|nc|netstat|nice|nl|node|nohup|notify-send|npm|nslookup|op|open|parted|passwd|paste|pathchk|ping|pkill|pnpm|podman|podman-compose|popd|pr|printcap|printenv|ps|pushd|pv|quota|quotacheck|quotactl|ram|rar|rcp|reboot|remsync|rename|renice|rev|rm|rmdir|rpm|rsync|scp|screen|sdiff|sed|sendmail|seq|service|sftp|sh|shellcheck|shuf|shutdown|sleep|slocate|sort|split|ssh|stat|strace|su|sudo|sum|suspend|swapon|sync|sysctl|tac|tail|tar|tee|time|timeout|top|touch|tr|traceroute|tsort|tty|umount|uname|unexpand|uniq|units|unrar|unshar|unzip|update-grub|uptime|useradd|userdel|usermod|users|uudecode|uuencode|v|vcpkg|vdir|vi|vim|virsh|vmstat|wait|watch|wc|wget|whereis|which|who|whoami|write|xargs|xdg-open|yarn|yes|zenity|zip|zsh|zypper|npx|eas|netlify|serve|vercel|firebase|adb|bun)(?=$|[)\s;|&])/,
+      lookbehind: true,
+    },
+    keyword: {
+      pattern:
+        /(^|[\s;|&]|[<>]\()(?:case|do|done|elif|else|esac|fi|for|function|if|in|select|then|until|while)(?=$|[)\s;|&])/,
+      lookbehind: true,
+    },
+    // https://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html
+    builtin: {
+      pattern:
+        /(^|[\s;|&]|[<>]\()(?:\.|:|alias|bind|break|builtin|caller|cd|command|continue|declare|echo|enable|eval|exec|exit|export|getopts|hash|help|let|local|logout|mapfile|printf|pwd|read|readarray|readonly|return|set|shift|shopt|source|test|times|trap|type|typeset|ulimit|umask|unalias|unset)(?=$|[)\s;|&])/,
+      lookbehind: true,
+      alias: 'class-name',
+    },
+    boolean: {
+      pattern: /(^|[\s;|&]|[<>]\()(?:false|true)(?=$|[)\s;|&])/,
+      lookbehind: true,
+    },
+    'file-descriptor': {
+      pattern: /\B&\d\b/,
+      alias: 'important',
+    },
+    operator: {
+      // Lots of redirections here, but not just that.
+      pattern: /\d?<>|>\||\+=|=[=~]?|!=?|<<[<-]?|[&\d]?>>|\d[<>]&?|[<>][&=]?|&[>&]?|\|[&|]?/,
+      inside: {
+        'file-descriptor': {
+          pattern: /^\d/,
+          alias: 'important',
+        },
+      },
+    },
+    punctuation: /\$?\(\(?|\)\)?|\.\.|[{}[\];\\]/,
+    number: {
+      pattern: /(^|\s)(?:[1-9]\d*|0)(?:[.,]\d+)?\b/,
+      lookbehind: true,
+    },
+  };
+
+  commandAfterHeredoc.inside = Prism.languages.bash;
+
+  /* Patterns in command substitution. */
+  const toBeCopied = [
+    'comment',
+    'function-name',
+    'for-or-select',
+    'assign-left',
+    'parameter',
+    'string',
+    'environment',
+    'function',
+    'keyword',
+    'builtin',
+    'boolean',
+    'file-descriptor',
+    'operator',
+    'punctuation',
+    'number',
+  ];
+  const inside = insideString.variable[1].inside;
+  for (let i = 0; i < toBeCopied.length; i++) {
+    inside[toBeCopied[i]] = Prism.languages.bash[toBeCopied[i]];
+  }
+
+  Prism.languages.sh = Prism.languages.bash;
+  Prism.languages.shell = Prism.languages.bash;
+})(Prism);


### PR DESCRIPTION
# Why

Add a basic code highlight for Terminal snippets to improve the readability and match bash/shell code block appearance.

# How

Add highlight for Terminal lines marked as commands (prefixed with `$`), other line types won't be highlighted.

Copy over, and modify, the base Prism `bash` language grammar definition, so it better suits our usage. Use the modified theme also for bash/shell code block highlight.

Perform small tweaks and changes to the pages file, when I have spotted missing command highlight.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-03-12 at 13 21 29](https://github.com/expo/expo/assets/719641/40476a07-68ca-47a8-b782-595aee3facd3)
![Screenshot 2024-03-12 at 15 21 39](https://github.com/expo/expo/assets/719641/a7793396-001d-45d2-b67b-b16f5514a95e)
![Screenshot 2024-03-12 at 15 22 46](https://github.com/expo/expo/assets/719641/5016f90e-b8d6-475b-8340-43cc5ec55593)
