### PR TITLE
[docs] Update Expo DevClient description

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -25,7 +25,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Configuration in app.json/app.config.js
 
-You can configure the development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -55,7 +55,7 @@ You can configure development client launcher using its built-in [config plugin]
         '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
         '* `launcher` - Opens the launcher screen.',
       ].join('\n'),
-      default: '"most-recent"',
+      default: 'most-recent',
       experimental: true,
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -55,7 +55,7 @@ You can configure development client launcher using its built-in [config plugin]
         '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
         '* `launcher` - Opens the launcher screen.',
       ].join('\n'),
-      default: 'most-recent',
+      default: '"most-recent"',
       experimental: true,
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: DevClient
-description: 'A library that allows to create a development build.'
+description: A library that allows creating a development build and includes useful development tools.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-dev-client'
 packageName: 'expo-dev-client'
 iconUrl: '/static/images/packages/expo-dev-client.png'
@@ -8,17 +8,14 @@ platforms: ['android', 'ios']
 ---
 
 import APISection from '~/components/plugins/APISection';
-import { APIInstallSection } from '~/components/plugins/InstallSection'
-import {
-  ConfigPluginExample,
-  ConfigPluginProperties,
-} from '~/components/plugins/ConfigSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 
 `expo-dev-client` adds various useful development tools to your debug builds:
 
