### PR TITLE
[sqlite] enable FTS

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -491,6 +491,8 @@ PODS:
   - ExpoSQLite (13.1.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
+    - sqlite3/fts (~> 3.42.0)
+    - sqlite3/fts5 (~> 3.42.0)
   - ExpoStoreReview (6.8.2):
     - ExpoModulesCore
   - ExpoSymbols (0.0.1):
@@ -1919,6 +1921,10 @@ PODS:
   - sqlite3 (3.42.0):
     - sqlite3/common (= 3.42.0)
   - sqlite3/common (3.42.0)
+  - sqlite3/fts (3.42.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.42.0):
+    - sqlite3/common
   - UMAppLoader (4.5.0)
   - Yoga (0.0.0)
   - ZXingObjC/Core (3.6.9)
@@ -2518,7 +2524,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 752ad6ae2b693de9cd4e7fddb78297bdc658b815
   ExpoSMS: aca5b62dbfef73670cb35d0ebd9a2017899bbb2d
   ExpoSpeech: 5e108798facd5e77e0ff040bdae6907aebeed6c5
-  ExpoSQLite: d94fa32e0c3c0038f6bd345530f4816abb0b89fb
+  ExpoSQLite: 9ef28fb70cdf40a134cbb6b59c85d5e7b8b3acb4
   ExpoStoreReview: c39b480799f1d7239f6100e9a79edbef64f2e733
   ExpoSymbols: 01f91e307a4b8bee4da4fc5bc47efe912a5cfcde
   ExpoSystemUI: 921601d83ed776533f1d654f02c0fdece0a0632b

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Enabled [FTS](https://www.sqlite.org/fts3.html) and [FTS5](https://www.sqlite.org/fts5.html) for SQLite. ([#27738](https://github.com/expo/expo/pull/27738) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-sqlite/android/CMakeLists.txt
+++ b/packages/expo-sqlite/android/CMakeLists.txt
@@ -10,11 +10,10 @@ set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
 set(SRC_DIR "${CMAKE_SOURCE_DIR}/src/main/cpp")
 file(GLOB SOURCES "${SRC_DIR}/*.cpp")
 
-if (NOT "${SQLITE_CUSTOM_BUILDFLAGS}" STREQUAL "")
-  add_compile_options(
-    "${SQLITE_CUSTOM_BUILDFLAGS}"
-  )
-endif()
+separate_arguments(SQLITE_BUILDFLAGS)
+add_compile_options(
+  ${SQLITE_BUILDFLAGS}
+)
 
 add_library(
   ${PACKAGE_NAME}

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -32,6 +32,20 @@ def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
 def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
 def SQLITE3_SRC_DIR = new File("$buildDir/sqlite3_src")
 
+def getSQLiteBuildFlags() {
+  def buildFlags = ''
+  if (findProperty('expo.sqlite.enableFTS') !== 'false') {
+    buildFlags <<= '-DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
+  } else {
+  }
+  def customBuildFlags = findProperty('expo.sqlite.customBuildFlags') ?: ''
+  if (customBuildFlags != '') {
+    buildFlags <<= " ${customBuildFlags}"
+  }
+  logger.info("SQLite build flags: ${buildFlags}")
+  return buildFlags
+}
+
 def reactNativeArchitectures() {
   def value = project.getProperties().get("reactNativeArchitectures")
   return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
@@ -123,7 +137,7 @@ android {
         abiFilters (*reactNativeArchitectures())
         arguments "-DANDROID_STL=c++_shared",
           "-DSQLITE3_SRC_DIR=${toPlatformIndependentPath(SQLITE3_SRC_DIR)}",
-          "-DSQLITE_CUSTOM_BUILDFLAGS=${findProperty('expo.sqlite.customBuildFlags') ?: ''}"
+          "-DSQLITE_BUILDFLAGS=${getSQLiteBuildFlags()}"
       }
     }
   }

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -1,6 +1,9 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
+
+SQLITE_VERSION = '3.42.0'
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoSQLite'
@@ -14,8 +17,12 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.dependency 'ExpoModulesCore'
-  # The builtin sqlite does not support extensions so we update it
-  s.dependency 'sqlite3', '~> 3.42.0'
+
+  s.dependency 'sqlite3', "~> #{SQLITE_VERSION}"
+  unless podfile_properties['expo.sqlite.enableFTS'] === 'false'
+    s.dependency 'sqlite3/fts', "~> #{SQLITE_VERSION}"
+    s.dependency 'sqlite3/fts5', "~> #{SQLITE_VERSION}"
+  end
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
-SQLITE_VERSION = '3.42.0'
+sqliteVersion = '3.42.0'
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoSQLite'
@@ -18,10 +18,10 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'ExpoModulesCore'
 
-  s.dependency 'sqlite3', "~> #{SQLITE_VERSION}"
+  s.dependency 'sqlite3', "~> #{sqliteVersion}"
   unless podfile_properties['expo.sqlite.enableFTS'] === 'false'
-    s.dependency 'sqlite3/fts', "~> #{SQLITE_VERSION}"
-    s.dependency 'sqlite3/fts5', "~> #{SQLITE_VERSION}"
+    s.dependency 'sqlite3/fts', "~> #{sqliteVersion}"
+    s.dependency 'sqlite3/fts5', "~> #{sqliteVersion}"
   end
 
   # Swift/Objective-C compatibility


### PR DESCRIPTION
# Why

fixes #26866
close ENG-11716

# How

- enable FTS 3/4/5 by default
- people could have `expo.sqlite.enableFTS=false` to disable the feature

side note: i also tried to investigate the android and ios default sqlite building flags
the android flags are [here](https://android.googlesource.com/platform/external/sqlite/+/d11514d85b96ef33b1a78080246df7df2cf5d9ea/dist/Android.bp#50)
ths ios flags are getting from `PRAGMA compile_options;` on ios 17 sdk:
i think the common flags are FTS. i will also add `SQLITE_ENABLE_BYTECODE_VTAB` when the 3.45.2 podspec is released.

```
Compile Option: ATOMIC_INTRINSICS=1
Compile Option: BUG_COMPATIBLE_20160819
Compile Option: CCCRYPT256
Compile Option: COMPILER=clang-15.0.0
Compile Option: DEFAULT_AUTOVACUUM
Compile Option: DEFAULT_CACHE_SIZE=128
Compile Option: DEFAULT_CKPTFULLFSYNC
Compile Option: DEFAULT_FILE_FORMAT=4
Compile Option: DEFAULT_JOURNAL_SIZE_LIMIT=32768
Compile Option: DEFAULT_LOOKASIDE=1200,40
Compile Option: DEFAULT_MEMSTATUS=0
Compile Option: DEFAULT_MMAP_SIZE=0
Compile Option: DEFAULT_PAGE_SIZE=4096
Compile Option: DEFAULT_PCACHE_INITSZ=20
Compile Option: DEFAULT_RECURSIVE_TRIGGERS
Compile Option: DEFAULT_SECTOR_SIZE=4096
Compile Option: DEFAULT_SYNCHRONOUS=2
Compile Option: DEFAULT_WAL_AUTOCHECKPOINT=1000
Compile Option: DEFAULT_WAL_SYNCHRONOUS=1
Compile Option: DEFAULT_WORKER_THREADS=0
Compile Option: DQS=3
Compile Option: ENABLE_API_ARMOR
Compile Option: ENABLE_BYTECODE_VTAB
Compile Option: ENABLE_COLUMN_METADATA
Compile Option: ENABLE_DBSTAT_VTAB
Compile Option: ENABLE_FTS3
Compile Option: ENABLE_FTS3_PARENTHESIS
Compile Option: ENABLE_FTS3_TOKENIZER
Compile Option: ENABLE_FTS4
Compile Option: ENABLE_FTS5
Compile Option: ENABLE_LOCKING_STYLE=1
Compile Option: ENABLE_MATH_FUNCTIONS
Compile Option: ENABLE_NORMALIZE
Compile Option: ENABLE_PREUPDATE_HOOK
Compile Option: ENABLE_RTREE
Compile Option: ENABLE_SESSION
Compile Option: ENABLE_SNAPSHOT
Compile Option: ENABLE_SQLLOG
Compile Option: ENABLE_STMT_SCANSTATUS
Compile Option: ENABLE_UNKNOWN_SQL_FUNCTION
Compile Option: ENABLE_UPDATE_DELETE_LIMIT
Compile Option: HAS_CODEC_RESTRICTED
Compile Option: HAVE_ISNAN
Compile Option: MALLOC_SOFT_LIMIT=1024
Compile Option: MAX_ATTACHED=10
Compile Option: MAX_COLUMN=2000
Compile Option: MAX_COMPOUND_SELECT=500
Compile Option: MAX_DEFAULT_PAGE_SIZE=8192
Compile Option: MAX_EXPR_DEPTH=1000
Compile Option: MAX_FUNCTION_ARG=127
Compile Option: MAX_LENGTH=2147483645
Compile Option: MAX_LIKE_PATTERN_LENGTH=50000
Compile Option: MAX_MMAP_SIZE=20971520
Compile Option: MAX_PAGE_COUNT=1073741823
Compile Option: MAX_PAGE_SIZE=65536
Compile Option: MAX_SQL_LENGTH=1000000000
Compile Option: MAX_TRIGGER_DEPTH=1000
Compile Option: MAX_VARIABLE_NUMBER=500000
Compile Option: MAX_VDBE_OP=250000000
Compile Option: MAX_WORKER_THREADS=8
Compile Option: MUTEX_UNFAIR
Compile Option: OMIT_AUTORESET
Compile Option: OMIT_LOAD_EXTENSION
Compile Option: STMTJRNL_SPILL=131072
Compile Option: SUBSTR_COMPATIBILITY
Compile Option: SYSTEM_MALLOC
Compile Option: TEMP_STORE=1
Compile Option: THREADSAFE=2
Compile Option: USE_URI
```

# Test Plan

manually test the following test case

```ts
  describe('FTS5', () => {
    it('should support FTS5', async () => {
      const db = await SQLite.openDatabaseAsync(':memory:');
      await db.execAsync(`
CREATE VIRTUAL TABLE mail USING fts5(subject, body);
INSERT INTO mail (subject, body) VALUES ('software', 'SQLite is a software library');
INSERT INTO mail (subject, body) VALUES ('open source', 'SQLite is open source');
INSERT INTO mail (subject, body) VALUES ('C programming', 'SQLite is written in C');
`);
      const result = await db.getAllAsync<any>('SELECT * FROM mail WHERE mail MATCH ?', 'software');
      expect(result.length).toBe(1);

      const result2 = await db.getAllAsync<any>('SELECT * FROM mail WHERE mail MATCH ?', 'SQLite');
      expect(result2.length).toBe(3);
      await db.closeAsync();
    });
  });
``` 
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
