### PR TITLE
[bare-expo] Temporarily disable dev-client

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
@@ -60,6 +60,6 @@ class MainApplication : Application(), ReactApplication {
   }
 
   companion object {
-    private const val USE_DEV_CLIENT = true
+    private const val USE_DEV_CLIENT = false
   }
 }

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.mm
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.mm
@@ -17,7 +17,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 #if DEBUG
-  BOOL useDevClient = YES;
+  BOOL useDevClient = NO;
 
   if (!useDevClient) {
     ExpoDevLauncherReactDelegateHandler.enableAutoSetup = NO;


### PR DESCRIPTION
# Why

Given that expo-dev-client is not compatible yet with bridgeless mode and for us to start testing new arch in bare-expo we should temporarily disable dev-client inside BareExpo

# How

Disable dev-client on BareExpo

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
