### PR TITLE
refactor(cli): remove duplicated cli version telemetry data

### DIFF
--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -207,10 +207,6 @@ commands[command]().then((exec) => {
     // We do this to determine how well deprecations are going before removing a command.
     const { logEventAsync } =
       require('../src/utils/telemetry') as typeof import('../src/utils/telemetry');
-    logEventAsync('action', {
-      action: `expo ${command}`,
-      source: 'expo/cli',
-      source_version: process.env.__EXPO_VERSION,
-    });
+    logEventAsync('action', { action: `expo ${command}` });
   }
 });

--- a/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/RudderClient.ts
@@ -93,11 +93,7 @@ export class RudderClient implements TelemetryClient {
       await this.rudderstack.track({
         event: record.event,
         originalTimestamp,
-        properties: {
-          ...(record.properties ?? {}),
-          source: 'expo/cli',
-          source_version: process.env.__EXPO_VERSION,
-        },
+        properties: record.properties,
         ...this.identity,
         context: {
           ...getContext(),

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
@@ -149,6 +149,8 @@ it('only re-identifies when user has changed', async () => {
   const client = new RudderClient(sdk);
 
   await client.identify({ ...mockActor, id: 'old' });
+  await client.identify({ ...mockActor, id: 'old' });
+  await client.identify({ ...mockActor, id: 'new' });
   await client.identify({ ...mockActor, id: 'new' });
 
   expect(sdk.identify).toHaveBeenCalledWith(expect.objectContaining({ userId: 'old' }));

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
@@ -37,10 +37,6 @@ it('tracks event when user is identified', async () => {
     userId: 'fake',
     anonymousId: 'anonymous-id',
     event: 'Start Project',
-    properties: expect.objectContaining({
-      source: 'expo/cli',
-      source_version: process.env.__EXPO_VERSION, // undefined in testing
-    }),
     context: {
       ...getContext(),
       client: { mode: 'attached' },
@@ -64,10 +60,6 @@ it('tracks event with correct mode', async () => {
       client: { mode: 'detached' },
     },
     event: 'Start Project',
-    properties: expect.objectContaining({
-      source: 'expo/cli',
-      source_version: process.env.__EXPO_VERSION, // undefined in testing
-    }),
   });
 });
 

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/RudderClient.test.ts
@@ -64,7 +64,10 @@ it('tracks event with correct mode', async () => {
       client: { mode: 'detached' },
     },
     event: 'Start Project',
-    properties: { source: 'expo/cli', source_version: undefined },
+    properties: expect.objectContaining({
+      source: 'expo/cli',
+      source_version: process.env.__EXPO_VERSION, // undefined in testing
+    }),
   });
 });
 

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/getContext.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/getContext.test.ts
@@ -24,7 +24,7 @@ it('contains os name and version', () => {
 it('contains app name and version', () => {
   process.env.__EXPO_VERSION = '1337';
   expect(getContext().app).toMatchObject({
-    name: 'expo',
+    name: 'expo/cli',
     version: '1337',
   });
 });

--- a/packages/@expo/cli/src/utils/telemetry/getContext.ts
+++ b/packages/@expo/cli/src/utils/telemetry/getContext.ts
@@ -8,7 +8,7 @@ export function getContext() {
     os: { name: os.platform(), version: os.release() },
     device: { arch: os.arch(), version: os.version(), memory: summarizeMemory() },
     cpu: summarizeCpuInfo(),
-    app: { name: 'expo', version: process.env.__EXPO_VERSION },
+    app: { name: 'expo/cli', version: process.env.__EXPO_VERSION },
     ci: ciInfo.isCI ? { name: ciInfo.name, isPr: ciInfo.isPR } : undefined,
   };
 }


### PR DESCRIPTION
# Why

This is split out from https://github.com/expo/expo/pull/27730, and stacked on #27789. It removes duplicate `expo/cli` version information from our telemetry.

# How

- Dropped `source` and `source_version` from `action` event
- Renamed `context.app.name` to `expo` → `expo/cli`

# Test Plan

TBD, see #27730 for a full test plan.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
