### PR TITLE
[tools] Clean up the working tree after publishing canaries

### DIFF
--- a/tools/src/commands/CherryPickCommand.ts
+++ b/tools/src/commands/CherryPickCommand.ts
@@ -172,7 +172,9 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
       logger.log(chalk.bold(chalk.yellow(`git checkout ${destination}`)));
     } else {
       logger.info(`Checking out ${chalk.bold(chalk.blue(destination))} branch...`);
-      await Git.checkoutAsync(destination);
+      await Git.checkoutAsync({
+        ref: destination,
+      });
     }
   }
 


### PR DESCRIPTION
# Why

Running `et publish --canary` was leaving a mess in the working tree: the tarballs created by `npm pack`, a lot of modified `package.json`, `bundledNativeModules.json` and so on.

# How

Added a new task to the canary publish pipeline that cleans up that mess.

# Test Plan

I ran `et publish --canary --dry` and then confirmed the working tree is clean.