### PR TITLE
[core][iOS] Allow emitting complex arguments, e.g. records

### DIFF
--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -39,6 +39,10 @@ open class SharedObject: AnySharedObject {
 // When put in the class, pack expansion is crashing with `EXC_BAD_ACCESS` code.
 // See https://github.com/apple/swift/issues/72381 for more details.
 public extension SharedObject { // swiftlint:disable:this no_grouping_extension
+  // Parameter packs feature requires Swift 5.9 (Xcode 15.0), but some CIs and EAS images may still use older versions.
+  // As of April 29, all submissions must be made with Xcode 15, so hopefully we can remove this condition soon.
+  // No one should use <15.0 these days.
+  #if swift(>=5.9)
   /**
    Schedules an event with the given name and arguments to be emitted to the associated JavaScript object.
    */
@@ -67,4 +71,10 @@ public extension SharedObject { // swiftlint:disable:this no_grouping_extension
       JSIUtils.emitEvent(event, to: jsObject, withArguments: arguments, in: runtime)
     }
   }
+  #else // swift(>=5.9)
+  @available(*, unavailable, message: "Unavailable in Xcode <15.0")
+  public func emit(event: String, arguments: AnyArgument...) {
+    fatalError("Emitting events to JS requires at least Xcode 15.0")
+  }
+  #endif // swift(<5.9)
 }

--- a/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
@@ -91,6 +91,9 @@ final class SharedObjectSpec: ExpoSpec {
     }
 
     describe("Native object") {
+      // Event emitting requires Xcode 15.0, but we're still using Xcode 14
+      // to run these tests on GitHub Actions due to some performance issues.
+      #if swift(>=5.9)
       it("emits events") {
         // Create the shared object
         let jsObject = try runtime
@@ -120,6 +123,7 @@ final class SharedObjectSpec: ExpoSpec {
         expect(try result.getProperty("string").asString()) == "test"
         expect(try result.getProperty("record").asObject().getProperty("boolean").asBool()) == true
       }
+      #endif // swift(>=5.9)
     }
   }
 }


### PR DESCRIPTION
# Why

Shared objects were not able to emit events with complex arguments such as records, other shared objects or JS values.

# How

- Used [parameter packs](https://www.hackingwithswift.com/swift/5.9/variadic-generics) to support variadic number of arguments with different types conforming to `AnyArgument`.
- Renamed `sendEvent(name:args:)` to `emit(event:arguments)` to match the JS side.
- Since parameter packs are supported only as of Swift 5.9 (Xcode 15.0), I marked the emit function as unavailable there. I think it's fine because no one should use Xcode <15.0 anymore. We do that on our CI but only for performance reasons.

I've found an issue in Swift that prevents us from using the parameter packs within the `SharedObject` class definition, so I opened a bug report here https://github.com/apple/swift/issues/72381.
A workaround is to define that function in the extension.

# Test Plan

I adjusted the existing test to also cover emitting records. However, because our CI workflow for native unit tests is running on Xcode 14, I disabled it there.

<!-- disable:changelog-checks -->