### PR TITLE
[docs] Update the "Create a mod" example so it works

### DIFF
--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -264,18 +264,16 @@ A mod plugin gets passed a `config` object with additional properties `modResult
 Say you wanted to write a mod to update the Xcode Project's "product name":
 
 ```ts my-config-plugin.ts
-import { ConfigPlugin, withXcodeProject } from 'expo/config-plugins';
+import { ConfigPlugin, withXcodeProject, IOSConfig } from 'expo/config-plugins';
 
-const withCustomProductName: ConfigPlugin = (config, customName) => {
+const withCustomProductName : ConfigPlugin<string> = (config, customName) => {
   return withXcodeProject(
     config,
     async (
       /* @info <b>{ modResults, modRequest }</b> */ config
       /* @end */
     ) => {
-      const xcodeProject = config.modResults;
-      xcodeProject.productName = customName;
-
+      config.modResults = IOSConfig.Name.setProductName({ name: customName }, config.modResults);
       return config;
     }
   );

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -266,7 +266,7 @@ Say you wanted to write a mod to update the Xcode Project's "product name":
 ```ts my-config-plugin.ts
 import { ConfigPlugin, withXcodeProject, IOSConfig } from 'expo/config-plugins';
 
-const withCustomProductName : ConfigPlugin<string> = (config, customName) => {
+const withCustomProductName: ConfigPlugin<string> = (config, customName) => {
   return withXcodeProject(
     config,
     async (


### PR DESCRIPTION
# Why
I was trying something with creating a config plugin, and I got a no-op when running this example as JS, and a `productName is a getter` error in TS.

# How
I eventually figured out how to make this update the product name, so updated the example to use the code that worked for me.

# Test Plan
Looked at it. Also, I ran the code ;-)

