### PR TITLE
[docs] fix importing sqlite db when using expo-updates

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -327,10 +327,13 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.Database
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
+  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
+  const asset = Asset.fromModule(require(pathToDatabaseFile));
+  if (asset.localUri) {
+    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
+  } else {
+    await FileSystem.downloadAsync(asset.uri, localDbPath);
+  }
   return await SQLite.openDatabaseAsync('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite-next.mdx
@@ -327,13 +327,11 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.Database
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
-  const asset = Asset.fromModule(require(pathToDatabaseFile));
-  if (asset.localUri) {
-    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
-  } else {
-    await FileSystem.downloadAsync(asset.uri, localDbPath);
-  }
+  const asset = await Asset.fromModule(require(pathToDatabaseFile)).downloadAsync();
+  await FileSystem.copyAsync({
+    from: asset.localUri,
+    to: FileSystem.documentDirectory + 'SQLite/myDatabaseName.db',
+  });
   return await SQLite.openDatabaseAsync('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -68,10 +68,13 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.SQLiteDa
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
+  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
+  const asset = Asset.fromModule(require(pathToDatabaseFile));
+  if (asset.localUri) {
+    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
+  } else {
+    await FileSystem.downloadAsync(asset.uri, localDbPath);
+  }
   return SQLite.openDatabase('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -68,13 +68,11 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.SQLiteDa
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
-  const asset = Asset.fromModule(require(pathToDatabaseFile));
-  if (asset.localUri) {
-    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
-  } else {
-    await FileSystem.downloadAsync(asset.uri, localDbPath);
-  }
+  const asset = await Asset.fromModule(require(pathToDatabaseFile)).downloadAsync();
+  await FileSystem.copyAsync({
+    from: asset.localUri,
+    to: FileSystem.documentDirectory + 'SQLite/myDatabaseName.db',
+  });
   return SQLite.openDatabase('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -329,10 +329,13 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.Database
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
+  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
+  const asset = Asset.fromModule(require(pathToDatabaseFile));
+  if (asset.localUri) {
+    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
+  } else {
+    await FileSystem.downloadAsync(asset.uri, localDbPath);
+  }
   return await SQLite.openDatabaseAsync('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -329,13 +329,11 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.Database
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
-  const asset = Asset.fromModule(require(pathToDatabaseFile));
-  if (asset.localUri) {
-    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
-  } else {
-    await FileSystem.downloadAsync(asset.uri, localDbPath);
-  }
+  const asset = await Asset.fromModule(require(pathToDatabaseFile)).downloadAsync();
+  await FileSystem.copyAsync({
+    from: asset.localUri,
+    to: FileSystem.documentDirectory + 'SQLite/myDatabaseName.db',
+  });
   return await SQLite.openDatabaseAsync('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
@@ -70,10 +70,13 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  await FileSystem.downloadAsync(
-    Asset.fromModule(require(pathToDatabaseFile)).uri,
-    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-  );
+  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
+  const asset = Asset.fromModule(require(pathToDatabaseFile));
+  if (asset.localUri) {
+    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
+  } else {
+    await FileSystem.downloadAsync(asset.uri, localDbPath);
+  }
   return SQLite.openDatabase('myDatabaseName.db');
 }
 ```

--- a/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite.mdx
@@ -70,13 +70,11 @@ async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDa
   if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
     await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  const localDbPath = FileSystem.documentDirectory + 'SQLite/myDatabaseName.db';
-  const asset = Asset.fromModule(require(pathToDatabaseFile));
-  if (asset.localUri) {
-    await FileSystem.copyAsync({ from: asset.localUri, to: localDbPath });
-  } else {
-    await FileSystem.downloadAsync(asset.uri, localDbPath);
-  }
+  const asset = await Asset.fromModule(require(pathToDatabaseFile)).downloadAsync();
+  await FileSystem.copyAsync({
+    from: asset.localUri,
+    to: FileSystem.documentDirectory + 'SQLite/myDatabaseName.db',
+  });
   return SQLite.openDatabase('myDatabaseName.db');
 }
 ```


### PR DESCRIPTION
# Why

found an issue of importing exisiting sqlite db with expo-updates when dogfooding. expo-updates may change the asset path to local path, the original doc presented code does not work because the uri is null.

# How

~check the asset path to support localUri for expo-updates~ Updates: use `Asset.downloadAsync()` + localUri as a copy source

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
