### PR TITLE
[core] fix shared object broken when r8 is enabled

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed errors on Android when running on bridgeless mode. ([#27725](https://github.com/expo/expo/pull/27725) by [@kudo](https://github.com/kudo))
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 - Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
+- Fixed SharedRef class names are obfuscated when R8 is enabled. ([#27965](https://github.com/expo/expo/pull/27965) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -6,6 +6,7 @@
 -keep class * implements expo.modules.kotlin.records.Record {
   *;
 }
+-keep class * extends expo.modules.kotlin.sharedobjects.SharedRef
 -keep enum * implements expo.modules.kotlin.types.Enumerable {
   *;
 }


### PR DESCRIPTION
# Why

noticed one sqlite issue when dogfooding
`Failed: Cannot read property 'prototype' of undefined`

# How

when r8 is enabled, the [`NativeDatabase`](https://github.com/expo/expo/blob/3ca396dd1f682eeaddc7d5c453cf5f43bae05ba8/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt#L8) is obfuscated and break from the [line](https://github.com/expo/expo/blob/3ca396dd1f682eeaddc7d5c453cf5f43bae05ba8/packages/expo-sqlite/src/next/SQLiteDatabase.ts#L423).

this pr fixes that problem by keeping all SharedRef names.

# Test Plan

enabled r8 on bare-expo and run SQLiteNext test cases

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
