### PR TITLE
[docs] add rounded borders for ImageSpotlight and Video components

### DIFF
--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -13,8 +13,9 @@ type Props = {
 
 export default function ImageSpotlight({ alt, src, style, containerClassName, caption }: Props) {
   return (
-    <figure className={mergeClasses('text-center bg-subtle py-2.5 my-5', containerClassName)}>
-      <LightboxImage src={src} alt={alt} style={style} className="inline" />
+    <figure
+      className={mergeClasses('text-center bg-subtle py-2.5 my-5 rounded-lg', containerClassName)}>
+      <LightboxImage src={src} alt={alt} style={style} className="inline rounded-md" />
       {caption && (
         <figcaption className="mt-[14px] text-secondary text-center text-xs px-8 py-2">
           {caption}

--- a/docs/components/plugins/Video.tsx
+++ b/docs/components/plugins/Video.tsx
@@ -87,6 +87,8 @@ const videoWrapperStyle = css({
   width: PLAYER_WIDTH,
   height: PLAYER_HEIGHT,
   backgroundColor: '#000',
+  borderRadius: 10,
+  overflow: 'hidden',
 });
 
 const dimmerStyle = css({


### PR DESCRIPTION
# Why

To make sure the component used inside of doc page content are more-less unfied.

# How

Add rounded borders for ImageSpotlight and Video components.

# Test Plan

The changes have been tested locally.

# Preview

![Screenshot 2024-03-22 at 12 46 27](https://github.com/expo/expo/assets/719641/841a6ce5-5052-42a4-9882-05a1d266c598)

![Screenshot 2024-03-22 at 12 54 41](https://github.com/expo/expo/assets/719641/5155fdad-3344-4302-bf73-95b8fca62168)

