### PR TITLE
[core][Android] Simplify unit type converter

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
@@ -1,15 +1,11 @@
 package expo.modules.kotlin.types
 
-import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
-class UnitTypeConverter : DynamicAwareTypeConverters<Any>(true) {
-  override fun convertFromDynamic(value: Dynamic): Any {
-    return Unit
-  }
-
-  override fun convertFromAny(value: Any): Any = Unit
+class UnitTypeConverter : TypeConverter<Unit>() {
+  override fun convert(value: Any?, context: AppContext?) = Unit
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }


### PR DESCRIPTION
# Why

Simplifies unit type converter.
It doesn't change the behavior, but we can make the unit converter much simpler. 