### PR TITLE
[expo-go] Fix incorrect graphql query name

### DIFF
--- a/apps/expo-go/graphql-codegen.yml
+++ b/apps/expo-go/graphql-codegen.yml
@@ -4,7 +4,7 @@ documents:
   - '**/*.graphql'
   - '!node_modules/**/*'
 generates:
-  graphql/types.ts:
+  src/graphql/types.ts:
     plugins:
       - typescript
       - typescript-operations

--- a/apps/expo-go/graphql.schema.json
+++ b/apps/expo-go/graphql.schema.json
@@ -1214,6 +1214,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isDisabled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isSSOEnabled",
             "description": "Whether this account has SSO enabled. Can be queried by all members.",
             "args": [],
@@ -1600,6 +1616,22 @@
             "deprecationReason": null
           },
           {
+            "name": "viewerUserPermission",
+            "description": "Permission info for the viewer on this account",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserPermission",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "willAutoRenewBuilds",
             "description": null,
             "args": [],
@@ -1717,6 +1749,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "searchTerm",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "sortByField",
             "description": null,
@@ -4699,6 +4743,18 @@
             "deprecationReason": null
           },
           {
+            "name": "googleServiceAccountKeyForFcmV1",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GoogleServiceAccountKey",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "googleServiceAccountKeyForSubmissions",
             "description": null,
             "args": [],
@@ -4802,6 +4858,18 @@
             "deprecationReason": null
           },
           {
+            "name": "googleServiceAccountKeyForFcmV1Id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "googleServiceAccountKeyForSubmissionsId",
             "description": null,
             "type": {
@@ -4889,6 +4957,71 @@
             "deprecationReason": null
           },
           {
+            "name": "createFcmV1Credential",
+            "description": "Create a GoogleServiceAccountKeyEntity to store credential and\nconnect it with an edge from AndroidAppCredential",
+            "args": [
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "androidAppCredentialsId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "credential",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AndroidAppCredentials",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "deleteAndroidAppCredentials",
             "description": "Delete a set of credentials for an Android app",
             "args": [
@@ -4927,6 +5060,55 @@
             "args": [
               {
                 "name": "fcmId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AndroidAppCredentials",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setGoogleServiceAccountKeyForFcmV1",
+            "description": "Set the Google Service Account Key to be used for Firebase Cloud Messaging V1",
+            "args": [
+              {
+                "name": "googleServiceAccountKeyId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -7668,6 +7850,22 @@
             "deprecationReason": null
           },
           {
+            "name": "internalDistributionBuildPrivacy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppInternalDistributionBuildPrivacy",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "iosAppCredentials",
             "description": "iOS app credentials for the project",
             "args": [
@@ -9248,6 +9446,18 @@
             "deprecationReason": null
           },
           {
+            "name": "internalDistributionBuildPrivacy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppInternalDistributionBuildPrivacy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "privacy",
             "description": null,
             "type": {
@@ -9545,6 +9755,29 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppInternalDistributionBuildPrivacy",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PRIVATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUBLIC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -14197,6 +14430,18 @@
             "deprecationReason": null
           },
           {
+            "name": "appIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appVersion",
             "description": null,
             "args": [],
@@ -14546,6 +14791,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isForIosSimulator",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isGitWorkingTreeDirty",
             "description": null,
             "args": [],
@@ -14705,6 +14966,18 @@
                 "name": "Project",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectMetadataFileUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -15845,6 +16118,18 @@
             "deprecationReason": null
           },
           {
+            "name": "simulator",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "type": {
@@ -15937,6 +16222,30 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "simulator",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -16860,6 +17169,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "simulator",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -17925,6 +18246,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isForIosSimulator",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -19297,6 +19634,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submitProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -23215,6 +23564,18 @@
             "deprecationReason": null
           },
           {
+            "name": "submitProfile",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "targetPattern",
             "description": null,
             "args": [],
@@ -23457,6 +23818,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -27454,6 +27831,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "EXPO_DEVELOPER_ONBOARDING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -27468,6 +27851,12 @@
         "enumValues": [
           {
             "name": "DEV_CLIENT_USERS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DID_SUBSCRIBE_TO_EAS_AT_LEAST_ONCE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -28420,6 +28809,12 @@
             "deprecationReason": null
           },
           {
+            "name": "BUILD_ERRORED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "BUILD_LIMIT_THRESHOLD_EXCEEDED",
             "description": null,
             "isDeprecated": false,
@@ -28433,6 +28828,12 @@
           },
           {
             "name": "SUBMISSION_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMISSION_ERRORED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -29582,6 +29983,18 @@
           },
           {
             "name": "gitRef",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadataLocation",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -32785,6 +33198,22 @@
             "deprecationReason": null
           },
           {
+            "name": "preferences",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserPreferences",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "primaryAccount",
             "description": "Associated accounts",
             "args": [],
@@ -34623,6 +35052,30 @@
             "deprecationReason": null
           },
           {
+            "name": "logFiles",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "logsUrl",
             "description": null,
             "args": [],
@@ -34631,8 +35084,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use logFiles instead"
           },
           {
             "name": "maxRetryTimeMinutes",
@@ -37023,6 +37476,18 @@
             "deprecationReason": null
           },
           {
+            "name": "submitProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "targetPattern",
             "description": null,
             "type": {
@@ -37445,6 +37910,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "EAS_BUILD_GCS_PROJECT_METADATA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "EAS_BUILD_GCS_PROJECT_SOURCES",
             "description": null,
             "isDeprecated": false,
@@ -37453,14 +37924,14 @@
           {
             "name": "EAS_BUILD_PROJECT_SOURCES",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use EAS_BUILD_GCS_PROJECT_SOURCES instead."
           },
           {
             "name": "EAS_SUBMIT_APP_ARCHIVE",
             "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use EAS_SUBMIT_GCS_APP_ARCHIVE instead."
           },
           {
             "name": "EAS_SUBMIT_GCS_APP_ARCHIVE",
@@ -38325,6 +38796,22 @@
             "deprecationReason": null
           },
           {
+            "name": "preferences",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserPreferences",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "primaryAccount",
             "description": "Associated accounts",
             "args": [],
@@ -39059,6 +39546,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "preferences",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserPreferences",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -40414,6 +40917,29 @@
             "type": {
               "kind": "INTERFACE",
               "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserPreferences",
+        "description": null,
+        "fields": [
+          {
+            "name": "selectedAccountName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,

--- a/apps/expo-go/src/components/BranchListItem.tsx
+++ b/apps/expo-go/src/components/BranchListItem.tsx
@@ -7,11 +7,10 @@ import React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import { DateFormats } from '../constants/DateFormats';
-import { WebContainerProjectPage_Query } from '../graphql/types';
+import { ProjectsQuery } from '../graphql/types';
 import { HomeStackRoutes } from '../navigation/Navigation.types';
 
-type Update =
-  WebContainerProjectPage_Query['app']['byId']['updateBranches'][number]['updates'][number];
+type Update = ProjectsQuery['app']['byId']['updateBranches'][number]['updates'][number];
 
 type Props = {
   name: string;

--- a/apps/expo-go/src/graphql/queries/ProjectsQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/ProjectsQuery.query.graphql
@@ -1,4 +1,4 @@
-query WebContainerProjectPage_Query(
+query ProjectsQuery(
   $appId: String!
   $platform: AppPlatform!
   $sdkVersions: [String!]!

--- a/apps/expo-go/src/graphql/types.ts
+++ b/apps/expo-go/src/graphql/types.ts
@@ -108,6 +108,7 @@ export type Account = {
   googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
   id: Scalars['ID'];
   isCurrent: Scalars['Boolean'];
+  isDisabled: Scalars['Boolean'];
   /** Whether this account has SSO enabled. Can be queried by all members. */
   isSSOEnabled: Scalars['Boolean'];
   name: Scalars['String'];
@@ -144,6 +145,8 @@ export type Account = {
   userInvitations: Array<UserInvitation>;
   /** Actors associated with this account and permissions they hold */
   users: Array<UserPermission>;
+  /** Permission info for the viewer on this account */
+  viewerUserPermission: UserPermission;
   /** @deprecated Build packs are no longer supported */
   willAutoRenewBuilds?: Maybe<Scalars['Boolean']>;
 };
@@ -310,6 +313,7 @@ export type AccountAppsEdge = {
 };
 
 export type AccountAppsFilterInput = {
+  searchTerm?: InputMaybe<Scalars['String']>;
   sortByField: AccountAppsSortByField;
 };
 
@@ -751,6 +755,7 @@ export type AndroidAppCredentials = {
   androidFcm?: Maybe<AndroidFcm>;
   app: App;
   applicationIdentifier?: Maybe<Scalars['String']>;
+  googleServiceAccountKeyForFcmV1?: Maybe<GoogleServiceAccountKey>;
   googleServiceAccountKeyForSubmissions?: Maybe<GoogleServiceAccountKey>;
   id: Scalars['ID'];
   isLegacy: Scalars['Boolean'];
@@ -763,6 +768,7 @@ export type AndroidAppCredentialsFilter = {
 
 export type AndroidAppCredentialsInput = {
   fcmId?: InputMaybe<Scalars['ID']>;
+  googleServiceAccountKeyForFcmV1Id?: InputMaybe<Scalars['ID']>;
   googleServiceAccountKeyForSubmissionsId?: InputMaybe<Scalars['ID']>;
 };
 
@@ -770,10 +776,17 @@ export type AndroidAppCredentialsMutation = {
   __typename?: 'AndroidAppCredentialsMutation';
   /** Create a set of credentials for an Android app */
   createAndroidAppCredentials: AndroidAppCredentials;
+  /**
+   * Create a GoogleServiceAccountKeyEntity to store credential and
+   * connect it with an edge from AndroidAppCredential
+   */
+  createFcmV1Credential: AndroidAppCredentials;
   /** Delete a set of credentials for an Android app */
   deleteAndroidAppCredentials: DeleteAndroidAppCredentialsResult;
   /** Set the FCM push key to be used in an Android app */
   setFcm: AndroidAppCredentials;
+  /** Set the Google Service Account Key to be used for Firebase Cloud Messaging V1 */
+  setGoogleServiceAccountKeyForFcmV1: AndroidAppCredentials;
   /** Set the Google Service Account Key to be used for submitting an Android app */
   setGoogleServiceAccountKeyForSubmissions: AndroidAppCredentials;
 };
@@ -786,6 +799,13 @@ export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
 };
 
 
+export type AndroidAppCredentialsMutationCreateFcmV1CredentialArgs = {
+  accountId: Scalars['ID'];
+  androidAppCredentialsId: Scalars['String'];
+  credential: Scalars['String'];
+};
+
+
 export type AndroidAppCredentialsMutationDeleteAndroidAppCredentialsArgs = {
   id: Scalars['ID'];
 };
@@ -793,6 +813,12 @@ export type AndroidAppCredentialsMutationDeleteAndroidAppCredentialsArgs = {
 
 export type AndroidAppCredentialsMutationSetFcmArgs = {
   fcmId: Scalars['ID'];
+  id: Scalars['ID'];
+};
+
+
+export type AndroidAppCredentialsMutationSetGoogleServiceAccountKeyForFcmV1Args = {
+  googleServiceAccountKeyId: Scalars['ID'];
   id: Scalars['ID'];
 };
 
@@ -1043,6 +1069,7 @@ export type App = Project & {
   id: Scalars['ID'];
   /** App query field for querying EAS Insights about this app */
   insights: AppInsights;
+  internalDistributionBuildPrivacy: AppInternalDistributionBuildPrivacy;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
   isDeleting: Scalars['Boolean'];
@@ -1368,6 +1395,7 @@ export type AppChannelsConnection = {
 
 export type AppDataInput = {
   id: Scalars['ID'];
+  internalDistributionBuildPrivacy?: InputMaybe<AppInternalDistributionBuildPrivacy>;
   privacy?: InputMaybe<Scalars['String']>;
 };
 
@@ -1413,6 +1441,11 @@ export type AppInsightsUniqueUsersByAppVersionOverTimeArgs = {
 export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
   timespan: InsightsTimespan;
 };
+
+export enum AppInternalDistributionBuildPrivacy {
+  Private = 'PRIVATE',
+  Public = 'PUBLIC'
+}
 
 export type AppMutation = {
   __typename?: 'AppMutation';
@@ -2080,6 +2113,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   actor?: Maybe<Actor>;
   app: App;
   appBuildVersion?: Maybe<Scalars['String']>;
+  appIdentifier?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
   buildMode?: Maybe<BuildMode>;
@@ -2109,6 +2143,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   /** @deprecated User type is deprecated */
   initiatingUser?: Maybe<User>;
   iosEnterpriseProvisioning?: Maybe<BuildIosEnterpriseProvisioning>;
+  isForIosSimulator: Scalars['Boolean'];
   isGitWorkingTreeDirty?: Maybe<Scalars['Boolean']>;
   isWaived: Scalars['Boolean'];
   logFiles: Array<Scalars['String']>;
@@ -2121,6 +2156,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   platform: AppPlatform;
   priority: BuildPriority;
   project: Project;
+  projectMetadataFileUrl?: Maybe<Scalars['String']>;
   projectRootDirectory?: Maybe<Scalars['String']>;
   provisioningStartedAt?: Maybe<Scalars['DateTime']>;
   /** Queue position is 1-indexed */
@@ -2274,6 +2310,7 @@ export type BuildFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersion?: InputMaybe<Scalars['String']>;
   sdkVersion?: InputMaybe<Scalars['String']>;
+  simulator?: InputMaybe<Scalars['Boolean']>;
   status?: InputMaybe<BuildStatus>;
 };
 
@@ -2283,6 +2320,8 @@ export type BuildFilterInput = {
   distributions?: InputMaybe<Array<DistributionType>>;
   platforms?: InputMaybe<Array<AppPlatform>>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  runtimeVersion?: InputMaybe<Scalars['String']>;
+  simulator?: InputMaybe<Scalars['Boolean']>;
 };
 
 export enum BuildIosEnterpriseProvisioning {
@@ -2400,6 +2439,7 @@ export type BuildMetadataInput = {
   runtimeVersion?: InputMaybe<Scalars['String']>;
   sdkVersion?: InputMaybe<Scalars['String']>;
   selectedImage?: InputMaybe<Scalars['String']>;
+  simulator?: InputMaybe<Scalars['Boolean']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']>;
   username?: InputMaybe<Scalars['String']>;
   workflow?: InputMaybe<BuildWorkflow>;
@@ -2580,6 +2620,7 @@ export type BuildPublicData = {
   artifacts: PublicArtifacts;
   distribution?: Maybe<DistributionType>;
   id: Scalars['ID'];
+  isForIosSimulator: Scalars['Boolean'];
   platform: AppPlatform;
   project: ProjectPublicData;
   status: BuildStatus;
@@ -2783,6 +2824,7 @@ export type CreateGitHubBuildTriggerInput = {
   platform: AppPlatform;
   /** A branch or tag name, or a wildcard pattern where the code change originates from. For example, `main` or `release/*`. */
   sourcePattern: Scalars['String'];
+  submitProfile?: InputMaybe<Scalars['String']>;
   /** A branch name or a wildcard pattern that the pull request targets. For example, `main` or `release/*`. */
   targetPattern?: InputMaybe<Scalars['String']>;
   type: GitHubBuildTriggerType;
@@ -3363,6 +3405,7 @@ export type GitHubBuildTrigger = {
   lastRunStatus?: Maybe<GitHubBuildTriggerRunStatus>;
   platform: AppPlatform;
   sourcePattern: Scalars['String'];
+  submitProfile?: Maybe<Scalars['String']>;
   targetPattern?: Maybe<Scalars['String']>;
   type: GitHubBuildTriggerType;
   updatedAt: Scalars['DateTime'];
@@ -3408,6 +3451,7 @@ export enum GitHubBuildTriggerType {
 export type GitHubRepository = {
   __typename?: 'GitHubRepository';
   app: App;
+  createdAt: Scalars['DateTime'];
   githubAppInstallation: GitHubAppInstallation;
   githubRepositoryIdentifier: Scalars['Int'];
   githubRepositoryUrl?: Maybe<Scalars['String']>;
@@ -3926,11 +3970,13 @@ export type LineDataset = {
 };
 
 export enum MailchimpAudience {
-  ExpoDevelopers = 'EXPO_DEVELOPERS'
+  ExpoDevelopers = 'EXPO_DEVELOPERS',
+  ExpoDeveloperOnboarding = 'EXPO_DEVELOPER_ONBOARDING'
 }
 
 export enum MailchimpTag {
   DevClientUsers = 'DEV_CLIENT_USERS',
+  DidSubscribeToEasAtLeastOnce = 'DID_SUBSCRIBE_TO_EAS_AT_LEAST_ONCE',
   EasMasterList = 'EAS_MASTER_LIST',
   NewsletterSignupList = 'NEWSLETTER_SIGNUP_LIST'
 }
@@ -4098,9 +4144,11 @@ export type Notification = {
 
 export enum NotificationEvent {
   BuildComplete = 'BUILD_COMPLETE',
+  BuildErrored = 'BUILD_ERRORED',
   BuildLimitThresholdExceeded = 'BUILD_LIMIT_THRESHOLD_EXCEEDED',
   BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
   SubmissionComplete = 'SUBMISSION_COMPLETE',
+  SubmissionErrored = 'SUBMISSION_ERRORED',
   Test = 'TEST'
 }
 
@@ -4245,6 +4293,7 @@ export type Project = {
 export type ProjectArchiveSourceInput = {
   bucketKey?: InputMaybe<Scalars['String']>;
   gitRef?: InputMaybe<Scalars['String']>;
+  metadataLocation?: InputMaybe<Scalars['String']>;
   repositoryUrl?: InputMaybe<Scalars['String']>;
   type: ProjectArchiveSourceType;
   url?: InputMaybe<Scalars['String']>;
@@ -4693,6 +4742,7 @@ export type SsoUser = Actor & UserActor & {
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   pinnedApps: Array<App>;
+  preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -4994,6 +5044,8 @@ export type Submission = ActivityTimelineProjectActivity & {
   id: Scalars['ID'];
   initiatingActor?: Maybe<Actor>;
   iosConfig?: Maybe<IosSubmissionConfig>;
+  logFiles: Array<Scalars['String']>;
+  /** @deprecated Use logFiles instead */
   logsUrl?: Maybe<Scalars['String']>;
   /** Retry time starts after completedAt */
   maxRetryTimeMinutes: Scalars['Int'];
@@ -5326,6 +5378,7 @@ export type UpdateGitHubBuildTriggerInput = {
   isActive: Scalars['Boolean'];
   platform: AppPlatform;
   sourcePattern: Scalars['String'];
+  submitProfile?: InputMaybe<Scalars['String']>;
   targetPattern?: InputMaybe<Scalars['String']>;
   type: GitHubBuildTriggerType;
 };
@@ -5394,8 +5447,11 @@ export type UploadSessionCreateUploadSessionArgs = {
 };
 
 export enum UploadSessionType {
+  EasBuildGcsProjectMetadata = 'EAS_BUILD_GCS_PROJECT_METADATA',
   EasBuildGcsProjectSources = 'EAS_BUILD_GCS_PROJECT_SOURCES',
+  /** @deprecated Use EAS_BUILD_GCS_PROJECT_SOURCES instead. */
   EasBuildProjectSources = 'EAS_BUILD_PROJECT_SOURCES',
+  /** @deprecated Use EAS_SUBMIT_GCS_APP_ARCHIVE instead. */
   EasSubmitAppArchive = 'EAS_SUBMIT_APP_ARCHIVE',
   EasSubmitGcsAppArchive = 'EAS_SUBMIT_GCS_APP_ARCHIVE'
 }
@@ -5480,6 +5536,7 @@ export type User = Actor & UserActor & {
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<UserInvitation>;
   pinnedApps: Array<App>;
+  preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -5583,6 +5640,7 @@ export type UserActor = {
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   pinnedApps: Array<App>;
+  preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
   profilePhoto: Scalars['String'];
@@ -5839,6 +5897,11 @@ export type UserPermission = {
   userActor?: Maybe<UserActor>;
 };
 
+export type UserPreferences = {
+  __typename?: 'UserPreferences';
+  selectedAccountName?: Maybe<Scalars['String']>;
+};
+
 export type UserQuery = {
   __typename?: 'UserQuery';
   /**
@@ -6056,15 +6119,6 @@ export type Home_ProfileSnacksQueryVariables = Exact<{
 
 export type Home_ProfileSnacksQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | { __typename?: 'User', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
 
-export type WebContainerProjectPage_QueryVariables = Exact<{
-  appId: Scalars['String'];
-  platform: AppPlatform;
-  sdkVersions: Array<Scalars['String']> | Scalars['String'];
-}>;
-
-
-export type WebContainerProjectPage_Query = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: string | null, playStoreUrl?: string | null, appStoreUrl?: string | null, sdkVersion: string, iconUrl?: string | null, privacy: string, icon?: { __typename?: 'AppIcon', url: string } | null, latestReleaseForReleaseChannel?: { __typename?: 'AppRelease', sdkVersion: string, runtimeVersion?: string | null } | null, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
-
 export type Home_AccountAppsQueryVariables = Exact<{
   accountName: Scalars['String'];
   limit: Scalars['Int'];
@@ -6073,6 +6127,15 @@ export type Home_AccountAppsQueryVariables = Exact<{
 
 
 export type Home_AccountAppsQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }> } } };
+
+export type ProjectsQueryVariables = Exact<{
+  appId: Scalars['String'];
+  platform: AppPlatform;
+  sdkVersions: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type ProjectsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: string | null, playStoreUrl?: string | null, appStoreUrl?: string | null, sdkVersion: string, iconUrl?: string | null, privacy: string, icon?: { __typename?: 'AppIcon', url: string } | null, latestReleaseForReleaseChannel?: { __typename?: 'AppRelease', sdkVersion: string, runtimeVersion?: string | null } | null, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
 
 export type Home_AccountSnacksQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -6560,84 +6623,6 @@ export type Home_ProfileSnacksQueryResult = Apollo.QueryResult<Home_ProfileSnack
 export function refetchHome_ProfileSnacksQuery(variables: Home_ProfileSnacksQueryVariables) {
       return { query: Home_ProfileSnacksDocument, variables: variables }
     }
-export const WebContainerProjectPage_QueryDocument = gql`
-    query WebContainerProjectPage_Query($appId: String!, $platform: AppPlatform!, $sdkVersions: [String!]!) {
-  app {
-    byId(appId: $appId) {
-      id
-      name
-      slug
-      fullName
-      username
-      published
-      description
-      githubUrl
-      playStoreUrl
-      appStoreUrl
-      sdkVersion
-      iconUrl
-      privacy
-      icon {
-        url
-      }
-      latestReleaseForReleaseChannel(platform: $platform, releaseChannel: "default") {
-        sdkVersion
-        runtimeVersion
-      }
-      updateBranches(limit: 100, offset: 0) {
-        id
-        name
-        updates(
-          limit: 1
-          offset: 0
-          filter: {platform: $platform, sdkVersions: $sdkVersions}
-        ) {
-          id
-          group
-          message
-          createdAt
-          runtimeVersion
-          platform
-          manifestPermalink
-        }
-      }
-    }
-  }
-}
-    `;
-
-/**
- * __useWebContainerProjectPage_Query__
- *
- * To run a query within a React component, call `useWebContainerProjectPage_Query` and pass it any options that fit your needs.
- * When your component renders, `useWebContainerProjectPage_Query` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useWebContainerProjectPage_Query({
- *   variables: {
- *      appId: // value for 'appId'
- *      platform: // value for 'platform'
- *      sdkVersions: // value for 'sdkVersions'
- *   },
- * });
- */
-export function useWebContainerProjectPage_Query(baseOptions: Apollo.QueryHookOptions<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>(WebContainerProjectPage_QueryDocument, options);
-      }
-export function useWebContainerProjectPage_QueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>(WebContainerProjectPage_QueryDocument, options);
-        }
-export type WebContainerProjectPage_QueryHookResult = ReturnType<typeof useWebContainerProjectPage_Query>;
-export type WebContainerProjectPage_QueryLazyQueryHookResult = ReturnType<typeof useWebContainerProjectPage_QueryLazyQuery>;
-export type WebContainerProjectPage_QueryQueryResult = Apollo.QueryResult<WebContainerProjectPage_Query, WebContainerProjectPage_QueryVariables>;
-export function refetchWebContainerProjectPage_Query(variables: WebContainerProjectPage_QueryVariables) {
-      return { query: WebContainerProjectPage_QueryDocument, variables: variables }
-    }
 export const Home_AccountAppsDocument = gql`
     query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!) {
   account {
@@ -6683,6 +6668,84 @@ export type Home_AccountAppsLazyQueryHookResult = ReturnType<typeof useHome_Acco
 export type Home_AccountAppsQueryResult = Apollo.QueryResult<Home_AccountAppsQuery, Home_AccountAppsQueryVariables>;
 export function refetchHome_AccountAppsQuery(variables: Home_AccountAppsQueryVariables) {
       return { query: Home_AccountAppsDocument, variables: variables }
+    }
+export const ProjectsQueryDocument = gql`
+    query ProjectsQuery($appId: String!, $platform: AppPlatform!, $sdkVersions: [String!]!) {
+  app {
+    byId(appId: $appId) {
+      id
+      name
+      slug
+      fullName
+      username
+      published
+      description
+      githubUrl
+      playStoreUrl
+      appStoreUrl
+      sdkVersion
+      iconUrl
+      privacy
+      icon {
+        url
+      }
+      latestReleaseForReleaseChannel(platform: $platform, releaseChannel: "default") {
+        sdkVersion
+        runtimeVersion
+      }
+      updateBranches(limit: 100, offset: 0) {
+        id
+        name
+        updates(
+          limit: 1
+          offset: 0
+          filter: {platform: $platform, sdkVersions: $sdkVersions}
+        ) {
+          id
+          group
+          message
+          createdAt
+          runtimeVersion
+          platform
+          manifestPermalink
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useProjectsQuery__
+ *
+ * To run a query within a React component, call `useProjectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useProjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useProjectsQuery({
+ *   variables: {
+ *      appId: // value for 'appId'
+ *      platform: // value for 'platform'
+ *      sdkVersions: // value for 'sdkVersions'
+ *   },
+ * });
+ */
+export function useProjectsQuery(baseOptions: Apollo.QueryHookOptions<ProjectsQuery, ProjectsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProjectsQuery, ProjectsQueryVariables>(ProjectsQueryDocument, options);
+      }
+export function useProjectsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProjectsQuery, ProjectsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProjectsQuery, ProjectsQueryVariables>(ProjectsQueryDocument, options);
+        }
+export type ProjectsQueryHookResult = ReturnType<typeof useProjectsQuery>;
+export type ProjectsQueryLazyQueryHookResult = ReturnType<typeof useProjectsQueryLazyQuery>;
+export type ProjectsQueryQueryResult = Apollo.QueryResult<ProjectsQuery, ProjectsQueryVariables>;
+export function refetchProjectsQuery(variables: ProjectsQueryVariables) {
+      return { query: ProjectsQueryDocument, variables: variables }
     }
 export const Home_AccountSnacksDocument = gql`
     query Home_AccountSnacks($accountName: String!, $limit: Int!, $offset: Int!) {

--- a/apps/expo-go/src/screens/ProjectScreen/EASUpdateLaunchSection.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/EASUpdateLaunchSection.tsx
@@ -7,10 +7,10 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import { BranchListItem } from '../../components/BranchListItem';
 import { SectionHeader } from '../../components/SectionHeader';
-import { WebContainerProjectPage_Query } from '../../graphql/types';
+import { ProjectsQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
-type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
+type ProjectPageApp = ProjectsQuery['app']['byId'];
 
 export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
   const branchesToRender = app.updateBranches.filter(

--- a/apps/expo-go/src/screens/ProjectScreen/LegacyLaunchSection.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/LegacyLaunchSection.tsx
@@ -8,11 +8,11 @@ import semver from 'semver';
 
 import { WarningBox } from './WarningBox';
 import { SectionHeader } from '../../components/SectionHeader';
-import { WebContainerProjectPage_Query } from '../../graphql/types';
+import { ProjectsQuery } from '../../graphql/types';
 import Environment from '../../utils/Environment';
 import * as UrlUtils from '../../utils/UrlUtils';
 
-type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
+type ProjectPageApp = ProjectsQuery['app']['byId'];
 
 function getSDKMajorVersionsForLegacyUpdates(app: ProjectPageApp): number | null {
   return app.sdkVersion ? semver.major(app.sdkVersion) : null;

--- a/apps/expo-go/src/screens/ProjectScreen/ProjectContainer.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/ProjectContainer.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { Platform } from 'react-native';
 
 import { ProjectView } from './ProjectView';
-import { AppPlatform, useWebContainerProjectPage_Query } from '../../graphql/types';
+import { AppPlatform, useProjectsQuery } from '../../graphql/types';
 import * as Kernel from '../../kernel/Kernel';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
 export function ProjectContainer(
   props: { appId: string } & StackScreenProps<HomeStackRoutes, 'ProjectDetails'>
 ) {
-  const query = useWebContainerProjectPage_Query({
+  const query = useProjectsQuery({
     fetchPolicy: 'cache-and-network',
     variables: {
       appId: props.appId,

--- a/apps/expo-go/src/screens/ProjectScreen/ProjectHeader.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/ProjectHeader.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { Image } from 'react-native';
 import FadeIn from 'react-native-fade-in-image';
 
-import { WebContainerProjectPage_Query } from '../../graphql/types';
+import { ProjectsQuery } from '../../graphql/types';
 
-type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
+type ProjectPageApp = ProjectsQuery['app']['byId'];
 
 export function ProjectHeader(props: { app: ProjectPageApp }) {
   const source = props.app.icon ? props.app.icon.url : props.app.iconUrl;

--- a/apps/expo-go/src/screens/ProjectScreen/ProjectView.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/ProjectView.tsx
@@ -12,7 +12,7 @@ import { ProjectHeader } from './ProjectHeader';
 import { ConstantItem } from '../../components/ConstantItem';
 import ScrollView from '../../components/NavigationScrollView';
 import ShareProjectButton from '../../components/ShareProjectButton';
-import { WebContainerProjectPage_Query } from '../../graphql/types';
+import { ProjectsQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
 const ERROR_TEXT = dedent`
@@ -23,10 +23,10 @@ const ERROR_TEXT = dedent`
 type Props = {
   loading: boolean;
   error?: Error;
-  data?: WebContainerProjectPage_Query;
+  data?: ProjectsQuery;
 } & StackScreenProps<HomeStackRoutes, 'ProjectDetails'>;
 
-type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
+type ProjectPageApp = ProjectsQuery['app']['byId'];
 
 export function ProjectView({ loading, error, data, navigation }: Props) {
   const theme = useExpoTheme();


### PR DESCRIPTION
# Why

Looks like a copypasta error. This PR corrects it so that the query shows up as different than the website.

# How

Rename, regenerate gql, fix script.

# Test Plan

`yarn tsc`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
