### PR TITLE
Update react-native-markdown-renderer library

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -13,7 +13,7 @@ There’s currently no default solution for that in the React Native ecosystem. 
 
 There are a lot of good options to display rich text:
 
-- For markdown content, you can use a markdown renderer such as [`react-native-markdown-renderer`](https://www.npmjs.com/package/react-native-markdown-renderer) or another.
+- For markdown content, you can use a markdown renderer such as [`react-native-markdown-display`](https://github.com/jonasmerlin/react-native-markdown-display) or another.
 
 - For HTML content, you can use [`@expo/html-elements`](https://www.npmjs.com/package/@expo/html-elements) or a webview ([`react-native-webview`](/versions/latest/sdk/webview/)).
 

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -13,7 +13,7 @@ There’s currently no default solution for that in the React Native ecosystem. 
 
 There are a lot of good options to display rich text:
 
-- For markdown content, you can use a markdown renderer such as [`react-native-markdown-display`](https://github.com/jonasmerlin/react-native-markdown-display) or another.
+- For markdown content, you can use a markdown renderer such as [`react-native-markdown-display`](https://www.npmjs.com/package/react-native-markdown-display) or another.
 
 - For HTML content, you can use [`@expo/html-elements`](https://www.npmjs.com/package/@expo/html-elements) or a webview ([`react-native-webview`](/versions/latest/sdk/webview/)).
 


### PR DESCRIPTION
react-native-markdown-renderer is no longer being updated. It has stopped supporting React 17 or above. Updated the library to use a fork of react-markdown-renderer that is still being updated and supports the latest version of React.

# Why

<!--
I was looking to install a markdown renderer, I followed what this documentation suggested but found it didn't support anything above react 16. I had to go find another library to do so. This could've saved me time
-->

# How

<!--
Just updated link to a supported library
-->

# Test Plan

<!--
Pure text changes, no tests required
-->