### PR TITLE
[docs] make Xcode 15 image default

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -208,7 +208,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-ventura-13.6-xcode-15.2` (`latest`)
+#### `macos-ventura-13.6-xcode-15.2` (alias `latest` and `default`)
 
 <Collapsible summary="Details">
 
@@ -262,7 +262,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.4-xcode-14.3.1` (`default`)
+#### `macos-ventura-13.4-xcode-14.3.1`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/turtle-v2/pull/1733

# How

Make Xcode 15 default in docs as well!

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
