### PR TITLE
[ios][av] Allow excluding microphone permission APIs from expo-av

### DIFF
--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -57,7 +57,7 @@ You can configure `expo-av` using its built-in [config plugin](/config-plugins/i
       name: 'microphonePermission',
       platform: 'ios',
       description:
-        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message.',
+        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message or `false` to disable microphone permissions.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
   ]}

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
+- [iOS] Allow excluding Microphone Permissions API's ([#28006](https://github.com/expo/expo/pull/28006) by [@ijzerenhein](https://github.com/ijzerenhein))
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV.podspec
+++ b/packages/expo-av/ios/EXAV.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
 Pod::Spec.new do |s|
   s.name           = 'EXAV'
@@ -30,6 +31,7 @@ Pod::Spec.new do |s|
     s.source_files = "#{s.name}/**/*.{h,m,mm,swift}"
     s.tvos.exclude_files = "#{s.name}/**/EXAudioRecordingPermissionRequester.{h,m}",
                            "#{s.name}/**/EXAV.m"
-    s.ios.exclude_files  = "#{s.name}/**/EXAVTV.m"
+    s.ios.exclude_files  = "#{s.name}/**/EXAVTV.m",
+                           "#{s.name}/**/EXAudioRecordingPermissionRequester#{podfile_properties['MICROPHONE_PERMISSION'] == 'false' ? '' : 'Disabled'}.m"
   end
 end

--- a/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequesterDisabled.m
+++ b/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequesterDisabled.m
@@ -1,0 +1,27 @@
+// Copyright 2016-present 650 Industries. All rights reserved.
+
+#import <EXAV/EXAudioRecordingPermissionRequester.h>
+#import <ExpoModulesCore/EXDefines.h>
+
+@implementation EXAudioRecordingPermissionRequester
+
++ (NSString *)permissionType
+{
+  return @"audioRecording";
+}
+
+- (NSDictionary *)getPermissions
+{
+  EXPermissionStatus status = EXPermissionStatusDenied;
+
+  return @{
+    @"status": @(status)
+  };
+}
+
+- (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
+{
+  resolve([self getPermissions]);
+}
+
+@end

--- a/packages/expo-av/plugin/build/withAV.js
+++ b/packages/expo-av/plugin/build/withAV.js
@@ -11,6 +11,12 @@ const withAV = (config, { microphonePermission } = {}) => {
             return config;
         });
     }
+    else {
+        config = (0, config_plugins_1.withPodfileProperties)(config, (config) => {
+            config.modResults.MICROPHONE_PERMISSION = 'false';
+            return config;
+        });
+    }
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         microphonePermission !== false && 'android.permission.RECORD_AUDIO',
         'android.permission.MODIFY_AUDIO_SETTINGS',

--- a/packages/expo-av/plugin/src/withAV.ts
+++ b/packages/expo-av/plugin/src/withAV.ts
@@ -3,6 +3,7 @@ import {
   ConfigPlugin,
   createRunOncePlugin,
   withInfoPlist,
+  withPodfileProperties,
 } from 'expo/config-plugins';
 
 const pkg = require('expo-av/package.json');
@@ -17,6 +18,11 @@ const withAV: ConfigPlugin<{ microphonePermission?: string | false } | void> = (
     config = withInfoPlist(config, (config) => {
       config.modResults.NSMicrophoneUsageDescription =
         microphonePermission || config.modResults.NSMicrophoneUsageDescription || MICROPHONE_USAGE;
+      return config;
+    });
+  } else {
+    config = withPodfileProperties(config, (config) => {
+      config.modResults.MICROPHONE_PERMISSION = 'false';
       return config;
     });
   }


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/issues/26730 and https://github.com/expo/expo/pull/17168

`expo-av` always requires that the Microphone Permissions is needed, even though your app might not need them. For instance, lots of users just use `expo-av` to play videos or audio files, but have no need to record any audio. As of XCode 15, Apple has started rejecting apps that contain the Microphone Permission API's. This PR solves that by allowing developers to set the `microphonePermission` in the expo-av plugin config to `false`. This in turn causes a "dummy" microphone requester file to be included which does not contain the problematic API's

# How

Added a `EXAudioRecordingPermissionRequesterDisabled.m` file which is used instead of `EXAudioRecordingPermissionRequester.m` when `microphonePermission=false`.

Configuration in `app.config.json`:

```json
{
  "plugins": [
    [
      "expo-av",
      {
        "microphonePermission": false,
      },
    ],
  ],
}
```

# Test Plan

- Regular build

*ios compile output*

![image](https://github.com/expo/expo/assets/6184593/52e6c4f9-b4dc-4c0f-b542-495566693e3d)


- When `microphonePermission` is set to `false`

![image](https://github.com/expo/expo/assets/6184593/4adf9fb6-681f-4307-8999-ffd4f6180b50)

*ios compile output*

![image](https://github.com/expo/expo/assets/6184593/366bee8c-73ea-48b2-a389-d6941990762c)

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
