### PR TITLE
[expo] support better hermes engine resolutions

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added missing `getJSEngineResolutionAlgorithm()` to `ReactNativeHostWrapper`. ([#27994](https://github.com/expo/expo/pull/27994) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 50.0.14 — 2024-03-20

--- a/packages/expo/android/src/reactNativeHostWrapper/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/reactNativeHostWrapper/expo/modules/ReactNativeHostWrapper.kt
@@ -1,6 +1,7 @@
 package expo.modules
 
 import android.app.Application
+import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.common.SurfaceDelegateFactory
@@ -21,6 +22,10 @@ class ReactNativeHostWrapper(
 
   override fun getReactPackageTurboModuleManagerDelegateBuilder(): ReactPackageTurboModuleManagerDelegate.Builder? {
     return invokeDelegateMethod("getReactPackageTurboModuleManagerDelegateBuilder")
+  }
+
+  override fun getJSEngineResolutionAlgorithm(): JSEngineResolutionAlgorithm? {
+    return invokeDelegateMethod("getJSEngineResolutionAlgorithm")
   }
 
   override fun getShouldRequireActivity(): Boolean {


### PR DESCRIPTION
# Why

fixes #27941 
close ENG-11841

# How

the [DefaultReactNativeHost will look up hermes if hermesEnabled=true](https://github.com/facebook/react-native/blob/0b23ff6631c1ec96bd867ba4206729e4d13155b2/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt#L73-L78). since we don't call `getJSEngineResolutionAlgorithm()` to DefaultReactHost, we will have the default behavior to [try jsc first then hermes](https://github.com/facebook/react-native/blob/2477fbc6005c4cbdc0ca3460413ce52e2e1e8bb5/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java#L364-L397).

this pr added the `getJSEngineResolutionAlgorithm()` support and delegate to DefaultReactNativeHost. then it would reduce some startup time and strange adb log for libjscexecutor.so not found when using hermes.
this is sdk-50 commit only since on main i've added this already for the work of bridgeless support.

# Test Plan

- ci passed
- test this patch on sdk 50
- test this patch on sdk 50 + expo-dev-client
- test this patch on sdk 50 + jsc

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
