### PR TITLE
Fix ESLint recommendations to match React team's recommendations

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -49,6 +49,10 @@ module.exports = {
     'universe/native',
     /* @end */
   ],
+  rules: {
+    // Re-enable an important rule disabled by that preset
+    'react-hooks/exhaustive-deps': 'warn',
+  },
 };
 ```
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -50,7 +50,7 @@ module.exports = {
     /* @end */
   ],
   rules: {
-    // Re-enable an important rule disabled by that preset
+    // Ensures props and state inside functions are always up-to-date
     'react-hooks/exhaustive-deps': 'warn',
   },
 };


### PR DESCRIPTION
It is very bad that this rule is disabled in something that's recommended on the website. This is how React gets reputation for having "stale closures". I guarantee that there are many many many hours of lost work attributed to this choice.

If https://github.com/expo/expo/pull/26964 has no path to merging, please let's at least merge this.
