### PR TITLE
[docs] Use `collapseHeight` and remove `@hide` in various docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -287,7 +287,7 @@ import Video from '~/components/plugins/Video';
 
 ### Add code block
 
-Code blocks are a great way to add code snippets to our docs. We leverage the usuall code block Markdown syntax, but it's expanded to support code block titles, and an additional params.
+Code blocks are a great way to add code snippets to our docs. We leverage the usual code block Markdown syntax, but it's expanded to support code block titles and additional params.
 
 <!-- prettier-ignore -->
 ```mdx
@@ -296,7 +296,7 @@ Code blocks are a great way to add code snippets to our docs. We leverage the us
     // Your code goes in here
     ```
 
-    {/* To add a title, just enter it right after language, in the code block starting line: */}
+    {/* To add a title, enter it right after the language, in the code block starting line: */}
     ```js myFile.js
     // Your code goes in here
     ```
@@ -317,7 +317,7 @@ Code blocks are a great way to add code snippets to our docs. We leverage the us
 
 | Param            | Type   | Description                                                                                                                                                            |
 | ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collapseHeight` | number | The custom height to which code block should be automatically collapsed, the default value is `408` and it's applied unless `collapseHeight` param has been specified. |
+| `collapseHeight` | number | The custom height that the code block uses to collapse automatically. The default value is `408` and is applied unless the `collapseHeight` param has been specified. |
 
 ### Add inline Snack examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -285,61 +285,96 @@ import Video from '~/components/plugins/Video';
 <Video file="guides/color-schemes.mp4" />;
 ```
 
-### Inline Snack examples
+### Add code block
+
+Code blocks are a great way to add code snippets to our docs. We leverage the usuall code block Markdown syntax, but it's expanded to support code block titles, and an additional params.
+
+<!-- prettier-ignore -->
+```mdx
+    {/* For plain code block the syntax is unchanged (but we recommend to always add a title to the snippet): */}
+    ```js
+    // Your code goes in here
+    ```
+
+    {/* To add a title, just enter it right after language, in the code block starting line: */}
+    ```js myFile.js
+    // Your code goes in here
+    ```
+    ```js Title for a code block
+    // Your code goes in here
+    ```
+
+    {/* Title and params can be separated by pipe ("|") characters, but they also work for block without a title: */}
+    ```js myFile.js|collapseHeight=600
+    // Your code goes in here
+    ```
+    ```js collapseHeight=200
+    // Your code goes in here
+    ```
+```
+
+#### Supported additional params
+
+| Param            | Type   | Description                                                                                                                                                            |
+| ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collapseHeight` | number | The custom height to which code block should be automatically collapsed, the default value is `408` and it's applied unless `collapseHeight` param has been specified. |
+
+### Add inline Snack examples
 
 Snacks are a great way to add instantly-runnable examples to our docs. The `SnackInline` component can be imported to any markdown file, and used like this:
 
 <!-- prettier-ignore -->
-```jsx
+```mdx
 import SnackInline from '~/components/plugins/SnackInline';
 
 <SnackInline label='My Example Label' dependencies={['array of', 'packages', 'this Snack relies on']}>
+    ```js
+    // All your code goes in here
 
-// All your JavaScript code goes in here
+    // You can use:
+    /* @info Some text goes here */
+    const myVariable = SomeCodeThatDoesStuff();
+    /* @end */
+    // to create hoverable-text, which reveals the text inside of `@info` onHover.
 
-// You can use:
-/* @info Some text goes here */
-  const myVariable = SomeCodeThatDoesStuff();
-/* @end */
-// to create hoverable-text, which reveals the text inside of `@info` onHover.
-
-// You can use:
-/* @hide Content that is still shown, like a preview. */
-  Everything in here is hidden in the example Snack until
-  you open it in snack.expo.dev
-/* @end */
-// to shorten the length of the Snack shown in our docs. Common example are hiding useless code in examples, like StyleSheets
-
+    // You can use:
+    /* @hide Content that is still shown, like a preview. */
+    Everything in here is hidden in the example Snack until
+    you open it in snack.expo.dev
+    /* @end */
+    // to shorten the length of code block shown in our docs.
+    // Hidden code will still be present when opening in Snack or using "Copy" action.
+    ```
 </SnackInline>
 ```
 
-### Embed multiple options of code
+### Add multiple code variants
 
 Sometimes it's useful to show multiple ways of doing something, for instance, maybe you'd like to have an example using a React class component, and also an example of a functional component.
 The `Tabs` plugin is really useful for this, and this is how you'd use it in a markdown file:
 
 <!-- prettier-ignore -->
-```jsx
+```mdx
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 <Tabs>
 <Tab label="Add 1 One Way">
-
+    ```js
     addOne = async x => {
-    /* @info This text will be shown onHover */
-    return x + 1;
-    /* @end */
+      /* @info This text will be shown onHover */
+      return x + 1;
+      /* @end */
     };
-
+    ```
 </Tab>
 <Tab label="Add 1 Another Way">
