### PR TITLE
feature(cli): add event marker for the new telemetry api

### DIFF
--- a/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
@@ -16,7 +16,10 @@ export class RudderClient implements TelemetryClient {
   /** The promise to initially identify the user */
   private initialIdentify: Promise<any> | undefined;
 
-  constructor(sdk?: RudderAnalytics) {
+  constructor(
+    sdk?: RudderAnalytics,
+    private mode: 'attached' | 'detached' = 'attached'
+  ) {
     if (!sdk) {
       sdk = new RudderAnalytics(
         env.EXPO_STAGING || env.EXPO_LOCAL
@@ -96,7 +99,10 @@ export class RudderClient implements TelemetryClient {
           source_version: process.env.__EXPO_VERSION,
         },
         ...this.identity,
-        context: getContext(),
+        context: {
+          ...getContext(),
+          client: { mode: this.mode },
+        },
       });
     }
   }

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
@@ -41,7 +41,30 @@ it('tracks event when user is identified', async () => {
       source: 'expo/cli',
       source_version: process.env.__EXPO_VERSION, // undefined in testing
     }),
-    context: getContext(),
+    context: {
+      ...getContext(),
+      client: { mode: 'attached' },
+    },
+  });
+});
+
+it('tracks event with correct mode', async () => {
+  const sdk = mockRudderAnalytics();
+  const client = new RudderClient(sdk, 'detached');
+  const actor = { id: 'fake', __typename: 'User' } as Actor;
+
+  await client.identify(actor);
+  await client.record({ event: 'Start Project' });
+
+  expect(sdk.track).toHaveBeenCalledWith({
+    userId: 'fake',
+    anonymousId: expect.any(String),
+    context: {
+      ...getContext(),
+      client: { mode: 'detached' },
+    },
+    event: 'Start Project',
+    properties: { source: 'expo/cli', source_version: undefined },
   });
 });
 

--- a/packages/@expo/cli/src/utils/telemetry/flushDetached.ts
+++ b/packages/@expo/cli/src/utils/telemetry/flushDetached.ts
@@ -28,7 +28,7 @@ async function flush() {
     return;
   }
 
-  const client = new RudderClient();
+  const client = new RudderClient(undefined, 'detached');
   await client.identify(data.actor || (await getUserAsync()));
 
   for (const record of data.records) {


### PR DESCRIPTION
# Why

This is split out from https://github.com/expo/expo/pull/27730, and stacked on #27789. It adds a marker for us to validate if the new telemetry API is working as intended.

# How

- Added `attached` and `detached` modes

# Test Plan

TBD, see #27730 for a full test plan.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
