### PR TITLE
[docs] Update Yarn recommendation in Get started section to Yarn 1

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -52,7 +52,7 @@ After installing Node.js, you can use `npx` to create a new app.
 
 ## Recommended tools
 
-- [Yarn](https://classic.yarnpkg.com/en/docs/install) for faster and more reliable dependency management. Use this instead of `npm` and `npx`.
+- [Yarn 1 (Classic)](https://classic.yarnpkg.com/en/docs/install) for faster and more reliable dependency management. Use this instead of `npm` and `npx`.
 - [VS Code editor](https://code.visualstudio.com/download) and the [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) for easier debugging and app config autocomplete.
 
 If you are using Yarn, you can bootstrap a new app using the following command:
@@ -62,6 +62,7 @@ If you are using Yarn, you can bootstrap a new app using the following command:
 ## Windows terminal support
 
 The Expo CLI is compatible with the following terminals on Windows 10 and higher:
+
 - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/overview) (the default terminal)
 - WSL 2 (Windows Subsystem for Linux) using a Bash shell
 

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -52,7 +52,7 @@ After installing Node.js, you can use `npx` to create a new app.
 
 ## Recommended tools
 
-- [Yarn 1 (Classic)](https://classic.yarnpkg.com/en/docs/install) for faster and more reliable dependency management. Use this instead of `npm` and `npx`.
+- [Yarn Classic (v1)](https://classic.yarnpkg.com/en/docs/install) for faster and more reliable dependency management. Use this instead of `npm` and `npx`.
 - [VS Code editor](https://code.visualstudio.com/download) and the [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) for easier debugging and app config autocomplete.
 
 If you are using Yarn, you can bootstrap a new app using the following command:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Reference: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1710368002590169)

Until we start supporting Yarn 2+ out of the box, in our recommended tools, we should mention Yarn 1. Right now, initializing a project with Yarn 4, doesn't use the node-modules node-linker by default.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update "Yarn" to "Yarn 1 (Classic)" in Get started > Installation > Recommended tools section.
- Apply Prettier formatting.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
