### PR TITLE
[core][Android] Add direct resolve functions for simple types

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -18,15 +18,15 @@ JavaCallback::JavaCallback(std::shared_ptr<CallbackContext> callbackContext)
 
 void JavaCallback::registerNatives() {
   registerHybrid({
-                   makeNativeMethod("invoke", JavaCallback::invoke),
-                   makeNativeMethod("invoke", JavaCallback::invokeBool),
-                   makeNativeMethod("invoke", JavaCallback::invokeInt),
-                   makeNativeMethod("invoke", JavaCallback::invokeDouble),
-                   makeNativeMethod("invoke", JavaCallback::invokeFloat),
-                   makeNativeMethod("invoke", JavaCallback::invokeString),
-                   makeNativeMethod("invoke", JavaCallback::invokeArray),
-                   makeNativeMethod("invoke", JavaCallback::invokeMap),
-                   makeNativeMethod("invoke", JavaCallback::invokeSharedRef),
+                   makeNativeMethod("invokeNative", JavaCallback::invoke),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeBool),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeInt),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeDouble),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeFloat),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeString),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeArray),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeMap),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeSharedRef),
                  });
 }
 
@@ -56,7 +56,6 @@ void JavaCallback::invokeJSFunction(
         throw std::runtime_error(
           "JavaCallback was already settled. Cannot invoke it again"
         );
-        return;
       }
 
       jsi::Function &jsFunction = context->jsFunctionHolder.value();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ArrayExtenstions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ArrayExtenstions.kt
@@ -1,0 +1,15 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package expo.modules.kotlin
+
+inline operator fun <T> Array<out T>.component6(): T {
+  return get(5)
+}
+
+inline operator fun <T> Array<out T>.component7(): T {
+  return get(6)
+}
+
+inline operator fun <T> Array<out T>.component8(): T {
+  return get(7)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
@@ -13,6 +13,16 @@ interface Promise {
     resolve(null)
   }
 
+  fun resolve(result: Int) = resolve(result as Any?)
+
+  fun resolve(result: Boolean) = resolve(result as Any?)
+
+  fun resolve(result: Double) = resolve(result as Any?)
+
+  fun resolve(result: Float) = resolve(result as Any?)
+
+  fun resolve(result: String) = resolve(result as Any?)
+
   fun reject(code: String, message: String?, cause: Throwable?)
 
   fun reject(exception: CodedException) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -2,8 +2,11 @@
 
 package expo.modules.kotlin.functions
 
+import expo.modules.kotlin.component6
+import expo.modules.kotlin.component7
+import expo.modules.kotlin.component8
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.toArgsArray
 
 class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
@@ -16,62 +19,78 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>())) { block(it[0] as P0) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+      block(p0 as P0)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { block(it[0] as P0, it[1] as P1) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      block(p0 as P0, p1 as P1)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { block(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      block(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
       asyncFunctionComponent = it
     }
   }
 
   @JvmName("AsyncBodyWithoutArgs")
   inline fun AsyncBody(crossinline body: () -> Any?): AsyncFunction {
-    return AsyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R> AsyncBody(crossinline body: () -> R): AsyncFunction {
-    return AsyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctionComponent = it
     }
   }
@@ -80,77 +99,126 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
     return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, emptyArray()) { _, promise -> body(promise as P0) }
     } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>())) { body(it[0] as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1) -> R): AsyncFunction {
-    return if (P1::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>())) { args, promise -> body(args[0] as P0, promise as P1) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      body(p0 as P0, p1 as P1)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0> AsyncBody(crossinline body: (p0: P0, p1: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+      body(p0 as P0, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2) -> R): AsyncFunction {
-    return if (P2::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      body(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+      body(p0 as P0, p1 as P1, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R): AsyncFunction {
-    return if (P3::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): AsyncFunction {
-    return if (P4::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): AsyncFunction {
-    return if (P5::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): AsyncFunction {
-    return if (P6::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
     }.also {
       asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): AsyncFunction {
-    return if (P7::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
     }.also {
       asyncFunctionComponent = it
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -4,12 +4,70 @@ import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.objects.enforceType
 import expo.modules.kotlin.types.AnyType
 
-class AsyncFunctionComponent(
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> createAsyncFunctionComponent(
   name: String,
   desiredArgsTypes: Array<AnyType>,
-  private val body: (args: Array<out Any?>) -> Any?
+  noinline body: (args: Array<out Any?>) -> T
+): AsyncFunction {
+  if (null is T) {
+    return AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
+  }
+  return when (T::class.java) {
+    Int::class.java -> {
+      enforceType<(args: Array<out Any?>) -> Int>(body)
+      IntAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
+    Boolean::class.java -> BoolAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Boolean)
+    Double::class.java -> DoubleAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Double)
+    Float::class.java -> FloatAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Float)
+    String::class.java -> StringAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> String)
+    else -> AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
+  }
+}
+
+class IntAsyncFunctionComponent(name: String, desiredArgsTypes: Array<AnyType>, body: (args: Array<out Any?>) -> Int) :
+  AsyncFunctionComponent<Int>(name, desiredArgsTypes, body) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
+  }
+}
+
+class BoolAsyncFunctionComponent(name: String, desiredArgsTypes: Array<AnyType>, body: (args: Array<out Any?>) -> Boolean) :
+  AsyncFunctionComponent<Boolean>(name, desiredArgsTypes, body) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
+  }
+}
+
+class DoubleAsyncFunctionComponent(name: String, desiredArgsTypes: Array<AnyType>, body: (args: Array<out Any?>) -> Double) :
+  AsyncFunctionComponent<Double>(name, desiredArgsTypes, body) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
+  }
+}
+
+class FloatAsyncFunctionComponent(name: String, desiredArgsTypes: Array<AnyType>, body: (args: Array<out Any?>) -> Float) :
+  AsyncFunctionComponent<Float>(name, desiredArgsTypes, body) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
+  }
+}
+
+class StringAsyncFunctionComponent(name: String, desiredArgsTypes: Array<AnyType>, body: (args: Array<out Any?>) -> String) :
+  AsyncFunctionComponent<String>(name, desiredArgsTypes, body) {
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
+  }
+}
+
+open class AsyncFunctionComponent<ReturnType>(
+  name: String,
+  desiredArgsTypes: Array<AnyType>,
+  protected val body: (args: Array<out Any?>) -> ReturnType
 ) : AsyncFunction(name, desiredArgsTypes) {
   @Throws(CodedException::class)
   override fun callUserImplementation(args: ReadableArray, promise: Promise) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -4,7 +4,6 @@ import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.objects.enforceType
 import expo.modules.kotlin.types.AnyType
 
 @Suppress("UNCHECKED_CAST")
@@ -17,10 +16,7 @@ inline fun <reified T> createAsyncFunctionComponent(
     return AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
   }
   return when (T::class.java) {
-    Int::class.java -> {
-      enforceType<(args: Array<out Any?>) -> Int>(body)
-      IntAsyncFunctionComponent(name, desiredArgsTypes, body)
-    }
+    Int::class.java -> IntAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Int)
     Boolean::class.java -> BoolAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Boolean)
     Double::class.java -> DoubleAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Double)
     Float::class.java -> FloatAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Float)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
