### PR TITLE
[core] Fix reloading crash on bridgeless mode

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
+- Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -5,6 +5,7 @@
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RCTHost.h>
+#import <ReactCommon/RCTHost+Internal.h>
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 #import <React-RCTAppDelegate/RCTAppDelegate.h>
@@ -17,9 +18,12 @@
 
 @end
 
-@interface RCTRootViewFactory () {
+@interface RCTRootViewFactory () <RCTContextContainerHandling> {
   RCTHost *_reactHost;
+  __weak id<RCTTurboModuleManagerDelegate> _turboModuleManagerDelegate;
 }
+
+- (std::shared_ptr<facebook::react::JSRuntimeFactory>)createJSRuntimeFactory;
 
 @property (nonatomic, strong, nullable) RCTHost *reactHost;
 @end
@@ -103,6 +107,41 @@
 - (void)setReactHost:(RCTHost *)reactHost
 {
   return [self setValue:reactHost forKey:@"_reactHost"];
+}
+
+/**
+ Override `createReactHostIfNeeded`:
+ - Reuse `RCTAppDelegate.rootViewFactory` for jsEngineProvider and ContextContainerHandler.
+   Since we just customize bundleURL, all the other references we could reuse from `RCTAppDelegate.rootViewFactory`.
+   That would also prevent `[weakSelf createJSRuntimeFactory]` from unretained self.
+ */
+- (void)createReactHostIfNeeded
+{
+  if ([self reactHost]) {
+    return;
+  }
+
+  RCTAppDelegate *appDelegate = [EXReactRootViewFactory getRCTAppDelegate];
+  RCTRootViewFactory *appRootViewFactory = (RCTRootViewFactory *)appDelegate.rootViewFactory;
+  __weak RCTRootViewFactory *weakAppRootViewFactory = appRootViewFactory;
+
+  RCTRootViewFactoryConfiguration *configuration = [self valueForKey:@"_configuration"];
+  NSURL *bundleURL = configuration.bundleURL;
+  id<RCTTurboModuleManagerDelegate> turboModuleManagerDelegate = [self valueForKey:@"_turboModuleManagerDelegate"];
+
+  RCTHost *reactHost = [[RCTHost alloc] initWithBundleURL:bundleURL
+                                     hostDelegate:nil
+                       turboModuleManagerDelegate:turboModuleManagerDelegate
+                                 jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
+                                   return [weakAppRootViewFactory createJSRuntimeFactory];
+                                 }];
+  [reactHost setBundleURLProvider:^NSURL *() {
+    return bundleURL;
+  }];
+  [reactHost setContextContainerHandler:appRootViewFactory];
+  [reactHost start];
+
+  [self setReactHost:reactHost];
 }
 
 + (RCTAppDelegate *)getRCTAppDelegate


### PR DESCRIPTION
# Why

fixed crash from reloading on ios bridgeless mode

# How

originally the `EXReactRootViewFactory.createDefaultReactRootView:` is a drop-and-free by design. it will return nil since we don't retain the root view factory anywhere
```
   jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
     return [weakSelf createJSRuntimeFactory];
   }];
```

this pr tries to use `createJSRuntimeFactory` from `RCTAppDelegate.rootViewFactory` and customize some logic from `createReactHostIfNeeded`

# Test Plan

test reload on fabric-tester

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
