### PR TITLE
[core][dev-launcher][updates] refactor EXReactRootViewFactory

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed breaking changes from React Native 0.74.0-rc.3. Also dropped support for React Native 0.73 and lower. ([#27573](https://github.com/expo/expo/pull/27573) by [@kudo](https://github.com/kudo))
 - [iOS] Added bridgeless support on ExpoReactDelegate. ([#27601](https://github.com/expo/expo/pull/27601), [#27689](https://github.com/expo/expo/pull/27689) by [@kudo](https://github.com/kudo))
 - Deprecate `experimentalLaunchMode` config plugin option and introduce new `launchMode` option. ([#27845](https://github.com/expo/expo/pull/27845) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Refactored out `EXReactRootViewFactory.createDefaultReactRootView:` to `RCTAppDelegate.recreateRootViewWithBundleURL:` category. ([#27945](https://github.com/expo/expo/pull/27945) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -8,7 +8,7 @@
 #import <React/RCTConstants.h>
 #import <React/RCTKeyCommands.h>
 
-#import <ExpoModulesCore/EXReactRootViewFactory.h>
+#import <ExpoModulesCore/RCTAppDelegate+Recreate.h>
 #import <EXDevLauncher/EXDevLauncherController.h>
 #import <EXDevLauncher/EXDevLauncherRCTBridge.h>
 #import <EXDevLauncher/EXDevLauncherManifestParser.h>
@@ -328,7 +328,11 @@
   }
 
   [self _removeInitModuleObserver];
-  UIView *rootView = [EXReactRootViewFactory createDefaultReactRootView:[self getSourceURL] moduleName:nil initialProperties:nil launchOptions:_launchOptions];
+
+  RCTAssert([UIApplication.sharedApplication.delegate isKindOfClass:[RCTAppDelegate class]],
+               @"The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.");
+  RCTAppDelegate *rctAppDelegate = (RCTAppDelegate *)UIApplication.sharedApplication.delegate;
+  UIView *rootView = [rctAppDelegate recreateRootViewWithBundleURL:[self getSourceURL] moduleName:nil initialProps:nil launchOptions:_launchOptions];
   _launcherBridge = _bridgeDelegate.bridge;
 
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -66,10 +66,13 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
   public func devLauncherController(_ developmentClientController: EXDevLauncherController, didStartWithSuccess success: Bool) {
     developmentClientController.appBridge = RCTBridge.current()
 
-    let rootView = ExpoReactRootViewFactory.createDefaultReactRootView(
-      developmentClientController.sourceUrl(),
+    guard let rctAppDelegate = (UIApplication.shared.delegate as? RCTAppDelegate) else {
+      fatalError("The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.")
+    }
+    let rootView = rctAppDelegate.recreateRootView(
+      withBundleURL: developmentClientController.sourceUrl(),
       moduleName: self.rootViewModuleName,
-      initialProperties: self.rootViewInitialProperties,
+      initialProps: self.rootViewInitialProperties,
       launchOptions: self.launchOptions
     )
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Added TypeScript declarations and documentation for global JSI bindings. ([#27465](https://github.com/expo/expo/pull/27465) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added bridgeless support on ExpoReactDelegate. ([#27601](https://github.com/expo/expo/pull/27601), [#27689](https://github.com/expo/expo/pull/27689) by [@kudo](https://github.com/kudo))
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
+- Refactored out `EXReactRootViewFactory.createDefaultReactRootView:` to `RCTAppDelegate.recreateRootViewWithBundleURL:` category. ([#27945](https://github.com/expo/expo/pull/27945) by [@kudo](https://github.com/kudo))
 
 ## 1.11.11 - 2024-03-11
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
+- Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -32,7 +32,6 @@
 - Fixed `RCTHost` is not retained on iOS bridgeless mode. ([#27715](https://github.com/expo/expo/pull/27715) by [@kudo](https://github.com/kudo))
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
-- Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.h
@@ -27,14 +27,11 @@ NS_SWIFT_NAME(ExpoReactRootViewFactory)
            turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate;
 
 /**
- Creates a root view bound to a default React instance.
- This is a wrapper for `RCTRootViewFactory` that creates `RCTRootViewFactoryConfiguration` from `UIApplication.sharedApplication.delegate`.
- All the nullable parameters will reference from AppDelegate when the value is null.
+ Calls super `viewWithModuleName:initialProperties:launchOptions:` from `RCTRootViewFactory`.
  */
-+ (UIView *)createDefaultReactRootView:(nullable NSURL *)bundleURL
-                            moduleName:(nullable NSString *)moduleName
-                     initialProperties:(nullable NSDictionary *)initialProperties
-                         launchOptions:(nullable NSDictionary *)launchOptions;
+- (UIView *)superViewWithModuleName:(NSString *)moduleName
+                  initialProperties:(NSDictionary *)initialProperties
+                      launchOptions:(NSDictionary *)launchOptions;
 
 @end
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactRootViewFactory.mm
@@ -3,8 +3,6 @@
 #import <ExpoModulesCore/EXReactRootViewFactory.h>
 
 #import <ExpoModulesCore/EXReactDelegateWrapper+Private.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
-#import <ReactCommon/RCTHost.h>
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 #import <React-RCTAppDelegate/RCTAppDelegate.h>
@@ -12,17 +10,6 @@
 // for importing the header from framework, the dash will be transformed to underscore
 #import <React_RCTAppDelegate/RCTAppDelegate.h>
 #endif
-
-@interface RCTAppDelegate () <RCTTurboModuleManagerDelegate>
-
-@end
-
-@interface RCTRootViewFactory () {
-  RCTHost *_reactHost;
-}
-
-@property (nonatomic, strong, nullable) RCTHost *reactHost;
-@end
 
 @implementation EXReactRootViewFactory
 
@@ -46,75 +33,11 @@
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
 }
 
-+ (UIView *)createDefaultReactRootView:(nullable NSURL *)_bundleURL
-                            moduleName:(nullable NSString *)_moduleName
-                     initialProperties:(nullable NSDictionary *)_initialProperties
-                         launchOptions:(nullable NSDictionary *)launchOptions
-{
-  RCTAppDelegate *appDelegate = [self getRCTAppDelegate];
-  NSURL *bundleURL = _bundleURL ?: appDelegate.bundleURL;
-  NSString *moduleName = _moduleName ?: appDelegate.moduleName;
-  NSDictionary *initialProperties = _initialProperties ?: appDelegate.initialProps;
-
-  if (![appDelegate.rootViewFactory isKindOfClass:EXReactRootViewFactory.class]) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"The appDelegate.rootViewFactory must be an EXReactRootViewFactory instance."
-                                 userInfo:nil];
-  }
-  EXReactRootViewFactory *appRootViewFactory = (EXReactRootViewFactory *)appDelegate.rootViewFactory;
-  RCTRootViewFactoryConfiguration *appRootViewFactoryConfiguration = [appRootViewFactory valueForKey:@"_configuration"];
-
-  RCTRootViewFactoryConfiguration *configuration =
-  [[RCTRootViewFactoryConfiguration alloc] initWithBundleURL:bundleURL
-                                              newArchEnabled:appDelegate.fabricEnabled
-                                          turboModuleEnabled:appDelegate.turboModuleEnabled
-                                           bridgelessEnabled:appDelegate.bridgelessEnabled];
-  configuration.createRootViewWithBridge = appRootViewFactoryConfiguration.createRootViewWithBridge;
-  configuration.createBridgeWithDelegate = appRootViewFactoryConfiguration.createBridgeWithDelegate;
-
-  EXReactRootViewFactory *factory = [[EXReactRootViewFactory alloc] initWithConfiguration:configuration andTurboModuleManagerDelegate:appDelegate];
-  UIView *rootView = [factory superViewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
-
-  // The RCTHost/RCTBridge instance is retained by the RCTRootViewFactory.
-  // We will have to replace these instance from the app to the newly created instance.
-  if (appDelegate.bridgelessEnabled) {
-    appRootViewFactory.reactHost = factory.reactHost;
-  } else {
-    appRootViewFactory.bridge = factory.bridge;
-  }
-  return rootView;
-}
-
-/**
- Calls origin `viewWithModuleName:initialProperties:launchOptions:` from superview (`RCTRootViewFactory`).
- */
 - (UIView *)superViewWithModuleName:(NSString *)moduleName
-                  initialProperties:(nullable NSDictionary *)initialProperties
-                      launchOptions:(nullable NSDictionary *)launchOptions
+                  initialProperties:(NSDictionary *)initialProperties
+                      launchOptions:(NSDictionary *)launchOptions
 {
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
-}
-
-- (RCTHost *)reactHost
-{
-  return [self valueForKey:@"_reactHost"];
-}
-
-- (void)setReactHost:(RCTHost *)reactHost
-{
-  return [self setValue:reactHost forKey:@"_reactHost"];
-}
-
-+ (RCTAppDelegate *)getRCTAppDelegate
-{
-  UIApplication *application = UIApplication.sharedApplication;
-  id delegate = application.delegate;
-  if (![delegate isKindOfClass:RCTAppDelegate.class]) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"The UIApplicationDelegate is a RCTAppDelegate."
-                                 userInfo:nil];
-  }
-  return (RCTAppDelegate *)delegate;
 }
 
 @end

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -20,7 +20,17 @@ public class ExpoReactDelegate: NSObject {
     return self.handlers.lazy
       .compactMap { $0.createReactRootView(reactDelegate: self, moduleName: moduleName, initialProperties: initialProperties, launchOptions: launchOptions) }
       .first(where: { _ in true })
-      ?? ExpoReactRootViewFactory.createDefaultReactRootView(nil, moduleName: moduleName, initialProperties: initialProperties, launchOptions: launchOptions)
+      ?? {
+        guard let rctAppDelegate = (UIApplication.shared.delegate as? RCTAppDelegate) else {
+          fatalError("The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.")
+        }
+        return rctAppDelegate.recreateRootView(
+          withBundleURL: nil,
+          moduleName: moduleName,
+          initialProps: initialProperties,
+          launchOptions: launchOptions
+        )
+      }()
   }
 
   @objc

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.h
@@ -1,0 +1,28 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
+#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
+// for importing the header from framework, the dash will be transformed to underscore
+#import <React_RCTAppDelegate/RCTAppDelegate.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTAppDelegate (Recreate)
+
+/**
+ Recreates a root view bound with customized bundleURL, moduleName, initialProps, and launchOptions.
+ If any of these parameters is null, the method will use the original one from `RCTAppDelegate` or `RCTRootViewFactory`.
+ This method should be used with `EXReactRootViewFactory` that to recreate a root view.
+ */
+- (UIView *)recreateRootViewWithBundleURL:(nullable NSURL *)bundleURL
+                               moduleName:(nullable NSString *)moduleName
+                             initialProps:(nullable NSDictionary *)initialProps
+                            launchOptions:(nullable NSDictionary *)launchOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
@@ -1,0 +1,45 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/RCTAppDelegate+Recreate.h>
+
+#import <ExpoModulesCore/EXReactRootViewFactory.h>
+
+@implementation RCTAppDelegate (Recreate)
+
+- (UIView *)recreateRootViewWithBundleURL:(nullable NSURL *)bundleURL
+                               moduleName:(nullable NSString *)moduleName
+                             initialProps:(nullable NSDictionary *)initialProps
+                            launchOptions:(nullable NSDictionary *)launchOptions
+{
+  if (self.bridgelessEnabled) {
+    id reactHost = [self.rootViewFactory valueForKey:@"_reactHost"];
+    RCTAssert(reactHost == nil, @"recreateRootViewWithBundleURL: does not support when react instance is created");
+  } else {
+    RCTAssert(self.rootViewFactory.bridge == nil, @"recreateRootViewWithBundleURL: does not support when react instance is created");
+  }
+
+  RCTRootViewFactory *rootViewFactory = self.rootViewFactory;
+  RCTRootViewFactoryConfiguration *configuration = [rootViewFactory valueForKey:@"_configuration"];
+  if (bundleURL != nil) {
+    configuration.bundleURL = bundleURL;
+  }
+  if (moduleName != nil) {
+    self.moduleName = moduleName;
+  }
+  if (initialProps != nil) {
+    self.initialProps = initialProps;
+  }
+
+  UIView *rootView;
+  if ([rootViewFactory isKindOfClass:[EXReactRootViewFactory class]]) {
+    // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
+    // we don't want to loop the ReactDelegate again. Otherwise it will be infinite loop.
+    EXReactRootViewFactory *factory = (EXReactRootViewFactory *)rootViewFactory;
+    rootView = [factory superViewWithModuleName:moduleName initialProperties:initialProps launchOptions:launchOptions];
+  } else {
+    rootView = [rootViewFactory viewWithModuleName:moduleName initialProperties:initialProps launchOptions:launchOptions];
+  }
+  return rootView;
+}
+
+@end

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Remove legacy expo bundle-assets utilities. ([#27123](https://github.com/expo/expo/pull/27123) by [@wschurman](https://github.com/wschurman))
 - [iOS] Added bridgeless support on ExpoReactDelegate. ([#27601](https://github.com/expo/expo/pull/27601), [#27689](https://github.com/expo/expo/pull/27689) by [@kudo](https://github.com/kudo))
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
+- Refactored out `EXReactRootViewFactory.createDefaultReactRootView:` to `RCTAppDelegate.recreateRootViewWithBundleURL:` category. ([#27945](https://github.com/expo/expo/pull/27945) by [@kudo](https://github.com/kudo))
 
 ## 0.24.12 - 2024-03-13
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -79,11 +79,13 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     guard let reactDelegate = self.reactDelegate else {
       fatalError("`reactDelegate` should not be nil")
     }
-
-    let rootView = ExpoReactRootViewFactory.createDefaultReactRootView(
-      AppController.sharedInstance.launchAssetUrl(),
+    guard let rctAppDelegate = (UIApplication.shared.delegate as? RCTAppDelegate) else {
+      fatalError("The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.")
+    }
+    let rootView = rctAppDelegate.recreateRootView(
+      withBundleURL: AppController.sharedInstance.launchAssetUrl(),
       moduleName: self.rootViewModuleName,
-      initialProperties: self.rootViewInitialProperties,
+      initialProps: self.rootViewInitialProperties,
       launchOptions: self.launchOptions
     )
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white


### PR DESCRIPTION
# Why

i don't like #27928 solution tbh. it hacks into the core of RCTRootViewFactory and increases maintainence cost. let have another try to refactor the code.

# How

i realized two facts:
- we may not able to reuse `EXReactRootViewFactory.createDefaultReactRootView:` for dev-client. the correct way for dev-client to have different react instances is to host `RCTRootViewFactory` inside dev-client.
- we could reuse `UIApplication.shared.delegate.rootViewFactory` to create the root view. since reactHost/bridge are not created at this moment, we could change bundleURL or other necessary fields beforehand. that would fulfill expo-updates and expo-dev-launcher's requirements.   

# Test Plan

- fabric-tester
- fabric-tester reload
- fabric-tester + expo-updates
- ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