@@ -2,7 +2,10 @@
 
 package expo.modules.kotlin.functions
 
-import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.component6
+import expo.modules.kotlin.component7
+import expo.modules.kotlin.component8
+import expo.modules.kotlin.types.toArgsArray
 
 class FunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
@@ -30,7 +33,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>())) { body(it[0] as P0) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+      body(p0 as P0)
+    }.also {
       functionComponent = it
     }
   }
@@ -39,7 +44,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      body(p0 as P0, p1 as P1)
+    }.also {
       functionComponent = it
     }
   }
@@ -48,7 +55,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      body(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
       functionComponent = it
     }
   }
@@ -57,7 +66,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
       functionComponent = it
     }
   }
@@ -66,7 +77,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
       functionComponent = it
     }
   }
@@ -75,7 +88,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
       functionComponent = it
     }
   }
@@ -84,7 +99,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
       functionComponent = it
     }
   }
@@ -93,7 +110,9 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
       functionComponent = it
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -11,23 +11,57 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
-  operator fun invoke(result: Any?) {
+  operator fun invoke(result: Any?) = checkIfValid {
+    if (result == null) {
+      invokeNative()
+      return
+    }
+    when (result) {
+      is Int -> invokeNative(result)
+      is Boolean -> invokeNative(result)
+      is Double -> invokeNative(result)
+      is Float -> invokeNative(result)
+      is String -> invokeNative(result)
+      is WritableNativeArray -> invokeNative(result)
+      is WritableNativeMap -> invokeNative(result)
+      is SharedRef<*> -> invokeNative(result)
+      else -> throw UnexpectedException("Unknown type: ${result.javaClass}")
+    }
+  }
+
+  operator fun invoke(result: Int) = checkIfValid {
+    invokeNative(result)
+  }
+
+  operator fun invoke(result: Boolean) = checkIfValid {
+    invokeNative(result)
+  }
+
+  operator fun invoke(result: Double) = checkIfValid {
+    invokeNative(result)
+  }
+
+  operator fun invoke(result: Float) = checkIfValid {
+    invokeNative(result)
+  }
+
+  operator fun invoke(result: String) = checkIfValid {
+    invokeNative(result)
+  }
+
+  private external fun invokeNative()
+  private external fun invokeNative(result: Int)
+  private external fun invokeNative(result: Boolean)
+  private external fun invokeNative(result: Double)
+  private external fun invokeNative(result: Float)
+  private external fun invokeNative(result: String)
+  private external fun invokeNative(result: WritableNativeArray)
+  private external fun invokeNative(result: WritableNativeMap)
+  private external fun invokeNative(result: SharedRef<*>)
+
+  private inline fun checkIfValid(body: () -> Unit) {
     try {
-      if (result == null) {
-        invoke()
-        return
-      }
-      when (result) {
-        is Int -> invoke(result)
-        is Boolean -> invoke(result)
-        is Double -> invoke(result)
-        is Float -> invoke(result)
-        is String -> invoke(result)
-        is WritableNativeArray -> invoke(result)
-        is WritableNativeMap -> invoke(result)
-        is SharedRef<*> -> invoke(result)
-        else -> throw UnexpectedException("Unknown type: ${result.javaClass}")
-      }
+      body()
     } catch (e: Throwable) {
       if (!mHybridData.isValid) {
         // We know that this particular JavaCallback was invalidated, so it shouldn't be invoked.
@@ -38,16 +72,6 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
       throw e
     }
   }
-
-  private external fun invoke()
-  private external fun invoke(result: Int)
-  private external fun invoke(result: Boolean)
-  private external fun invoke(result: Double)
-  private external fun invoke(result: Float)
-  private external fun invoke(result: String)
-  private external fun invoke(result: WritableNativeArray)
-  private external fun invoke(result: WritableNativeMap)
-  private external fun invoke(result: SharedRef<*>)
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -44,6 +44,26 @@ class PromiseImpl @DoNotStrip internal constructor(
     )
   }
 
+  override fun resolve(result: Int) = checkIfWasSettled {
+    resolveBlock.invoke(result)
+  }
+
+  override fun resolve(result: Boolean) = checkIfWasSettled {
+    resolveBlock.invoke(result)
+  }
+
+  override fun resolve(result: Double) = checkIfWasSettled {
+    resolveBlock.invoke(result)
+  }
+
+  override fun resolve(result: Float) = checkIfWasSettled {
+    resolveBlock.invoke(result)
+  }
+
+  override fun resolve(result: String) = checkIfWasSettled {
+    resolveBlock.invoke(result)
+  }
+
   // Copy of the reject method from [com.facebook.react.bridge.PromiseImpl]
   override fun reject(code: String, message: String?, cause: Throwable?) = checkIfWasSettled {
     val errorInfo = WritableNativeMap()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -4,18 +4,21 @@ package expo.modules.kotlin.objects
 
 import com.facebook.react.bridge.Arguments
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.component6
+import expo.modules.kotlin.component7
+import expo.modules.kotlin.component8
 import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.functions.AsyncFunction
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
-import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
 import expo.modules.kotlin.functions.FunctionBuilder
 import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.functions.createAsyncFunctionComponent
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.toArgsArray
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
 
@@ -75,7 +78,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: () -> Any?
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf()) { body() }.also {
+    return SyncFunctionComponent(name, emptyArray()) { body() }.also {
       syncFunctions[name] = it
     }
   }
@@ -93,7 +96,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>())) { body(it[0] as P0) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+      body(p0 as P0)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -102,7 +107,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      body(p0 as P0, p1 as P1)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -111,7 +118,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      body(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -120,7 +129,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -129,7 +140,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -138,7 +151,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -147,7 +162,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -156,7 +173,9 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
       syncFunctions[name] = it
     }
   }
