### PR TITLE
[ci] Add scheduled Expo Go build

### DIFF
--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -13,6 +13,8 @@ on:
       - .github/workflows/client-android-eas.yml
       - apps/eas-expo-go/**
       - apps/expo-go/android/**
+  schedule:
+    - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - .github/workflows/client-ios-eas.yml
       - apps/eas-expo-go/**
-      - ios/**
+      - apps/expo-go/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
       - secrets/**
@@ -23,6 +23,8 @@ on:
       - secrets/**
       - fastlane/**
       - Gemfile.lock
+  schedule:
+    - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why

These were in the old non-EAS versions of these workflows, but never got transferred to the EAS version (since the EAS version was just testing for a while, now it is the only version).

https://github.com/expo/expo/blob/eed7331ab4eecc3097e7927307832508aa22eae1/.github/workflows/client-ios.yml#L6

Both Expo Go builds are broken I think, so this should help us to catch breakage.

# How

Copy old schedule.

# Test Plan

inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
