### PR TITLE
[core][Android] Stop exporting methods and constants from native proxy

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -2,13 +2,11 @@ package expo.modules.adapters.react;
 
 import android.util.SparseArray;
 
-import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableType;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -96,11 +96,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     kotlinModuleRegistry.installJSIInterop();
 
     Map<String, Object> constants = new HashMap<>(3);
-    constants.put(MODULES_CONSTANTS_KEY, mKotlinInteropModuleRegistry.exportedModulesConstants());
-    constants.put(EXPORTED_METHODS_KEY, mKotlinInteropModuleRegistry.exportMethods((name, info) -> {
-      assignExportedMethodsKeys(name, (List<Map<String, Object>>) info);
-      return null;
-    }));
+    constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
+    constants.put(EXPORTED_METHODS_KEY, new HashMap<>());
     constants.put(VIEW_MANAGERS_METADATA_KEY, mKotlinInteropModuleRegistry.viewManagersMetadata());
 
     CoreLoggerKt.getLogger().info("✅ Constants were exported");

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -44,33 +44,6 @@ class KotlinInteropModuleRegistry(
     }
   }
 
-  fun exportedModulesConstants(): Map<ModuleName, ModuleConstants> =
-    trace("KotlinInteropModuleRegistry.exportedModulesConstants") {
-      registry
-        // prevent infinite recursion - exclude NativeProxyModule constants
-        .filter { holder -> holder.name != NativeModulesProxyModuleName }
-        .associate { holder ->
-          holder.name to holder.definition.constantsProvider()
-        }
-    }
-
-  fun exportMethods(exportKey: (String, List<ModuleMethodInfo>) -> Unit = { _, _ -> }): Map<ModuleName, List<ModuleMethodInfo>> =
-    trace("KotlinInteropModuleRegistry.exportMethods") {
-      registry.associate { holder ->
-        val methodsInfo = holder
-          .definition
-          .asyncFunctions
-          .map { (name, method) ->
-            mapOf(
-              "name" to name,
-              "argumentsCount" to method.argsCount
-            )
-          }
-        exportKey(holder.name, methodsInfo)
-        holder.name to methodsInfo
-      }
-    }
-
   fun exportViewManagers(): List<ViewManager<*, *>> =
     trace("KotlinInteropModuleRegistry.exportViewManagers") {
       registry

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -4,20 +4,15 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.ViewManager
 import expo.modules.adapters.react.NativeModulesProxy
-import expo.modules.kotlin.views.ViewManagerType
-import expo.modules.kotlin.defaultmodules.NativeModulesProxyModuleName
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.views.GroupViewManagerWrapper
 import expo.modules.kotlin.views.SimpleViewManagerWrapper
+import expo.modules.kotlin.views.ViewManagerType
 import expo.modules.kotlin.views.ViewManagerWrapperDelegate
 import expo.modules.kotlin.views.ViewWrapperDelegateHolder
 import java.lang.ref.WeakReference
-
-private typealias ModuleName = String
-private typealias ModuleConstants = Map<String, Any?>
-private typealias ModuleMethodInfo = Map<String, Any?>
 
 class KotlinInteropModuleRegistry(
   modulesProvider: ModulesProvider,

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -83,27 +83,6 @@ class KotlinInteropModuleRegistryTest {
   }
 
   @Test
-  fun `should export constants`() {
-    Truth.assertThat(interopModuleRegistry.exportedModulesConstants())
-      .containsAtLeast(
-        "test-1",
-        mapOf("c1" to 123, "c2" to "123"),
-        "test-2",
-        emptyMap<String, Any>()
-      )
-  }
-
-  @Test
-  fun `should export view manages`() {
-    val rnManagers = interopModuleRegistry.exportViewManagers()
-    val expoManagersNames = interopModuleRegistry.viewManagersMetadata().keys
-
-    Truth.assertThat(rnManagers).hasSize(1)
-    Truth.assertThat(rnManagers.first().name).isEqualTo("ViewManagerAdapter_test-2")
-    Truth.assertThat(expoManagersNames).containsExactly("test-2")
-  }
-
-  @Test
   fun `call method should reject if something goes wrong`() {
     val mockedPromise = PromiseMock()
     val mockedPromise2 = PromiseMock()


### PR DESCRIPTION
# Why

Stops exporting methods and constants from the native modules proxy.
Improves startup time.

# How

All modules on Android were rewritten to the new API. We can start removing parts of the legacy API. 

# Test Plan

- bare-expo ✅ 