### PR TITLE
[ios][camera] Fix legacy camera getAvailablePictureSizes

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix camera orientation on initial render. ([#27545](https://github.com/expo/expo/pull/27545) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix an issue where the configuration can be interuppted when the dev menu is presented on intial launch. ([#27572](https://github.com/expo/expo/pull/27572) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix `getAvailablePictureSizes` in the legacy package.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Ensure `mute` prop is passed to native so it is correctly initialiased even when not provided from JS. ([#27546](https://github.com/expo/expo/pull/27546) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix camera orientation on initial render. ([#27545](https://github.com/expo/expo/pull/27545) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix an issue where the configuration can be interuppted when the dev menu is presented on intial launch. ([#27572](https://github.com/expo/expo/pull/27572) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix `getAvailablePictureSizes` in the legacy package.
+- On `iOS`, fix `getAvailablePictureSizes` in the legacy package. ([#27642](https://github.com/expo/expo/pull/27642) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -201,7 +201,7 @@ public final class CameraViewModule: Module {
 
     AsyncFunction("getAvailablePictureSizes") { (_: String?, _: Int) in
       // Argument types must be compatible with Android which receives the ratio and view tag.
-      return pictureSizesDict.map { (k, _) in
+      return pictureSizesDict.map { k, _ in
         k
       }
     }

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -201,7 +201,9 @@ public final class CameraViewModule: Module {
 
     AsyncFunction("getAvailablePictureSizes") { (_: String?, _: Int) in
       // Argument types must be compatible with Android which receives the ratio and view tag.
-      return pictureSizesDict.keys
+      return pictureSizesDict.map { (k, _) in
+        k
+      }
     }
 
     AsyncFunction("getAvailableVideoCodecsAsync") { () -> [String] in


### PR DESCRIPTION
# Why
Fixes an issue reported by @kbrandwijk, where the `pictureSize` was not being set

# How
The problem was `getAvailablePictureSizes` was returning `pictureSizesDict.keys` which does not return an array of `String` but an array of `Key` structs. This would not get correctly parsed so would result in an empty array being sent back to JS.

# Test Plan
Bare-expo. The array is now correctly sent back and using the `pictureSize` prop works correctly.
