### PR TITLE
[expo-go] Fix bundling error for home

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -13,6 +13,7 @@ import com.facebook.soloader.SoLoader
 import com.squareup.leakcanary.LeakCanary
 import de.greenrobot.event.EventBus
 import expo.modules.application.ApplicationModule
+import expo.modules.asset.AssetModule
 import expo.modules.barcodescanner.BarCodeScannerModule
 import expo.modules.barcodescanner.BarCodeScannerPackage
 import expo.modules.blur.BlurModule
@@ -163,6 +164,7 @@ open class HomeActivity : BaseExperienceActivity() {
 
     override fun getModulesList(): List<Class<out Module>> {
       return listOf(
+        AssetModule::class.java,
         BarCodeScannerModule::class.java,
         BlurModule::class.java,
         CameraViewModule::class.java,

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -1,6 +1,7 @@
 package versioned.host.exp.exponent
 
 import expo.modules.application.ApplicationModule
+import expo.modules.asset.AssetModule
 import expo.modules.av.AVModule
 import expo.modules.av.AVPackage
 import expo.modules.av.video.VideoViewModule
@@ -124,6 +125,7 @@ object ExperiencePackagePicker : ModulesProvider {
     ApplicationModule::class.java,
     // Sensors
     AccelerometerModule::class.java,
+    AssetModule::class.java,
     BarometerModule::class.java,
     GyroscopeModule::class.java,
     LightSensorModule::class.java,


### PR DESCRIPTION
# Why

Was seeing this error:
```
ERROR  Error: Cannot find native module 'ExpoAsset', js engine: hermes
 ERROR  Invariant Violation: "main" has not been registered.
```

This fixes it by putting ExpoAsset in the modules for home.

# How

Add to the lists.

# Test Plan

`yarn start` in apps/expo-go
Build on android studio, see it now works and bundles successfully.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
