### PR TITLE
[docs] Add "Review" section in Home Overview

### DIFF
--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 hideTOC: true
 ---
 
-import { TerminalBrowserIcon, Rocket01Icon } from '@expo/styleguide-icons';
+import { TerminalBrowserIcon, Rocket01Icon, StoplightIcon } from '@expo/styleguide-icons';
 import { HandWaveIcon } from '~/ui/components/CustomIcons/HandWaveIcon';
 
 Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
@@ -14,13 +14,15 @@ Learn about prerequisites and how to quickly start a universal project with Expo
 
 ### <span className="inline-flex items-center gap-2"><TerminalBrowserIcon />Develop</span>
 
-Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
+Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) that you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
 
-{/* TODO: (@aman) Add a section for Review later when its are ready. */}
+### <span className="inline-flex items-center gap-2"><StoplightIcon />Review</span>
+
+Distributing a preview version of your app requires sharing it with your team for quality assurance (QA). This creates a feedback loop that helps you to improve your app before deploying it to the app stores. Expo provides a quicker way to [distribute your app for review](/review/overview/) using [EAS Update](/eas-update/introduction/) with development builds. This eliminates the need to rebuild or upload the app to an app store's test track and allows you to respond to feedback promptly.
 
 ### <span className="inline-flex items-center gap-2"><Rocket01Icon />Deploy</span>
 
-Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
+Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
 
 ### Other content
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add a "Review" section introduction in Home > Overview.

Also, fix a couple of grammatical issues in the existing sections in the same doc.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/overview/

## Preview

![CleanShot 2024-03-29 at 23 11 45@2x](https://github.com/expo/expo/assets/10234615/e96b67b4-ae8e-4fab-bdfe-d94607d3be43)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
