### PR TITLE
[go] Update incompatible version screen with links to `expo.dev/go`

### DIFF
--- a/apps/expo-go/android/app/src/main/res/layout/error_fragment.xml
+++ b/apps/expo-go/android/app/src/main/res/layout/error_fragment.xml
@@ -15,8 +15,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center_vertical"
+    android:gravity="center_vertical"
     android:layout_above="@+id/view_error_log"
-    android:gravity="center"
     android:orientation="vertical">
 
     <TextView
@@ -27,7 +27,6 @@
       android:layout_marginLeft="20dp"
       android:layout_marginTop="30dp"
       android:layout_marginRight="20dp"
-      android:gravity="center"
       android:text="@string/error_header"
       android:textColor="@color/white"
       android:textSize="24sp"/>
@@ -40,7 +39,6 @@
       android:layout_marginTop="20dp"
       android:layout_marginLeft="20dp"
       android:layout_marginRight="20dp"
-      android:gravity="center"
       android:text="@string/error_default_client"
       android:textColor="@color/white"
       android:textSize="16sp"/>

--- a/apps/expo-go/android/app/src/main/res/layout/error_fragment.xml
+++ b/apps/expo-go/android/app/src/main/res/layout/error_fragment.xml
@@ -24,9 +24,9 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_centerHorizontal="true"
-      android:layout_marginLeft="20dp"
+      android:layout_marginLeft="15dp"
       android:layout_marginTop="30dp"
-      android:layout_marginRight="20dp"
+      android:layout_marginRight="15dp"
       android:text="@string/error_header"
       android:textColor="@color/white"
       android:textSize="24sp"/>
@@ -37,8 +37,8 @@
       android:layout_height="wrap_content"
       android:layout_centerHorizontal="true"
       android:layout_marginTop="20dp"
-      android:layout_marginLeft="20dp"
-      android:layout_marginRight="20dp"
+      android:layout_marginLeft="15dp"
+      android:layout_marginRight="15dp"
       android:text="@string/error_default_client"
       android:textColor="@color/white"
       android:textSize="16sp"/>

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
@@ -61,6 +61,13 @@ object ExceptionUtils {
     return null
   }
 
