### PR TITLE
[docs] add a dev mode only info about missing APISection entries

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -79,3 +79,27 @@ export const chunkArray = (array: any[], chunkSize: number) => {
     return acc;
   }, []);
 };
+
+export function listMissingHashLinkTargets(apiName?: string) {
+  const contentLinks = document.querySelectorAll(
+    `div.size-full.overflow-x-hidden.overflow-y-auto a`
+  ) as NodeListOf<HTMLAnchorElement>;
+
+  const wantedHashes = Array.from(contentLinks)
+    .map(link => {
+      if (link.hostname !== 'localhost' || !link.href.startsWith(link.baseURI.split('#')[0])) {
+        return '';
+      }
+      return link.hash.substring(1);
+    })
+    .filter(hash => hash !== '');
+
+  const availableIDs = Array.from(document.querySelectorAll('*[id]')).map(link => link.id);
+  const missingEntries = wantedHashes.filter(hash => !availableIDs.includes(hash));
+
+  if (missingEntries.length) {
+    console.group(`🚨 The following links targets are missing in the ${apiName} API reference:`);
+    console.table(missingEntries);
+    console.groupEnd();
+  }
+}

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -187,7 +187,6 @@ export function Code({ className, children }: PropsWithChildren<Props>) {
     });
 
     if (contentRef?.current?.clientHeight) {
-      console.warn(contentRef.current.clientHeight, collapseHeight);
       if (contentRef.current.clientHeight > collapseHeight) {
         setExpanded(false);
       }

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { listMissingHashLinkTargets } from '~/common/utilities';
 import { ClassDefinitionData, GeneratedData } from '~/components/plugins/api/APIDataTypes';
 import APISectionClasses from '~/components/plugins/api/APISectionClasses';
 import APISectionComponents from '~/components/plugins/api/APISectionComponents';
@@ -323,30 +324,7 @@ const APISection = ({ forceVersion, ...restProps }: Props) => {
 
   useEffect(() => {
     if (isDevMode) {
-      const contentLinks = document.querySelectorAll(
-        `div.size-full.overflow-x-hidden.overflow-y-auto a`
-      ) as NodeListOf<HTMLAnchorElement>;
-
-      const wantedHashes = Array.from(contentLinks)
-        .map(link => {
-          if (link.hostname !== 'localhost' || !link.href.startsWith(link.baseURI.split('#')[0])) {
-            return '';
-          }
-          return link.hash.substring(1);
-        })
-        .filter(hash => hash !== '');
-      const availableIDs = Array.from(document.querySelectorAll('*[id]')).map(link => link.id);
-      const missingEntries = wantedHashes.filter(x => !availableIDs.includes(x));
-
-      if (missingEntries.length) {
-        console.group(
-          `🚨 DEV MODE ERROR ONLY
------------------------
-The following links targets are missing in the '${restProps.packageName}' API reference:`
-        );
-        console.table(missingEntries);
-        console.groupEnd();
-      }
+      listMissingHashLinkTargets(restProps.apiName);
     }
   }, []);
 

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { ClassDefinitionData, GeneratedData } from '~/components/plugins/api/APIDataTypes';
 import APISectionClasses from '~/components/plugins/api/APISectionClasses';
 import APISectionComponents from '~/components/plugins/api/APISectionComponents';
@@ -311,11 +313,43 @@ const renderAPI = (
   }
 };
 
+const isDevMode = process.env.NODE_ENV === 'development';
+
 const APISection = ({ forceVersion, ...restProps }: Props) => {
   const { version } = usePageApiVersion();
   const resolvedVersion =
     forceVersion ||
     (version === 'unversioned' ? version : version === 'latest' ? LATEST_VERSION : version);
+
+  useEffect(() => {
+    if (isDevMode) {
+      const contentLinks = document.querySelectorAll(
+        `div.size-full.overflow-x-hidden.overflow-y-auto a`
+      ) as NodeListOf<HTMLAnchorElement>;
+
+      const wantedHashes = Array.from(contentLinks)
+        .map(link => {
+          if (link.hostname !== 'localhost' || !link.href.startsWith(link.baseURI.split('#')[0])) {
+            return '';
+          }
+          return link.hash.substring(1);
+        })
+        .filter(hash => hash !== '');
+      const availableIDs = Array.from(document.querySelectorAll('*[id]')).map(link => link.id);
+      const missingEntries = wantedHashes.filter(x => !availableIDs.includes(x));
+
+      if (missingEntries.length) {
+        console.group(
+          `🚨 DEV MODE ERROR ONLY
+-----------------------
+The following links targets are missing in the '${restProps.packageName}' API reference:`
+        );
+        console.table(missingEntries);
+        console.groupEnd();
+      }
+    }
+  }, []);
+
   return renderAPI(resolvedVersion, restProps);
 };
 


### PR DESCRIPTION
# Why

This small feature should allow the API reference contributors caught easier the missing parts of the created API docs.

Fixes ENG-11801

# How

Add a simple console log message listing all of the missing hash link targets on a given API Reference page.

It should also help to caught quicker the regressions, when altering the APISection components code.

I have also removed leftover console.warn from code block auto collapse feature development. 

# Test Plan

New message pops out when visiting API pages locally.

# Preview

![Screenshot 2024-03-26 at 13 11 43](https://github.com/expo/expo/assets/719641/e6021b49-bcc3-441f-b50f-6afdf28aa616)