-
+    ```js
     addOne = async x => {
-    /* @info This text will be shown onHover */
-    return x++;
-    /* @end */
+      /* @info This text will be shown onHover */
+      return x++;
+      /* @end */
     };
-
+    ```
 </Tab>
 </Tabs>
 ```
@@ -363,13 +398,13 @@ If you just want to hide a single page from the sidebar, set `hideInSidebar: tru
 
 Whenever shell commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported into any markdown file.
 
-```jsx
+```mdx
 import { Terminal } from '~/ui/components/Snippet';
 
-// for single command and one prop
+{/* for single command and one prop: */}
 <Terminal cmd={["$ npx expo install package"]} />
 
-// for multiple commands
+{/* for multiple commands: */}
 
 <Terminal cmd={[
   "# Create a new native project",

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6954,7 +6954,7 @@ This uses both
     </p>
     <pre>
       <pre
-        class="last:mb-0 css-1r21cuo-Code"
+        class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
         data-text="true"
       >
         <code

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -81,7 +81,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </p>
   <pre>
     <pre
-      class="last:mb-0 css-1r21cuo-Code"
+      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
       data-text="true"
     >
       <code

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -608,7 +608,7 @@ export const withSimpleAppDelegateHeaderMod = config => {
 
 To use this new base mod, add it to the plugins array. The base mod **MUST** be added last after all other plugins that use the mod, this is because it must write the results to disk at the end of the process.
 
-```js app.config.js
+```js app.config.js|collapseHeight=420
 // Required for external files using TS
 require('ts-node/register');
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -148,7 +148,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -156,7 +155,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -260,12 +258,13 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      <Text style={{ fontFamily: 'Inter_900Black', fontSize: 40 }}>Inter Black</Text>
+      <Text style={{ fontFamily: 'Inter_900Black', fontSize: 40 }}>
+        Inter Black
+      </Text>
     </View>
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -273,7 +272,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -78,7 +78,7 @@ Below is a minimal working example that uses the `useSafeAreaInsets` hook to app
 
 <SnackInline label="Using react-native-safe-area-context" dependencies={['react-native-safe-area-context']}>
 
-```jsx
+```jsx collapseHeight=320
 import { Text, View } from 'react-native';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -194,7 +194,7 @@ Next time you deploy your website, the banner should appear when you visit it on
 
 Implementing deep links on Android (without a custom URL scheme) is somewhat simpler than on iOS. You need to add `intentFilters` to the [`android`](/versions/latest/config/app/#android) section of your [app config](/workflow/configuration/). The following basic configuration will cause your app to be presented in the standard Android dialog as an option for handling any record links to `myapp.io`:
 
-```json app.json
+```json app.json|collapseHeight=454
 {
   "expo": {
     "android": {

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -16,7 +16,7 @@ The component loads the `Ionicons` font and renders a checkmark icon in the foll
 
 <SnackInline label='Vector icons' dependencies={['@expo/vector-icons']}>
 
-```jsx
+```jsx collapseHeight=350
 import * as React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
@@ -31,7 +31,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -39,7 +38,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -121,7 +119,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -129,7 +126,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -147,7 +143,7 @@ import { createIconSetFromFontello } from '@expo/vector-icons';
 // Import the config file
 import fontelloConfig from './config.json';
 
-// Both the font name and files exported from Fontello are most likely called "fontello". 
+// Both the font name and files exported from Fontello are most likely called "fontello".
 // Ensure this is the `fontname.ttf` and not the file path.
 const Icon = createIconSetFromFontello(fontelloConfig, 'fontello', 'fontello.ttf');
 ```
@@ -160,7 +156,7 @@ You can use the `Image` component from [Expo Image](/versions/latest/sdk/image/)
 
 <Tab label="Expo Image">
 
-```jsx
+```jsx collapseHeight=440
 import { Image } from 'expo-image';
 import { View, StyleSheet } from 'react-native';
 
@@ -172,7 +168,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -180,7 +175,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </Tab>
@@ -203,7 +197,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -211,7 +204,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -249,7 +241,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -257,7 +248,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -102,7 +102,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     backgroundColor: '#fff',
@@ -115,7 +114,6 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -119,7 +119,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create( */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -128,7 +127,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -256,7 +254,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -268,7 +265,6 @@ const styles = StyleSheet.create({
     paddingTop: 58,
   },
 });
-/* @end */
 ```
 
 </Step>

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -277,7 +277,7 @@ The modal allows the user to choose an emoji from a list of available emoji. Cre
 - `children`: used later to display a list of emoji.
 
 {/* prettier-ignore */}
-```jsx EmojiPicker.js
+```jsx EmojiPicker.js|collapseHeight=430
 import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
@@ -506,7 +506,7 @@ The `horizontal` prop renders the list horizontally instead of vertically. The `
 Now, modify the `App` component. Import the `<EmojiList>` component and replace the comments where the `<EmojiPicker>` component is used with the following code snippet:
 
 {/* prettier-ignore */}
-```jsx App.js
+```jsx App.js|collapseHeight=440
 //...rest of the import statements remain same
 /* @info Import the EmojiList component.*/ import EmojiList from './components/EmojiList';/* @end */
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -42,7 +42,7 @@ We'll create a function to launch the device's image library to implement this f
 In **App.js**, import the `expo-image-picker` library and create a `pickImageAsync()` function inside the `App` component:
 
 {/* prettier-ignore */}
-```jsx App.js
+```jsx App.js|collapseHeight=440
 // ...rest of the import statements remain unchanged
 /* @info Import the ImagePicker. */ import * as ImagePicker from 'expo-image-picker'; /* @end */
 
@@ -140,7 +140,7 @@ To demonstrate what properties the `result` object contains, here is an example 
       "width": 3200
     }
   ],
-  "canceled": false,
+  "canceled": false
 }
 ```
 

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -44,7 +44,7 @@ Throughout the tutorial, any important code or code that has changed between exa
 <SnackInline label="Hello world">
 
 {/* prettier-ignore */}
-```jsx
+```jsx collapseHeight=425
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
@@ -73,8 +73,8 @@ const styles = StyleSheet.create({
 >
 > <br />
 > Go ahead and press the above button. You will see the above code running in a Snack. Try to switch
-> between Android, iOS or the web tabs. You can also open it on your device in the Expo Go app from
-> the **My device** tab.
+> between Android, iOS or the web tabs. You can also open it on your device in the Expo Go app from the
+> **My device** tab.
 >
 > <br />
 > Throughout this tutorial, use Snack to copy and paste the code into your project on your computer.

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -85,7 +85,7 @@ The `react-native-view-shot` library provides a method called `captureRef()` tha
 To capture a `<View>`, wrap the `<ImageViewer>` and `<EmojiSticker>` components inside a `<View>` and then pass a reference to it. Using the `useRef()` hook from React, let's create an `imageRef` variable inside `<App>`.
 
 {/* prettier-ignore */}
-```jsx App.js
+```jsx App.js|collapseHeight=440
 import { useState, /* @info Import the useRef hook from React. */useRef/* @end */ } from 'react';
 
 export default function App() {
@@ -148,7 +148,7 @@ files={{
 }}>
 
 {/* prettier-ignore */}
-```jsx
+```jsx collapseHeight=440
 export default function App() {
   /* @info Replace the comment with the code to capture the screenshot and save the image. */
   const onSaveImageAsync = async () => {

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -104,7 +104,7 @@ Here, we'll define a global style for the class name `.container`:
 
 We can then use the class name in our component by importing the stylesheet and using `.container`:
 
-```jsx App.js
+```jsx App.js|collapseHeight=470
 import './styles.css';
 import { View } from 'react-native';
 
@@ -157,7 +157,7 @@ Flipping the extension, for example, `App.ios.module.css` will not work and resu
 
 > You cannot pass styles to the `className` prop of a React Native or React Native for web component. Instead, you must use the `style` prop.
 
-```jsx App.js
+```jsx App.js|collapseHeight=470
 import styles, { unstable_styles } from './App.module.css';
 
 export default function Page() {
@@ -394,7 +394,7 @@ module.exports.transform = async ({ src, filename, options }) => {
 
 Expo CLI extends the default Metro resolver to add features like Web, Server, and tsconfig aliases support. You can similarly customize the default resolution behavior of Metro by chaining the `config.resolver.resolveRequest` function.
 
-```tsx metro.config.js
+```tsx metro.config.js|collapseHeight=470
 const { getDefaultConfig } = require('expo/metro-config');
 
 /** @type {import('expo/metro-config').MetroConfig} */

--- a/docs/pages/versions/unversioned/sdk/accelerometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/accelerometer.mdx
@@ -75,7 +75,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -103,7 +102,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -109,7 +109,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -121,7 +120,6 @@ const styles = StyleSheet.create({
     height: 44,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -80,7 +79,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -143,7 +141,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -152,7 +149,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -84,7 +84,6 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
   { uri: 'http://foo/bar.mp3' },
   { shouldPlay: true }
 );
-...
 ```
 
 See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
@@ -92,25 +91,21 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 ### Example: `Video`
 
 ```js
-...
+/* @hide ... */ /* @end */
 _handleVideoRef = component => {
   const playbackObject = component;
   ...
 }
-
-...
+/* @hide ... */ /* @end */
 
 render() {
   return (
-    ...
       <Video
         ref={this._handleVideoRef}
-        ...
       />
-    ...
+      /* @hide ... */ /* @end */
   )
 }
-...
 ```
 
 See the [video documentation](video.mdx) for further information.
@@ -142,22 +137,21 @@ _onPlaybackStatusUpdate = playbackStatus => {
       // The player has just finished playing and will stop. Maybe you want to play something else?
     }
 
-    ... // etc
+    /* @hide ... */ /* @end */
   }
 };
 
-... // Load the playbackObject and obtain the reference.
+// Load the playbackObject and obtain the reference.
 playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
-...
 ```
 
 ### Example: Loop media exactly 20 times
 
 ```js
 const N = 20;
-...
+/* @hide ... */ /* @end */
 
-_onPlaybackStatusUpdate = (playbackStatus) => {
+_onPlaybackStatusUpdate = playbackStatus => {
   if (playbackStatus.didJustFinish) {
     if (this.state.numberOfLoops == N - 1) {
       playbackObject.setIsLooping(false);
@@ -166,12 +160,11 @@ _onPlaybackStatusUpdate = (playbackStatus) => {
   }
 };
 
-...
+/* @hide ... */ /* @end */
 this.setState({ numberOfLoops: 0 });
-... // Load the playbackObject and obtain the reference.
+// Load the playbackObject and obtain the reference.
 playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 playbackObject.setIsLooping(true);
-...
 ```
 
 ## What is seek tolerance and why would I want to use it [iOS only]

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -128,7 +128,6 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
@@ -142,7 +141,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -163,7 +163,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -171,7 +170,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/barometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/barometer.mdx
@@ -61,7 +61,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   button: {
     justifyContent: 'center',
@@ -77,7 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/battery.mdx
+++ b/docs/pages/versions/unversioned/sdk/battery.mdx
@@ -37,7 +37,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -46,7 +45,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -65,7 +65,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -99,7 +98,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/brightness.mdx
+++ b/docs/pages/versions/unversioned/sdk/brightness.mdx
@@ -57,7 +57,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -26,7 +26,7 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 <ConfigPluginExample>
 
-```json app.json
+```json app.json|collapseHeight=450
 {
   "expo": {
     "plugins": [
@@ -52,7 +52,7 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 ### Example app.config.js usage
 
-```js app.config.js
+```js app.config.js|collapseHeight=450
 export default {
   expo: {
     plugins: [

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -122,7 +122,6 @@ async function createCalendar() {
   console.log(`Your new calendar ID is: ${newCalendarID}`);
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -131,7 +130,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/camera-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-next.mdx
@@ -134,7 +134,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -160,7 +159,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 ## Web support

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -133,7 +133,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -159,7 +158,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/clipboard.mdx
+++ b/docs/pages/versions/unversioned/sdk/clipboard.mdx
@@ -52,7 +52,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
     color: 'red',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -100,7 +100,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -109,7 +108,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/crypto.mdx
+++ b/docs/pages/versions/unversioned/sdk/crypto.mdx
@@ -47,7 +47,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -60,13 +60,11 @@ const App = () => (
   />
 );
 
-/* @hide const handleFacesDetected = ({ faces }) => { ... }; */
 const handleFacesDetected = ({ faces }) => {
   console.log(faces);
 };
 
 export default App;
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -51,7 +51,8 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
   properties={[
     {
       name: 'fonts',
-      description: 'An array of font files to link to the native project. The paths should be relative to the project root, and the file names will become the font family names.',
+      description:
+        'An array of font files to link to the native project. The paths should be relative to the project root, and the file names will become the font family names.',
       default: '[]',
     },
   ]}
@@ -103,7 +104,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -111,7 +111,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/gyroscope.mdx
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.mdx
@@ -78,7 +78,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -106,7 +105,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -103,7 +103,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -118,7 +117,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -72,7 +72,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -128,7 +128,7 @@ export default function ImagePickerExample() {
 
 When you run this example and pick an image, you will see the image that you picked show up in your app, and a similar log will be shown in the console:
 
-```json
+```json collapseHeight=425
 {
   "assets": [
     {

--- a/docs/pages/versions/unversioned/sdk/light-sensor.mdx
+++ b/docs/pages/versions/unversioned/sdk/light-sensor.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: 'row',
@@ -90,7 +89,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -72,7 +71,6 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -169,7 +169,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -182,7 +181,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/magnetometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.mdx
@@ -80,7 +80,6 @@ export default function Compass() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -108,7 +107,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/pedometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/pedometer.mdx
@@ -67,7 +67,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -76,7 +75,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -88,7 +88,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -104,7 +103,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -68,7 +68,6 @@ export default function AnimatedStyleUpdateExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -82,7 +81,6 @@ const styles = StyleSheet.create({
     margin: 30,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -99,7 +99,6 @@ export default function ScreenCaptureExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -107,7 +106,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -173,7 +173,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -196,7 +195,6 @@ const styles = StyleSheet.create({
     padding: 4,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -41,7 +41,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -50,7 +49,6 @@ const styles = StyleSheet.create({
     padding: 8,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -28,25 +28,28 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline dependencies={["expo-status-bar"]}>
 
-```js
+```js collapseHeight=310
 import React from 'react';
 import { Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
-const App = () => (
-  <View
-    style={{
-      flex: 1,
-      backgroundColor: '#000',
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-    <Text style={{ color: '#fff' }}>Notice that the status bar has light text!</Text>
-    <StatusBar style="light" />
-  </View>
-);
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={{ color: '#fff' }}>Notice that the status bar has light text!</Text>
+      <StatusBar style="light" />
+    </View>
+  );
+}
 
-export default App;
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -93,7 +93,6 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   }
 });
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -101,7 +100,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 
 export default PermissionsButton;
 ```

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -94,7 +94,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -102,7 +101,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -53,7 +53,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     height: 200,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -60,7 +60,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -78,7 +77,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -28,14 +28,13 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 ## Example
 
 ```js
-import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 
-const MyPager = () => {
+export default function MyPager() {
   return (
-    <View style={{ flex: 1 }}>
-      <PagerView style={styles.viewPager} initialPage={0}>
+    <View style={styles.container}>
+      <PagerView style={styles.container} initialPage={0}>
         <View style={styles.page} key="1">
           <Text>First page</Text>
           <Text>Swipe ➡️</Text>
@@ -49,10 +48,10 @@ const MyPager = () => {
       </PagerView>
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
-  viewPager: {
+  container: {
     flex: 1,
   },
   page: {
@@ -60,6 +59,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
-export default MyPager;
 ```

--- a/docs/pages/versions/unversioned/sdk/webbrowser.mdx
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ecf0f1',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -24,13 +24,10 @@ You should refer to the [react-native-webview docs](https://github.com/react-nat
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 
 {/* prettier-ignore */}
-```jsx
-import * as React from 'react';
+```jsx collapseHeight=310
 import { WebView } from 'react-native-webview';
-/* @hide */
-import { StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
-/* @end */
+import { StyleSheet } from 'react-native';
 
 export default function App() {
   return (
@@ -41,14 +38,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -57,13 +52,10 @@ Minimal example with inline HTML:
 
 <SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
 
-```jsx
-import * as React from 'react';
+```jsx collapseHeight=310
 import { WebView } from 'react-native-webview';
-/* @hide */
-import { StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
-/* @end */
+import { StyleSheet } from 'react-native';
 
 export default function App() {
   return (
@@ -75,14 +67,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/accelerometer.mdx
@@ -75,7 +75,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -103,7 +102,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
@@ -102,7 +102,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -114,7 +113,6 @@ const styles = StyleSheet.create({
     height: 44,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/audio.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -80,7 +79,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -143,7 +141,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -152,7 +149,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/background-fetch.mdx
@@ -128,7 +128,6 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
@@ -142,7 +141,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
@@ -161,7 +161,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -169,7 +168,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/barometer.mdx
@@ -61,7 +61,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   button: {
     justifyContent: 'center',
@@ -77,7 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/battery.mdx
@@ -61,7 +61,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -70,7 +69,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
@@ -63,7 +63,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -97,7 +96,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/brightness.mdx
@@ -57,7 +57,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/calendar.mdx
@@ -122,7 +122,6 @@ async function createCalendar() {
   console.log(`Your new calendar ID is: ${newCalendarID}`);
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -131,7 +130,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/camera.mdx
@@ -124,7 +124,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -150,7 +149,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/clipboard.mdx
@@ -52,7 +52,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
     color: 'red',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/contacts.mdx
@@ -100,7 +100,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -109,7 +108,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/crypto.mdx
@@ -47,7 +47,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/font.mdx
@@ -58,7 +58,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/gyroscope.mdx
@@ -78,7 +78,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -106,7 +105,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/haptics.mdx
@@ -107,7 +107,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -122,7 +121,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagemanipulator.mdx
@@ -72,7 +72,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/docs/pages/versions/v48.0.0/sdk/light-sensor.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/light-sensor.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: 'row',
@@ -90,7 +89,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/linear-gradient.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -72,7 +71,6 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/location.mdx
@@ -163,7 +163,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -176,7 +175,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/magnetometer.mdx
@@ -80,7 +80,6 @@ export default function Compass() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -108,7 +107,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/pedometer.mdx
@@ -67,7 +67,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -76,7 +75,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/print.mdx
@@ -88,7 +88,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -104,7 +103,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
@@ -96,7 +96,6 @@ export default function AnimatedStyleUpdateExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -110,7 +109,6 @@ const styles = StyleSheet.create({
     margin: 30,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/screen-capture.mdx
@@ -90,7 +90,6 @@ export default function ScreenCaptureExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -98,7 +97,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/securestore.mdx
@@ -121,7 +121,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -144,7 +143,6 @@ const styles = StyleSheet.create({
     padding: 4,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/speech.mdx
@@ -41,7 +41,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -50,7 +49,6 @@ const styles = StyleSheet.create({
     padding: 8,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
@@ -93,7 +93,6 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   }
 });
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -101,7 +100,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 
 export default PermissionsButton;
 ```

--- a/docs/pages/versions/v48.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/tracking-transparency.mdx
@@ -94,7 +94,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -102,7 +101,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/video-thumbnails.mdx
@@ -53,7 +53,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     height: 200,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/video.mdx
@@ -60,7 +60,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -78,7 +77,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/webbrowser.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ecf0f1',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v48.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/webview.mdx
@@ -41,14 +41,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -75,14 +73,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
@@ -75,7 +75,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -103,7 +102,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
@@ -109,7 +109,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -121,7 +120,6 @@ const styles = StyleSheet.create({
     height: 44,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -80,7 +79,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -143,7 +141,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -152,7 +149,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
@@ -128,7 +128,6 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
@@ -142,7 +141,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -161,7 +161,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -169,7 +168,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/barometer.mdx
@@ -61,7 +61,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   button: {
     justifyContent: 'center',
@@ -77,7 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/battery.mdx
@@ -37,7 +37,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -46,7 +45,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -72,7 +72,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -106,7 +105,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/brightness.mdx
@@ -57,7 +57,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/calendar.mdx
@@ -122,7 +122,6 @@ async function createCalendar() {
   console.log(`Your new calendar ID is: ${newCalendarID}`);
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -131,7 +130,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/camera.mdx
@@ -124,7 +124,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -150,7 +149,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
@@ -52,7 +52,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
     color: 'red',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/contacts.mdx
@@ -100,7 +100,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -109,7 +108,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/crypto.mdx
@@ -47,7 +47,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/font.mdx
@@ -58,7 +58,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
@@ -78,7 +78,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -106,7 +105,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/haptics.mdx
@@ -103,7 +103,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -118,7 +117,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
@@ -72,7 +72,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/docs/pages/versions/v49.0.0/sdk/light-sensor.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/light-sensor.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: 'row',
@@ -90,7 +89,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -72,7 +71,6 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -163,7 +163,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -176,7 +175,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
@@ -80,7 +80,6 @@ export default function Compass() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -108,7 +107,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
@@ -67,7 +67,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -76,7 +75,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/print.mdx
@@ -88,7 +88,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -104,7 +103,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/screen-capture.mdx
@@ -90,7 +90,6 @@ export default function ScreenCaptureExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -98,7 +97,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/securestore.mdx
@@ -121,7 +121,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -144,7 +143,6 @@ const styles = StyleSheet.create({
     padding: 4,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/speech.mdx
@@ -41,7 +41,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -50,7 +49,6 @@ const styles = StyleSheet.create({
     padding: 8,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
@@ -93,7 +93,6 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   }
 });
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -101,7 +100,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 
 export default PermissionsButton;
 ```

--- a/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
@@ -94,7 +94,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -102,7 +101,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
@@ -53,7 +53,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     height: 200,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video.mdx
@@ -60,7 +60,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -78,7 +77,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ecf0f1',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v49.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webview.mdx
@@ -41,14 +41,14 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
+
 ```
 
 </SnackInline>
@@ -75,14 +75,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -104,7 +104,7 @@ Here, we'll define a global style for the class name `.container`:
 
 We can then use the class name in our component by importing the stylesheet and using `.container`:
 
-```js App.js
+```js App.js|collapseHeight=470
 import './styles.css';
 import { View } from 'react-native';
 
@@ -157,7 +157,7 @@ Flipping the extension, for example, `App.ios.module.css` will not work and resu
 
 > You cannot pass styles to the `className` prop of a React Native or React Native for web component. Instead, you must use the `style` prop.
 
-```js App.js
+```js App.js|collapseHeight=470
 import styles, { unstable_styles } from './App.module.css';
 
 export default function Page() {
@@ -394,7 +394,7 @@ module.exports.transform = async ({ src, filename, options }) => {
 
 Expo CLI extends the default Metro resolver to add features like Web, Server, and tsconfig aliases support. You can similarly customize the default resolution behavior of Metro by chaining the `config.resolver.resolveRequest` function.
 
-```tsx metro.config.js
+```tsx metro.config.js|collapseHeight=470
 const { getDefaultConfig } = require('expo/metro-config');
 
 /** @type {import('expo/metro-config').MetroConfig} */

--- a/docs/pages/versions/v50.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/accelerometer.mdx
@@ -75,7 +75,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -103,7 +102,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/apple-authentication.mdx
@@ -109,7 +109,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -121,7 +120,6 @@ const styles = StyleSheet.create({
     height: 44,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/audio.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -80,7 +79,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -143,7 +141,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -152,7 +149,6 @@ const styles = StyleSheet.create({
     padding: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -92,25 +92,21 @@ See the [audio documentation](audio.mdx) for further information on `Audio.Sound
 ### Example: `Video`
 
 ```js
-...
+/* @hide ... */ /* @end */
 _handleVideoRef = component => {
   const playbackObject = component;
   ...
 }
-
-...
+/* @hide ... */ /* @end */
 
 render() {
   return (
-    ...
       <Video
         ref={this._handleVideoRef}
-        ...
       />
-    ...
+      /* @hide ... */ /* @end */
   )
 }
-...
 ```
 
 See the [video documentation](video.mdx) for further information.
@@ -142,22 +138,21 @@ _onPlaybackStatusUpdate = playbackStatus => {
       // The player has just finished playing and will stop. Maybe you want to play something else?
     }
 
-    ... // etc
+    /* @hide ... */ /* @end */
   }
 };
 
-... // Load the playbackObject and obtain the reference.
+// Load the playbackObject and obtain the reference.
 playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
-...
 ```
 
 ### Example: Loop media exactly 20 times
 
 ```js
 const N = 20;
-...
+/* @hide ... */ /* @end */
 
-_onPlaybackStatusUpdate = (playbackStatus) => {
+_onPlaybackStatusUpdate = playbackStatus => {
   if (playbackStatus.didJustFinish) {
     if (this.state.numberOfLoops == N - 1) {
       playbackObject.setIsLooping(false);
@@ -166,12 +161,11 @@ _onPlaybackStatusUpdate = (playbackStatus) => {
   }
 };
 
-...
+/* @hide ... */ /* @end */
 this.setState({ numberOfLoops: 0 });
-... // Load the playbackObject and obtain the reference.
+// Load the playbackObject and obtain the reference.
 playbackObject.setOnPlaybackStatusUpdate(this._onPlaybackStatusUpdate);
 playbackObject.setIsLooping(true);
-...
 ```
 
 ## What is seek tolerance and why would I want to use it [iOS only]

--- a/docs/pages/versions/v50.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/background-fetch.mdx
@@ -128,7 +128,6 @@ export default function BackgroundFetchScreen() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
@@ -142,7 +141,6 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/bar-code-scanner.mdx
@@ -163,7 +163,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -171,7 +170,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/barometer.mdx
@@ -61,7 +61,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   button: {
     justifyContent: 'center',
@@ -77,7 +76,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/battery.mdx
@@ -37,7 +37,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -46,7 +45,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/blur-view.mdx
@@ -65,7 +65,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -99,7 +98,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/brightness.mdx
@@ -57,7 +57,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/build-properties.mdx
@@ -26,7 +26,7 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 <ConfigPluginExample>
 
-```json app.json
+```json app.json|collapseHeight=450
 {
   "expo": {
     "plugins": [
@@ -52,7 +52,7 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 ### Example app.config.js usage
 
-```js app.config.js
+```js app.config.js|collapseHeight=450
 export default {
   expo: {
     plugins: [

--- a/docs/pages/versions/v50.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/calendar.mdx
@@ -122,7 +122,6 @@ async function createCalendar() {
   console.log(`Your new calendar ID is: ${newCalendarID}`);
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -131,7 +130,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-around',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera-next.mdx
@@ -134,7 +134,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -160,7 +159,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 ## Web support

--- a/docs/pages/versions/v50.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera.mdx
@@ -133,7 +133,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -159,7 +158,6 @@ const styles = StyleSheet.create({
     color: 'white',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
@@ -52,7 +52,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
     color: 'red',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/contacts.mdx
@@ -100,7 +100,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -109,7 +108,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/crypto.mdx
@@ -47,7 +47,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -60,13 +60,11 @@ const App = () => (
   />
 );
 
-/* @hide const handleFacesDetected = ({ faces }) => { ... }; */
 const handleFacesDetected = ({ faces }) => {
   console.log(faces);
 };
 
 export default App;
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/font.mdx
@@ -51,7 +51,8 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
   properties={[
     {
       name: 'fonts',
-      description: 'An array of font files to link to the native project. The paths should be relative to the project root, and the file names will become the font family names.',
+      description:
+        'An array of font files to link to the native project. The paths should be relative to the project root, and the file names will become the font family names.',
       default: '[]',
     },
   ]}
@@ -103,7 +104,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -111,7 +111,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
@@ -78,7 +78,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -106,7 +105,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/haptics.mdx
@@ -103,7 +103,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -118,7 +117,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
@@ -72,7 +72,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
@@ -128,7 +128,7 @@ export default function ImagePickerExample() {
 
 When you run this example and pick an image, you will see the image that you picked show up in your app, and a similar log will be shown in the console:
 
-```json
+```json collapseHeight=425
 {
   "assets": [
     {

--- a/docs/pages/versions/v50.0.0/sdk/light-sensor.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/light-sensor.mdx
@@ -71,7 +71,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   buttonContainer: {
     flexDirection: 'row',
@@ -90,7 +89,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -72,7 +71,6 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -169,7 +169,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -182,7 +181,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
@@ -80,7 +80,6 @@ export default function Compass() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -108,7 +107,6 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
@@ -67,7 +67,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -76,7 +75,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/print.mdx
@@ -88,7 +88,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -104,7 +103,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -68,7 +68,6 @@ export default function AnimatedStyleUpdateExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -82,7 +81,6 @@ const styles = StyleSheet.create({
     margin: 30,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/screen-capture.mdx
@@ -90,7 +90,6 @@ export default function ScreenCaptureExample() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -98,7 +97,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -173,7 +173,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -196,7 +195,6 @@ const styles = StyleSheet.create({
     padding: 4,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/speech.mdx
@@ -41,7 +41,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -50,7 +49,6 @@ const styles = StyleSheet.create({
     padding: 8,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/status-bar.mdx
@@ -28,25 +28,28 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline dependencies={["expo-status-bar"]}>
 
-```js
+```js collapseHeight=310
 import React from 'react';
 import { Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
-const App = () => (
-  <View
-    style={{
-      flex: 1,
-      backgroundColor: '#000',
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-    <Text style={{ color: '#fff' }}>Notice that the status bar has light text!</Text>
-    <StatusBar style="light" />
-  </View>
-);
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={{ color: '#fff' }}>Notice that the status bar has light text!</Text>
+      <StatusBar style="light" />
+    </View>
+  );
+}
 
-export default App;
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
@@ -93,7 +93,6 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
   }
 });
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -101,7 +100,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 
 export default PermissionsButton;
 ```

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -94,7 +94,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -102,7 +101,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
@@ -53,7 +53,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -66,7 +65,6 @@ const styles = StyleSheet.create({
     height: 200,
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video.mdx
@@ -60,7 +60,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -78,7 +77,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
@@ -28,14 +28,13 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 ## Example
 
 ```js
-import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 
-const MyPager = () => {
+export default function MyPager() {
   return (
-    <View style={{ flex: 1 }}>
-      <PagerView style={styles.viewPager} initialPage={0}>
+    <View style={styles.container}>
+      <PagerView style={styles.container} initialPage={0}>
         <View style={styles.page} key="1">
           <Text>First page</Text>
           <Text>Swipe ➡️</Text>
@@ -49,10 +48,10 @@ const MyPager = () => {
       </PagerView>
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
-  viewPager: {
+  container: {
     flex: 1,
   },
   page: {
@@ -60,6 +59,4 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
-export default MyPager;
 ```

--- a/docs/pages/versions/v50.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webbrowser.mdx
@@ -46,7 +46,6 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#ecf0f1',
   },
 });
-/* @end */
 ```
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webview.mdx
@@ -24,13 +24,10 @@ You should refer to the [react-native-webview docs](https://github.com/react-nat
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 
 {/* prettier-ignore */}
-```jsx
-import * as React from 'react';
+```jsx collapseHeight=310
 import { WebView } from 'react-native-webview';
-/* @hide */
-import { StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
-/* @end */
+import { StyleSheet } from 'react-native';
 
 export default function App() {
   return (
@@ -41,14 +38,12 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
 ```
 
 </SnackInline>
@@ -57,13 +52,10 @@ Minimal example with inline HTML:
 
 <SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
 
-```jsx
-import * as React from 'react';
+````jsx collapseHeight=310
 import { WebView } from 'react-native-webview';
-/* @hide */
-import { StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
-/* @end */
+import { StyleSheet } from 'react-native';
 
 export default function App() {
   return (
@@ -75,14 +67,13 @@ export default function App() {
   );
 }
 
-/* @hide const styles = StyleSheet.create({ ... }); */
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Constants.statusBarHeight,
   },
 });
-/* @end */
-```
+``` */
+````
 
 </SnackInline>

--- a/docs/pages/versions/v50.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webview.mdx
@@ -52,7 +52,7 @@ Minimal example with inline HTML:
 
 <SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
 
-````jsx collapseHeight=310
+```jsx collapseHeight=310
 import { WebView } from 'react-native-webview';
 import Constants from 'expo-constants';
 import { StyleSheet } from 'react-native';
@@ -73,7 +73,6 @@ const styles = StyleSheet.create({
     marginTop: Constants.statusBarHeight,
   },
 });
-``` */
-````
+```
 
 </SnackInline>

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -21,9 +21,8 @@ module.exports = {
   ],
   ...getExpoTheme({
     backgroundImage: theme => ({
-      'default-fade': `linear-gradient(to bottom, ${theme(
-        'backgroundColor.default'
-      )}, transparent)`,
+      'default-fade': `linear-gradient(to bottom, ${theme('backgroundColor.default')}, transparent)`,
+      'default-fade-down': `linear-gradient(to bottom, transparent, ${theme('backgroundColor.default')})`,
       appjs: "url('/static/images/appjs.svg'), linear-gradient(#0033cc, #0033cc)",
     }),
     fontSize: {

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -19,7 +19,7 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
           wordWrap && '!whitespace-pre-wrap !break-words',
-          'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
+          'relative text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
           'prose-code:!px-0',
           alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
           hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from '@expo/styleguide';
 
-export const EXPAND_SNIPPET_BOUND = 410;
-export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[410px]';
+export const EXPAND_SNIPPET_BOUND = 408;
+export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[408px]';
 
 type Props = {
   onClick?: ButtonProps['onClick'];
@@ -11,7 +11,7 @@ export function SnippetExpandOverlay({ onClick }: Props) {
   return (
     <div className="flex absolute bottom-0 left-0 p-6 w-full bg-default-fade-down">
       <Button theme="secondary" onClick={onClick} className="mx-auto">
-        Expand snippet
+        Show more
       </Button>
     </div>
   );

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -1,0 +1,18 @@
+import { Button, ButtonProps } from '@expo/styleguide';
+
+export const EXPAND_SNIPPET_BOUND = 410;
+export const EXPAND_SNIPPET_BOUND_CLASSNAME = 'max-h-[410px]';
+
+type Props = {
+  onClick?: ButtonProps['onClick'];
+};
+
+export function SnippetExpandOverlay({ onClick }: Props) {
+  return (
+    <div className="flex absolute bottom-0 left-0 p-6 w-full bg-default-fade-down">
+      <Button theme="secondary" onClick={onClick} className="mx-auto">
+        Expand snippet
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Use `collapseHeight` and remove `@hide` in various docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs manually and check modified files.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
