### PR TITLE
[docs] Use Tailwind style from Styleguide in Expo FileSystem reference

### DIFF
--- a/docs/global-styles/global.css
+++ b/docs/global-styles/global.css
@@ -6,11 +6,6 @@ input {
   appearance: unset;
 }
 
-/* This isn't being included by Tailwind by default */
-.bg-white {
-  background-color: #fff;
-}
-
 #__next[aria-hidden] {
   filter: none !important;
 }

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -15,18 +15,29 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { CODE } from '~/ui/components/Text';
 
 `expo-file-system` provides access to a file system stored locally on the device. It is also capable of uploading and downloading files from network URLs.
 
-<Collapsible summary="Diagram explaining how expo-file-system interacts with different resources">
+<Collapsible
+  summary={
+    <>
+      Diagram explaining how <CODE>expo-file-system</CODE> interacts with different resources
+    </>
+  }>
   <ImageSpotlight
     alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
     src="/static/images/sdk/file-system/file-system-diagram.png"
-    containerClassName="bg-white"
+    containerClassName="bg-pallette-white"
   />
 </Collapsible>
 
-<Collapsible summary="How expo-file-system works differently inside of the Expo Go app">
+<Collapsible
+  summary={
+    <>
+      How <CODE>expo-file-system</CODE> works differently inside of the Expo Go app
+    </>
+  }>
   Within Expo Go, each project has a separate file system scope and has no access to the file system
   of other projects.
 </Collapsible>

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -14,20 +14,31 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { CODE } from '~/ui/components/Text';
 
 `expo-file-system` provides access to a file system stored locally on the device. It is also capable of uploading and downloading files from network URLs.
 
 <PlatformsSection android emulator ios simulator />
 
-<Collapsible summary="Diagram explaining how expo-file-system interacts with different resources">
+<Collapsible
+  summary={
+    <>
+      Diagram explaining how <CODE>expo-file-system</CODE> interacts with different resources
+    </>
+  }>
   <ImageSpotlight
     alt="Diagram of the various pieces of expo-file-system and how they interact with different resources"
     src="/static/images/sdk/file-system/file-system-diagram.png"
-    containerClassName="bg-white"
+    containerClassName="bg-pallette-white"
   />
 </Collapsible>
 
-<Collapsible summary="How expo-file-system works differently inside of the Expo Go app">
+<Collapsible
+  summary={
+    <>
+      How <CODE>expo-file-system</CODE> works differently inside of the Expo Go app
+    </>
+  }>
   Within Expo Go, each project has a separate file system scope and has no access to the file system
   of other projects.
 </Collapsible>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up [this commit](https://github.com/expo/expo/commit/79f7d73ead8155df9f40bc6b73ea5da100db6fd3#diff-1850dd65ceb4fbab1f0f24587fbd25e9384d49266c8df15695034a62038af13b) for Expo FileSystem API reference.

Also use inline syntax highlight for referencing library name in `Collapsible` summary.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/filesystem/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
