### PR TITLE
[router] include ctx-shared.js in package files

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Export `toHaveRouterState` and other matcher types from `expo-router/testing-library` ([#27646](https://github.com/expo/expo/pull/27646) by [@marklawlor](https://github.com/marklawlor))
 - Fix missing types from typed routes ([#27412](https://github.com/expo/expo/pull/27412) by [@marklawlor](https://github.com/marklawlor))
 - Fork NavigationContainer on web to use custom linking context ([#27712](https://github.com/expo/expo/pull/27712) by [@marklawlor](https://github.com/marklawlor))
+- Fix failure to find ctx-shared import while generating route types ([#27740](https://github.com/expo/expo/issues/27740) by [@chriszs](https://github.com/chriszs))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Export `toHaveRouterState` and other matcher types from `expo-router/testing-library` ([#27646](https://github.com/expo/expo/pull/27646) by [@marklawlor](https://github.com/marklawlor))
 - Fix missing types from typed routes ([#27412](https://github.com/expo/expo/pull/27412) by [@marklawlor](https://github.com/marklawlor))
 - Fork NavigationContainer on web to use custom linking context ([#27712](https://github.com/expo/expo/pull/27712) by [@marklawlor](https://github.com/marklawlor))
-- Fix failure to find ctx-shared import while generating route types ([#27740](https://github.com/expo/expo/issues/27740) by [@chriszs](https://github.com/chriszs))
+- Fix failure to find ctx-shared import while generating route types ([#27741](https://github.com/expo/expo/pull/27741) by [@chriszs](https://github.com/chriszs))
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -19,6 +19,7 @@
     "types",
     "_ctx.*",
     "_ctx-html.js",
+    "_ctx-shared.js",
     "_error.js",
     "app.plugin.js",
     "babel.js",


### PR DESCRIPTION
# Why

Fixes the failure documented in #27740 wherein typed route generation failed to find an import called `ctx-shared` in the Expo Router canary package.

# How

Includes the `ctx-shared.js` file used by typed route generation in the expo-router package files by adding it to the explicit list of included files in `package.json`.

# Test Plan

To test I started with my [minimal reproduction](https://github.com/chriszs/test-expo-app/pull/3) (in which `npm start` fails), downloaded [ctx-shared.js](https://github.com/chriszs/expo/blob/main/packages/expo-router/_ctx-shared.js), moved it into `node_modules/expo-router/` and, added an empty `/app` directory to satisfy an unrelated failure, then ran `npm start` again (successfully). Test process demonstrated with patch-package [here](https://github.com/chriszs/test-expo-app/compare/demonstrate-router-canary-issue...demonstrate-fix-for-router-canary-import-failure).