### PR TITLE
[core][iOS] Implement OnStartObserving/OnStopObserving for the new event emitters

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Implemented sending events from native shared objects. ([#27523](https://github.com/expo/expo/pull/27523) by [@lukmccall](https://github.com/lukmccall))
 - JS object of the native module is now an instance of the `NativeModule` class that inherits from `EventEmitter`. ([#27510](https://github.com/expo/expo/pull/27510) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed a function on the runtime to schedule some work with synchronized access to JS. ([#27567](https://github.com/expo/expo/pull/27567) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event. ([#27766](https://github.com/expo/expo/pull/27766) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Api/Factories/ObjectFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ObjectFactories.swift
@@ -42,13 +42,13 @@ public func Events(_ names: [String]) -> EventsDefinition {
 /**
  Function that is invoked when the first event listener is added.
  */
-public func OnStartObserving(@_implicitSelfCapture _ body: @escaping () -> Void) -> AsyncFunctionDefinition<(), Void, Void> {
-  return AsyncFunctionDefinition("startObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
+public func OnStartObserving(_ event: String? = nil, @_implicitSelfCapture _ closure: @escaping () -> Void) -> EventObservingDefinition {
+  return EventObservingDefinition(type: .startObserving, event: event, closure)
 }
 
 /**
  Function that is invoked when all event listeners are removed.
  */
-public func OnStopObserving(@_implicitSelfCapture _ body: @escaping () -> Void) -> AsyncFunctionDefinition<(), Void, Void> {
-  return AsyncFunctionDefinition("stopObserving", firstArgType: Void.self, dynamicArgumentTypes: [], body)
+public func OnStopObserving(_ event: String? = nil, @_implicitSelfCapture _ closure: @escaping () -> Void) -> EventObservingDefinition {
+  return EventObservingDefinition(type: .stopObserving, event: event, closure)
 }

--- a/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
@@ -1,0 +1,79 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+internal enum EventObservingType: String {
+  case startObserving
+  case stopObserving
+}
+
+internal protocol AnyEventObservingDefinition: AnyDefinition {
+  var event: String? { get }
+
+  var type: EventObservingType { get }
+
+  func call()
+}
+
+public final class EventObservingDefinition: AnyEventObservingDefinition {
+  public typealias ClosureType = () -> Void
+
+  let type: EventObservingType
+
+  let event: String?
+
+  let closure: ClosureType
+
+  init(type: EventObservingType, event: String?, _ closure: @escaping ClosureType) {
+    self.type = type
+    self.event = event
+    self.closure = closure
+  }
+
+  func call() {
+    closure()
+  }
+}
+
+public struct EventObservingDecorator: JavaScriptObjectDecorator {
+  let definitions: [any AnyEventObservingDefinition]
+
+  /**
+   Decorates the given object with `startObserving` and `stopObserving` functions.
+   These functions are automatically called by the `EventEmitter` implementation.
+   */
+  func decorate(object: JavaScriptObject, appContext: AppContext) throws {
+    // We need to keep track the number of observed events
+    // so we can call observers not attached to any event in the right moment.
+    var observingEvents: Int = 0
+
+    let startObserving = AsyncFunctionDefinition(
+      EventObservingType.startObserving.rawValue,
+      firstArgType: String.self,
+      dynamicArgumentTypes: [~String.self]
+    ) { (event: String) in
+      observingEvents += 1
+
+      for definition in definitions where definition.type == .startObserving {
+        if definition.event == event || (observingEvents == 1 && definition.event == nil) {
+          definition.call()
+        }
+      }
+    }
+
+    let stopObserving = AsyncFunctionDefinition(
+      EventObservingType.stopObserving.rawValue,
+      firstArgType: String.self,
+      dynamicArgumentTypes: [~String.self]
+    ) { (event: String) in
+      observingEvents -= 1
+
+      for definition in definitions where definition.type == .stopObserving {
+        if definition.event == event || (observingEvents == 0 && definition.event == nil) {
+          definition.call()
+        }
+      }
+    }
+
+    object.setProperty(startObserving.name, value: try startObserving.build(appContext: appContext))
+    object.setProperty(stopObserving.name, value: try stopObserving.build(appContext: appContext))
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -118,11 +118,10 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
   // MARK: - JavaScriptObjectBuilder
 
   func build(appContext: AppContext) throws -> JavaScriptObject {
-    return try appContext.runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args, resolve, reject in
-      guard let self = self else {
-        let exception = NativeFunctionUnavailableException(name)
-        return reject(exception.code, exception.description, nil)
-      }
+    // It seems to be safe to capture a strong reference to `self` here. This is needed for detached functions, that are not part of the module definition.
+    // Module definitions are held in memory anyway, but detached definitions (returned by other functions) are not, so we need to capture them here.
+    // It will be deallocated when that JS host function is garbage-collected by the JS VM.
+    return try appContext.runtime.createAsyncFunction(name, argsCount: argumentsCount) { [self] this, args, resolve, reject in
       self.call(by: this, withArguments: args, appContext: appContext) { result in
         switch result {
         case .failure(let error):

--- a/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
@@ -23,6 +23,8 @@ public final class ModuleDefinition: ObjectDefinition {
    */
   let eventNames: [String]
 
+  let eventObservers: [AnyEventObservingDefinition]
+
   /**
    Initializer that is called by the `ModuleDefinitionBuilder` results builder.
    */
@@ -43,6 +45,9 @@ public final class ModuleDefinition: ObjectDefinition {
         .compactMap { ($0 as? EventsDefinition)?.names }
         .joined()
     )
+
+    self.eventObservers = definitions
+      .compactMap { $0 as? AnyEventObservingDefinition }
 
     super.init(definitions: definitions)
   }
@@ -70,6 +75,11 @@ public final class ModuleDefinition: ObjectDefinition {
     if let viewDefinition = view {
       let reactComponentPrototype = try viewDefinition.createReactComponentPrototype(appContext: appContext)
       object.setProperty("ViewPrototype", value: reactComponentPrototype)
+    }
+
+    if !eventObservers.isEmpty {
+      try EventObservingDecorator(definitions: eventObservers)
+        .decorate(object: object, appContext: appContext)
     }
 
     // Give the module object a name. It's used for compatibility reasons, see `EventEmitter.ts`.


### PR DESCRIPTION
# Why

The new EventEmitter written in C++ calls `startObserving` and `stopObserving` on the emitter with the event name that is started/stopped. Previously it was called once for all events, so some modules (like `expo-battery`) were observing more than they need when only one listener was added.

With this PR, the following DSL will become possible on iOS:

```swift
OnStartObserving("batteryLevelChange") {
  // start observing the battery level, without the need to observe battery state or power mode too
}

OnStopObserving("batteryLevelChange") {
  // stop observing only the battery level
}
```

# How

`OnStartObserving` and `OnStopObserving` now return `EventObservingDefinition`s which are aggregated and then used by `EventObservingDecorator` to decorate the object with `startObserving` and `stopObserving` functions.

# Test Plan
