### PR TITLE
[docs] Update Config Plugins introduction to explicitly mention about when double `[[]]` are required

### DIFF
--- a/docs/pages/config-plugins/introduction.mdx
+++ b/docs/pages/config-plugins/introduction.mdx
@@ -24,7 +24,7 @@ For example, `expo-camera` has a plugin that adds camera permissions to the **An
 
 <Terminal cmd={['$ npx expo install expo-camera']} />
 
-In your app's config (**app.json**, or **app.config.js**), you can add `expo-camera` to the list of plugins:
+In your [app's config](/versions/latest/config/app/), you can add `expo-camera` to the list of plugins:
 
 ```json app.json
 {
@@ -34,7 +34,7 @@ In your app's config (**app.json**, or **app.config.js**), you can add `expo-cam
 }
 ```
 
-Some plugins such as for [`expo-camera`](/versions/latest/sdk/camera/) can be customized by passing an array, where the second argument is the options:
+Some config plugins offer flexibility by allowing you to pass options to customize their configuration. To do this, you can pass an array with the Expo library name as the first argument, and an object containing the options as the second argument. For example, the `expo-camera` plugin allows you to customize the camera permission message:
 
 ```json app.json
 {
@@ -51,9 +51,9 @@ Some plugins such as for [`expo-camera`](/versions/latest/sdk/camera/) can be cu
 }
 ```
 
-> For each Expo package that a config plugin is available for, you'll find more information about that in the [package's API reference](/versions/latest/).
+> **info** **Tip**: For every Expo library that has a config plugin, you'll find more information about that in the library's API reference. For example, the [`expo-camera` library has a config plugin section](/versions/latest/sdk/camera/#configuration-in-appjsonappconfigjs).
 
-On running the `npx expo prebuild`, the [`mods`]() are compiled, and the native files change.
+On running the `npx expo prebuild`, the [`mods`](/config-plugins/plugins-and-mods/#how-mods-work) are compiled, and the native files change.
 
 The changes don't take effect until you rebuild the native project, for example, with Xcode. **If you're using config plugins in a managed app,
 they will be applied during the prebuild phase on `eas build`**.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-6563

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding the context of when to  use `[[]]` syntax when using a config plugin in a project.
- Also, make the callout as a tip and improve verbiage. Also, link to the `expo-camera` config plugin section since linking to the SDK docs overview doesn't make sense or provide a practical example for the end user.
- Add missing internal link when mentioning `mods` in the last section

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/config-plugins/introduction/#use-a-config-plugin.

## Preview

![CleanShot 2024-04-03 at 00 24 22](https://github.com/expo/expo/assets/10234615/4ed8f82b-7725-44be-8c02-5faa180ac937)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
