### PR TITLE
[go] Update eas.json cache key

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -20,7 +20,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk50-0.73.4",
+          "key": "sdk51-0.74.0-rc.4",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "macos-ventura-13.6-xcode-15.0",


### PR DESCRIPTION
# Why

We forgot to update the cache key of Expo Go on https://github.com/expo/expo/pull/27790 and this is causing the `iOS Client - EAS Build` workflow to fail

https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/builds/4fdb4546-ffd7-4f05-a8ae-eec3fc89a54b

# How

Update `eas.json` cache key

# Test Plan

CI should de green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
