### PR TITLE
[docs] few small fixes

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -305,6 +305,7 @@ export const CodeBlock = ({ children, theme, inline = false }: CodeBlockProps) =
         codeBlockContainerStyle,
         inline && codeBlockInlineContainerStyle,
       ]}
+      className="[&_span]:!text-inherit"
       {...attributes}>
       <CODE
         theme={theme}

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -828,7 +828,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Example
       </strong>
       <span
-        class="css-1nzh6mw-CodeBlock"
+        class="[&_span]:!text-inherit css-1nzh6mw-CodeBlock"
         data-text="true"
       >
         <code

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -16,7 +16,7 @@ export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props)
       'flex my-2 items-center justify-between',
       'max-xl-gutters:flex-col max-xl-gutters:items-start'
     )}>
-    <H1 className="!my-0">
+    <H1 className="!my-0 !font-bold">
       {iconUrl && (
         <img
           src={iconUrl}

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -59,7 +59,7 @@ const InnerTabs = ({
           </TabButton>
         ))}
       </TabList>
-      <TabPanels css={tabsPanelStyle} className="last:[&>*]:!mb-0">
+      <TabPanels css={tabsPanelStyle} className="last:[&>div>*]:!mb-0">
         {children}
       </TabPanels>
     </ReachTabs>


### PR DESCRIPTION
# Why

Fixes for few small issues I spotted recently, while working with docs app.

# How

The following changes have been made:
* match PageTitle weight with one used on docs home page
* make sure we do not add unnecessary spacing to the last element in Tab container
* ensure that multiline types correctly inherit font size

# Test Plan

The changes have been tested locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-03-22 at 13 17 13](https://github.com/expo/expo/assets/719641/ea2c287a-55bb-4040-9ccd-2037f7b8dd01)
![Screenshot 2024-03-22 at 13 18 23](https://github.com/expo/expo/assets/719641/9b51754a-b70f-4f32-8b70-198f584c9c22)
![Screenshot 2024-03-22 at 13 17 00](https://github.com/expo/expo/assets/719641/ffff274d-9146-4969-b9ea-a68b7bc2f6dd)

