### PR TITLE
feat(cli): Export source maps outputs when exporting API route bundles

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add source map outputs when exporting API route bundles.
 - Add experimental support for using a canary build of the React Native renderer. ([#27303](https://github.com/expo/expo/pull/27303) by [@EvanBacon](https://github.com/EvanBacon))
 - Add basic `react-server` support. ([#27264](https://github.com/expo/expo/pull/27264) by [@EvanBacon](https://github.com/EvanBacon))
 - Add warnings when URI schemes cannot be resolved for dev client launches. ([#27241](https://github.com/expo/expo/pull/27241) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add source map outputs when exporting API route bundles.
+- Add source map outputs when exporting API route bundles. ([#27913](https://github.com/expo/expo/pull/27913) by [@kitten](https://github.com/kitten))
 - Add experimental support for using a canary build of the React Native renderer. ([#27303](https://github.com/expo/expo/pull/27303) by [@EvanBacon](https://github.com/EvanBacon))
 - Add basic `react-server` support. ([#27264](https://github.com/expo/expo/pull/27264) by [@EvanBacon](https://github.com/EvanBacon))
 - Add warnings when URI schemes cannot be resolved for dev client launches. ([#27241](https://github.com/expo/expo/pull/27241) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -169,6 +169,7 @@ describe('server-output', () => {
 
     it(`can serve up API route in array group`, async () => {
       expect(getFiles()).toContain('server/_expo/functions/(a,b)/multi-group-api+api.js');
+      expect(getFiles()).toContain('server/_expo/functions/(a,b)/multi-group-api+api.js.map');
       expect(getFiles()).not.toContain('server/_expo/functions/(a)/multi-group-api+api.js');
       expect(getFiles()).not.toContain('server/_expo/functions/(b)/multi-group-api+api.js');
 
@@ -348,11 +349,15 @@ describe('server-output', () => {
 
       // Has functions
       expect(files).toContain('server/_expo/functions/methods+api.js');
+      expect(files).toContain('server/_expo/functions/methods+api.js.map');
       expect(files).toContain('server/_expo/functions/api/[dynamic]+api.js');
+      expect(files).toContain('server/_expo/functions/api/[dynamic]+api.js.map');
       expect(files).toContain('server/_expo/functions/api/externals+api.js');
+      expect(files).toContain('server/_expo/functions/api/externals+api.js.map');
 
       // TODO: We shouldn't export this
       expect(files).toContain('server/_expo/functions/api/empty+api.js');
+      expect(files).toContain('server/_expo/functions/api/empty+api.js.map');
 
       // Has single variation of group file
       expect(files).toContain('server/(alpha)/beta.html');

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs/promises';
 import execa from 'execa';
 import klawSync from 'klaw-sync';
 import path from 'path';
@@ -176,6 +177,16 @@ describe('server-output', () => {
       expect(
         await fetch('http://localhost:3000/multi-group-api').then((res) => res.json())
       ).toEqual({ value: 'multi-group-api-get' });
+
+      // Load the sourcemap and check that the paths are relative
+      const map = JSON.parse(
+        await fs.readFile(
+          path.join(outputDir, 'server/_expo/functions/(a,b)/multi-group-api+api.js.map'),
+          { encoding: 'utf8' },
+        )
+      );
+
+      expect(map.sources).toContain('__e2e__/server/app/(a,b)/multi-group-api+api.ts');
     });
 
     it(`can serve up API route in specific array group`, async () => {

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -173,7 +173,7 @@ export async function exportAppAsync(
         outputDir: outputPath,
         minify,
         baseUrl,
-        includeSourceMaps: true,
+        includeSourceMaps: sourceMaps,
         routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
         exportServer,
         maxWorkers,

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -173,7 +173,7 @@ export async function exportAppAsync(
         outputDir: outputPath,
         minify,
         baseUrl,
-        includeSourceMaps: sourceMaps,
+        includeSourceMaps: true,
         routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
         exportServer,
         maxWorkers,

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -248,6 +248,7 @@ async function exportFromServerAsync(
       outputDir,
       server: devServer,
       manifest: serverManifest,
+      includeSourceMaps,
     });
 
     // Add the api routes to the files to export.
@@ -412,16 +413,18 @@ export function getPathVariations(routePath: string): string[] {
 }
 
 async function exportApiRoutesAsync({
+  includeSourceMaps,
   outputDir,
   server,
   ...props
-}: Pick<Options, 'outputDir'> & {
+}: Pick<Options, 'outputDir' | 'includeSourceMaps'> & {
   server: MetroBundlerDevServer;
   manifest: ExpoRouterServerManifestV1;
 }): Promise<ExportAssetMap> {
   const { manifest, files } = await server.exportExpoRouterApiRoutesAsync({
     outputDir: '_expo/functions',
     prerenderManifest: props.manifest,
+    includeSourceMaps,
   });
 
   Log.log(chalk.bold`Exporting ${files.size} API Routes.`);

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -248,7 +248,8 @@ async function exportFromServerAsync(
       outputDir,
       server: devServer,
       manifest: serverManifest,
-      includeSourceMaps,
+      // NOTE(kitten): For now, we always output source maps for API route exports
+      includeSourceMaps: true,
     });
 
     // Add the api routes to the files to export.

--- a/packages/@expo/cli/src/start/server/getStaticRenderFunctions.ts
+++ b/packages/@expo/cli/src/start/server/getStaticRenderFunctions.ts
@@ -166,7 +166,7 @@ export async function requireFileContentsWithMetro(
 async function metroFetchAsync(
   projectRoot: string,
   url: string
-): Promise<{ src: string; filename: string }> {
+): Promise<{ src: string; filename: string; map?: any }> {
   debug('Fetching from Metro:', url);
   // TODO: Skip the dev server and use the Metro instance directly for better results, faster.
   const res = await fetch(url);
@@ -191,7 +191,11 @@ async function metroFetchAsync(
   const map = await fetch(url.replace('.bundle?', '.map?')).then((r) => r.json());
   cachedSourceMaps.set(url, { url: projectRoot, map });
 
-  return { src: wrapBundle(content), filename: url };
+  return {
+    src: wrapBundle(content),
+    filename: url,
+    map,
+  };
 }
 
 export async function getStaticRenderFunctionsForEntry<T = any>(

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -147,9 +147,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
             contents: JSON.stringify({
               version: contents.map.version,
               sources: contents.map.sources.map((source: string) => {
-                source = typeof source === 'string' && source.startsWith(this.projectRoot)
-                  ? path.relative(this.projectRoot, source)
-                  : source;
+                source =
+                  typeof source === 'string' && source.startsWith(this.projectRoot)
+                    ? path.relative(this.projectRoot, source)
+                    : source;
                 return source.split(path.sep).join('/');
               }),
               sourcesContent: new Array(contents.map.sources.length).fill(null),

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -147,9 +147,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
             contents: JSON.stringify({
               version: contents.map.version,
               sources: contents.map.sources.map((source: string) => {
-                return typeof source === 'string' && source.startsWith(this.projectRoot)
+                source = typeof source === 'string' && source.startsWith(this.projectRoot)
                   ? path.relative(this.projectRoot, source)
                   : source;
+                return source.split(path.sep).join('/');
               }),
               sourcesContent: new Array(contents.map.sources.length).fill(null),
               names: contents.map.names,

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -135,6 +135,9 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       if (contents) {
         let src = contents.src;
         if (includeSourceMaps && contents.map) {
+          // TODO(kitten): Merge the source map transformer in the future
+          // https://github.com/expo/expo/blob/0dffdb15/packages/%40expo/metro-config/src/serializer/serializeChunks.ts#L422-L439
+          // Alternatively, check whether `sourcesRoot` helps here
           const artifactBasename = encodeURIComponent(path.basename(artifactFilename) + '.map');
           src = src.replace(
             /\/\/# sourceMappingURL=.*/g,


### PR DESCRIPTION
# Why

We previously didn't output source maps when exporting API routes.

# How

- Passthrough existing source map data when exporting server bundles
- Reformat source map paths before doing so (See note)