### PR TITLE
[core][Android] Refactor promise wrapper

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -33,7 +33,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptFunction::registerNatives();
     expo::JavaScriptTypedArray::registerNatives();
     expo::JavaCallback::registerNatives();
-    expo::SharedRef::registerNatives();
 #if RN_FABRIC_ENABLED
     expo::FabricComponentsRegistry::registerNatives();
 #endif

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -2,14 +2,19 @@
 
 #include "JavaCallback.h"
 #include "JSIContext.h"
+#include "types/JNIToJSIConverter.h"
+#include "Exceptions.h"
+
 #include <fbjni/fbjni.h>
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
 
+#include <functional>
+
 namespace expo {
 
-JavaCallback::JavaCallback(Callback callback)
-  : callback(std::move(callback)) {}
+JavaCallback::JavaCallback(std::shared_ptr<CallbackContext> callbackContext)
+  : callbackContext(std::move(callbackContext)) {}
 
 void JavaCallback::registerNatives() {
   registerHybrid({
@@ -25,69 +30,223 @@ void JavaCallback::registerNatives() {
                  });
 }
 
-void SharedRef::registerNatives() {
-  registerHybrid({
-                   makeNativeMethod("initHybrid", SharedRef::initHybrid)
-                 });
-}
-
-jni::local_ref<SharedRef::jhybriddata>
-SharedRef::initHybrid(jni::alias_ref<jhybridobject> jThis) {
-  return makeCxxInstance();
-}
-
-jni::local_ref<SharedRef::jhybriddata>
-SharedObjectId::initHybrid(jni::alias_ref<jhybridobject> jThis) {
-  return makeCxxInstance();
-}
-
-SharedRef::SharedRef() = default;
-
-SharedObjectId::SharedObjectId() = default;
 
 jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
   JSIContext *jsiContext,
-  Callback callback
+  std::shared_ptr<CallbackContext> callbackContext
 ) {
-  auto object = JavaCallback::newObjectCxxArgs(std::move(callback));
+  auto object = JavaCallback::newObjectCxxArgs(std::move(callbackContext));
   jsiContext->jniDeallocator->addReference(object);
   return object;
 }
 
+template<typename T>
+void JavaCallback::invokeJSFunction(
+  ArgsConverter<T> argsConverter,
+  T arg
+) {
+  const auto jsInvoker = callbackContext->jsCallInvokerHolder;
+  jsInvoker->invokeAsync(
+    [
+      context = std::move(callbackContext),
+      argsConverter = std::move(argsConverter),
+      arg = std::move(arg)
+    ]() -> void {
+      if (!context->jsFunctionHolder.has_value()) {
+        throw std::runtime_error(
+          "JavaCallback was already settled. Cannot invoke it again"
+        );
+        return;
+      }
+
+      jsi::Function &jsFunction = context->jsFunctionHolder.value();
+      jsi::Runtime &rt = context->rt;
+
+      argsConverter(rt, jsFunction, std::move(arg), context->isRejectCallback);
+      context->jsFunctionHolder.reset();
+    });
+}
+
+template<class T>
+void JavaCallback::invokeJSFunction(T arg) {
+  invokeJSFunction<T>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      T arg,
+      bool isRejectCallback
+    ) {
+      jsFunction.call(rt, {jsi::Value(rt, arg)});
+    },
+    arg
+  );
+}
+
 void JavaCallback::invoke() {
-  // passing null
-  callback(folly::dynamic());
+  invokeJSFunction<nullptr_t>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      nullptr_t arg,
+      bool isRejectCallback
+    ) {
+      jsFunction.call(rt, {jsi::Value::null()});
+    },
+    nullptr
+  );
 }
 
 void JavaCallback::invokeBool(bool result) {
-  callback({result});
+  invokeJSFunction(result);
 }
 
 void JavaCallback::invokeInt(int result) {
-  callback({result});
+  invokeJSFunction(result);
 }
 
 void JavaCallback::invokeDouble(double result) {
-  callback({result});
+  invokeJSFunction(result);
 }
 
 void JavaCallback::invokeFloat(float result) {
-  callback({result});
+  invokeJSFunction(result);
 }
 
 void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
