### PR TITLE
chore(babel): add hermes tests for language features

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Add Hermes language support tests.
 - Remove unused peer dependency on `@babel/preset-env`. ([#27705](https://github.com/expo/expo/pull/27705) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
 - Add additional tests for undefined platform minification behavior. ([#27515](https://github.com/expo/expo/pull/27515) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Add Hermes language support tests.
+- Add Hermes language support tests. ([#27900](https://github.com/expo/expo/pull/27900) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused peer dependency on `@babel/preset-env`. ([#27705](https://github.com/expo/expo/pull/27705) by [@EvanBacon](https://github.com/EvanBacon))
 - Disable color in snapshot tests in CI. ([#27301](https://github.com/expo/expo/pull/27301) by [@EvanBacon](https://github.com/EvanBacon))
 - Add additional tests for undefined platform minification behavior. ([#27515](https://github.com/expo/expo/pull/27515) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -1,0 +1,122 @@
+import * as babel from '@babel/core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import preset from '..';
+import { hermesAsync } from './hermes-util';
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+jest.mock('../common.ts', () => ({
+  ...jest.requireActual('../common.ts'),
+  hasModule: jest.fn((moduleId) => {
+    if (['react-native-reanimated', 'expo-router', '@expo/vector-icons'].includes(moduleId)) {
+      return true;
+    }
+    return false;
+  }),
+}));
+
+const SAMPLE_CODE = `
+try {
+
+} catch ({ message }) {
+
+}
+`;
+
+const LANGUAGE_SAMPLES: {
+  name: string;
+  code: string;
+  getCompiledCode: (props: { platform: string }) => string;
+  hermesError?: RegExp;
+}[] = [
+  // Unsupported features
+  {
+    name: `destructuring in catch statement (ES10)`,
+    code: SAMPLE_CODE,
+    getCompiledCode({ platform }) {
+      return 'try{}catch(_ref){var message=_ref.message;}';
+    },
+    hermesError: /Destructuring in catch parameters is currently unsupported/,
+  },
+  {
+    name: `classes`,
+    code: `class Test {
+        constructor(name) {
+          this.name = name;
+        }
+      
+        logger() {
+          console.log("Hello", this.name);
+        }
+      }`,
+    getCompiledCode({ platform }) {
+      return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var Test=function(){function Test(name){(0,_classCallCheck2.default)(this,Test);this.name=name;}(0,_createClass2.default)(Test,[{key:"logger",value:function logger(){console.log("Hello",this.name);}}]);return Test;}();';
+    },
+    hermesError: /invalid statement encountered\./,
+  },
+
+  // Supported natively
+  {
+    name: 'numeric-separator',
+    code: `var budget = 1_000_000_000_000;
+    var nibbles = 0b1010_0001_1000_0101;
+    var message = 0xa0_b0_c0;`,
+    getCompiledCode({ platform }) {
+      return `var budget=1_000_000_000_000;var nibbles=0b1010_0001_1000_0101;var message=0xa0_b0_c0;`;
+    },
+  },
+  {
+    name: 'sticky-regex',
+    code: `var regex = /foo+/y;`,
+    getCompiledCode({ platform }) {
+      return `var regex=/foo+/y;`;
+    },
+  },
+  {
+    name: 'spread',
+    code: `var h = ["a", "b", "c"];
+
+    var i = [...h, "foo"];
+    
+    var j = foo(...h);`,
+    getCompiledCode({ platform }) {
+      return `var h=["a","b","c"];var i=[...h,"foo"];var j=foo(...h);`;
+    },
+  },
+];
+
+LANGUAGE_SAMPLES.forEach((sample) => {
+  describe(sample.name, () => {
+    ['ios', 'web'].forEach((platform) => {
+      it(`babel-preset-expo shims support (platform: ${platform})`, async () => {
+        const options = {
+          babelrc: false,
+          presets: [preset],
+          filename: '/unknown',
+          sourceMaps: true,
+          caller: getCaller({ name: 'metro', platform, engine: 'hermes' }),
+        };
+
+        const babelResults = babel.transform(sample.code, options)!;
+        expect(babelResults.code).toEqual(sample.getCompiledCode({ platform }));
+
+        // Will not throw
+        await hermesAsync({ code: babelResults.code! });
+      });
+    });
+
+    if (sample.hermesError) {
+      it(`Hermes does not have native support`, async () => {
+        await expect(hermesAsync({ code: sample.code })).rejects.toThrowError(sample.hermesError);
+      });
+    } else {
+      it(`Hermes compiles directly`, async () => {
+        await hermesAsync({ code: sample.code });
+      });
+    }
+  });
+});

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -1,9 +1,7 @@
 import * as babel from '@babel/core';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 
-import preset from '..';
 import { hermesAsync } from './hermes-util';
+import preset from '..';
 
 function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
   return props as unknown as babel.TransformCaller;
@@ -94,7 +92,7 @@ const LANGUAGE_SAMPLES: {
         }
       }`,
     getCompiledCode() {
-      return `var _interopRequireDefault=require(\"@babel/runtime/helpers/interopRequireDefault\");var _classCallCheck2=_interopRequireDefault(require(\"@babel/runtime/helpers/classCallCheck\"));var _createClass2=_interopRequireDefault(require(\"@babel/runtime/helpers/createClass\"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require(\"@babel/runtime/helpers/classPrivateFieldLooseKey\"));function _checkInRHS(e){if(Object(e)!==e)throw TypeError(\"right-hand side of 'in' should be an object, got \"+(null!==e?typeof e:\"null\"));return e;}var _bar=(0,_classPrivateFieldLooseKey2.default)(\"bar\");var Foo=function(){function Foo(){(0,_classCallCheck2.default)(this,Foo);Object.defineProperty(this,_bar,{writable:true,value:\"bar\"});}(0,_createClass2.default)(Foo,[{key:\"test\",value:function test(obj){return Object.prototype.hasOwnProperty.call(_checkInRHS(obj),_bar);}}]);return Foo;}();`;
+      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));function _checkInRHS(e){if(Object(e)!==e)throw TypeError("right-hand side of 'in' should be an object, got "+(null!==e?typeof e:"null"));return e;}var _bar=(0,_classPrivateFieldLooseKey2.default)("bar");var Foo=function(){function Foo(){(0,_classCallCheck2.default)(this,Foo);Object.defineProperty(this,_bar,{writable:true,value:"bar"});}(0,_createClass2.default)(Foo,[{key:"test",value:function test(obj){return Object.prototype.hasOwnProperty.call(_checkInRHS(obj),_bar);}}]);return Foo;}();`;
     },
     hermesError: /private properties are not supported/,
   },

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -96,6 +96,25 @@ const LANGUAGE_SAMPLES: {
     },
     hermesError: /private properties are not supported/,
   },
+  {
+    // Sanity check. It appears Hermes can parse JSX optionally.
+    name: `JSX`,
+    code: `const value = (<div />)`,
+    getCompiledCode() {
+      return `var _jsxRuntime=require("react/jsx-runtime");var value=(0,_jsxRuntime.jsx)("div",{});`;
+    },
+    hermesError: /possible JSX: pass -parse-jsx to parse/,
+  },
+  {
+    // https://babeljs.io/docs/babel-plugin-transform-export-namespace-from
+    // babel-preset-expo adds support for this.
+    name: `export-namespace-from`,
+    code: `export * as ns from "mod";`,
+    getCompiledCode() {
+      return `Object.defineProperty(exports,"__esModule",{value:true});exports.ns=void 0;var _ns=_interopRequireWildcard(require("mod"));exports.ns=_ns;function _getRequireWildcardCache(e){if("function"!=typeof WeakMap)return null;var r=new WeakMap(),t=new WeakMap();return(_getRequireWildcardCache=function(e){return e?t:r;})(e);}function _interopRequireWildcard(e,r){if(!r&&e&&e.__esModule)return e;if(null===e||"object"!=typeof e&&"function"!=typeof e)return{default:e};var t=_getRequireWildcardCache(r);if(t&&t.has(e))return t.get(e);var n={__proto__:null},a=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var u in e)if("default"!==u&&Object.prototype.hasOwnProperty.call(e,u)){var i=a?Object.getOwnPropertyDescriptor(e,u):null;i&&(i.get||i.set)?Object.defineProperty(n,u,i):n[u]=e[u];}return n.default=e,t&&t.set(e,n),n;}`;
+    },
+    hermesError: /error: 'export' statement requires module mode/,
+  },
 
   // Supported natively
   {
@@ -108,6 +127,15 @@ const LANGUAGE_SAMPLES: {
       };`,
     getCompiledCode() {
       return `var obj={["x"+foo]:"heh",["y"+bar]:"noo",foo:"foo",bar:"bar"};`;
+    },
+  },
+  {
+    // No babel transform is run on this but we did observe runtime issues with Reflect when adopting bridgeless mode and the new architecture.
+    // These tests will likely not be capable of replicating the failure but it's a public reference to the issue in case anything changes in the future.
+    name: 'Reflect',
+    code: `const obj = Reflect.get({ foo: 'bar' }, 'foo');`,
+    getCompiledCode() {
+      return `var obj=Reflect.get({foo:'bar'},'foo');`;
     },
   },
   {

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -1,6 +1,6 @@
 import * as babel from '@babel/core';
 
-import { hermesAsync } from './hermes-util';
+import { compileToHermesBytecodeAsync } from './hermes-util';
 import preset from '..';
 
 function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
@@ -277,17 +277,19 @@ LANGUAGE_SAMPLES.forEach((sample) => {
         expect(babelResults.code).toEqual(sample.getCompiledCode());
 
         // Will not throw
-        await hermesAsync({ code: babelResults.code! });
+        await compileToHermesBytecodeAsync({ code: babelResults.code! });
       });
     });
 
     if (sample.hermesError) {
       it(`Hermes does not have native support`, async () => {
-        await expect(hermesAsync({ code: sample.code })).rejects.toThrowError(sample.hermesError);
+        await expect(compileToHermesBytecodeAsync({ code: sample.code })).rejects.toThrowError(
+          sample.hermesError
+        );
       });
     } else {
       it(`Hermes compiles directly`, async () => {
-        await hermesAsync({ code: sample.code });
+        await compileToHermesBytecodeAsync({ code: sample.code });
       });
     }
   });

--- a/packages/babel-preset-expo/src/__tests__/hermes-util.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-util.ts
@@ -1,0 +1,83 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs';
+import fse from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import process from 'process';
+import resolveFrom from 'resolve-from';
+
+const debug = require('debug')('expo:metro:hermes') as typeof console.log;
+
+const reactNativeDir = path.join(require.resolve('react-native/package.json'), '..');
+
+function importHermesCommandFromProject(): string {
+  const platformExecutable = getHermesCommandPlatform();
+  const hermescLocations = [
+    // Override hermesc dir by environment variables
+    process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']
+      ? `${process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']}/build/bin/hermesc`
+      : '',
+
+    // Building hermes from source
+    'react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc',
+
+    // Prebuilt hermesc in official react-native 0.69+
+    `react-native/sdks/hermesc/${platformExecutable}`,
+
+    // Legacy hermes-engine package
+    `hermes-engine/${platformExecutable}`,
+  ];
+
+  for (const location of hermescLocations) {
+    try {
+      return resolveFrom(reactNativeDir, location);
+    } catch {}
+  }
+  throw new Error('Cannot find the hermesc executable.');
+}
+
+function getHermesCommandPlatform(): string {
+  switch (os.platform()) {
+    case 'darwin':
+      return 'osx-bin/hermesc';
+    case 'linux':
+      return 'linux64-bin/hermesc';
+    case 'win32':
+      return 'win64-bin/hermesc.exe';
+    default:
+      throw new Error(`Unsupported host platform for Hermes compiler: ${os.platform()}`);
+  }
+}
+
+type BuildHermesOptions = {
+  code: string;
+  minify?: boolean;
+};
+
+export async function hermesAsync({ code, minify = false }: BuildHermesOptions): Promise<Buffer> {
+  const tempDir = path.join(os.tmpdir(), `expo-babel-test-${Math.random()}-${Date.now()}`);
+  await fs.promises.mkdir(tempDir, { recursive: true });
+  try {
+    const tempBundleFile = path.join(tempDir, 'index.js');
+    await fs.promises.writeFile(tempBundleFile, code);
+
+    const tempHbcFile = path.join(tempDir, 'index.hbc');
+    const hermesCommand = importHermesCommandFromProject();
+    const args = ['-emit-binary', '-out', tempHbcFile, tempBundleFile];
+    if (minify) {
+      args.push('-O');
+    }
+
+    debug(`Running hermesc: ${hermesCommand} ${args.join(' ')}`);
+    await spawnAsync(hermesCommand, args);
+
+    return await fs.promises.readFile(tempHbcFile);
+  } catch (error: any) {
+    if ('status' in error) {
+      throw new Error(error.output.join('\n'));
+    }
+    throw error;
+  } finally {
+    await fse.remove(tempDir);
+  }
+}

--- a/packages/babel-preset-expo/src/__tests__/hermes-util.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-util.ts
@@ -63,7 +63,7 @@ export async function hermesAsync({ code, minify = false }: BuildHermesOptions):
 
     const tempHbcFile = path.join(tempDir, 'index.hbc');
     const hermesCommand = importHermesCommandFromProject();
-    const args = ['-emit-binary', '-out', tempHbcFile, tempBundleFile];
+    const args = ['-emit-binary', '-strict', '-out', tempHbcFile, tempBundleFile];
     if (minify) {
       args.push('-O');
     }

--- a/packages/babel-preset-expo/src/__tests__/hermes-util.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-util.ts
@@ -15,7 +15,7 @@ function importHermesCommandFromProject(): string {
   const hermescLocations = [
     // Override hermesc dir by environment variables
     process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']
-      ? `${process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR']}/build/bin/hermesc`
+      ? path.join(process.env['REACT_NATIVE_OVERRIDE_HERMES_DIR'], 'build/bin/hermesc')
       : '',
 
     // Building hermes from source
@@ -54,7 +54,10 @@ type BuildHermesOptions = {
   minify?: boolean;
 };
 
-export async function hermesAsync({ code, minify = false }: BuildHermesOptions): Promise<Buffer> {
+export async function compileToHermesBytecodeAsync({
+  code,
+  minify = false,
+}: BuildHermesOptions): Promise<Buffer> {
   const tempDir = path.join(os.tmpdir(), `expo-babel-test-${Math.random()}-${Date.now()}`);
   await fs.promises.mkdir(tempDir, { recursive: true });
   try {


### PR DESCRIPTION
# Why

- Inspired by https://github.com/expo/expo/pull/27885
- Even though we have tests which catch a wide range of missing language features, it would be nice to have the tests fail faster and in isolation from a native build. Right now, they only run after a full native build has completed, which could lead to instances where the native build fails and we think it's fine to land anyways.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Add Hermes compilation to the babel jest tests and a number of language.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- There's a chance this PR doesn't work in CI.


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
