### PR TITLE
[expo] fix NoSuchMethodException on getReactHost for r8

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 - Added `ReactNativeHost.getJSBundleFile()` support for bridgeless mode. ([#27804](https://github.com/expo/expo/pull/27804) by [@kudo](https://github.com/kudo))
+- Fixed `NoSuchMethodException` on `getReactHost` when R8 is enabled on Android. ([#27964](https://github.com/expo/expo/pull/27964) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -42,7 +42,7 @@ class ReactActivityDelegateWrapper(
     invokeDelegateMethod("getReactNativeHost")
   }
   private val _reactHost: ReactHost? by lazy {
-    invokeDelegateMethod("getReactHost")
+    delegate.reactHost
   }
 
   /**


### PR DESCRIPTION
# Why

fixes updates e2e crash on android when R8 is enabled: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/592e06b7-b9b1-4a72-9f24-f55c9ea9d532
```
   @Thread DefaultDispatcher-worker-2(41):
    java.lang.NoSuchMethodException: com.facebook.react.r.getReactHost []
    	at java.lang.Class.getMethod(Class.java:2103)
    	at java.lang.Class.getDeclaredMethod(Class.java:2081)
    	at a5.g.w(SourceFile:1)
    	at a5.g.s(SourceFile:1)
    	at a5.g$a.a(SourceFile:1)
    	at a5.g$a.invoke(SourceFile:1)
    	at m7.s.getValue(SourceFile:1)
    	at a5.g.u(SourceFile:1)
    	at a5.g.t(SourceFile:1)
    	at a5.g.y(SourceFile:1)
    	at a5.g.p(SourceFile:1)
    	at a5.f.run(SourceFile:1)
    	at expo.modules.updates.UpdatesPackage$c$b.invokeSuspend(Unknown Source:12)
    	at kotlin.coroutines.jvm.internal.a.resumeWith(Unknown Source:11)
    	at la.s0.run(SourceFile:1)
    	at android.os.Handler.handleCallback(Handler.java:938)
    	at android.os.Handler.dispatchMessage(Handler.java:99)
    	at android.os.Looper.loopOnce(Looper.java:201)
    	at android.os.Looper.loop(Looper.java:288)
    	at android.app.ActivityThread.main(ActivityThread.java:7839)
    	at java.lang.reflect.Method.invoke(Native Method)
    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
    	Suppressed: la.q0: [a2{Cancelling}@94e852b, Dispatchers.IO]
```

# How

the `getReactHost` is a [public method](https://github.com/facebook/react-native/blob/220588004b100717b0984bf33a48391746ecd3ff/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java#L86-L88) and we don't keep name for public method. we could call the method directly without reflection. 

# Test Plan

updates e2e ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
