### PR TITLE
fix(cli): use correct `script src` path when exporting web development build

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix development codesigning certificate validity checks. ([#27361](https://github.com/expo/expo/pull/27361) by [@wschurman](https://github.com/wschurman))
 - Included groups in Expo Router typed routes generation ([#27690](https://github.com/expo/expo/pull/27690) by [@marklawlor](https://github.com/marklawlor))
 - Filter ADB trace logs when resolving Android devices. ([#27473](https://github.com/expo/expo/pull/27473) by [@byCedric](https://github.com/byCedric))
+- Use correct script src path when exporting web development builds. ([#27946](https://github.com/expo/expo/pull/27946) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`serializes development export static html with correct script src 1`] = `
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/Users/path/to/expo/app/node_modules/expo/AppEntry.js" defer></script>
+</body></html>"
+`;
+
 exports[`serializes development static html 1`] = `
 "<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/packages/expo-router/entry.bundle?platform=web" defer></script>
 </body></html>"

--- a/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`serializes development export static html with correct baseUrl and script src 1`] = `
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="custom/base/url/Users/path/to/expo/app/node_modules/expo/AppEntry.js" defer></script>
+</body></html>"
+`;
+
 exports[`serializes development export static html with correct script src 1`] = `
 "<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/Users/path/to/expo/app/node_modules/expo/AppEntry.js" defer></script>
 </body></html>"

--- a/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`serializes development export static html with correct baseUrl and script src 1`] = `
-"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="custom/base/url/Users/path/to/expo/app/node_modules/expo/AppEntry.js" defer></script>
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/custom/base/url/Users/path/to/expo/app/node_modules/expo/AppEntry.js" defer></script>
 </body></html>"
 `;
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -63,3 +63,27 @@ it('serializes development export static html with correct script src', () => {
     /<script src="\/Users\/path\/to\/expo\/app\/node_modules\/expo\/AppEntry.js" defer>/
   );
 });
+
+it('serializes development export static html with correct baseUrl and script src', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: '/Users/path/to/expo/app/node_modules/expo/AppEntry.js',
+        originFilename: 'node_modules/expo/AppEntry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+    ],
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    // Note, when `isExporting` is true, we combine `baseUrl` with the filename
+    // Wehn empty, this caused an additional `/` to be added at the beginning of the `<script src="" />` tag
+    baseUrl: 'custom/base/url',
+    isExporting: true,
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(
+    // Note the explicit `/Users` part, not adding a double `//` by accident
+    /<script src="custom\/base\/url\/Users\/path\/to\/expo\/app\/node_modules\/expo\/AppEntry.js" defer>/
+  );
+});

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -39,3 +39,27 @@ it('serializes production static html for export', () => {
   expect(res).toMatchSnapshot();
   expect(res).toMatch(/<script src="\/dist\/entry\.js" defer>/);
 });
+
+it('serializes development export static html with correct script src', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: '/Users/path/to/expo/app/node_modules/expo/AppEntry.js',
+        originFilename: 'node_modules/expo/AppEntry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+    ],
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    // Note, when `isExporting` is true, we combine `baseUrl` with the filename
+    // Wehn empty, this caused an additional `/` to be added at the beginning of the `<script src="" />` tag
+    baseUrl: '',
+    isExporting: true,
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(
+    // Note the explicit `/Users` part, not adding a double `//` by accident
+    /<script src="\/Users\/path\/to\/expo\/app\/node_modules\/expo\/AppEntry.js" defer>/
+  );
+});

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -78,12 +78,12 @@ it('serializes development export static html with correct baseUrl and script sr
     template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
     // Note, when `isExporting` is true, we combine `baseUrl` with the filename
     // Wehn empty, this caused an additional `/` to be added at the beginning of the `<script src="" />` tag
-    baseUrl: 'custom/base/url',
+    baseUrl: '/custom/base/url/',
     isExporting: true,
   });
   expect(res).toMatchSnapshot();
   expect(res).toMatch(
     // Note the explicit `/Users` part, not adding a double `//` by accident
-    /<script src="custom\/base\/url\/Users\/path\/to\/expo\/app\/node_modules\/expo\/AppEntry.js" defer>/
+    /<script src="\/custom\/base\/url\/Users\/path\/to\/expo\/app\/node_modules\/expo\/AppEntry.js" defer>/
   );
 });

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -65,8 +65,8 @@ function htmlFromSerialAssets(
     .map(({ metadata, filename, source }) => {
       if (isExporting) {
         return [
-          `<link rel="preload" href="${combineUrlPath(baseUrl || '/', filename)}" as="style">`,
-          `<link rel="stylesheet" href="${combineUrlPath(baseUrl || '/', filename)}">`,
+          `<link rel="preload" href="/${combineUrlPath(baseUrl, filename)}" as="style">`,
+          `<link rel="stylesheet" href="/${combineUrlPath(baseUrl, filename)}">`,
         ].join('');
       } else {
         return `<style data-expo-css-hmr="${metadata.hmrId}">` + source + '\n</style>';
@@ -105,7 +105,7 @@ function htmlFromSerialAssets(
             // return `<script src="/${combineUrlPath(baseUrl, filename)" defer></script>`;
           }
 
-          return `<script src="${combineUrlPath(baseUrl || '/', filename)}" defer></script>`;
+          return `<script src="/${combineUrlPath(baseUrl, filename)}" defer></script>`;
         })
         .join('');
 

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -31,6 +31,17 @@ export function serializeHtmlWithAssets({
   });
 }
 
+/**
+ * Combine the path segments of a URL.
+ * This filters out empty segments and joins them with `/`.
+ */
+function combineUrlPath(...segments: string[]) {
+  return segments
+    .filter(Boolean)
+    .map((segment) => segment.replace(/^\/+|\/+$/g, ''))
+    .join('/');
+}
+
 function htmlFromSerialAssets(
   assets: SerialAsset[],
   {
@@ -54,8 +65,8 @@ function htmlFromSerialAssets(
     .map(({ metadata, filename, source }) => {
       if (isExporting) {
         return [
-          `<link rel="preload" href="${baseUrl}/${filename}" as="style">`,
-          `<link rel="stylesheet" href="${baseUrl}/${filename}">`,
+          `<link rel="preload" href="${combineUrlPath(baseUrl || '/', filename)}" as="style">`,
+          `<link rel="stylesheet" href="${combineUrlPath(baseUrl || '/', filename)}">`,
         ].join('');
       } else {
         return `<style data-expo-css-hmr="${metadata.hmrId}">` + source + '\n</style>';
@@ -91,10 +102,10 @@ function htmlFromSerialAssets(
               return '';
             }
             // Mark async chunks as defer so they don't block the page load.
-            // return `<script src="${baseUrl}/${filename}" defer></script>`;
+            // return `<script src="/${combineUrlPath(baseUrl, filename)" defer></script>`;
           }
 
-          return `<script src="${baseUrl}/${filename}" defer></script>`;
+          return `<script src="${combineUrlPath(baseUrl || '/', filename)}" defer></script>`;
         })
         .join('');
 


### PR DESCRIPTION
# Why

Fixes #27803

# How

When exporting a development version of the (web) app, it seems we are using the absolute paths of modules. This doesn't work well with our `baseUrl` handling, and accidentally adds multiple starting slashes (as mentioned in #27803).

# Test Plan

- Added method to filter empty segments when creating URL pathnames
- Added tests to ensure no regression

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
