### PR TITLE
Rename @expo/video to expo-video

### DIFF
--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -45,7 +45,7 @@
       "policy": "appVersion"
     },
     "plugins": [
-      "@expo/video",
+      "expo-video",
       "expo-background-fetch",
       [
         "expo-font",

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -501,7 +501,7 @@ PODS:
     - ExpoModulesCore
   - ExpoTrackingTransparency (3.3.0):
     - ExpoModulesCore
-  - ExpoVideo (0.3.1):
+  - ExpoVideo (1.0.0-alpha.1):
     - ExpoModulesCore
   - ExpoVideoThumbnails (7.9.0):
     - ExpoModulesCore
@@ -2484,7 +2484,7 @@ SPEC CHECKSUMS:
   expo-dev-menu: 3f87f2b892d4dd30f2ab3fe2a356a72fe0e3de11
   expo-dev-menu-interface: 3c36b4d5032397e022958a2041afe91a130ea74c
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
-  ExpoAsset: 518654245b6a5f4d498b96d49eaa9888070e70e8
+  ExpoAsset: 751d84b1c4d91a1eddf4a4e356c9e9948ae20153
   ExpoAudio: 5e7d15c9b6901eb32913a220b0e99590739f4db3
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
   ExpoBattery: c75a7c094d64d89d96d3e3f419627b152da94f29
@@ -2495,7 +2495,7 @@ SPEC CHECKSUMS:
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
   ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
   ExpoContacts: f38a91d87fa5e5e25ef144f2619de24fdd0f9eb7
-  ExpoCrypto: f1c0cbaa168759159e781abf16cf8055a9a1a624
+  ExpoCrypto: 37237535ce83cad43186b5998cdb3f2ae421dd7c
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
   ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc
@@ -2514,7 +2514,7 @@ SPEC CHECKSUMS:
   ExpoMediaLibrary: 488827a3f563c2242b318553ca018a7b8c0c4644
   ExpoModulesCore: 39172e342cd3015c0b2ece5e71986d96211b21af
   ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
-  ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
+  ExpoNetwork: ce6ddfce15230a6585c2aea973033abf783ca84e
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7
   ExpoRandom: f0cd58e154e463d913462f3b445870b12d1c2f12
   ExpoScreenCapture: c3c120b095594bf7ae003251c1b89260566587f6
@@ -2529,7 +2529,7 @@ SPEC CHECKSUMS:
   ExpoSymbols: 01f91e307a4b8bee4da4fc5bc47efe912a5cfcde
   ExpoSystemUI: 921601d83ed776533f1d654f02c0fdece0a0632b
   ExpoTrackingTransparency: bbae3e495bc58c79b9430cfbc217a56c2ddc9354
-  ExpoVideo: 5c7f090a003df15ab6a0e73184995cc22529b4dd
+  ExpoVideo: 48de519a2cbd639218f2fcff8da50f650dc21b22
   ExpoVideoThumbnails: 9b6c0dada0b3240dd3527e0dc688711e17842c88
   ExpoWebBrowser: 2b660d423b818c4c45b6b3d22a3c0652153fb176
   EXSplashScreen: 91d2f07e12c7dbbf3bad42ddab15588042a2500a

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -166,7 +166,7 @@ PODS:
     - ExpoModulesCore
   - ExpoTrackingTransparency (3.3.0):
     - ExpoModulesCore
-  - ExpoVideo (0.3.1):
+  - ExpoVideo (1.0.0-alpha.1):
     - ExpoModulesCore
   - ExpoVideoThumbnails (7.9.0):
     - ExpoModulesCore
@@ -1976,7 +1976,7 @@ SPEC CHECKSUMS:
   EXNotifications: 6e3b49fa7f916bc2783d37fbd5599509b160776c
   Expo: 2d88b1f9b7a511015414d8c40cc8c6af13c469eb
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
-  ExpoAsset: 518654245b6a5f4d498b96d49eaa9888070e70e8
+  ExpoAsset: 751d84b1c4d91a1eddf4a4e356c9e9948ae20153
   ExpoAudio: 5e7d15c9b6901eb32913a220b0e99590739f4db3
   ExpoBackgroundFetch: 094377b73648adb55032a440f50cad1a5d3c3a89
   ExpoBattery: c75a7c094d64d89d96d3e3f419627b152da94f29
@@ -1987,7 +1987,7 @@ SPEC CHECKSUMS:
   ExpoCellular: 463763547a7489d8fc68d3cc539b666f308a0fe9
   ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
   ExpoContacts: f38a91d87fa5e5e25ef144f2619de24fdd0f9eb7
-  ExpoCrypto: f1c0cbaa168759159e781abf16cf8055a9a1a624
+  ExpoCrypto: 37237535ce83cad43186b5998cdb3f2ae421dd7c
   ExpoDevice: 30d5e44aff42048ab016fa0c37a51fdb6b1f8608
   ExpoDocumentPicker: 015978166ecdb556dbeff1db7413a051f8c03bc7
   ExpoFileSystem: d36501dcf237026e7ddb26324abcbfe44461aecc
@@ -2005,7 +2005,7 @@ SPEC CHECKSUMS:
   ExpoMediaLibrary: 488827a3f563c2242b318553ca018a7b8c0c4644
   ExpoModulesCore: 7944dab86cc6d2cd3fd291293296aa33fd0d5b2c
   ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
-  ExpoNetwork: 97d7774ab8f62e35f08db77fbef0388d5e1f2c76
+  ExpoNetwork: ce6ddfce15230a6585c2aea973033abf783ca84e
   ExpoPrint: e7ecdd682436eb5a74b744c4ce36dc490df851b7
   ExpoRandom: f0cd58e154e463d913462f3b445870b12d1c2f12
   ExpoScreenCapture: c3c120b095594bf7ae003251c1b89260566587f6
@@ -2020,7 +2020,7 @@ SPEC CHECKSUMS:
   ExpoSymbols: 01f91e307a4b8bee4da4fc5bc47efe912a5cfcde
   ExpoSystemUI: 921601d83ed776533f1d654f02c0fdece0a0632b
   ExpoTrackingTransparency: bbae3e495bc58c79b9430cfbc217a56c2ddc9354
-  ExpoVideo: 5c7f090a003df15ab6a0e73184995cc22529b4dd
+  ExpoVideo: 48de519a2cbd639218f2fcff8da50f650dc21b22
   ExpoVideoThumbnails: 9b6c0dada0b3240dd3527e0dc688711e17842c88
   ExpoWebBrowser: 2b660d423b818c4c45b6b3d22a3c0652153fb176
   EXSplashScreen: d6d7ea9582e4ed7655cf893b32dca13ef0712279

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
-    "@expo/video": "~0.3.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "7.6.1",
     "@react-native-community/netinfo": "11.1.0",
@@ -119,6 +118,7 @@
     "expo-three": "6.0.1",
     "expo-tracking-transparency": "~3.3.0",
     "expo-updates": "0.24.3",
+    "expo-video": "1.0.0-alpha.1",
     "expo-video-thumbnails": "~7.9.0",
     "expo-web-browser": "~12.8.0",
     "fbemitter": "^2.1.1",

--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -1,8 +1,8 @@
-import { useVideoPlayer, VideoView, VideoSource } from '@expo/video';
 import Slider from '@react-native-community/slider';
 import { Picker } from '@react-native-picker/picker';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
 import { Platform } from 'expo-modules-core';
+import { useVideoPlayer, VideoView, VideoSource } from 'expo-video';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { PixelRatio, ScrollView, StyleSheet, Text, View } from 'react-native';
 

--- a/packages/expo-video/README.md
+++ b/packages/expo-video/README.md
@@ -25,9 +25,9 @@ For bare React Native projects, you must ensure that you have [installed and con
 ### Add the package to your npm dependencies
 
 ```
-npm install @expo/video
+npm install expo-video
 ```
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-video/package.json
+++ b/packages/expo-video/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@expo/video",
+  "name": "expo-video",
   "title": "Expo Video",
-  "version": "0.3.1",
+  "version": "1.0.0-alpha.1",
   "description": "A cross-platform, performant video component for React Native and Expo with Web support",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# Why

A package called `expo-video` already existed and so we were using `@expo/video` so far, hoping that we will take it over at some point. It's now in our hands, so we can rename it.

# How

- Renamed `@expo/video` with `expo-video`
- Reinstalled node modules and pods
- Deprecated all versions that were already published to npm
- Used `1.0.0-alpha.1` version

# Test Plan

CI checks are passing, expect iOS Client which seems to be failing for different reason (also on `main`)