### PR TITLE
[docs]: Update link for Ignite UI

### DIFF
--- a/docs/pages/ui-programming/user-interface-libraries.mdx
+++ b/docs/pages/ui-programming/user-interface-libraries.mdx
@@ -18,7 +18,7 @@ Below are some of the most popular UI Libraries. Test them all out and see what 
 | [Tamagui](https://tamagui.dev)                                                    | [Link](https://tamagui.dev/docs/intro/installation)                                                             |
 | [NativeWind](https://www.nativewind.dev/)                                         | [Link](https://www.nativewind.dev/)                                                                             |
 | [Gluestack UI](https://ui.gluestack.io/)                                          | [Link](https://ui.gluestack.io/)                                                                                |
-| [Ignite UI](https://docs.infinite.red/ignite-cli/)                                | [Link](https://docs.infinite.red/ignite-cli/boilerplate/components/)                            |
+| [Ignite UI](https://docs.infinite.red/ignite-cli/)                                | [Link](https://docs.infinite.red/ignite-cli/boilerplate/app/components/)                            |
 | [React Native Reusables](https://github.com/mrzachnugent/react-native-reusables)  | [Link](https://github.com/mrzachnugent/react-native-reusables)                            |
 | [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten)         | [Link](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten) |
 


### PR DESCRIPTION
# Why

In [this page](https://docs.expo.dev/ui-programming/user-interface-libraries/), link for Infinite Red is broken.

![image](https://github.com/expo/expo/assets/43630681/296c0748-4fc3-4576-8100-ff26ef97dc8e)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update to new link

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
