### PR TITLE
[core] add getJSBundleFile support for bridgeless mode

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
+- Added `ReactNativeHost.getJSBundleFile()` support for bridgeless mode. ([#27804](https://github.com/expo/expo/pull/27804) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -41,6 +41,12 @@ object ExpoReactHostFactory {
     override val jsBundleLoader: JSBundleLoader
       get() {
         val context = weakContext.get() ?: throw IllegalStateException("Unable to get concrete Context")
+        reactNativeHostWrapper.jsBundleFile?.let { jsBundleFile ->
+          if (jsBundleFile.startsWith("assets://")) {
+            return JSBundleLoader.createAssetLoader(context, jsBundleFile, true)
+          }
+          return JSBundleLoader.createFileLoader(jsBundleFile)
+        }
         val jsBundleAssetPath = reactNativeHostWrapper.bundleAssetName
         return JSBundleLoader.createAssetLoader(context, "assets://$jsBundleAssetPath", true)
       }


### PR DESCRIPTION
# Why

expo-updates uses the `ReactNativeHost.getJSBundleFile()` to define the launch bundle path. the defaultReactHost doesn't support it, so expo-updates always uses the embedded bundle.

# How

reference the logic from bridged ReactInstanceManager to support the `getJSBundleFile()`: https://github.com/facebook/react-native/blob/15a5638c621cbec4a9fcb5ae94938120cdc32fae/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java#L107-L114

# Test Plan

test canary + expo-updates + eas updates that should launch the remote bundle

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
