### PR TITLE
[updates] fix error recovery on ios

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed ANR issue from Detox testing on Android. ([#27031](https://github.com/expo/expo/pull/27031) by [@kudo](https://github.com/kudo))
 - Fix inconsistent hashes for autolinking for fingerprint policy. ([#27390](https://github.com/expo/expo/pull/27390) by [@wschurman](https://github.com/wschurman))
 - Fixed launch crash when running on a project without expo-dev-client and debug build. ([#27780](https://github.com/expo/expo/pull/27780) by [@kudo](https://github.com/kudo))
+- Fixed bridgeless error recovery support for launch errors on iOS. ([#27805](https://github.com/expo/expo/pull/27805) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

error recovery is broken on bridgeless mode. this pr tries to fix the ios part.
close ENG-11707

# How

this pr tries to recover the launch crash before content appears.

for content appeared flow, i'm not quite understand the previous design and would keep it as-is.

# Test Plan

canary + expo-updates + eas-update with the following code

```tsx
import { StatusBar } from 'expo-status-bar';
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';

setTimeout(() => {
  blah.blah;
}, 10);
export default function App() {
  return (
    <View style={styles.container}>
      <Text>Open up App.js to start working on your app!</Text>
     <StatusBar style="auto" />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#fff',
    alignItems: 'center',
    justifyContent: 'center',
  },
});
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
