### PR TITLE
[cli] update dev tools plugins prompt

### DIFF
--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -157,7 +157,7 @@ export class DevServerManagerActions {
       const pluginMenuItems = (
         await this.devServerManager.devtoolsPluginManager.queryPluginsAsync()
       ).map((plugin) => ({
-        title: chalk`Open devtools plugin - {bold ${plugin.packageName}}`,
+        title: chalk`Open {bold ${plugin.packageName}}`,
         value: `devtoolsPlugin:${plugin.packageName}`,
         action: async () => {
           const url = new URL(


### PR DESCRIPTION
# Why

Fixes ENG-10834

# How

Alter the dev tools plugins CLI prompt options label.

# Test Plan

The change has been tested locally.

# Preview

![Screenshot 2024-04-01 at 11 11 29](https://github.com/expo/expo/assets/719641/3a6039d0-018c-4e4d-92f7-d38279cc32fe)
