### PR TITLE
[docs] MediaLibrary: add a basic usage example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -15,6 +15,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
@@ -80,6 +81,91 @@ Learn how to configure the native projects in the [installation instructions in 
     },
   ]}
 />
+
+## Usage
+
+<SnackInline label='Fetching albums and displaying assets' dependencies={['expo-media-library']}>
+
+```jsx
+import { useState, useEffect } from 'react';
+import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import * as MediaLibrary from 'expo-media-library';
+
+export default function App() {
+  const [albums, setAlbums] = useState(null);
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+
+  async function getAlbums() {
+    if (permissionResponse.status !== 'granted') {
+      await requestPermission();
+    }
+    const fetchedAlbums = await MediaLibrary.getAlbumsAsync({
+      includeSmartAlbums: true,
+    });
+    setAlbums(fetchedAlbums);
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Button onPress={getAlbums} title="Get albums" />
+      <ScrollView>
+        {albums && albums.map((album) => <AlbumEntry album={album} />)}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function AlbumEntry({ album }) {
+  const [assets, setAssets] = useState([]);
+
+  useEffect(() => {
+    async function getAlbumAssets() {
+      const albumAssets = await MediaLibrary.getAssetsAsync({ album });
+      setAssets(albumAssets.assets);
+    }
+    getAlbumAssets();
+  }, [album]);
+
+  return (
+    <View key={album.id} style={styles.albumContainer}>
+      <Text>
+        {album.title} - {album.assetCount ?? 'no'} assets
+      </Text>
+      <View style={styles.albumAssetsContainer}>
+        {assets && assets.map((asset) => (
+          <Image source={{ uri: asset.uri }} width={50} height={50} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 8,
+    justifyContent: 'center',
+    ...Platform.select({
+      android: {
+        paddingTop: 40
+      }
+    }),
+  },
+  albumContainer: {
+    paddingHorizontal: 20,
+    marginBottom: 12,
+    gap: 4,
+  },
+  albumAssetsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/media-library.mdx
@@ -15,6 +15,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
@@ -82,6 +83,91 @@ Learn how to configure the native projects in the [installation instructions in 
     },
   ]}
 />
+
+## Usage
+
+<SnackInline label='Fetching albums and displaying assets' dependencies={['expo-media-library']}>
+
+```jsx
+import { useState, useEffect } from 'react';
+import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import * as MediaLibrary from 'expo-media-library';
+
+export default function App() {
+  const [albums, setAlbums] = useState(null);
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+
+  async function getAlbums() {
+    if (permissionResponse.status !== 'granted') {
+      await requestPermission();
+    }
+    const fetchedAlbums = await MediaLibrary.getAlbumsAsync({
+      includeSmartAlbums: true,
+    });
+    setAlbums(fetchedAlbums);
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Button onPress={getAlbums} title="Get albums" />
+      <ScrollView>
+        {albums && albums.map((album) => <AlbumEntry album={album} />)}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function AlbumEntry({ album }) {
+  const [assets, setAssets] = useState([]);
+
+  useEffect(() => {
+    async function getAlbumAssets() {
+      const albumAssets = await MediaLibrary.getAssetsAsync({ album });
+      setAssets(albumAssets.assets);
+    }
+    getAlbumAssets();
+  }, [album]);
+
+  return (
+    <View key={album.id} style={styles.albumContainer}>
+      <Text>
+        {album.title} - {album.assetCount ?? 'no'} assets
+      </Text>
+      <View style={styles.albumAssetsContainer}>
+        {assets && assets.map((asset) => (
+          <Image source={{ uri: asset.uri }} width={50} height={50} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 8,
+    justifyContent: 'center',
+    ...Platform.select({
+      android: {
+        paddingTop: 40
+      }
+    }),
+  },
+  albumContainer: {
+    paddingHorizontal: 20,
+    marginBottom: 12,
+    gap: 4,
+  },
+  albumAssetsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v49.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/media-library.mdx
@@ -15,6 +15,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
@@ -82,6 +83,92 @@ Learn how to configure the native projects in the [installation instructions in 
     },
   ]}
 />
+
+## Usage
+
+<SnackInline label='Fetching albums and displaying assets' dependencies={['expo-media-library']}>
+
+```jsx
+import { useState, useEffect } from 'react';
+import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import * as MediaLibrary from 'expo-media-library';
+
+export default function App() {
+  const [albums, setAlbums] = useState(null);
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+
+  async function getAlbums() {
+    if (permissionResponse.status !== 'granted') {
+      await requestPermission();
+    }
+    const fetchedAlbums = await MediaLibrary.getAlbumsAsync({
+      includeSmartAlbums: true,
+    });
+    setAlbums(fetchedAlbums);
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Button onPress={getAlbums} title="Get albums" />
+      <ScrollView>
+        {albums && albums.map((album) => <AlbumEntry album={album} />)}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function AlbumEntry({ album }) {
+  const [assets, setAssets] = useState([]);
+
+  useEffect(() => {
+    async function getAlbumAssets() {
+      const albumAssets = await MediaLibrary.getAssetsAsync({ album });
+      setAssets(albumAssets.assets);
+    }
+    getAlbumAssets();
+  }, [album]);
+
+  return (
+    <View key={album.id} style={styles.albumContainer}>
+      <Text>
+        {album.title} - {album.assetCount ?? 'no'} assets
+      </Text>
+      <View style={styles.albumAssetsContainer}>
+        {assets && assets.map((asset) => (
+          <Image source={{ uri: asset.uri }} width={50} height={50} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 8,
+    justifyContent: 'center',
+    ...Platform.select({
+      android: {
+        paddingTop: 40
+      }
+    }),
+  },
+  albumContainer: {
+    paddingHorizontal: 20,
+    marginBottom: 12,
+    gap: 4,
+  },
+  albumAssetsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
+
 
 ## API
 

--- a/docs/pages/versions/v50.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/media-library.mdx
@@ -15,6 +15,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
@@ -82,6 +83,91 @@ Learn how to configure the native projects in the [installation instructions in 
     },
   ]}
 />
+
+## Usage
+
+<SnackInline label='Fetching albums and displaying assets' dependencies={['expo-media-library']}>
+
+```jsx
+import { useState, useEffect } from 'react';
+import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import * as MediaLibrary from 'expo-media-library';
+
+export default function App() {
+  const [albums, setAlbums] = useState(null);
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
+
+  async function getAlbums() {
+    if (permissionResponse.status !== 'granted') {
+      await requestPermission();
+    }
+    const fetchedAlbums = await MediaLibrary.getAlbumsAsync({
+      includeSmartAlbums: true,
+    });
+    setAlbums(fetchedAlbums);
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Button onPress={getAlbums} title="Get albums" />
+      <ScrollView>
+        {albums && albums.map((album) => <AlbumEntry album={album} />)}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function AlbumEntry({ album }) {
+  const [assets, setAssets] = useState([]);
+
+  useEffect(() => {
+    async function getAlbumAssets() {
+      const albumAssets = await MediaLibrary.getAssetsAsync({ album });
+      setAssets(albumAssets.assets);
+    }
+    getAlbumAssets();
+  }, [album]);
+
+  return (
+    <View key={album.id} style={styles.albumContainer}>
+      <Text>
+        {album.title} - {album.assetCount ?? 'no'} assets
+      </Text>
+      <View style={styles.albumAssetsContainer}>
+        {assets && assets.map((asset) => (
+          <Image source={{ uri: asset.uri }} width={50} height={50} />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 8,
+    justifyContent: 'center',
+    ...Platform.select({
+      android: {
+        paddingTop: 40
+      }
+    }),
+  },
+  albumContainer: {
+    paddingHorizontal: 20,
+    marginBottom: 12,
+    gap: 4,
+  },
+  albumAssetsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+});
+/* @end */
+```
+
+</SnackInline>
 
 ## API
 


### PR DESCRIPTION
# Why

Refs ENG-6370

# How

Add a basic usage Snack example to the MediaLibrary API reference page, so it easier for users to experiment with package.

# Test Plan

The changes have been tested locally. The example code have been verified on Snack.

# Preview

![Screenshot 2024-03-20 at 18 35 29](https://github.com/expo/expo/assets/719641/c99f2be8-e08e-40b6-854e-265231727ced)

