### PR TITLE
[android][camera] batch updates after prop changes

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,6 +17,7 @@
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - On `Android`, requesting audio permissions was meant to be optional in the config plugin. ([#27365](https://github.com/expo/expo/pull/27365) by [@alanjhughes](https://github.com/alanjhughes))
 - Prevent unnecessary configuration changes wherever possible. ([#27919](https://github.com/expo/expo/pull/27919) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, only recreate camera after certain props have changed.
 
 ## 14.1.1 - 2024-03-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,7 +17,7 @@
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - On `Android`, requesting audio permissions was meant to be optional in the config plugin. ([#27365](https://github.com/expo/expo/pull/27365) by [@alanjhughes](https://github.com/alanjhughes))
 - Prevent unnecessary configuration changes wherever possible. ([#27919](https://github.com/expo/expo/pull/27919) by [@alanjhughes](https://github.com/alanjhughes))
-- On `Android`, only recreate camera after certain props have changed.
+- On `Android`, only recreate camera after certain props have changed. ([#27952](https://github.com/expo/expo/pull/27952) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 14.1.1 - 2024-03-13
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/CameraViewNextModule.kt
@@ -148,6 +148,10 @@ class CameraViewNextModule : Module() {
         }
       }
 
+      OnViewDidUpdateProps { view ->
+        view.createCamera()
+      }
+
       AsyncFunction("takePicture") { view: ExpoCameraView, options: PictureOptions, promise: Promise ->
         if (!EmulatorUtilities.isRunningOnEmulator()) {
           view.takePicture(options, promise, cacheDirectory)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -29,7 +29,6 @@ import androidx.camera.core.Preview
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
-import androidx.camera.extensions.internal.Version
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.FileOutputOptions

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/next/ExpoCameraView.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.graphics.ImageFormat
 import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCharacteristics
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.Size
@@ -28,6 +29,7 @@ import androidx.camera.core.Preview
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.extensions.internal.Version
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.FileOutputOptions
@@ -92,29 +94,30 @@ class ExpoCameraView(
 
   private var previewView = PreviewView(context)
   private val scope = CoroutineScope(Dispatchers.Main)
+  private var shouldCreateCamera = false
 
   var lenFacing = CameraType.BACK
     set(value) {
       field = value
-      createCamera()
+      shouldCreateCamera = true
     }
 
   var cameraMode: CameraMode = CameraMode.PICTURE
     set(value) {
       field = value
-      createCamera()
+      shouldCreateCamera = true
     }
 
   var videoQuality: VideoQuality = VideoQuality.VIDEO1080P
     set(value) {
       field = value
-      createCamera()
+      shouldCreateCamera = true
     }
 
   var pictureSize: String = ""
     set(value) {
       field = value
-      createCamera()
+      shouldCreateCamera = true
     }
 
   var mute: Boolean = false
@@ -236,7 +239,11 @@ class ExpoCameraView(
   }
 
   @SuppressLint("UnsafeOptInUsageError")
-  private fun createCamera() {
+  fun createCamera() {
+    if (!shouldCreateCamera) {
+      return
+    }
+    shouldCreateCamera = false
     providerFuture.addListener(
       {
         val cameraProvider: ProcessCameraProvider = providerFuture.get()
@@ -266,13 +273,7 @@ class ExpoCameraView(
           }
           .build()
 
-        val cameraInfo = cameraProvider.availableCameraInfos.filter {
-          Camera2CameraInfo
-            .from(it)
-            .getCameraCharacteristic(CameraCharacteristics.LENS_FACING) == lenFacing.mapToCharacteristic()
-        }
-
-        val videoCapture = createVideoCapture(cameraInfo)
+        val videoCapture = createVideoCapture()
         imageAnalysisUseCase = createImageAnalyzer()
 
         val useCases = UseCaseGroup.Builder().apply {
@@ -326,7 +327,7 @@ class ExpoCameraView(
         }
       }
 
-  private fun createVideoCapture(info: List<CameraInfo>): VideoCapture<Recorder> {
+  private fun createVideoCapture(): VideoCapture<Recorder> {
     val preferredQuality = videoQuality.mapToQuality()
     val fallbackStrategy = FallbackStrategy.lowerQualityOrHigherThan(preferredQuality)
     val qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
@@ -365,15 +366,18 @@ class ExpoCameraView(
 
   fun setShouldScanBarcodes(shouldScanBarcodes: Boolean) {
     this.shouldScanBarcodes = shouldScanBarcodes
-    createCamera()
+    shouldCreateCamera = true
   }
 
   fun setBarcodeScannerSettings(settings: BarcodeSettings?) {
     barcodeFormats = settings?.barcodeTypes ?: emptyList()
   }
 
-  private fun getDeviceOrientation() =
+  private fun getDeviceOrientation() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    appContext.reactContext?.display?.rotation ?: 0
+  } else {
     (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
+  }
 
   fun releaseCamera() {
     appContext.mainQueue.launch {


### PR DESCRIPTION
# Why
Use `OnViewDidUpdateProps` to only recreate the camera when certain props have changed.

# How
Call `createCamera` in `OnViewDidUpdateProps`. It will only recreate the camera if `shouldCreateCamera` has been set to true by changing props that require the camera to be recreated.

# Test Plan
Bare expo. Significantly reduces the number of times the camera is recreated.
