### PR TITLE
[core][Android] Fix SharedObject deallocation crashing the app

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -93,7 +93,9 @@ void JSIInteropModuleRegistry::prepareRuntime() {
   SharedObject::installBaseClass(
     runtimeHolder->get(),
     [this](const SharedObject::ObjectId objectId) {
-      deleteSharedObject(objectId);
+      jni::ThreadScope::WithClassLoader([this, objectId = objectId] {
+        deleteSharedObject(objectId);
+      });
     }
   );
 
@@ -238,8 +240,10 @@ void JSIInteropModuleRegistry::jniSetNativeStateForSharedObject(
 ) {
   auto nativeState = std::make_shared<expo::SharedObject::NativeState>(
     id,
-    [this](int id) {
-      deleteSharedObject(id);
+    [this](const SharedObject::ObjectId objectId) {
+      jni::ThreadScope::WithClassLoader([this, objectId = objectId] {
+        deleteSharedObject(objectId);
+      });
     }
   );
 


### PR DESCRIPTION
# Why

Fixes:
```
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A  Cmdline: dev.expo.payments
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A  pid: 16094, tid: 16328, name: hades  >>> dev.expo.payments <<<
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #01 pc 00000000000d1cc0  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libc++_shared.so (BuildId: a777ae836b797ddfce8ce3564b3b5d6565a0ab08)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #02 pc 00000000000d1e74  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libc++_shared.so (BuildId: a777ae836b797ddfce8ce3564b3b5d6565a0ab08)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #03 pc 00000000000e6b74  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libc++_shared.so (BuildId: a777ae836b797ddfce8ce3564b3b5d6565a0ab08)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #04 pc 00000000000e6b0c  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libc++_shared.so (std::terminate()+56) (BuildId: a777ae836b797ddfce8ce3564b3b5d6565a0ab08)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #05 pc 0000000000098658  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libexpo-modules-core.so (BuildId: 904b6929e508d683c18fc50088af306b22c5a190)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #06 pc 00000000000a2494  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libexpo-modules-core.so (expo::SharedObject::NativeState::~NativeState()+196) (BuildId: 904b6929e508d683c18fc50088af306b22c5a190)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #07 pc 00000000000aec90  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #08 pc 00000000001f6d60  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #09 pc 0000000000200050  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #10 pc 00000000001fe718  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #11 pc 00000000001ff7a8  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:48:02.120 16405-16405 DEBUG                   pid-16405                            A        #12 pc 00000000001ff570  /data/app/~~1c_3-TLIV8sFeNnhLnzDiQ==/dev.expo.payments-9iCEqSZyaec4fj16Tu2wjA==/base.apk!libhermes.so (BuildId: c5defc0c4fc083ab1d503086f61e8773657d6b32)
2024-03-13 14:49:13.118   382-382   adbd                    adbd                                 E  failed to connect to socket 'localabstract:/dev.expo.payments-0/platform-1710337751713.sock': could not connect to localabstract address 'localabstract:/dev.expo.payments-0/platform-1710337751713.sock'
```

# How

To deallocate the `SharedObject`, we can temporarily attach the Hades thread (GC thread of Hermes). I haven't found any other solution yet, so let's test it and check the performance overhead of attaching and detaching the thread to the Java VM. If it turns out to be slow, we can look into finding an alternative solution.

# Test Plan

- bare-expo ✅