### PR TITLE
[packages][Android] Add return type to parameterless async functions

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : ReactActivity() {
     // Set the theme to AppTheme BEFORE onCreate to support
     // coloring the background, status bar, and navigation bar.
     // This is required for expo-splash-screen.
-    setTheme(R.style.AppTheme);
+    setTheme(R.style.AppTheme)
     super.onCreate(null)
   }
 
@@ -31,31 +31,32 @@ class MainActivity : ReactActivity() {
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(
-          this,
-          BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
-          object : DefaultReactActivityDelegate(
-              this,
-              mainComponentName,
-              fabricEnabled
-          ){})
+      this,
+      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+      object : DefaultReactActivityDelegate(
+        this,
+        mainComponentName,
+        fabricEnabled
+      ) {}
+    )
   }
 
   /**
-    * Align the back button behavior with Android S
-    * where moving root activities to background instead of finishing activities.
-    * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
-    */
+   * Align the back button behavior with Android S
+   * where moving root activities to background instead of finishing activities.
+   * @see <a href="https://developer.android.com/reference/android/app/Activity#onBackPressed()">onBackPressed</a>
+   */
   override fun invokeDefaultOnBackPressed() {
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
-          if (!moveTaskToBack(false)) {
-              // For non-root activities, use the default implementation to finish them.
-              super.invokeDefaultOnBackPressed()
-          }
-          return
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+      if (!moveTaskToBack(false)) {
+        // For non-root activities, use the default implementation to finish them.
+        super.invokeDefaultOnBackPressed()
       }
+      return
+    }
 
