### PR TITLE
[core] fix RCTHost not retained

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26587](https://github.com/expo/expo/pull/26587) by [@kudo](https://github.com/kudo))
 - [Android] Unit converter now ignores nullability. It will always return unit regardless of whether the input value is null or not. ([#27591](https://github.com/expo/expo/pull/27591) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -2,7 +2,6 @@
 
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 
-#import <objc/runtime.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RCTHost.h>

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -57,11 +57,11 @@
   NSString *moduleName = _moduleName ?: appDelegate.moduleName;
   NSDictionary *initialProperties = _initialProperties ?: appDelegate.initialProps;
 
-   if (![appDelegate.rootViewFactory isKindOfClass:EXReactRootViewFactory.class]) {
-     @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                    reason:@"The appDelegate.rootViewFactory must be an EXReactRootViewFactory instance."
-                                  userInfo:nil];
-   }
+  if (![appDelegate.rootViewFactory isKindOfClass:EXReactRootViewFactory.class]) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"The appDelegate.rootViewFactory must be an EXReactRootViewFactory instance."
+                                 userInfo:nil];
+  }
   EXReactRootViewFactory *appRootViewFactory = (EXReactRootViewFactory *)appDelegate.rootViewFactory;
   RCTRootViewFactoryConfiguration *appRootViewFactoryConfiguration = [appRootViewFactory valueForKey:@"_configuration"];
 


### PR DESCRIPTION
# Why

fix blank view on ios bridgeless mode 

# How

unlike RCTBridge which is retained by RCTRootView. the `RCTHost` is retained by `RCTRootViewFactory` and the RCTRootViewFactory is retained by AppDelegate. if we create a local `RCTRootViewFactory.viewWithModuleName:...`, the created RCTHost will be released right away.

this pr tries to retain the RCTHost/RCTBridge by the root view.

# Test Plan

test on https://github.com/brentvatne/blank-bridgeless 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
