### PR TITLE
[core][Android] Simplify `JSIContext` access

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/TestRunner.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/TestRunner.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
 import com.facebook.soloader.SoLoader
-import expo.modules.kotlin.jni.JSIInteropModuleRegistry
+import expo.modules.kotlin.jni.JSIContext
 
 /**
  * A simple test runner that ensures all needed libraries will be loaded before starting any tests.
@@ -13,8 +13,8 @@ class TestRunner : AndroidJUnitRunner() {
   override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application {
     // Loads libs like hermes
     SoLoader.init(context, /* native exopackage */false)
-    // Using `JSIInteropModuleRegistry.Companion` ensures that static libs will be loaded.
-    JSIInteropModuleRegistry.Companion
+    // Using `JSIContext.Companion` ensures that static libs will be loaded.
+    JSIContext.Companion
 
     return super.newApplication(cl, className, context)
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIContextTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIContextTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
 import org.junit.Test
 
-class JSIInteropModuleRegistryTest {
+class JSIContextTest {
   @Test
   fun module_should_be_registered() = withSingleModule({
     Function("syncFunction") {}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -48,7 +48,7 @@ internal fun defaultAppContextMock(
 @OptIn(ExperimentalCoroutinesApi::class)
 internal inline fun withJSIInterop(
   vararg modules: Module,
-  block: JSIInteropModuleRegistry.(methodQueue: TestScope) -> Unit,
+  block: JSIContext.(methodQueue: TestScope) -> Unit,
   afterCleanup: (deallocator: JNIDeallocator) -> Unit
 ) {
   val jniDeallocator = JNIDeallocator(
@@ -95,7 +95,7 @@ internal inline fun withJSIInterop(
   every { appContextMock.registry } answers { registry }
   every { appContextMock.sharedObjectRegistry } answers { sharedObjectRegistry }
 
-  val jsiIterop = JSIInteropModuleRegistry()
+  val jsiIterop = JSIContext()
   every { appContextMock.jsiInterop } answers { jsiIterop }
   jsiIterop.installJSIForTests(appContextMock, jniDeallocator)
 
@@ -108,7 +108,7 @@ internal inline fun withJSIInterop(
 }
 
 open class TestContext(
-  val jsiInterop: JSIInteropModuleRegistry,
+  val jsiInterop: JSIContext,
   val methodQueue: TestScope
 ) {
   fun global() = jsiInterop.global()
@@ -119,7 +119,7 @@ open class TestContext(
 
 class SingleTestContext(
   moduleName: String,
-  jsiInterop: JSIInteropModuleRegistry,
+  jsiInterop: JSIContext,
   methodQueue: TestScope
 ) : TestContext(jsiInterop, methodQueue) {
   val moduleRef = "expo.modules.$moduleName"
@@ -166,7 +166,7 @@ class SingleTestContext(
 
 internal inline fun withJSIInterop(
   vararg modules: Module,
-  block: JSIInteropModuleRegistry.(methodQueue: TestScope) -> Unit
+  block: JSIContext.(methodQueue: TestScope) -> Unit
 ) = withJSIInterop(*modules, block = block, afterCleanup = {})
 
 internal inline fun withSingleModule(
@@ -204,7 +204,7 @@ internal inline fun inlineModule(
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalCoroutinesApi::class)
 @Throws(PromiseException::class)
-internal inline fun JSIInteropModuleRegistry.waitForAsyncFunction(
+internal inline fun JSIContext.waitForAsyncFunction(
   methodQueue: TestScope,
   jsCode: String
 ): JavaScriptValue {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
@@ -5,11 +5,11 @@ import org.junit.Before
 import org.junit.Test
 
 class JavaScriptFunctionTest {
-  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  private lateinit var jsiInterop: JSIContext
 
   @Before
   fun before() {
-    jsiInterop = JSIInteropModuleRegistry().apply {
+    jsiInterop = JSIContext().apply {
       installJSIForTests(defaultAppContextMock())
     }
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -8,7 +8,7 @@ import org.junit.Before
 import org.junit.Test
 
 class JavaScriptObjectTest {
-  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  private lateinit var jsiInterop: JSIContext
 
   private fun emptyObject(): JavaScriptObject {
     return jsiInterop.evaluateScript("({ })").getObject()
@@ -16,7 +16,7 @@ class JavaScriptObjectTest {
 
   @Before
   fun before() {
-    jsiInterop = JSIInteropModuleRegistry().apply {
+    jsiInterop = JSIContext().apply {
       installJSIForTests(defaultAppContextMock())
     }
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -7,11 +7,11 @@ import org.junit.Before
 import org.junit.Test
 
 class JavaScriptRuntimeTest {
-  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  private lateinit var jsiInterop: JSIContext
 
   @Before
   fun before() {
-    jsiInterop = JSIInteropModuleRegistry().apply {
+    jsiInterop = JSIContext().apply {
       installJSIForTests(defaultAppContextMock())
     }
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -6,11 +6,11 @@ import org.junit.Before
 import org.junit.Test
 
 class JavaScriptValueTest {
-  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  private lateinit var jsiInterop: JSIContext
 
   @Before
   fun before() {
-    jsiInterop = JSIInteropModuleRegistry().apply {
+    jsiInterop = JSIContext().apply {
       installJSIForTests(defaultAppContextMock())
     }
   }

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -2,7 +2,7 @@
 
 #include "Exceptions.h"
 
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 #include "JSReferencesCache.h"
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -12,7 +12,7 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 /**
  * A convenient wrapper for the Kotlin CodedException.

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -11,7 +11,7 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 
-ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer)
+ExpoModulesHostObject::ExpoModulesHostObject(JSIContext *installer)
   : installer(installer) {}
 
 /**
@@ -21,7 +21,6 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
   facebook::react::LongLivedObjectCollection::get().clear();
   installer->jsRegistry.reset();
   installer->runtimeHolder.reset();
-  installer->jsInvoker.reset();
   installer->jniDeallocator.reset();
 }
 
@@ -40,7 +39,6 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
   LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(
     [this, cName](jsi::Runtime &rt) {
       auto module = installer->getModule(cName);
-      module->cthis()->jsiInteropModuleRegistry = installer;
       return module->cthis()->getJSIObject(rt);
     });
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 #include <jsi/jsi.h>
 
@@ -22,7 +22,7 @@ using UniqueJSIObject = std::unique_ptr<jsi::Object>;
  */
 class ExpoModulesHostObject : public jsi::HostObject {
 public:
-  ExpoModulesHostObject(JSIInteropModuleRegistry *installer);
+  ExpoModulesHostObject(JSIContext *installer);
 
   ~ExpoModulesHostObject() override;
 
@@ -33,7 +33,7 @@ public:
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
 private:
-  JSIInteropModuleRegistry *installer;
+  JSIContext *installer;
   std::unordered_map<std::string, UniqueJSIObject> modulesCache;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
@@ -25,7 +25,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaReferencesCache::instance()->loadJClasses(jni::Environment::current());
     expo::FrontendConverterProvider::instance()->createConverters();
 
-    expo::JSIInteropModuleRegistry::registerNatives();
+    expo::JSIContext::registerNatives();
     expo::JavaScriptModuleObject::registerNatives();
     expo::JavaScriptValue::registerNatives();
     expo::JavaScriptObject::registerNatives();

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -32,11 +32,12 @@ namespace expo {
 /**
  * A JNI wrapper to initialize CPP part of modules and access all data from the module registry.
  */
-class JSIInteropModuleRegistry : public jni::HybridClass<JSIInteropModuleRegistry> {
+class JSIContext : public jni::HybridClass<JSIContext> {
 public:
   static auto constexpr
-    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JSIInteropModuleRegistry;";
-  static auto constexpr TAG = "JSIInteropModuleRegistry";
+  kJavaDescriptor = "Lexpo/modules/kotlin/jni/JSIContext;";
+  static auto constexpr
+  TAG = "JSIContext";
 
   static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
 
@@ -112,7 +113,6 @@ public:
    */
   void drainJSEventLoop();
 
-  std::shared_ptr<react::CallInvoker> jsInvoker;
   std::shared_ptr<JavaScriptRuntime> runtimeHolder;
   std::unique_ptr<JSReferencesCache> jsRegistry;
   jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
@@ -124,13 +124,13 @@ public:
 
   jni::local_ref<JavaScriptObject::javaobject> getJavascriptClass(jni::local_ref<jclass> native);
 
-  ~JSIInteropModuleRegistry();
+  ~JSIContext();
 
 private:
   friend HybridBase;
-  jni::global_ref<JSIInteropModuleRegistry::javaobject> javaPart_;
+  jni::global_ref<JSIContext::javaobject> javaPart_;
 
-  explicit JSIInteropModuleRegistry(jni::alias_ref<jhybridobject> jThis);
+  explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 
   inline jni::local_ref<JavaScriptModuleObject::javaobject>
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
@@ -145,6 +145,43 @@ private:
 
   void prepareRuntime();
 
-  void jniSetNativeStateForSharedObject(int id, jni::alias_ref<JavaScriptObject::javaobject> jsObject);
+  void
+  jniSetNativeStateForSharedObject(int id, jni::alias_ref<JavaScriptObject::javaobject> jsObject);
 };
+
+/**
+ * We are binding the JSIContext to the runtime using a thread-local map.
+ * This is a simplification of how we're accessing the JSIContext from different places.
+ * We're using a thread-local map to prevent from accessing the wrong JSIContext from a different thread.
+ * It's much safer than passing around the JSIContext as a parameter.
+ */
+extern thread_local std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
+
+/**
+ * Binds the JSIContext to the runtime.
+ * @param runtime
+ * @param jsiContext
+ */
+void bindJSIContext(const jsi::Runtime &runtime, JSIContext *jsiContext);
+
+/**
+ * Unbinds the JSIContext from the runtime.
+ * @param runtime
+ */
+void unbindJSIContext(const jsi::Runtime &runtime);
+
+/**
+ * Gets the JSIContext for the given runtime.
+ * @param runtime
+ * @return JSIContext * - it should never be stored when received from this function.
+ * It might throw an exception if the JSIContext for the given runtime doesn't exist.
+ */
+inline JSIContext *getJSIContext(const jsi::Runtime &runtime) {
+  const auto iterator = jsiContexts.find(reinterpret_cast<uintptr_t>(&runtime));
+  if (iterator == jsiContexts.end()) {
+    throw std::invalid_argument("JSIContext for the given runtime doesn't exist");
+  }
+  return iterator->second;
+}
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaCallback.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 #include <fbjni/fbjni.h>
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
@@ -10,8 +10,6 @@ namespace expo {
 
 JavaCallback::JavaCallback(Callback callback)
   : callback(std::move(callback)) {}
-
-JSIInteropModuleRegistry *JavaCallback::jsiRegistry_ = nullptr;
 
 void JavaCallback::registerNatives() {
   registerHybrid({
@@ -48,12 +46,11 @@ SharedRef::SharedRef() = default;
 SharedObjectId::SharedObjectId() = default;
 
 jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  JSIContext *jsiContext,
   Callback callback
 ) {
   auto object = JavaCallback::newObjectCxxArgs(std::move(callback));
-  jsiRegistry_ = jsiInteropModuleRegistry;
-  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  jsiContext->jniDeallocator->addReference(object);
   return object;
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -42,7 +42,7 @@ struct SharedRef : public jni::HybridClass<SharedRef, SharedObjectId> {
     friend HybridBase;
 };
 
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 typedef std::variant<folly::dynamic, jni::global_ref<SharedRef::javaobject>> CallbackArg;
 
@@ -57,11 +57,9 @@ public:
   static void registerNatives();
 
   static jni::local_ref<JavaCallback::javaobject> newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jsiContext,
     Callback callback
   );
-
-  static JSIInteropModuleRegistry *jsiRegistry_;
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
@@ -38,7 +38,6 @@ jobject JavaScriptFunction::invoke(
   jni::alias_ref<ExpectedType::javaobject> expectedReturnType
 ) {
   auto &rt = runtimeHolder.getJSRuntime();
-  auto moduleRegistry = runtimeHolder.getModuleRegistry();
   JNIEnv *env = jni::Environment::current();
 
   size_t size = args->size();
@@ -47,7 +46,7 @@ jobject JavaScriptFunction::invoke(
 
   for (size_t i = 0; i < size; i++) {
     jni::local_ref<jni::JObject> arg = args->getElement(i);
-    convertedArgs.push_back(convert(moduleRegistry, env, rt, std::move(arg)));
+    convertedArgs.push_back(convert(env, rt, std::move(arg)));
   }
 
   // TODO(@lukmccall): add better error handling
@@ -65,12 +64,12 @@ jobject JavaScriptFunction::invoke(
     );
 
   auto converter = AnyType(jni::make_local(expectedReturnType)).converter;
-  auto convertedResult = converter->convert(rt, env, moduleRegistry, result);
+  auto convertedResult = converter->convert(rt, env, result);
   return convertedResult;
 }
 
 jni::local_ref<JavaScriptFunction::javaobject> JavaScriptFunction::newInstance(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  JSIContext *jsiContext,
   std::weak_ptr<JavaScriptRuntime> runtime,
   std::shared_ptr<jsi::Function> jsFunction
 ) {
@@ -78,7 +77,7 @@ jni::local_ref<JavaScriptFunction::javaobject> JavaScriptFunction::newInstance(
     std::move(runtime),
     std::move(jsFunction)
   );
-  jsiInteropModuleRegistry->jniDeallocator->addReference(function);
+  jsiContext->jniDeallocator->addReference(function);
   return function;
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
@@ -29,7 +29,7 @@ public:
   static void registerNatives();
 
   static jni::local_ref<JavaScriptFunction::javaobject> newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jsiContext,
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Function> jsFunction
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -18,27 +18,24 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 class JavaScriptModuleObject;
 
 void decorateObjectWithFunctions(
   jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
   jsi::Object *jsObject,
   JavaScriptModuleObject *objectData
 );
 
 void decorateObjectWithProperties(
   jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
   jsi::Object *jsObject,
   JavaScriptModuleObject *objectData
 );
 
 void decorateObjectWithConstants(
   jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
   jsi::Object *jsObject,
   JavaScriptModuleObject *objectData
 );
@@ -58,11 +55,6 @@ public:
   static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
 
   static void registerNatives();
-
-  /**
-   * Pointer to the module registry interop.
-   */
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry;
 
   /**
    * Returns a cached instance of jsi::Object representing this module.
@@ -141,21 +133,18 @@ private:
 
   friend void decorateObjectWithFunctions(
     jsi::Runtime &runtime,
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
     jsi::Object *jsObject,
     JavaScriptModuleObject *objectData
   );
 
   friend void decorateObjectWithProperties(
     jsi::Runtime &runtime,
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
     jsi::Object *jsObject,
     JavaScriptModuleObject *objectData
   );
 
   friend void decorateObjectWithConstants(
     jsi::Runtime &runtime,
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
     jsi::Object *jsObject,
     JavaScriptModuleObject *objectData
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -8,7 +8,7 @@
 #include "JSITypeConverter.h"
 #include "ObjectDeallocator.h"
 #include "JavaReferencesCache.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 namespace expo {
 void JavaScriptObject::registerNatives() {
@@ -77,7 +77,7 @@ jni::local_ref<JavaScriptValue::javaobject> JavaScriptObject::jniGetProperty(
 ) {
   auto result = std::make_shared<jsi::Value>(getProperty(name->toStdString()));
   return JavaScriptValue::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     result
   );
@@ -113,7 +113,7 @@ jni::local_ref<jni::JArrayClass<jstring>> JavaScriptObject::jniGetPropertyNames(
 
 jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject> JavaScriptObject::createWeak() {
   return JavaScriptWeakObject::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     get()
   );
@@ -123,7 +123,7 @@ jni::local_ref<JavaScriptFunction::javaobject> JavaScriptObject::jniAsFunction()
   auto &jsRuntime = runtimeHolder.getJSRuntime();
   auto jsFuncion = std::make_shared<jsi::Function>(jsObject->asFunction(jsRuntime));
   return JavaScriptFunction::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsFuncion
   );
@@ -158,12 +158,12 @@ jsi::Object JavaScriptObject::preparePropertyDescriptor(
 }
 
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptObject::newInstance(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  JSIContext *jsiContext,
   std::weak_ptr<JavaScriptRuntime> runtime,
   std::shared_ptr<jsi::Object> jsObject
 ) {
   auto object = JavaScriptObject::newObjectCxxArgs(std::move(runtime), std::move(jsObject));
-  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  jsiContext->jniDeallocator->addReference(object);
   return object;
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -37,7 +37,7 @@ public:
   static void registerNatives();
 
   static jni::local_ref<JavaScriptObject::javaobject> newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jsiContext,
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Object> jsObject
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -4,7 +4,7 @@
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
 #include "Exceptions.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 #include "JSIUtils.h"
 
 #if UNIT_TEST
@@ -35,7 +35,9 @@ namespace {
  */
 class SyncCallInvoker : public react::CallInvoker {
 public:
-  void invokeAsync(std::function<void()> &&func) noexcept override {
+  void invokeAsync(std::function<void()> &&func)
+
+  noexcept override{
     func();
   }
 
@@ -48,11 +50,8 @@ public:
 
 } // namespace
 
-JavaScriptRuntime::JavaScriptRuntime(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry
-)
-  : jsInvoker(std::make_shared<SyncCallInvoker>()),
-    jsiInteropModuleRegistry(jsiInteropModuleRegistry) {
+JavaScriptRuntime::JavaScriptRuntime()
+  : jsInvoker(std::make_shared<SyncCallInvoker>()) {
 #if !UNIT_TEST
   throw std::logic_error(
     "The JavaScriptRuntime constructor is only available when UNIT_TEST is defined.");
@@ -111,11 +110,9 @@ JavaScriptRuntime::JavaScriptRuntime(
 }
 
 JavaScriptRuntime::JavaScriptRuntime(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
   jsi::Runtime *runtime,
   std::shared_ptr<react::CallInvoker> jsInvoker
-) : jsInvoker(std::move(jsInvoker)),
-    jsiInteropModuleRegistry(jsiInteropModuleRegistry) {
+) : jsInvoker(std::move(jsInvoker)) {
   // Creating a shared pointer that points to the runtime but doesn't own it, thus doesn't release it.
   // In this code flow, the runtime should be owned by something else like the CatalystInstance.
   // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
@@ -131,7 +128,7 @@ JavaScriptRuntime::evaluateScript(const std::string &script) {
   auto scriptBuffer = std::make_shared<jsi::StringBuffer>(script);
   try {
     return JavaScriptValue::newInstance(
-      jsiInteropModuleRegistry,
+      getJSIContext(get()),
       weak_from_this(),
       std::make_shared<jsi::Value>(runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"))
     );
@@ -154,12 +151,12 @@ JavaScriptRuntime::evaluateScript(const std::string &script) {
 
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::global() {
   auto global = std::make_shared<jsi::Object>(runtime->global());
-  return JavaScriptObject::newInstance(jsiInteropModuleRegistry, weak_from_this(), global);
+  return JavaScriptObject::newInstance(getJSIContext(get()), weak_from_this(), global);
 }
 
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::createObject() {
   auto newObject = std::make_shared<jsi::Object>(*runtime);
-  return JavaScriptObject::newInstance(jsiInteropModuleRegistry, weak_from_this(), newObject);
+  return JavaScriptObject::newInstance(getJSIContext(get()), weak_from_this(), newObject);
 }
 
 void JavaScriptRuntime::drainJSEventLoop() {
@@ -167,8 +164,7 @@ void JavaScriptRuntime::drainJSEventLoop() {
 }
 
 void JavaScriptRuntime::installMainObject() {
-  auto coreModule = jsiInteropModuleRegistry->getCoreModule();
-  coreModule->cthis()->jsiInteropModuleRegistry = jsiInteropModuleRegistry;
+  auto coreModule = getJSIContext(get())->getCoreModule();
 
   // As opposed to other modules, the core module is represented by a raw JS object instead of an instance of NativeModule class.
   mainObject = std::make_shared<jsi::Object>(*runtime);
@@ -192,9 +188,5 @@ void JavaScriptRuntime::installMainObject() {
 
 std::shared_ptr<jsi::Object> JavaScriptRuntime::getMainObject() {
   return mainObject;
-}
-
-JSIInteropModuleRegistry *JavaScriptRuntime::getModuleRegistry() {
-  return jsiInteropModuleRegistry;
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -18,7 +18,7 @@ class JavaScriptValue;
 
 class JavaScriptObject;
 
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 /**
  * A wrapper for the jsi::Runtime.
@@ -35,12 +35,9 @@ public:
    * This flow is mostly intended for tests. The JS call invoker is set to `SyncCallInvoker`.
    * See **JavaScriptRuntime.cpp** for the `SyncCallInvoker` implementation.
    */
-  JavaScriptRuntime(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry
-  );
+  JavaScriptRuntime();
 
   JavaScriptRuntime(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
     jsi::Runtime *runtime,
     std::shared_ptr<react::CallInvoker> jsInvoker
   );
@@ -80,11 +77,8 @@ public:
 
   std::shared_ptr<jsi::Object> getMainObject();
 
-  JSIInteropModuleRegistry *getModuleRegistry();
-
 private:
   std::shared_ptr<jsi::Runtime> runtime;
   std::shared_ptr<jsi::Object> mainObject;
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
@@ -1,7 +1,7 @@
 #include "JavaScriptTypedArray.h"
 
 #include "JavaScriptRuntime.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 namespace expo {
 
@@ -91,7 +91,7 @@ void JavaScriptTypedArray::writeBuffer(
 }
 
 jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptTypedArray::newInstance(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  JSIContext *jSIContext,
   std::weak_ptr<JavaScriptRuntime> runtime,
   std::shared_ptr<jsi::Object> jsObject
 ) {
@@ -99,7 +99,7 @@ jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptTypedArray::newInstan
     std::move(runtime),
     std::move(jsObject)
   );
-  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  jSIContext->jniDeallocator->addReference(object);
   return object;
 }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
@@ -26,7 +26,7 @@ public:
   static void registerNatives();
 
   static jni::local_ref<JavaScriptTypedArray::javaobject> newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jSIContext,
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Object> jsObject
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -8,7 +8,7 @@
 #include "JavaScriptFunction.h"
 #include "TypedArray.h"
 #include "Exceptions.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 namespace expo {
 void JavaScriptValue::registerNatives() {
@@ -157,7 +157,7 @@ jni::local_ref<JavaScriptObject::javaobject> JavaScriptValue::getObject() {
   auto &jsRuntime = runtimeHolder.getJSRuntime();
   auto jsObject = std::make_shared<jsi::Object>(jsValue->getObject(jsRuntime));
   return JavaScriptObject::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsObject
   );
@@ -168,7 +168,7 @@ jni::local_ref<JavaScriptFunction::javaobject> JavaScriptValue::jniGetFunction()
   auto jsFunction = std::make_shared<jsi::Function>(
     jsValue->getObject(jsRuntime).asFunction(jsRuntime));
   return JavaScriptFunction::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsFunction
   );
@@ -176,7 +176,7 @@ jni::local_ref<JavaScriptFunction::javaobject> JavaScriptValue::jniGetFunction()
 
 jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> JavaScriptValue::getArray() {
   auto &jsRuntime = runtimeHolder.getJSRuntime();
-  auto moduleRegistry = runtimeHolder.getModuleRegistry();
+  auto moduleRegistry = runtimeHolder.getJSIContext();
 
   auto jsArray = jsValue
     ->getObject(jsRuntime)
@@ -210,14 +210,14 @@ jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptValue::getTypedArray(
   auto &jsRuntime = runtimeHolder.getJSRuntime();
   auto jsObject = std::make_shared<jsi::Object>(jsValue->getObject(jsRuntime));
   return JavaScriptTypedArray::newInstance(
-    runtimeHolder.getModuleRegistry(),
+    runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsObject
   );
 }
 
 jni::local_ref<JavaScriptValue::javaobject> JavaScriptValue::newInstance(
-  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  JSIContext *jsiContext,
   std::weak_ptr<JavaScriptRuntime> runtime,
   std::shared_ptr<jsi::Value> jsValue
 ) {
@@ -225,7 +225,7 @@ jni::local_ref<JavaScriptValue::javaobject> JavaScriptValue::newInstance(
     std::move(runtime),
     std::move(jsValue)
   );
-  jsiInteropModuleRegistry->jniDeallocator->addReference(value);
+  jsiContext->jniDeallocator->addReference(value);
   return value;
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -36,7 +36,7 @@ public:
   static void registerNatives();
 
   static jni::local_ref<JavaScriptValue::javaobject> newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jsiContext,
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Value> jsValue
   );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #include "JavaScriptWeakObject.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 namespace expo {
 
@@ -23,18 +23,18 @@ jni::local_ref<JavaScriptObject::javaobject> JavaScriptWeakObject::lock() {
   if (!objectPtr) {
     return nullptr;
   }
-  return JavaScriptObject::newInstance(_runtimeHolder.getModuleRegistry(),
+  return JavaScriptObject::newInstance(_runtimeHolder.getJSIContext(),
                                        _runtimeHolder, objectPtr);
 }
 
 jni::local_ref<jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject>
 JavaScriptWeakObject::newInstance(
-    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    JSIContext *jSIContext,
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Object> jsObject) {
   auto weakObject = JavaScriptWeakObject::newObjectCxxArgs(std::move(runtime),
                                                            std::move(jsObject));
-  jsiInteropModuleRegistry->jniDeallocator->addReference(weakObject);
+  jSIContext->jniDeallocator->addReference(weakObject);
   return weakObject;
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
@@ -32,7 +32,7 @@ public:
 
   static jni::local_ref<
       jni::HybridClass<JavaScriptWeakObject, Destructible>::javaobject>
-  newInstance(JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  newInstance(JSIContext *jSIContext,
               std::weak_ptr<JavaScriptRuntime> runtime,
               std::shared_ptr<jsi::Object> jsObject);
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -1,5 +1,5 @@
 #include "MethodMetadata.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
 #include "JavaScriptTypedArray.h"
@@ -10,6 +10,7 @@
 
 #include <utility>
 #include <functional>
+#include <unistd.h>
 
 #include "JSReferencesCache.h"
 
@@ -24,10 +25,10 @@ namespace expo {
 jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
   jsi::Function &&function,
   jsi::Runtime &rt,
-  JSIInteropModuleRegistry *moduleRegistry,
   bool isRejectCallback = false
 ) {
-  std::shared_ptr<react::CallInvoker> jsInvoker = moduleRegistry->runtimeHolder->jsInvoker;
+  JSIContext *jsiContext = getJSIContext(rt);
+  std::shared_ptr<react::CallInvoker> jsInvoker = jsiContext->runtimeHolder->jsInvoker;
   auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
                                                         std::move(jsInvoker));
 
@@ -45,8 +46,7 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
       weakWrapper,
       callbackWrapperOwner = std::move(callbackWrapperOwner),
       wrapperWasCalled = false,
-      isRejectCallback,
-      moduleRegistry
+      isRejectCallback
     ](
       CallbackArg responses) mutable {
       if (wrapperWasCalled) {
@@ -65,8 +65,7 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
             weakWrapper,
             callbackWrapperOwner = std::move(callbackWrapperOwner),
             responses = std::move(responses),
-            isRejectCallback,
-            moduleRegistry
+            isRejectCallback
           ]() mutable {
             auto strongWrapper2 = weakWrapper.lock();
             if (!strongWrapper2) {
@@ -126,7 +125,8 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
               std::get<jni::global_ref<SharedRef::javaobject>>(responses)
             );
 
-            auto jsClass = moduleRegistry->getJavascriptClass(native->getClass());
+            const auto jsiContext = getJSIContext(rt);
+            auto jsClass = jsiContext->getJavascriptClass(native->getClass());
             auto jsObject = jsClass
               ->cthis()
               ->get()
@@ -136,14 +136,14 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
 
             auto objSharedPtr = std::make_shared<jsi::Object>(std::move(jsObject));
             auto jsObjectInstance = JavaScriptObject::newInstance(
-              moduleRegistry,
-              moduleRegistry->runtimeHolder,
+              jsiContext,
+              jsiContext->runtimeHolder,
               objSharedPtr
             );
             jni::local_ref<JavaScriptObject::javaobject> jsRef = jni::make_local(
               jsObjectInstance
             );
-            moduleRegistry->registerSharedObject(native, jsRef);
+            jsiContext->registerSharedObject(native, jsRef);
 
             auto ret = jsi::Value(rt, *objSharedPtr);
             callback.call(
@@ -159,11 +159,10 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
       wrapperWasCalled = true;
     };
 
-  return JavaCallback::newInstance(moduleRegistry, std::move(fn));
+  return JavaCallback::newInstance(jsiContext, std::move(fn));
 }
 
 jobjectArray MethodMetadata::convertJSIArgsToJNI(
-  JSIInteropModuleRegistry *moduleRegistry,
   JNIEnv *env,
   jsi::Runtime &rt,
   const jsi::Value &thisValue,
@@ -210,7 +209,7 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
     auto &type = argTypes[argIndex];
 
     if (type->converter->canConvert(rt, arg)) {
-      auto converterValue = type->converter->convert(rt, env, moduleRegistry, arg);
+      auto converterValue = type->converter->convert(rt, env, arg);
       env->SetObjectArrayElement(argumentArray, argIndex, converterValue);
       env->DeleteLocalRef(converterValue);
     } else if (arg.isNull() || arg.isUndefined()) {
@@ -263,14 +262,13 @@ MethodMetadata::MethodMetadata(
 }
 
 std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
-  jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *moduleRegistry
+  jsi::Runtime &runtime
 ) {
   if (body == nullptr) {
     if (isAsync) {
-      body = std::make_shared<jsi::Function>(toAsyncFunction(runtime, moduleRegistry));
+      body = std::make_shared<jsi::Function>(toAsyncFunction(runtime));
     } else {
-      body = std::make_shared<jsi::Function>(toSyncFunction(runtime, moduleRegistry));
+      body = std::make_shared<jsi::Function>(toSyncFunction(runtime));
     }
   }
 
@@ -278,14 +276,13 @@ std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
 }
 
 jsi::Function MethodMetadata::toSyncFunction(
-  jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *moduleRegistry
+  jsi::Runtime &runtime
 ) {
   return jsi::Function::createFromHostFunction(
     runtime,
-    moduleRegistry->jsRegistry->getPropNameID(runtime, name),
+    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, name),
     argTypes.size(),
-    [this, moduleRegistry](
+    [this](
       jsi::Runtime &rt,
       const jsi::Value &thisValue,
       const jsi::Value *args,
@@ -294,7 +291,6 @@ jsi::Function MethodMetadata::toSyncFunction(
       try {
         return this->callSync(
           rt,
-          moduleRegistry,
           thisValue,
           args,
           count
@@ -308,7 +304,6 @@ jsi::Function MethodMetadata::toSyncFunction(
 jni::local_ref<jobject> MethodMetadata::callJNISync(
   JNIEnv *env,
   jsi::Runtime &rt,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &thisValue,
   const jsi::Value *args,
   size_t count
@@ -317,7 +312,7 @@ jni::local_ref<jobject> MethodMetadata::callJNISync(
     return nullptr;
   }
 
-  auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, thisValue, args, count);
+  auto convertedArgs = convertJSIArgsToJNI(env, rt, thisValue, args, count);
 
   // Cast in this place is safe, cause we know that this function is promise-less.
   auto syncFunction = jni::static_ref_cast<JNIFunctionBody>(this->jBodyReference);
@@ -331,7 +326,6 @@ jni::local_ref<jobject> MethodMetadata::callJNISync(
 
 jsi::Value MethodMetadata::callSync(
   jsi::Runtime &rt,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &thisValue,
   const jsi::Value *args,
   size_t count
@@ -344,30 +338,30 @@ jsi::Value MethodMetadata::callSync(
   */
   jni::JniLocalScope scope(env, (int) count);
 
-  auto result = this->callJNISync(env, rt, moduleRegistry, thisValue, args, count);
-  return convert(moduleRegistry, env, rt, std::move(result));
+  auto result = this->callJNISync(env, rt, thisValue, args, count);
+  return convert(env, rt, std::move(result));
 }
 
 jsi::Function MethodMetadata::toAsyncFunction(
-  jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *moduleRegistry
+  jsi::Runtime &runtime
 ) {
   return jsi::Function::createFromHostFunction(
     runtime,
-    moduleRegistry->jsRegistry->getPropNameID(runtime, name),
+    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, name),
     argTypes.size(),
-    [this, moduleRegistry](
+    [this](
       jsi::Runtime &rt,
       const jsi::Value &thisValue,
       const jsi::Value *args,
       size_t count
     ) -> jsi::Value {
+      JSIContext *jsiContext = getJSIContext(rt);
       /**
        * Halt execution during cleaning phase as modules and js context will be deallocated soon.
        * The output of this method doesn't matter.
        * We added that check to prevent the app from crashing when users reload their apps.
        */
-      if (moduleRegistry->wasDeallocated) {
+      if (jsiContext->wasDeallocated) {
         return jsi::Value::undefined();
       }
 
@@ -380,19 +374,19 @@ jsi::Function MethodMetadata::toAsyncFunction(
        */
       jni::JniLocalScope scope(env, (int) count);
 
-      auto &Promise = moduleRegistry->jsRegistry->getObject<jsi::Function>(
+      auto &Promise = jsiContext->jsRegistry->getObject<jsi::Function>(
         JSReferencesCache::JSKeys::PROMISE
       );
 
       try {
-        auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, thisValue, args, count);
+        auto convertedArgs = convertJSIArgsToJNI(env, rt, thisValue, args, count);
         auto globalConvertedArgs = (jobjectArray) env->NewGlobalRef(convertedArgs);
         env->DeleteLocalRef(convertedArgs);
 
         // Creates a JSI promise
         jsi::Value promise = Promise.callAsConstructor(
           rt,
-          createPromiseBody(rt, moduleRegistry, globalConvertedArgs)
+          createPromiseBody(rt, globalConvertedArgs)
         );
         return promise;
       } catch (jni::JniException &jniException) {
@@ -409,7 +403,7 @@ jsi::Function MethodMetadata::toAsyncFunction(
           rt,
           jsi::Function::createFromHostFunction(
             rt,
-            moduleRegistry->jsRegistry->getPropNameID(rt, "promiseFn"),
+            jsiContext->jsRegistry->getPropNameID(rt, "promiseFn"),
             2,
             [code, message](
               jsi::Runtime &rt,
@@ -443,14 +437,13 @@ jsi::Function MethodMetadata::toAsyncFunction(
 
 jsi::Function MethodMetadata::createPromiseBody(
   jsi::Runtime &runtime,
-  JSIInteropModuleRegistry *moduleRegistry,
   jobjectArray globalArgs
 ) {
   return jsi::Function::createFromHostFunction(
     runtime,
-    moduleRegistry->jsRegistry->getPropNameID(runtime, "promiseFn"),
+    getJSIContext(runtime)->jsRegistry->getPropNameID(runtime, "promiseFn"),
     2,
-    [this, globalArgs, moduleRegistry](
+    [this, globalArgs](
       jsi::Runtime &rt,
       const jsi::Value &thisVal,
       const jsi::Value *promiseConstructorArgs,
@@ -465,14 +458,12 @@ jsi::Function MethodMetadata::createPromiseBody(
 
       jobject resolve = createJavaCallbackFromJSIFunction(
         std::move(resolveJSIFn),
-        rt,
-        moduleRegistry
+        rt
       ).release();
 
       jobject reject = createJavaCallbackFromJSIFunction(
         std::move(rejectJSIFn),
         rt,
-        moduleRegistry,
         true
       ).release();
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -20,7 +20,7 @@ namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 /**
  * A class that holds information about the exported function.
@@ -69,12 +69,10 @@ public:
    * Transforms metadata to a jsi::Function.
    *
    * @param runtime
-   * @param moduleRegistry
    * @return shared ptr to the jsi::Function that wrapped the underlying Kotlin's function.
    */
   std::shared_ptr<jsi::Function> toJSFunction(
-    jsi::Runtime &runtime,
-    JSIInteropModuleRegistry *moduleRegistry
+    jsi::Runtime &runtime
   );
 
   /**
@@ -82,7 +80,6 @@ public:
    */
   jsi::Value callSync(
     jsi::Runtime &rt,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &thisValue,
     const jsi::Value *args,
     size_t count
@@ -91,7 +88,6 @@ public:
   jni::local_ref<jobject> callJNISync(
     JNIEnv *env,
     jsi::Runtime &rt,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &thisValue,
     const jsi::Value *args,
     size_t count
@@ -111,18 +107,16 @@ private:
    */
   std::shared_ptr<jsi::Function> body = nullptr;
 
-  jsi::Function toSyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
+  jsi::Function toSyncFunction(jsi::Runtime &runtime);
 
-  jsi::Function toAsyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
+  jsi::Function toAsyncFunction(jsi::Runtime &runtime);
 
   jsi::Function createPromiseBody(
     jsi::Runtime &runtime,
-    JSIInteropModuleRegistry *moduleRegistry,
     jobjectArray globalArgs
   );
 
   jobjectArray convertJSIArgsToJNI(
-    JSIInteropModuleRegistry *moduleRegistry,
     JNIEnv *env,
     jsi::Runtime &rt,
     const jsi::Value &thisValue,

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
@@ -1,6 +1,6 @@
 #include "WeakRuntimeHolder.h"
 #include "JavaScriptRuntime.h"
-#include "JSIInteropModuleRegistry.h"
+#include "JSIContext.h"
 
 namespace expo {
 WeakRuntimeHolder::WeakRuntimeHolder(std::weak_ptr<JavaScriptRuntime> runtime)
@@ -16,9 +16,9 @@ void WeakRuntimeHolder::ensureRuntimeIsValid() {
   assert((!expired()) && "JS Runtime was used after deallocation");
 }
 
-JSIInteropModuleRegistry *WeakRuntimeHolder::getModuleRegistry() {
+JSIContext *WeakRuntimeHolder::getJSIContext() {
   auto runtime = lock();
   assert((runtime != nullptr) && "JS Runtime was used after deallocation");
-  return runtime->getModuleRegistry();
+  return expo::getJSIContext(runtime->get());
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
@@ -12,7 +12,7 @@ namespace jsi = facebook::jsi;
 
 class JavaScriptRuntime;
 
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 /**
  * A convenient class to access underlying jni::Runtime and hold a weak reference to expo::JavaScriptRuntime.
@@ -33,7 +33,7 @@ public:
    */
   jsi::Runtime &getJSRuntime();
 
-  JSIInteropModuleRegistry *getModuleRegistry();
+  JSIContext *getJSIContext();
 
   void ensureRuntimeIsValid();
 };

--- a/packages/expo-modules-core/android/src/main/cpp/types/AnyType.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/AnyType.cpp
@@ -2,7 +2,7 @@
 
 #include "AnyType.h"
 #include "FrontendConverterProvider.h"
-#include "../JSIInteropModuleRegistry.h"
+#include "../JSIContext.h"
 
 namespace expo {
 AnyType::AnyType(

--- a/packages/expo-modules-core/android/src/main/cpp/types/AnyType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/AnyType.h
@@ -10,7 +10,7 @@
 namespace jni = facebook::jni;
 
 namespace expo {
-class JSIInteropModuleRegistry;
+class JSIContext;
 
 /**
  * Holds information about the expected Kotlin type.

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -6,7 +6,7 @@
 #include "../JavaReferencesCache.h"
 #include "../Exceptions.h"
 #include "../JavaScriptTypedArray.h"
-#include "../JSIInteropModuleRegistry.h"
+#include "../JSIContext.h"
 #include "../JavaScriptObject.h"
 #include "../JavaScriptValue.h"
 #include "../JavaScriptFunction.h"
@@ -27,7 +27,6 @@ namespace expo {
 jobject IntegerFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto &integerClass = JavaReferencesCache::instance()
@@ -44,7 +43,6 @@ bool IntegerFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &va
 jobject LongFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto &longClass = JavaReferencesCache::instance()
@@ -61,7 +59,6 @@ bool LongFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value
 jobject FloatFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto &floatClass = JavaReferencesCache::instance()
@@ -78,7 +75,6 @@ bool FloatFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &valu
 jobject BooleanFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto &booleanClass = JavaReferencesCache::instance()
@@ -94,7 +90,6 @@ bool BooleanFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &va
 jobject DoubleFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto &doubleClass = JavaReferencesCache::instance()
@@ -110,7 +105,6 @@ bool DoubleFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &val
 jobject StringFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   return env->NewStringUTF(value.asString(rt).utf8(rt).c_str());
@@ -123,7 +117,6 @@ bool StringFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &val
 jobject ReadableNativeArrayFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto dynamic = jsi::dynamicFromValue(rt, value);
@@ -140,7 +133,6 @@ bool ReadableNativeArrayFrontendConverter::canConvert(
 jobject ReadableNativeMapArrayFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto dynamic = jsi::dynamicFromValue(rt, value);
@@ -156,7 +148,6 @@ bool ReadableNativeMapArrayFrontendConverter::canConvert(
 jobject ByteArrayFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto typedArray = TypedArray(rt, value.asObject(rt));
@@ -183,12 +174,12 @@ bool ByteArrayFrontendConverter::canConvert(
 jobject TypedArrayFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
+  JSIContext *jsiContext = getJSIContext(rt);
   return JavaScriptTypedArray::newInstance(
-    moduleRegistry,
-    moduleRegistry->runtimeHolder->weak_from_this(),
+    jsiContext,
+    jsiContext->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Object>(value.asObject(rt))
   ).release();
 }
@@ -203,12 +194,12 @@ bool TypedArrayFrontendConverter::canConvert(
 jobject JavaScriptValueFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
+  JSIContext *jsiContext = getJSIContext(rt);
   return JavaScriptValue::newInstance(
-    moduleRegistry,
-    moduleRegistry->runtimeHolder->weak_from_this(),
+    jsiContext,
+    jsiContext->runtimeHolder->weak_from_this(),
     // TODO(@lukmccall): make sure that copy here is necessary
     std::make_shared<jsi::Value>(jsi::Value(rt, value))
   ).release();
@@ -221,12 +212,12 @@ bool JavaScriptValueFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::V
 jobject JavaScriptObjectFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
+  JSIContext *jsiContext = getJSIContext(rt);
   return JavaScriptObject::newInstance(
-    moduleRegistry,
-    moduleRegistry->runtimeHolder->weak_from_this(),
+    jsiContext,
+    jsiContext->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Object>(value.asObject(rt))
   ).release();
 }
@@ -241,12 +232,12 @@ bool JavaScriptObjectFrontendConverter::canConvert(
 jobject JavaScriptFunctionFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
+  JSIContext *jsiContext = getJSIContext(rt);
   return JavaScriptFunction::newInstance(
-    moduleRegistry,
-    moduleRegistry->runtimeHolder->weak_from_this(),
+    jsiContext,
+    jsiContext->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Function>(value.asObject(rt).asFunction(rt))
   ).release();
 }
@@ -261,7 +252,6 @@ bool JavaScriptFunctionFrontendConverter::canConvert(
 jobject UnknownFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto stringRepresentation = value.toString(rt).utf8(rt);
@@ -297,12 +287,11 @@ bool PolyFrontendConverter::canConvert(
 jobject PolyFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   for (auto &converter: converters) {
     if (converter->canConvert(rt, value)) {
-      return converter->convert(rt, env, moduleRegistry, value);
+      return converter->convert(rt, env, value);
     }
   }
   // That shouldn't happen.
@@ -345,7 +334,6 @@ jobject createPrimitiveArray(
 jobject PrimitiveArrayFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto jsArray = value.asObject(rt).asArray(rt);
@@ -394,7 +382,7 @@ jobject PrimitiveArrayFrontendConverter::convert(
   );
   for (size_t i = 0; i < size; i++) {
     auto convertedElement = parameterConverter->convert(
-      rt, env, moduleRegistry, jsArray.getValueAtIndex(rt, i)
+      rt, env, jsArray.getValueAtIndex(rt, i)
     );
     env->SetObjectArrayElement(result, i, convertedElement);
     env->DeleteLocalRef(convertedElement);
@@ -417,7 +405,6 @@ ListFrontendConverter::ListFrontendConverter(
 jobject ListFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto jsArray = value.asObject(rt).asArray(rt);
@@ -434,7 +421,7 @@ jobject ListFrontendConverter::convert(
     }
 
     auto convertedElement = parameterConverter->convert(
-      rt, env, moduleRegistry, jsValue
+      rt, env, jsValue
     );
     arrayList->add(convertedElement);
     env->DeleteLocalRef(convertedElement);
@@ -458,7 +445,6 @@ MapFrontendConverter::MapFrontendConverter(
 jobject MapFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   auto jsObject = value.asObject(rt);
@@ -479,7 +465,7 @@ jobject MapFrontendConverter::convert(
     }
 
     auto convertedValue = valueConverter->convert(
-      rt, env, moduleRegistry, jsValue
+      rt, env, jsValue
     );
 
     map->put(convertedKey, convertedValue);
@@ -498,9 +484,11 @@ bool MapFrontendConverter::canConvert(
   return value.isObject();
 }
 
-jobject ViewTagFrontendConverter::convert(jsi::Runtime &rt, JNIEnv *env,
-                                          JSIInteropModuleRegistry *moduleRegistry,
-                                          const jsi::Value &value) const {
+jobject ViewTagFrontendConverter::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  const jsi::Value &value
+) const {
   auto nativeTag = value.asObject(rt).getProperty(rt, "nativeTag");
   if (nativeTag.isNull()) {
     return nullptr;
@@ -517,9 +505,11 @@ bool ViewTagFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &va
   return value.isObject() && value.getObject(rt).hasProperty(rt, "nativeTag");
 }
 
-jobject SharedObjectIdConverter::convert(jsi::Runtime &rt, JNIEnv *env,
-                                         JSIInteropModuleRegistry *moduleRegistry,
-                                         const jsi::Value &value) const {
+jobject SharedObjectIdConverter::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  const jsi::Value &value
+) const {
   auto objectId = value.asObject(rt).getProperty(rt, "__expo_shared_object_id__");
   if (objectId.isNull()) {
     return nullptr;
@@ -539,7 +529,6 @@ bool SharedObjectIdConverter::canConvert(jsi::Runtime &rt, const jsi::Value &val
 jobject AnyFrontendConvert::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
-  JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
   if (value.isUndefined() || value.isNull()) {
@@ -547,15 +536,15 @@ jobject AnyFrontendConvert::convert(
   }
 
   if (booleanConverter.canConvert(rt, value)) {
-    return booleanConverter.convert(rt, env, moduleRegistry, value);
+    return booleanConverter.convert(rt, env, value);
   }
 
   if (doubleConverter.canConvert(rt, value)) {
-    return doubleConverter.convert(rt, env, moduleRegistry, value);
+    return doubleConverter.convert(rt, env, value);
   }
 
   if (stringConverter.canConvert(rt, value)) {
-    return stringConverter.convert(rt, env, moduleRegistry, value);
+    return stringConverter.convert(rt, env, value);
   }
 
   if (!value.isObject()) {
@@ -573,7 +562,7 @@ jobject AnyFrontendConvert::convert(
       auto jsValue = jsArray.getValueAtIndex(rt, i);
 
       auto convertedElement = this->convert(
-        rt, env, moduleRegistry, jsValue
+        rt, env, jsValue
       );
       arrayList->add(convertedElement);
       env->DeleteLocalRef(convertedElement);
@@ -593,7 +582,7 @@ jobject AnyFrontendConvert::convert(
 
     auto convertedKey = env->NewStringUTF(key.utf8(rt).c_str());
     auto convertedValue = this->convert(
-      rt, env, moduleRegistry, jsValue
+      rt, env, jsValue
     );
 
     map->put(convertedKey, convertedValue);

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -11,7 +11,7 @@ namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 
 namespace expo {
-class JSIInteropModuleRegistry;
+class JSIContext;
 class SingleType;
 
 /**
@@ -35,7 +35,6 @@ public:
   virtual jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const = 0;
 };
@@ -48,7 +47,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -63,7 +61,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -78,7 +75,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -93,7 +89,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -108,7 +103,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -123,7 +117,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -138,7 +131,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -153,7 +145,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -168,7 +159,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -183,7 +173,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -198,7 +187,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -213,7 +201,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -228,7 +215,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -243,7 +229,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -258,7 +243,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -275,7 +259,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -297,7 +280,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -317,7 +299,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -350,7 +331,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -374,7 +354,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 
@@ -394,7 +373,6 @@ public:
   jobject convert(
     jsi::Runtime &rt,
     JNIEnv *env,
-    JSIInteropModuleRegistry *moduleRegistry,
     const jsi::Value &value
   ) const override;
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -52,7 +52,6 @@ std::optional<jsi::Value> convertStringToFollyDynamicIfNeeded(jsi::Runtime &rt, 
 namespace expo {
 
 jsi::Value convert(
-  JSIInteropModuleRegistry *moduleRegistry,
   JNIEnv *env,
   jsi::Runtime &rt,
   jni::local_ref<jobject> value
@@ -113,7 +112,6 @@ jsi::Value convert(
   if (env->IsInstanceOf(unpackedValue, JavaScriptModuleObject::javaClassStatic().get())) {
     auto anonymousObject = jni::static_ref_cast<JavaScriptModuleObject::javaobject>(value)
       ->cthis();
-    anonymousObject->jsiInteropModuleRegistry = moduleRegistry;
     auto jsiObject = anonymousObject->getJSIObject(rt);
 
     jni::global_ref<jobject> globalRef = jni::make_global(value);
@@ -134,12 +132,13 @@ jsi::Value convert(
       "expo/modules/kotlin/sharedobjects/SharedObject").clazz
   )) {
     auto jsObject = std::make_shared<jsi::Object>(jsi::Object(rt));
+    JSIContext *jsiContext = getJSIContext(rt);
     auto jsObjectRef = JavaScriptObject::newInstance(
-      moduleRegistry,
-      moduleRegistry->runtimeHolder,
+      jsiContext,
+      jsiContext->runtimeHolder,
       jsObject
     );
-    moduleRegistry->registerSharedObject(jni::make_local(unpackedValue), jsObjectRef);
+    jsiContext->registerSharedObject(jni::make_local(unpackedValue), jsObjectRef);
     return jsi::Value(rt, *jsObject);
   }
   if (env->IsInstanceOf(

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "../JSIInteropModuleRegistry.h"
+#include "../JSIContext.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -14,7 +14,6 @@ namespace jsi = facebook::jsi;
 namespace expo {
 
 jsi::Value convert(
-  JSIInteropModuleRegistry *moduleRegistry,
   JNIEnv *env,
   jsi::Runtime &rt,
   jni::local_ref<jobject> value

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -40,7 +40,7 @@ import expo.modules.kotlin.events.KModuleEventEmitterWrapper
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.jni.JNIDeallocator
-import expo.modules.kotlin.jni.JSIInteropModuleRegistry
+import expo.modules.kotlin.jni.JSIContext
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.providers.CurrentActivityProvider
 import expo.modules.kotlin.sharedobjects.ClassRegistry
@@ -65,8 +65,8 @@ class AppContext(
 
   private var hostWasDestroyed = false
 
-  // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
-  internal lateinit var jsiInterop: JSIInteropModuleRegistry
+  // We postpone creating the `JSIContext` to not load so files in unit tests.
+  internal lateinit var jsiInterop: JSIContext
 
   /**
    * The core module that defines the `expo` object in the global scope of the JS runtime.
@@ -154,7 +154,7 @@ class AppContext(
 
     trace("AppContext.installJSIInterop") {
       try {
-        jsiInterop = JSIInteropModuleRegistry()
+        jsiInterop = JSIContext()
         val reactContext = reactContextHolder.get() ?: return@trace
         val jsContextHolder = reactContext.javaScriptContextHolder?.get() ?: return@trace
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -14,12 +14,12 @@ import java.lang.ref.WeakReference
 
 /**
  * Despite the fact that this class is marked as [Destructible], it is not included in the [JNIDeallocator].
- * The deallocation of the [JSIInteropModuleRegistry] should be performed at the very end
+ * The deallocation of the [JSIContext] should be performed at the very end
  * to prevent the destructor of the [Destructible] object from accessing data that has already been freed.
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JSIInteropModuleRegistry : Destructible {
+class JSIContext : Destructible {
   internal lateinit var appContextHolder: WeakReference<AppContext> // = WeakReference(appContext)
 
   // Has to be called "mHybridData" - fbjni uses it via reflection


### PR DESCRIPTION
# Why

Simplifies `JSIContext` access 

# How

Renamed `JSIInteropModuleRegistry` to `JSIContext`.

We are binding the JSIContext to the runtime using a thread-local map. This is a simplification of how we're accessing the JSIContext from different places. We're using a thread-local map to prevent accessing the wrong JSIContext from a different thread. It's much safer than passing around the JSIContext as a parameter.

# Test Plan

- bare-expo ✅