### PR TITLE
[updates] fix crash in project without expo-dev-client on debug build

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Add ability to override build-time fingerprint. ([#27597](https://github.com/expo/expo/pull/27597) by [@wschurman](https://github.com/wschurman))
 - Expose emergency launch reason on constants. ([#27714](https://github.com/expo/expo/pull/27714) by [@wschurman](https://github.com/wschurman))
 
-
 ### 🐛 Bug fixes
 
 - Fix development status for modern updates. ([#26042](https://github.com/expo/expo/pull/26042) by [@wschurman](https://github.com/wschurman))
@@ -28,6 +27,7 @@
 - Make error messages consistent across platforms for dev client and disabled controllers. ([#26988](https://github.com/expo/expo/pull/26988) by [@wschurman](https://github.com/wschurman))
 - Fixed ANR issue from Detox testing on Android. ([#27031](https://github.com/expo/expo/pull/27031) by [@kudo](https://github.com/kudo))
 - Fix inconsistent hashes for autolinking for fingerprint policy. ([#27390](https://github.com/expo/expo/pull/27390) by [@wschurman](https://github.com/wschurman))
+- Fixed launch crash when running on a project without expo-dev-client and debug build. ([#27780](https://github.com/expo/expo/pull/27780) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -3,10 +3,12 @@ package expo.modules.updates
 import android.content.Context
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
+import expo.modules.kotlin.AppContext
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
+import java.lang.ref.WeakReference
 
 /**
  * Main entry point to expo-updates. Singleton that keeps track of updates state, holds references
@@ -140,6 +142,24 @@ class UpdatesController {
       } else {
         val logger = UpdatesLogger(context)
         logger.warn("Failed to overrideConfiguration: invalid configuration: ${updatesConfigurationValidationResult.name}")
+      }
+    }
+
+    /**
+     * For [UpdatesModule] to set the [shouldEmitJsEvents] property.
+     */
+    internal var shouldEmitJsEvents: Boolean
+      get() = singletonInstance?.shouldEmitJsEvents ?: false
+      set(value) {
+        singletonInstance?.let { it.shouldEmitJsEvents = value }
+      }
+
+    /**
+     * Binds the [AppContext] instance from [UpdatesModule].
+     */
+    internal fun bindAppContext(appContext: WeakReference<AppContext>) {
+      singletonInstance?.let {
+        it.appContext = appContext
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -78,15 +78,15 @@ class UpdatesModule : Module() {
     }
 
     OnCreate {
-      UpdatesController.instance.appContext = WeakReference(appContext)
+      UpdatesController.bindAppContext(WeakReference(appContext))
     }
 
     OnStartObserving {
-      UpdatesController.instance.shouldEmitJsEvents = true
+      UpdatesController.shouldEmitJsEvents = true
     }
 
     OnStopObserving {
-      UpdatesController.instance.shouldEmitJsEvents = false
+      UpdatesController.shouldEmitJsEvents = false
     }
 
     AsyncFunction("reload") { promise: Promise ->

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -279,6 +279,21 @@ public class AppController: NSObject {
       throw dbError
     }
   }
+
+  /**
+   For `UpdatesModule` to set the `shouldEmitJsEvents` property
+   */
+  internal static var shouldEmitJsEvents: Bool {
+    get { _sharedInstance?.shouldEmitJsEvents ?? false }
+    set { _sharedInstance?.shouldEmitJsEvents = newValue }
+  }
+
+  /**
+   Binds the `AppContext` instance from `UpdatesModule`.
+   */
+  internal static func bindAppContext(_ appContext: AppContext?) {
+    _sharedInstance?.appContext = appContext
+  }
 }
 
 // swiftlint:enable identifier_name

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -70,15 +70,15 @@ public final class UpdatesModule: Module {
     }
 
     OnCreate {
-      AppController.sharedInstance.appContext = self.appContext
+      AppController.bindAppContext(self.appContext)
     }
 
     OnStartObserving {
-      AppController.sharedInstance.shouldEmitJsEvents = true
+      AppController.shouldEmitJsEvents = true
     }
 
     OnStopObserving {
-      AppController.sharedInstance.shouldEmitJsEvents = false
+      AppController.shouldEmitJsEvents = false
     }
 
     AsyncFunction("reload") { (promise: Promise) in


### PR DESCRIPTION
# Why

found a regression when running expo-updates on debug build without expo-dev-client. this is from accessing the singleton instance before initialization.

# How

check if the singleton instance is initialized

# Test Plan

test on sdk canary + expo-updates canary + new architecture mode

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
