### PR TITLE
[camera] prevent config changes where possible

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - On `Android`, requesting audio permissions was meant to be optional in the config plugin. ([#27365](https://github.com/expo/expo/pull/27365) by [@alanjhughes](https://github.com/alanjhughes))
-- Prevent unnecessary configuration changes wherever possible.
+- Prevent unnecessary configuration changes wherever possible. ([#27919](https://github.com/expo/expo/pull/27919) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 14.1.1 - 2024-03-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - On `Android`, requesting audio permissions was meant to be optional in the config plugin. ([#27365](https://github.com/expo/expo/pull/27365) by [@alanjhughes](https://github.com/alanjhughes))
+- Prevent unnecessary configuration changes wherever possible.
 
 ## 14.1.1 - 2024-03-13
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
@@ -81,35 +81,49 @@ class CameraViewNextModule : Module() {
     View(ExpoCameraView::class) {
       Events(cameraEvents)
 
-      Prop("facing") { view, facing: CameraType ->
-        view.lenFacing = facing
+      Prop("facing") { view, facing: CameraType? ->
+        facing?.let {
+          if (view.lenFacing != facing) {
+            view.lenFacing = it
+          }
+        }
       }
 
-      Prop("flashMode") { view, flashMode: FlashMode ->
-        view.setCameraFlashMode(flashMode)
+      Prop("flashMode") { view, flashMode: FlashMode? ->
+        flashMode?.let {
+          view.setCameraFlashMode(it)
+        }
       }
 
-      Prop("enableTorch") { view, enabled: Boolean ->
-        view.setTorchEnabled(enabled)
+      Prop("enableTorch") { view, enabled: Boolean? ->
+        view.setTorchEnabled(enabled ?: false)
       }
 
-      Prop("zoom") { view, zoom: Float ->
-        view.camera?.cameraControl?.setLinearZoom(zoom)
+      Prop("zoom") { view, zoom: Float? ->
+        zoom?.let {
+          view.camera?.cameraControl?.setLinearZoom(it)
+        }
       }
 
-      Prop("mode") { view, mode: CameraMode ->
-        view.cameraMode = mode
+      Prop("mode") { view, mode: CameraMode? ->
+        mode?.let {
+          if (view.cameraMode != mode) {
+            view.cameraMode = it
+          }
+        }
       }
 
       Prop("mute") { view, muted: Boolean? ->
-        view.mute = muted ?: false
+        muted?.let {
+          if (it != view.mute) {
+            view.mute = it
+          }
+        }
       }
 
       Prop("videoQuality") { view, quality: VideoQuality? ->
-        if (quality != null) {
-          view.videoQuality = quality
-        } else {
-          view.videoQuality = VideoQuality.VIDEO1080P
+        quality?.let {
+          view.videoQuality = it
         }
       }
 
@@ -121,11 +135,17 @@ class CameraViewNextModule : Module() {
       }
 
       Prop("barcodeScannerEnabled") { view, enabled: Boolean? ->
-        view.setShouldScanBarcodes(enabled ?: false)
+        enabled?.let {
+          view.setShouldScanBarcodes(enabled)
+        }
       }
 
       Prop("pictureSize") { view, pictureSize: String? ->
-        view.pictureSize = pictureSize ?: ""
+        pictureSize?.let {
+          if (view.pictureSize != pictureSize) {
+            view.pictureSize = it
+          }
+        }
       }
 
       AsyncFunction("takePicture") { view: ExpoCameraView, options: PictureOptions, promise: Promise ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -186,7 +186,9 @@ class ExpoCameraView(
   }
 
   fun setCameraFlashMode(mode: FlashMode) {
-    imageCaptureUseCase?.flashMode = mode.mapToLens()
+    if (imageCaptureUseCase?.flashMode != mode.mapToLens()) {
+      imageCaptureUseCase?.flashMode = mode.mapToLens()
+    }
   }
 
   fun setTorchEnabled(enabled: Boolean) {

--- a/packages/expo-camera/ios/CameraView.swift
+++ b/packages/expo-camera/ios/CameraView.swift
@@ -891,7 +891,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         barCodeScanner.stopBarCodeScanning()
       }
 
-      self.session.stopRunning()
       self.session.beginConfiguration()
       self.motionManager.stopAccelerometerUpdates()
       self.previewLayer?.removeFromSuperlayer()
@@ -904,6 +903,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         self.session.removeOutput(output)
       }
       self.session.commitConfiguration()
+      self.session.stopRunning()
     }
   }
 

--- a/packages/expo-camera/ios/CameraViewNextModule.swift
+++ b/packages/expo-camera/ios/CameraViewNextModule.swift
@@ -42,56 +42,66 @@ public final class CameraViewNextModule: Module, ScannerResultHandler {
     View(CameraViewNext.self) {
       Events(cameraNextEvents)
 
-      Prop("facing") { (view, type: CameraTypeNext) in
-        if view.presetCamera != type.toPosition() {
+      Prop("facing") { (view, type: CameraTypeNext?) in
+        if let type, view.presetCamera != type.toPosition() {
           view.presetCamera = type.toPosition()
         }
       }
 
-      Prop("flashMode") { (view, flashMode: CameraFlashModeNext) in
-        if view.flashMode != flashMode {
+      Prop("flashMode") { (view, flashMode: CameraFlashModeNext?) in
+        if let flashMode, view.flashMode != flashMode {
           view.flashMode = flashMode
         }
       }
 
-      Prop("enableTorch") { (view, enabled: Bool) in
-        view.torchEnabled = enabled
+      Prop("enableTorch") { (view, enabled: Bool?) in
+        view.torchEnabled = enabled ?? false
       }
 
       Prop("pictureSize") { (view, pictureSize: PictureSize?) in
-        view.pictureSize = pictureSize ?? .high
+        if let pictureSize, view.pictureSize != pictureSize {
+          view.pictureSize = pictureSize
+        }
       }
 
-      Prop("zoom") { (view, zoom: Double) in
-        if fabs(view.zoom - zoom) > Double.ulpOfOne {
+      Prop("zoom") { (view, zoom: Double?) in
+        if let zoom, fabs(view.zoom - zoom) > Double.ulpOfOne {
           view.zoom = zoom
         }
       }
 
-      Prop("mode") { (view, mode: CameraModeNext) in
-        if view.mode != mode {
+      Prop("mode") { (view, mode: CameraModeNext?) in
+        if let mode, view.mode != mode {
           view.mode = mode
         }
       }
 
       Prop("barcodeScannerEnabled") { (view, scanBarcodes: Bool?) in
-        view.isScanningBarcodes = scanBarcodes ?? false
+        if let scanBarcodes, view.isScanningBarcodes != scanBarcodes {
+          view.isScanningBarcodes = scanBarcodes
+        }
       }
 
-      Prop("barcodeScannerSettings") { (view, settings: BarcodeSettings) in
-        view.setBarcodeScannerSettings(settings: settings)
+      Prop("barcodeScannerSettings") { (view, settings: BarcodeSettings?) in
+        if let settings {
+          view.setBarcodeScannerSettings(settings: settings)
+        }
       }
 
-      Prop("mute") { (view, muted: Bool) in
-        view.isMuted = muted
+      Prop("mute") { (view, muted: Bool?) in
+        if let muted, view.isMuted != muted {
+          view.isMuted = muted
+        }
       }
 
-      Prop("videoQuality") { (view, quality: VideoQuality) in
-        view.videoQuality = quality
+      Prop("videoQuality") { (view, quality: VideoQuality?) in
+        if let quality, view.videoQuality != quality {
+          view.videoQuality = quality
+        }
       }
 
-      Prop("responsiveOrientationWhenOrientationLocked") { (view, responsiveOrientation: Bool) in
-        if view.responsiveWhenOrientationLocked != responsiveOrientation {
+      Prop("responsiveOrientationWhenOrientationLocked") { (view, responsiveOrientation: Bool?) in
+        if let responsiveOrientation, view.responsiveWhenOrientationLocked != responsiveOrientation {
           view.responsiveWhenOrientationLocked = responsiveOrientation
         }
       }

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -218,18 +218,15 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
     }
 
     sessionQueue.async {
-      self.session.beginConfiguration()
-
       let photoOutput = AVCapturePhotoOutput()
+      photoOutput.isLivePhotoCaptureEnabled = false
       if self.session.canAddOutput(photoOutput) {
         self.session.addOutput(photoOutput)
-        photoOutput.isLivePhotoCaptureEnabled = false
         self.photoOutput = photoOutput
       }
 
       self.addErrorNotification()
       self.changePreviewOrientation()
-      self.session.commitConfiguration()
 
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
# Why
Because the camera is so sensitive to config changes, we should limit them as much as possible. This also improves performance as the camera is not doing unnecessary setup for default values.

# How
Check that the incoming prop value is different from the current configuration before applying it.

# Test Plan
Bare-expo

