### PR TITLE
[modules-core] fix ios use_frameworks build errors

### DIFF
--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -46,6 +46,12 @@ Pod::Spec.new do |s|
     '"${PODS_ROOT}/Headers/Private/React-Core"',
   ]
 
+  if ENV['USE_FRAMEWORKS']
+    header_search_paths.concat([
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspector/jsinspector_modern.framework/Headers"',
+    ])
+  end
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'USE_HEADERMAP' => 'YES',

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -46,12 +46,6 @@ Pod::Spec.new do |s|
     '"${PODS_ROOT}/Headers/Private/React-Core"',
   ]
 
-  if ENV['USE_FRAMEWORKS']
-    header_search_paths.concat([
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspector/jsinspector_modern.framework/Headers"',
-    ])
-  end
-
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'USE_HEADERMAP' => 'YES',
@@ -90,6 +84,7 @@ Pod::Spec.new do |s|
   s.dependency 'ReactCommon/turbomodule/core'
   s.dependency 'React-RCTAppDelegate' if reactNativeTargetVersion >= 71
   s.dependency 'React-NativeModulesApple' if reactNativeTargetVersion >= 72
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
   if fabric_enabled
     compiler_flags << ' ' << fabric_compiler_flags


### PR DESCRIPTION
# Why

When trying to build fabric-tester with ``"ios.useFrameworks": "static"` users are faced with the following build error 
<img width="743" alt="image" src="https://github.com/expo/expo/assets/11707729/518826aa-11e8-4ca3-9672-53c870c26ddf">


# How

Add `jsinspector` headers to `HEADER_SEARCH_PATHS` when in `use_frameworks!` mode.

# Test Plan

Run fabric-tester with `"ios.useFrameworks": "static"` inside `Podfile.properties.json` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
