### PR TITLE
[docs] Add launchMode config plugin option to dev-client docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -36,7 +36,7 @@ You can configure development client launcher using its built-in [config plugin]
       [
         "expo-dev-launcher",
         {
-          "launchModeExperimental": "most-recent"
+          "launchMode": "most-recent"
         }
       ]
     ]
@@ -49,14 +49,13 @@ You can configure development client launcher using its built-in [config plugin]
 <ConfigPluginProperties
   properties={[
     {
-      name: 'launchModeExperimental',
+      name: 'launchMode',
       description: [
         'Determines whether to launch the most recently opened project or navigate to the launcher screen.',
         '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
         '* `launcher` - Opens the launcher screen.',
       ].join('\n'),
       default: '"most-recent"',
-      experimental: true,
     },
   ]}
 />


### PR DESCRIPTION
# Why

Update dev-client unversioned docs to reflect the changes of https://github.com/expo/expo/pull/27845

# How

Run docs locally

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
