### PR TITLE
[tools] Publishing canary templates in the publish script

### DIFF
--- a/tools/src/ProjectTemplates.ts
+++ b/tools/src/ProjectTemplates.ts
@@ -10,20 +10,69 @@ export type Template = {
   path: string;
 };
 
+const DEPENDENCIES_KEYS = ['dependencies', 'devDependencies', 'peerDependencies'];
+
 export async function getAvailableProjectTemplatesAsync(): Promise<Template[]> {
-  const templates = await fs.readdir(TEMPLATES_DIR);
+  const templates = (await fs.readdir(TEMPLATES_DIR, { withFileTypes: true }))
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => path.join(TEMPLATES_DIR, dirent.name));
 
   return Promise.all<Template>(
-    templates.map(async (template) => {
+    templates.map(async (templatePath) => {
       const packageJson = await JsonFile.readAsync<Template>(
-        path.join(TEMPLATES_DIR, template, 'package.json')
+        path.join(templatePath, 'package.json')
       );
 
       return {
         name: packageJson.name,
         version: packageJson.version,
-        path: path.join(TEMPLATES_DIR, template),
+        path: templatePath,
       };
     })
   );
+}
+
+/**
+ * Updates version of the template and its dependencies.
+ */
+export async function updateTemplateVersionsAsync(
+  templatePath: string,
+  templateVersion: string,
+  dependenciesToUpdate: Record<string, string>
+): Promise<void> {
+  const packageJsonPath = path.join(templatePath, 'package.json');
+  const packageJson = require(packageJsonPath);
+
+  packageJson.version = templateVersion;
+
+  for (const dependencyKey of DEPENDENCIES_KEYS) {
+    const dependencies = packageJson[dependencyKey];
+
+    if (!dependencies) {
+      continue;
+    }
+    for (const dependencyName in dependencies) {
+      const currentVersion = dependencies[dependencyName];
+      const targetVersion = resolveTargetVersionRange(
+        dependenciesToUpdate[dependencyName],
+        currentVersion
+      );
+
+      if (targetVersion && targetVersion !== currentVersion) {
+        packageJson[dependencyKey][dependencyName] = targetVersion;
+      }
+    }
+  }
+  await JsonFile.writeAsync(packageJsonPath, packageJson);
+}
+
+/**
+ * Finds target version range, that is usually `bundledModuleVersion` param,
+ * but in some specific cases we want to use different version range.
+ */
+function resolveTargetVersionRange(targetVersionRange: string, currentVersion: string) {
+  if (currentVersion === '*') {
+    return currentVersion;
+  }
+  return targetVersionRange;
 }


### PR DESCRIPTION
# Why

`et publish --canary` is only publishing packages from the `packages` folder, but it would be nice to also publish project templates that use the canary version of our packages.

# How

- Added a new task to the canary publish pipeline that updates and publishes canary project templates.
- I copied some functionalities from `et update-project-templates` to `ProjectTemplates` utils, but left the command unchanged so I don't break it. In the future I think it would be good to merge `et update-project-templates` and `et publish-project-templates` into the non-canary flow of `et publish` as well.

# Test Plan

`et publish --canary --dry` passed and confirmed whether changes in the `templates` folder (version bumps) are correct.