### PR TITLE
[core] Fix EXReactRootViewFactory not being retained

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
+- Fixed `EXReactRootViewFactory` not retained on iOS bridgeless mode.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
-- Fixed `EXReactRootViewFactory` not retained on iOS bridgeless mode.
+- Fixed `EXReactRootViewFactory` not retained on iOS bridgeless mode. ([#27912](https://github.com/expo/expo/pull/27912) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -77,14 +77,8 @@
 
   // The RCTHost/RCTBridge instance is retained by the RCTRootViewFactory.
   // We will have to replace these instance from the app to the newly created instance.
-  if (appDelegate.bridgelessEnabled) {
-    appRootViewFactory.reactHost = factory.reactHost;
-  } else {
-    appRootViewFactory.bridge = factory.bridge;
-  }
-  
   appDelegate.rootViewFactory = factory;
-
+  
   return rootView;
 }
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -82,6 +82,7 @@
   } else {
     appRootViewFactory.bridge = factory.bridge;
   }
+  appDelegate.rootViewFactory = factory;
   return rootView;
 }
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -82,7 +82,9 @@
   } else {
     appRootViewFactory.bridge = factory.bridge;
   }
+  
   appDelegate.rootViewFactory = factory;
+
   return rootView;
 }
 


### PR DESCRIPTION
# Why
When reloading the app by pressing "r" in the simulator, the app will crash. This is because we create a new `EXReactRootViewFactory` instance in `createDefaultReactRootView`, assign it's `reactHost` and `bridge` properties, and create the root view but we don't retain the new factory instance. This causes it to be nil on reload.
 
# How
Assign the appDelegates rootViewFactory property to the new factory instance.
Not sure if this is the correct solution @Kudo?

# Test Plan
Fabric tester with bridgeless enabled and disabled