### PR TITLE
[ci] downgrade test-suite ios-test macos

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -79,14 +79,15 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-14
+    runs-on: macos-12
+    # runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 15.2
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+      # - name: 🔨 Switch to Xcode 15.2
+      #   run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
@@ -100,8 +101,8 @@ jobs:
           brew tap facebook/fb
           brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
-        env:
-          MAESTRO_VERSION: '1.33.1'
+        # env:
+        #   MAESTRO_VERSION: '1.33.1'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -94,14 +94,15 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-14
+    runs-on: macos-12
+    # runs-on: macos-14
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 15.2
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app
+      # - name: 🔨 Switch to Xcode 15.2
+      #   run: sudo xcode-select --switch /Applications/Xcode_15.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
@@ -115,8 +116,8 @@ jobs:
           brew tap facebook/fb
           brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
-        env:
-          MAESTRO_VERSION: '1.33.1'
+        # env:
+        #   MAESTRO_VERSION: '1.33.1'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -5,8 +5,10 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import path from 'path';
 
-const TARGET_DEVICE = 'iPhone 15';
-const TARGET_DEVICE_IOS_VERSION = 17;
+const TARGET_DEVICE = 'iPhone 14';
+const TARGET_DEVICE_IOS_VERSION = 16;
+// const TARGET_DEVICE = 'iPhone 15';
+// const TARGET_DEVICE_IOS_VERSION = 17;
 const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start


### PR DESCRIPTION
# Why

the test-suite ios-test failures are too annoying to me

# How

downgrade macos and change back again once github runner having better performance on xcode 15

# Test Plan

retries ios-test three times and all passed