### PR TITLE
[expo-asset] Add Apple TV support

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added config plugin to allow assets to be linked at build time. ([#27052](https://github.com/expo/expo/pull/27052) by [@alanjhughes](https://github.com/alanjhughes))
+- Add Apple TV support to the new iOS native module. ([#27823](https://github.com/expo/expo/pull/27823) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-asset/expo-module.config.json
+++ b/packages/expo-asset/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "tvos"],
   "ios": {
     "modules": ["AssetModule"]
   },

--- a/packages/expo-asset/ios/ExpoAsset.podspec
+++ b/packages/expo-asset/ios/ExpoAsset.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true


### PR DESCRIPTION
# Why

`expo-asset` now has an iOS native directory, and this package is required for proper Expo support of Apple TV.

# How

Add Apple TV support to Expo module config and Podfile. No source code changes needed.

# Test Plan

- Tested in a local project created with the `with-canary-new-arch-tv` example
- TV compile CI should pass when it is reenabled

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
