### PR TITLE
[sqlite] prevent closing shared database on android

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Enabled [FTS](https://www.sqlite.org/fts3.html) and [FTS5](https://www.sqlite.org/fts5.html) for SQLite. ([#27738](https://github.com/expo/expo/pull/27738) by [@kudo](https://github.com/kudo))
+- Fixed `NullPointerException` on Android when opening the same database multiple times. ([#27748](https://github.com/expo/expo/pull/27748) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -3,9 +3,15 @@
 package expo.modules.sqlite
 
 import expo.modules.kotlin.sharedobjects.SharedRef
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class NativeDatabase(val databaseName: String, val openOptions: OpenDatabaseOptions) : SharedRef<NativeDatabaseBinding>(NativeDatabaseBinding()) {
   var isClosed = false
+  private val refCount = AtomicInteger(1)
+
+  internal fun addRef() {
+    refCount.incrementAndGet()
+  }
 
   override fun equals(other: Any?): Boolean {
     return other is NativeDatabase && this.ref == other.ref
@@ -13,6 +19,9 @@ internal class NativeDatabase(val databaseName: String, val openOptions: OpenDat
 
   override fun deallocate() {
     super.deallocate()
-    this.ref.close()
+    val shouldClose = refCount.decrementAndGet() <= 0
+    if (shouldClose) {
+      this.ref.close()
+    }
   }
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
@@ -60,6 +60,7 @@ class SQLiteModuleNext : Module() {
 
           // Try to find opened database for fast refresh
           findCachedDatabase { it.databaseName == databaseName && it.openOptions == options && !options.useNewConnection }?.let {
+            it.addRef()
             return@Constructor it
           }
 


### PR DESCRIPTION
# Why

fixes #27619
close ENG-11740

# How

by design, we [reuse opened database](https://github.com/expo/expo/blob/92a3dd7e81d62c2d5f5f4eda6041439f323c2325/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt#L61-L64). however, if there's multiple `openDatabaseAsync` and multiple shared objects linked to the same database. if there's one shared object deallocated by GC, it will accidentally [close all the shared database](https://github.com/expo/expo/blob/92a3dd7e81d62c2d5f5f4eda6041439f323c2325/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt#L16).

this pr addes reference counting to the NativeDatabase and close the underlying HybridData only when all references are deallocated.

# Test Plan

- ci passed
- test repro from https://github.com/expo/expo/issues/27619

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
