### PR TITLE
[docs] update overview pages content and presentation

### DIFF
--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -4,11 +4,28 @@ sidebar_title: Overview
 hideTOC: true
 ---
 
+import { RouterLogo } from '@expo/styleguide';
+import { CodeSquare01Icon, CpuChip01Icon, PlanEnterpriseIcon } from '@expo/styleguide-icons';
+
 This section contains information about the development with Expo and Expo Application Services (EAS):
 
-- **Development process**: Learn about the process of [building an app with Expo](/workflow/overview/) to help understand the mental model of the core development loop. This section also dives into additional configurations and workflows you may require during the development process to help you develop, deploy, and maintain your app. It contains in-depth information about [app config](/workflow/configuration/), [permissions](/guides/permissions/), [universal links](/guides/deep-linking/), [custom native code](/workflow/continuous-native-generation/), [web](/workflow/web/), and more.
-- **Expo Router**: Learn about using different navigation functionalities from the [Expo Router](/router/advanced/root-layout/) library. It also covers a comprehensive [Hooks API](/router/reference/hooks/) that the library provides and other aspects of navigation such as [Authentication](/router/reference/authentication/), [Redirects](/router/reference/redirects/), [Testing](/router/reference/testing/), and more.
-- **Expo Modules API**: Learn how to add and use Native modules in your app using [Expo Modules API](/modules/overview/).
-- **Expo Application Services (EAS)**: Deeply integrated cloud services for Expo and React Native apps from the team behind Expo. Learn about [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), and [EAS Insights](/eas-insights/introduction/).
+### <span className="inline-flex items-center gap-2"><CodeSquare01Icon />Development process</span>
+
+Learn about the process of [building an app with Expo](/workflow/overview/) to help understand the mental model of the core development loop. This section also dives into additional configurations and workflows you may require during the development process to help you develop, deploy, and maintain your app. It contains in-depth information about [app config](/workflow/configuration/), [permissions](/guides/permissions/), [universal links](/guides/deep-linking/), [custom native code](/workflow/continuous-native-generation/), [web](/workflow/web/), and more.
+
+### <span className="inline-flex items-center gap-2"><RouterLogo />Expo Router</span>
+
+Learn about using different navigation functionalities from the [Expo Router](/router/advanced/root-layout/) library. It also covers a comprehensive [Hooks API](/router/reference/hooks/) that the library provides and other aspects of navigation such as [Authentication](/router/reference/authentication/), [Redirects](/router/reference/redirects/), [Testing](/router/reference/testing/), and more.
+
+
+### <span className="inline-flex items-center gap-2"><CpuChip01Icon />Expo Modules API</span>
+
+Learn how to add and use Native modules in your app using [Expo Modules API](/modules/overview/).
+
+### <span className="inline-flex items-center gap-2"><PlanEnterpriseIcon />Expo Application Services (EAS)</span>
+
+Deeply integrated cloud services for Expo and React Native apps from the team behind Expo. Learn about [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), and [EAS Insights](/eas-insights/introduction/).
+
+### Other content
 
 Apart from the essentials listed above, there are plenty of other features to explore such as [Push notifications](/push-notifications/overview/) and best practices on [distributing your app](/distribution/introduction/) to the app stores. We also have a collection of guides in the **Assorted** and third-party **Integrations** sections.

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -3,14 +3,25 @@ title: Overview
 hideTOC: true
 ---
 
+import { TerminalBrowserIcon, Rocket01Icon } from '@expo/styleguide-icons';
+import { HandWaveIcon } from '~/ui/components/CustomIcons/HandWaveIcon';
+
 Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
-- **Develop**: Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
+### <span className="inline-flex items-center gap-2"><HandWaveIcon className="icon-md" />Get Started</span>
 
-- **Navigation**: Developing an app that requires navigation involves creating different screens, linking them to URLs, switching between screens, and displaying UI elements related to navigation on specific platforms. [Expo Router](/router/introduction/) simplifies this process by converting each file in the app directory into a route and offering automatic deep linking.
+Learn about prerequisites, and how to quickstart an universal project with Expo.
+
+### <span className="inline-flex items-center gap-2"><TerminalBrowserIcon />Develop</span>
+
+Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
 
 {/* TODO: (@aman) Add a section for Review later when its are ready. */}
 
-- **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
+### <span className="inline-flex items-center gap-2"><Rocket01Icon />Deploy</span>
+
+Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
+
+### Other content
 
 There are plenty of other features and best practices to continue exploring along the way, such as [collaborating with your team](/accounts/account-types/#organizations), using [Expo modules](/versions/latest/), [debugging](/debugging/runtime-issues/), and working on the command line with [Expo CLI](/more/expo-cli).

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -10,7 +10,7 @@ Expo is an [open-source framework](https://github.com/expo/expo/) for apps that 
 
 ### <span className="inline-flex items-center gap-2"><HandWaveIcon className="icon-md" />Get Started</span>
 
-Learn about prerequisites, and how to quickstart an universal project with Expo.
+Learn about prerequisites and how to quickly start a universal project with Expo.
 
 ### <span className="inline-flex items-center gap-2"><TerminalBrowserIcon />Develop</span>
 

--- a/docs/ui/components/CustomIcons/HandWaveIcon.tsx
+++ b/docs/ui/components/CustomIcons/HandWaveIcon.tsx
@@ -1,8 +1,14 @@
-export function HandWaveIcon() {
+import { mergeClasses } from '@expo/styleguide';
+
+type Props = {
+  className?: string;
+};
+
+export function HandWaveIcon({ className }: Props) {
   return (
     <svg
       viewBox="0 0 15 16"
-      className="icon-sm stroke-icon-default"
+      className={mergeClasses('icon-sm stroke-icon-default', className)}
       fill="none"
       xmlns="http://www.w3.org/2000/svg">
       <path


### PR DESCRIPTION
# Why

Spotted that not all content on the Overview pages still reflect the sidebar sections we use.

# How

Update overview pages content to match the sidebar arrangement. Update presentation to mark better the relation between sidebar sections and page content.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-03-12 at 16 55 01](https://github.com/expo/expo/assets/719641/3085cf6b-cda4-43db-a99b-111a2d8fb945)

![Screenshot 2024-03-12 at 16 53 57](https://github.com/expo/expo/assets/719641/137451c3-5fe3-415a-8a7c-5265749e7f9e)
