### PR TITLE
[docs] Version hardcodedTypeLinks

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -45,7 +45,7 @@ const filterDataByKind = (
       additionalCondition(entry)
   );
 
-const isHook = ({ name }: GeneratedData) =>
+const isHook = ({ name }: { name: string }) =>
   name.startsWith('use') &&
   // note(simek): hardcode this exception until the method will be renamed
   name !== 'useSystemBrightnessAsync';
@@ -98,7 +98,7 @@ const groupByHeader = (entries: GeneratedData[]) => {
 };
 
 const renderAPI = (
-  version: string,
+  sdkVersion: string,
   {
     packageName,
     apiName,
@@ -115,16 +115,16 @@ const renderAPI = (
       data = packageName
         .map(name => {
           const { children } = testRequire
-            ? testRequire(`~/public/static/data/${version}/${name}.json`)
-            : require(`~/public/static/data/${version}/${name}.json`);
+            ? testRequire(`~/public/static/data/${sdkVersion}/${name}.json`)
+            : require(`~/public/static/data/${sdkVersion}/${name}.json`);
           return children;
         })
         .flat()
         .sort((a: GeneratedData, b: GeneratedData) => a.name.localeCompare(b.name));
     } else {
       const { children } = testRequire
-        ? testRequire(`~/public/static/data/${version}/${packageName}.json`)
-        : require(`~/public/static/data/${version}/${packageName}.json`);
+        ? testRequire(`~/public/static/data/${sdkVersion}/${packageName}.json`)
+        : require(`~/public/static/data/${sdkVersion}/${packageName}.json`);
       data = children;
     }
 
@@ -234,7 +234,7 @@ const renderAPI = (
         method?.kind === TypeDocKind.Method &&
         method?.flags?.isStatic === true &&
         !methodsNames.includes(method.name) &&
-        !isHook(method as GeneratedData)
+        !isHook(method)
     );
     const componentMethods = componentsChildren
       .filter(
@@ -260,32 +260,48 @@ const renderAPI = (
                   data={categorizedMethods[key]}
                   header={header}
                   key={`${header}-${index}`}
+                  sdkVersion={sdkVersion}
                 />
               ))
             : Object.entries(categorizedMethods).map(([key, data], index) => (
-                <APISectionMethods data={data} header={key} key={`${key}-${index}`} />
+                <APISectionMethods
+                  data={data}
+                  header={key}
+                  key={`${key}-${index}`}
+                  sdkVersion={sdkVersion}
+                />
               )))}
-        <APISectionComponents data={components} componentsProps={componentsProps} />
-        <APISectionMethods data={staticMethods} header="Static Methods" />
-        <APISectionMethods data={componentMethods} header="Component Methods" />
-        <APISectionConstants data={constants} apiName={apiName} />
-        <APISectionMethods data={hooks} header="Hooks" />
+        <APISectionComponents
+          data={components}
+          sdkVersion={sdkVersion}
+          componentsProps={componentsProps}
+        />
+        <APISectionMethods data={staticMethods} header="Static Methods" sdkVersion={sdkVersion} />
+        <APISectionMethods
+          data={componentMethods}
+          header="Component Methods"
+          sdkVersion={sdkVersion}
+        />
+        <APISectionConstants data={constants} apiName={apiName} sdkVersion={sdkVersion} />
+        <APISectionMethods data={hooks} header="Hooks" sdkVersion={sdkVersion} />
         <APISectionClasses
           data={classes}
+          sdkVersion={sdkVersion}
           exposeAllClassPropsInSidebar={restProps.exposeAllClassPropsInSidebar}
         />
         {props && !componentsProps.length ? (
-          <APISectionProps data={props} defaultProps={defaultProps} />
+          <APISectionProps data={props} sdkVersion={sdkVersion} defaultProps={defaultProps} />
         ) : null}
-        <APISectionMethods data={methods} apiName={apiName} />
+        <APISectionMethods data={methods} apiName={apiName} sdkVersion={sdkVersion} />
         <APISectionMethods
           data={eventSubscriptions}
           apiName={apiName}
           header="Event Subscriptions"
+          sdkVersion={sdkVersion}
         />
-        <APISectionNamespaces data={namespaces} />
-        <APISectionInterfaces data={interfaces} />
-        <APISectionTypes data={types} />
+        <APISectionNamespaces data={namespaces} sdkVersion={sdkVersion} />
+        <APISectionInterfaces data={interfaces} sdkVersion={sdkVersion} />
+        <APISectionTypes data={types} sdkVersion={sdkVersion} />
         <APISectionEnums data={enums} />
       </>
     );

--- a/docs/components/plugins/api/APIDataType.tsx
+++ b/docs/components/plugins/api/APIDataType.tsx
@@ -6,9 +6,13 @@ import { CODE } from '~/ui/components/Text';
 const typeDefinitionContainsObject = (typDef: TypeDefinitionData) =>
   typDef.type === 'reflection' && typDef.declaration?.children;
 
-type APIDataTypeProps = { typeDefinition: TypeDefinitionData; inline?: boolean };
+type APIDataTypeProps = {
+  typeDefinition: TypeDefinitionData;
+  sdkVersion: string;
+  inline?: boolean;
+};
 
