### PR TITLE
[docs] Added instruction on installing development build with EAS CLI

### DIFF
--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -32,14 +32,13 @@ You can also direct your teammate to the build page in the Expo dashboard. From 
   src="/static/images/share-dev-build/expo-dashboard.png"
 />
 
-### Get development build with EAS CLI
+### Use EAS CLI
 
-Your teammate can also download and install the development build using EAS CLI.
-Make sure to sign in to the Expo Account associated with the app before running the command.
+Your teammate can also download and install the development build using EAS CLI. They have to make sure that they are signed from the Expo account associated with the development build and then can run the following command:
 
 <Terminal cmd={['$ eas build:run --profile development']} />
 
-Change the build profile if you define a different name for the development build.
+If the profile name for the development build is different from `development`, use it instead with `--profile`.
 
 ### iOS-only instructions
 

--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -8,6 +8,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { Terminal } from '~/ui/components/Snippet';
 
 Android and iOS both offer ways to install a build of your application directly on devices. This gives you full control of putting specific builds on devices, allowing you to iterate quickly and have multiple builds of your application available for review at the same time. You can also share it with your team or run it on multiple test devices.
 
@@ -30,6 +31,15 @@ You can also direct your teammate to the build page in the Expo dashboard. From 
   alt="An example of shareable development build URL from Expo dashboard."
   src="/static/images/share-dev-build/expo-dashboard.png"
 />
+
+### Get development build with EAS CLI
+
+Your teammate can also download and install the development build using EAS CLI.
+Make sure to sign in to the Expo Account associated with the app before running the command.
+
+<Terminal cmd={['$ eas build:run --profile development']} />
+
+Change the build profile if you define a different name for the development build.
 
 ### iOS-only instructions
 


### PR DESCRIPTION
# Why

Added download and install development build using EAS CLI instruction as shared by @brentvatne on Discord [link](https://discord.com/channels/695411232856997968/695411232856997971/1218359215836495912)

This will help developers download and install the build directly without leaving their terminal.

# How

Updated the `share-with-your-team.mdx` file and include a terminal command.

# Test Plan

Run the docs locally and review the `Share With Your Team` page.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
