### PR TITLE
List iOS APIs requiring privacy reasons

### DIFF
--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 5.8.3 - 2024-01-18

--- a/packages/expo-application/ios/ApplicationModule.swift
+++ b/packages/expo-application/ios/ApplicationModule.swift
@@ -26,7 +26,7 @@ public class ApplicationModule: Module {
 
       do {
         let fileAttributes = try FileManager.default.attributesOfItem(atPath: urlToDocumentsFolder.path)
-        // HANDLEDREASON C617.1
+        // Uses required reason API based on the following reason: C617.1
         if let installDate = fileAttributes[FileAttributeKey.creationDate] as? Date {
           return installDate.timeIntervalSince1970 * 1000
         }

--- a/packages/expo-application/ios/ApplicationModule.swift
+++ b/packages/expo-application/ios/ApplicationModule.swift
@@ -25,6 +25,7 @@ public class ApplicationModule: Module {
       }
 
       do {
+        // REASON C617.1
         let fileAttributes = try FileManager.default.attributesOfItem(atPath: urlToDocumentsFolder.path)
         if let installDate = fileAttributes[FileAttributeKey.creationDate] as? Date {
           return installDate.timeIntervalSince1970 * 1000

--- a/packages/expo-application/ios/ApplicationModule.swift
+++ b/packages/expo-application/ios/ApplicationModule.swift
@@ -25,8 +25,8 @@ public class ApplicationModule: Module {
       }
 
       do {
-        // REASON C617.1
         let fileAttributes = try FileManager.default.attributesOfItem(atPath: urlToDocumentsFolder.path)
+        // HANDLEDREASON C617.1
         if let installDate = fileAttributes[FileAttributeKey.creationDate] as? Date {
           return installDate.timeIntervalSince1970 * 1000
         }

--- a/packages/expo-application/ios/EXApplication.podspec
+++ b/packages/expo-application/ios/EXApplication.podspec
@@ -23,6 +23,8 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
+  s.resource_bundles = {'ExpoApplication_privacy' => ['PrivacyInfo.xcprivacy']}
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-application/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-application/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - [expo-updates] Migrate to requireNativeModule/requireOptionalNativeModule. ([#25648](https://github.com/expo/expo/pull/25648) by [@wschurman](https://github.com/wschurman))
 - Remove most of Constants.appOwnership. ([#26313](https://github.com/expo/expo/pull/26313) by [@wschurman](https://github.com/wschurman))
 - Improve updates types and clarity in expo-asset. ([#26337](https://github.com/expo/expo/pull/26337) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -43,7 +43,8 @@ Pod::Spec.new do |s|
   # Generate EXConstants.bundle without existing resources
   # `get-app-config-ios.sh` will generate app.config in EXConstants.bundle
   s.resource_bundles = {
-    'EXConstants' => []
+    'EXConstants' => [],
+    'ExpoConstants_privacy' => ['PrivacyInfo.xcprivacy']
   }
 
 end

--- a/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
+++ b/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
@@ -41,7 +41,7 @@ static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUU
   if (installationId) {
     return installationId;
   }
-  // HANDLEDREASON CA92.1
+  // Uses required reason API based on the following reason: CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
+++ b/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
@@ -41,7 +41,7 @@ static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUU
   if (installationId) {
     return installationId;
   }
-  // REASON CA92.1
+  // HANDLEDREASON CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
+++ b/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
@@ -1,5 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
-
+// TODO: Remove
 #import <EXConstants/EXConstantsInstallationIdProvider.h>
 
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";
@@ -41,7 +41,7 @@ static NSString * const kEXDeviceInstallationUUIDLegacyKey = @"EXDeviceInstallUU
   if (installationId) {
     return installationId;
   }
-  
+  // REASON CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
+++ b/packages/expo-constants/ios/EXConstantsInstallationIdProvider.m
@@ -1,5 +1,4 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
-// TODO: Remove
 #import <EXConstants/EXConstantsInstallationIdProvider.h>
 
 static NSString * const kEXDeviceInstallationUUIDKey = @"EXDeviceInstallationUUIDKey";

--- a/packages/expo-constants/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-constants/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
+
 ## 5.9.3 - 2024-01-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -28,7 +28,7 @@ public class DeviceModule: Module {
     }
 
     AsyncFunction("getUptimeAsync") { () -> Double in
-    // Uses required reason API based on the following reason: 35F9.1 – there's not really a matching reason here
+      // Uses required reason API based on the following reason: 35F9.1 – there's not really a matching reason here
       return ProcessInfo.processInfo.systemUptime * 1000
     }
 

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -28,7 +28,7 @@ public class DeviceModule: Module {
     }
 
     AsyncFunction("getUptimeAsync") { () -> Double in
-    // HANDLEDREASON 35F9.1 – there's not really a matching reason here
+    // Uses required reason API based on the following reason: 35F9.1 – there's not really a matching reason here
       return ProcessInfo.processInfo.systemUptime * 1000
     }
 

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -28,7 +28,7 @@ public class DeviceModule: Module {
     }
 
     AsyncFunction("getUptimeAsync") { () -> Double in
-    // REASON 35F9.1 – there's not really a matching reason here
+    // HANDLEDREASON 35F9.1 – there's not really a matching reason here
       return ProcessInfo.processInfo.systemUptime * 1000
     }
 

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -28,6 +28,7 @@ public class DeviceModule: Module {
     }
 
     AsyncFunction("getUptimeAsync") { () -> Double in
+    // REASON 35F9.1 – there's not really a matching reason here
       return ProcessInfo.processInfo.systemUptime * 1000
     }
 

--- a/packages/expo-device/ios/ExpoDevice.podspec
+++ b/packages/expo-device/ios/ExpoDevice.podspec
@@ -23,6 +23,8 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
+  s.resource_bundles = {'ExpoDevice_privacy' => ['PrivacyInfo.xcprivacy']}
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-device/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-device/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-device/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-device/ios/PrivacyInfo.xcprivacy
@@ -4,18 +4,6 @@
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeContacts</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/packages/expo-device/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-device/ios/PrivacyInfo.xcprivacy
@@ -4,6 +4,18 @@
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeContacts</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 16.0.8 - 2024-03-07

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -23,7 +23,7 @@
     result[@"exists"] = @(YES);
     result[@"isDirectory"] = @(NO);
     result[@"uri"] = fileUri;
-    // 3B52.1
+    // REASON 3B52.1
     result[@"modificationTime"] = @(asset.modificationDate.timeIntervalSince1970);
     if (options[@"md5"] || options[@"size"]) {
       [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -23,7 +23,7 @@
     result[@"exists"] = @(YES);
     result[@"isDirectory"] = @(NO);
     result[@"uri"] = fileUri;
-    // HANDLEDREASON 3B52.1
+    // Uses required reason API based on the following reason: 3B52.1
     result[@"modificationTime"] = @(asset.modificationDate.timeIntervalSince1970);
     if (options[@"md5"] || options[@"size"]) {
       [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -23,6 +23,7 @@
     result[@"exists"] = @(YES);
     result[@"isDirectory"] = @(NO);
     result[@"uri"] = fileUri;
+    // 3B52.1
     result[@"modificationTime"] = @(asset.modificationDate.timeIntervalSince1970);
     if (options[@"md5"] || options[@"size"]) {
       [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -23,7 +23,7 @@
     result[@"exists"] = @(YES);
     result[@"isDirectory"] = @(NO);
     result[@"uri"] = fileUri;
-    // REASON 3B52.1
+    // HANDLEDREASON 3B52.1
     result[@"modificationTime"] = @(asset.modificationDate.timeIntervalSince1970);
     if (options[@"md5"] || options[@"size"]) {
       [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset options:nil resultHandler:^(NSData * _Nullable imageData, NSString * _Nullable dataUTI, CGImagePropertyOrientation orientation, NSDictionary * _Nullable info) {

--- a/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
@@ -21,7 +21,7 @@
       result[@"md5"] = [[NSData dataWithContentsOfFile:path] md5String];
     }
     result[@"size"] = @([EXFileSystemLocalFileHandler getFileSize:path attributes:attributes]);
-    // REASON 0A2A.1
+    // HANDLEDREASON 0A2A.1
     result[@"modificationTime"] = @(attributes.fileModificationDate.timeIntervalSince1970);
     resolve(result);
   } else {

--- a/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
@@ -21,7 +21,7 @@
       result[@"md5"] = [[NSData dataWithContentsOfFile:path] md5String];
     }
     result[@"size"] = @([EXFileSystemLocalFileHandler getFileSize:path attributes:attributes]);
-    // HANDLEDREASON 0A2A.1
+    // Uses required reason API based on the following reason: 0A2A.1
     result[@"modificationTime"] = @(attributes.fileModificationDate.timeIntervalSince1970);
     resolve(result);
   } else {

--- a/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
@@ -21,7 +21,7 @@
       result[@"md5"] = [[NSData dataWithContentsOfFile:path] md5String];
     }
     result[@"size"] = @([EXFileSystemLocalFileHandler getFileSize:path attributes:attributes]);
-    // 0A2A.1
+    // REASON 0A2A.1
     result[@"modificationTime"] = @(attributes.fileModificationDate.timeIntervalSince1970);
     resolve(result);
   } else {

--- a/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemLocalFileHandler.m
@@ -21,6 +21,7 @@
       result[@"md5"] = [[NSData dataWithContentsOfFile:path] md5String];
     }
     result[@"size"] = @([EXFileSystemLocalFileHandler getFileSize:path attributes:attributes]);
+    // 0A2A.1
     result[@"modificationTime"] = @(attributes.fileModificationDate.timeIntervalSince1970);
     resolve(result);
   } else {

--- a/packages/expo-file-system/ios/ExpoFileSystem.podspec
+++ b/packages/expo-file-system/ios/ExpoFileSystem.podspec
@@ -26,6 +26,8 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
+  s.resource_bundles = {'ExpoFileSystem_privacy' => ['PrivacyInfo.xcprivacy']}
+
   s.source_files = "**/*.{h,m,swift}"
 
   s.exclude_files = 'Tests/'

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -256,7 +256,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int in
-    // HANDLEDREASON E174.1 85F4.1
+    // Uses required reason API based on the following reason: E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeAvailableCapacityKey])
 
       guard let availableCapacity = resourceValues?.volumeAvailableCapacity else {
@@ -266,7 +266,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getTotalDiskCapacityAsync") { () -> Int in
-        // HANDLEDREASON E174.1 85F4.1
+        // Uses required reason API based on the following reason: E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeTotalCapacityKey])
 
       guard let totalCapacity = resourceValues?.volumeTotalCapacity else {

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -256,6 +256,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int in
+    // REASON E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeAvailableCapacityKey])
 
       guard let availableCapacity = resourceValues?.volumeAvailableCapacity else {
@@ -265,6 +266,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getTotalDiskCapacityAsync") { () -> Int in
+        // REASON E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeTotalCapacityKey])
 
       guard let totalCapacity = resourceValues?.volumeTotalCapacity else {

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -256,7 +256,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int in
-    // REASON E174.1 85F4.1
+    // HANDLEDREASON E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeAvailableCapacityKey])
 
       guard let availableCapacity = resourceValues?.volumeAvailableCapacity else {
@@ -266,7 +266,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getTotalDiskCapacityAsync") { () -> Int in
-        // REASON E174.1 85F4.1
+        // HANDLEDREASON E174.1 85F4.1
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeTotalCapacityKey])
 
       guard let totalCapacity = resourceValues?.volumeTotalCapacity else {

--- a/packages/expo-file-system/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-file-system/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix es-419 locale returning empty list. ([#27250](https://github.com/expo/expo/pull/27250) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others

--- a/packages/expo-localization/ios/ExpoLocalization.podspec
+++ b/packages/expo-localization/ios/ExpoLocalization.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+  
+  s.resource_bundles = {'ExpoLocalization_privacy' => ['PrivacyInfo.xcprivacy']}
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "**/*.h"

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -57,7 +57,7 @@ public class LocalizationModule: Module {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     // On iOS we need to set both forceRTL and allowRTL so apps don't have to include localization strings.
-    // REASON CA92.1
+    // HANDLEDREASON CA92.1
     UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
     UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
     UserDefaults.standard.synchronize()

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -57,6 +57,7 @@ public class LocalizationModule: Module {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     // On iOS we need to set both forceRTL and allowRTL so apps don't have to include localization strings.
+    // REASON CA92.1
     UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
     UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
     UserDefaults.standard.synchronize()

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -57,7 +57,7 @@ public class LocalizationModule: Module {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     // On iOS we need to set both forceRTL and allowRTL so apps don't have to include localization strings.
-    // HANDLEDREASON CA92.1
+    // Uses required reason API based on the following reason: CA92.1
     UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
     UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
     UserDefaults.standard.synchronize()

--- a/packages/expo-localization/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-localization/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Migrate to expo modules. ([#25587](https://github.com/expo/expo/pull/25587) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
@@ -18,6 +18,8 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
 
+  s.resource_bundles = {'ExpoMediaLibrary_privacy' => ['PrivacyInfo.xcprivacy']}
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES'

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -77,9 +77,9 @@ func exportAsset(asset: PHAsset?) -> [String: Any?]? {
     "mediaSubtypes": stringifyMedia(mediaSubtypes: asset.mediaSubtypes),
     "width": asset.pixelWidth,
     "height": asset.pixelHeight,
-    // HANDLEDREASON 0A2A.1
+    // Uses required reason API based on the following reason: 0A2A.1
     "creationTime": exportDate(asset.creationDate),
-    // HANDLEDREASON 0A2A.1
+    // Uses required reason API based on the following reason: 0A2A.1
     "modificationTime": exportDate(asset.modificationDate),
     "duration": asset.duration
   ]

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -77,7 +77,9 @@ func exportAsset(asset: PHAsset?) -> [String: Any?]? {
     "mediaSubtypes": stringifyMedia(mediaSubtypes: asset.mediaSubtypes),
     "width": asset.pixelWidth,
     "height": asset.pixelHeight,
+    // REASON 0A2A.1
     "creationTime": exportDate(asset.creationDate),
+    // REASON 0A2A.1
     "modificationTime": exportDate(asset.modificationDate),
     "duration": asset.duration
   ]

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -77,9 +77,9 @@ func exportAsset(asset: PHAsset?) -> [String: Any?]? {
     "mediaSubtypes": stringifyMedia(mediaSubtypes: asset.mediaSubtypes),
     "width": asset.pixelWidth,
     "height": asset.pixelHeight,
-    // REASON 0A2A.1
+    // HANDLEDREASON 0A2A.1
     "creationTime": exportDate(asset.creationDate),
-    // REASON 0A2A.1
+    // HANDLEDREASON 0A2A.1
     "modificationTime": exportDate(asset.modificationDate),
     "duration": asset.duration
   ]

--- a/packages/expo-media-library/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-media-library/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.27.5 - 2024-01-25

--- a/packages/expo-notifications/ios/EXNotifications.podspec
+++ b/packages/expo-notifications/ios/EXNotifications.podspec
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
 
+  s.resource_bundles = {'ExpoNotifications_privacy' => ['PrivacyInfo.xcprivacy']}
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
@@ -52,6 +52,7 @@ EX_EXPORT_METHOD_AS(getInstallationIdAsync,
     return installationId;
   }
   
+  // REASON CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
@@ -52,7 +52,7 @@ EX_EXPORT_METHOD_AS(getInstallationIdAsync,
     return installationId;
   }
   
-  // REASON CA92.1
+  // HANDLEDREASON CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
+++ b/packages/expo-notifications/ios/EXNotifications/EXServerRegistrationModule.m
@@ -52,7 +52,7 @@ EX_EXPORT_METHOD_AS(getInstallationIdAsync,
     return installationId;
   }
   
-  // HANDLEDREASON CA92.1
+  // Uses required reason API based on the following reason: CA92.1
   NSString *legacyUUID = [[NSUserDefaults standardUserDefaults] stringForKey:kEXDeviceInstallationUUIDLegacyKey];
   if (legacyUUID) {
     installationId = legacyUUID;

--- a/packages/expo-notifications/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-notifications/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - Use `typeof window` checks for removing server code. ([#27514](https://github.com/expo/expo/pull/27514) by [@EvanBacon](https://github.com/EvanBacon))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-system-ui/ios/ExpoSystemUI.podspec
+++ b/packages/expo-system-ui/ios/ExpoSystemUI.podspec
@@ -22,6 +22,9 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
+  s.resource_bundles = {'ExpoSystemUI_privacy' => ['PrivacyInfo.xcprivacy']}
+
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -43,7 +43,7 @@ public class ExpoSystemUIModule: Module {
     EXUtilities.performSynchronously {
       if color == nil {
         if let window = UIApplication.shared.delegate?.window {
-          // HANDLEDREASON CA92.1
+          // Uses required reason API based on the following reason: CA92.1
           UserDefaults.standard.removeObject(forKey: colorKey)
           let interfaceStyle = window?.traitCollection.userInterfaceStyle
           window?.backgroundColor = nil

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -43,6 +43,7 @@ public class ExpoSystemUIModule: Module {
     EXUtilities.performSynchronously {
       if color == nil {
         if let window = UIApplication.shared.delegate?.window {
+          // REASON CA92.1
           UserDefaults.standard.removeObject(forKey: colorKey)
           let interfaceStyle = window?.traitCollection.userInterfaceStyle
           window?.backgroundColor = nil

--- a/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
+++ b/packages/expo-system-ui/ios/ExpoSystemUI/ExpoSystemUIModule.swift
@@ -43,7 +43,7 @@ public class ExpoSystemUIModule: Module {
     EXUtilities.performSynchronously {
       if color == nil {
         if let window = UIApplication.shared.delegate?.window {
-          // REASON CA92.1
+          // HANDLEDREASON CA92.1
           UserDefaults.standard.removeObject(forKey: colorKey)
           let interfaceStyle = window?.traitCollection.userInterfaceStyle
           window?.backgroundColor = nil

--- a/packages/expo-system-ui/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-system-ui/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 11.7.1 - 2024-01-25

--- a/packages/expo-task-manager/ios/EXTaskManager.podspec
+++ b/packages/expo-task-manager/ios/EXTaskManager.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'UMAppLoader'
 
+  s.resource_bundles = {'ExpoTaskManager_privacy' => ['PrivacyInfo.xcprivacy']}
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "#{s.name}/**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -451,7 +451,7 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
  */
 - (void)_saveConfigWithDictionary:(nonnull NSDictionary *)dict
 {
-  // HANDLEDREASON CA92.1
+  // Uses required reason API based on the following reason: CA92.1
   NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
   [userDefaults setObject:dict forKey:NSStringFromClass([self class])];
   [userDefaults synchronize];

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -451,7 +451,7 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
  */
 - (void)_saveConfigWithDictionary:(nonnull NSDictionary *)dict
 {
-  // REASON CA92.1
+  // HANDLEDREASON CA92.1
   NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
   [userDefaults setObject:dict forKey:NSStringFromClass([self class])];
   [userDefaults synchronize];

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -451,6 +451,7 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
  */
 - (void)_saveConfigWithDictionary:(nonnull NSDictionary *)dict
 {
+  // REASON CA92.1
   NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
   [userDefaults setObject:dict forKey:NSStringFromClass([self class])];
   [userDefaults synchronize];

--- a/packages/expo-task-manager/ios/PrivacyInfo.xcprivacy
+++ b/packages/expo-task-manager/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
# Why

As per https://developer.apple.com/documentation/bundleresources/privacy_manifest_files, 3rd party SDKs need to provide .xcprivacy files if:

- The 3rd party dependency uses one of the APIs listed in required reasons APIs. This is also relevant for 3rd party SDKs shipped as swift code = entire expo SDK.

We need to add an .xcprivacy file to expo-go to pass app review after May 1st, so we bundle xcprivacy files with expo-modules that require it.

We use this mechanism: https://github.com/SDWebImage/SDWebImage/blob/98d058a1ea053484bc4df447153654a0e4a70549/SDWebImage.podspec#L49, that I tested and confirmed to bundle correctly.

I identifed all expo-modules that make use of APIs listed in required reasons – using https://github.com/Wooder/ios_17_required_reason_api_scanner

Related to:
https://github.com/expo/expo/issues/27796
https://linear.app/expo/issue/ENG-11731/investigate-ios-privacy-manifest-requirements


# Test Plan

Tested by generating a privacy report using xCode – the items don't show since they don't add any privacy labels, but after adding the label to any of the generated xcprivacy files those labels do show up:

<img width="1761" alt="image" src="https://github.com/expo/expo/assets/5597580/af887839-90db-456b-b76a-5ad6d9fe4511">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
