### PR TITLE
[updates] fix error recovery on android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [iOS] Added bridgeless support on ExpoReactDelegate. ([#27601](https://github.com/expo/expo/pull/27601), [#27689](https://github.com/expo/expo/pull/27689) by [@kudo](https://github.com/kudo))
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
 - Refactored out `EXReactRootViewFactory.createDefaultReactRootView:` to `RCTAppDelegate.recreateRootViewWithBundleURL:` category. ([#27945](https://github.com/expo/expo/pull/27945) by [@kudo](https://github.com/kudo))
+- Added `ReactNativeHostHandler.onReactInstanceException()` for client to listen for exceptions on Android. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 
 ## 1.11.11 - 2024-03-11
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -1,5 +1,6 @@
 package expo.modules.core.interfaces;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
@@ -50,7 +51,7 @@ public interface ReactNativeHostHandler {
    *
    * @return custom DevSupportManagerFactory, or null if not to override
    *
-   * NOTE: This callback is not support in bridgeless mode
+   * NOTE: This callback is not support on bridgeless mode
    */
   @Nullable
   default Object getDevSupportManagerFactory() { return null; }
@@ -58,7 +59,7 @@ public interface ReactNativeHostHandler {
   /**
    * Given chance for modules to override the javascript executor factory.
    *
-   * NOTE: This callback is not support in bridgeless mode
+   * NOTE: This callback is not support on bridgeless mode
    */
   @Nullable
   default JavaScriptExecutorFactory getJavaScriptExecutorFactory() { return null; }
@@ -74,6 +75,13 @@ public interface ReactNativeHostHandler {
    * Callback after react instance creation
    */
   default void onDidCreateReactInstance(boolean useDeveloperSupport, ReactContext reactContext) {}
+
+  /**
+   * Callback when receiving unhandled React Native exceptions
+   *
+   * NOTE: This callback is only available on bridgeless mode
+   */
+  default void onReactInstanceException(boolean useDeveloperSupport, @NonNull Exception exception) {}
 
   //endregion
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -51,7 +51,7 @@ public interface ReactNativeHostHandler {
    *
    * @return custom DevSupportManagerFactory, or null if not to override
    *
-   * NOTE: This callback is not support on bridgeless mode
+   * NOTE: This callback is not supported on bridgeless mode
    */
   @Nullable
   default Object getDevSupportManagerFactory() { return null; }
@@ -59,7 +59,7 @@ public interface ReactNativeHostHandler {
   /**
    * Given chance for modules to override the javascript executor factory.
    *
-   * NOTE: This callback is not support on bridgeless mode
+   * NOTE: This callback is not supported on bridgeless mode
    */
   @Nullable
   default JavaScriptExecutorFactory getJavaScriptExecutorFactory() { return null; }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed ANR issue from Detox testing on Android. ([#27031](https://github.com/expo/expo/pull/27031) by [@kudo](https://github.com/kudo))
 - Fix inconsistent hashes for autolinking for fingerprint policy. ([#27390](https://github.com/expo/expo/pull/27390) by [@wschurman](https://github.com/wschurman))
 - Fixed launch crash when running on a project without expo-dev-client and debug build. ([#27780](https://github.com/expo/expo/pull/27780) by [@kudo](https://github.com/kudo))
+- Fixed bridgeless error recovery support for launch errors on Android. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -1,11 +1,10 @@
 package expo.modules.updates
 
+import android.app.Activity
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
-import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.AppContext
@@ -43,11 +42,8 @@ class EnabledUpdatesController(
 ) : IUpdatesController, UpdatesStateChangeEventSender {
   override var appContext: WeakReference<AppContext>? = null
 
-  private val reactNativeHost: WeakReference<ReactNativeHost>? = if (context is ReactApplication) {
-    WeakReference(context.reactNativeHost)
-  } else {
-    null
-  }
+  /** Keep the activity for [RelaunchProcedure] to relaunch the app. */
+  private var weakActivity: WeakReference<Activity>? = null
   private val logger = UpdatesLogger(context)
   private val fileDownloader = FileDownloader(context, updatesConfiguration)
   private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
@@ -124,6 +120,11 @@ class EnabledUpdatesController(
 
   override fun onDidCreateReactInstanceManager(reactContext: ReactContext) {
     startupProcedure.onDidCreateReactInstanceManager(reactContext)
+    weakActivity = WeakReference(reactContext.currentActivity)
+  }
+
+  override fun onReactInstanceException(exception: Exception) {
+    startupProcedure.onReactInstanceException(exception)
   }
 
   @Synchronized
@@ -144,12 +145,12 @@ class EnabledUpdatesController(
   private fun relaunchReactApplication(shouldRunReaper: Boolean, callback: LauncherCallback) {
     val procedure = RelaunchProcedure(
       context,
+      weakActivity,
       updatesConfiguration,
       databaseHolder,
       updatesDirectory,
       fileDownloader,
       selectionPolicy,
-      reactNativeHost,
       getCurrentLauncher = { startupProcedure.launcher!! },
       setCurrentLauncher = { currentLauncher -> startupProcedure.setLauncher(currentLauncher) },
       shouldRunReaper = shouldRunReaper,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -46,6 +46,8 @@ interface IUpdatesController {
 
   fun onDidCreateReactInstanceManager(reactContext: ReactContext)
 
+  fun onReactInstanceException(exception: java.lang.Exception)
+
   /**
    * Starts the update process to launch a previously-loaded update and (if configured to do so)
    * check for a new update from the server. This method should be called as early as possible in

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -2,7 +2,6 @@ package expo.modules.updates
 
 import android.content.Context
 import com.facebook.react.ReactApplication
-import com.facebook.react.ReactNativeHost
 import expo.modules.kotlin.AppContext
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode
@@ -18,9 +17,6 @@ import java.lang.ref.WeakReference
  * the application lifecycle, via [UpdatesPackage]. It delegates to an instance of [LoaderTask] to
  * start the process of loading and launching an update, then responds appropriately depending on
  * the callbacks that are invoked.
- *
- * This class also optionally holds a reference to the app's [ReactNativeHost], which allows
- * expo-updates to reload JS and send events to JS.
  */
 class UpdatesController {
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -81,6 +81,8 @@ class UpdatesDevLauncherController(
 
   override fun onDidCreateReactInstanceManager(reactContext: ReactContext) {}
 
+  override fun onReactInstanceException(exception: java.lang.Exception) {}
+
   override fun start() {
     throw Exception("IUpdatesController.start should not be called in dev client")
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -51,6 +51,12 @@ class UpdatesPackage : Package {
         }
         // WHEN_VERSIONING_REMOVE_TO_HERE
       }
+
+      override fun onReactInstanceException(useDeveloperSupport: Boolean, exception: Exception) {
+        if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) {
+          UpdatesController.instance.onReactInstanceException(exception)
+        }
+      }
     }
     return listOf(handler)
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarker.MarkerListener
 import com.facebook.react.bridge.ReactMarkerConstants
+import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.devsupport.DisabledDevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.updates.logging.UpdatesErrorCode
@@ -91,8 +92,13 @@ class ErrorRecovery(
 
   private fun getDevSupportManager(reactContext: ReactContext): DevSupportManager {
     val reactApplication = reactContext.applicationContext as ReactApplication
-    return reactApplication.reactHost?.devSupportManager
-      ?: reactApplication.reactNativeHost.reactInstanceManager.devSupportManager
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      val reactHost = reactApplication.reactHost
+      check(reactHost != null)
+      return reactHost.devSupportManager ?: throw IllegalStateException("Unable to get DevSupportManager from ReactHost")
+    }
+
+    return reactApplication.reactNativeHost.reactInstanceManager.devSupportManager
   }
 
   private fun registerErrorHandler(reactContext: ReactContext) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -17,7 +17,7 @@ class RecreateReactContextProcedure(
   override val loggerTimerLabel = "timer-recreate-react-context"
 
   override fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context.applicationContext as? ReactApplication ?: run {
+    val reactApplication = context.applicationContext as? ReactApplication ?: run inner@ {
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -17,7 +17,7 @@ class RecreateReactContextProcedure(
   override val loggerTimerLabel = "timer-recreate-react-context"
 
   override fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context.applicationContext as? ReactApplication ?: run inner@ {
+    val reactApplication = context.applicationContext as? ReactApplication ?: run inner@{
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -1,31 +1,32 @@
 package expo.modules.updates.procedures
 
+import android.app.Activity
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactApplication
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import java.lang.ref.WeakReference
 
 class RecreateReactContextProcedure(
-  private val reactNativeHost: WeakReference<ReactNativeHost>?,
+  private val context: Context,
+  private val weakActivity: WeakReference<Activity>?,
   private val callback: Launcher.LauncherCallback
 ) : StateMachineProcedure() {
   override val loggerTimerLabel = "timer-recreate-react-context"
 
   override fun run(procedureContext: ProcedureContext) {
-    val host = reactNativeHost?.get()
-    if (host == null) {
+    val reactApplication = context.applicationContext as? ReactApplication ?: run {
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }
 
     procedureContext.processStateEvent(UpdatesStateEvent.Restart())
-
-    val instanceManager = host.reactInstanceManager
     callback.onSuccess()
-    val handler = Handler(Looper.getMainLooper())
-    handler.post { instanceManager.recreateReactContextInBackground() }
+    Handler(Looper.getMainLooper()).post {
+      reactApplication.restart(weakActivity?.get(), "Restart from RecreateReactContextProcedure")
+    }
     procedureContext.resetState()
     procedureContext.onComplete()
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -37,7 +37,7 @@ class RelaunchProcedure(
   override val loggerTimerLabel = "timer-relaunch"
 
   override fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context as? ReactApplication ?: run {
+    val reactApplication = context as? ReactApplication ?: run inner@ {
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -1,12 +1,15 @@
 package expo.modules.updates.procedures
 
+import android.app.Activity
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.JSBundleLoader
+import com.facebook.react.config.ReactFeatureFlags
+import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.Reaper
@@ -20,12 +23,12 @@ import java.lang.ref.WeakReference
 
 class RelaunchProcedure(
   private val context: Context,
+  private val weakActivity: WeakReference<Activity>?,
   private val updatesConfiguration: UpdatesConfiguration,
   private val databaseHolder: DatabaseHolder,
   private val updatesDirectory: File,
   private val fileDownloader: FileDownloader,
   private val selectionPolicy: SelectionPolicy,
-  private val reactNativeHost: WeakReference<ReactNativeHost>?,
   private val getCurrentLauncher: () -> Launcher,
   private val setCurrentLauncher: (launcher: Launcher) -> Unit,
   private val shouldRunReaper: Boolean,
@@ -34,8 +37,7 @@ class RelaunchProcedure(
   override val loggerTimerLabel = "timer-relaunch"
 
   override fun run(procedureContext: ProcedureContext) {
-    val host = reactNativeHost?.get()
-    if (host == null) {
+    val reactApplication = context as? ReactApplication ?: run {
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }
@@ -63,27 +65,18 @@ class RelaunchProcedure(
           setCurrentLauncher(newLauncher)
           databaseHolder.releaseDatabase()
 
-          val instanceManager = host.reactInstanceManager
-
           val newLaunchAssetFile = getCurrentLauncher().launchAssetFile
           if (newLaunchAssetFile != null && newLaunchAssetFile != oldLaunchAssetFile) {
-            // Unfortunately, even though RN exposes a way to reload an application,
-            // it assumes that the JS bundle will stay at the same location throughout
-            // the entire lifecycle of the app. Since we need to change the location of
-            // the bundle, we need to use reflection to set an otherwise inaccessible
-            // field of the ReactInstanceManager.
             try {
-              val newJSBundleLoader = JSBundleLoader.createFileLoader(newLaunchAssetFile)
-              val jsBundleLoaderField = instanceManager.javaClass.getDeclaredField("mBundleLoader")
-              jsBundleLoaderField.isAccessible = true
-              jsBundleLoaderField[instanceManager] = newJSBundleLoader
+              replaceLaunchAssetFileIfNeeded(reactApplication, newLaunchAssetFile)
             } catch (e: Exception) {
-              Log.e(TAG, "Could not reset JSBundleLoader in ReactInstanceManager", e)
+              Log.e(TAG, "Could not reset launchAssetFile for the ReactApplication", e)
             }
           }
           callback.onSuccess()
-          val handler = Handler(Looper.getMainLooper())
-          handler.post { instanceManager.recreateReactContextInBackground() }
+          Handler(Looper.getMainLooper()).post {
+            reactApplication.restart(weakActivity?.get(), "Restart from RelaunchProcedure")
+          }
           if (shouldRunReaper) {
             runReaper()
           }
@@ -105,6 +98,31 @@ class RelaunchProcedure(
       )
       databaseHolder.releaseDatabase()
     }
+  }
+
+  /**
+   * For bridgeless mode, the restarting will pull the new [JSBundleLoader]
+   * based on the new [DatabaseLauncher] through the [ReactNativeHostHandler].
+   * So this method is a no-op for bridgeless mode.
+   *
+   * For bridge mode unfortunately, even though RN exposes a way to reload an application,
+   * it assumes that the JS bundle will stay at the same location throughout
+   * the entire lifecycle of the app. To change the location of the bundle,
+   * we need to use reflection to set an inaccessible field in the
+   * [com.facebook.react.ReactInstanceManager].
+   */
+  private fun replaceLaunchAssetFileIfNeeded(
+    reactApplication: ReactApplication,
+    launchAssetFile: String
+  ) {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      return
+    }
+
+    val instanceManager = reactApplication.reactNativeHost.reactInstanceManager
+    val jsBundleLoaderField = instanceManager.javaClass.getDeclaredField("mBundleLoader")
+    jsBundleLoaderField.isAccessible = true
+    jsBundleLoaderField[instanceManager] = JSBundleLoader.createFileLoader(launchAssetFile)
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -37,7 +37,7 @@ class RelaunchProcedure(
   override val loggerTimerLabel = "timer-relaunch"
 
   override fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context as? ReactApplication ?: run inner@ {
+    val reactApplication = context as? ReactApplication ?: run inner@{
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
@@ -1,0 +1,26 @@
+package expo.modules.updates.procedures
+
+import android.app.Activity
+import com.facebook.react.ReactApplication
+import com.facebook.react.common.LifecycleState
+import com.facebook.react.config.ReactFeatureFlags
+
+/**
+ * An extension for [ReactApplication] to restart the app
+ *
+ * @param activity For bridgeless mode if the ReactHost is destroyed, we need an Activity to resume it.
+ * @param reason The restart reason. Only used on bridgeless mode.
+ */
+internal fun ReactApplication.restart(activity: Activity?, reason: String) {
+  if (ReactFeatureFlags.enableBridgelessArchitecture) {
+    val reactHost = this.reactHost
+    check(reactHost != null)
+    if (reactHost.lifecycleState != LifecycleState.RESUMED && activity != null) {
+      reactHost.onHostResume(activity)
+    }
+    reactHost.reload(reason)
+    return
+  }
+
+  reactNativeHost.reactInstanceManager.recreateReactContextInBackground()
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -227,6 +227,10 @@ class StartupProcedure(
     errorRecovery.startMonitoring(reactContext)
   }
 
+  fun onReactInstanceException(exception: Exception) {
+    errorRecovery.handleException(exception)
+  }
+
   private fun setRemoteLoadStatus(status: ErrorRecoveryDelegate.RemoteLoadStatus) {
     remoteLoadStatus = status
     errorRecovery.notifyNewRemoteLoadStatus(status)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -228,7 +228,7 @@ class StartupProcedure(
   }
 
   fun onReactInstanceException(exception: Exception) {
-    errorRecovery.handleException(exception)
+    errorRecovery.onReactInstanceException(exception)
   }
 
   private fun setRemoteLoadStatus(status: ErrorRecoveryDelegate.RemoteLoadStatus) {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [expo-updates] Migrate to requireNativeModule/requireOptionalNativeModule. ([#25648](https://github.com/expo/expo/pull/25648) by [@wschurman](https://github.com/wschurman))
 - Remove implicit dependency on expo-updates to do runtime version check at runtime. ([#26080](https://github.com/expo/expo/pull/26080) by [@wschurman](https://github.com/wschurman))
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
+- [Android] Added `ReactNativeHostHandler.onReactInstanceException()` for expo-updates to handle exceptions on bridgeless mode. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 
 ## 50.0.14 - 2024-03-20
 

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -34,7 +34,6 @@ object ExpoReactHostFactory {
     private val reactNativeHostWrapper: ReactNativeHostWrapper,
     override val bindingsInstaller: BindingsInstaller? = null,
     private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
-    private val exceptionHandler: (Exception) -> Unit = {},
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder =
       DefaultTurboModuleManagerDelegate.Builder()
   ) : ReactHostDelegate {
@@ -66,7 +65,12 @@ object ExpoReactHostFactory {
 
     override fun getReactNativeConfig(): ReactNativeConfig = reactNativeConfig
 
-    override fun handleInstanceException(error: Exception) = exceptionHandler(error)
+    override fun handleInstanceException(error: Exception) {
+      val useDeveloperSupport = reactNativeHostWrapper.useDeveloperSupport
+      reactNativeHostWrapper.reactNativeHostHandlers.forEach { handler ->
+        handler.onReactInstanceException(useDeveloperSupport, error)
+      }
+    }
   }
 
   @OptIn(UnstableReactNativeAPI::class)


### PR DESCRIPTION
# Why

add bridgeless support for expo-updates's error recovery on android
close ENG-11707

# How

- the `DefaultJSExceptionHandler` from DevSupportManager doesn't work on bridgeless mode. we should add a `ReactNativeHostHandler.onReactInstanceException` to pull the exception from ReactHost
- add `ReactApplication.restart()` to support both bridgeless and bridge mode.
- decouple from ReactNativeHost

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
