### PR TITLE
[docs] Link to new files from native project diffs

### DIFF
--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,10 +1,10 @@
-import { mergeClasses, LinkBase } from '@expo/styleguide';
+import { mergeClasses } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import React, { ReactNode, ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { FileStatus } from './FileStatus';
 
-import { LABEL, A } from '~/ui/components/Text';
+import { LABEL } from '~/ui/components/Text';
 
 export type SnippetHeaderProps = PropsWithChildren<{
   title: string | ReactNode;
@@ -42,10 +42,12 @@ export const SnippetHeader = ({
       {Icon && <Icon className="icon-sm" />}
       {title}
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
-      <ArrowUpRightIcon
-        onClick={() => window.open(linkUrl, '_blank')}
-        className="text-icon-secondary shrink-0 icon-sm"
-      />
+      {linkUrl && (
+        <ArrowUpRightIcon
+          onClick={() => window.open(linkUrl, '_blank')}
+          className="text-icon-secondary shrink-0 icon-sm"
+        />
+      )}
     </LABEL>
     {!!children && <div className="flex justify-end items-center">{children}</div>}
   </div>

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,9 +1,10 @@
-import { mergeClasses } from '@expo/styleguide';
+import { mergeClasses, LinkBase } from '@expo/styleguide';
+import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import React, { ReactNode, ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { FileStatus } from './FileStatus';
 
-import { LABEL } from '~/ui/components/Text';
+import { LABEL, A } from '~/ui/components/Text';
 
 export type SnippetHeaderProps = PropsWithChildren<{
   title: string | ReactNode;
@@ -12,6 +13,7 @@ export type SnippetHeaderProps = PropsWithChildren<{
   float?: boolean;
   operationType?: 'delete' | 'add' | 'modify' | undefined;
   showOperation?: boolean;
+  linkUrl?: string;
 }>;
 
 export const SnippetHeader = ({
@@ -22,6 +24,7 @@ export const SnippetHeader = ({
   alwaysDark = false,
   operationType,
   showOperation = false,
+  linkUrl,
 }: SnippetHeaderProps) => (
   <div
     className={mergeClasses(
@@ -39,6 +42,10 @@ export const SnippetHeader = ({
       {Icon && <Icon className="icon-sm" />}
       {title}
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
+      <ArrowUpRightIcon
+        onClick={() => window.open(linkUrl, '_blank')}
+        className="text-icon-secondary shrink-0 icon-sm"
+      />
     </LABEL>
     {!!children && <div className="flex justify-end items-center">{children}</div>}
   </div>

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,4 +1,4 @@
-import { mergeClasses, Button } from '@expo/styleguide';
+import { mergeClasses } from '@expo/styleguide';
 import React, { ReactNode, ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { FileStatus } from './FileStatus';
@@ -12,7 +12,6 @@ export type SnippetHeaderProps = PropsWithChildren<{
   float?: boolean;
   operationType?: 'delete' | 'add' | 'modify' | undefined;
   showOperation?: boolean;
-  linkUrl?: string;
 }>;
 
 export const SnippetHeader = ({
@@ -23,7 +22,6 @@ export const SnippetHeader = ({
   alwaysDark = false,
   operationType,
   showOperation = false,
-  linkUrl,
 }: SnippetHeaderProps) => (
   <div
     className={mergeClasses(
@@ -42,17 +40,6 @@ export const SnippetHeader = ({
       {title}
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
     </LABEL>
-    {linkUrl && (
-      <LABEL className="flex flex-1 justify-end items-center pr-2">
-        <Button
-          size="xs"
-          theme="secondary"
-          onClick={() => window.open(linkUrl, '_blank')}
-          openInNewTab>
-          Raw
-        </Button>
-      </LABEL>
-    )}
     {!!children && <div className="flex justify-end items-center">{children}</div>}
   </div>
 );

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,4 +1,4 @@
-import { mergeClasses } from '@expo/styleguide';
+import { mergeClasses, Button } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import React, { ReactNode, ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
@@ -42,13 +42,18 @@ export const SnippetHeader = ({
       {Icon && <Icon className="icon-sm" />}
       {title}
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
-      {linkUrl && (
-        <ArrowUpRightIcon
-          onClick={() => window.open(linkUrl, '_blank')}
-          className="text-icon-secondary shrink-0 icon-sm"
-        />
-      )}
     </LABEL>
+    {linkUrl && (
+      <LABEL className="flex flex-1 justify-end items-center pr-2">
+        <Button
+          size="xs"
+          theme="secondary"
+          onClick={() => window.open(linkUrl, '_blank')}
+          openInNewTab>
+          Raw
+        </Button>
+      </LABEL>
+    )}
     {!!children && <div className="flex justify-end items-center">{children}</div>}
   </div>
 );

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,5 +1,4 @@
 import { mergeClasses, Button } from '@expo/styleguide';
-import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import React, { ReactNode, ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { FileStatus } from './FileStatus';

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -25,6 +25,7 @@ type Props = PropsWithChildren<{
   source?: string;
   raw?: string;
   filenameModifier?: (filename: string) => string;
+  filenameToLinkUrl?: (filename: string) => string;
   showOperation?: boolean;
   collapseDeletedFiles?: boolean;
   SnippetHeaderComponent?: typeof SnippetHeader | typeof PermalinkedSnippetHeader;
@@ -34,6 +35,7 @@ export const DiffBlock = ({
   source,
   raw,
   filenameModifier = str => str,
+  filenameToLinkUrl,
   showOperation = false,
   collapseDeletedFiles = false,
   SnippetHeaderComponent = SnippetHeader,
@@ -75,6 +77,7 @@ export const DiffBlock = ({
           Icon={Copy07Icon}
           operationType={type}
           showOperation={showOperation}
+          linkUrl={filenameToLinkUrl ? filenameToLinkUrl(newPath) : undefined}
           float={collapseDeletedFiles && type === 'delete'}>
           <SettingsAction />
         </SnippetHeaderComponent>

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -77,7 +77,7 @@ export const DiffBlock = ({
           Icon={Copy07Icon}
           operationType={type}
           showOperation={showOperation}
-          linkUrl={filenameToLinkUrl ? filenameToLinkUrl(newPath) : undefined}
+          linkUrl={filenameToLinkUrl && type !== 'delete' ? filenameToLinkUrl(newPath) : undefined}
           float={collapseDeletedFiles && type === 'delete'}>
           <SettingsAction />
         </SnippetHeaderComponent>

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -81,7 +81,7 @@ export const DiffBlock = ({
           float={collapseDeletedFiles && type === 'delete'}>
           {newPath && filenameToLinkUrl && type !== 'delete' ? (
             <SnippetAction
-              leftSlot={<ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />}
+              rightSlot={<ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />}
               onClick={() => {
                 window.open(filenameToLinkUrl(newPath), '_blank');
               }}>

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -1,9 +1,10 @@
-import { Copy07Icon } from '@expo/styleguide-icons';
+import { ArrowUpRightIcon, Copy07Icon } from '@expo/styleguide-icons';
 import { useEffect, useState, PropsWithChildren } from 'react';
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 
 import { PermalinkedSnippetHeader } from '../PermalinkedSnippetHeader';
 import { Snippet } from '../Snippet';
+import { SnippetAction } from '../SnippetAction';
 import { SnippetContent } from '../SnippetContent';
 import { SnippetHeader } from '../SnippetHeader';
 
@@ -77,8 +78,16 @@ export const DiffBlock = ({
           Icon={Copy07Icon}
           operationType={type}
           showOperation={showOperation}
-          linkUrl={filenameToLinkUrl && type !== 'delete' ? filenameToLinkUrl(newPath) : undefined}
           float={collapseDeletedFiles && type === 'delete'}>
+          {newPath && filenameToLinkUrl && type !== 'delete' ? (
+            <SnippetAction
+              leftSlot={<ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />}
+              onClick={() => {
+                window.open(filenameToLinkUrl(newPath), '_blank');
+              }}>
+              Raw
+            </SnippetAction>
+          ) : null}
           <SettingsAction />
         </SnippetHeaderComponent>
         {!collapseDeletedFiles || type !== 'delete' ? (

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -89,6 +89,9 @@ export const TemplateBareMinimumDiffViewer = () => {
             showOperation
             collapseDeletedFiles
             SnippetHeaderComponent={PermalinkedSnippetHeader}
+            filenameToLinkUrl={filename =>
+              `https://github.com/expo/expo/tree/sdk-${toVersion}/${filename}`
+            }
           />
         </>
       ) : null}


### PR DESCRIPTION
# Why
A user of the Native Project Upgrade Helper suggested that it would be great to link to the new file in the diff, because sometimes (often?) you want to just copy that whole file over. I can definitely relate to this from past native project upgrades.

# How
This is probably not the final form.

I tried adding a simple link icon/button to the `SnippetHeader` that would send you to the new file.

However, using a normal `A` or `LinkBase` ends up with this error:
![image](https://github.com/expo/expo/assets/8053974/15f1aa0c-4e6d-4c03-9927-1b62841daa46)

This is due to the embedded `A` tags on account of the `PermalinkedSnippetHeader`. I can hack around it with `window.open()`, which seems wrong. It also means the link doesn't show correctly when you hover over it.

I could fix this by moving the permalinking to a lower level, but wanted to check first if this is the preferred UI for such a thing.

It's not entirely different from the React Native Upgrade Advisor, which puts the new file behind the "Raw" button:
<img width="670" alt="image" src="https://github.com/expo/expo/assets/8053974/80d41159-7063-479f-9478-f8e91241aeb3">

# Test Plan
- [x] make sure links work on native project diffs
- [x] make sure links don't show up on other difffs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
