### PR TITLE
[doctor] skip cocoapods version check on non-macOS machines

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Skip Cocoapods version check when not on macOS ([#27751](https://github.com/expo/expo/pull/27751) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.5.0 — 2024-03-06

--- a/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
@@ -6,6 +6,9 @@ import semver from 'semver';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 async function checkCocoapodsVersionAsync(): Promise<string | null> {
+  if (process.platform !== 'darwin') {
+    return null;
+  }
   try {
     const cocoapodsVersionResponse = await spawnAsync('pod', ['--version']);
     const cocoapodsVersion = cocoapodsVersionResponse.stdout.trim();


### PR DESCRIPTION
# Why
Fixes https://github.com/expo/expo/issues/27483

# How
Added bypass to check when `process.platform !== 'darwin'`.

# Test Plan
Test that it only triggers on macOS, even if podfile is present.
