### PR TITLE
[core][Android] Use cpp event emitter in modules

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -3,6 +3,7 @@
 #include "JavaScriptModuleObject.h"
 #include "JSIContext.h"
 #include "JSIUtils.h"
+#include "EventEmitter.h"
 #include "SharedObject.h"
 #include "NativeModule.h"
 
@@ -94,7 +95,9 @@ void JavaScriptModuleObject::registerNatives() {
                    makeNativeMethod("registerClass",
                                     JavaScriptModuleObject::registerClass),
                    makeNativeMethod("registerViewPrototype",
-                                    JavaScriptModuleObject::registerViewPrototype)
+                                    JavaScriptModuleObject::registerViewPrototype),
+                   makeNativeMethod("emitEvent",
+                                    JavaScriptModuleObject::emitEvent)
                  });
 }
 
@@ -342,6 +345,41 @@ void JavaScriptModuleObject::registerProperty(
   );
 
   properties.insert({cName, std::move(functions)});
+}
+
+void JavaScriptModuleObject::emitEvent(
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
+) {
+  const std::string name = eventName->toStdString();
+  folly::dynamic body;
+  if (eventBody) {
+    body = eventBody->cthis()->consume();
+  }
+
+  const JSIContext *jsiContext = jsiContextRef->cthis();
+
+  jsiContext->runtimeHolder->jsInvoker->invokeAsync([
+    jsiContext,
+    name = std::move(name),
+    body = std::move(body),
+    weakThis = jsiObject
+  ]() {
+    std::shared_ptr<jsi::Object> jsThis = weakThis.lock();
+    if (!jsThis) {
+      return;
+    }
+
+    // TODO(@lukmccall): refactor when jsInvoker recieves a runtime as a parameter
+    jsi::Runtime &rt  = jsiContext->runtimeHolder->get();
+
+    jsi::Value convertedBody = jsi::valueFromDynamic(rt, body);
+    std::vector<jsi::Value> args;
+    args.emplace_back(std::move(convertedBody));
+
+    EventEmitter::emitEvent(rt, *jsThis, name, args);
+  });
 }
 
 JavaScriptModuleObject::JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -5,6 +5,7 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <react/jni/ReadableNativeArray.h>
+#include <react/jni/ReadableNativeMap.h>
 #include <jni/JCallback.h>
 
 #include <unordered_map>
@@ -123,6 +124,17 @@ public:
     jboolean setterTakesOwner,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> setter
