### PR TITLE
[video][Android] Improve readability of code and simplify playback service

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/ExpoVideoPlaybackService.kt
@@ -8,16 +8,16 @@ import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import androidx.annotation.OptIn
 import androidx.core.app.NotificationCompat
-import androidx.media3.session.MediaSession
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.CommandButton
+import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SessionCommand
 import com.google.common.collect.ImmutableList
-import androidx.annotation.OptIn
-import androidx.media3.common.util.UnstableApi
 
 class PlaybackServiceBinder(val service: ExpoVideoPlaybackService) : Binder()
 
@@ -25,7 +25,6 @@ class PlaybackServiceBinder(val service: ExpoVideoPlaybackService) : Binder()
 class ExpoVideoPlaybackService : MediaSessionService() {
   private val mediaSessions = mutableMapOf<ExoPlayer, MediaSession>()
   private val binder = PlaybackServiceBinder(this)
-  private var mediaSession: MediaSession? = null
 
   private val commandSeekForward = SessionCommand(SEEK_FORWARD_COMMAND, Bundle.EMPTY)
   private val commandSeekBackward = SessionCommand(SEEK_BACKWARD_COMMAND, Bundle.EMPTY)
@@ -58,9 +57,10 @@ class ExpoVideoPlaybackService : MediaSessionService() {
 
   fun unregisterPlayer(player: ExoPlayer) {
     hidePlayerNotification(player)
-    mediaSessions[player]?.release()
-    mediaSessions.remove(player)
+    val session = mediaSessions.remove(player)
+    session?.release()
     if (mediaSessions.isEmpty()) {
+      cleanup()
       stopSelf()
     }
   }
@@ -75,21 +75,17 @@ class ExpoVideoPlaybackService : MediaSessionService() {
   }
 
   override fun onTaskRemoved(rootIntent: Intent?) {
+    cleanup()
     stopSelf()
   }
 
   override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
-    return mediaSession
+    return null
   }
 
   override fun onDestroy() {
     cleanup()
     super.onDestroy()
-  }
-
-  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    super.onStartCommand(intent, flags, startId)
-    return START_NOT_STICKY
   }
 
   private fun createNotification(session: MediaSession) {
@@ -115,11 +111,11 @@ class ExpoVideoPlaybackService : MediaSessionService() {
   }
 
   private fun cleanup() {
+    hideAllNotifications()
     mediaSessions.forEach { (_, session) ->
       session.release()
     }
     mediaSessions.clear()
-    hideAllNotifications()
   }
 
   private fun hidePlayerNotification(player: ExoPlayer) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/PlayerViewExtension.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/PlayerViewExtension.kt
@@ -28,5 +28,9 @@ internal fun PlayerView.setTimeBarInteractive(interactive: Boolean) {
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 internal fun PlayerView.setFullscreenButtonVisibility(visible: Boolean) {
   val fullscreenButton = findViewById<android.widget.ImageButton>(androidx.media3.ui.R.id.exo_fullscreen)
-  fullscreenButton?.visibility = if (visible) android.view.View.VISIBLE else android.view.View.GONE
+  fullscreenButton?.visibility = if (visible) {
+    android.view.View.VISIBLE
+  } else {
+    android.view.View.GONE
+  }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -12,7 +12,7 @@ object VideoManager {
   private var videoViews = mutableMapOf<String, VideoView>()
 
   // Keeps track of all existing VideoPlayers, and whether they are attached to a VideoView
-  private var videoPlayersToVideoViews = mutableMapOf<VideoPlayer, ArrayList<VideoView>>()
+  private var videoPlayersToVideoViews = mutableMapOf<VideoPlayer, MutableList<VideoView>>()
 
   fun registerVideoView(videoView: VideoView) {
     videoViews[videoView.id] = videoView
@@ -27,7 +27,7 @@ object VideoManager {
   }
 
   fun registerVideoPlayer(videoPlayer: VideoPlayer) {
-    videoPlayersToVideoViews[videoPlayer] = videoPlayersToVideoViews[videoPlayer] ?: arrayListOf()
+    videoPlayersToVideoViews[videoPlayer] = videoPlayersToVideoViews[videoPlayer] ?: mutableListOf()
   }
 
   fun unregisterVideoPlayer(videoPlayer: VideoPlayer) {
@@ -56,9 +56,7 @@ object VideoManager {
     }
   }
 
-  fun onAppForegrounded() {
-    // TODO: Left here for future use
-  }
+  fun onAppForegrounded() = Unit
 
   fun onAppBackgrounded() {
     for (videoView in videoViews.values) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -37,7 +37,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   private val currentActivity = appContext.currentActivity
     ?: throw Exceptions.MissingActivity()
   private val decorView = currentActivity.window.decorView
-  private val rootView = decorView.findViewById(android.R.id.content) as ViewGroup
+  private val rootView = decorView.findViewById<ViewGroup>(android.R.id.content)
 
   private val rectHint: Rect = Rect()
   private val rootViewChildrenOriginalVisibility: ArrayList<Int> = arrayListOf()

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/DRMOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/DRMOptions.kt
@@ -13,11 +13,13 @@ internal class DRMOptions(
   @Field var multiKey: Boolean = false
 ) : Record, Serializable {
 
-  fun toDRMConfiguration(): MediaItem.DrmConfiguration {
-    val drmConfiguration = MediaItem.DrmConfiguration.Builder(type.toUUID())
-    licenseServer?.let { drmConfiguration.setLicenseUri(it) }
-    headers?.let { drmConfiguration.setLicenseRequestHeaders(it) }
-    drmConfiguration.setMultiSession(multiKey)
-    return drmConfiguration.build()
-  }
+  fun toDRMConfiguration() = MediaItem
+    .DrmConfiguration
+    .Builder(type.toUUID())
+    .apply {
+      licenseServer?.let { setLicenseUri(it) }
+      headers?.let { setLicenseRequestHeaders(it) }
+      setMultiSession(multiKey)
+    }
+    .build()
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -10,18 +10,17 @@ internal class VideoSource(
   @Field var uri: String? = null,
   @Field var drm: DRMOptions? = null
 ) : Record, Serializable {
-  fun toMediaItem(): MediaItem {
-    val mediaItem = MediaItem
-      .Builder()
-      .setUri(this.uri ?: "")
-
-    this.drm?.let {
-      if (it.type.isSupported()) {
-        mediaItem.setDrmConfiguration(it.toDRMConfiguration())
-      } else {
-        throw UnsupportedDRMTypeException(it.type)
+  fun toMediaItem() = MediaItem
+    .Builder()
+    .apply {
+      setUri(uri ?: "")
+      drm?.let {
+        if (it.type.isSupported()) {
+          setDrmConfiguration(it.toDRMConfiguration())
+        } else {
+          throw UnsupportedDRMTypeException(it.type)
+        }
       }
     }
-    return mediaItem.build()
-  }
+    .build()
 }


### PR DESCRIPTION
# Why

Improves readability and simplifies the playback service logic.
Removes some of the unneeded parts. 

# How

The most significant change is connected to the playback service - where I changed the service from being non-sticky to sticky. It follows the implementation of the `MediaSessionService`. It shouldn't affect the user app behavior. 

# Test Plan

- bare-expo with NCL example ✅
