### PR TITLE
[core] Refactor common code for events to support native module objects

### DIFF
--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -1,5 +1,6 @@
 #include "JSIUtils.h"
 #include "EventEmitter.h"
+#include "LazyObject.h"
 
 namespace expo::EventEmitter {
 
@@ -59,7 +60,7 @@ NativeState::~NativeState() {
   listeners.clear();
 }
 
-NativeState::Shared NativeState::get(jsi::Runtime &runtime, jsi::Object &object, bool createIfMissing) {
+NativeState::Shared NativeState::get(jsi::Runtime &runtime, const jsi::Object &object, bool createIfMissing) {
   if (object.hasNativeState<NativeState>(runtime)) {
     return object.getNativeState<NativeState>(runtime);
   }
@@ -71,14 +72,9 @@ NativeState::Shared NativeState::get(jsi::Runtime &runtime, jsi::Object &object,
   return nullptr;
 }
 
-#pragma mark - SubscriptionNativeState
-
-SubscriptionNativeState::SubscriptionNativeState(jsi::Object emitter, jsi::Function listener)
-  : jsi::NativeState(), emitter(std::move(emitter)), listener(std::move(listener)) {}
-
 #pragma mark - Utils
 
-void callObservingFunction(jsi::Runtime &runtime, jsi::Object &object, const char* functionName, std::string eventName) {
+void callObservingFunction(jsi::Runtime &runtime, const jsi::Object &object, const char* functionName, std::string eventName) {
   jsi::Value fnValue = object.getProperty(runtime, functionName);
 
   if (!fnValue.isObject()) {
@@ -94,7 +90,7 @@ void callObservingFunction(jsi::Runtime &runtime, jsi::Object &object, const cha
     });
 }
 
-void addListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener) {
+void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener) {
   if (NativeState::Shared state = NativeState::get(runtime, emitter, true)) {
     state->listeners.add(runtime, eventName, listener);
 
@@ -104,7 +100,7 @@ void addListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::string 
   }
 }
 
-void removeListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener) {
+void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener) {
   if (NativeState::Shared state = NativeState::get(runtime, emitter, false)) {
     size_t listenersCountBefore = state->listeners.listenersCount(eventName);
 
@@ -116,7 +112,7 @@ void removeListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::stri
   }
 }
 
-void removeAllListeners(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName) {
+void removeAllListeners(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName) {
   if (NativeState::Shared state = NativeState::get(runtime, emitter, false)) {
     size_t listenersCountBefore = state->listeners.listenersCount(eventName);
 
@@ -128,29 +124,29 @@ void removeAllListeners(jsi::Runtime &runtime, jsi::Object &emitter, const std::
   }
 }
 
-void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Value *args, size_t count) {
+void emitEvent(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Value *args, size_t count) {
   if (NativeState::Shared state = NativeState::get(runtime, emitter, false)) {
     state->listeners.call(runtime, eventName, emitter, args, count);
   }
 }
 
-jsi::Object createEventSubscription(jsi::Runtime &runtime, const std::string &eventName, jsi::Object emitter, jsi::Function listener) {
+jsi::Value createEventSubscription(jsi::Runtime &runtime, const std::string &eventName, const jsi::Object &emitter, const jsi::Function &listener) {
   jsi::Object subscription(runtime);
   jsi::PropNameID removeProp = jsi::PropNameID::forAscii(runtime, "remove", 6);
-  SubscriptionNativeState::Shared nativeState = std::make_shared<SubscriptionNativeState>(std::move(emitter), std::move(listener));
-  jsi::HostFunctionType removeSubscription = [eventName](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
-    jsi::Object thisObject = thisValue.getObject(runtime);
+  std::shared_ptr<jsi::Value> emitterValue = std::make_shared<jsi::Value>(runtime, emitter);
+  std::shared_ptr<jsi::Value> listenerValue = std::make_shared<jsi::Value>(runtime, listener);
 
-    if (SubscriptionNativeState::Shared state = thisObject.getNativeState<SubscriptionNativeState>(runtime)) {
-      removeListener(runtime, state->emitter, eventName, state->listener);
-    }
+  jsi::HostFunctionType removeSubscription = [eventName, emitterValue, listenerValue](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    jsi::Object emitter = emitterValue->getObject(runtime);
+    jsi::Function listener = listenerValue->getObject(runtime).getFunction(runtime);
+
+    removeListener(runtime, emitter, eventName, listener);
     return jsi::Value::undefined();
   };
 
-  subscription.setNativeState(runtime, nativeState);
   subscription.setProperty(runtime, removeProp, jsi::Function::createFromHostFunction(runtime, removeProp, 0, removeSubscription));
 
-  return subscription;
+  return jsi::Value(runtime, subscription);
 }
 
 #pragma mark - Public API
@@ -171,16 +167,21 @@ void installClass(jsi::Runtime &runtime) {
   jsi::HostFunctionType addListenerHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
     jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
-    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    // `this` might be an object that is representing a host object, in which case it's not possible to get the native state.
+    // For native modules we need to unwrap it to get the object used under the hood by `LazyObject` host object.
+    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
 
     addListener(runtime, thisObject, eventName, listener);
-    return createEventSubscription(runtime, eventName, std::move(thisObject), std::move(listener));
+    return createEventSubscription(runtime, eventName, thisObject, listener);
   };
 
   jsi::HostFunctionType removeListenerHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
     jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
-    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    // Unwrap `this` object if it's a lazy object (e.g. native module).
+    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
 
     removeListener(runtime, thisObject, eventName, listener);
     return jsi::Value::undefined();
@@ -188,7 +189,9 @@ void installClass(jsi::Runtime &runtime) {
 
   jsi::HostFunctionType removeAllListenersHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
-    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    // Unwrap `this` object if it's a lazy object (e.g. native module).
+    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
 
     removeAllListeners(runtime, thisObject, eventName);
     return jsi::Value::undefined();
@@ -196,7 +199,9 @@ void installClass(jsi::Runtime &runtime) {
 
   jsi::HostFunctionType emit = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
-    jsi::Object thisObject = thisValue.getObject(runtime);
+
+    // Unwrap `this` object if it's a lazy object (e.g. native module).
+    const jsi::Object &thisObject = thisValue.getObject(runtime);
 
     // Make a new pointer that skips the first argument which is the event name.
     const jsi::Value *eventArgs = count > 1 ? &args[1] : nullptr;

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -16,10 +16,10 @@ namespace expo::EventEmitter {
 class Listeners {
 private:
   friend class NativeState;
-  friend void addListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener);
-  friend void removeListener(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener);
-  friend void removeAllListeners(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName);
-  friend void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const jsi::Value *args, size_t count);
+  friend void addListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener);
+  friend void removeListener(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Function &listener);
+  friend void removeAllListeners(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName);
+  friend void emitEvent(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Value *args, size_t count);
 
   /**
    Type of the list containing listeners for the specific event name.
@@ -86,20 +86,7 @@ public:
    Gets event emitter's native state from the given object.
    If `createIfMissing` is set to `true`, the state will be automatically created.
    */
-  static Shared get(jsi::Runtime &runtime, jsi::Object &object, bool createIfMissing = false);
-};
-
-/**
- Native state for the event listener subscription. Holds the related emitter and listener.
- */
-class JSI_EXPORT SubscriptionNativeState : public jsi::NativeState {
-public:
-  using Shared = std::shared_ptr<SubscriptionNativeState>;
-
-  SubscriptionNativeState(jsi::Object emitter, jsi::Function listener);
-
-  jsi::Object emitter;
-  const jsi::Function listener;
+  static Shared get(jsi::Runtime &runtime, const jsi::Object &object, bool createIfMissing = false);
 };
 
 /**

--- a/packages/expo-modules-core/common/cpp/LazyObject.cpp
+++ b/packages/expo-modules-core/common/cpp/LazyObject.cpp
@@ -17,14 +17,14 @@ jsi::Value LazyObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
       // React Native asks for this property for some reason, we can just ignore it.
       return jsi::Value::undefined();
     }
-    backedObject = initializer(runtime);
+    initializeBackedObject(runtime);
   }
   return backedObject ? backedObject->getProperty(runtime, name) : jsi::Value::undefined();
 }
 
 void LazyObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) {
   if (!backedObject) {
-    backedObject = initializer(runtime);
+    initializeBackedObject(runtime);
   }
   if (backedObject) {
     backedObject->setProperty(runtime, name, value);
@@ -33,13 +33,25 @@ void LazyObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name, const j
 
 std::vector<jsi::PropNameID> LazyObject::getPropertyNames(jsi::Runtime &runtime) {
   if (!backedObject) {
-    backedObject = initializer(runtime);
+    initializeBackedObject(runtime);
   }
   if (backedObject) {
     jsi::Array propertyNames = backedObject->getPropertyNames(runtime);
     return common::jsiArrayToPropNameIdsVector(runtime, propertyNames);
   }
   return {};
+}
+
+const jsi::Object &LazyObject::unwrapObjectIfNecessary(jsi::Runtime &runtime, const jsi::Object &object) {
+  if (object.isHostObject<LazyObject>(runtime)) {
+    LazyObject::Shared lazyObject = object.getHostObject<LazyObject>(runtime);
+
+    if (!lazyObject->backedObject) {
+      lazyObject->initializeBackedObject(runtime);
+    }
+    return *lazyObject->backedObject;
+  }
+  return object;
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/LazyObject.h
+++ b/packages/expo-modules-core/common/cpp/LazyObject.h
@@ -32,9 +32,22 @@ public:
 
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
+  /**
+   If the given object is a host object of type `LazyObject`, it returns its backed object.
+   Otherwise, the given object is returned back.
+   */
+  static const jsi::Object &unwrapObjectIfNecessary(jsi::Runtime &runtime, const jsi::Object &object);
+
 private:
   const LazyObjectInitializer initializer;
   std::shared_ptr<jsi::Object> backedObject;
+
+  /**
+   Initializes the backed object. It shouldn't be invoked more than once, so first make sure that `backedObject` is a null pointer.
+   */
+  inline void initializeBackedObject(jsi::Runtime &runtime) {
+    backedObject = initializer(runtime);
+  }
 
 }; // class LazyObject
 


### PR DESCRIPTION
# Why

Preparation for #27766 

# How

- Native module objects are lazy host objects, which cannot have a native state. Thus, we need to unwrap `this` in all EventEmitter methods to the object backed by `LazyObject`.
- Removed the native state for event subscriptions as it was storing the emitter incorrectly, causing the underlying JSI pointer to be invalidated. Using a shared pointer and the `jsi::Value` seems to be a better approach to retain them for the `remove` host function.
- Added `const`s to reference types for `jsi::Object`.

# Test Plan

Unit tests are passing and I tested it as part of #27766 