+  );
+
+  /**
+   * Emits an event using cached jsi::Object with the given name and body.
+   * @param eventName
+   * @param eventBody
+   */
+  void emitEvent(
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
   );
 
 private:

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -30,6 +30,9 @@ class ModuleHolder<T : Module>(val module: T) {
       JavaScriptModuleObject(jniDeallocator, name).apply {
         initUsingObjectDefinition(appContext, definition.objectDefinition)
 
+        // Give the module object a name. It's used for compatibility reasons, see `EventEmitter.ts`.
+        registerProperty("__expo_module_name__", false, emptyArray(), { name }, false, emptyArray(), null)
+
         val viewFunctions = definition.viewManagerDefinition?.asyncFunctions
         if (viewFunctions?.isNotEmpty() == true) {
           trace("Attaching view prototype") {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/ErrorManagerModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/ErrorManagerModule.kt
@@ -15,8 +15,7 @@ class ErrorManagerModule : Module() {
   }
 
   fun reportExceptionToLogBox(codedException: CodedException) {
-    val eventEmitter = appContext.eventEmitter(this) ?: return
-    eventEmitter.emit(
+    sendEvent(
       onNewException,
       Bundle().apply {
         putString("message", codedException.message ?: codedException.toString())
@@ -25,8 +24,7 @@ class ErrorManagerModule : Module() {
   }
 
   fun reportWarningToLogBox(warning: String) {
-    val eventEmitter = appContext.eventEmitter(this) ?: return
-    eventEmitter.emit(
+    sendEvent(
       onNewWarning,
       Bundle().apply {
         putString("message", warning)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -3,12 +3,14 @@ package expo.modules.kotlin.events
 import android.os.Bundle
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableNativeMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.JSTypeConverter
+import expo.modules.kotlin.types.toJSValue
 import java.lang.ref.WeakReference
 
 /**
@@ -23,22 +25,27 @@ class KModuleEventEmitterWrapper(
 ) : KEventEmitterWrapper(legacyEventEmitter, reactContextHolder) {
   override fun emit(eventName: String, eventBody: Bundle?) {
     checkIfEventWasExported(eventName)
-    super.emit(eventName, eventBody)
+    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
   }
 
   override fun emit(eventName: String, eventBody: WritableMap?) {
     checkIfEventWasExported(eventName)
-    super.emit(eventName, eventBody)
+    emitNative(eventName, eventBody as? ReadableNativeMap)
   }
 
   override fun emit(eventName: String, eventBody: Record?) {
     checkIfEventWasExported(eventName)
-    super.emit(eventName, eventBody)
+    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
   }
 
   override fun emit(eventName: String, eventBody: Map<*, *>?) {
     checkIfEventWasExported(eventName)
-    super.emit(eventName, eventBody)
+    emitNative(eventName, eventBody?.toJSValue(JSTypeConverter.DefaultContainerProvider) as? ReadableNativeMap)
+  }
+
+  private fun emitNative(eventName: String, eventBody: ReadableNativeMap?) {
+    val appContext = moduleHolder.module.appContext
+    moduleHolder.jsObject.emitEvent(appContext.jsiInterop, eventName, eventBody)
   }
 
   private fun checkIfEventWasExported(eventName: String) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.jni
 import com.facebook.jni.HybridData
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.NativeMap
+import com.facebook.react.bridge.ReadableNativeMap
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.objects.ObjectDefinitionData
@@ -85,6 +86,8 @@ class JavaScriptModuleObject(
   external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, ownerClass: Class<*>?, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
+
+  external fun emitEvent(jsiContext: JSIContext, eventName: String, eventBody: ReadableNativeMap?)
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -329,14 +329,16 @@ open class ObjectDefinitionBuilder {
    * Creates module's lifecycle listener that is called right after the first event listener is added.
    */
   inline fun OnStartObserving(crossinline body: () -> Unit) {
-    AsyncFunction("startObserving", body)
+    @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+    AsyncFunction("startObserving") { eventName: String? -> body() }
   }
 
   /**
    * Creates module's lifecycle listener that is called right after all event listeners are removed.
    */
   inline fun OnStopObserving(crossinline body: () -> Unit) {
-    AsyncFunction("stopObserving", body)
+    @Suppress("UNUSED_ANONYMOUS_PARAMETER")
+    AsyncFunction("stopObserving") { eventName: String? -> body() }
   }
 
   /**

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -238,17 +238,31 @@ void installClass(jsi::Runtime &runtime) {
     return jsi::Value((int)getListenerCount(runtime, thisObject, eventName));
   };
 
+  // Added for compatibility with the old EventEmitter API.
+  jsi::HostFunctionType removeSubscriptionHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+    jsi::Object subscription = args[0].asObject(runtime);
+
+    subscription.getProperty(runtime, "remove")
+      .asObject(runtime)
+      .asFunction(runtime)
+      .callWithThis(runtime, subscription, {});
+
+    return jsi::Value::undefined();
+  };
+
   jsi::PropNameID addListenerProp = jsi::PropNameID::forAscii(runtime, "addListener", 11);
   jsi::PropNameID removeListenerProp = jsi::PropNameID::forAscii(runtime, "removeListener", 14);
   jsi::PropNameID removeAllListenersProp = jsi::PropNameID::forAscii(runtime, "removeAllListeners", 18);
   jsi::PropNameID emitProp = jsi::PropNameID::forAscii(runtime, "emit", 4);
   jsi::PropNameID listenerCountProp = jsi::PropNameID::forAscii(runtime, "listenerCount", 13);
+  jsi::PropNameID removeSubscriptionProp = jsi::PropNameID::forAscii(runtime, "removeSubscription", 18);
 
   prototype.setProperty(runtime, addListenerProp, jsi::Function::createFromHostFunction(runtime, addListenerProp, 2, addListenerHost));
   prototype.setProperty(runtime, removeListenerProp, jsi::Function::createFromHostFunction(runtime, removeListenerProp, 2, removeListenerHost));
   prototype.setProperty(runtime, removeAllListenersProp, jsi::Function::createFromHostFunction(runtime, removeAllListenersProp, 1, removeAllListenersHost));
   prototype.setProperty(runtime, emitProp, jsi::Function::createFromHostFunction(runtime, emitProp, 2, emit));
   prototype.setProperty(runtime, listenerCountProp, jsi::Function::createFromHostFunction(runtime, listenerCountProp, 1, listenerCountHost));
+  prototype.setProperty(runtime, removeSubscriptionProp, jsi::Function::createFromHostFunction(runtime, removeSubscriptionProp, 1, removeSubscriptionHost));
 
   common::getCoreObject(runtime)
     .setProperty(runtime, "EventEmitter", eventEmitterClass);


### PR DESCRIPTION
# Why

A followup to the https://github.com/expo/expo/pull/27871/files.

A new cpp event emitter is used to send events from the module.

# How

- Added the ability to send events via CPP.
- Added `removeSubscription` to ensure compatibility with the old API.
- Fied `onStart` and `onStop` observing

# Test Plan

- bare-expo ✅ 