### PR TITLE
[modules-core][ios] fix recreateRootViewWithBundleURL parameters

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -332,7 +332,7 @@
   RCTAssert([UIApplication.sharedApplication.delegate isKindOfClass:[RCTAppDelegate class]],
                @"The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.");
   RCTAppDelegate *rctAppDelegate = (RCTAppDelegate *)UIApplication.sharedApplication.delegate;
-  UIView *rootView = [rctAppDelegate recreateRootViewWithBundleURL:[self getSourceURL] moduleName:nil initialProps:nil launchOptions:_launchOptions];
+  UIView *rootView = [rctAppDelegate recreateRootViewWithBundleURL:[self getSourceURL] moduleName:@"main" initialProps:nil launchOptions:_launchOptions];
   _launcherBridge = _bridgeDelegate.bridge;
 
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -332,7 +332,7 @@
   RCTAssert([UIApplication.sharedApplication.delegate isKindOfClass:[RCTAppDelegate class]],
                @"The `UIApplication.shared.delegate` is not a `RCTAppDelegate` instance.");
   RCTAppDelegate *rctAppDelegate = (RCTAppDelegate *)UIApplication.sharedApplication.delegate;
-  UIView *rootView = [rctAppDelegate recreateRootViewWithBundleURL:[self getSourceURL] moduleName:@"main" initialProps:nil launchOptions:_launchOptions];
+  UIView *rootView = [rctAppDelegate recreateRootViewWithBundleURL:[self getSourceURL] moduleName:nil initialProps:nil launchOptions:_launchOptions];
   _launcherBridge = _bridgeDelegate.bridge;
 
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fixed breaking changes from React Native 0.75. ([#27773](https://github.com/expo/expo/pull/27773) by [@kudo](https://github.com/kudo))
 - Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
 - Fixed SharedRef class names are obfuscated when R8 is enabled. ([#27965](https://github.com/expo/expo/pull/27965) by [@kudo](https://github.com/kudo))
+- [iOS] Fix `recreateRootViewWithBundleURL` parameters. ([#27989](https://github.com/expo/expo/pull/27989) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/RCTAppDelegate+Recreate.mm
@@ -35,9 +35,9 @@
     // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
     // we don't want to loop the ReactDelegate again. Otherwise it will be infinite loop.
     EXReactRootViewFactory *factory = (EXReactRootViewFactory *)rootViewFactory;
-    rootView = [factory superViewWithModuleName:moduleName initialProperties:initialProps launchOptions:launchOptions];
+    rootView = [factory superViewWithModuleName:self.moduleName initialProperties:self.initialProps launchOptions:launchOptions];
   } else {
-    rootView = [rootViewFactory viewWithModuleName:moduleName initialProperties:initialProps launchOptions:launchOptions];
+    rootView = [rootViewFactory viewWithModuleName:self.moduleName initialProperties:self.initialProps launchOptions:launchOptions];
   }
   return rootView;
 }


### PR DESCRIPTION
# Why

When trying to run BareExpo users are faced with the following error 
![image](https://github.com/expo/expo/assets/11707729/192369a4-af7b-4684-af83-3646ee543608)


# How

Specify `moduleName` when creating the launcher rootView

# Test Plan

Run BareExpo and Fabric-tester locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
