### PR TITLE
[go][tools] use autolinking for vendoring modules

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -351,3 +351,6 @@ project.afterEvaluate {
 }
 
 useVendoredModulesForExpoView('unversioned')
+
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
+applyNativeModulesAppBuildGradle(project)

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -12,6 +12,9 @@ include ':app'
 apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
 apply from: new File(rootDir, "versioning_linking.gradle")
 
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
+applyNativeModulesSettingsGradle(settings)
+
 includeBuild('../../../react-native-lab/react-native/packages/react-native-gradle-plugin/')
 
 include ':expoview'

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -53,6 +53,7 @@ target 'Expo Go' do
   use_pods! 'vendored/unversioned/**/*.podspec.json'
 
   # React Native
+  use_native_modules!
   use_react_native!(
     :path => '../../../react-native-lab/react-native/packages/react-native',
     :hermes_enabled => true,

--- a/apps/expo-go/react-native.config.js
+++ b/apps/expo-go/react-native.config.js
@@ -1,0 +1,28 @@
+const DISABLED_AUTOLINKING_PKGS = [
+  '@react-native-async-storage/async-storage',
+  '@react-native-community/netinfo',
+  'react-native-gesture-handler',
+  'react-native-maps',
+  'react-native-reanimated',
+  'react-native-safe-area-context',
+  'react-native-screens',
+];
+
+module.exports = {
+  dependencies: {
+    ...createDisabledAutolinkingConfig(),
+  },
+};
+
+function createDisabledAutolinkingConfig() {
+  const config = {};
+  for (const pkg of DISABLED_AUTOLINKING_PKGS) {
+    config[pkg] = {
+      platforms: {
+        android: null,
+        ios: null,
+      },
+    };
+  }
+  return config;
+}

--- a/tools/src/vendoring/index.ts
+++ b/tools/src/vendoring/index.ts
@@ -1,3 +1,4 @@
+import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import Table from 'cli-table3';
 import semver from 'semver';
@@ -7,6 +8,7 @@ import {
   VendoringProvider,
   VendoringTargetModulesConfig,
 } from './types';
+import { EXPO_GO_DIR } from '../Constants';
 import { link } from '../Formatter';
 import logger from '../Logger';
 import * as Npm from '../Npm';
@@ -41,8 +43,9 @@ export async function listAvailableVendoredModulesAsync(
   modules: VendoringTargetModulesConfig,
   onlyOutdated: boolean = false
 ) {
-  const bundledNativeModules = await getBundledVersionsAsync();
-  const vendoredPackageNames = Object.keys(modules);
+  const autolinkedModules = await listExpoGoAutoLinkingModulesAsync();
+  const bundledNativeModules = { ...(await getBundledVersionsAsync()), ...autolinkedModules };
+  const vendoredPackageNames = [...Object.keys(modules), ...Object.keys(autolinkedModules)];
   const packageViews: Npm.PackageViewType[] = await Promise.all(
     vendoredPackageNames.map((packageName: string) => Npm.getPackageViewAsync(packageName))
   );
@@ -65,7 +68,12 @@ export async function listAvailableVendoredModulesAsync(
     const isOutdated = !bundledVersion || semver.gtr(latestVersion, bundledVersion);
 
     if (!onlyOutdated || isOutdated) {
-      const { source } = modules[packageName];
+      let source: string;
+      if (packageName in modules) {
+        source = modules[packageName].source;
+      } else {
+        source = `https://www.npmjs.com/package/${packageName}`;
+      }
 
       table.push([
         link(chalk.bold.green(packageName), source),
@@ -76,6 +84,28 @@ export async function listAvailableVendoredModulesAsync(
     }
   }
   logger.log(table.toString());
+}
+
+/**
+ * Lists all modules that are linked with Expo Go.
+ * @returns Object with module names as keys and their versions as values.
+ */
+async function listExpoGoAutoLinkingModulesAsync(): Promise<Record<string, string>> {
+  const { stdout } = await spawnAsync('npx', ['react-native', 'config'], {
+    cwd: EXPO_GO_DIR,
+  });
+  const { dependencies } = JSON.parse(stdout);
+  const result = {};
+  for (const [moduleName, moduleInfo] of Object.entries<Record<string, any>>(dependencies)) {
+    if (moduleName === 'expo') {
+      // Skip Expo package since it's not vendored.
+      continue;
+    }
+    const packageRoot = moduleInfo.root;
+    const { version } = require(`${packageRoot}/package.json`);
+    result[moduleName] = version;
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
# Why

since we don't have to support versioning, we have no reason to pull vendor modules here to increase maintenance cost

# How

- this pr tries to add rn-cli autolinking to expo-go and i have #27973 to pull skia.
- temporarily disable autolinking for those modules already in expo-go dependencies (pulled from home) but not yet migrate to the new vendoring approach.
- [tools] update `et uvm -l` a little bit to support listing modules from autolinking

# Test Plan

test on #27973

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
