### PR TITLE
[docs] Fix missing Push notification icon in BoxLinks

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -4,12 +4,7 @@ description: A list of common questions and limitations about Expo and related s
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import {
-  BuildIcon,
-  EasMetadataIcon,
-  LayersTwo02Icon,
-  BellRinging04Icon,
-} from '@expo/styleguide-icons';
+import { BuildIcon, EasMetadataIcon, LayersTwo02Icon, Bell03Icon } from '@expo/styleguide-icons';
 
 This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [Forums](https://chat.expo.dev/) for more common questions.
 
@@ -142,7 +137,7 @@ For more information on what current limitations exist with EAS, see the followi
   title="Notifications"
   description="Push Notifications are an important feature, no matter what kind of app you're building. In some situations, you might want to know about common issues when setting up push notifications with Expo. Learn more."
   href="/push-notifications/faq"
-  Icon={BellRinging04Icon}
+  Icon={Bell03Icon}
 />
 
 #### Bare workflow

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -5,6 +5,7 @@ description: An overview of Expo's push notification service.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Bell03Icon } from '@expo/styleguide-icons';
 
 Expo makes implementing push notifications easy. All the hassle with device information and communicating with Firebase Cloud Messaging (FCM) or Apple Push Notification Service (APNs) is done behind the scenes. This allows you to treat Android and iOS notifications in the same way and save time both on the front-end and back-end.
 
@@ -12,22 +13,26 @@ Expo makes implementing push notifications easy. All the hassle with device info
   title="Setup push notifications, get a push token and credentials"
   description="Learn how to set up push notifications, get credentials for development and production, and test sending push notifications with a minimal working example."
   href="/push-notifications/push-notifications-setup"
+  Icon={Bell03Icon}
 />
 
 <BoxLink
   title="Send a push notification"
   description="Learn how to call Expo's Push API with the token when you want to send a notification."
   href="/push-notifications/sending-notifications"
+  Icon={Bell03Icon}
 />
 
 <BoxLink
   title="Receive a push notification"
   description="Learn how to respond to a notification received by your app and take action based on the event."
   href="/push-notifications/receiving-notifications"
+  Icon={Bell03Icon}
 />
 
 <BoxLink
-  title="Common questions and FAQs"
+  title="Common questions"
   description="A collection of common questions about Expo's push notification service."
   href="/push-notifications/faq"
+  Icon={Bell03Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR updates BoxLink on Push notification Overview doc to add the missing icon. It also updates the icon for BoxLink item for Push notification on FAQ doc. The icon used on all BoxLinks here is same as the one currently used in side navigation (`Bell03Icon`).

Also, fix BoxLink title for the last item on the Overview page. Common questions and FAQ mentions mean same in this case.

## Preview

![CleanShot 2024-03-20 at 16 57 37@2x](https://github.com/expo/expo/assets/10234615/8c5160a2-a32a-4a53-8dcc-6d2ec3c10961)



![CleanShot 2024-03-20 at 16 57 49@2x](https://github.com/expo/expo/assets/10234615/3dd2537c-cde6-46fa-966a-2d798433c188)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/push-notifications/overview/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
