### PR TITLE
[ENG-11699][docs] Update expo-updates brownfield installation

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -29,7 +29,7 @@ Once installation is complete, apply the changes from the following diffs to con
 Modify the `expo` section of **app.json**. (If you originally created your app using `npx react-native init`, you will need to add this section.)
 The changes below add the updates URL to the Expo configuration.
 
-> The example updates URL and project ID shown here is for use with EAS Update, where the EAS CLI will set this URL correctly for the EAS Update service when running `eas update:configure`.
+> The example `updates` URL and `projectId` shown below are for use with EAS Update. The EAS CLI sets this URL correctly for the EAS Update service when running `eas update:configure`.
 
 ```diff app.json
  {

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -29,7 +29,7 @@ Once installation is complete, apply the changes from the following diffs to con
 Modify the `expo` section of **app.json**. (If you originally created your app using `npx react-native init`, you will need to add this section.)
 The changes below add the updates URL to the Expo configuration.
 
-> The example URL shown here is for use with a custom update server running on the same machine. When using EAS Update, the EAS CLI will set this URL correctly for the EAS Update service.
+> The example updates URL and project ID shown here is for use with EAS Update, where the EAS CLI will set this URL correctly for the EAS Update service when running `eas update:configure`.
 
 ```diff app.json
  {
@@ -47,9 +47,34 @@ The changes below add the updates URL to the Expo configuration.
 +    },
 +    "runtimeVersion": "1.0.0",
 +    "updates": {
-+      "url": "http://localhost:3000/api/manifest"
++      "url": "https://u.expo.dev/[your-project-id]"
++    },
++    "extra": {
++      "eas": {
++        "projectId": "[your-project-id]"
++      }
 +    }
 +  }
+ }
+```
+
+Run `eas update:configure` to set the updates URL and project ID in **app.json**.
+<Terminal cmd={['$ eas update:configure']} />
+
+If you want to set up a [custom server](/eas-update/custom-updates-server) instead, add your URL to `updates.url` in **app.json**.
+
+```diff app.json
+ {
+   "name": "MyApp",
+   "displayName": "MyApp",
+   "expo": {
+     "name": "MyApp",
+     ...
+     "updates": {
+-      "url": "https://u.expo.dev/[your-project-id]"
++      "url": "http://localhost:3000/api/manifest"
+     }
+   }
  }
 ```
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -58,7 +58,8 @@ The changes below add the updates URL to the Expo configuration.
  }
 ```
 
-Run `eas update:configure` to set the updates URL and project ID in **app.json**.
+Run `eas update:configure` to set the `updates` URL and `projectId` in **app.json**.
+
 <Terminal cmd={['$ eas update:configure']} />
 
 If you want to set up a [custom server](/eas-update/custom-updates-server) instead, add your URL to `updates.url` in **app.json**.

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -69,7 +69,7 @@ If you want to set up a [custom server](/eas-update/custom-updates-server) inste
    "displayName": "MyApp",
    "expo": {
      "name": "MyApp",
-     ...
+      ...
      "updates": {
 -      "url": "https://u.expo.dev/[your-project-id]"
 +      "url": "http://localhost:3000/api/manifest"


### PR DESCRIPTION
# Why

Point the `update.url` to EAS Update, and document the alternate custom server usecase.

Discussion: https://exponent-internal.slack.com/archives/C013ZK4SA12/p1710291867299079


# Test Plan

- [ ] inspected manually with `yarn run dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
