### PR TITLE
[docs] Fix the link for expo-server-sdk-java to maintained one

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -35,7 +35,7 @@ The Expo team and community have taken care of creating back-ends for you in a f
 | [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang)                 | Golang   | Community     |
 | [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir)                        | Elixir   | Community     |
 | [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet)                             | dotnet   | Community     |
-| [expo-server-sdk-java](https://github.com/jav/expo-server-sdk-java)                                      | Java     | Community     |
+| [expo-server-sdk-java](https://github.com/nia-medtech/expo-server-sdk-java)                                      | Java     | Community     |
 | [laravel-expo-notifier](https://github.com/YieldStudio/laravel-expo-notifier)                            | Laravel  | Community     |
 
 Each of the example servers above is a wrapper around Expo's Push API.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I corrected the link to the maintained repository for expo-server-sdk-java. The previous link was pointing to an unmaintained repository.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I just changed the link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Make sure that the link to the Java library on the /push-notifications/sending-notifications/#send-push-notifications-using-a-server doc goes to https://github.com/nia-medtech/expo-server-sdk-java

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
