### PR TITLE
[module-template] Fix typo in `metro.config.js` comments

### DIFF
--- a/packages/expo-module-template/example/metro.config.js
+++ b/packages/expo-module-template/example/metro.config.js
@@ -5,7 +5,7 @@ const path = require('path');
 const config = getDefaultConfig(__dirname);
 
 // npm v7+ will install ../node_modules/react and ../node_modules/react-native because of peerDependencies.
-// To prevent the incompatible react-native bewtween ./node_modules/react-native and ../node_modules/react-native,
+// To prevent the incompatible react-native between ./node_modules/react-native and ../node_modules/react-native,
 // excludes the one from the parent folder when bundling.
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),


### PR DESCRIPTION
# Why

I noticed this typo while working on a new expo-module.

# How

n/a

# Test Plan

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
