### PR TITLE
[expo-video][android] Fix video pausing when entering PiP and Fullscreen

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/PictureInPictureHelperFragment.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/PictureInPictureHelperFragment.kt
@@ -13,6 +13,7 @@ class PictureInPictureHelperFragment(private val videoView: VideoView) : Fragmen
       videoView.layoutForPiPEnter()
       videoView.onPictureInPictureStart(Unit)
     } else {
+      videoView.willEnterPiP = false
       videoView.layoutForPiPExit()
       videoView.onPictureInPictureStop(Unit)
     }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -77,7 +77,10 @@ object VideoManager {
 
   fun onAppBackgrounded() {
     for (videoView in videoViews.values) {
-      if (videoView.videoPlayer?.staysActiveInBackground == false) {
+      if (videoView.videoPlayer?.staysActiveInBackground == false &&
+        !videoView.willEnterPiP &&
+        !videoView.isInFullscreen
+      ) {
         videoView.videoPlayer?.player?.pause()
       }
     }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -34,6 +34,10 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   val onPictureInPictureStart by EventDispatcher<Unit>()
   val onPictureInPictureStop by EventDispatcher<Unit>()
 
+  var willEnterPiP: Boolean = false
+  var isInFullscreen: Boolean = false
+    private set
+
   private val currentActivity = appContext.currentActivity
     ?: throw Exceptions.MissingActivity()
   private val decorView = currentActivity.window.decorView
@@ -144,6 +148,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     } else {
       currentActivity.overridePendingTransition(0, 0)
     }
+    isInFullscreen = true
   }
 
   fun exitFullscreen() {
@@ -151,6 +156,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     val fullScreenButton: ImageButton = playerView.findViewById(androidx.media3.ui.R.id.exo_fullscreen)
     fullScreenButton.setImageResource(androidx.media3.ui.R.drawable.exo_icon_fullscreen_enter)
     videoPlayer?.changePlayerView(playerView)
+    isInFullscreen = false
   }
 
   fun enterPictureInPicture() {
@@ -185,6 +191,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     }
 
     calculateRectHint()
+    willEnterPiP = true
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       currentActivity.enterPictureInPictureMode(PictureInPictureParams.Builder().build())
     } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {


### PR DESCRIPTION
# Why

The activity calls the background event when entering Fullscreen and PiP, which caused the video to pause. This fixes this issue. Video will still pause when auto-entering PiP, as we have no way of knowing for sure if the activity will enter PiP or just background. Once `onUserLeaveHint` is available to us we will be able to fix this easily.

# How

Added a check that checks if the video is in fullscreen or will enter PiP when deciding if we should pause the video

# Test Plan

Tested on Android 14 emulator in Bare Expo
