### PR TITLE
chore(babel): drop `@babel/plugin-transform-destructuring` plugin

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Remove unused `@babel/plugin-transform-destructuring` plugin on all platforms.
 - Remove unused peer dependency on `@babel/preset-env`. ([#27705](https://github.com/expo/expo/pull/27705) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
 - Add additional tests for undefined platform minification behavior. ([#27515](https://github.com/expo/expo/pull/27515) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Remove unused `@babel/plugin-transform-destructuring` plugin on all platforms.
+- Remove unused `@babel/plugin-transform-destructuring` plugin on all platforms. ([#27885](https://github.com/expo/expo/pull/27885) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused peer dependency on `@babel/preset-env`. ([#27705](https://github.com/expo/expo/pull/27705) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
 - Add additional tests for undefined platform minification behavior. ([#27515](https://github.com/expo/expo/pull/27515) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -50,7 +50,11 @@ function babelPresetExpo(api, options = {}) {
         }
     }
     if (platformOptions.unstable_transformProfile == null) {
-        platformOptions.unstable_transformProfile = engine === 'hermes' ? 'hermes-stable' : 'default';
+        // Using hermes canary will disable the destructuring transform. Disabling this transform reduces
+        // an additional import on a babel helper in every file with destructuring, i.e. `useState`.
+        // This may have outstanding performance regressions for development Hermes.
+        // Ref: https://github.com/facebook/react-native/pull/43662
+        platformOptions.unstable_transformProfile = engine === 'hermes' ? 'hermes-canary' : 'default';
     }
     // Note that if `options.lazyImports` is not set (i.e., `null` or `undefined`),
     // `@react-native/babel-preset` will handle it.

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -41,6 +41,10 @@ var obj = {
   bar: "bar"
 };
 
+// @babel/plugin-transform-destructuring
+var { x, y } = { x: "x", y: "y" };
+var [a, b, ...c] = [1, 2, 3];
+
 // @babel/plugin-transform-shorthand-properties
 var a1 = 0;
 var c = { a1 };

--- a/packages/babel-preset-expo/src/__tests__/jsx-import.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/jsx-import.test.ts
@@ -184,14 +184,17 @@ it(`supports nested React components in destructured props in Metro + developmen
 
   expect(code).toMatch(/"react\/jsx-dev-runtime"/);
   expect(code).toMatch(/var _this = this;/);
-  expect(code).toMatch(/var _ref\$button/);
+  const lines = code!.split('\n');
+  expect(lines.findIndex((line) => line.match(/_this = this;/))).toBeLessThan(
+    lines.findIndex((line) => line.match(/_this\);/))
+  );
   expect(code).toMatchInlineSnapshot(`
     "var _jsxDevRuntime = require("react/jsx-dev-runtime");
     var _jsxFileName = "/unknown";
     function Foo(_ref) {
       var _this = this;
-      var _ref$button = _ref.button,
-        button = _ref$button === void 0 ? function () {
+      var {
+        button = function () {
           return /*#__PURE__*/(0, _jsxDevRuntime.jsxDEV)(Text, {
             children: "Foo"
           }, void 0, false, {
@@ -199,7 +202,8 @@ it(`supports nested React components in destructured props in Metro + developmen
             lineNumber: 4,
             columnNumber: 14
           }, _this);
-        } : _ref$button;
+        }
+      } = _ref;
       return /*#__PURE__*/(0, _jsxDevRuntime.jsxDEV)(_jsxDevRuntime.Fragment, {
         children: button()
       }, void 0, false);

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -107,7 +107,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   }
 
   if (platformOptions.unstable_transformProfile == null) {
-    platformOptions.unstable_transformProfile = engine === 'hermes' ? 'hermes-stable' : 'default';
+    // Using hermes canary will disable the destructuring transform. Disabling this transform reduces
+    // an additional import on a babel helper in every file with destructuring, i.e. `useState`.
+    // This may have outstanding performance regressions for development Hermes.
+    // Ref: https://github.com/facebook/react-native/pull/43662
+    platformOptions.unstable_transformProfile = engine === 'hermes' ? 'hermes-canary' : 'default';
   }
 
   // Note that if `options.lazyImports` is not set (i.e., `null` or `undefined`),


### PR DESCRIPTION
# Why

- Fast forward https://github.com/facebook/react-native/pull/43662
- This transform pulls in a helper module to every file with destructuring (i.e. any file with `). 
- In an Expo Router iOS app (hermes, no minify) there are are 77 fewer resolutions (from 1721 to 1644) ~4.4% decrease, and 10 less modules (from 776 to 766). In a fully cached build, it's about 10-15ms faster (with fast resolver) (~330ms down to ~315ms). 
- Ultimately, this PR helps unblock our ability to add a transform for optimizing server components that are shared across server/client. A shared component should be able to add `useState` and have it automatically removed when running in the server to prevent errors. This transform generally requires that we keep the useState syntax intact.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- The canary flag is only used to toggle this plugin, enabling it allows us to disable destructuring transforms.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Extensive test plan and reasoning in here https://github.com/facebook/react-native/pull/43662
- Updated our language tests and added some new ones to prevent regressions.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
