### PR TITLE
[dev-launcher] Remove experimental flag from launchMode config plugin option

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Remove debug settings for EAS Updates extension. ([#27603](https://github.com/expo/expo/pull/27603) by [@wschurman](https://github.com/wschurman))
 - Fixed breaking changes from React Native 0.74.0-rc.3. Also dropped support for React Native 0.73 and lower. ([#27573](https://github.com/expo/expo/pull/27573) by [@kudo](https://github.com/kudo))
 - [iOS] Added bridgeless support on ExpoReactDelegate. ([#27601](https://github.com/expo/expo/pull/27601), [#27689](https://github.com/expo/expo/pull/27689) by [@kudo](https://github.com/kudo))
+- Deprecate `experimentalLaunchMode` config plugin option and introduce new `launchMode` option. ([#27845](https://github.com/expo/expo/pull/27845) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -22,7 +22,7 @@ export type PluginConfigOptionsByPlatform = {
  */
 export type PluginConfigOptions = {
     /**
-     * **Experimental:** Determines whether to launch the most recently opened project or navigate to the launcher screen.
+     * Determines whether to launch the most recently opened project or navigate to the launcher screen.
      *
      * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
      * fall back to the launcher screen.
@@ -30,6 +30,10 @@ export type PluginConfigOptions = {
      * - `'launcher'` - Opens the launcher screen.
      *
      * @default 'most-recent'
+     */
+    launchMode?: 'most-recent' | 'launcher';
+    /**
+     * @deprecated use the `launchMode` property instead
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
 };

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -8,6 +8,11 @@ const ajv_1 = __importDefault(require("ajv"));
 const schema = {
     type: 'object',
     properties: {
+        launchMode: {
+            type: 'string',
+            enum: ['most-recent', 'launcher'],
+            nullable: true,
+        },
         launchModeExperimental: {
             type: 'string',
             enum: ['most-recent', 'launcher'],
@@ -16,6 +21,11 @@ const schema = {
         android: {
             type: 'object',
             properties: {
+                launchMode: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
@@ -27,6 +37,11 @@ const schema = {
         ios: {
             type: 'object',
             properties: {
+                launchMode: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
@@ -45,6 +60,18 @@ function validateConfig(config) {
     if (!validate(config)) {
         throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
     }
+    if (config.launchModeExperimental ||
+        config.ios?.launchModeExperimental ||
+        config.android?.launchModeExperimental) {
+        warnOnce('The `launchModeExperimental` property of expo-dev-launcher config plugin is deprecated and will be removed in a future SDK release. Use `launchMode` instead.');
+    }
     return config;
 }
 exports.validateConfig = validateConfig;
+const warnMap = {};
+function warnOnce(message) {
+    if (!warnMap[message]) {
+        warnMap[message] = true;
+        console.warn(message);
+    }
+}

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -5,13 +5,21 @@ const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
 exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
     (0, pluginConfig_1.validateConfig)(props);
-    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
+    const iOSLaunchMode = props.ios?.launchMode ??
+        props.launchMode ??
+        props.ios?.launchModeExperimental ??
+        props.launchModeExperimental;
+    if (iOSLaunchMode === 'launcher') {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
             config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
             return config;
         });
     }
-    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
+    const androidLaunchMode = props.android?.launchMode ??
+        props.launchMode ??
+        props.android?.launchModeExperimental ??
+        props.launchModeExperimental;
+    if (androidLaunchMode === 'launcher') {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', false?.toString());

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -26,7 +26,7 @@ export type PluginConfigOptionsByPlatform = {
  */
 export type PluginConfigOptions = {
   /**
-   * **Experimental:** Determines whether to launch the most recently opened project or navigate to the launcher screen.
+   * Determines whether to launch the most recently opened project or navigate to the launcher screen.
    *
    * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
    * fall back to the launcher screen.
@@ -35,12 +35,21 @@ export type PluginConfigOptions = {
    *
    * @default 'most-recent'
    */
+  launchMode?: 'most-recent' | 'launcher';
+  /**
+   * @deprecated use the `launchMode` property instead
+   */
   launchModeExperimental?: 'most-recent' | 'launcher';
 };
 
 const schema: JSONSchemaType<PluginConfigType> = {
   type: 'object',
   properties: {
+    launchMode: {
+      type: 'string',
+      enum: ['most-recent', 'launcher'],
+      nullable: true,
+    },
     launchModeExperimental: {
       type: 'string',
       enum: ['most-recent', 'launcher'],
@@ -49,6 +58,11 @@ const schema: JSONSchemaType<PluginConfigType> = {
     android: {
       type: 'object',
       properties: {
+        launchMode: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
@@ -60,6 +74,11 @@ const schema: JSONSchemaType<PluginConfigType> = {
     ios: {
       type: 'object',
       properties: {
+        launchMode: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
@@ -80,5 +99,23 @@ export function validateConfig<T>(config: T): PluginConfigType {
     throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
   }
 
+  if (
+    config.launchModeExperimental ||
+    config.ios?.launchModeExperimental ||
+    config.android?.launchModeExperimental
+  ) {
+    warnOnce(
+      'The `launchModeExperimental` property of expo-dev-launcher config plugin is deprecated and will be removed in a future SDK release. Use `launchMode` instead.'
+    );
+  }
+
   return config;
+}
+
+const warnMap: Record<string, boolean> = {};
+function warnOnce(message: string) {
+  if (!warnMap[message]) {
+    warnMap[message] = true;
+    console.warn(message);
+  }
 }

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -13,14 +13,24 @@ export default createRunOncePlugin<PluginConfigType>(
   (config, props = {}) => {
     validateConfig(props);
 
-    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
+    const iOSLaunchMode =
+      props.ios?.launchMode ??
+      props.launchMode ??
+      props.ios?.launchModeExperimental ??
+      props.launchModeExperimental;
+    if (iOSLaunchMode === 'launcher') {
       config = withInfoPlist(config, (config) => {
         config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
         return config;
       });
     }
 
-    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'launcher') {
+    const androidLaunchMode =
+      props.android?.launchMode ??
+      props.launchMode ??
+      props.android?.launchModeExperimental ??
+      props.launchModeExperimental;
+    if (androidLaunchMode === 'launcher') {
       config = withAndroidManifest(config, (config) => {
         const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 


### PR DESCRIPTION
# Why

The `launchModeExperimental` option was initially introduced on SDK 50 as an experiment and so far we haven't got any bug reports related to this. For SDK 51 we are removing the `Experimental` suffix from the option and deprecating the `launchModeExperimental`

# How

Add a new `launchMode` property to the `dev-launcher` config plugin and deprecate the `launchModeExperimental` option.

# Test Plan

Run yarn prebuild and make sure a deprecation warning is thrown when using `launchModeExperimental` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
