### PR TITLE
Move tv-compile-test to use RNTV 0.74

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -337,8 +337,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.73.4-0',
-        '@react-native-tvos/config-tv': '^0.0.6',
+        'react-native': 'npm:react-native-tvos@~0.74.0-0rc0',
+        '@react-native-tvos/config-tv': '^0.0.7',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

Move the TV compile CI to use the 0.74 version of RNTV, as main is now moved to RN 0.74.

Once this is merged, it should be safe to reenable the tv-compile-test workflow.

# How

Update the dependencies in `project.ts`.

# Test Plan

- Once reenabled, tv-compile-test should pass again
- Tested the workflow locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
