### PR TITLE
[core][Android] Fix app crashes during reloads

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -52,6 +52,8 @@ public:
     std::shared_ptr<jsi::Object> jsObject
   );
 
+  virtual ~JavaScriptObject() = default;
+
   std::shared_ptr<jsi::Object> get() override;
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -180,7 +180,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
+    super.invalidate();
     mModuleRegistry.onDestroy();
     mKotlinInteropModuleRegistry.onDestroy();
   }


### PR DESCRIPTION
# Why

Fixes random app crashes shortly after the hard reload

# How

Sometimes, after a hard reload, the app crashes. A change in the RN causes it — the hard reload doesn't call `onCatalystInstanceDestroy` anymore. I've changed it to `invalidate`, which seems to be called on both exit and hard reload. 

# Test Plan

- bare-expo ✅