### PR TITLE
[ios][android] Update @react-native-community/datetimepicker@7.6.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1837,7 +1837,7 @@ PODS:
     - React-Core
   - RNCPicker (2.5.1):
     - React-Core
-  - RNDateTimePicker (7.6.1):
+  - RNDateTimePicker (7.6.3):
     - React-Core
   - RNFlashList (1.6.3):
     - React-Core
@@ -2608,7 +2608,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNCMaskedView: f7c74478c83c4fdfc5cf4df51f80c0dd5cf125c6
   RNCPicker: 529d564911e93598cc399b56cc0769ce3675f8c8
-  RNDateTimePicker: 8fb39263b721223e095248acaf6f406d5b7f6713
+  RNDateTimePicker: 7b38b71bcd7c4cfa1cb95f2dff9a4f1faed2dced
   RNFlashList: 4b4b6b093afc0df60ae08f9cbf6ccd4c836c667a
   RNGestureHandler: ce6dc347cb4edb664bfc250fc37cd753ae7432ec
   RNReanimated: ba5db5a81395c0cac529dbb1719453dd5c4c6f24

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "1.18.2",
-    "@react-native-community/datetimepicker": "7.6.1",
+    "@react-native-community/datetimepicker": "7.6.3",
     "@react-native-community/netinfo": "11.1.0",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.3.0",

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -73,7 +73,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     if (display == RNTimePickerDisplay.SPINNER) {
         return new RNDismissableTimePickerDialog(
                 activityContext,
-                host.exp.expoview.R.style.SpinnerTimePickerDialog,
+								host.exp.expoview.R.style.SpinnerTimePickerDialog,
                 onTimeSetListener,
                 hour,
                 minute,

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
@@ -1,4 +1,5 @@
 #import <React/RCTShadowView.h>
+#import <React/RCTLog.h>
 #import "RNDateTimePicker.h"
 
 @interface RNDateTimePickerShadowView : RCTShadowView

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
@@ -41,11 +41,7 @@
   YGNodeMarkDirty(self.yogaNode);
 }
 
-static YGSize RNDateTimePickerShadowViewMeasure(YGNodeConstRef node,
-                                                float width,
-                                                YGMeasureMode widthMode,
-                                                float height,
-                                                YGMeasureMode heightMode)
+static YGSize RNDateTimePickerShadowViewMeasure(YGNodeConstRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
 {
   RNDateTimePickerShadowView *shadowPickerView = (__bridge RNDateTimePickerShadowView *)YGNodeGetContext(node);
 

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "1.18.2",
-    "@react-native-community/datetimepicker": "7.6.1",
+    "@react-native-community/datetimepicker": "7.6.3",
     "@react-native-community/netinfo": "11.1.0",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.3.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^14.0.0",
   "@react-native-async-storage/async-storage": "1.21.0",
-  "@react-native-community/datetimepicker": "7.6.1",
+  "@react-native-community/datetimepicker": "7.6.3",
   "@react-native-masked-view/masked-view": "0.3.0",
   "@react-native-community/netinfo": "11.1.0",
   "@react-native-community/slider": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,10 +3351,10 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@react-native-community/datetimepicker@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.6.1.tgz#98bdee01e3df490526ee1125e438c2030becac1f"
-  integrity sha512-g66Q2Kd9Uw3eRL7kkrTsGhi+eXxNoPDRFYH6z78sZQuYjPkUQgJDDMUYgBmaBsQx/fKMtemPrCj1ulGmyi0OSw==
+"@react-native-community/datetimepicker@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.6.3.tgz#c6b7b84a3d6a824b55d2710658d86fe64ce12a72"
+  integrity sha512-Ceb+zWwX67tJKK8gTk6JRRIlU1DqIuwe2kaFwz28s6SKrU8bn/nSSB8/y9B4vic3hb8Z0WTo22807GA1Kg4W7A==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Why
Closes #27743

# How
`et uvm -m @react-native-community/datetimepicker -c v7.6.3`

# Test Plan
~~Could only test in bare-expo as expo go is not currently building~~

Android bare-expo + NCL ✅
iOS bare-expo + NCL ✅
Android expo go + NCL ✅
iOS expo go  + NCL ✅
