### PR TITLE
[patch-project] Set CLI to executable on build for consistency with yarn in root

### DIFF
--- a/packages/patch-project/package.json
+++ b/packages/patch-project/package.json
@@ -5,10 +5,10 @@
   "main": "build/withPatchPlugin.js",
   "types": "build/withPatchPlugin.d.ts",
   "scripts": {
-    "build": "expo-module tsc",
+    "build": "expo-module tsc && chmod +x build/cli/index.js",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "prepare": "expo-module clean && expo-module tsc",
+    "prepare": "yarn run clean && yarn run build",
     "prepublishOnly": "expo-module prepublishOnly",
     "test": "expo-module test",
     "test:e2e": "expo-module clean && expo-module tsc && expo-module test --config e2e/jest.config.js",


### PR DESCRIPTION
# Why

- I noticed that the working tree was dirty when trying to run this job: https://github.com/expo/expo/actions/runs/8287945362/job/22681450966
- I saw when I ran `yarn` locally in the root of the repo (by chance, I happened to do it with a clean slate / no node_modules) it modified build/cli/index.js to add +x to mode.
- I figured this would be fine to commit and solve all of our problems. But then check-packages failed: https://github.com/expo/expo/actions/runs/8289007758/job/22684616383

So:

### 1. after running yarn clean && yarn build in patch-project

```
ls -l build/cli/index.js
-rw-r--r--@ 1 brent  staff  4002 14 Mar 17:49 build/cli/index.js
```

### 2. after running yarn from root (with a clean node_modules):

```
ls -l build/cli/index.js
-rwxr-xr-x@ 1 brent  staff  4002 14 Mar 17:49 build/cli/index.js
```

I believe this happens because `yarn` will link all workspace `bin`s and ensure they are executable. When we use `expo-module clean` we delete the build directory and re-generate it, re-creating it without executable mode. This is usually fine because in other pkgs we don't keep the bin inside of src, but in this case..

# How

Add `chmod +x` in build script 

# Test Plan

- patch-package and iOS Client - EAS workflows should both work.  ([confirmed iOS client here](https://github.com/expo/expo/actions/runs/8289875387/job/22687033418))
- The two scenarios I shared in the "Why" section both produce the same results