### PR TITLE
[templates] Remove the rest of expo-updates stuff from the native templates

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
   </queries>
 
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme">
-    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="YOUR-APP-URL-HERE"/>
     <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/Supporting/Expo.plist
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/Supporting/Expo.plist
@@ -2,7 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-        <key>EXUpdatesURL</key>
-        <string>YOUR-APP-URL-HERE</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Why

Wasn't aware that there was expo-updates stuff in these templates to begin with. I think it's a remnant of classic updates which are gone as of SDK 50. It's especially not needed since `expo-updates` isn't in the package.json: https://github.com/expo/expo/blob/e1bd9fd075a8593a0770431503549ef705693756/templates/expo-template-bare-minimum/package.json

This is a continuation of https://github.com/expo/expo/commit/af634b1c84ea9eeb1505bd580efa5381b66ef8d3 and https://github.com/expo/expo/commit/dd8f245bfb048ed385cee09673339769bd2dd343.

# How

Remove.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
