### PR TITLE
[core][dev-menu] fix nightlies testing for 0.75

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed `Unrecognised selector` crash for `extraModulesForBridge:` on iOS. ([#26523](https://github.com/expo/expo/pull/26523) by [@kudo](https://github.com/kudo))
 - Fix runtime version overflow ([#27172](https://github.com/expo/expo/pull/27172) by [@kadikraman](https://github.com/kadikraman))
 - Fixed registerDevMenuItems duplicating items rather than replacing. ([#27356](https://github.com/expo/expo/pull/27356) by [@lukmccall](https://github.com/lukmccall))
+- Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -47,6 +47,9 @@ class DevMenuActivity : ReactActivity() {
 
         val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
           .getPrivateDeclaredFieldValue("mReactDelegate", this)
+        if (!rootViewWasInitialized()) {
+          rootView = reactDelegate.reactRootView
+        }
 
         ReactDelegate::class.java
           .setPrivateDeclaredFieldValue("mFabricEnabled", reactDelegate, fabricEnabled)
@@ -57,7 +60,7 @@ class DevMenuActivity : ReactActivity() {
         (rootView.parent as? ViewGroup)?.removeView(rootView)
 
         // Attaches the root view to the current activity
-        plainActivity.setContentView(reactDelegate.getReactRootView())
+        plainActivity.setContentView(reactDelegate.reactRootView)
       }
 
       override fun getReactNativeHost() = DevMenuManager.getMenuHost()
@@ -71,24 +74,11 @@ class DevMenuActivity : ReactActivity() {
         putStringArray("registeredCallbacks", DevMenuManager.registeredCallbacks.map { it.name }.toTypedArray())
       }
 
-      override fun createRootView(): ReactRootView {
+      override fun createRootView(): ReactRootView? {
         if (rootViewWasInitialized()) {
           return rootView
         }
-
-        rootView = super.createRootView().apply { setIsFabric(fabricEnabled) }
-
-        return rootView
-      }
-
-      override fun createRootView(bundle: Bundle?): ReactRootView {
-        if (rootViewWasInitialized()) {
-          return rootView
-        }
-
-        rootView = super.createRootView(bundle)
-
-        return rootView
+        return super.createRootView()
       }
     }
   }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuActivity.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuActivity.kt
@@ -38,17 +38,18 @@ class DevMenuActivity : ReactActivity() {
       override fun onDestroy() = Unit
 
       override fun loadApp(appKey: String?) {
-        // On the first launch of this activity we need to call super.loadApp() to start the dev menu
-        if (!appWasLoaded) {
-          super.loadApp(appKey)
-          appWasLoaded = true
-          return
-        }
-
         val reactDelegate: ReactDelegate = ReactActivityDelegate::class.java
           .getPrivateDeclaredFieldValue("mReactDelegate", this)
-        if (!rootViewWasInitialized()) {
-          rootView = reactDelegate.reactRootView
+
+        // On the first launch of this activity we need to call super.loadApp() to start the dev menu
+        // and cache the rootView for reuse
+        if (!appWasLoaded) {
+          super.loadApp(appKey)
+          if (!rootViewWasInitialized()) {
+            rootView = reactDelegate.reactRootView
+          }
+          appWasLoaded = true
+          return
         }
 
         ReactDelegate::class.java
@@ -74,6 +75,8 @@ class DevMenuActivity : ReactActivity() {
         putStringArray("registeredCallbacks", DevMenuManager.registeredCallbacks.map { it.name }.toTypedArray())
       }
 
+      // NOTE: We could remove this suppress after dropping Expo SDK 51
+      @Suppress("RETURN_TYPE_MISMATCH_ON_OVERRIDE")
       override fun createRootView(): ReactRootView? {
         if (rootViewWasInitialized()) {
           return rootView

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Android] Unit converter now ignores nullability. It will always return unit regardless of whether the input value is null or not. ([#27591](https://github.com/expo/expo/pull/27591) by [@lukmccall](https://github.com/lukmccall))
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
+- Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -18,7 +18,12 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIContext *installer)
  * Clears jsi references held by JSRegistry and JavaScriptRuntime. 
  */
 ExpoModulesHostObject::~ExpoModulesHostObject() {
+#if REACT_NATIVE_TARGET_VERSION >= 75
+  auto &runtime = installer->runtimeHolder->get();
+  facebook::react::LongLivedObjectCollection::get(runtime).clear();
+#else
   facebook::react::LongLivedObjectCollection::get().clear();
+#endif
   installer->jsRegistry.reset();
   installer->runtimeHolder.reset();
   installer->jniDeallocator.reset();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
@@ -17,15 +17,6 @@ import androidx.annotation.Nullable;
  */
 public interface ReactActivityHandler {
   /**
-   * Given modules a chance to override the default {@link ReactRootView}
-   * @return the override ReactRootView instance or null if not to override
-   */
-  @Nullable
-  default ReactRootView createReactRootView(Activity activity) {
-    return null;
-  }
-
-  /**
    * Gives modules a chance to create a ViewGroup that is used as a container for the ReactRootView,
    * which is added as a child to the container if non-null.
    * @return a ViewGroup to be used as a container, or null if no container is needed

--- a/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
@@ -13,6 +13,15 @@ class BridgelessJSCallInvoker : public react::CallInvoker {
 public:
   explicit BridgelessJSCallInvoker(react::RuntimeExecutor runtimeExecutor) : runtimeExecutor_(std::move(runtimeExecutor)) {}
 
+#if REACT_NATIVE_TARGET_VERSION >= 75
+  void invokeAsync(react::CallFunc &&func) noexcept override {
+    runtimeExecutor_([func = std::move(func)](jsi::Runtime &runtime) { func(runtime); });
+  }
+
+  void invokeSync(react::CallFunc &&func) override {
+    throw std::runtime_error("Synchronous native -> JS calls are currently not supported.");
+  }
+#else
   void invokeAsync(std::function<void()> &&func) noexcept override {
     runtimeExecutor_([func = std::move(func)](jsi::Runtime &runtime) { func(); });
   }
@@ -20,6 +29,7 @@ public:
   void invokeSync(std::function<void()> &&func) override {
     throw std::runtime_error("Synchronous native -> JS calls are currently not supported.");
   }
+#endif
 
 private:
   react::RuntimeExecutor runtimeExecutor_;

--- a/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
@@ -1,0 +1,44 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <ReactCommon/CallInvoker.h>
+
+namespace expo {
+
+/**
+ * Dummy CallInvoker that invokes everything immediately.
+ * Used in the test environment to check the async flow.
+ */
+class TestingSyncJSCallInvoker : public facebook::react::CallInvoker {
+public:
+  TestingSyncJSCallInvoker(std::shared_ptr<jsi::Runtime> runtime) : runtime(runtime) {}
+
+#if REACT_NATIVE_TARGET_VERSION >= 75
+  void invokeAsync(react::CallFunc &&func) noexcept override {
+    func(*runtime);
+  }
+
+  void invokeSync(react::CallFunc &&func) override {
+    func(*runtime);
+  }
+#else
+  void invokeAsync(std::function<void()> &&func) noexcept override {
+    func();
+  }
+
+  void invokeSync(std::function<void()> &&func) override {
+    func();
+  }
+#endif
+
+  ~TestingSyncJSCallInvoker() override = default;
+
+  std::shared_ptr<jsi::Runtime> runtime;
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
+- Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

fix breaking changes for nightlies testing (0.75.0-nightly-20240319-d97741af6)

# How

upstream changes:
- `LongLivedObjectCollection::get()` should pass runtime https://github.com/facebook/react-native/commit/3706bf077e62b82a8c15874ac1ee6f0a7497468d
- `CallInvoker()` has new parameter for runtime: https://github.com/facebook/react-native/commit/76ce7890141f22ba75cf62806762179be3c8cfa9
- `ReactActivityDelegate::createRootView()` may return null https://github.com/facebook/react-native/commit/da21799ca34a47168ed54420b6b1808396b24116

this pr includes:
- moving testing SyncCallInvoker to shared TestingSyncJSCallInvoker
- remove unused `ReactActivityHandler.createReactRootView()` since this is not used for bridgeless mode
- slightly change `DevMenuActivity.createRootView()`. rather than get root view from `super.createRootView()`. let's get root view from `mReactDelegate.reactRootView` after loadApp()

# Test Plan

- ci passed
- tested on an app generated by `bunx create-expo-nightly --expo-repo /path/to/expo/expo`. there is a build error from [HermesExecutorFactory.h](https://github.com/facebook/react-native/blob/1fe82671e8101f3878ab6724b244bcdae2696d7f/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h#L11). i've reached out to meta that the include is not reachable by cocoapods. i have to manually modify the include.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
