### PR TITLE
[docs] Remove specifying exact Bun version for EAS, add Prerequisites, & add missing `bun` option in EAS JSON schema

### DIFF
--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -7,9 +7,11 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [Bun](https://bun.sh/) is a JavaScript runtime and a drop-in alternative for [Node.js](https://nodejs.org/en). In Expo projects, Bun can be used to install npm packages and run Node.js scripts. The benefits of using Bun are faster package installation than npm, pnpm, or yarn and [at least 4x faster startup time compared to Node.js](https://bun.sh/docs#design-goals), which gives a huge boost to your local development experience.
 
-## Start a new Expo project with Bun
+## Prerequisites
 
-To create a new app using Bun, [install Bun on your local machine](https://bun.sh/) by running the command:
+To create a new app using Bun, [install Bun on your local machine](https://bun.sh/docs/installation#installing).
+
+## Start a new Expo project with Bun
 
 <Terminal cmd={['$ curl -fsSL https://bun.sh/install | bash']} />
 
@@ -31,7 +33,9 @@ EAS decides which package manager to use based on the lockfile in your codebase.
 
 ### Customize Bun version on EAS
 
-EAS uses `bun@1.0.14` by default. If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
+Bun is installed by default when using EAS. To check the default version of Bun when creating an EAS Build, see [Android latest server image](/build-reference/infrastructure/#details) and [iOS latest server image](/build-reference/infrastructure/#details-7).
+
+If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -13,7 +13,7 @@ To create a new app using Bun, [install Bun on your local machine](https://bun.s
 
 ## Start a new Expo project with Bun
 
-Now, create your new Expo project:
+To create a new project, run the command:
 
 <Terminal cmd={['$ bun create expo my-app']} />
 
@@ -31,7 +31,7 @@ EAS decides which package manager to use based on the lockfile in your codebase.
 
 ### Customize Bun version on EAS
 
-Bun is installed by default when using EAS. To check the default version of Bun when creating an EAS Build, see [Android latest server image](/build-reference/infrastructure/#details) and [iOS latest server image](/build-reference/infrastructure/#details-7).
+Bun is installed by default when using EAS. See the [Android server images section](build-reference/infrastructure/#android-server-images) and [iOS server images section](/build-reference/infrastructure/#details-7) to learn which version of Bun is used by the image your build is running on.
 
 If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
 

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -13,8 +13,6 @@ To create a new app using Bun, [install Bun on your local machine](https://bun.s
 
 ## Start a new Expo project with Bun
 
-<Terminal cmd={['$ curl -fsSL https://bun.sh/install | bash']} />
-
 Now, create your new Expo project:
 
 <Terminal cmd={['$ bun create expo my-app']} />

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -31,9 +31,9 @@ EAS decides which package manager to use based on the lockfile in your codebase.
 
 ### Customize Bun version on EAS
 
-Bun is installed by default when using EAS. See the [Android server images section](build-reference/infrastructure/#android-server-images) and [iOS server images section](/build-reference/infrastructure/#details-7) to learn which version of Bun is used by the image your build is running on.
+Bun is installed by default when using EAS. See the [Android server images section](/build-reference/infrastructure/#android-server-images) and [iOS server images section](/build-reference/infrastructure/#ios-server-images) to learn which version of Bun is used by your build's image.
 
-If you need to use a particular version of Bun, you can configure the exact version in each build in your **eas.json**:
+If you need to use a [specific version of Bun](/eas/json/#bun), you can configure the exact version in each build in your **eas.json**:
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -92,17 +92,22 @@ export default [
   {
     name: 'node',
     type: 'string',
-    description: ['Version of Node.js.'],
+    description: ['Version of Node.js used for build.'],
   },
   {
     name: 'yarn',
     type: 'string',
-    description: ['Version of Yarn.'],
+    description: ['Version of Yarn used for build.'],
   },
   {
     name: 'pnpm',
     type: 'string',
-    description: ['Version of pnpm.'],
+    description: ['Version of pnpm used for build.'],
+  },
+  {
+    name: 'bun',
+    type: 'string',
+    description: ['Version of Bun used for build. You can also use a specific version. Learn [how to configure the exact version in eas.json](/guides/using-bun/#customize-bun-version-on-eas).'],
   },
   {
     name: 'expoCli',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The question about difference between Bun versions for Android and iOS build images was brought up in this PR: https://github.com/expo/expo/pull/27825#issue-2203871977.

# How

<!--
How did you build this feature or fix this bug and why?
-->

After investigating this with @szdziedzic, we've decided to mention a direct version since Bun version used for Android and iOS is different.

This PR:
- Updates the context about how Bun is installed by default when using EAS Build
- Removes instruction to install Bun using `curl` since Bun's documentation now provides installation instructions for Windows as well. Added a "Prerequisites" section here, which links to installation instructions from Bun's docs. 
- Add `"bun"` option in **eas.json** scehma.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and see: http://localhost:3002/guides/using-bun/#customize-bun-version-on-eas & http://localhost:3002/guides/using-bun/#prerequisites.

## Preview
![CleanShot 2024-04-02 at 23 58 20](https://github.com/expo/expo/assets/10234615/26436249-0ea3-469c-bf64-54e18785e476)


![CleanShot 2024-04-02 at 23 58 27](https://github.com/expo/expo/assets/10234615/6a0d0b88-5509-4e9d-9e7d-26f1d7259086)

![CleanShot 2024-04-03 at 16 52 01@2x](https://github.com/expo/expo/assets/10234615/e9c9a88c-7132-4192-93bf-c2cc5d51c00e)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
