### PR TITLE
[docs] Add `eas/resolve_build_config`

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -652,6 +652,7 @@ When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcre
 - [`eas/checkout`](#eascheckout)
 - [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/resolve_build_config`](#easresolve_build_config)
 - [`eas/prebuild`](#easprebuild)
 - [`eas/configure_eas_update`](#easconfigure_eas_update)
 - [`eas/run_gradle`](#easrun_gradle)
@@ -662,7 +663,7 @@ When a build configuration uses credentials (for both `internal` and `store` [di
 - [`eas/checkout`](#eascheckout)
 - [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
-- [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+- [`eas/resolve_build_config`](#easresolve_build_config)
 - [`eas/prebuild`](#easprebuild)
 - [`eas/configure_eas_update`](#easconfigure_eas_update)
 - [`eas/inject_android_credentials`](#easinject_android_credentials)
@@ -677,6 +678,7 @@ When a build configuration is using [`withoutCredentials`](/eas/json/#withoutcre
 - [`eas/checkout`](#eascheckout)
 - [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
+- [`eas/resolve_build_config`](#easresolve_build_config)
 - [`eas/prebuild`](#easprebuild)
 - Install pods using the `pod install` command
 - [`eas/configure_eas_update`](#easconfigure_eas_update)
@@ -689,7 +691,7 @@ When a build configuration uses credentials (for both `internal` and `store` [di
 - [`eas/checkout`](#eascheckout)
 - [`eas/use_npm_token`](#easuse_npm_token)
 - [`eas/install_node_modules`](#easinstall_node_modules)
-- [`eas/get_credentials_for_build_triggered_by_github_integration`](#easget_credentials_for_build_triggered_by_github_integration)
+- [`eas/resolve_build_config`](#easresolve_build_config)
 - [`eas/resolve_apple_team_id_from_credentials`](#easresolve_apple_team_id_from_credentials)
 - [`eas/prebuild`](#easprebuild)
 - Install pods using the `pod install` command
@@ -934,37 +936,22 @@ build:
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
 />
 
-#### `eas/get_credentials_for_build_triggered_by_github_integration`
+#### `eas/resolve_build_config`
 
-Resolves the credentials for a build triggered by our [GitHub integration](/build/building-from-github/). Call this function if you are using the GitHub integration and your custom build needs to use credentials.
+Resolves and prints the build configuration. If the build has been triggered by the GitHub integration, it will update current `job` and `metadata` context values. It should be called after installing the dependencies, because the config may be influenced by config plugins.
 
-This is a no-op if the build was not triggered by the GitHub integration. This function is automatically executed by [`eas/build`](#easbuild) function group.
-
-```yaml example.yml
-build:
-  name: Example Android config for a build triggered by GitHub integration
-  steps:
-    - eas/checkout
-    - eas/use_npm_token
-    - eas/install_node_modules
-    # @info #
-    - eas/get_credentials_for_build_triggered_by_github_integration
-    # @end #
-    - eas/configure_eas_update:
-        inputs:
-          throw_if_not_configured: false
-    - eas/inject_android_credentials
-    - eas/configure_android_version
-    - eas/run_gradle
-    - eas/find_and_upload_build_artifacts
-```
+This function is automatically executed by the [`eas/build`](#easbuild) function group.
 
 <BoxLink
-  title="eas/get_credentials_for_build_triggered_by_github_integration source code"
-  description="View the source code for the eas/get_credentials_for_build_triggered_by_github_integration function on GitHub."
+  title="eas/resolve_build_config source code"
+  description="View the source code for the eas/resolve_build_config function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/getCredentialsForBuildTriggeredByGitHubIntegration.ts"
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/resolveBuildConfig.ts"
 />
+
+#### `eas/get_credentials_for_build_triggered_by_github_integration`
+
+> **warning** **Deprecated:** Replace this step with `eas/resolve_build_config`.
 
 #### `eas/resolve_apple_team_id_from_credentials`
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -938,7 +938,7 @@ build:
 
 #### `eas/resolve_build_config`
 
-Resolves and prints the build configuration. If the build has been triggered by the GitHub integration, it will update current `job` and `metadata` context values. It should be called after installing the dependencies, because the config may be influenced by config plugins.
+Resolves and prints the build configuration. If the build has been triggered by the GitHub integration, it will update the current `job` and `metadata` context values. It should be called after installing the dependencies because the config may be influenced by config plugins.
 
 This function is automatically executed by the [`eas/build`](#easbuild) function group.
 
@@ -951,7 +951,7 @@ This function is automatically executed by the [`eas/build`](#easbuild) function
 
 #### `eas/get_credentials_for_build_triggered_by_github_integration`
 
-> **warning** **Deprecated:** Replace this step with `eas/resolve_build_config`.
+> **warning** **Deprecated:** Replace this step with [`eas/resolve_build_config`](#easresolve_build_config).
 
 #### `eas/resolve_apple_team_id_from_credentials`
 


### PR DESCRIPTION
# Why

We've realized resolving build config is necessary in all steps. So, we've added `eas/resolve_build_config` function which should be used in all build scenarios. It supersedes old `eas/get_credentials...` function.

# How

Added succinct docs for the new function. Deprecated the old one. Added `eas/resolve_build_config` to lists of functions for each scenario.

# Test Plan

I've tested manually that this fixed the underlying issue. https://github.com/expo/eas-custom-builds-example/pull/25

<img width="809" alt="Zrzut ekranu 2024-03-14 o 17 26 43" src="https://github.com/expo/expo/assets/1151041/205932a8-efe0-4174-8580-84138ba51936">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
