### PR TITLE
[expo-updates] Add ability to override build-time fingerprint

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Add --version top-level flag and also add handler for missing command in expo-update cli. ([#27296](https://github.com/expo/expo/pull/27296) by [@wschurman](https://github.com/wschurman))
 - Add more debug information to runtimeversion:resolve CLI output. ([#27323](https://github.com/expo/expo/pull/27323), [#27387](https://github.com/expo/expo/pull/27387) by [@wschurman](https://github.com/wschurman))
 - Added React Native New Architecture support. ([#27216](https://github.com/expo/expo/pull/27216) by [@kudo](https://github.com/kudo))
+- Add ability to override build-time fingerprint. ([#27597](https://github.com/expo/expo/pull/27597) by [@wschurman](https://github.com/wschurman))
+
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
@@ -35,9 +35,18 @@ async function createFingerprintForBuildAsync(platform, possibleProjectRoot, des
         // not a policy that needs fingerprinting
         return;
     }
-    const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
-    const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, {});
-    console.log(JSON.stringify(fingerprint.sources));
+    let fingerprint;
+    const override = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
+    if (override) {
+        console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${override}`);
+        fingerprint = { hash: override };
+    }
+    else {
+        const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
+        const createdFingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, {});
+        console.log(JSON.stringify(createdFingerprint.sources));
+        fingerprint = createdFingerprint;
+    }
     fs_1.default.writeFileSync(path_1.default.join(destinationDir, 'fingerprint'), fingerprint.hash);
 }
 exports.createFingerprintForBuildAsync = createFingerprintForBuildAsync;

--- a/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
@@ -38,10 +38,18 @@ export async function createFingerprintForBuildAsync(
     return;
   }
 
-  const workflow = await resolveWorkflowAsync(projectRoot, platform);
-  const fingerprint = await createFingerprintAsync(projectRoot, platform, workflow, {});
+  let fingerprint: { hash: string };
 
-  console.log(JSON.stringify(fingerprint.sources));
+  const override = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
+  if (override) {
+    console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${override}`);
+    fingerprint = { hash: override };
+  } else {
+    const workflow = await resolveWorkflowAsync(projectRoot, platform);
+    const createdFingerprint = await createFingerprintAsync(projectRoot, platform, workflow, {});
+    console.log(JSON.stringify(createdFingerprint.sources));
+    fingerprint = createdFingerprint;
+  }
 
   fs.writeFileSync(path.join(destinationDir, 'fingerprint'), fingerprint.hash);
 }


### PR DESCRIPTION
# Why

Generic projects (including those that do continuous native generation, CNG) are having some issues with fingerprint when built on EAS build. This is because EAS build does mutations of the native files just before build, thus generating a different logical runtime from the fingerprint perspective. (https://github.com/expo/eas-build/blob/main/packages/build-tools/src/android/expoUpdates.ts#L55 for example). https://github.com/expo/expo/pull/27576 was one possible solution, but this PR (in combination with a eas-build PR: https://github.com/expo/eas-build/pull/361) is the better solution.

# How

The way to fix this is to calculate the fingerprint ahead of native file mutation in EAS build, and then force the build step to use that fingerprint.

This PR adds this fingerprint override mechanism so that the caller who has previously calculated a fingerprint may force the build step to use their calculated one instead of calculating it at build time. This should be used cautiously since if it is used incorrectly it may end up causing runtime incompatibility.

# Test Plan

1. Create project
2. Make changes to `eas-build` locally to set this environment variable during a build step before project modification.
3. Run build locally using `eas-build` local instructions. (note: need to yarn link this package in a post-install script)
4. See the following log: `[RUN_GRADLEW] Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: a8715b7f12f5736af20ed1f66daa693d37c43585`, indicating the the override is respected and used
5. Check built aab for overridden fingerprint

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