-export const APIDataType = ({ typeDefinition, inline = true }: APIDataTypeProps) => {
+export const APIDataType = ({ typeDefinition, sdkVersion, inline = true }: APIDataTypeProps) => {
   const { type, declaration, types, elementType, typeArguments } = typeDefinition;
 
   const isObjectDefinition = type === 'reflection' && declaration?.children?.length;
@@ -24,11 +28,11 @@ export const APIDataType = ({ typeDefinition, inline = true }: APIDataTypeProps)
 
   return isObjectDefinition || isIntersectionWithObject || isUnionWithObject || isObjectWrapped ? (
     <CodeBlock inline={inline} key={typeDefinition.name}>
-      {resolveTypeName(typeDefinition)}
+      {resolveTypeName(typeDefinition, sdkVersion)}
     </CodeBlock>
   ) : (
     <CODE key={typeDefinition.name} className="[&>span]:!text-inherit">
-      {resolveTypeName(typeDefinition)}
+      {resolveTypeName(typeDefinition, sdkVersion)}
     </CODE>
   );
 };

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -27,6 +27,7 @@ import { H2, P, CODE, MONOSPACE, DEMI } from '~/ui/components/Text';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
+  sdkVersion: string;
 
   /**
    * Whether to expose all classes props in the sidebar.
@@ -74,7 +75,8 @@ const remapClass = (clx: ClassDefinitionData) => {
 
 const renderClass = (
   clx: ClassDefinitionData,
-  options: { exposeAllClassPropsInSidebar: boolean; baseNestingLevelForClassProps: number }
+  options: { exposeAllClassPropsInSidebar: boolean; baseNestingLevelForClassProps: number },
+  sdkVersion: string
 ): JSX.Element => {
   const { name, comment, type, extendedTypes, children, implementedTypes, isSensor } = clx;
 
@@ -96,12 +98,14 @@ const renderClass = (
       {(extendedTypes?.length || implementedTypes?.length) && (
         <P className="mb-3">
           <DEMI theme="secondary">Type: </DEMI>
-          {type ? <CODE>{resolveTypeName(type)}</CODE> : 'Class'}
+          {type ? <CODE>{resolveTypeName(type, sdkVersion)}</CODE> : 'Class'}
           {extendedTypes?.length && (
             <>
               <span> extends </span>
               {extendedTypes.map(extendedType => (
-                <CODE key={`extends-${extendedType.name}`}>{resolveTypeName(extendedType)}</CODE>
+                <CODE key={`extends-${extendedType.name}`}>
+                  {resolveTypeName(extendedType, sdkVersion)}
+                </CODE>
               ))}
             </>
           )}
@@ -110,7 +114,7 @@ const renderClass = (
               <span> implements </span>
               {implementedTypes.map(implementedType => (
                 <CODE key={`implements-${implementedType.name}`}>
-                  {resolveTypeName(implementedType)}
+                  {resolveTypeName(implementedType, sdkVersion)}
                 </CODE>
               ))}
             </>
@@ -135,7 +139,7 @@ const renderClass = (
           />
           <div>
             {properties.map(property =>
-              renderProp(property, property?.defaultValue, {
+              renderProp(property, sdkVersion, property?.defaultValue, {
                 exposeInSidebar: options.exposeAllClassPropsInSidebar,
                 baseNestingLevel: options.baseNestingLevelForClassProps + 1,
               })
@@ -154,6 +158,7 @@ const renderClass = (
             renderMethod(method, {
               exposeInSidebar: options.exposeAllClassPropsInSidebar,
               baseNestingLevel: options.baseNestingLevelForClassProps + 1,
+              sdkVersion,
             })
           )}
         </>
@@ -162,7 +167,7 @@ const renderClass = (
   );
 };
 
-const APISectionClasses = ({ data, ...props }: APISectionClassesProps) => {
+const APISectionClasses = ({ data, sdkVersion, ...props }: APISectionClassesProps) => {
   if (data?.length) {
     const hasMultipleClasses = data.length > 1;
     const exposeAllClassPropsInSidebar = props.exposeAllClassPropsInSidebar ?? !hasMultipleClasses;
@@ -173,10 +178,14 @@ const APISectionClasses = ({ data, ...props }: APISectionClassesProps) => {
       <>
         <H2>Classes</H2>
         {data.map(clx =>
-          renderClass(remapClass(clx), {
-            exposeAllClassPropsInSidebar,
-            baseNestingLevelForClassProps,
-          })
+          renderClass(
+            remapClass(clx),
+            {
+              exposeAllClassPropsInSidebar,
+              baseNestingLevelForClassProps,
+            },
+            sdkVersion
+          )
         )}
       </>
     );

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -20,6 +20,7 @@ import { H2, DEMI, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionComponentsProps = {
   data: GeneratedData[];
+  sdkVersion: string;
   componentsProps: PropsDefinitionData[];
 };
 
@@ -48,6 +49,7 @@ const getComponentTypeParameters = ({
 
 const renderComponent = (
   { name, comment, type, extendedTypes, children, signatures }: GeneratedData,
+  sdkVersion: string,
   componentsProps?: PropsDefinitionData[]
 ): JSX.Element => {
   const resolvedType = getComponentType({ signatures });
@@ -67,10 +69,10 @@ const renderComponent = (
           <DEMI theme="secondary">Type:</DEMI>{' '}
           <CODE>
             {extendedTypes ? (
-              <>React.{resolveTypeName(resolvedTypeParameters)}</>
+              <>React.{resolveTypeName(resolvedTypeParameters, sdkVersion)}</>
             ) : (
               <>
-                {resolvedType}&lt;{resolveTypeName(resolvedTypeParameters)}&gt;
+                {resolvedType}&lt;{resolveTypeName(resolvedTypeParameters, sdkVersion)}&gt;
               </>
             )}
           </CODE>
@@ -79,6 +81,7 @@ const renderComponent = (
       <CommentTextBlock comment={extractedComment} />
       {componentsProps && componentsProps.length ? (
         <APISectionProps
+          sdkVersion={sdkVersion}
           data={componentsProps}
           header={componentsProps.length === 1 ? 'Props' : `${resolvedName}Props`}
         />
@@ -87,13 +90,14 @@ const renderComponent = (
   );
 };
 
-const APISectionComponents = ({ data, componentsProps }: APISectionComponentsProps) =>
+const APISectionComponents = ({ data, sdkVersion, componentsProps }: APISectionComponentsProps) =>
   data?.length ? (
     <>
       <H2 key="components-header">{data.length === 1 ? 'Component' : 'Components'}</H2>
       {data.map(component =>
         renderComponent(
           component,
+          sdkVersion,
           componentsProps.filter(cp =>
             cp.name.includes(getComponentName(component.name, component.children))
           )

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -12,11 +12,13 @@ import { H2, DEMI, P, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
+  sdkVersion: string;
   apiName?: string;
 };
 
 const renderConstant = (
   { name, comment, type }: ConstantDefinitionData,
+  sdkVersion: string,
   apiName?: string
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} css={STYLES_APIBOX} className="[&>*:last-child]:!mb-0">
@@ -30,7 +32,8 @@ const renderConstant = (
     </H3Code>
     {type && (
       <P>
-        <DEMI theme="secondary">Type:</DEMI> <APIDataType typeDefinition={type} />
+        <DEMI theme="secondary">Type:</DEMI>{' '}
+        <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </P>
     )}
     {comment && (
@@ -39,11 +42,11 @@ const renderConstant = (
   </div>
 );
 
-const APISectionConstants = ({ data, apiName }: APISectionConstantsProps) =>
+const APISectionConstants = ({ data, sdkVersion, apiName }: APISectionConstantsProps) =>
   data?.length ? (
     <>
       <H2 key="constants-header">Constants</H2>
-      {data.map(constant => renderConstant(constant, apiName))}
+      {data.map(constant => renderConstant(constant, sdkVersion, apiName))}
     </>
   ) : null;
 

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -31,9 +31,11 @@ import { H2, BOLD, CALLOUT, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
+  sdkVersion: string;
 };
 
 const renderInterfaceComment = (
+  sdkVersion: string,
   comment?: CommentData,
   signatures?: MethodSignatureData[],
   defaultValue?: string
@@ -45,9 +47,9 @@ const renderInterfaceComment = (
       defaultValue || (defaultTag ? getCommentContent(defaultTag.content) : undefined);
     return (
       <>
-        {parameters?.length ? parameters.map(param => renderParamRow(param)) : null}
+        {parameters?.length ? parameters.map(param => renderParamRow(param, sdkVersion)) : null}
         <DEMI>Returns</DEMI>
-        <CODE>{resolveTypeName(type)}</CODE>
+        <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
         {signatureComment && (
           <>
             <br />
@@ -78,14 +80,10 @@ const renderInterfaceComment = (
   }
 };
 
-const renderInterfacePropertyRow = ({
-  name,
-  flags,
-  type,
-  comment,
-  signatures,
-  defaultValue,
-}: PropData): JSX.Element => {
+const renderInterfacePropertyRow = (
+  { name, flags, type, comment, signatures, defaultValue }: PropData,
+  sdkVersion: string
+): JSX.Element => {
   const defaultTag = getTagData('default', comment);
   const initValue = parseCommentContent(
     defaultValue || (defaultTag ? getCommentContent(defaultTag.content) : '')
@@ -97,19 +95,17 @@ const renderInterfacePropertyRow = ({
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell fitContent>
-        <APIDataType typeDefinition={type} />
+        <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </Cell>
-      <Cell fitContent>{renderInterfaceComment(comment, signatures, initValue)}</Cell>
+      <Cell fitContent>{renderInterfaceComment(sdkVersion, comment, signatures, initValue)}</Cell>
     </Row>
   );
 };
 
-const renderInterface = ({
-  name,
-  children,
-  comment,
-  extendedTypes,
-}: InterfaceDefinitionData): JSX.Element | null => {
+const renderInterface = (
+  { name, children, comment, extendedTypes }: InterfaceDefinitionData,
+  sdkVersion: string
+): JSX.Element | null => {
   const interfaceChildren = children?.filter(child => !child?.inheritedFrom) || [];
 
   if (!interfaceChildren.length) return null;
@@ -132,7 +128,9 @@ const renderInterface = ({
             Extends:{' '}
           </CALLOUT>
           {extendedTypes.map(extendedType => (
-            <CODE key={`extend-${extendedType.name}`}>{resolveTypeName(extendedType)}</CODE>
+            <CODE key={`extend-${extendedType.name}`}>
+              {resolveTypeName(extendedType, sdkVersion)}
+            </CODE>
           ))}
         </CALLOUT>
       ) : null}
@@ -140,7 +138,9 @@ const renderInterface = ({
       {interfaceMethods.length ? (
         <>
           <BoxSectionHeader text={`${name} Methods`} />
-          {interfaceMethods.map(method => renderMethod(method, { exposeInSidebar: false }))}
+          {interfaceMethods.map(method =>
+            renderMethod(method, { exposeInSidebar: false, sdkVersion })
+          )}
         </>
       ) : undefined}
       {interfaceFields.length ? (
@@ -148,7 +148,7 @@ const renderInterface = ({
           <BoxSectionHeader text={`${name} Properties`} />
           <Table>
             <ParamsTableHeadRow />
-            <tbody>{interfaceFields.map(renderInterfacePropertyRow)}</tbody>
+            <tbody>{interfaceFields.map(f => renderInterfacePropertyRow(f, sdkVersion))}</tbody>
           </Table>
           <br />
         </>
@@ -157,11 +157,11 @@ const renderInterface = ({
   );
 };
 
-const APISectionInterfaces = ({ data }: APISectionInterfacesProps) =>
+const APISectionInterfaces = ({ data, sdkVersion }: APISectionInterfacesProps) =>
   data?.length ? (
     <>
       <H2 key="interfaces-header">Interfaces</H2>
-      {data.map(renderInterface)}
+      {data.map(d => renderInterface(d, sdkVersion))}
     </>
   ) : null;
 

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -29,6 +29,7 @@ import { H2, LI, UL, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionMethodsProps = {
   data: (MethodDefinitionData | PropData)[];
+  sdkVersion: string;
   apiName?: string;
   header?: string;
   exposeInSidebar?: boolean;
@@ -36,6 +37,7 @@ export type APISectionMethodsProps = {
 
 export type RenderMethodOptions = {
   apiName?: string;
+  sdkVersion: string;
   header?: string;
   exposeInSidebar?: boolean;
   baseNestingLevel?: number;
@@ -43,7 +45,7 @@ export type RenderMethodOptions = {
 
 export const renderMethod = (
   method: MethodDefinitionData | AccessorDefinitionData | PropData,
-  { apiName, exposeInSidebar = true, ...options }: RenderMethodOptions = {}
+  { apiName, exposeInSidebar = true, sdkVersion, ...options }: RenderMethodOptions
 ) => {
   const signatures =
     (method as MethodDefinitionData).signatures ||
@@ -72,18 +74,18 @@ export const renderMethod = (
           </HeaderComponent>
           {parameters && parameters.length > 0 && (
             <>
-              {renderParams(parameters)}
+              {renderParams(parameters, sdkVersion)}
               <br />
             </>
           )}
           <CommentTextBlock comment={comment} includePlatforms={false} />
-          {resolveTypeName(type) !== 'undefined' && (
+          {resolveTypeName(type, sdkVersion) !== 'undefined' && (
             <>
               <BoxSectionHeader text="Returns" />
               <UL className="!list-none !ml-0">
                 <LI>
                   <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" />
-                  <APIDataType typeDefinition={type} />
+                  <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
                 </LI>
               </UL>
               <>
@@ -100,6 +102,7 @@ export const renderMethod = (
 
 const APISectionMethods = ({
   data,
+  sdkVersion,
   apiName,
   header = 'Methods',
   exposeInSidebar = true,
@@ -108,7 +111,7 @@ const APISectionMethods = ({
     <>
       <H2 key={`${header}-header`}>{header}</H2>
       {data.map((method: MethodDefinitionData | PropData) =>
-        renderMethod(method, { apiName, header, exposeInSidebar })
+        renderMethod(method, { apiName, sdkVersion, header, exposeInSidebar })
       )}
     </>
   ) : null;
@@ -117,6 +120,7 @@ export default APISectionMethods;
 
 export const APIMethod = ({
   name,
+  sdkVersion,
   comment,
   returnTypeName,
   isProperty = false,
@@ -127,6 +131,7 @@ export const APIMethod = ({
 }: {
   exposeInSidebar?: boolean;
   name: string;
+  sdkVersion: string;
   comment: string;
   returnTypeName: string;
   isProperty: boolean;
@@ -168,6 +173,6 @@ export const APIMethod = ({
       ],
       kind: isProperty ? TypeDocKind.Property : TypeDocKind.Function,
     },
-    { exposeInSidebar }
+    { sdkVersion, exposeInSidebar }
   );
 };

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -22,6 +22,7 @@ import { H2, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionNamespacesProps = {
   data: GeneratedData[];
+  sdkVersion: string;
 };
 
 const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
@@ -31,7 +32,11 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   !child.name.startsWith('_') &&
   !child?.implementationOf;
 
-const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolean): JSX.Element => {
+const renderNamespace = (
+  namespace: ClassDefinitionData,
+  exposeInSidebar: boolean,
+  sdkVersion: string
+): JSX.Element => {
   const { name, comment, children } = namespace;
 
   const methods = children
@@ -59,20 +64,20 @@ const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolea
       {methods?.length ? (
         <>
           <BoxSectionHeader text={`${name} Methods`} exposeInSidebar={exposeInSidebar} />
-          {methods.map(method => renderMethod(method, { exposeInSidebar }))}
+          {methods.map(method => renderMethod(method, { exposeInSidebar, sdkVersion }))}
         </>
       ) : undefined}
     </div>
   );
 };
 
-const APISectionNamespaces = ({ data }: APISectionNamespacesProps) => {
+const APISectionNamespaces = ({ data, sdkVersion }: APISectionNamespacesProps) => {
   if (data?.length) {
     const exposeInSidebar = data.length < 2;
     return (
       <>
         <H2>Namespaces</H2>
-        {data.map(namespace => renderNamespace(namespace, exposeInSidebar))}
+        {data.map(namespace => renderNamespace(namespace, exposeInSidebar, sdkVersion))}
       </>
     );
   }

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -5,18 +5,22 @@ import { CommentTextBlock, resolveTypeName } from './APISectionUtils';
 
 describe('APISectionUtils.resolveTypeName', () => {
   test('void', () => {
-    const { container } = render(<>{resolveTypeName({ type: 'intrinsic', name: 'void' })}</>);
+    const { container } = render(
+      <>{resolveTypeName({ type: 'intrinsic', name: 'void' }, 'v49.0.0')}</>
+    );
     expect(container).toMatchSnapshot();
   });
 
   test('generic type', () => {
-    const { container } = render(<>{resolveTypeName({ type: 'intrinsic', name: 'string' })}</>);
+    const { container } = render(
+      <>{resolveTypeName({ type: 'intrinsic', name: 'string' }, 'v49.0.0')}</>
+    );
     expect(container).toMatchSnapshot();
   });
 
   test('custom type', () => {
     const { container } = render(
-      <>{resolveTypeName({ type: 'reference', name: 'SpeechSynthesisEvent' })}</>
+      <>{resolveTypeName({ type: 'reference', name: 'SpeechSynthesisEvent' }, 'v49.0.0')}</>
     );
     expect(container).toMatchSnapshot();
   });
@@ -24,10 +28,13 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('custom type array', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'array',
-          elementType: { type: 'reference', name: 'AppleAuthenticationScope' },
-        })}
+        {resolveTypeName(
+          {
+            type: 'array',
+            elementType: { type: 'reference', name: 'AppleAuthenticationScope' },
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -36,10 +43,13 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('custom type non-linkable array', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'array',
-          elementType: { type: 'reference', name: 'T' },
-        })}
+        {resolveTypeName(
+          {
+            type: 'array',
+            elementType: { type: 'reference', name: 'T' },
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -48,11 +58,14 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('query type', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [{ queryType: { type: 'reference', name: 'View' }, type: 'query' }],
-          name: 'React.ComponentProps',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [{ queryType: { type: 'reference', name: 'View' }, type: 'query' }],
+            name: 'React.ComponentProps',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -61,11 +74,14 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('Promise', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [{ type: 'intrinsic', name: 'void' }],
-          name: 'Promise',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [{ type: 'intrinsic', name: 'void' }],
+            name: 'Promise',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -74,11 +90,14 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('Promise with custom type', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [{ type: 'reference', name: 'AppleAuthenticationCredential' }],
-          name: 'Promise',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [{ type: 'reference', name: 'AppleAuthenticationCredential' }],
+            name: 'Promise',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -87,14 +106,17 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('Record', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [
-            { type: 'intrinsic', name: 'string' },
-            { type: 'intrinsic', name: 'any' },
-          ],
-          name: 'Record',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [
+              { type: 'intrinsic', name: 'string' },
+              { type: 'intrinsic', name: 'any' },
+            ],
+            name: 'Record',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -103,20 +125,28 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('alternative generic object notation', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'array',
-          elementType: {
-            type: 'reflection',
-            declaration: {
-              name: '__type',
-              indexSignature: {
-                name: '__index',
-                parameters: [{ name: 'column', type: { type: 'intrinsic', name: 'string' } }],
-                type: { type: 'intrinsic', name: 'any' },
+        {resolveTypeName(
+          {
+            type: 'array',
+            elementType: {
+              type: 'reflection',
+              declaration: {
+                name: '__type',
+                indexSignature: {
+                  name: '__index',
+                  parameters: [
+                    {
+                      name: 'column',
+                      type: { type: 'intrinsic', name: 'string' },
+                    },
+                  ],
+                  type: { type: 'intrinsic', name: 'any' },
+                },
               },
             },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -125,21 +155,24 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('Record with union', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [
-            { type: 'intrinsic', name: 'string' },
-            {
-              type: 'union',
-              types: [
-                { type: 'intrinsic', name: 'number' },
-                { type: 'intrinsic', name: 'boolean' },
-                { type: 'intrinsic', name: 'string' },
-              ],
-            },
-          ],
-          name: 'Record',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [
+              { type: 'intrinsic', name: 'string' },
+              {
+                type: 'union',
+                types: [
+                  { type: 'intrinsic', name: 'number' },
+                  { type: 'intrinsic', name: 'boolean' },
+                  { type: 'intrinsic', name: 'string' },
+                ],
+              },
+            ],
+            name: 'Record',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -148,13 +181,16 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('union', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'union',
-          types: [
-            { type: 'reference', name: 'SpeechEventCallback' },
-            { type: 'literal', value: null },
-          ],
-        })}
+        {resolveTypeName(
+          {
+            type: 'union',
+            types: [
+              { type: 'reference', name: 'SpeechEventCallback' },
+              { type: 'literal', value: null },
+            ],
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -163,13 +199,16 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('union with array', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'union',
-          types: [
-            { type: 'array', elementType: { type: 'intrinsic', name: 'number' } },
-            { type: 'literal', value: null },
-          ],
-        })}
+        {resolveTypeName(
+          {
+            type: 'union',
+            types: [
+              { type: 'array', elementType: { type: 'intrinsic', name: 'number' } },
+              { type: 'literal', value: null },
+            ],
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -178,13 +217,16 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('union with custom type and array', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'union',
-          types: [
-            { type: 'array', elementType: { type: 'reference', name: 'AssetRef' } },
-            { type: 'reference', name: 'AssetRef' },
-          ],
-        })}
+        {resolveTypeName(
+          {
+            type: 'union',
+            types: [
+              { type: 'array', elementType: { type: 'reference', name: 'AssetRef' } },
+              { type: 'reference', name: 'AssetRef' },
+            ],
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -193,16 +235,19 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('union of array values', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'array',
-          elementType: {
-            type: 'union',
-            types: [
-              { type: 'reference', name: 'ResultSetError' },
-              { type: 'reference', name: 'ResultSet' },
-            ],
+        {resolveTypeName(
+          {
+            type: 'array',
+            elementType: {
+              type: 'union',
+              types: [
+                { type: 'reference', name: 'ResultSetError' },
+                { type: 'reference', name: 'ResultSet' },
+              ],
+            },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -211,11 +256,14 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('generic type', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [{ type: 'reference', name: 'Asset' }],
-          name: 'PagedInfo',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [{ type: 'reference', name: 'Asset' }],
+            name: 'PagedInfo',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -224,13 +272,16 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('tuple type', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'tuple',
-          elements: [
-            { type: 'reference', name: 'SortByKey' },
-            { type: 'intrinsic', name: 'boolean' },
-          ],
-        })}
+        {resolveTypeName(
+          {
+            type: 'tuple',
+            elements: [
+              { type: 'reference', name: 'SortByKey' },
+              { type: 'intrinsic', name: 'boolean' },
+            ],
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -239,17 +290,20 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('generic type in Promise', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [
-            {
-              type: 'reference',
-              typeArguments: [{ type: 'reference', name: 'Asset' }],
-              name: 'PagedInfo',
-            },
-          ],
-          name: 'Promise',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [
+              {
+                type: 'reference',
+                typeArguments: [{ type: 'reference', name: 'Asset' }],
+                name: 'PagedInfo',
+              },
+            ],
+            name: 'Promise',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -258,25 +312,28 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('function', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reflection',
-          declaration: {
-            signatures: [
-              {
-                type: {
-                  type: 'union',
-                  types: [
-                    { type: 'intrinsic', name: 'void' },
-                    {
-                      type: 'reference',
-                      name: 'SpeechEventCallback',
-                    },
-                  ],
+        {resolveTypeName(
+          {
+            type: 'reflection',
+            declaration: {
+              signatures: [
+                {
+                  type: {
+                    type: 'union',
+                    types: [
+                      { type: 'intrinsic', name: 'void' },
+                      {
+                        type: 'reference',
+                        name: 'SpeechEventCallback',
+                      },
+                    ],
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -285,28 +342,31 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('function with arguments', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reflection',
-          declaration: {
-            signatures: [
-              {
-                parameters: [
-                  {
-                    name: 'error',
-                    type: { type: 'reference', name: 'Error' },
-                  },
-                ],
-                type: {
-                  type: 'union',
-                  types: [
-                    { type: 'intrinsic', name: 'void' },
-                    { type: 'reference', name: 'SpeechEventCallback' },
+        {resolveTypeName(
+          {
+            type: 'reflection',
+            declaration: {
+              signatures: [
+                {
+                  parameters: [
+                    {
+                      name: 'error',
+                      type: { type: 'reference', name: 'Error' },
+                    },
                   ],
+                  type: {
+                    type: 'union',
+                    types: [
+                      { type: 'intrinsic', name: 'void' },
+                      { type: 'reference', name: 'SpeechEventCallback' },
+                    ],
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -315,22 +375,25 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('function with non-linkable custom type', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reflection',
-          declaration: {
-            signatures: [
-              {
-                parameters: [
-                  {
-                    name: 'error',
-                    type: { type: 'reference', name: 'Error' },
-                  },
-                ],
-                type: { type: 'intrinsic', name: 'void' },
-              },
-            ],
+        {resolveTypeName(
+          {
+            type: 'reflection',
+            declaration: {
+              signatures: [
+                {
+                  parameters: [
+                    {
+                      name: 'error',
+                      type: { type: 'reference', name: 'Error' },
+                    },
+                  ],
+                  type: { type: 'intrinsic', name: 'void' },
+                },
+              ],
+            },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -339,21 +402,24 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('object reflection', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reflection',
-          declaration: {
-            children: [
-              {
-                name: 'target',
-                type: { type: 'intrinsic', name: 'number' },
-              },
-              {
-                name: 'value',
-                type: { type: 'intrinsic', name: 'boolean' },
-              },
-            ],
+        {resolveTypeName(
+          {
+            type: 'reflection',
+            declaration: {
+              children: [
+                {
+                  name: 'target',
+                  type: { type: 'intrinsic', name: 'number' },
+                },
+                {
+                  name: 'value',
+                  type: { type: 'intrinsic', name: 'boolean' },
+                },
+              ],
+            },
           },
-        })}
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -362,14 +428,17 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('custom type with single pick', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [
-            { type: 'reference', name: 'FontResource' },
-            { type: 'literal', value: 'display' },
-          ],
-          name: 'Pick',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [
+              { type: 'reference', name: 'FontResource' },
+              { type: 'literal', value: 'display' },
+            ],
+            name: 'Pick',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();
@@ -378,29 +447,32 @@ describe('APISectionUtils.resolveTypeName', () => {
   test('props with multiple omits', () => {
     const { container } = render(
       <>
-        {resolveTypeName({
-          type: 'reference',
-          typeArguments: [
-            {
-              type: 'reference',
-              typeArguments: [
-                { type: 'reference', name: 'ViewStyle' },
-                {
-                  type: 'union',
-                  types: [
-                    { type: 'literal', value: 'backgroundColor' },
-                    {
-                      type: 'literal',
-                      value: 'borderRadius',
-                    },
-                  ],
-                },
-              ],
-              name: 'Omit',
-            },
-          ],
-          name: 'StyleProp',
-        })}
+        {resolveTypeName(
+          {
+            type: 'reference',
+            typeArguments: [
+              {
+                type: 'reference',
+                typeArguments: [
+                  { type: 'reference', name: 'ViewStyle' },
+                  {
+                    type: 'union',
+                    types: [
+                      { type: 'literal', value: 'backgroundColor' },
+                      {
+                        type: 'literal',
+                        value: 'borderRadius',
+                      },
+                    ],
+                  },
+                ],
+                name: 'Omit',
+              },
+            ],
+            name: 'StyleProp',
+          },
+          'v49.0.0'
+        )}
       </>
     );
     expect(container).toMatchSnapshot();

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -198,6 +198,15 @@ const hardcodedTypeLinks: Record<string, string> = {
   WebGLFramebuffer: 'https://developer.mozilla.org/en-US/docs/Web/API/WebGLFramebuffer',
 };
 
+const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string>> = {
+  'v48.0.0': {
+    Manifest: '/versions/v48.0.0/sdk/constants/#manifest',
+  },
+  'v49.0.0': {
+    Manifest: '/versions/v49.0.0/sdk/constants/#manifest',
+  },
+};
+
 const packageLinks: Record<string, string> = {
   'expo-manifests': 'manifests',
 };
@@ -206,10 +215,12 @@ const renderWithLink = ({
   name,
   type,
   typePackage,
+  sdkVersion,
 }: {
   name: string;
   type?: string;
   typePackage: string | undefined;
+  sdkVersion: string;
 }) => {
   const replacedName = replaceableTypes[name] ?? name;
 
@@ -230,7 +241,11 @@ const renderWithLink = ({
     replacedName + (type === 'array' ? '[]' : '')
   ) : (
     <A
-      href={hardcodedTypeLinks[replacedName] || `#${replacedName.toLowerCase()}`}
+      href={
+        sdkVersionHardcodedTypeLinks[sdkVersion]?.[replacedName] ??
+        hardcodedTypeLinks[replacedName] ??
+        `#${replacedName.toLowerCase()}`
+      }
       key={`type-link-${replacedName}`}>
       {replacedName}
       {type === 'array' && '[]'}
@@ -238,9 +253,9 @@ const renderWithLink = ({
   );
 };
 
-const renderUnion = (types: TypeDefinitionData[]) =>
+const renderUnion = (types: TypeDefinitionData[], { sdkVersion }: { sdkVersion: string }) =>
   types
-    .map(type => resolveTypeName(type))
+    .map(type => resolveTypeName(type, sdkVersion))
     .map((valueToRender, index) => (
       <span key={`union-type-${index}`}>
         {valueToRender}
@@ -249,7 +264,8 @@ const renderUnion = (types: TypeDefinitionData[]) =>
     ));
 
 export const resolveTypeName = (
-  typeDefinition: TypeDefinitionData
+  typeDefinition: TypeDefinitionData,
+  sdkVersion: string
 ): string | JSX.Element | (string | JSX.Element)[] => {
   if (!typeDefinition) {
     return 'undefined';
@@ -281,7 +297,7 @@ export const resolveTypeName = (
                 <span className="text-quaternary">{'<'}</span>
                 {typeArguments.map((type, index) => (
                   <span key={`record-type-${index}`}>
-                    {resolveTypeName(type)}
+                    {resolveTypeName(type, sdkVersion)}
                     {index !== typeArguments.length - 1 ? (
                       <span className="text-quaternary">, </span>
                     ) : null}
@@ -293,11 +309,11 @@ export const resolveTypeName = (
           } else {
             return (
               <>
-                {renderWithLink({ name, typePackage: typeDefinition.package })}
+                {renderWithLink({ name, typePackage: typeDefinition.package, sdkVersion })}
                 <span className="text-quaternary">{'<'}</span>
                 {typeArguments.map((type, index) => (
                   <span key={`${name}-nested-type-${index}`}>
-                    {resolveTypeName(type)}
+                    {resolveTypeName(type, sdkVersion)}
                     {index !== typeArguments.length - 1 ? (
                       <span className="text-quaternary">, </span>
                     ) : null}
@@ -308,7 +324,7 @@ export const resolveTypeName = (
             );
           }
         } else {
-          return renderWithLink({ name, typePackage: typeDefinition.package });
+          return renderWithLink({ name, typePackage: typeDefinition.package, sdkVersion });
         }
       } else {
         return name;
@@ -319,6 +335,7 @@ export const resolveTypeName = (
           name: elementType.name,
           type,
           typePackage: typeDefinition.package,
+          sdkVersion,
         });
       } else if (type === 'array') {
         return elementType.name + '[]';
@@ -328,17 +345,17 @@ export const resolveTypeName = (
       if (type === 'array') {
         const { parameters, type: paramType } = elementType.declaration.indexSignature || {};
         if (parameters && paramType) {
-          return `{ [${listParams(parameters)}]: ${resolveTypeName(paramType)} }`;
+          return `{ [${listParams(parameters)}]: ${resolveTypeName(paramType, sdkVersion)} }`;
         }
       }
       return elementType.name + type;
     } else if (type === 'union' && types?.length) {
-      return renderUnion(types);
+      return renderUnion(types, { sdkVersion });
     } else if (elementType && elementType.type === 'union' && elementType?.types?.length) {
       const unionTypes = elementType?.types || [];
       return (
         <>
-          ({renderUnion(unionTypes)}){type === 'array' && '[]'}
+          ({renderUnion(unionTypes, { sdkVersion })}){type === 'array' && '[]'}
         </>
       );
     } else if (declaration?.signatures) {
@@ -350,18 +367,20 @@ export const resolveTypeName = (
             {baseSignature.parameters?.map((param, index) => (
               <span key={`param-${index}-${param.name}`}>
                 {param.name}
-                <span className="text-quaternary">:</span> {resolveTypeName(param.type)}
+                <span className="text-quaternary">:</span> {resolveTypeName(param.type, sdkVersion)}
                 {index + 1 !== baseSignature.parameters?.length && ', '}
               </span>
             ))}
             <span className="text-quaternary">)</span>{' '}
-            <span className="text-quaternary">{'=>'}</span> {resolveTypeName(baseSignature.type)}
+            <span className="text-quaternary">{'=>'}</span>{' '}
+            {resolveTypeName(baseSignature.type, sdkVersion)}
           </>
         );
       } else {
         return (
           <>
-            <span className="text-quaternary">{'() =>'}</span> {resolveTypeName(baseSignature.type)}
+            <span className="text-quaternary">{'() =>'}</span>{' '}
+            {resolveTypeName(baseSignature.type, sdkVersion)}
           </>
         );
       }
@@ -373,7 +392,7 @@ export const resolveTypeName = (
             <span key={`reflection-${name}-${i}`}>
               {'  '}
               {child.name + ': '}
-              {resolveTypeName(child.type)}
+              {resolveTypeName(child.type, sdkVersion)}
               {i + 1 !== declaration?.children?.length ? ', ' : null}
               {'\n'}
             </span>
@@ -387,7 +406,7 @@ export const resolveTypeName = (
           [
           {elements.map((elem, i) => (
             <span key={`tuple-${name}-${i}`}>
-              {resolveTypeName(elem)}
+              {resolveTypeName(elem, sdkVersion)}
               {i + 1 !== elements.length ? ', ' : null}
             </span>
           ))}
@@ -405,7 +424,7 @@ export const resolveTypeName = (
         .filter(({ name }) => !omittableTypes.includes(name ?? ''))
         .map((value, index, array) => (
           <span key={`intersection-${name}-${index}`}>
-            {resolveTypeName(value)}
+            {resolveTypeName(value, sdkVersion)}
             {index + 1 !== array.length && ' & '}
           </span>
         ));
@@ -427,13 +446,10 @@ export const resolveTypeName = (
 
 export const parseParamName = (name: string) => (name.startsWith('__') ? name.substr(2) : name);
 
-export const renderParamRow = ({
-  comment,
-  name,
-  type,
-  flags,
-  defaultValue,
-}: MethodParamData): JSX.Element => {
+export const renderParamRow = (
+  { comment, name, type, flags, defaultValue }: MethodParamData,
+  sdkVersion: string
+): JSX.Element => {
   const defaultData = getTagData('default', comment);
   const initValue = parseCommentContent(
     defaultValue || (defaultData ? getCommentContent(defaultData.content) : '')
@@ -445,7 +461,7 @@ export const renderParamRow = ({
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell>
-        <APIDataType typeDefinition={type} />
+        <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </Cell>
       <Cell>
         <CommentTextBlock
@@ -501,10 +517,10 @@ export const BoxSectionHeader = ({
   );
 };
 
-export const renderParams = (parameters: MethodParamData[]) => (
+export const renderParams = (parameters: MethodParamData[], sdkVersion: string) => (
   <Table>
     <ParamsTableHeadRow />
-    <tbody>{parameters?.map(renderParamRow)}</tbody>
+    <tbody>{parameters?.map(p => renderParamRow(p, sdkVersion))}</tbody>
   </Table>
 );
 
@@ -518,11 +534,17 @@ export const renderDefaultValue = (defaultValue?: string) =>
     </div>
   ) : undefined;
 
-export const renderTypeOrSignatureType = (
-  type?: TypeDefinitionData,
-  signatures?: MethodSignatureData[] | TypeSignaturesData[],
-  allowBlock: boolean = false
-) => {
+export const renderTypeOrSignatureType = ({
+  type,
+  signatures,
+  allowBlock = false,
+  sdkVersion,
+}: {
+  type?: TypeDefinitionData;
+  signatures?: MethodSignatureData[] | TypeSignaturesData[];
+  allowBlock?: boolean;
+  sdkVersion: string;
+}) => {
   if (signatures && signatures.length) {
     return (
       <CODE key={`signature-type-${signatures[0].name}`}>
@@ -533,19 +555,19 @@ export const renderTypeOrSignatureType = (
               <span key={`signature-param-${param.name}`}>
                 {param.name}
                 {param.flags?.isOptional && '?'}
-                <span className="text-quaternary">:</span> {resolveTypeName(param.type)}
+                <span className="text-quaternary">:</span> {resolveTypeName(param.type, sdkVersion)}
               </span>
             ))
         )}
         <span className="text-quaternary">{') =>'}</span>{' '}
-        {signatures[0].type ? resolveTypeName(signatures[0].type) : 'void'}
+        {signatures[0].type ? resolveTypeName(signatures[0].type, sdkVersion) : 'void'}
       </CODE>
     );
   } else if (type) {
     if (allowBlock) {
-      return <APIDataType typeDefinition={type} />;
+      return <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />;
     }
-    return <CODE key={`signature-type-${type.name}`}>{resolveTypeName(type)}</CODE>;
+    return <CODE key={`signature-type-${type.name}`}>{resolveTypeName(type, sdkVersion)}</CODE>;
   }
   return undefined;
 };


### PR DESCRIPTION
# Why

`hardcodedTypeLinks` needs to be versioned since the link can change depending on the SDK version. This is mainly true for SDK 48 and SDK 49 for the updates Manifest type, where if the type were overridden for SDK 50 as well it would make SDK 50 incorrect.

# How

Add `sdkVersionHardcodedTypeLinks`, pass sdkVersion through the render tree. Could maybe have also accomplished this with a context field, but I haven't really done those before so idk. If someone who knows more about context wants to give that a try, feel free to supplant this PR.

# Test Plan

Go to updates reference for 48, 49, ensure that the manifest links now work correctly.
Sanity check 50 as well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
