### PR TITLE
[docs] fixes typo in tutorial

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -372,32 +372,7 @@ files={{
 
 export default function App() {
   /* @info Create a state variable.*/const [isModalVisible, setIsModalVisible] = useState(false);  /* @end */
-  /* @hide const [showAppOptions, setShowAppOptions] = useState(false); */
-  const [showAppOptions, setShowAppOptions] = useState(false);
-  const [selectedImage, setSelectedImage] = useState(null);
-
-  const pickImageAsync = async () => {
-    let result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,
-      aspect: [4, 3],
-      quality: 1,
-    });
-
-    if (!result.cancelled) {
-      setSelectedImage(result.uri);
-      setShowAppOptions(true);
-    } else {
-      alert("You did not select any image.");
-    }
-  };
-
-  const onReset = () => {
-    setShowAppOptions(false);
-  };
-  const onSaveImageAsync = async () => {
-    // we will implement this later
-  };
-  /* @end */
+  // ...rest of the code remains same
 
   /* @info Update functions to control the modal's visibility.*/
   const onAddSticker = () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When doing the tutorial I got a bit confused by this part and what this greyed-out line of code was:
![Screenshot 2024-03-13 215318](https://github.com/expo/expo/assets/26029690/db773eb4-541f-4c63-b921-ca9c1de347c9)


 On further inspection indicates code that is not gonna be repeated from previous steps, but it's not consistent with the rest of the tutorial where it typically states something like "...rest of the code remains same"



# How

Fixed the typo and checked that it looked as intended by running the docs locally:

![image](https://github.com/expo/expo/assets/26029690/2bfb359d-2095-453b-82f2-fffb28516104)

I'm not sure what the intention is with the `/* @hide */` but it's not visible in the docs and this code isn't there in the further steps so I removed it.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run docs locally and visit: http://localhost:3002/tutorial/create-a-modal/#create-an-emoji-picker-modal.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
