### PR TITLE
Fix mismatching `tsc` binary versions in expo-module-scripts in monorepos

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Use appropriate version of `tsc` when executing `expo-module build` in monorepos with multiple typescript versions installed ([#27779](https://github.com/expo/expo/pull/27779) by [@peter.jozsa](https://github.com/peter.jozsa)
+
 ### 💡 Others
 
 - Target Node 18 in the Babel CLI preset. ([#26847](https://github.com/expo/expo/pull/26847) by [@simek](https://github.com/simek))

--- a/packages/expo-module-scripts/bin/expo-module-tsc
+++ b/packages/expo-module-scripts/bin/expo-module-tsc
@@ -4,4 +4,4 @@ set -eo pipefail
 
 script_dir="$(dirname "$0")"
 
-"$script_dir/npx" tsc "$@"
+"$script_dir/npx" --package=typescript tsc "$@"


### PR DESCRIPTION
# Why

If you have a monorepo in which you have different versions of typescript installed you may see that `expo-module build plugin` fails because of unknown TS compiler options. I think it happens because wrong version of `tsc` picked up by `npx`.

Related GitHub issues:
https://github.com/npm/cli/issues/6765

# How

As far as I understand the root cause of this issue is that if we simply run `npx tsc ...` npm does not know `tsc` binary belongs to the `typescript` package and it will simply try to resolve it from the root workspace's `node_modules/.bin` where  it will find the wrong version of `tsc` because of dependency hoisting. It should start looking up `tsc` in the workspace's `node_modules/.bin` (from where we're executing `expo-module build plugin`) but that is not the case for some reason. We can only achieve this by giving a hint to `npx` that `tsc` belongs to the package called `typescript`. In this case it will start the binary lookup from the workspace's `node_modules/.bin` folder and use the correct version to build our module plugin.

# Test Plan

1. Create a Yarn v2 Berry monorepo.
2. Create a module (`packages/cool-module`) by following the official tutorial **with a config plugin** (https://docs.expo.dev/modules/config-plugin-and-native-module-tutorial/)
3. Add `typescript@^4.5.5` to your workspace root as a dev dependency (or add you could have multiple other workspaces that depend on `typescript@^4.5.5`, e.g. `packages/my-api`)
4. At this point you should see that the 4.5.5 `tsc` is installed in your root `node_modules` and 5.3.0 `tsc` is installed in your `packages/cool-module/node_modules` folder.
5. If you try to run `cd packages/cool-module && yarn run build plugin` you should receive TypeScript config errors since `packages/cool-module/plugin/tsconfig.json` inherits configuration options that are unknown to 4.5.5 `tsc`. (e.g. `"lib": ["es2023"]`). At this point you know something is wrong since `expo-module-scripts` depends on  `typescript": "^5.1.3"` that should be aware of `es2023` and `node16` module resolution logic.
6. Go to your module workspace folder (`cd packages/cool-module`) and execute the same command that is executed by `expo-module build plugin` under the hood: `yarn exec -- npx tsc --version`. It should give the **mismatched** `4.5.5` version.
7. Stay in the module workspace folder (`packages/cool-module`) and execute now the following command: `yarn exec -- npx --package=typescript tsc --version`. It should give the **correct** `5.3.0` version.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
