### PR TITLE
[docs] clarify import rules for dynamic config

### DIFF
--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -59,7 +59,7 @@ Library authors can extend the app config by using [Expo Config plugins](/config
 For more customization, you can use the JavaScript (**app.config.js**) or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of) (**app.config.ts**). These configs have the following properties:
 
 - Comments, variables, and single quotes.
-- Importing/requiring other JavaScript files. Using import/export syntax in external files is not supported. All imported files must be transpiled to support your current version of Node.js.
+- `import` / `export` syntax is not supported, except when using [TypeScript with ts-node](https://docs.expo.dev/guides/typescript/#appconfigjs). JS files can be imported with `require()`, but they must be transpiled to support your current version of Node.js.
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.
@@ -153,7 +153,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 });
 ```
 
-If you want to import other TypeScript files or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs).
+To import other TypeScript files into **app.config.ts** or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs). `ts-node` also enables imports in any file imported by **app.config.ts**, meaning you can write local [config plugins](/config-plugins/introduction/) in TypeScript with full language features.
 
 ### Configuration resolution rules
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -153,7 +153,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 });
 ```
 
-To import other TypeScript files into **app.config.ts** or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs). `ts-node` also enables imports in any file imported by **app.config.ts**. This means you can write local [config plugins](/config-plugins/introduction/) in TypeScript with full language features.
+To import other TypeScript files into **app.config.ts** or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs). `ts-node` also enables using `import` syntax in any file imported by **app.config.ts**. This means you can write local [config plugins](/config-plugins/introduction/) in TypeScript with full language features.
 
 ### Configuration resolution rules
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -59,7 +59,7 @@ Library authors can extend the app config by using [Expo Config plugins](/config
 For more customization, you can use the JavaScript (**app.config.js**) or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of) (**app.config.ts**). These configs have the following properties:
 
 - Comments, variables, and single quotes.
-- `import` / `export` syntax is not supported, except when using [TypeScript with ts-node](https://docs.expo.dev/guides/typescript/#appconfigjs). JS files can be imported with `require()`, but they must be transpiled to support your current version of Node.js.
+- ESM import syntax (e.g., the `import` keyword) is not supported, except when using [TypeScript with ts-node](https://docs.expo.dev/guides/typescript/#appconfigjs). JS files that are compatible with your current version of Node.js can be imported with `require()`.
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.
@@ -153,7 +153,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
 });
 ```
 
-To import other TypeScript files into **app.config.ts** or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs). `ts-node` also enables imports in any file imported by **app.config.ts**, meaning you can write local [config plugins](/config-plugins/introduction/) in TypeScript with full language features.
+To import other TypeScript files into **app.config.ts** or customize the language features, we recommend using [`ts-node`](/guides/typescript/#appconfigjs). `ts-node` also enables imports in any file imported by **app.config.ts**. This means you can write local [config plugins](/config-plugins/introduction/) in TypeScript with full language features.
 
 ### Configuration resolution rules
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -59,7 +59,7 @@ Library authors can extend the app config by using [Expo Config plugins](/config
 For more customization, you can use the JavaScript (**app.config.js**) or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of) (**app.config.ts**). These configs have the following properties:
 
 - Comments, variables, and single quotes.
-- ESM import syntax (e.g., the `import` keyword) is not supported, except when using [TypeScript with ts-node](https://docs.expo.dev/guides/typescript/#appconfigjs). JS files that are compatible with your current version of Node.js can be imported with `require()`.
+- ESM import syntax (the `import` keyword) is not supported, except when using [TypeScript with `ts-node`](/guides/typescript/#appconfigjs). JS files that are compatible with your current version of Node.js can be imported with `require()`.
 - TypeScript support with nullish coalescing and optional chaining.
 - Updated whenever Metro bundler reloads.
 - Provide environment information to your app.


### PR DESCRIPTION
# Why
I learned about `ts-node` and how it can let you write local config plugins in full TS without a compilation step. I didn't even think to look for this because I stopped at "you can't import into a dynamic config".

# How
Updated "you can't import" bullet to clarify that there's an exception. Also connected the dots on config plugins in the app.config.ts section below that.

# Test Plan
Looked at it. Tried it.