### PR TITLE
[docs] Remove "iOS 13+" reference in AppleAuthentication API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -1,9 +1,9 @@
 ---
 title: AppleAuthentication
-description: A library that provides Sign in with Apple capability for iOS 13 and higher.
+description: A library that provides Sign-in with Apple capability for iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
-platforms: ['ios 13+', 'tvos']
+platforms: ['ios', 'tvos']
 ---
 
 import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
@@ -11,9 +11,9 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
+`expo-apple-authentication` provides Apple authentication for iOS. It does not yet support Android or web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 ## Installation
 
@@ -65,7 +65,7 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
+Also, set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign-in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -149,15 +149,15 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 
 ## Error codes
 
-Most of the error codes matches the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
+Most of the error codes match the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
 
-| Code                        | Description                                                                            |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                                 |
-| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                                |
-| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.      |
-| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                           |
-| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for an additional information. |
-| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn’t correctly handled.                                    |
-| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn’t interactive.                                           |
-| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                                |
+| Code                        | Description                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                              |
+| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                             |
+| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.   |
+| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                        |
+| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for additional information. |
+| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn't correctly handled.                                 |
+| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn't interactive.                                        |
+| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                             |

--- a/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-description: A library that provides Sign in with Apple capability for iOS 13 and higher.
+description: A library that provides Sign-in with Apple capability for iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-48/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
 ---
@@ -11,10 +11,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
+`expo-apple-authentication` provides Apple authentication for iOS. It does not yet support Android or web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
-to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -60,7 +59,7 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
+Also, set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign-in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -144,15 +143,15 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 
 ## Error codes
 
-Most of the error codes matches the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
+Most of the error codes match the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
 
-| Code                        | Description                                                                            |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                                 |
-| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                                |
-| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.      |
-| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                           |
-| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for an additional information. |
-| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn’t correctly handled.                                    |
-| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn’t interactive.                                           |
-| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                                |
+| Code                        | Description                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                              |
+| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                             |
+| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.   |
+| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                        |
+| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for additional information. |
+| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn't correctly handled.                                 |
+| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn't interactive.                                        |
+| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                             |

--- a/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-description: A library that provides Sign in with Apple capability for iOS 13 and higher.
+description: A library that provides Sign-in with Apple capability for iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
 ---
@@ -11,9 +11,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
+`expo-apple-authentication` provides Apple authentication for iOS. It does not yet support Android or web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -67,7 +67,7 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
+Also, set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign-in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -151,15 +151,15 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 
 ## Error codes
 
-Most of the error codes matches the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
+Most of the error codes match the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
 
-| Code                        | Description                                                                            |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                                 |
-| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                                |
-| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.      |
-| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                           |
-| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for an additional information. |
-| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn’t correctly handled.                                    |
-| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn’t interactive.                                           |
-| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                                |
+| Code                        | Description                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                              |
+| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                             |
+| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.   |
+| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                        |
+| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for additional information. |
+| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn't correctly handled.                                 |
+| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn't interactive.                                        |
+| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                             |

--- a/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: AppleAuthentication
-description: A library that provides Sign in with Apple capability for iOS 13 and higher.
+description: A library that provides Sign-in with Apple capability for iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-50/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
 ---
@@ -11,9 +11,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
+`expo-apple-authentication` provides Apple authentication for iOS. It does not yet support Android or web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Any app that includes third-party authentication options **must** provide Apple authentication as an option to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -67,7 +67,7 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
+Also, set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign-in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -151,15 +151,15 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 
 ## Error codes
 
-Most of the error codes matches the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
+Most of the error codes match the official [Apple Authorization errors](https://developer.apple.com/documentation/authenticationservices/asauthorizationerror/code).
 
-| Code                        | Description                                                                            |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                                 |
-| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                                |
-| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.      |
-| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                           |
-| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for an additional information. |
-| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn’t correctly handled.                                    |
-| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn’t interactive.                                           |
-| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                                |
+| Code                        | Description                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| ERR_INVALID_OPERATION       | An invalid authorization operation has been performed.                              |
+| ERR_INVALID_RESPONSE        | The authorization request received an invalid response.                             |
+| ERR_INVALID_SCOPE           | An invalid [`AppleAuthenticationScope`](#appleauthenticationscope) was passed in.   |
+| ERR_REQUEST_CANCELED        | The user canceled the authorization attempt.                                        |
+| ERR_REQUEST_FAILED          | The authorization attempt failed. See the error message for additional information. |
+| ERR_REQUEST_NOT_HANDLED     | The authorization request wasn't correctly handled.                                 |
+| ERR_REQUEST_NOT_INTERACTIVE | The authorization request isn't interactive.                                        |
+| ERR_REQUEST_UNKNOWN         | The authorization attempt failed for an unknown reason.                             |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1711053684424169)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Since all supported SDKs require iOS 13 and above version, this PR:
- Removes iOS 13+ references in AppleAuthentication API reference
- Update verbiage and fix typos in the same doc.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/latest/sdk/apple-authentication/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
