### PR TITLE
[cli] Add information link to web platform metro error

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 💡 Others
 
+- Add information link to web platform metro error ([#27884](https://github.com/expo/expo/pull/27884) by [@kbrandwijk](https://github.com/kbrandwijk))
 - add modal component ([#37365](https://github.com/expo/expo/pull/37365) by [@Ubax](https://github.com/Ubax))
 - Use Vaul for modals and sheets on web with a custom stack ([#37767](https://github.com/expo/expo/pull/37767) by [@hirbod](https://github.com/hirbod))
 - fix web back/forward buttons ([#37747](https://github.com/expo/expo/pull/37747) by [@Ubax](https://github.com/Ubax))

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -47,7 +47,7 @@ export function resolvePlatformOption(
       )}].`;
 
       if (platform === 'web') {
-        error += ' ' + learnMore("https://docs.expo.dev/guides/customizing-metro/#web-support");
+        error += ' ' + learnMore('https://docs.expo.dev/guides/customizing-metro/#web-support');
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -47,7 +47,9 @@ export function resolvePlatformOption(
       )}].`;
 
       if (platform === 'web') {
-        error = `${error} ${learnMore('https://docs.expo.dev/guides/customizing-metro/#web-support')}`;
+        error = `${error} ${learnMore(
+          'https://docs.expo.dev/guides/customizing-metro/#web-support'
+        )}`;
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -40,11 +40,18 @@ export function resolvePlatformOption(
         // Pass through so the more robust error message is shown.
         return platform;
       }
+
+      let error = `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config, or is missing from the supported platforms in the platforms array: [${exp.platforms?.join(
+        ', '
+      )}].`
+
+      if (platform === 'web') {
+        error += ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.'
+      }
+
       throw new CommandError(
         'BAD_ARGS',
-        `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config, or is missing from the supported platforms in the platforms array: [${exp.platforms?.join(
-          ', '
-        )}].`
+        error
       );
     }
 

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -46,8 +46,8 @@ export function resolvePlatformOption(
       )}].`;
 
       if (platform === 'web') {
-        error += 
-          ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.'
+        error +=
+          ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.';
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -47,8 +47,7 @@ export function resolvePlatformOption(
       )}].`;
 
       if (platform === 'web') {
-        error +=
-          ' ' + learnMore("https://docs.expo.dev/guides/customizing-metro/#web-support");
+        error += ' ' + learnMore("https://docs.expo.dev/guides/customizing-metro/#web-support");
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -47,7 +47,7 @@ export function resolvePlatformOption(
       )}].`;
 
       if (platform === 'web') {
-        error += ' ' + learnMore('https://docs.expo.dev/guides/customizing-metro/#web-support');
+        error = `${error} ${learnMore('https://docs.expo.dev/guides/customizing-metro/#web-support')}`;
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -2,6 +2,7 @@ import { ExpoConfig, getConfig, Platform } from '@expo/config';
 
 import { getPlatformBundlers, PlatformBundlers } from '../start/server/platformBundlers';
 import { CommandError } from '../utils/errors';
+import { learnMore } from '../utils/link';
 
 export type Options = {
   outputDir: string;
@@ -47,7 +48,7 @@ export function resolvePlatformOption(
 
       if (platform === 'web') {
         error +=
-          ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.';
+          ' ' + learnMore("https://docs.expo.dev/guides/customizing-metro/#web-support");
       }
 
       throw new CommandError('BAD_ARGS', error);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -43,16 +43,14 @@ export function resolvePlatformOption(
 
       let error = `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config, or is missing from the supported platforms in the platforms array: [${exp.platforms?.join(
         ', '
-      )}].`
+      )}].`;
 
       if (platform === 'web') {
-        error += ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.'
+        error += 
+          ' More information: https://docs.expo.dev/guides/customizing-metro/#adding-web-support-to-metro.'
       }
 
-      throw new CommandError(
-        'BAD_ARGS',
-        error
-      );
+      throw new CommandError('BAD_ARGS', error);
     }
 
     return platform;


### PR DESCRIPTION
# Why

See ENG-10222. The docs provide additional information for adding web support to metro. We can add a link to this to the error message for the 'web' platform to provide better guidance to the user.

# How

Only for web, appended a more information link to the existing error message.

# Test Plan

Export for web without adding the web bundler directive to app.json, observe the error. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