-  callback({result->toStdString()});
+  invokeJSFunction<std::string>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      std::string arg,
+      bool isRejectCallback
+    ) {
+      std::optional<jsi::Value> extendedString = convertStringToFollyDynamicIfNeeded(
+        rt,
+        arg
+      );
+
+      if (extendedString.has_value()) {
+        const jsi::Value &jsValue = extendedString.value();
+        jsFunction.call(
+          rt,
+          (const jsi::Value *) &jsValue,
+          (size_t) 1
+        );
+        return;
+      }
+
+      jsFunction.call(rt, {jsi::String::createFromUtf8(rt, arg)});
+    },
+    result->toStdString()
+  );
 }
 
 void JavaCallback::invokeArray(jni::alias_ref<react::WritableNativeArray::javaobject> result) {
-  callback({result->cthis()->consume()});
+  invokeJSFunction<folly::dynamic>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      folly::dynamic arg,
+      bool isRejectCallback
+    ) {
+      jsi::Value convertedArg = jsi::valueFromDynamic(rt, arg);
+      auto enhancedArg = decorateValueForDynamicExtension(rt, convertedArg);
+      if (enhancedArg) {
+        convertedArg = std::move(*enhancedArg);
+      }
+
+      jsFunction.call(
+        rt,
+        (const jsi::Value *) &convertedArg,
+        (size_t) 1
+      );
+    },
+    result->cthis()->consume()
+  );
 }
 
 void JavaCallback::invokeMap(jni::alias_ref<react::WritableNativeMap::javaobject> result) {
-  callback({result->cthis()->consume()});
+  invokeJSFunction<folly::dynamic>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      folly::dynamic arg,
+      bool isRejectCallback
+    ) {
+      if (isRejectCallback) {
+        auto errorCode = arg.find("code")->second.asString();
+        auto message = arg.find("message")->second.asString();
+
+        auto codedError = makeCodedError(
+          rt,
+          jsi::String::createFromUtf8(rt, errorCode),
+          jsi::String::createFromUtf8(rt, message)
+        );
+
+        jsFunction.call(
+          rt,
+          (const jsi::Value *) &codedError,
+          (size_t) 1
+        );
+
+        return;
+      }
+
+      jsi::Value convertedArg = jsi::valueFromDynamic(rt, arg);
+      auto enhancedArg = decorateValueForDynamicExtension(rt, convertedArg);
+      if (enhancedArg) {
+        convertedArg = std::move(*enhancedArg);
+      }
+
+      jsFunction.call(
+        rt,
+        (const jsi::Value *) &convertedArg,
+        (size_t) 1
+      );
+    },
+    result->cthis()->consume()
+  );
 }
 
 void JavaCallback::invokeSharedRef(jni::alias_ref<SharedRef::javaobject> result) {
-  callback({jni::make_global(result)});
+  invokeJSFunction<jni::global_ref<SharedRef::javaobject>>(
+    [](
+      jsi::Runtime &rt,
+      jsi::Function &jsFunction,
+      jni::global_ref<SharedRef::javaobject> arg,
+      bool isRejectCallback
+    ) {
+      const auto jsiContext = getJSIContext(rt);
+      auto native = jni::make_local(arg);
+
+      auto jsClass = jsiContext->getJavascriptClass(native->getClass());
+      auto jsObject = jsClass
+        ->cthis()
+        ->get()
+        ->asFunction(rt)
+        .callAsConstructor(rt)
+        .asObject(rt);
+
+      auto objSharedPtr = std::make_shared<jsi::Object>(std::move(jsObject));
+      auto jsObjectInstance = JavaScriptObject::newInstance(
+        jsiContext,
+        jsiContext->runtimeHolder,
+        objSharedPtr
+      );
+      jni::local_ref<JavaScriptObject::javaobject> jsRef = jni::make_local(
+        jsObjectInstance
+      );
+      jsiContext->registerSharedObject(native, jsRef);
+
+      auto ret = jsi::Value(rt, *objSharedPtr);
+
+      jsFunction.call(
+        rt,
+        (const jsi::Value *) &ret,
+        (size_t) 1
+      );
+    },
+    jni::make_global(result)
+  );
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -11,7 +11,7 @@
 
 namespace react = facebook::react;
 
-namespace {
+namespace expo {
 
 // This value should be synced with the value in **FollyDynamicExtensionConverter.kt**
 constexpr char DYNAMIC_EXTENSION_PREFIX[] = "__expo_dynamic_extension__#";
@@ -46,10 +46,6 @@ std::optional<jsi::Value> convertStringToFollyDynamicIfNeeded(jsi::Runtime &rt, 
   }
   return std::nullopt;
 }
-
-} // namespace
-
-namespace expo {
 
 jsi::Value convert(
   JNIEnv *env,

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -20,6 +20,11 @@ jsi::Value convert(
 );
 
 /**
+ * Convert a string with FollyDynamicExtensionConverter support.
+ */
+std::optional<jsi::Value> convertStringToFollyDynamicIfNeeded(jsi::Runtime &rt, const std::string& string);
+
+/**
  * Decorate jsi::Value with FollyDynamicExtensionConverter support.
  */
 std::optional<jsi::Value> decorateValueForDynamicExtension(jsi::Runtime &rt, const jsi::Value &value);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.sharedobjects
 
-import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -10,10 +10,5 @@ import expo.modules.kotlin.AppContext
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-open class SharedRef<RefType>(val ref: RefType, appContext: AppContext? = null) : SharedObject(appContext) {
-
-  @DoNotStrip
-  private val mHybridData = initHybrid()
-
-  private external fun initHybrid(): HybridData
-}
+open class SharedRef<RefType>(val ref: RefType, appContext: AppContext? = null) :
+  SharedObject(appContext)


### PR DESCRIPTION
# Why

Refactors promise wrappers. 

# How

We are currently using a `CallbackWrapper` to ensure that all necessary data will still be available when the Kotlin implementation attempts to finalize the underlying promise. However, I believe that the current arrangement is overly complicated and needs to be simplified. Therefore, I have restructured how data is transmitted to the JavaScript runtime and how we are converting from JNI to JSI values. 

# Test Plan

- bare-expo ✅
- unit tests ✅
