### PR TITLE
[asset] fix reentrant promise resolving crash

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed "Tried to resolve a promise more than once" crash on iOS. ([#27672](https://github.com/expo/expo/pull/27672) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Create native module for iOS and Android. Migrate `downloadAsync` to a native implementation. ([#27369](https://github.com/expo/expo/pull/27369) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-asset/ios/AssetModule.swift
+++ b/packages/expo-asset/ios/AssetModule.swift
@@ -20,6 +20,7 @@ public class AssetModule: Module {
     AsyncFunction("downloadAsync") { (url: URL, md5Hash: String?, type: String, promise: Promise) in
       if url.isFileURL {
         promise.resolve(url.standardizedFileURL.absoluteString)
+        return
       }
       guard let cacheFileId = md5Hash ?? getMD5Hash(fromURL: url),
       let cachesDirectory = appContext?.fileSystem?.cachesDirectory,


### PR DESCRIPTION
# Why

ios bare-expo release build was crashing because of "Tried to resolve a promise more than once."

# How

i think we should have early return after resolving the promise.

# Test Plan

- launch bare-expo release build will not crash

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