-      // Use the default back button implementation on Android S
-      // because it's doing more than [Activity.moveTaskToBack] in fact.
-      super.invokeDefaultOnBackPressed()
+    // Use the default back button implementation on Android S
+    // because it's doing more than [Activity.moveTaskToBack] in fact.
+    super.invokeDefaultOnBackPressed()
   }
 }

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
@@ -20,21 +20,21 @@ import expo.modules.devmenu.DevMenuPackageDelegate
 class MainApplication : Application(), ReactApplication {
 
   override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
-        this,
-        object : DefaultReactNativeHost(this) {
-          override fun getPackages(): List<ReactPackage> {
-            // Packages that cannot be autolinked yet can be added manually here, for example:
-            // packages.add(new MyReactNativePackage());
-            return PackageList(this).packages
-          }
-
-          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
-
-          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-
-          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+    this,
+    object : DefaultReactNativeHost(this) {
+      override fun getPackages(): List<ReactPackage> {
+        // Packages that cannot be autolinked yet can be added manually here, for example:
+        // packages.add(new MyReactNativePackage());
+        return PackageList(this).packages
       }
+
+      override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+
+      override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+      override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+    }
   )
 
   override val reactHost: ReactHost

--- a/packages/expo-application/android/src/main/java/expo/modules/application/ApplicationModule.kt
+++ b/packages/expo-application/android/src/main/java/expo/modules/application/ApplicationModule.kt
@@ -37,7 +37,7 @@ class ApplicationModule : Module() {
       Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
     }
 
-    AsyncFunction("getInstallationTimeAsync") {
+    AsyncFunction<Double>("getInstallationTimeAsync") {
       val packageManager = context.packageManager
       val packageName = context.packageName
       packageManager
@@ -46,7 +46,7 @@ class ApplicationModule : Module() {
         .toDouble()
     }
 
-    AsyncFunction("getLastUpdateTimeAsync") {
+    AsyncFunction<Double>("getLastUpdateTimeAsync") {
       val packageManager = context.packageManager
       val packageName = context.packageName
       packageManager

--- a/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
+++ b/packages/expo-battery/android/src/main/java/expo/modules/battery/BatteryModule.kt
@@ -52,11 +52,11 @@ class BatteryModule : Module() {
       unregisterBroadcastReceivers(context)
     }
 
-    AsyncFunction("getBatteryLevelAsync") {
+    AsyncFunction<Float>("getBatteryLevelAsync") {
       val batteryIntent = context.applicationContext.registerReceiver(
         null,
         IntentFilter(Intent.ACTION_BATTERY_CHANGED)
-      ) ?: return@AsyncFunction -1
+      ) ?: return@AsyncFunction -1f
 
       val level = batteryIntent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
       val scale = batteryIntent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
@@ -69,7 +69,7 @@ class BatteryModule : Module() {
       return@AsyncFunction batteryLevel
     }
 
-    AsyncFunction("getBatteryStateAsync") {
+    AsyncFunction<Int>("getBatteryStateAsync") {
       val batteryIntent = context.applicationContext.registerReceiver(
         null,
         IntentFilter(Intent.ACTION_BATTERY_CHANGED)
@@ -79,11 +79,11 @@ class BatteryModule : Module() {
       return@AsyncFunction batteryStatusNativeToJS(status).value
     }
 
-    AsyncFunction("isLowPowerModeEnabledAsync") {
+    AsyncFunction<Boolean>("isLowPowerModeEnabledAsync") {
       isLowPowerModeEnabled
     }
 
-    AsyncFunction("isBatteryOptimizationEnabledAsync") {
+    AsyncFunction<Boolean>("isBatteryOptimizationEnabledAsync") {
       val packageName = context.applicationContext.packageName
       val powerManager = context.applicationContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
       return@AsyncFunction powerManager?.isIgnoringBatteryOptimizations(packageName) == false

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -38,7 +38,7 @@ class BrightnessModule : Module() {
       currentActivity.window.attributes = lp // must be done on UI thread
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getBrightnessAsync") {
+    AsyncFunction<Float>("getBrightnessAsync") {
       val lp = currentActivity.window.attributes
       val brightness = if (lp.screenBrightness == WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE) {
         // system brightness is not overridden by the current activity, so just resolve with it
@@ -50,7 +50,7 @@ class BrightnessModule : Module() {
       return@AsyncFunction brightness
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getSystemBrightnessAsync") {
+    AsyncFunction<Float>("getSystemBrightnessAsync") {
       return@AsyncFunction getSystemBrightness()
     }
 
@@ -79,12 +79,12 @@ class BrightnessModule : Module() {
       currentActivity.window.attributes = lp // must be done on UI thread
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("isUsingSystemBrightnessAsync") {
+    AsyncFunction<Boolean>("isUsingSystemBrightnessAsync") {
       val lp = currentActivity.window.attributes
       return@AsyncFunction lp.screenBrightness == WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getSystemBrightnessModeAsync") {
+    AsyncFunction<Int>("getSystemBrightnessModeAsync") {
       val brightnessMode = Settings.System.getInt(
         currentActivity.contentResolver,
         Settings.System.SCREEN_BRIGHTNESS_MODE

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -29,7 +29,7 @@ class CellularModule : Module() {
       )
     }
 
-    AsyncFunction("getCellularGenerationAsync") {
+    AsyncFunction<Int>("getCellularGenerationAsync") {
       try {
         getCurrentGeneration()
       } catch (e: SecurityException) {
@@ -38,23 +38,23 @@ class CellularModule : Module() {
       }
     }
 
-    AsyncFunction("allowsVoipAsync") {
+    AsyncFunction<Boolean>("allowsVoipAsync") {
       SipManager.isVoipSupported(context)
     }
 
-    AsyncFunction("getIsoCountryCodeAsync") {
+    AsyncFunction<String?>("getIsoCountryCodeAsync") {
       telephonyManager()?.simCountryIso
     }
 
-    AsyncFunction("getCarrierNameAsync") {
+    AsyncFunction<String?>("getCarrierNameAsync") {
       telephonyManager()?.simOperatorName
     }
 
-    AsyncFunction("getMobileCountryCodeAsync") {
+    AsyncFunction<String?>("getMobileCountryCodeAsync") {
       telephonyManager()?.simOperator?.substring(0, 3)
     }
 
-    AsyncFunction("getMobileNetworkCodeAsync") {
+    AsyncFunction<String?>("getMobileNetworkCodeAsync") {
       telephonyManager()?.simOperator?.substring(3)
     }
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -58,7 +58,7 @@ class ClipboardModule : Module() {
       return@AsyncFunction true
     }
 
-    AsyncFunction("hasStringAsync") {
+    AsyncFunction<Boolean>("hasStringAsync") {
       clipboardManager
         .primaryClipDescription
         ?.hasTextContent
@@ -102,7 +102,7 @@ class ClipboardModule : Module() {
       }
     }
 
-    AsyncFunction("hasImageAsync") {
+    AsyncFunction<Boolean>("hasImageAsync") {
       clipboardManager.primaryClipDescription?.hasMimeType("image/*") == true
     }
     //endregion

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
@@ -13,7 +13,7 @@ class ConstantsModule : Module() {
       return@Constants appContext.constants?.constants ?: emptyMap()
     }
 
-    AsyncFunction("getWebViewUserAgentAsync") {
+    AsyncFunction<String?>("getWebViewUserAgentAsync") {
       return@AsyncFunction System.getProperty("http.agent")
     }
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -3,7 +3,6 @@ package expo.modules.devlauncher
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.annotation.UiThread
 import com.facebook.react.ReactActivity

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
@@ -7,7 +7,7 @@ import expo.modules.devlauncher.react.DevLauncherPackagerConnectionSettings
 internal class DevLauncherInternalSettings(
   context: Context,
   debugServerHost: String
-) : DevInternalSettings(context, Listener{}) {
+) : DevInternalSettings(context, Listener {}) {
   private var packagerConnectionSettings = DevLauncherPackagerConnectionSettings(context, debugServerHost)
 
   override fun getPackagerConnectionSettings() = packagerConnectionSettings

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -61,7 +61,7 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, runtimeVersion:
     "checkOnLaunch" to "ALWAYS",
     "enabled" to true,
     "requestHeaders" to requestHeaders,
-    "runtimeVersion" to runtimeVersion,
+    "runtimeVersion" to runtimeVersion
   )
 }
 

--- a/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/debug/expo/modules/devlauncher/rncompatibility/DevLauncherReactNativeHostHandler.kt
@@ -16,7 +16,7 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
   private val contextHolder = WeakReference(context)
   override fun getDevSupportManagerFactory(): DevSupportManagerFactory? {
     if (DevLauncherPackageDelegate.enableAutoSetup != null && DevLauncherPackageDelegate.enableAutoSetup == false) {
-     return null
+      return null
     }
     return DevLauncherDevSupportManagerFactory()
   }

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -90,6 +90,7 @@ class DevLauncherDevSupportManager(
   }
 
   override fun showNewJavaError(message: String?, e: Throwable) {
+    Log.e("DevLauncher", "$message", e)
     if (!DevLauncherController.wasInitialized()) {
       Log.e("DevLauncher", "DevLauncher wasn't initialized. Couldn't intercept native error handling.")
       super.showNewJavaError(message, e)

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -72,7 +72,7 @@ internal class DevLauncherUpdatesHelperTest {
 
     val urlString2 = "https://exp.host/@test/second-app"
     val url2 = Uri.parse(urlString2)
-    val configuration2 = createUpdatesConfigurationWithUrl(url2, url2, runtimeVersion,null)
+    val configuration2 = createUpdatesConfigurationWithUrl(url2, url2, runtimeVersion, null)
 
     val scopeKey1 = configuration1["scopeKey"]
     val scopeKey2 = configuration2["scopeKey"]

--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
@@ -3,7 +3,6 @@
 package com.facebook.react.devsupport
 
 import android.content.Context
-import android.content.SharedPreferences
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 import expo.modules.devmenu.react.DevMenuPackagerConnectionSettings

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuInternalModule.kt
@@ -24,7 +24,7 @@ class DevMenuInternalModule : Module() {
       "doesDeviceSupportKeyCommands" to EmulatorUtilities.isRunningOnEmulator()
     )
 
-    AsyncFunction("loadFontsAsync") {
+    AsyncFunction<Unit>("loadFontsAsync") {
       DevMenuManager.loadFonts(context)
     }
 
@@ -32,11 +32,11 @@ class DevMenuInternalModule : Module() {
       DevMenuManager.dispatchCallable(callableId, args)
     }
 
-    AsyncFunction("hideMenu") {
+    AsyncFunction<Unit>("hideMenu") {
       DevMenuManager.hideMenu()
     }
 
-    AsyncFunction("closeMenu") {
+    AsyncFunction<Unit>("closeMenu") {
       DevMenuManager.closeMenu()
     }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -13,15 +13,15 @@ class DevMenuModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoDevMenu")
 
-    AsyncFunction("openMenu") {
+    AsyncFunction<Unit>("openMenu") {
       DevMenuManager.openMenu(currentActivity)
     }
 
-    AsyncFunction("closeMenu") {
+    AsyncFunction<Unit>("closeMenu") {
       DevMenuManager.closeMenu()
     }
 
-    AsyncFunction("hideMenu") {
+    AsyncFunction<Unit>("hideMenu") {
       DevMenuManager.hideMenu()
     }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/modules/DevMenuPreferences.kt
@@ -102,7 +102,7 @@ class DevMenuPreferences : Module() {
   override fun definition() = ModuleDefinition {
     Name("DevMenuPreferences")
 
-    AsyncFunction("getPreferencesAsync") {
+    AsyncFunction<WritableMap>("getPreferencesAsync") {
       preferencesHandel.serialize()
     }
 

--- a/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+++ b/packages/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
@@ -66,20 +66,20 @@ class DeviceModule : Module() {
       )
     }
 
-    AsyncFunction("getDeviceTypeAsync") {
+    AsyncFunction<Int>("getDeviceTypeAsync") {
       return@AsyncFunction getDeviceType(context).JSValue
     }
 
-    AsyncFunction("getUptimeAsync") {
+    AsyncFunction<Double>("getUptimeAsync") {
       return@AsyncFunction SystemClock.uptimeMillis().toDouble()
     }
 
-    AsyncFunction("getMaxMemoryAsync") {
+    AsyncFunction<Double>("getMaxMemoryAsync") {
       val maxMemory = Runtime.getRuntime().maxMemory()
-      return@AsyncFunction if (maxMemory != Long.MAX_VALUE) maxMemory.toDouble() else -1
+      return@AsyncFunction if (maxMemory != Long.MAX_VALUE) maxMemory.toDouble() else -1.0
     }
 
-    AsyncFunction("isRootedExperimentalAsync") {
+    AsyncFunction<Boolean>("isRootedExperimentalAsync") {
       val isRooted: Boolean
       val isDevice = !isRunningOnEmulator
 
@@ -97,7 +97,7 @@ class DeviceModule : Module() {
       return@AsyncFunction isRooted
     }
 
-    AsyncFunction("isSideLoadingEnabledAsync") {
+    AsyncFunction<Boolean>("isSideLoadingEnabledAsync") {
       return@AsyncFunction if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
         Settings.Global.getInt(
           context.applicationContext.contentResolver,
@@ -109,7 +109,7 @@ class DeviceModule : Module() {
       }
     }
 
-    AsyncFunction("getPlatformFeaturesAsync") {
+    AsyncFunction<List<String>>("getPlatformFeaturesAsync") {
       val allFeatures = context.applicationContext.packageManager.systemAvailableFeatures
       return@AsyncFunction allFeatures.filterNotNull().map { it.name }
     }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -368,7 +368,7 @@ open class FileSystemModule : Module() {
       }
     }
 
-    AsyncFunction("getTotalDiskCapacityAsync") {
+    AsyncFunction<Double>("getTotalDiskCapacityAsync") {
       val root = StatFs(Environment.getDataDirectory().absolutePath)
       val blockCount = root.blockCountLong
       val blockSize = root.blockSizeLong
@@ -377,7 +377,7 @@ open class FileSystemModule : Module() {
       return@AsyncFunction capacity.toDouble().coerceAtMost(2.0.pow(53.0) - 1)
     }
 
-    AsyncFunction("getFreeDiskStorageAsync") {
+    AsyncFunction<Double>("getFreeDiskStorageAsync") {
       val external = StatFs(Environment.getDataDirectory().absolutePath)
       val availableBlocks = external.availableBlocksLong
       val blockSize = external.blockSizeLong

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
@@ -31,7 +31,7 @@ class HapticsModule : Module() {
       vibrate(HapticsNotificationType.fromString(type))
     }
 
-    AsyncFunction("selectionAsync") {
+    AsyncFunction<Unit>("selectionAsync") {
       vibrate(HapticsSelectionType)
     }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -80,13 +80,13 @@ class ExpoImageModule : Module() {
       }
     }
 
-    AsyncFunction("clearMemoryCache") {
+    AsyncFunction<Boolean>("clearMemoryCache") {
       val activity = appContext.currentActivity ?: return@AsyncFunction false
       Glide.get(activity).clearMemory()
       return@AsyncFunction true
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("clearDiskCache") {
+    AsyncFunction<Boolean>("clearDiskCache") {
       val activity = appContext.currentActivity ?: return@AsyncFunction false
       activity.let {
         Glide.get(activity).clearDiskCache()

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
@@ -30,7 +30,7 @@ class KeepAwakeModule : Module() {
       }
     }
 
-    AsyncFunction("isActivated") {
+    AsyncFunction<Boolean>("isActivated") {
       return@AsyncFunction keepAwakeManager.isActivated
     }
   }

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -34,7 +34,7 @@ class LocalAuthenticationModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoLocalAuthentication")
 
-    AsyncFunction("supportedAuthenticationTypesAsync") {
+    AsyncFunction<Set<Int>>("supportedAuthenticationTypesAsync") {
       val results = mutableSetOf<Int>()
       if (canAuthenticateUsingWeakBiometrics() == BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE) {
         return@AsyncFunction results
@@ -52,15 +52,15 @@ class LocalAuthenticationModule : Module() {
       return@AsyncFunction results
     }
 
-    AsyncFunction("hasHardwareAsync") {
+    AsyncFunction<Boolean>("hasHardwareAsync") {
       canAuthenticateUsingWeakBiometrics() != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
     }
 
-    AsyncFunction("isEnrolledAsync") {
+    AsyncFunction<Boolean>("isEnrolledAsync") {
       canAuthenticateUsingWeakBiometrics() == BiometricManager.BIOMETRIC_SUCCESS
     }
 
-    AsyncFunction("getEnrolledLevelAsync") {
+    AsyncFunction<Int>("getEnrolledLevelAsync") {
       var level = SECURITY_LEVEL_NONE
       if (isDeviceSecure) {
         level = SECURITY_LEVEL_SECRET

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -36,7 +36,7 @@ class LocalizationModule : Module() {
       bundledConstants.toShallowMap()
     }
 
-    AsyncFunction("getLocalizationAsync") {
+    AsyncFunction<Bundle>("getLocalizationAsync") {
       return@AsyncFunction bundledConstants
     }
 
@@ -51,7 +51,7 @@ class LocalizationModule : Module() {
     Events(LOCALE_SETTINGS_CHANGED, CALENDAR_SETTINGS_CHANGED)
 
     OnCreate {
-      appContext?.reactContext?.let {
+      appContext.reactContext?.let {
         setRTLFromStringResources(it)
       }
       observer = {

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -35,7 +35,6 @@ import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
-import expo.modules.kotlin.functions.BoolAsyncFunctionComponent
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -35,6 +35,7 @@ import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.functions.BoolAsyncFunctionComponent
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -161,7 +162,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       return@AsyncFunction getCurrentPositionAsync(options, promise)
     }
 
-    AsyncFunction("getProviderStatusAsync") {
+    AsyncFunction<LocationProviderStatus>("getProviderStatusAsync") {
       val state = SmartLocation.with(mContext).location().state()
 
       return@AsyncFunction LocationProviderStatus().apply {
@@ -253,7 +254,7 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
       }
     }
 
-    AsyncFunction("hasServicesEnabledAsync") {
+    AsyncFunction<Boolean>("hasServicesEnabledAsync") {
       return@AsyncFunction LocationHelpers.isAnyProviderAvailable(mContext)
     }
 

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
@@ -20,7 +20,7 @@ class MailComposerModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoMailComposer")
 
-    AsyncFunction("isAvailableAsync") {
+    AsyncFunction<Boolean>("isAvailableAsync") {
       return@AsyncFunction true
     }
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -28,7 +28,7 @@ class NavigationBarModule : Module() {
       NavigationBar.setBackgroundColor(activity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getBackgroundColorAsync") {
+    AsyncFunction<String>("getBackgroundColorAsync") {
       return@AsyncFunction colorToHex(activity.window.navigationBarColor)
     }.runOnQueue(Queues.MAIN)
 
@@ -36,7 +36,7 @@ class NavigationBarModule : Module() {
       NavigationBar.setBorderColor(activity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getBorderColorAsync") {
+    AsyncFunction<String>("getBorderColorAsync") {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         return@AsyncFunction colorToHex(activity.window.navigationBarDividerColor)
       } else {
@@ -55,7 +55,7 @@ class NavigationBarModule : Module() {
       )
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getButtonStyleAsync") {
+    AsyncFunction<String>("getButtonStyleAsync") {
       WindowInsetsControllerCompat(activity.window, activity.window.decorView).let { controller ->
         return@AsyncFunction if (controller.isAppearanceLightNavigationBars) "dark" else "light"
       }
@@ -65,7 +65,7 @@ class NavigationBarModule : Module() {
       NavigationBar.setVisibility(activity, visibility, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getVisibilityAsync") {
+    AsyncFunction<String>("getVisibilityAsync") {
       val isVisible = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         activity.window.decorView.rootWindowInsets.isVisible(WindowInsets.Type.navigationBars())
       } else {
@@ -79,7 +79,7 @@ class NavigationBarModule : Module() {
       NavigationBar.setPosition(activity, position, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("unstable_getPositionAsync") {
+    AsyncFunction<String>("unstable_getPositionAsync") {
       return@AsyncFunction if (ViewCompat.getFitsSystemWindows(activity.window.decorView)) "relative" else "absolute"
     }.runOnQueue(Queues.MAIN)
 
@@ -87,7 +87,7 @@ class NavigationBarModule : Module() {
       NavigationBar.setBehavior(activity, behavior, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getBehaviorAsync") {
+    AsyncFunction<String>("getBehaviorAsync") {
       WindowInsetsControllerCompat(activity.window, activity.window.decorView).let { controller ->
         val behavior = when (controller.systemBarsBehavior) {
           // TODO: Maybe relative / absolute
@@ -103,7 +103,7 @@ class NavigationBarModule : Module() {
 
     // We are not using `OnStartObserving` and `OnStopObserving` here because when switching threads
     // they will resolve the promise quicker and the JS won't wait for observer removal
-    AsyncFunction("startObserving") {
+    AsyncFunction<Unit>("startObserving") {
       val decorView = activity.window.decorView
       @Suppress("DEPRECATION")
       decorView.setOnSystemUiVisibilityChangeListener { visibility: Int ->
@@ -119,7 +119,7 @@ class NavigationBarModule : Module() {
       }
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("stopObserving") {
+    AsyncFunction<Unit>("stopObserving") {
       val decorView = activity.window.decorView
       @Suppress("DEPRECATION")
       decorView.setOnSystemUiVisibilityChangeListener(null)

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -67,11 +67,11 @@ class NetworkModule : Module() {
       }
     }
 
-    AsyncFunction("getIpAddressAsync") {
+    AsyncFunction<String>("getIpAddressAsync") {
       return@AsyncFunction rawIpToString(wifiInfo.ipAddress)
     }
 
-    AsyncFunction("isAirplaneModeEnabledAsync") {
+    AsyncFunction<Boolean>("isAirplaneModeEnabledAsync") {
       return@AsyncFunction Settings.Global.getInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
     }
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeModule.kt
@@ -8,7 +8,7 @@ class BadgeModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoBadgeModule")
 
-    AsyncFunction("getBadgeCountAsync") {
+    AsyncFunction<Int>("getBadgeCountAsync") {
       BadgeHelper.badgeCount
     }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelGroupManagerModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelGroupManagerModule.kt
@@ -1,6 +1,7 @@
 package expo.modules.notifications.notifications.channels
 
 import android.os.Build
+import android.os.Bundle
 import expo.modules.core.arguments.ReadableArguments
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -34,7 +35,7 @@ class NotificationChannelGroupManagerModule : Module() {
       }
     }
 
-    AsyncFunction("getNotificationChannelGroupsAsync") {
+    AsyncFunction<List<Bundle?>?>("getNotificationChannelGroupsAsync") {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         groupManager
           .notificationChannelGroups

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelManagerModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/channels/NotificationChannelManagerModule.kt
@@ -30,7 +30,7 @@ open class NotificationChannelManagerModule : Module() {
       channelSerializer = provider.channelSerializer
     }
 
-    AsyncFunction("getNotificationChannelsAsync") {
+    AsyncFunction<List<Bundle?>>("getNotificationChannelsAsync") {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
         return@AsyncFunction emptyList<Bundle>()
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
@@ -43,7 +43,7 @@ open class NotificationsEmitter : Module(), NotificationListener {
       notificationManager.removeListener(this@NotificationsEmitter)
     }
 
-    AsyncFunction("getLastNotificationResponseAsync") {
+    AsyncFunction<Bundle?>("getLastNotificationResponseAsync") {
       lastNotificationResponse?.let(NotificationSerializer::toBundle)
     }
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/serverregistration/ServerRegistrationModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/serverregistration/ServerRegistrationModule.kt
@@ -15,9 +15,9 @@ open class ServerRegistrationModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("NotificationsServerRegistrationModule")
 
-    AsyncFunction("getInstallationIdAsync", this@ServerRegistrationModule::getInstallationId)
+    AsyncFunction<String>("getInstallationIdAsync", this@ServerRegistrationModule::getInstallationId)
 
-    AsyncFunction("getRegistrationInfoAsync") {
+    AsyncFunction<String?>("getRegistrationInfoAsync") {
       mRegistrationInfo.get()
     }
 

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -55,11 +55,11 @@ class ScreenCaptureModule : Module() {
       }
     }
 
-    AsyncFunction("preventScreenCapture") {
+    AsyncFunction<Unit>("preventScreenCapture") {
       currentActivity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("allowScreenCapture") {
+    AsyncFunction<Unit>("allowScreenCapture") {
       currentActivity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }.runOnQueue(Queues.MAIN)
 

--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -47,11 +47,11 @@ class ScreenOrientationModule : Module(), LifecycleEventListener {
       currentActivity.requestedOrientation = orientationAttr.value
     }
 
-    AsyncFunction("getOrientationAsync") {
+    AsyncFunction<Int>("getOrientationAsync") {
       return@AsyncFunction getScreenOrientation(currentActivity).value
     }
 
-    AsyncFunction("getOrientationLockAsync") {
+    AsyncFunction<OrientationLock>("getOrientationLockAsync") {
       try {
         return@AsyncFunction OrientationLock.fromPlatformInt(currentActivity.requestedOrientation)
       } catch (e: Exception) {
@@ -59,7 +59,7 @@ class ScreenOrientationModule : Module(), LifecycleEventListener {
       }
     }
 
-    AsyncFunction("getPlatformOrientationLockAsync") {
+    AsyncFunction<Int>("getPlatformOrientationLockAsync") {
       try {
         return@AsyncFunction currentActivity.requestedOrientation
       } catch (e: Exception) {

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/SensorProxy.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/SensorProxy.kt
@@ -108,7 +108,7 @@ internal fun ModuleDefinitionBuilder.UseSensorProxy(
     sensorProxyGetter().setUpdateInterval(updateInterval)
   }
 
-  AsyncFunction("isAvailableAsync") {
+  AsyncFunction<Boolean>("isAvailableAsync") {
     val sensorManager = module.appContext.reactContext?.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
     sensorManager?.getDefaultSensor(sensorType) != null
   }

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -80,7 +80,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
       }
     }
 
-    AsyncFunction("isAvailableAsync") {
+    AsyncFunction<Boolean>("isAvailableAsync") {
       val mSensorManager = appContext.reactContext?.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
         ?: return@AsyncFunction false
       val sensorTypes = arrayListOf(Sensor.TYPE_GYROSCOPE, Sensor.TYPE_ACCELEROMETER, Sensor.TYPE_LINEAR_ACCELERATION, Sensor.TYPE_ROTATION_VECTOR, Sensor.TYPE_GRAVITY)

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSModule.kt
@@ -35,7 +35,7 @@ class SMSModule : Module(), LifecycleEventListener {
       sendSMSAsync(addresses, message, options, promise)
     }
 
-    AsyncFunction("isAvailableAsync") {
+    AsyncFunction<Boolean>("isAvailableAsync") {
       return@AsyncFunction context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
     }
 

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
@@ -36,11 +36,11 @@ class SpeechModule : Module() {
       textToSpeech.shutdown()
     }
 
-    AsyncFunction("isSpeaking") {
+    AsyncFunction<Boolean>("isSpeaking") {
       textToSpeech.isSpeaking
     }
 
-    AsyncFunction("getVoices") {
+    AsyncFunction<List<VoiceRecord>>("getVoices") {
       val nativeVoices = try {
         textToSpeech.voices.toList()
       } catch (_: Exception) {
@@ -63,7 +63,7 @@ class SpeechModule : Module() {
       }
     }
 
-    AsyncFunction("stop") {
+    AsyncFunction<Unit>("stop") {
       textToSpeech.stop()
     }
 

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -22,8 +22,8 @@ class StoreReviewModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoStoreReview")
 
-    AsyncFunction("isAvailableAsync") {
-      return@AsyncFunction Build.VERSION.SDK_INT >= 21 && isPlayStoreInstalled()
+    AsyncFunction<Boolean>("isAvailableAsync") {
+      return@AsyncFunction isPlayStoreInstalled()
     }
 
     AsyncFunction("requestReview") { promise: Promise ->

--- a/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
+++ b/packages/expo-store-review/android/src/main/java/expo/modules/storereview/StoreReviewModule.kt
@@ -2,7 +2,6 @@ package expo.modules.storereview
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import com.google.android.gms.common.GooglePlayServicesUtil
 import com.google.android.play.core.review.ReviewManager
 import com.google.android.play.core.review.ReviewManagerFactory

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIModule.kt
@@ -50,7 +50,7 @@ class SystemUIModule : Module() {
       setBackgroundColor(color ?: systemBackgroundColor)
     }.runOnQueue(Queues.MAIN)
 
-    AsyncFunction("getBackgroundColorAsync") {
+    AsyncFunction<String?>("getBackgroundColorAsync") {
       val background = currentActivity.window.decorView.background
       return@AsyncFunction if (background is ColorDrawable) {
         colorToHex((background.mutate() as ColorDrawable).color)

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.taskManager
 
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import expo.modules.core.errors.ModuleNotFoundException
@@ -29,7 +30,7 @@ class TaskManagerModule : Module() {
       "EVENT_NAME" to TaskManagerInterface.EVENT_NAME
     )
 
-    AsyncFunction("isAvailableAsync") {
+    AsyncFunction<Boolean>("isAvailableAsync") {
       return@AsyncFunction true
     }
 
@@ -45,7 +46,7 @@ class TaskManagerModule : Module() {
       taskService.getTaskOptions(taskName, appScopeKey)
     }
 
-    AsyncFunction("getRegisteredTasksAsync") {
+    AsyncFunction<List<Bundle>>("getRegisteredTasksAsync") {
       taskService.getTasksForAppScopeKey(appScopeKey)
     }
 
@@ -53,7 +54,7 @@ class TaskManagerModule : Module() {
       taskService.unregisterTask(taskName, appScopeKey, null)
     }
 
-    AsyncFunction("unregisterAllTasksAsync") {
+    AsyncFunction<Unit>("unregisterAllTasksAsync") {
       taskService.unregisterAllTasksForAppScopeKey(appScopeKey)
     }
 

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
@@ -65,7 +65,7 @@ class WebBrowserModule : Module() {
     }
 
     // throws CurrentActivityNotFoundException
-    AsyncFunction("getCustomTabsSupportingBrowsersAsync") {
+    AsyncFunction<Bundle>("getCustomTabsSupportingBrowsersAsync") {
       val activities = customTabsResolver.customTabsResolvingActivities
       val services = customTabsResolver.customTabsResolvingServices
       val preferredPackage = customTabsResolver.getPreferredCustomTabsResolvingActivity(activities)


### PR DESCRIPTION
# Why

A follow-up to https://github.com/expo/expo/pull/27890. 

When creating a parameterless function, Kotlin uses general function overload, which prevents it from deducing the correct return type.

For example:

with definitions like this:
```
<ReturnType> function AsyncFunction(name, body: () -> ReturnType)
function AsyncFunction(name, body: () -> Any?)
```

the invocation:
```
AsyncFunction("x") { false } 
```

is resolved to:

```
function AsyncFunction(name, body: () -> Any?)
```

So the return type is settled to `Any?`. 

After adding a return type to all async functions that don't have arguments, we were able to use a more specific function overload. 

# Test Plan

- bare-expo ✅