### PR TITLE
[docs] update EAS Build images docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -98,7 +98,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-8-ndk-r21e`
+#### `ubuntu-22.04-jdk-8-ndk-r21e` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -130,7 +130,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r21e`
+#### `ubuntu-20.04-jdk-8-ndk-r21e` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -146,7 +146,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r19c`
+#### `ubuntu-20.04-jdk-11-ndk-r19c` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -162,7 +162,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r19c`
+#### `ubuntu-20.04-jdk-8-ndk-r19c` (deprecated)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -8,7 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **March 25th, 2024**.
+> This document was last updated on **April 8th, 2024**.
 
 ## Builder IP addresses
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -8,7 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **January 17th, 2024**.
+> This document was last updated on **March 25th, 2024**.
 
 ## Builder IP addresses
 
@@ -18,13 +18,17 @@ Here is the [up-to-date list of builder IP addresses](https://expo.dev/eas-build
 
 Images for each platform have one specific version of Node.js, yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json). If there is no dedicated configuration option you are looking for, you can use [npm hooks](/build-reference/npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Consider that those customizations are applied during the build and will increase your build times.
 
-When selecting an image for the build you can use the full name provided below or one of the aliases: `default`, `latest`.
+When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, `sdk-50` or `sdk-49`.
 
 - The use of a specific name guarantees a consistent environment with only minor updates.
-- `default` alias will be assigned to the environment that most closely resembles the configuration used for Expo SDK development.
-- `latest` alias will be assigned to the image with the most up-to-date versions of the software.
+- When using the `auto` alias, the build image will be selected based on the project configuration, Expo SDK version, and React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
+- The `latest` alias will be assigned to the image with the most up-to-date versions of the software.
+- The `sdk-50` alias will be assigned to the image best suited for SDK 50 builds.
+- The `sdk-49` alias will be assigned to the image best suited for SDK 49 builds.
+- SDK aliases will be updated with every new SDK release.
+- The `latest` alias will be updated with every new image release.
 
-> **info** **Note:** If you do not provide `image` in **eas.json**, your build will use `default` image. However, in some cases, we select a more appropriate image based on the Expo SDK version or React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
+> **info** **Note:** If you do not provide `image` in **eas.json**, your build by default will use the `auto` alias.
 
 ## Android build server configurations
 
@@ -62,7 +66,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-17-ndk-r21e` (alias `latest`)
+#### `ubuntu-22.04-jdk-17-ndk-r21e` (`latest`, `sdk-50`)
 
 <Collapsible summary="Details">
 
@@ -78,7 +82,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-11-ndk-r21e` (alias `default`)
+#### `ubuntu-22.04-jdk-11-ndk-r21e` (`sdk-49`)
 
 <Collapsible summary="Details">
 
@@ -226,7 +230,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.2`
+#### `macos-ventura-13.6-xcode-15.2` (`sdk-50`, `sdk-49`)
 
 <Collapsible summary="Details">
 
@@ -280,7 +284,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.4-xcode-14.3.1` (`default`)
+#### `macos-ventura-13.4-xcode-14.3.1`
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -284,7 +284,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.4-xcode-14.3.1`
+#### `macos-ventura-13.4-xcode-14.3.1` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -302,7 +302,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.3-xcode-14.3`
+#### `macos-ventura-13.3-xcode-14.3` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -320,7 +320,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.2`
+#### `macos-monterey-12.6-xcode-14.2` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -338,7 +338,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.1`
+#### `macos-monterey-12.6-xcode-14.1` (deprecated)
 
 <Collapsible summary="Details">
 
@@ -356,7 +356,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.0`
+#### `macos-monterey-12.6-xcode-14.0` (deprecated)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -98,7 +98,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-8-ndk-r21e` (deprecated)
+#### `ubuntu-22.04-jdk-8-ndk-r21e`
 
 <Collapsible summary="Details">
 
@@ -130,7 +130,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r21e` (deprecated)
+#### `ubuntu-20.04-jdk-8-ndk-r21e`
 
 <Collapsible summary="Details">
 
@@ -146,7 +146,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r19c` (deprecated)
+#### `ubuntu-20.04-jdk-11-ndk-r19c`
 
 <Collapsible summary="Details">
 
@@ -162,7 +162,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r19c` (deprecated)
+#### `ubuntu-20.04-jdk-8-ndk-r19c`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

For the full context see [this](https://exponent-internal.slack.com/archives/C9PRD479V/p1710257552292179) discussion

# How

Update docs. Delete the deprecated `default` image alias from the docs. Add new `auto` and SDK tags.

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
