### PR TITLE
docs(using-bun): update default version to match infrastructure page

### DIFF
--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -31,7 +31,7 @@ EAS decides which package manager to use based on the lockfile in your codebase.
 
 ### Customize Bun version on EAS
 
-EAS uses `bun@1.0.2` by default. If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
+EAS uses `bun@1.0.14` by default. If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
 
 {/* prettier-ignore */}
 ```json eas.json


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Read over the `Using Bun` section and noticed the default version mentioned did not match what is shown on the [Infrastructure](https://docs.expo.dev/build-reference/infrastructure/) page, which is mostly 1.0.14 aside from the setup with Xcode 15.2. where it's 1.0.23.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
