### PR TITLE
[docs] Add a hover opacity effect on ImageSpotlight

### DIFF
--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -15,7 +15,12 @@ export default function ImageSpotlight({ alt, src, style, containerClassName, ca
   return (
     <figure
       className={mergeClasses('text-center bg-subtle py-2.5 my-5 rounded-lg', containerClassName)}>
-      <LightboxImage src={src} alt={alt} style={style} className="inline rounded-md" />
+      <LightboxImage
+        src={src}
+        alt={alt}
+        style={style}
+        className="inline rounded-md transition duration-300 ease-in-out hover:opacity-70"
+      />
       {caption && (
         <figcaption className="mt-[14px] text-secondary text-center text-xs px-8 py-2">
           {caption}

--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -19,7 +19,7 @@ export default function ImageSpotlight({ alt, src, style, containerClassName, ca
         src={src}
         alt={alt}
         style={style}
-        className="inline rounded-md transition duration-300 ease-in-out hover:opacity-70"
+        className="inline rounded-md transition duration-300 ease-in-out hover:opacity-80"
       />
       {caption && (
         <figcaption className="mt-[14px] text-secondary text-center text-xs px-8 py-2">

--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -19,7 +19,7 @@ export default function ImageSpotlight({ alt, src, style, containerClassName, ca
         src={src}
         alt={alt}
         style={style}
-        className="inline rounded-md transition duration-300 ease-in-out hover:opacity-80"
+        className="inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80"
       />
       {caption && (
         <figcaption className="mt-[14px] text-secondary text-center text-xs px-8 py-2">


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in discussion with @jonsamp that currently, apart from the mouse indicator to click the image, we do not have a strong visual indicator that the image is clickable.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I played around with a couple of solutions:
- Add a simple hover effect that applies opacity when hovered over an image
- Add a button on top right corner to indicate that this image is zoomable. The button doesn't have functionality because the `LightboxImage` component (which is the child component of the `ImageSpotlight` has that functionality). 


I didn't want to introduce a custom way to zoom in an image, so I decided to use the hover image effect. (Let me know if this pattern is not satisfactory.)

## Preview

https://github.com/expo/expo/assets/10234615/72bbb819-2ef8-4365-9fc5-f046e83d6625


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally:
- Visit http://localhost:3002/develop/user-interface/splash-screen/#splashbackgroundcolor
- Bring your mouse over the first image

OR

- Use preview and visit: /develop/user-interface/splash-screen/#splashbackgroundcolor
- Bring your mouse over the first image

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).