### PR TITLE
[docs] Add cross-package link capability

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -55,6 +55,7 @@ export type TypeDefinitionData = {
   declaration?: TypeDeclarationContentData;
   value?: string | number | boolean | null;
   operator?: string;
+  package?: string;
   objectType?: {
     name: string;
     type: string;

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -198,10 +198,33 @@ const hardcodedTypeLinks: Record<string, string> = {
   WebGLFramebuffer: 'https://developer.mozilla.org/en-US/docs/Web/API/WebGLFramebuffer',
 };
 
-const renderWithLink = (name: string, type?: string) => {
+const packageLinks: Record<string, string> = {
+  'expo-manifests': 'manifests',
+};
+
+const renderWithLink = ({
+  name,
+  type,
+  typePackage,
+}: {
+  name: string;
+  type?: string;
+  typePackage: string | undefined;
+}) => {
   const replacedName = replaceableTypes[name] ?? name;
 
   if (name.includes('.')) return name;
+
+  if (typePackage && packageLinks[typePackage]) {
+    return (
+      <A
+        href={`${packageLinks[typePackage]}/#${replacedName.toLowerCase()}`}
+        key={`type-link-${replacedName}`}>
+        {replacedName}
+        {type === 'array' && '[]'}
+      </A>
+    );
+  }
 
   return nonLinkableTypes.includes(replacedName) ? (
     replacedName + (type === 'array' ? '[]' : '')
@@ -270,7 +293,7 @@ export const resolveTypeName = (
           } else {
             return (
               <>
-                {renderWithLink(name)}
+                {renderWithLink({ name, typePackage: typeDefinition.package })}
                 <span className="text-quaternary">{'<'}</span>
                 {typeArguments.map((type, index) => (
                   <span key={`${name}-nested-type-${index}`}>
@@ -285,14 +308,18 @@ export const resolveTypeName = (
             );
           }
         } else {
-          return renderWithLink(name);
+          return renderWithLink({ name, typePackage: typeDefinition.package });
         }
       } else {
         return name;
       }
     } else if (elementType?.name) {
       if (elementType.type === 'reference') {
-        return renderWithLink(elementType.name, type);
+        return renderWithLink({
+          name: elementType.name,
+          type,
+          typePackage: typeDefinition.package,
+        });
       } else if (type === 'array') {
         return elementType.name + '[]';
       }


### PR DESCRIPTION
# Why

First todo from https://github.com/expo/expo/pull/27671.

This adds the ability for types from other packages to be linked in a package without using the hardcoded link.

Closes https://github.com/expo/expo/issues/27640.

# How

Add code to handle cross-package links when possible. This could probably be a lot more sophisticated (support other packages automatically) but I'm not familiar enough with the docs codebase to immediately know how to do it.

# Test Plan

Run docs site locally, go to updates reference, see links to manifests now work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
