### PR TITLE
[core][iOS] Emit events to shared objects directly from C++

### DIFF
--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -103,6 +103,12 @@ public:
 };
 
 /**
+ Emits an event with the given name and arguments to the emitter object.
+ Does nothing if the given object is not an instance of the EventEmitter class.
+ */
+void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments);
+
+/**
  Gets `expo.EventEmitter` class from the given runtime.
  */
 jsi::Function getClass(jsi::Runtime &runtime);

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -58,4 +58,9 @@ NS_SWIFT_NAME(JSIUtils)
 
 + (nonnull EXJavaScriptObject *)createNativeModuleObject:(nonnull EXJavaScriptRuntime *)runtime;
 
++ (void)emitEvent:(nonnull NSString *)eventName
+         toObject:(nonnull EXJavaScriptObject *)object
+    withArguments:(nonnull NSArray<id> *)arguments
+        inRuntime:(nonnull EXJavaScriptRuntime *)runtime;
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -7,6 +7,7 @@
 #import <ExpoModulesCore/EXJSIUtils.h>
 #import <ExpoModulesCore/JSIUtils.h>
 #import <ExpoModulesCore/NativeModule.h>
+#import <ExpoModulesCore/EventEmitter.h>
 
 namespace expo {
 
@@ -142,6 +143,15 @@ jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *messa
 {
   std::shared_ptr<jsi::Object> nativeModule = std::make_shared<jsi::Object>(expo::NativeModule::createInstance(*[runtime get]));
   return [[EXJavaScriptObject alloc] initWith:nativeModule runtime:runtime];
+}
+
++ (void)emitEvent:(nonnull NSString *)eventName
+         toObject:(nonnull EXJavaScriptObject *)object
+    withArguments:(nonnull NSArray<id> *)arguments
+        inRuntime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  const std::vector<jsi::Value> argumentsVector(expo::convertNSArrayToStdVector(*[runtime get], arguments));
+  expo::EventEmitter::emitEvent(*[runtime get], *[object get], [eventName UTF8String], std::move(argumentsVector));
 }
 
 @end


### PR DESCRIPTION
# Why

Emitting events by calling JS methods is probably not the best idea due to performance reasons, JS calls will always be slower.

# How

Instead of calling JS function from native, I exposed `emitEvent` function from C++ and used it directly from Swift & Objective-C.

# Test Plan

Unit tests are still passing. I also tested it in NCL by emitting an event to the player from `expo-video`.