### PR TITLE
Updated map-view.mdx instructions

### DIFF
--- a/docs/pages/versions/v50.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/map-view.mdx
@@ -109,7 +109,16 @@ const styles = StyleSheet.create({
 <Step label="4">
 #### Add the API key to your project
 
-- Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
+- Copy your **API Key** into your your .env file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` field like so 
+```json
+    "android": {
+      "config": {
+        "googleMaps": {
+          "apiKey": "process.env.GOOGLE_MAPS_API_KEY",
+        },
+      },
+    }
+```
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/create-a-build/#create-a-development-build-for-emulatorsimulator).
 
@@ -142,7 +151,15 @@ const styles = StyleSheet.create({
 <Step label="3">
 #### Add the API key to your project
 
-- Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
+- Copy your **API Key** into your your .env file and then add it to your **app.json** under `ios.config.googleMapsApiKey` field like so:
+
+```json
+    "ios": {
+      "config": {
+        "googleMapsApiKey":  "process.env.GOOGLE_MAPS_API_KEY",
+        },
+      }
+```
 - In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
 - Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/develop/development-builds/create-a-build/#create-a-development-build-for-emulatorsimulator).
 


### PR DESCRIPTION
# Why
Current instructions could lead user's to accidentally leaking Google Maps API key given app.json is not ignored by default in '.gitignore' when bootstrapping a project with ''npx create-expo-app@latest -t tabs@50' " from (https://expo.dev/changelog/2024/01-23-router-3)



- [ *] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ *] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ *] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
