### PR TITLE
[docs] update store assets demo to link to our Figma template

### DIFF
--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -62,8 +62,7 @@ In this option, on the app store pages, you can incorporate elements of your app
 
 Google has specific requirements for the store asset format and dimensions, which are different from Apple's. For the most up-to-date specifications, see [official documentation](https://support.google.com/googleplay/android-developer/answer/9866151) for detailed requirements for your Google Play Store assets.
 
-See our [Store Asset Requirements Figma](https://www.figma.com/file/5lQcrHYhUZkIxsLYCZa3S6/Store-Asset-Requirements?type=design&node-id=1-171&mode=design&t=YC6s5lYVJiwSQPki-0) for a summary
-of the minimum asset requirements for an Android App.
+You can refer to our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
 
 ### App icon
 
@@ -85,7 +84,7 @@ You can add one preview video to your Store Listing. The video needs to be uploa
 
 For the iOS App Store, you can upload screenshots (images) and previews (videos). For each, Apple requires specific widths and heights. Make sure to reference the [Screenshot specifications from Apple](https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/) for the exact sizing. Even a single pixel-off will mean you cannot submit the images.
 
-See our [Store Asset Requirements Figma](https://www.figma.com/file/5lQcrHYhUZkIxsLYCZa3S6/Store-Asset-Requirements?type=design&node-id=1-43&mode=design&t=eFTsHStO7OY2lLsd-0) for an overview of the minimum asset requirements for an iOS App.
+You can refer to our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
 
 ### Screenshots
 

--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -62,7 +62,7 @@ In this option, on the app store pages, you can incorporate elements of your app
 
 Google has specific requirements for the store asset format and dimensions, which are different from Apple's. For the most up-to-date specifications, see [official documentation](https://support.google.com/googleplay/android-developer/answer/9866151) for detailed requirements for your Google Play Store assets.
 
-You can refer to our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
+See our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
 
 ### App icon
 
@@ -84,7 +84,7 @@ You can add one preview video to your Store Listing. The video needs to be uploa
 
 For the iOS App Store, you can upload screenshots (images) and previews (videos). For each, Apple requires specific widths and heights. Make sure to reference the [Screenshot specifications from Apple](https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/) for the exact sizing. Even a single pixel-off will mean you cannot submit the images.
 
-You can refer to our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
+See our [Figma Template](https://www.figma.com/community/file/1352686667495694112) for a summary of the minimum asset requirements.
 
 ### Screenshots
 


### PR DESCRIPTION
# Why

Currently the we link to a public Figma file which gives a decent overview, but it ultimately read-only.

We've updated this template to be a bit more template-y and [published to Figma](https://www.figma.com/community/file/1352686667495694112).

# How

Update the link in the sore assets doc.

# Test Plan

Verify the link works.