-- a configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
-- [a powerful and extensible developer menu UI](/debugging/tools#developer-menu)
+- A configurable launcher UI, so you can launch updates (such as from [PR previews](/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
+- Improved debugging tools (such as support for [inspecting network requests](/debugging/tools/#inspecting-network-requests))
+- [A powerful and extensible developer menu UI](/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](/develop/development-builds/introduction/).
 
@@ -28,24 +25,24 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Configuration in app.json/app.config.js
 
-You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure the development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 
-  ```json app.json
-  {
-    "expo": {
-      "plugins": [
-        [
-          "expo-dev-launcher",
-          {
-            "launchModeExperimental": "most-recent"
-          }
-        ]
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-dev-launcher",
+        {
+          "launchModeExperimental": "most-recent"
+        }
       ]
-    }
+    ]
   }
-  ```
+}
+```
 
 </ConfigPluginExample>
 
@@ -54,9 +51,9 @@ You can configure development client launcher using its built-in [config plugin]
     {
       name: 'launchModeExperimental',
       description: [
-        "Determines whether to launch the most recently opened project or navigate to the launcher screen.",
-        "* `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.",
-        "* `'launcher'` - Opens the launcher screen."
+        'Determines whether to launch the most recently opened project or navigate to the launcher screen.',
+        '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+        '* `launcher` - Opens the launcher screen.',
       ].join('\n'),
       default: '"most-recent"',
       experimental: true,
@@ -70,4 +67,4 @@ You can configure development client launcher using its built-in [config plugin]
 import * as DevClient from 'expo-dev-client';
 ```
 
-<APISection packageName={["expo-dev-menu", "expo-dev-launcher"]} apiName="DevClient" />
+<APISection packageName={['expo-dev-menu', 'expo-dev-launcher']} apiName="DevClient" />

--- a/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
@@ -27,7 +27,7 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Configuration in app.json/app.config.js
 
-You can configure the development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 

--- a/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/dev-client.mdx
@@ -1,17 +1,14 @@
 ---
 title: DevClient
-description: 'A library that allows to create a development build.'
+description: A library that allows creating a development build and includes useful development tools.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-dev-client'
 packageName: 'expo-dev-client'
 iconUrl: '/static/images/packages/expo-dev-client.png'
 ---
 
 import APISection from '~/components/plugins/APISection';
-import { APIInstallSection } from '~/components/plugins/InstallSection'
-import {
-  ConfigPluginExample,
-  ConfigPluginProperties,
-} from '~/components/plugins/ConfigSection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `expo-dev-client` adds various useful development tools to your debug builds:
@@ -30,24 +27,24 @@ Expo documentation refers to debug builds that include `expo-dev-client` as [dev
 
 ## Configuration in app.json/app.config.js
 
-You can configure development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure the development client launcher using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 
-  ```json app.json
-  {
-    "expo": {
-      "plugins": [
-        [
-          "expo-dev-launcher",
-          {
-            "launchModeExperimental": "most-recent"
-          }
-        ]
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-dev-launcher",
+        {
+          "launchModeExperimental": "most-recent"
+        }
       ]
-    }
+    ]
   }
-  ```
+}
+```
 
 </ConfigPluginExample>
 
@@ -56,9 +53,9 @@ You can configure development client launcher using its built-in [config plugin]
     {
       name: 'launchModeExperimental',
       description: [
-        "Determines whether to launch the most recently opened project or navigate to the launcher screen.",
-        "* `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.",
-        "* `'launcher'` - Opens the launcher screen."
+        'Determines whether to launch the most recently opened project or navigate to the launcher screen.',
+        '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+        '* `launcher` - Opens the launcher screen.',
       ].join('\n'),
       default: '"most-recent"',
       experimental: true,
@@ -72,4 +69,4 @@ You can configure development client launcher using its built-in [config plugin]
 import * as DevClient from 'expo-dev-client';
 ```
 
-<APISection packageName={["expo-dev-menu", "expo-dev-launcher"]} apiName="DevClient" />
+<APISection packageName={['expo-dev-menu', 'expo-dev-launcher']} apiName="DevClient" />

--- a/packages/expo-dev-client/README.md
+++ b/packages/expo-dev-client/README.md
@@ -9,9 +9,9 @@
 
 `expo-dev-client` adds various useful development tools to your debug builds:
 
-- a configurable launcher UI, so you can launch updates (such as from [PR previews](https://docs.expo.dev/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
-- improved debugging tools (such as support for [inspecting network requests](https://docs.expo.dev/debugging/tools/#inspecting-network-requests))
-- [a powerful and extensible developer menu UI](https://docs.expo.dev/debugging/tools#developer-menu)
+- A configurable launcher UI, so you can launch updates (such as from [PR previews](https://docs.expo.dev/develop/development-builds/development-workflows#pr-previews)) and switch between development servers without needing to recompile the native app
+- Improved debugging tools (such as support for [inspecting network requests](https://docs.expo.dev/debugging/tools/#inspecting-network-requests))
+- [A powerful and extensible developer menu UI](https://docs.expo.dev/debugging/tools#developer-menu)
 
 Expo documentation refers to debug builds that include `expo-dev-client` as [development builds](https://docs.expo.dev/develop/development-builds/introduction/).
 
@@ -21,7 +21,7 @@ You can find more information in the [Expo documentation](https://docs.expo.dev/
 
 ## Issues
 
-If you encounter any issues using this package in your project, please [report your issue here](https://github.com/expo/expo/issues/new?template=dev_client_bug_report.yml). 
+If you encounter any issues using this package in your project, please [report your issue here](https://github.com/expo/expo/issues/new?template=dev_client_bug_report.yml).
 
 ## Contributing
 


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Recently, Dan provided feedback on how the description of Expo DevClient API reference felt like reading a sentence fragment. Also, the current description is short and doesn't satisfy the SEO requirements (which is to be of at least 60 characters).

# How

<!--
How did you build this feature or fix this bug and why?
-->
This PR:
- Updates the `description` metadata for the Expo DevClient `unversioned` and `SDK 50` API reference
- Also, applies docs default Prettier config to both of the `.mdx` files
- Remove single quotes from Properties described in the config plugin properties table. We are already highlighting them inline.
- Follow consistent patterns on how to list items in a list. Update `expo-dev-client` README.md file to follow the same pattern and also apply docs default Prettier formatting.

## Preview

![CleanShot 2024-03-20 at 16 24 06@2x](https://github.com/expo/expo/assets/10234615/9945dee0-e03d-4020-a43b-e26231c0665d)

![CleanShot 2024-03-20 at 16 25 20@2x](https://github.com/expo/expo/assets/10234615/dba5c7cb-de03-4f97-bbe1-0d972f9ac992)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/dev-client/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