@@ -166,7 +185,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: () -> Any?
   ): AsyncFunction {
-    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctions[name] = it
     }
   }
@@ -175,7 +194,7 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: () -> R
   ): AsyncFunction {
-    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctions[name] = it
     }
   }
@@ -184,10 +203,11 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0) -> R
   ): AsyncFunction {
-    return if (P0::class == Promise::class) {
+    // We can't split that function, because that introduces a ambiguity when creating DSL component without parameters.
+    return if (P0::class.java == Promise::class.java) {
       AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>())) { body(it[0] as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
     }.also {
       asyncFunctions[name] = it
     }
@@ -197,10 +217,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunction {
-    return if (P1::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>())) { args, promise -> body(args[0] as P0, promise as P1) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      body(p0 as P0, p1 as P1)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+      body(p0 as P0, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -210,10 +240,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunction {
-    return if (P2::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      body(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+      body(p0 as P0, p1 as P1, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -223,10 +263,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunction {
-    return if (P3::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -236,10 +286,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunction {
-    return if (P4::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -249,10 +309,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunction {
-    return if (P5::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -262,10 +332,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunction {
-    return if (P6::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -275,10 +355,20 @@ open class ObjectDefinitionBuilder {
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunction {
-    return if (P7::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
     }.also {
       asyncFunctions[name] = it
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -56,6 +56,134 @@ inline fun <reified T> toAnyType(): AnyType {
   return { typeOf<T>() }.toAnyType<T>()
 }
 
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0> toArgsArray(
+  p0: Class<P0> = P0::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>(),
+    toAnyType<P3>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>(),
+    toAnyType<P3>(),
+    toAnyType<P4>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>(),
+    toAnyType<P3>(),
+    toAnyType<P4>(),
+    toAnyType<P5>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java,
+  p6: Class<P6> = P6::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>(),
+    toAnyType<P3>(),
+    toAnyType<P4>(),
+    toAnyType<P5>(),
+    toAnyType<P6>()
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java,
+  p6: Class<P6> = P6::class.java,
+  p7: Class<P7> = P7::class.java
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(),
+    toAnyType<P1>(),
+    toAnyType<P2>(),
+    toAnyType<P3>(),
+    toAnyType<P4>(),
+    toAnyType<P5>(),
+    toAnyType<P6>(),
+    toAnyType<P7>()
+  )
+}
+
 class AnyType(
   val kType: KType
 ) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -12,15 +12,17 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.functions.AsyncFunction
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
-import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
 import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.functions.createAsyncFunctionComponent
 import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
 import kotlin.reflect.KType
-import kotlin.reflect.full.primaryConstructor
+import expo.modules.kotlin.component6
+import expo.modules.kotlin.component7
+import expo.modules.kotlin.component8
+import expo.modules.kotlin.types.toArgsArray
 
 @DefinitionMarker
 class ViewDefinitionBuilder<T : View>(
@@ -171,7 +173,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: () -> Any?
   ): AsyncFunction {
-    return AsyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctions[name] = it
     }
   }
@@ -180,7 +182,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: () -> R
   ): AsyncFunction {
-    return AsyncFunctionComponent(name, emptyArray()) { body() }.also {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
       asyncFunctions[name] = it
     }
   }
@@ -189,10 +191,11 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0) -> R
   ): AsyncFunction {
+    // We can't split that function, because that introduces a ambiguity when creating DSL component without parameters.
     return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, emptyArray()) { _, promise -> body(promise as P0) }
     } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>())) { body(it[0] as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
     }.also {
       asyncFunctions[name] = it
     }
@@ -202,10 +205,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunction {
-    return if (P1::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>())) { args, promise -> body(args[0] as P0, promise as P1) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+      body(p0 as P0, p1 as P1)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+      body(p0 as P0, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -215,10 +228,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunction {
-    return if (P2::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      body(p0 as P0, p1 as P1, p2 as P2)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+      body(p0 as P0, p1 as P1, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -228,10 +251,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunction {
-    return if (P3::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -241,10 +274,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunction {
-    return if (P4::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -254,10 +297,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunction {
-    return if (P5::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -267,10 +320,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunction {
-    return if (P6::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -280,10 +343,20 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunction {
-    return if (P7::class == Promise::class) {
-      AsyncFunctionWithPromiseComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
-    } else {
-      AsyncFunctionComponent(name, arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("AsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
+  ): AsyncFunction {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -343,15 +416,5 @@ class ViewDefinitionBuilder<T : View>(
     } else {
       ErrorView(context)
     }
-  }
-
-  private fun getPrimaryConstructor(): KFunction<T>? {
-    val kotlinContractor = viewClass.primaryConstructor
-    if (kotlinContractor != null) {
-      return kotlinContractor
-    }
-
-    // Add compatibility with Java
-    return viewClass.constructors.firstOrNull()
   }
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -31,7 +31,8 @@ private class TestModule1 : Module() {
     AsyncFunction("f1") {
       throw NullPointerException()
     }
-    AsyncFunction<Int, TestRecord>("f2") {
+    @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+    AsyncFunction<Int, TestRecord>("f2") { record ->
       throw NullPointerException()
     }
     Constants {


### PR DESCRIPTION
# Why

We are currently performing multiple checks to determine if we need to convert the promise's value. This pull request intends to add direct resolve functions to streamline the data flow when the exported function's return type is known.

Additionally, I have simplified the process of creating functions for DSL components.

# How

Use the Kotlin compiler to bind the return type with the correct resolve function.

# Test Plan

- bare-expo ✅
- unit tests ✅ 