### PR TITLE
[core] Provide native backwards compatibility for EventEmitter

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/EventEmitterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/EventEmitterTest.kt
@@ -5,8 +5,20 @@ import org.junit.Test
 
 class EventEmitterTest {
   @Test
-  fun evnet_emitter_class_should_exists() = withJSIInterop {
+  fun event_emitter_class_should_exists() = withJSIInterop {
     val sharedObjectClass = evaluateScript("expo.EventEmitter")
     Truth.assertThat(sharedObjectClass.isFunction()).isTrue()
+  }
+
+  @Test
+  fun event_emitter_provides_backwards_compatibility() = withJSIInterop {
+    val emittersAreEqual = evaluateScript(
+      """
+      emitterA = new expo.EventEmitter();
+      emitterB = new expo.EventEmitter(emitterA);
+      emitterA === emitterB;
+      """.trimIndent()
+    )
+    Truth.assertThat(emittersAreEqual.getBool()).isTrue()
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -150,7 +150,7 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
         const jsi::Value &thisValue,
         const jsi::Value *args,
         size_t count
-      ) {
+      ) -> jsi::Value {
         auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
         decorateObjectWithProperties(runtime, thisObject.get(),
                                      classObject);
@@ -170,7 +170,7 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
             count
           );
           if (result == nullptr) {
-            return;
+            return jsi::Value(runtime, thisValue);
           }
           jobject unpackedResult = result.get();
           jclass resultClass = env->GetObjectClass(unpackedResult);
@@ -187,6 +187,7 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
             );
             jsiContext->registerSharedObject(result, jsThisObject);
           }
+          return jsi::Value(runtime, thisValue);
         } catch (jni::JniException &jniException) {
           rethrowAsCodedError(runtime, jniException);
         }

--- a/packages/expo-modules-core/common/cpp/JSIUtils.cpp
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.cpp
@@ -10,7 +10,7 @@ jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstruc
 
   // Create a string buffer of the source code to evaluate.
   std::stringstream source;
-  source << "(function " << name << "(...args) { this." << nativeConstructorKey << "(...args); return this; })";
+  source << "(function " << name << "(...args) { return this." << nativeConstructorKey << "(...args); })";
   std::shared_ptr<jsi::StringBuffer> sourceBuffer = std::make_shared<jsi::StringBuffer>(source.str());
 
   // Evaluate the code and obtain returned value (the constructor function).
@@ -26,9 +26,9 @@ jsi::Function createClass(jsi::Runtime &runtime, const char *name, ClassConstruc
     0,
     [constructor](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
       if (constructor) {
-        constructor(runtime, thisValue, args, count);
+        return constructor(runtime, thisValue, args, count);
       }
-      return jsi::Value::undefined();
+      return jsi::Value(runtime, thisValue);
     });
 
   jsi::Object descriptor(runtime);

--- a/packages/expo-modules-core/common/cpp/JSIUtils.h
+++ b/packages/expo-modules-core/common/cpp/JSIUtils.h
@@ -23,7 +23,7 @@ inline jsi::Object getCoreObject(jsi::Runtime &runtime) {
 /**
  Type of the native constructor of the JS classes.
  */
-typedef std::function<void(jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count)> ClassConstructor;
+typedef std::function<jsi::Value(jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count)> ClassConstructor;
 
 /**
  Creates a class with the given name and native constructor.

--- a/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EventEmitterSpec.swift
@@ -171,6 +171,15 @@ final class EventEmitterSpec: ExpoSpec {
 
         expect(try counter.asInt()) == 2
       }
+
+      it("provides backwards compatibility for the legacy wrapper") {
+        let emittersAreEqual = try runtime.eval([
+          "emitterA = new expo.EventEmitter()",
+          "emitterB = new expo.EventEmitter(emitterA)",
+          "emitterA === emitterB"
+        ])
+        expect(try emittersAreEqual.asBool()) == true
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

To entirely get rid of the legacy EventEmitter in JS and don't have to apply changes to the existing modules immediately, the constructor of the new one should return the provided argument if it's already an instance of the native EventEmitter.
That way we don't have to change other modules and remove the existing `EventEmitter.ts` logic.

# How

- Made it possible to return values in the native constructor (so the entire constructor can return something else than `this`)
- In the `EventEmitter` class constructor, return the first argument if it is already an event emitter (the goal is to handle native modules)
- Added native unit tests

# Test Plan

Existing unit tests are passing and I also added a new one for both Android and iOS.