### PR TITLE
[docs] Remove Xcode resource signing step from migration guide

### DIFF
--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -59,14 +59,6 @@ If the command fails, refer to the ["Installing Expo modules" guide](/bare/insta
 </Step>
 
 <Step label="4">
-## Turn off resource bundle signing (Xcode 14+ only)
-
-In Xcode 14 and higher, resource bundles are signed by default, which requires setting the development team for each resource bundle target.
-To resolve this issue, downgrade to an older Xcode version using the `image` field in **eas.json**, or turn off signing resource bundles in your Podfile. See the ["disable bundle resource signing" example](https://expo.fyi/r/disable-bundle-resource-signing).
-
-</Step>
-
-<Step label="5">
 ## Install the latest EAS CLI
 
 EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
@@ -79,7 +71,7 @@ You can also use the above command to check if a new version of EAS CLI is avail
 
 </Step>
 
-<Step label="6">
+<Step label="5">
 ## Log in to your Expo account
 
 If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
@@ -90,7 +82,7 @@ You can check whether you are logged in by running `eas whoami`.
 
 </Step>
 
-<Step label="7">
+<Step label="6">
 ## Configure project, deploy builds and publish updates
 
 We have finished all the steps tailored for a CodePush-enabled bare React Native project. To proceed with the configuration of your project, please begin with Step 4 in [the main guide](/eas-update/getting-started/#create-a-build-for-the-project) and follow it through to completion.
@@ -99,7 +91,7 @@ We have finished all the steps tailored for a CodePush-enabled bare React Native
 
 </Step>
 
-<Step label="8">
+<Step label="7">
 ## Verifying the migration and resubmitting your app
 
 After completing the migration and setting up your project with EAS Update, you should test your app to ensure that over-the-air updates are working correctly. To do this:


### PR DESCRIPTION
# Why

This was relevant at the time the guide was written, but we should assume people are using a recent version of Xcode / React Native now.

# How

Delete

# Test Plan

-

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
