### PR TITLE
[router] update Babel preset deprecation error

### DIFF
--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -1,1 +1,3 @@
-throw new Error('expo-router/babel is deprecated in favor of babel-preset-expo in SDK 50.');
+throw new Error(
+  'expo-router/babel is deprecated in favor of babel-preset-expo in SDK 50. To fix the issue, remove "expo-router/babel" from "plugins" in your babel.config.js file.'
+);


### PR DESCRIPTION
# Why

Fixes ENG-10833

# How

Update Babel preset deprecation throw to be more clear when it comes to the next steps and include the information how to fix the problem.

# Test Plan

Change has been tested locally.

# Preview

![Screenshot 2024-04-01 at 11 31 47](https://github.com/expo/expo/assets/719641/7030180e-d4fd-4c3f-a60f-1db4d9bcf36e)
