### PR TITLE
[image][video][Android] Use `PropGroup` from core instead of defining own version

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.image
 
 import android.graphics.drawable.Drawable
-import android.view.View
 import androidx.core.view.doOnDetach
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DataSource
@@ -25,7 +24,6 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.kotlin.views.ViewDefinitionBuilder
 
 class ExpoImageModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -262,16 +260,5 @@ class ExpoImageModule : Module() {
         }
       }
     }
-  }
-}
-
-// TODO(@lukmccall): Remove when the same functionality will be defined by the expo-modules-core in SDK 48
-@Suppress("FunctionName")
-private inline fun <reified T : View, reified PropType, reified CustomValueType> ViewDefinitionBuilder<T>.PropGroup(
-  vararg props: Pair<String, CustomValueType>,
-  noinline body: (view: T, value: CustomValueType, prop: PropType) -> Unit
-) {
-  for ((name, value) in props) {
-    Prop<T, PropType>(name) { view, prop -> body(view, value, prop) }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -130,7 +130,7 @@ class ViewDefinitionBuilder<T : View>(
     )
   }
 
-  private inline fun <reified ViewType : View, reified PropType, reified CustomValueType> PropGroup(
+  inline fun <reified ViewType : View, reified PropType, reified CustomValueType> PropGroup(
     vararg props: Pair<String, CustomValueType>,
     noinline body: (view: ViewType, value: CustomValueType, prop: PropType) -> Unit
   ) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -3,21 +3,19 @@
 package expo.modules.video
 
 import android.app.Activity
-import android.view.View
 import androidx.media3.common.PlaybackParameters
-import expo.modules.kotlin.apifeatures.EitherType
-import androidx.media3.common.Player.REPEAT_MODE_ONE
 import androidx.media3.common.Player.REPEAT_MODE_OFF
+import androidx.media3.common.Player.REPEAT_MODE_ONE
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.ViewProps
 import com.facebook.yoga.YogaConstants
+import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.types.Either
 import expo.modules.video.records.VideoSource
-import expo.modules.kotlin.views.ViewDefinitionBuilder
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -279,15 +277,5 @@ class VideoModule : Module() {
     OnActivityEntersBackground {
       VideoManager.onAppBackgrounded()
     }
-  }
-}
-
-@Suppress("FunctionName")
-private inline fun <reified T : View, reified PropType, reified CustomValueType> ViewDefinitionBuilder<T>.PropGroup(
-  vararg props: Pair<String, CustomValueType>,
-  noinline body: (view: T, value: CustomValueType, prop: PropType) -> Unit
-) {
-  for ((name, value) in props) {
-    Prop<T, PropType>(name) { view, prop -> body(view, value, prop) }
   }
 }


### PR DESCRIPTION
# Why

Uses the `PropGroup` DSL component from code instead of defining it in each package.
