### PR TITLE
[iOS] Don't require main queue setup

### DIFF
--- a/packages/expo-modules-core/ios/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/ExpoBridgeModule.swift
@@ -39,7 +39,7 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
   }
 
   public static func requiresMainQueueSetup() -> Bool {
-    return true
+    return false
   }
 
   public var bridge: RCTBridge! {

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -140,7 +140,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (nonnull EXModulesProxyConfig *)nativeModulesConfig


### PR DESCRIPTION
# Why

This may solve some race condition issues when the bridge is not yet set when we're trying to install JSI bindings