### PR TITLE
Bump SDK version to 51.0.0-unreleased

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -45,7 +45,7 @@
     "@react-native-picker/picker": "2.5.1",
     "@react-native-segmented-control/segmented-control": "2.4.1",
     "@shopify/flash-list": "1.6.3",
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-camera": "~14.0.0",
     "expo-dev-client": "~3.3.0",
     "expo-face-detector": "~12.6.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -33,7 +33,7 @@
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",
     "es6-error": "^4.1.1",
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-application": "~5.8.0",
     "expo-asset": "~9.0.0",
     "expo-barcode-scanner": "~12.9.0",
@@ -86,7 +86,7 @@
     "@types/react-redux": "^7.1.16",
     "@types/semver": "^7.5.0",
     "expo-module-scripts": "^3.0.0",
-    "jest-expo": "~50.0.0-alpha.0",
+    "jest-expo": "~51.0.0-unreleased",
     "react-native-bundle-visualizer": "^3.0.0"
   }
 }

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -9,7 +9,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-apple-authentication": "~6.3.0",
     "expo-av": "~13.10.0",
     "expo-blur": "~12.9.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "dependencies": {
     "@expo/mux": "^1.0.7",
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-clipboard": "~5.0.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -51,7 +51,7 @@
     "@shopify/react-native-skia": "0.1.221",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-2d-context": "^0.0.4",
     "expo-apple-authentication": "~6.3.0",
     "expo-application": "^5.0.0",

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-camera": "~14.0.0",
     "expo-dev-client": "~3.3.0",
     "expo-face-detector": "~12.6.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -7,7 +7,7 @@
     "start:react-native-canary": "EXPO_E2E_RSC=1 E2E_ROUTER_SRC=react-native-canary expo start"
   },
   "dependencies": {
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-router": "^3.0.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -8,7 +8,7 @@
     "ios": "expo start --ios"
   },
   "dependencies": {
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-router": "^3.0.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -13,7 +13,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "async-retry": "^1.1.4",
-    "expo": "~50.0.0-alpha.0",
+    "expo": "~51.0.0-unreleased",
     "expo-application": "~5.8.0",
     "expo-asset": "~9.0.0",
     "expo-av": "~13.10.0",

--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -33,7 +33,7 @@
     "paths"
   ],
   "dependencies": {
-    "@expo/config-types": "^50.0.0-alpha.1",
+    "@expo/config-types": "^51.0.0-unreleased",
     "@expo/json-file": "~8.3.0",
     "@expo/plist": "^0.1.0",
     "@expo/sdk-runtime-versions": "^1.0.0",

--- a/packages/@expo/config-types/package.json
+++ b/packages/@expo/config-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/config-types",
-  "version": "50.0.0",
+  "version": "51.0.0-unreleased",
   "description": "Types for the Expo config object app.config.ts",
   "types": "build/ExpoConfig.d.ts",
   "main": "build/ExpoConfig.js",

--- a/packages/@expo/config/package.json
+++ b/packages/@expo/config/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/code-frame": "~7.10.4",
     "@expo/config-plugins": "~7.8.0",
-    "@expo/config-types": "^50.0.0-alpha.1",
+    "@expo/config-types": "^51.0.0-unreleased",
     "@expo/json-file": "^8.3.0",
     "getenv": "^1.0.0",
     "glob": "7.1.6",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@expo/config": "~8.5.0",
     "@expo/config-plugins": "~7.8.0",
-    "@expo/config-types": "^50.0.0-alpha.1",
+    "@expo/config-types": "^51.0.0-unreleased",
     "@expo/image-utils": "^0.4.0",
     "@expo/json-file": "^8.3.0",
     "debug": "^4.3.1",

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "expo-module-scripts": "^3.0.0",
-    "jest-expo": "~50.0.0-alpha.0"
+    "jest-expo": "~51.0.0-unreleased"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -40,7 +40,7 @@
     "eslint-config-universe": "^12.0.0",
     "find-yarn-workspace-root": "^2.0.0",
     "glob": "^7.1.7",
-    "jest-expo": "~50.0.1",
+    "jest-expo": "~51.0.0-unreleased",
     "jest-snapshot-prettier": "npm:prettier@^2",
     "jest-watch-typeahead": "2.2.1",
     "ts-jest": "~29.0.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -79,7 +79,7 @@
   "expo-updates": "~0.24.3",
   "expo-video-thumbnails": "~7.9.0",
   "expo-web-browser": "~12.8.0",
-  "jest-expo": "~50.0.1",
+  "jest-expo": "~51.0.0-unreleased",
   "lottie-react-native": "6.4.1",
   "react": "18.2.0",
   "react-dom": "18.2.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo",
-  "version": "50.0.0-preview.4",
+  "version": "51.0.0-unreleased",
   "description": "The Expo SDK",
   "main": "build/Expo.js",
   "module": "build/Expo.js",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-expo",
-  "version": "50.0.1",
+  "version": "51.0.0-unreleased",
   "description": "A Jest preset to painlessly test your Expo / React Native apps.",
   "license": "MIT",
   "main": "src",

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~50.0.0-preview.4",
+    "expo": "~51.0.0-unreleased",
     "expo-status-bar": "~1.11.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~50.0.0-preview.4",
+    "expo": "~51.0.0-unreleased",
     "expo-status-bar": "~1.11.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "~50.0.0-preview.4",
+    "expo": "~51.0.0-unreleased",
     "expo-status-bar": "~1.11.0",
     "react": "18.2.0",
     "react-native": "0.74.0-rc.3"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",
     "@react-navigation/native": "^6.0.2",
-    "expo": "~50.0.0-preview.4",
+    "expo": "~51.0.0-unreleased",
     "expo-font": "~11.10.0",
     "expo-linking": "~6.2.1",
     "expo-router": "~3.4.0",
@@ -35,7 +35,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~18.2.45",
     "jest": "^29.2.1",
-    "jest-expo": "~50.0.1",
+    "jest-expo": "~51.0.0-unreleased",
     "react-test-renderer": "18.2.0",
     "typescript": "^5.1.3"
   }


### PR DESCRIPTION
# Why

Canary releases still use v50 as the version of the expo package was set to prerelease already.

# How

- Updated SDK-constrained packages (`expo`, `jest-expo`, `@expo/config-types`) to `51.0.0-unreleased`, following Brent's suggestion
- Ran `et sync-bundled-native-modules` to enable SDK 51 on staging and production endpoints

# Test Plan

n/a