### PR TITLE
[expo-network][expo-crypto] Add Apple TV support

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add Apple TV support. ([#27819](https://github.com/expo/expo/pull/27819) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-crypto/ios/ExpoCrypto.podspec
+++ b/packages/expo-crypto/ios/ExpoCrypto.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '13.4',
+    :tvos => '13.4',
     :osx => '10.15'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add Apple TV support. ([#27819](https://github.com/expo/expo/pull/27819) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-network/expo-module.config.json
+++ b/packages/expo-network/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-network",
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "tvos"],
   "ios": {
     "modules": ["NetworkModule"]
   },

--- a/packages/expo-network/ios/ExpoNetwork.podspec
+++ b/packages/expo-network/ios/ExpoNetwork.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -48,7 +48,7 @@ function getExpoDependencyChunks({
       ? [['expo-dev-menu-interface'], ['expo-dev-menu'], ['expo-dev-launcher'], ['expo-dev-client']]
       : []),
     ...(includeTV
-      ? [['expo-av', 'expo-blur', 'expo-image', 'expo-linear-gradient', 'expo-localization']]
+      ? [['expo-av', 'expo-blur', 'expo-image', 'expo-linear-gradient', 'expo-localization', 'expo-crypto', 'expo-network']]
       : []),
   ];
 }


### PR DESCRIPTION
# Why

Add support for `expo-network` and `expo-crypto`.

# How

Add tvOS to module config and Podfile for each module. No code changes needed.

# Test Plan

- TV compile CI should pass (will be reenabled soon after RNTV 0.74 first release candidate)
- Tested in a local project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
