### PR TITLE
[docs] add website link to error recovery

### DIFF
--- a/docs/pages/eas-update/error-recovery.mdx
+++ b/docs/pages/eas-update/error-recovery.mdx
@@ -19,7 +19,7 @@ The important thing is to **publish a new update with a fix as soon as possible 
 
 The first thing to try is rolling back to an older update that you know was working. **However, this may not always be safe;** your broken update may, for example, have modified persistent state (such as data stored in AsyncStorage or on the device's file system) in a non-backwards-compatible way. It's important to test in a staging environment that emulates an end user's device state as closely as possible to load the broken update and then roll back.
 
-If you can identify an older update that is safe to roll back to, you can do so using [EAS Update's `republish` option](/eas-update/eas-cli/#republish-a-previous-update-within-a-branch).
+If you can identify an older update that is safe to roll back to, you can do so using EAS Update's `republish` option from the [website](https://expo.dev/accounts/[account]/projects/[project]/updates) or [CLI](/eas-update/eas-cli/#republish-a-previous-update-within-a-branch).
 
 If you cannot identify an older update that is safe to roll back to, you'll need to fix it forward. While it's best to roll out a fix as quickly as possible, you should take the time to ensure your fix is solid, and know that even users who download your broken update in the meantime should be able to download your fix.
 

--- a/docs/pages/eas-update/error-recovery.mdx
+++ b/docs/pages/eas-update/error-recovery.mdx
@@ -19,7 +19,7 @@ The important thing is to **publish a new update with a fix as soon as possible 
 
 The first thing to try is rolling back to an older update that you know was working. **However, this may not always be safe;** your broken update may, for example, have modified persistent state (such as data stored in AsyncStorage or on the device's file system) in a non-backwards-compatible way. It's important to test in a staging environment that emulates an end user's device state as closely as possible to load the broken update and then roll back.
 
-If you can identify an older update that is safe to roll back to, you can do so using EAS Update's `republish` option from the [website](https://expo.dev/accounts/[account]/projects/[project]/updates) or [CLI](/eas-update/eas-cli/#republish-a-previous-update-within-a-branch).
+If you can identify an older update that is safe to roll back to, you can do so using EAS Update's `republish` option from [Expo dashboard](https://expo.dev/accounts/[account]/projects/[project]/updates) or [EAS CLI](/eas-update/eas-cli/#republish-a-previous-update-within-a-branch).
 
 If you cannot identify an older update that is safe to roll back to, you'll need to fix it forward. While it's best to roll out a fix as quickly as possible, you should take the time to ensure your fix is solid, and know that even users who download your broken update in the meantime should be able to download your fix.
 


### PR DESCRIPTION
# Why

Republishing is also possible from the website so amend that in the error recovery doc


# Test Plan

- [ ] inspected in `yarn run dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
