### PR TITLE
[ci] upgrade to cache v4

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -75,7 +75,7 @@ runs:
   steps:
     - name: ♻️ Restore workspace node modules
       if: inputs.yarn-workspace == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: workspace-modules-cache
       with:
         # See "workspaces" → "packages" in the root package.json for the source of truth of
@@ -91,7 +91,7 @@ runs:
 
     - name: ♻️ Restore /tools node modules and bins
       if: inputs.yarn-tools == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: tools-modules-cache
       with:
         path: |
@@ -100,21 +100,21 @@ runs:
 
     - name: ♻️ Restore /docs node modules
       if: inputs.yarn-docs == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: docs-modules-cache
       with:
         path: docs/node_modules
         key: ${{ runner.os }}-docs-modules-${{ hashFiles('docs/yarn.lock') }}
     - name: ♻️ Restore Docs Next cache
       if: inputs.yarn-docs == 'true' && steps.docs-modules-cache.outputs.cache-hit == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: docs/.next/cache
         key: ${{ runner.os }}-docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/next.config.js') }}
 
     - name: ♻️ Restore ios/Pods from cache
       if: inputs.ios-pods == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: ios-pods-cache
       with:
         path: ios/Pods
@@ -122,7 +122,7 @@ runs:
 
     - name: ♻️ Restore apps/bare-expo/ios/Pods from cache
       if: inputs.bare-expo-pods == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: bare-expo-pods-cache
       with:
         path: apps/bare-expo/ios/Pods
@@ -130,7 +130,7 @@ runs:
 
     - name: ♻️ Restore apps/native-tests/ios/Pods from cache
       if: inputs.native-tests-pods == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: native-tests-pods-cache
       with:
         path: apps/native-tests/ios/Pods
@@ -142,7 +142,7 @@ runs:
 
     - name: ♻️ Restore Android NDK from cache
       if: inputs.ndk == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-android-ndk
       with:
         path: /usr/local/lib/android/sdk/ndk/${{ inputs.ndk-version }}/
@@ -158,7 +158,7 @@ runs:
       run: echo "sha256=$(git lfs ls-files | openssl dgst -sha256)" >> $GITHUB_OUTPUT
       shell: bash
     - name: ♻️ Restore Git LFS cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: inputs.git-lfs == 'true'
       with:
         path: .git/lfs
@@ -166,7 +166,7 @@ runs:
 
     - name: ♻️ Restore hermes-engine AAR cache
       if: inputs.hermes-engine-aar == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: android/prebuiltHermes
         key: hermes-engine-aar-v2-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
@@ -205,7 +205,7 @@ runs:
       run: echo "REACT_NATIVE_DOWNLOADS_DIR=$HOME/.gradle/react-native-downloads" >> $GITHUB_ENV
     - name: ♻️ Restore Gradle downloads cache for React Native libraries
       if: inputs.react-native-gradle-downloads == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.REACT_NATIVE_DOWNLOADS_DIR }}
         key: gradle-downloads-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
# Why

actions/cache@v3 runs on Node 16 which is no longer supported. Upgrading to v4 has no breaking changes and includes only running on Node 20 now, so the upgrade should be painless.

# How

Replaced all instances of cache@v3 by cache@v4

# Test Plan

Not sure how to test this properly. Maybe by seeing the actions on this PR branch run without the warning message? Although it seems that it doesn't pick up the change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
