### PR TITLE
refactor(cli): rework the device information

### DIFF
--- a/packages/@expo/cli/src/utils/telemetry/__tests__/getContext.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/getContext.test.ts
@@ -3,11 +3,6 @@ import os from 'os';
 import { getContext } from '../getContext';
 
 const originalVersion = process.env.__EXPO_VERSION;
-const knownPlatformNames = {
-  darwin: 'Mac',
-  linux: 'Linux',
-  win32: 'Windows',
-};
 
 jest.mock('ci-info', () => ({ isCI: true, isPR: true, name: 'GitHub Actions' }));
 
@@ -21,15 +16,8 @@ afterAll(() => {
 
 it('contains os name and version', () => {
   expect(getContext().os).toMatchObject({
-    name: knownPlatformNames[os.platform()] || os.platform(),
+    name: os.platform(),
     version: os.release(),
-  });
-});
-
-it('contains device type and model', () => {
-  expect(getContext().device).toMatchObject({
-    type: knownPlatformNames[os.platform()] || os.platform(),
-    model: knownPlatformNames[os.platform()] || os.platform(),
   });
 });
 

--- a/packages/@expo/cli/src/utils/telemetry/getContext.ts
+++ b/packages/@expo/cli/src/utils/telemetry/getContext.ts
@@ -1,6 +1,8 @@
 import * as ciInfo from 'ci-info';
 import os from 'os';
 
+import { groupBy } from '../array';
+
 const PLATFORM_TO_TELEMETRY_PLATFORM: { [platform: string]: string } = {
   darwin: 'Mac',
   win32: 'Windows',
@@ -11,8 +13,29 @@ export function getContext() {
   const platform = PLATFORM_TO_TELEMETRY_PLATFORM[os.platform()] || os.platform();
   return {
     os: { name: platform, version: os.release() },
-    device: { type: platform, model: platform },
+    device: { arch: os.arch(), version: os.version(), memory: summarizeMemory() },
+    cpu: summarizeCpuInfo(),
     app: { name: 'expo', version: process.env.__EXPO_VERSION },
     ci: ciInfo.isCI ? { name: ciInfo.name, isPr: ciInfo.isPR } : undefined,
   };
+}
+
+function summarizeMemory() {
+  const gb = os.totalmem() / 1024 / 1024 / 1024;
+  return Math.round(gb * 100) / 100;
+}
+
+function summarizeCpuInfo() {
+  const cpus = groupBy(os.cpus() ?? [], (item) => item.model);
+  const summary = { model: '', speed: 0, count: 0 };
+
+  for (const key in cpus) {
+    if (cpus[key].length > summary.count) {
+      summary.model = key;
+      summary.speed = cpus[key][0].speed;
+      summary.count = cpus[key].length;
+    }
+  }
+
+  return !summary.model || !summary.count ? undefined : summary;
 }

--- a/packages/@expo/cli/src/utils/telemetry/getContext.ts
+++ b/packages/@expo/cli/src/utils/telemetry/getContext.ts
@@ -3,16 +3,9 @@ import os from 'os';
 
 import { groupBy } from '../array';
 
-const PLATFORM_TO_TELEMETRY_PLATFORM: { [platform: string]: string } = {
-  darwin: 'Mac',
-  win32: 'Windows',
-  linux: 'Linux',
-};
-
 export function getContext() {
-  const platform = PLATFORM_TO_TELEMETRY_PLATFORM[os.platform()] || os.platform();
   return {
-    os: { name: platform, version: os.release() },
+    os: { name: os.platform(), version: os.release() },
     device: { arch: os.arch(), version: os.version(), memory: summarizeMemory() },
     cpu: summarizeCpuInfo(),
     app: { name: 'expo', version: process.env.__EXPO_VERSION },


### PR DESCRIPTION
# Why

This is split out from https://github.com/expo/expo/pull/27730, and stacked on #27789. It replaced the "useless" device info with useful performance info.

# How

- Replaced `device` with new `device` properties
- Added `cpu` for basic performance context

# Test Plan

TBD, see #27730 for a full test plan.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