+  fun exceptionToCanRetry(exception: Exception): Boolean {
+    if (exception is ManifestException) {
+      return exception.canRetry
+    }
+    return true
+  }
+
   private fun getUserErrorMessage(exception: Exception?, context: Context): String? {
     if (exception is UnknownHostException || exception is ConnectException) {
       if (isAirplaneModeOn(context)) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -13,6 +13,10 @@ import expo.modules.core.utilities.EmulatorUtilities.isRunningOnEmulator
 class ManifestException : ExponentException {
   private val manifestUrl: String
   private var errorJSON: JSONObject? = null
+  private lateinit var errorMessage: String
+  private var fixInstructions: String? = null
+
+  var canRetry: Boolean = true
   val errorHeader: String?
     get() = errorJSON?.let {
       try {
@@ -30,6 +34,7 @@ class ManifestException : ExponentException {
   constructor(originalException: Exception?, manifestUrl: String) : super(originalException) {
     this.manifestUrl = manifestUrl
     this.errorJSON = null
+    processException()
   }
 
   constructor(originalException: Exception?, manifestUrl: String, errorJSON: JSONObject?) : super(
@@ -37,109 +42,129 @@ class ManifestException : ExponentException {
   ) {
     this.errorJSON = errorJSON
     this.manifestUrl = manifestUrl
+    processException()
   }
 
-  override fun toString(): String {
+  private fun processException() {
     val extraMessage = if (ExpoViewBuildConfig.DEBUG) {
       " Are you sure expo-cli is running?"
     } else {
       ""
     }
 
-    return when (manifestUrl) {
-      else -> {
-        var formattedMessage = "Could not load $manifestUrl.$extraMessage"
-        val supportedSdks = Constants.SDK_VERSIONS_LIST.map {
-          it.substring(0, it.indexOf('.')).toInt()
-        }.sorted()
-        val supportedSdksString = { conjunction: String ->
-          if (supportedSdks.size == 1) {
-            supportedSdks[0]
-          } else {
-            supportedSdks.subList(0, supportedSdks.size - 1)
-              .joinToString(", ") + " $conjunction ${supportedSdks.last()}"
-          }
-        }
-
-        errorJSON?.let { errorJSON ->
-          try {
-            val errorCode = errorJSON.getString("errorCode")
-            val rawMessage = errorJSON.getString("message")
-            when (errorCode) {
-              "EXPERIENCE_NOT_FOUND", // Really doesn't exist
-              "EXPERIENCE_NOT_PUBLISHED_ERROR", // Not published
-              "EXPERIENCE_RELEASE_NOT_FOUND_ERROR" -> // Can't find a release for the requested release channel
-                formattedMessage =
-                  "No project found at $manifestUrl."
-
-              "EXPERIENCE_SDK_VERSION_OUTDATED" -> {
-                val metadata = errorJSON.getJSONObject("metadata")
-                val availableSDKVersions = metadata.getJSONArray("availableSDKVersions")
-                val sdkVersionRequired = availableSDKVersions.getString(0).let {
-                  it.substring(0, it.indexOf('.'))
-                }
-                val maybePluralSDKsString = "SDK${"s".takeIf { supportedSdks.size > 1 } ?: ""}"
-                val expoDevLink = "https://expo.dev/go?sdkVersion=$sdkVersionRequired&platform=android&device=${!isRunningOnEmulator()}"
-
-                formattedMessage =
-                  "This project uses SDK $sdkVersionRequired, but this version of Expo Go supports only $maybePluralSDKsString ${supportedSdksString("and")}.<br><br>" +
-                  "To open this project you can either:<br>" +
-                  "• Update it to SDK ${supportedSdksString("or")}.<br>" +
-                  "• Install an older version of Expo Go that supports the project's SDK version.<br><br>" +
-                  "If you are unsure how to update the project refer to the <a href='https://docs.expo.dev/get-started/expo-go/#sdk-versions'>SDK Versions Guide</a>.<br>" +
-                  "You can also learn how to <a href='$expoDevLink'> install a suitable Expo Go version</a>."
-              }
-
-              "EXPERIENCE_SDK_VERSION_TOO_NEW" ->
-                formattedMessage =
-                  "This project requires a newer version of Expo Go - please download the latest version from the Play Store."
-
-              "EXPERIENCE_NOT_VIEWABLE" ->
-                formattedMessage =
-                  rawMessage // From server: The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.
-
-              "USER_SNACK_NOT_FOUND", "SNACK_NOT_FOUND" ->
-                formattedMessage =
-                  "No snack found at $manifestUrl."
-
-              "SNACK_RUNTIME_NOT_RELEASED" ->
-                formattedMessage =
-                  rawMessage // From server: `The Snack runtime for corresponding sdk version of this Snack ("${sdkVersions[0]}") is not released.`,
-
-              "SNACK_NOT_FOUND_FOR_SDK_VERSION" -> run closure@{
-                val metadata = errorJSON.getJSONObject("metadata")
-                val fullName = metadata["fullName"] ?: ""
-                val snackSdkVersion =
-                  (metadata["sdkVersions"] as? JSONArray)?.get(0) as? String ?: "unknown"
-                val maybePluralSDKsString = "SDK${"s".takeIf { supportedSdks.size > 1 } ?: ""}"
-
-                if (snackSdkVersion == "unknown" || snackSdkVersion.indexOf(".") == -1) {
-                  formattedMessage = rawMessage
-                  return@closure
-                }
-
-                val snackSdkVersionValue = try {
-                  Integer.parseInt(snackSdkVersion.substring(0, snackSdkVersion.indexOf(".")))
-                } catch (e: NumberFormatException) {
-                  formattedMessage = rawMessage
-                  return@closure
-                }
-                formattedMessage =
-                  "The snack \"${fullName}\" was found, but it is not compatible with your version of Expo Go. It was released for SDK $snackSdkVersionValue, but your Expo Go supports only $maybePluralSDKsString ${supportedSdksString("and")}."
-                formattedMessage += if (supportedSdks.last() < snackSdkVersionValue) {
-                  "<br><br>You need to update your Expo Go app in order to run this Snack."
-                } else {
-                  "<br><br>Snack needs to be upgraded to a current SDK version. To do it, open the project at <a href='https://snack.expo.dev'>Expo Snack website</a>. It will be automatically upgraded to a supported SDK version."
-                }
-                formattedMessage += "<br><br><a href='https://docs.expo.dev/get-started/expo-go/#sdk-versions'>Learn more about SDK versions and Expo Go</a>."
-              }
-            }
-          } catch (e: JSONException) {
-            return formattedMessage
-          }
-        }
-        formattedMessage
+    var formattedMessage = "Could not load $manifestUrl.$extraMessage"
+    val supportedSdks = Constants.SDK_VERSIONS_LIST.map {
+      it.substring(0, it.indexOf('.')).toInt()
+    }.sorted()
+    val supportedSdksString = { conjunction: String ->
+      if (supportedSdks.size == 1) {
+        supportedSdks[0]
+      } else {
+        supportedSdks.subList(0, supportedSdks.size - 1)
+          .joinToString(", ") + " $conjunction ${supportedSdks.last()}"
       }
     }
+
+    errorJSON?.let { errorJSON ->
+      try {
+        val errorCode = errorJSON.getString("errorCode")
+        val rawMessage = errorJSON.getString("message")
+        when (errorCode) {
+          "EXPERIENCE_NOT_FOUND", // Really doesn't exist
+          "EXPERIENCE_NOT_PUBLISHED_ERROR", // Not published
+          "EXPERIENCE_RELEASE_NOT_FOUND_ERROR" -> // Can't find a release for the requested release channel
+            formattedMessage = "No project found at $manifestUrl."
+
+          "EXPERIENCE_SDK_VERSION_OUTDATED" -> {
+            val metadata = errorJSON.getJSONObject("metadata")
+            val availableSDKVersions = metadata.getJSONArray("availableSDKVersions")
+            val sdkVersionRequired = availableSDKVersions.getString(0).let {
+              it.substring(0, it.indexOf('.'))
+            }
+            val maybePluralSDKsString = "SDK${"s".takeIf { supportedSdks.size > 1 } ?: ""}"
+            val expoDevLink =
+              "https://expo.dev/go?sdkVersion=$sdkVersionRequired&platform=android&device=${!isRunningOnEmulator()}"
+
+            formattedMessage =
+              "• The currently installed version of Expo Go is for <b>$maybePluralSDKsString ${
+                supportedSdksString(
+                  "and"
+                )
+              }</b>.<br>" +
+              "• The project you attempted to open uses <b>SDK $sdkVersionRequired</b>."
+            fixInstructions =
+              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>" +
+              "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
+              "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
+            canRetry = false
+          }
+
+          "EXPERIENCE_SDK_VERSION_TOO_NEW" -> {
+            formattedMessage = "This project requires a newer version of Expo Go."
+            fixInstructions = "Download the latest version of Expo Go from the Play Store."
+            canRetry = false
+          }
+
+          "EXPERIENCE_NOT_VIEWABLE" -> {
+            formattedMessage = "The experience you requested is not viewable by you."
+            fixInstructions =
+              "You need to log in. If the snack is still unavailable after logging in, ask the owner to grant you access."
+          }
+
+          "USER_SNACK_NOT_FOUND", "SNACK_NOT_FOUND" ->
+            formattedMessage = "No snack found at $manifestUrl."
+
+          "SNACK_RUNTIME_NOT_RELEASED" ->
+            formattedMessage =
+              rawMessage // From server: `The Snack runtime for corresponding sdk version of this Snack ("${sdkVersions[0]}") is not released.`,
+
+          "SNACK_NOT_FOUND_FOR_SDK_VERSION" -> run closure@{
+            val metadata = errorJSON.getJSONObject("metadata")
+            val fullName = metadata["fullName"] ?: ""
+            val snackSdkVersion =
+              (metadata["sdkVersions"] as? JSONArray)?.get(0) as? String ?: "unknown"
+            val maybePluralSDKsString = "SDK${"s".takeIf { supportedSdks.size > 1 } ?: ""}"
+
+            if (snackSdkVersion == "unknown" || snackSdkVersion.indexOf(".") == -1) {
+              formattedMessage = rawMessage
+              return@closure
+            }
+
+            val snackSdkVersionValue = try {
+              Integer.parseInt(snackSdkVersion.substring(0, snackSdkVersion.indexOf(".")))
+            } catch (e: NumberFormatException) {
+              formattedMessage = rawMessage
+              return@closure
+            }
+            formattedMessage =
+              "The snack \"${fullName}\" was found, but it is not compatible with your version of Expo Go. It was released for SDK $snackSdkVersionValue, but your Expo Go supports only $maybePluralSDKsString ${
+                supportedSdksString(
+                  "and"
+                )
+              }."
+
+            fixInstructions = if (supportedSdks.last() < snackSdkVersionValue) {
+              "You need to update your Expo Go app in order to run this Snack."
+            } else {
+              "Snack needs to be upgraded to a current SDK version. To do it, open the project at <a href='https://snack.expo.dev'>Expo Snack website</a>. It will be automatically upgraded to a supported SDK version."
+            }
+            fixInstructions += "<br><br><a href='https://docs.expo.dev/get-started/expo-go/#sdk-versions'>Learn more about SDK versions and Expo Go</a>."
+            canRetry = false
+          }
+        }
+      } catch (e: JSONException) {
+        errorMessage = formattedMessage
+        fixInstructions = null
+        canRetry = true
+      }
+    }
+    errorMessage = formattedMessage
+  }
+
+  override fun toString(): String {
+    if (fixInstructions != null) {
+      return "$errorMessage<br><br><h5><b>How to fix this error</b></h5><br>$fixInstructions"
+    }
+    return errorMessage
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -86,12 +86,12 @@ class ManifestException : ExponentException {
               "https://expo.dev/go?sdkVersion=$sdkVersionRequired&platform=android&device=${!isRunningOnEmulator()}"
 
             formattedMessage =
-              "• The currently installed version of Expo Go is for <b>$maybePluralSDKsString ${
+              "• The installed version of Expo Go is for <b>$maybePluralSDKsString ${
                 supportedSdksString(
                   "and"
                 )
               }</b>.<br>" +
-              "• The project you attempted to open uses <b>SDK $sdkVersionRequired</b>."
+              "• The project you opened uses <b>SDK $sdkVersionRequired</b>."
             fixInstructions =
               "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>" +
               "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
@@ -163,7 +163,7 @@ class ManifestException : ExponentException {
 
   override fun toString(): String {
     if (fixInstructions != null) {
-      return "$errorMessage<br><br><h5><b>How to fix this error</b></h5><br>$fixInstructions"
+      return "$errorMessage<br><br><h5><b>How to fix this error</b></h5>$fixInstructions"
     }
     return errorMessage
   }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
@@ -131,6 +131,7 @@ class ErrorActivity() : FragmentActivity() {
     const val DEVELOPER_ERROR_MESSAGE_KEY = "developerErrorMessage"
     const val DEBUG_MODE_KEY = "isDebugModeEnabled"
     const val ERROR_HEADER_KEY = "errorHeader"
+    const val CAN_RETRY_KEY = "canRetry"
 
     @JvmStatic var visibleActivity: ErrorActivity? = null
       private set

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorFragment.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorFragment.kt
@@ -54,6 +54,7 @@ class ErrorFragment : Fragment() {
     val userErrorMessage = bundle.getString(ErrorActivity.USER_ERROR_MESSAGE_KEY)
     val developerErrorMessage = bundle.getString(ErrorActivity.DEVELOPER_ERROR_MESSAGE_KEY)
     val errorHeader = bundle.getString(ErrorActivity.ERROR_HEADER_KEY)
+    val canRetry = bundle.getBoolean(ErrorActivity.CAN_RETRY_KEY, true)
 
     var defaultErrorMessage = userErrorMessage
 
@@ -72,6 +73,10 @@ class ErrorFragment : Fragment() {
     if (isHomeError || manifestUrl == null) {
       // Cannot go home in any of these cases
       binding.homeButton.visibility = View.GONE
+    }
+
+    if (!canRetry) {
+      binding.reloadButton.visibility = View.GONE
     }
 
     // Some errors are in HTML format and contain hyperlinks with instructions / more information (

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentError.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentError.kt
@@ -11,7 +11,8 @@ class ExponentError(
   val errorHeader: String?,
   val stack: Array<Bundle>,
   val exceptionId: Int,
-  val isFatal: Boolean
+  val isFatal: Boolean,
+  val canRetry: Boolean = true
 ) {
   val timestamp: Date = Calendar.getInstance().time
 
@@ -22,6 +23,7 @@ class ExponentError(
         put("errorMessage", errorMessage.developerErrorMessage())
         put("exceptionId", exceptionId)
         put("isFatal", isFatal)
+        put("canRetry", canRetry)
       }
     } catch (e: JSONException) {
       null

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -924,7 +924,7 @@ class Kernel : KernelInterface() {
   }
 
   override fun handleError(exception: Exception) {
-    handleReactNativeError(ExceptionUtils.exceptionToErrorMessage(exception), null, -1, true, ExceptionUtils.exceptionToErrorHeader(exception))
+    handleReactNativeError(ExceptionUtils.exceptionToErrorMessage(exception), null, -1, true, ExceptionUtils.exceptionToErrorHeader(exception), ExceptionUtils.exceptionToCanRetry(exception))
   }
 
   // TODO: probably need to call this from other places.
@@ -1072,7 +1072,8 @@ class Kernel : KernelInterface() {
       detailsUnversioned: Any?,
       exceptionId: Int?,
       isFatal: Boolean,
-      errorHeader: String? = null
+      errorHeader: String? = null,
+      canRetry: Boolean = true
     ) {
       val stackList = ArrayList<Bundle>()
       if (detailsUnversioned != null) {
@@ -1116,7 +1117,8 @@ class Kernel : KernelInterface() {
           errorHeader,
           stack,
           getExceptionId(exceptionId),
-          isFatal
+          isFatal,
+          canRetry
         )
       )
     }

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSError *)verifyManifestSdkVersion:(EXManifestsManifest *)maybeManifest;
 - (NSError *)formatError:(NSError *)error;
 + (NSString * _Nonnull)formatHeader:(NSError * _Nonnull)error;
-+ (NSAttributedString * _Nonnull)addErrorStringHyperlinks:(NSString * _Nonnull)errorString;
++ (NSAttributedString * _Nonnull)parseUrls:(NSString * _Nonnull)inputString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -1,10 +1,14 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXCachedResource.h"
+#import <UIKit/UIFont.h>
 
 @class EXManifestsManifest;
 
 NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const EXFixInstructionsKey;
+extern NSString * const EXShowTryAgainButtonKey;
 
 @interface EXManifestResource : EXCachedResource
 
@@ -29,7 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSError *)verifyManifestSdkVersion:(EXManifestsManifest *)maybeManifest;
 - (NSError *)formatError:(NSError *)error;
 + (NSString * _Nonnull)formatHeader:(NSError * _Nonnull)error;
-+ (NSAttributedString * _Nonnull)parseUrls:(NSString * _Nonnull)inputString;
++ (NSAttributedString *)parseUrlsInAttributedString:(NSAttributedString *)inputString;
++ (NSAttributedString *)parseBoldInAttributedString:(NSAttributedString *)inputString withFont:(UIFont *)font;
++ (NSAttributedString *)parseUrlsAndBoldInAttributedString:(NSAttributedString *)inputString withFont:(UIFont *)font;
 
 @end
 

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -15,6 +15,8 @@
 
 NSString * const kEXPublicKeyUrl = @"https://exp.host/--/manifest-public-key";
 NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
+NSString * const EXFixInstructionsKey = @"fixInstructions";
+NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
 
 @interface EXManifestResource ()
 
@@ -202,16 +204,31 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
 
 - (NSInteger)sdkVersionStringToInt:(nonnull NSString *)sdkVersion {
   NSRange snackSdkVersionRange = [sdkVersion rangeOfString: @"."];
-  return [[sdkVersion substringToIndex: snackSdkVersionRange.location] intValue];
+  return [[sdkVersion substringToIndex:snackSdkVersionRange.location] intValue];
+}
+
+-(NSArray<NSNumber *> *)supportedSdkVersionInts {
+  NSArray *supportedSDKVersions = [EXVersions sharedInstance].versions[@"sdkVersions"];
+  NSMutableArray *supportedSDKVersionInts = [NSMutableArray arrayWithCapacity:[supportedSDKVersions count]];
+
+  [supportedSDKVersions enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    if ([obj isKindOfClass:[NSString class]]){
+      NSString *stringObj = (NSString *) obj;
+      NSNumber *versionNumber = [NSNumber numberWithInt:[stringObj intValue]];
+      [supportedSDKVersionInts addObject:versionNumber];
+    }
+  }];
+  [supportedSDKVersionInts sortUsingSelector:@selector(compare:)];
+  return supportedSDKVersionInts;
 }
 
 - (NSString *)supportedSdkVersionsConjunctionString:(nonnull NSString *)conjunction {
-  NSArray *supportedSDKVersions = [EXVersions sharedInstance].versions[@"sdkVersions"];
-  NSString *stringBeginning = [[supportedSDKVersions subarrayWithRange:NSMakeRange(0, supportedSDKVersions.count - 1)] componentsJoinedByString:@", "];
-  if (supportedSDKVersions.count > 1) {
-    return [NSString stringWithFormat:@"%@ %@ %@", stringBeginning, conjunction, [supportedSDKVersions lastObject]];
+  NSArray *supportedSDKVersionInts = [self supportedSdkVersionInts];
+  NSString *stringBeginning = [[supportedSDKVersionInts subarrayWithRange:NSMakeRange(0, supportedSDKVersionInts.count - 1)] componentsJoinedByString:@", "];
+  if (supportedSDKVersionInts.count > 1) {
+    return [NSString stringWithFormat:@"%@ %@ %@", stringBeginning, conjunction, [supportedSDKVersionInts lastObject]];
   }
-  return [supportedSDKVersions firstObject];
+  return [NSString stringWithFormat:@"%d", [[supportedSDKVersionInts firstObject] intValue]];
 }
 
 - (NSError *)verifyManifestSdkVersion:(EXManifestsManifest *)maybeManifest
@@ -292,7 +309,9 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
   NSString *errorCode = userInfo[@"errorCode"];
   NSString *rawMessage = [error localizedDescription];
-  
+  NSString *fixInstructions = nil;
+  Boolean showTryAgainButton = true;
+
   NSString *formattedMessage = [NSString stringWithFormat:@"Could not load %@.", self.originalUrl];
   if ([errorCode isEqualToString:@"EXPERIENCE_NOT_FOUND"]
       || [errorCode isEqualToString:@"EXPERIENCE_NOT_PUBLISHED_ERROR"]
@@ -300,49 +319,57 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     formattedMessage = [NSString stringWithFormat:@"No project found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_OUTDATED"]) {
     NSDictionary *metadata = userInfo[@"metadata"];
+    NSArray *supportedSDKVersions = [EXVersions sharedInstance].versions[@"sdkVersions"];
     NSArray *availableSDKVersions = metadata[@"availableSDKVersions"];
     NSString *sdkVersionRequired = [availableSDKVersions firstObject];
     int requiredVersionNum = [sdkVersionRequired intValue];
-    NSArray *supportedSDKVersions = [EXVersions sharedInstance].versions[@"sdkVersions"];
+    NSString * expoDevLink = [NSString stringWithFormat:@"https://expo.dev/go?sdkVersion=%d&platform=ios&device=false", requiredVersionNum];
+    NSArray *supportedSDKVersionInts = [self supportedSdkVersionInts];
+
     NSString *maybePluralSdkString = [supportedSDKVersions count] == 1 ? @"SDK" : @"SDKs";
 
-#if (TARGET_OS_SIMULATOR)
-    NSString * expoDevLink = [NSString stringWithFormat: @"https://expo.dev/go?sdkVersion=%d&platform=ios&device=false", requiredVersionNum];
+    showTryAgainButton = false;
     formattedMessage = [NSString stringWithFormat:
-                          @"This project uses SDK %@, but this version of Expo Go supports only %@ %@.\n\n"
-                        @"To open this project you can either:\n"
-                        @"• Update it to SDK %@.\n"
-                        @"• Install an older version of Expo Go that supports the project's SDK version.\n\n"
-                        @"If you are unsure how to update the project refer to the [https://docs.expo.dev/get-started/expo-go/#sdk-versions](SDK Versions Guide).\n"
-                        @"You can also learn how to [%@](install a suitable Expo Go version).",
-                        sdkVersionRequired,
+                          @"• The currently installed version of Expo Go is for **%@ %@**.\n"
+                        @"• The project you attempted to open uses **SDK %d**.",
                         maybePluralSdkString,
                         [self supportedSdkVersionsConjunctionString:@"and"],
-                        [self supportedSdkVersionsConjunctionString:@"or"],
-                        expoDevLink
+                        requiredVersionNum
+    ];
+
+#if (TARGET_OS_SIMULATOR)
+    fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@ or install a version of Expo Go that is compatible with your project.\n\n"
+                       @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
+                       @"[%@](Learn how to install Expo Go for SDK %d.)",
+                       [self supportedSdkVersionsConjunctionString:@"or"],
+                       [[supportedSDKVersionInts lastObject] intValue],
+                       expoDevLink,
+                       requiredVersionNum
     ];
 #else
-    NSString * expoDevLink = [NSString stringWithFormat: @"https://expo.dev/go?sdkVersion=%d&platform=ios&device=true", requiredVersionNum];
-    formattedMessage = [NSString stringWithFormat:
-                          @"This project uses SDK %@, but this version of Expo Go supports only %@ %@.\n\n"
-                        @"To open this project on a physical iOS device you have to update it to SDK %@.\n\n"
-                        @"[%@](Learn more about SDK compatibility for Expo Go running on iOS devices.)",
-                        sdkVersionRequired,
-                        maybePluralSdkString,
-                        [self supportedSdkVersionsConjunctionString:@"and"],
-                        [self supportedSdkVersionsConjunctionString:@"or"],
-                        expoDevLink
+    fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
+                       @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
+                       @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
+                       [self supportedSdkVersionsConjunctionString:@"or"],
+                       [[supportedSDKVersionInts lastObject] intValue],
+                       expoDevLink,
+                       requiredVersionNum
     ];
 #endif
   } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
     NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];
-    formattedMessage = [NSString stringWithFormat:@"Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): %@. A development build must be used to load other runtimes.\n[https://docs.expo.dev/develop/development-builds/introduction/](Learn more about development builds).", supportedSDKVersions];
+    formattedMessage = [NSString stringWithFormat:@"Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): %@", supportedSDKVersions];
+    fixInstructions = @"A development build must be used to load other runtimes.\n[https://docs.expo.dev/develop/development-builds/introduction/](Learn more about development builds).";
+    showTryAgainButton = false;
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
-    formattedMessage = @"The project you requested requires a newer version of Expo Go. Please download the latest version from the App Store.";
+    formattedMessage = @"The project you requested requires a newer version of Expo Go.";
+    fixInstructions = @"Download the latest version of Expo Go from the App Store.";
+    showTryAgainButton = false;
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
-    formattedMessage = rawMessage; // From server: The experience you requested is not viewable by you. You will need to log in or ask the owner to grant you access.
+    formattedMessage = @"The experience you requested is not viewable by you."; 
+    fixInstructions = @"You need to log in. If the snack is still unavailable after logging in, ask the owner to grant you access.";
   } else if ([errorCode isEqualToString:@"USER_SNACK_NOT_FOUND"] || [errorCode isEqualToString:@"SNACK_NOT_FOUND"]) {
     formattedMessage = [NSString stringWithFormat:@"No snack found at %@.", self.originalUrl];
   } else if ([errorCode isEqualToString:@"SNACK_RUNTIME_NOT_RELEASE"]) {
@@ -351,20 +378,23 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     NSDictionary *metadata = userInfo[@"metadata"];
     NSString *fullName = metadata[@"fullName"];
     NSString *snackSdkVersion = metadata[@"sdkVersions"][0];
-    NSInteger snackSdkVersionValue = [self sdkVersionStringToInt: snackSdkVersion];
+    NSInteger snackSdkVersionValue = [self sdkVersionStringToInt:snackSdkVersion];
     NSArray *supportedSdkVersions = [EXVersions sharedInstance].versions[@"sdkVersions"];
-    NSInteger latestSupportedSdkVersionValue = [self sdkVersionStringToInt: supportedSdkVersions[0]];
+    NSInteger latestSupportedSdkVersionValue = [self sdkVersionStringToInt:supportedSdkVersions[0]];
     NSString *maybePluralSdkString = [supportedSdkVersions count] == 1 ? @"SDK" : @"SDKs";
 
     formattedMessage = [NSString stringWithFormat:@"The snack \"%@\" was found, but it is not compatible with your version of Expo Go. It was released for SDK %@, but your Expo Go supports only %@ %@.", fullName, snackSdkVersion, maybePluralSdkString, [self supportedSdkVersionsConjunctionString:@"and"]];
 
     if (snackSdkVersionValue > latestSupportedSdkVersionValue) {
-      formattedMessage = [NSString stringWithFormat:@"%@\n\nYou need to update your Expo Go app in order to run this snack.", formattedMessage];
+      fixInstructions = @"You need to update your Expo Go app in order to run this snack.";
     } else {
-      formattedMessage = [NSString stringWithFormat:@"%@\n\nSnack needs to be upgraded to a current SDK version. To do it, open the project at [https://snack.expo.dev](Expo Snack website). It will be automatically upgraded to a supported SDK version.", formattedMessage];
+      fixInstructions = @"Snack needs to be upgraded to a current SDK version. To do it, open the project at [https://snack.expo.dev](Expo Snack website). It will be automatically upgraded to a supported SDK version";
     }
-    formattedMessage = [NSString stringWithFormat:@"%@\n\nLearn more about SDK versions and Expo Go in the [https://docs.expo.dev/get-started/expo-go/#sdk-versions](SDK Versions Guide).", formattedMessage];
+    fixInstructions = [NSString stringWithFormat:@"%@\n\nLearn more about SDK versions and Expo Go in the [https://docs.expo.dev/get-started/expo-go/#sdk-versions](SDK Versions Guide).", fixInstructions];
+    showTryAgainButton = false;
   }
+  userInfo[EXShowTryAgainButtonKey] = [NSNumber numberWithBool:showTryAgainButton];
+  userInfo[EXFixInstructionsKey] = fixInstructions;
   userInfo[NSLocalizedDescriptionKey] = formattedMessage;
   
   return [NSError errorWithDomain:EXRuntimeErrorDomain code:error.code userInfo:userInfo];
@@ -383,31 +413,64 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
   return nil;
 }
 
-+ (NSAttributedString * _Nonnull)parseUrls:(NSString * _Nonnull)inputString {
++ (NSAttributedString *)parseUrlsInAttributedString:(NSAttributedString *)inputString {
   NSError *error = NULL;
 
-  // [anystring](anystring)
-  NSString *pattern = @"\\[(.*?)\\]\\((.*?)\\)";
-  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                         options:NSRegularExpressionCaseInsensitive
-                                                                           error:&error];
-  NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:inputString];
-  NSArray *matches = [regex matchesInString:inputString
-                                    options:0
-                                      range:NSMakeRange(0, [inputString length])];
-  NSArray* reverseMatches = [[matches reverseObjectEnumerator] allObjects];
+  // [url](text)
+  NSString *urlPattern = @"\\[(.*?)\\]\\((.*?)\\)";
+  NSRegularExpression *urlRegex = [NSRegularExpression regularExpressionWithPattern:urlPattern
+                                                                            options:NSRegularExpressionCaseInsensitive
+                                                                              error:&error];
 
-  // Iterate the matches in reverse order to avoid index problems when replacing text
-  for (NSTextCheckingResult *match in reverseMatches) {
+  NSMutableAttributedString *attributedString = [inputString mutableCopy];
+  NSArray *urlMatches = [urlRegex matchesInString:attributedString.string options:0 range:NSMakeRange(0, attributedString.length)];
+  NSArray *reverseUrlMatches = [[urlMatches reverseObjectEnumerator] allObjects];
+
+  // Iterate in reverse to avoid issues with replacing text
+  for (NSTextCheckingResult *match in reverseUrlMatches) {
     for (int i = [match numberOfRanges] - 1; i > 1; i--) { // Ignore match no.1, which is a full match
-      NSString *link = [inputString substringWithRange:[match rangeAtIndex:1]];
-      NSString *replacement = [inputString substringWithRange:[match rangeAtIndex:2]];
+      NSString *link = [attributedString.string substringWithRange:[match rangeAtIndex:1]];
+      NSString *replacement = [attributedString.string substringWithRange:[match rangeAtIndex:2]];
 
       [attributedString replaceCharactersInRange:match.range withString:replacement];
       [attributedString addAttribute:NSLinkAttributeName value:link range:NSMakeRange(match.range.location, replacement.length)];
     }
   }
   return attributedString;
+}
+
++ (NSAttributedString *)parseBoldInAttributedString:(NSAttributedString *)inputString withFont:(UIFont *)font {
+  NSError *error = NULL;
+
+  // **text to bold**
+  NSString *boldPattern = @"\\*\\*(.*?)\\*\\*";
+  NSRegularExpression *boldRegex = [NSRegularExpression regularExpressionWithPattern:boldPattern
+                                                                             options:NSRegularExpressionCaseInsensitive
+                                                                               error:&error];
+
+  NSMutableAttributedString *attributedString = [inputString mutableCopy];
+  NSArray *boldMatches = [boldRegex matchesInString:attributedString.string options:0 range:NSMakeRange(0, attributedString.length)];
+  NSArray *reverseBoldMatches = [[boldMatches reverseObjectEnumerator] allObjects];
+
+  [attributedString addAttributes:@{NSFontAttributeName:font} range:NSMakeRange(0, attributedString.length)];
+
+  // Iterate in reverse to avoid issues with replacing text
+  for (NSTextCheckingResult *match in reverseBoldMatches) {
+    NSRange matchRange = [match rangeAtIndex:1];
+    NSString *textToBold = [attributedString.string substringWithRange:matchRange];
+    NSAttributedString *boldString = [[NSAttributedString alloc]
+                                      initWithString:textToBold
+                                      attributes:@{NSFontAttributeName:[UIFont boldSystemFontOfSize:font.pointSize]}
+    ];
+    [attributedString replaceCharactersInRange:match.range withAttributedString:boldString];
+  }
+
+  return attributedString;
+}
+
++ (NSAttributedString *)parseUrlsAndBoldInAttributedString:(NSAttributedString *)inputString withFont:(UIFont *)font {
+  NSAttributedString *boldProcessedString = [self parseBoldInAttributedString:inputString withFont:font];
+  return [self parseUrlsInAttributedString:boldProcessedString];
 }
 
 @end

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -330,8 +330,8 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
 
     showTryAgainButton = false;
     formattedMessage = [NSString stringWithFormat:
-                          @"• The currently installed version of Expo Go is for **%@ %@**.\n"
-                        @"• The project you attempted to open uses **SDK %d**.",
+                          @"• The installed version of Expo Go is for **%@ %@**.\n"
+                        @"• The project you opened uses **SDK %d**.",
                         maybePluralSdkString,
                         [self supportedSdkVersionsConjunctionString:@"and"],
                         requiredVersionNum

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -104,7 +104,7 @@
       break;
     }
   }
-  NSAttributedString *attributedErrorString = [EXManifestResource addErrorStringHyperlinks:errorDetail];
+  NSAttributedString *attributedErrorString = [EXManifestResource parseUrls:errorDetail];
 
   UIFont *font = _txtErrorDetail.font;
   _txtErrorDetail.attributedText = attributedErrorString;

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -20,6 +20,9 @@
 @property (nonatomic, strong) IBOutlet UILabel *lblUrl;
 @property (nonatomic, strong) IBOutlet UITextView *txtErrorDetail;
 @property (nonatomic, strong) IBOutlet UIScrollView *vContainer;
+@property (nonatomic, strong) IBOutlet UILabel *lblFixHeader;
+@property (nonatomic, strong) IBOutlet UITextView *txtFixDetail;
+
 
 - (void)_onTapRetry;
 
@@ -38,7 +41,10 @@
 
     [_txtErrorDetail setTextContainerInset:UIEdgeInsetsZero];
     _txtErrorDetail.textContainer.lineFragmentPadding = 0;
-    
+
+    [_txtFixDetail setTextContainerInset:UIEdgeInsetsZero];
+    _txtFixDetail.textContainer.lineFragmentPadding = 0;
+
     for (UIButton *btnToStyle in @[ _btnRetry, _btnBack ]) {
       btnToStyle.layer.cornerRadius = 4.0;
       btnToStyle.layer.masksToBounds = YES;
@@ -77,7 +83,10 @@
   _error = error;
   NSString *errorHeader = [EXManifestResource formatHeader:error];
   NSString *errorDetail = [error localizedDescription];
-  
+  NSString *errorFixInstructions = [error userInfo][EXFixInstructionsKey];
+  NSNumber *showTryAgainButtonNumber = [error userInfo][EXShowTryAgainButtonKey];
+  Boolean showTryAgainButton = [showTryAgainButtonNumber boolValue];
+
   if (errorHeader != nil) {
     _lblError.text = errorHeader;
   }
@@ -104,12 +113,27 @@
       break;
     }
   }
-  NSAttributedString *attributedErrorString = [EXManifestResource parseUrls:errorDetail];
 
   UIFont *font = _txtErrorDetail.font;
+  NSAttributedString *attributedErrorString =[[NSAttributedString alloc] initWithString:errorDetail];
+  attributedErrorString = [EXManifestResource parseUrlsAndBoldInAttributedString:attributedErrorString withFont:font];
+
   _txtErrorDetail.attributedText = attributedErrorString;
-  _txtErrorDetail.font = font;
   _txtErrorDetail.textColor = [UIColor colorNamed:@"textDefault"];
+
+  if (errorFixInstructions != nil) {
+    NSAttributedString *attributedFixInstructions = [[NSAttributedString alloc] initWithString:errorFixInstructions];
+    attributedFixInstructions = [EXManifestResource parseUrlsAndBoldInAttributedString:attributedFixInstructions withFont:font];
+    _txtFixDetail.attributedText = attributedFixInstructions;
+    _txtFixDetail.textColor = [UIColor colorNamed:@"textDefault"];
+  } else {
+    [_lblFixHeader removeFromSuperview];
+    [_txtFixDetail removeFromSuperview];
+  }
+
+  if (!showTryAgainButton) {
+    [_btnRetry removeFromSuperview];
+  }
 
   [self _resetUIState];
 }

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -17,8 +17,10 @@
                 <outlet property="btnStack" destination="Mh8-u0-LCN" id="0eD-IY-253"/>
                 <outlet property="btnStackContainer" destination="3xg-me-cwE" id="Gyu-3k-RG8"/>
                 <outlet property="lblError" destination="iXc-4d-VpK" id="1Sa-Te-jkb"/>
+                <outlet property="lblFixHeader" destination="net-Bc-aEY" id="adP-Lk-1lH"/>
                 <outlet property="lblUrl" destination="uZA-n9-0bf" id="jvM-WQ-o0R"/>
                 <outlet property="txtErrorDetail" destination="b2p-se-FvF" id="end-RV-Org"/>
+                <outlet property="txtFixDetail" destination="UCx-uh-Nic" id="ZOA-Dk-eFW"/>
                 <outlet property="vContainer" destination="zz8-rt-yG1" id="V5Q-DG-oIp"/>
             </connections>
         </placeholder>
@@ -38,6 +40,22 @@
                         </label>
                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Error Detail" translatesAutoresizingMaskIntoConstraints="NO" id="b2p-se-FvF">
                             <rect key="frame" x="16" y="69" width="382" height="35.5"/>
+                            <color key="textColor" name="textDefault"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                            <variation key="heightClass=regular-widthClass=compact">
+                                <color key="textColor" name="textDefault"/>
+                            </variation>
+                        </textView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How To Fix This Error" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="net-Bc-aEY">
+                            <rect key="frame" x="16" y="120.5" width="382" height="19.5"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                            <color key="textColor" name="textDefault"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Fix Detail" translatesAutoresizingMaskIntoConstraints="NO" id="UCx-uh-Nic" userLabel="Fix Detail View">
+                            <rect key="frame" x="16" y="156" width="382" height="35.5"/>
                             <color key="textColor" name="textDefault"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -96,7 +114,7 @@
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https::/expo.dev" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-n9-0bf" userLabel="URL">
-                            <rect key="frame" x="16" y="120.5" width="382" height="17"/>
+                            <rect key="frame" x="16" y="207.5" width="382" height="17"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.34509803919999998" green="0.37254901959999998" blue="0.41176470590000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -104,7 +122,11 @@
                     </subviews>
                     <color key="backgroundColor" name="backgroundDefault"/>
                     <constraints>
+                        <constraint firstItem="uZA-n9-0bf" firstAttribute="top" secondItem="b2p-se-FvF" secondAttribute="bottom" priority="100" constant="16" id="36Q-h8-DbH"/>
+                        <constraint firstAttribute="trailing" secondItem="UCx-uh-Nic" secondAttribute="trailing" constant="16" id="5RF-z4-fHZ"/>
+                        <constraint firstAttribute="trailing" secondItem="net-Bc-aEY" secondAttribute="trailing" constant="16" id="CML-2E-6dH"/>
                         <constraint firstItem="uZA-n9-0bf" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="Cui-bY-DKE"/>
+                        <constraint firstItem="net-Bc-aEY" firstAttribute="leading" secondItem="zz8-rt-yG1" secondAttribute="leading" constant="16" id="DeD-NU-gUb"/>
                         <constraint firstAttribute="bottom" secondItem="3xg-me-cwE" secondAttribute="bottom" id="EgY-Lw-8hH"/>
                         <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="uZA-n9-0bf" secondAttribute="trailing" constant="16" id="FZ2-yM-eP7"/>
                         <constraint firstItem="3xg-me-cwE" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" id="Ipc-jE-LO6"/>
@@ -112,11 +134,14 @@
                         <constraint firstItem="iXc-4d-VpK" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="TT1-8U-uOh"/>
                         <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="iXc-4d-VpK" secondAttribute="trailing" constant="16" id="UGR-Hv-DvO"/>
                         <constraint firstAttribute="trailing" secondItem="b2p-se-FvF" secondAttribute="trailing" constant="16" id="WFh-gD-g1e"/>
+                        <constraint firstItem="uZA-n9-0bf" firstAttribute="top" secondItem="UCx-uh-Nic" secondAttribute="bottom" priority="101" constant="16" id="WuI-4y-SCu"/>
                         <constraint firstItem="iXc-4d-VpK" firstAttribute="top" secondItem="fm7-WM-hm7" secondAttribute="top" constant="24" id="a35-DY-9eM"/>
                         <constraint firstItem="b2p-se-FvF" firstAttribute="top" secondItem="iXc-4d-VpK" secondAttribute="bottom" constant="16" id="aEJ-db-2Z1"/>
                         <constraint firstAttribute="trailing" secondItem="iXc-4d-VpK" secondAttribute="trailing" constant="16" id="cNY-0g-EDJ"/>
-                        <constraint firstItem="uZA-n9-0bf" firstAttribute="top" secondItem="b2p-se-FvF" secondAttribute="bottom" constant="16" id="lwE-aa-vgb"/>
+                        <constraint firstItem="UCx-uh-Nic" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="ejR-Ow-lIT"/>
                         <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="3xg-me-cwE" secondAttribute="trailing" id="mbs-0b-6Ha"/>
+                        <constraint firstItem="net-Bc-aEY" firstAttribute="top" secondItem="b2p-se-FvF" secondAttribute="bottom" constant="16" id="mjt-W8-arK"/>
+                        <constraint firstItem="UCx-uh-Nic" firstAttribute="top" secondItem="net-Bc-aEY" secondAttribute="bottom" constant="16" id="oZ2-Q3-ec3"/>
                         <constraint firstItem="b2p-se-FvF" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="uNY-Uo-9gb"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="ipk-Hz-A80"/>
@@ -131,7 +156,7 @@
                 <constraint firstItem="zz8-rt-yG1" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="-2" id="RtF-FP-x5O"/>
                 <constraint firstItem="zz8-rt-yG1" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="44" id="Xdc-k0-Hk4"/>
             </constraints>
-            <point key="canvasLocation" x="131.8840579710145" y="118.52678571428571"/>
+            <point key="canvasLocation" x="163.768115942029" y="118.52678571428571"/>
         </view>
     </objects>
     <resources>
@@ -139,19 +164,19 @@
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <namedColor name="buttonSecondaryBackground">
-            <color red="0.94117647058823528" green="0.94509803921568625" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94099998474121094" green="0.94499999284744263" blue="0.94900000095367432" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="buttonSecondaryText">
-            <color red="0.10588235294117647" green="0.12156862745098039" blue="0.13725490196078433" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.10599999874830246" green="0.12200000137090683" blue="0.13699999451637268" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="buttonTertiaryBackground">
-            <color red="0.10588235294117647" green="0.12156862745098039" blue="0.13725490196078433" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.10599999874830246" green="0.12200000137090683" blue="0.13699999451637268" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="buttonTertiaryText">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="textDefault">
-            <color red="0.14117647058823529" green="0.16078431372549018" blue="0.18431372549019609" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+            <color red="0.14100000262260437" green="0.16099999845027924" blue="0.18400000035762787" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
@@ -48,14 +48,14 @@
                                 <color key="textColor" name="textDefault"/>
                             </variation>
                         </textView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How To Fix This Error" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="net-Bc-aEY">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How to fix this error" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="net-Bc-aEY">
                             <rect key="frame" x="16" y="120.5" width="382" height="19.5"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                             <color key="textColor" name="textDefault"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Fix Detail" translatesAutoresizingMaskIntoConstraints="NO" id="UCx-uh-Nic" userLabel="Fix Detail View">
-                            <rect key="frame" x="16" y="156" width="382" height="35.5"/>
+                            <rect key="frame" x="16" y="142" width="382" height="35.5"/>
                             <color key="textColor" name="textDefault"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -114,7 +114,7 @@
                             </constraints>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https::/expo.dev" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-n9-0bf" userLabel="URL">
-                            <rect key="frame" x="16" y="207.5" width="382" height="17"/>
+                            <rect key="frame" x="16" y="193.5" width="382" height="17"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.34509803919999998" green="0.37254901959999998" blue="0.41176470590000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -141,7 +141,7 @@
                         <constraint firstItem="UCx-uh-Nic" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="ejR-Ow-lIT"/>
                         <constraint firstItem="fm7-WM-hm7" firstAttribute="trailing" secondItem="3xg-me-cwE" secondAttribute="trailing" id="mbs-0b-6Ha"/>
                         <constraint firstItem="net-Bc-aEY" firstAttribute="top" secondItem="b2p-se-FvF" secondAttribute="bottom" constant="16" id="mjt-W8-arK"/>
-                        <constraint firstItem="UCx-uh-Nic" firstAttribute="top" secondItem="net-Bc-aEY" secondAttribute="bottom" constant="16" id="oZ2-Q3-ec3"/>
+                        <constraint firstItem="UCx-uh-Nic" firstAttribute="top" secondItem="net-Bc-aEY" secondAttribute="bottom" constant="2" id="oZ2-Q3-ec3"/>
                         <constraint firstItem="b2p-se-FvF" firstAttribute="leading" secondItem="fm7-WM-hm7" secondAttribute="leading" constant="16" id="uNY-Uo-9gb"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="ipk-Hz-A80"/>


### PR DESCRIPTION
# Why

We want to link people to `https://expo.dev/go` when they launch an incompatible project in Expo Go so it's easier for them to install a compatible Expo Go app.

ENG-11732

# How

Edited the existing messages to include installation links. Depending if running on a iOS device or in a simulator the behaviour is slightly different.

Also updated the code to work correctly when only one SDK version is available, on iOS added a more universal link parser that changes any combination of `[link](description)` into a hyperlink instead.

# Test Plan

Tested in Expo Go on a physical Android device, emulator, physical iOS device and iOS emulator

|Android|iOS Simulator|iOS Device|
| --- | --- | --- |
|<img width="200" alt="android" src="https://github.com/expo/expo/assets/31368152/bbcbeb16-af72-4d04-a078-bc4185093fdc"> | <img width="200" alt="simulator" src="https://github.com/expo/expo/assets/31368152/676296fa-e867-4153-b01a-690eb9a36664">| <img width="200" alt="physical" src="https://github.com/expo/expo/assets/31368152/9bbfa919-a052-4bd8-9b52-8fbce07a5042">|
