### PR TITLE
[docs] cleanup incorrect Tailwind usecase

### DIFF
--- a/docs/global-styles/global.css
+++ b/docs/global-styles/global.css
@@ -6,11 +6,6 @@ input {
   appearance: unset;
 }
 
-/* This isn't being included by Tailwind by default */
-.bg-white {
-  background-color: #fff;
-}
-
 #__next[aria-hidden] {
   filter: none !important;
 }

--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -14,7 +14,7 @@ The [`expo-notifications`](/versions/latest/sdk/notifications) library provides 
 <ImageSpotlight
   alt="Diagram explaining sending a push from your server to device"
   src="/static/images/sending-notification.png"
-  containerClassName="bg-white"
+  containerClassName="bg-palette-white"
 />
 
 ## Send push notifications using a server

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   <ImageSpotlight
     alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
     src="/static/images/sdk/file-system/file-system-diagram.png"
-    containerClassName="bg-white"
+    containerClassName="bg-palette-white"
   />
 </Collapsible>
 

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerClassName="bg-white"
+  containerClassName="bg-palette-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -22,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
   src="/static/images/sdk/file-system/file-system-diagram.png"
   style={{ maxWidth: 850, maxHeight: 600 }}
-  containerClassName="bg-white"
+  containerClassName="bg-palette-white"
 />
 
 <PlatformsSection android emulator ios simulator />

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   <ImageSpotlight
     alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
     src="/static/images/sdk/file-system/file-system-diagram.png"
-    containerClassName="bg-white"
+    containerClassName="bg-palette-white"
   />
 </Collapsible>
 

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -12,7 +12,7 @@ function getExpoTheme(extend = {}, plugins = []) {
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './pages/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx}',
     './ui/foundations/**/*.{js,ts,jsx,tsx}',
     './ui/components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
# Why

Refs https://github.com/expo/expo/commit/79f7d73ead8155df9f40bc6b73ea5da100db6fd3

# How

Switch to the correct/existing class, remove redundant manually defined global class, make sure that we look for custom "className" props in MDX.

# Test Plan

Changes have been tested locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-03-13 at 12 11 20](https://github.com/expo/expo/assets/719641/7eb91584-06ee-4e59-b5aa-58d1cf6c1544)
