### PR TITLE
[docs] Update third-party-library.mdx

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -80,7 +80,7 @@ In another terminal window, compile and run the example app:
 
 Now, add the native dependencies to the module by editing the **android/build.gradle** and **ios/ExpoRadialChart.podspec** files:
 
-```diff android/build.grade
+```diff android/build.gradle
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
@@ -114,7 +114,7 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 
 Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the folder as a repository:
 
-```diff android/build.grade
+```diff android/build.gradle
   repositories {
     mavenCentral()
 +   flatDir {
@@ -125,7 +125,7 @@ Inside the **android** directory, create another directory called **libs** and p
 
 Finally, add the dependency to the `dependencies` list. Instead of the filename, use the package path, which includes the `@aar` at the end:
 
-```diff android/build.grade
+```diff android/build.gradle
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"


### PR DESCRIPTION
Fix typo in Android build files documentation

# Why

While reading this documentation, this appears to be a typo

# How

Update the doc to fix the typo

<img width="647" alt="Screenshot 2024-03-29 at 1 03 16 PM" src="https://github.com/expo/expo/assets/6617776/5c886171-b8ed-41ea-a2e1-577dfd2cde4a">

# Test Plan

N/A



# Checklist


- [ ] Check other docs for similar mistakes?
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
