### PR TITLE
[templates] Fix canary templates including node_modules

### DIFF
--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "expo-template-blank-typescript",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "version": "50.0.16",
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -2,7 +2,7 @@
   "name": "expo-template-blank",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "version": "50.0.16",
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
# Why

`expo-template-blank` and `expo-template-blank-typescript` has the main that points to `node_modules/expo/AppEntry.js`. This causes `npm pack` to bundle the entire `node_modules` folder (if exists) in the tarball.
Changing it to `expo/AppEntry.js` is enough to fix that behavior. This is also what `expo-template-tabs` does (it has `expo-router/entry`).

# How

Changed the main entry point of the blank templates

# Test Plan

In the template folder I ran `yarn` and then `npm pack` to confirm the tarball is small and doesn't include node_modules