### PR TITLE
[docs] Fix and update ImagePicker example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -89,9 +89,9 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```js
-import React, { useState, useEffect } from 'react';
-import { Button, Image, View, Platform } from 'react-native';
+```jsx
+import { useState } from 'react';
+import { Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
@@ -114,12 +114,24 @@ export default function ImagePickerExample() {
   };
 
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <View style={styles.container}>
       <Button title="Pick an image from camera roll" onPress={pickImage} />
-      {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      {image && <Image source={{ uri: image }} style={styles.image}} />}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  image: {
+    width: 200,
+    height: 200,
+  },
+});
 ```
 
 </SnackInline>
@@ -142,8 +154,7 @@ When you run this example and pick an image, you will see the image that you pic
       "width": 3024
     }
   ],
-  "canceled": false,
-  "cancelled": false
+  "canceled": false
 }
 ```
 

--- a/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
@@ -91,9 +91,9 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <SnackInline label='Image Picker' dependencies={['expo-image-picker']}>
 
-```js
-import React, { useState, useEffect } from 'react';
-import { Button, Image, View, Platform } from 'react-native';
+```jsx
+import { useState } from 'react';
+import { Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
@@ -116,12 +116,24 @@ export default function ImagePickerExample() {
   };
 
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <View style={styles.container}>
       <Button title="Pick an image from camera roll" onPress={pickImage} />
-      {image && <Image source={{ uri: image }} style={{ width: 200, height: 200 }} />}
+      {image && <Image source={{ uri: image }} style={styles.image}} />}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  image: {
+    width: 200,
+    height: 200,
+  },
+});
 ```
 
 </SnackInline>
@@ -145,7 +157,6 @@ When you run this example and pick an image, you will see the image that you pic
     }
   ],
   "canceled": false,
-  "cancelled": false
 }
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the ImagePicker example result references deprecated removed `cancelled` property in the picker result.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Removes `cancelled` from the image picker result (To confirm this, I tested this manually both on Android Emulator and iOS Simulator by running the basic usage example)
- Removes unused imported fields in the example
- Adds `jsx` for correct syntax highlight
- Also, update the example to follow our common pattern to not inline styles (for consistency)

All of these changes are applied to `unversioned` and SDK 50 references.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v50.0.0/sdk/imagepicker/

## Preview

![CleanShot 2024-03-29 at 23 49 58@2x](https://github.com/expo/expo/assets/10234615/0745949f-6d8b-4c16-a4be-f078bb9c45c4)


![CleanShot 2024-03-29 at 23 50 02@2x](https://github.com/expo/expo/assets/10234615/0db60070-6acf-4589-a62f-5b9bba45a196)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
