### PR TITLE
[updates][Android] Fix `UpdatesController.instance was called before the module was initialized`

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -23,6 +23,9 @@ class UpdatesController {
     private var singletonInstance: IUpdatesController? = null
     private var overrideConfiguration: UpdatesConfiguration? = null
 
+    @JvmStatic val wasInitialized: Boolean
+      get() = singletonInstance != null
+
     @JvmStatic val instance: IUpdatesController
       get() {
         return checkNotNull(singletonInstance) { "UpdatesController.instance was called before the module was initialized" }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -37,6 +37,10 @@ class UpdatesModule : Module() {
     )
 
     Constants {
+      if (!UpdatesController.wasInitialized) {
+        return@Constants emptyMap()
+      }
+
       UpdatesLogger(context).info("UpdatesModule: getConstants called", UpdatesErrorCode.None)
       mutableMapOf<String, Any?>().apply {
         val constantsForModule = UpdatesController.instance.getConstantsForModule()


### PR DESCRIPTION
# Why

Fixes:
```
 ERROR  Error: Exception in HostObject::get for prop 'NativeUnimoduleProxy': java.lang.IllegalStateException: UpdatesController.instance was called before the module was initialized, js engine: hermes
 ERROR  Invariant Violation: "main" has not been registered. This can happen if:
* Metro (the local dev server) is run from the wrong folder. Check if Metro is running, stop it and restart it in the current project.
* A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called., js engine: hermes
```

# How

The updated modules will attempt to export constants even if the controller was not initialized. A simple check has been added to prevent the app from throwing an error during initialization.

# Test Plan

- bare-expo ✅ 