### PR TITLE
[core][Android] Reduce number of type casts

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -2,11 +2,15 @@
 
 package expo.modules.kotlin.classcomponent
 
+import expo.modules.kotlin.component6
+import expo.modules.kotlin.component7
+import expo.modules.kotlin.component8
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.objects.PropertyComponentBuilderWithThis
 import expo.modules.kotlin.sharedobjects.SharedRef
-import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.enforceType
+import expo.modules.kotlin.types.toArgsArray
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
@@ -51,7 +55,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0> Constructor(
     crossinline body: (p0: P0) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>())) { body(it[0] as P0) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0>()) { (p0) ->
+      enforceType<P0>(p0)
+      body(p0)
+    }.also {
       constructor = it
     }
   }
@@ -59,7 +66,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1> Constructor(
     crossinline body: (p0: P0, p1: P1) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1>()) { (p0, p1) ->
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
+    }.also {
       constructor = it
     }
   }
@@ -67,7 +77,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
+    }.also {
       constructor = it
     }
   }
@@ -75,7 +88,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
+    }.also {
       constructor = it
     }
   }
@@ -83,7 +99,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
+    }.also {
       constructor = it
     }
   }
@@ -91,7 +110,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
+    }.also {
       constructor = it
     }
   }
@@ -99,7 +121,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
+    }.also {
       constructor = it
     }
   }
@@ -107,7 +132,10 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", arrayOf(toAnyType<P0>(), toAnyType<P1>(), toAnyType<P2>(), toAnyType<P3>(), toAnyType<P4>(), toAnyType<P5>(), toAnyType<P6>(), toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
+    }.also {
       constructor = it
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 
 class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
@@ -20,7 +21,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
-      block(p0 as P0)
+      enforceType<P0>(p0)
+      block(p0)
     }.also {
       asyncFunctionComponent = it
     }
@@ -28,7 +30,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      block(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      block(p0, p1)
     }.also {
       asyncFunctionComponent = it
     }
@@ -36,7 +39,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      block(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      block(p0, p1, p2)
     }.also {
       asyncFunctionComponent = it
     }
@@ -44,7 +48,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      block(p0, p1, p2, p3)
     }.also {
       asyncFunctionComponent = it
     }
@@ -52,7 +57,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      block(p0, p1, p2, p3, p4)
     }.also {
       asyncFunctionComponent = it
     }
@@ -60,7 +66,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      block(p0, p1, p2, p3, p4, p5)
     }.also {
       asyncFunctionComponent = it
     }
@@ -68,7 +75,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      block(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       asyncFunctionComponent = it
     }
@@ -76,7 +84,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      block(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      block(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       asyncFunctionComponent = it
     }
@@ -99,7 +108,10 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
     return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, emptyArray()) { _, promise -> body(promise as P0) }
     } else {
-      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+        enforceType<P0>(p0)
+        body(p0)
+      }
     }.also {
       asyncFunctionComponent = it
     }
@@ -107,7 +119,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      body(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
     }.also {
       asyncFunctionComponent = it
     }
@@ -116,7 +129,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0> AsyncBody(crossinline body: (p0: P0, p1: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
-      body(p0 as P0, promise)
+      enforceType<P0>(p0)
+      body(p0, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -124,7 +138,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      body(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
     }.also {
       asyncFunctionComponent = it
     }
@@ -133,7 +148,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
-      body(p0 as P0, p1 as P1, promise)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -141,7 +157,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
     }.also {
       asyncFunctionComponent = it
     }
@@ -150,7 +167,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, promise)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -158,7 +176,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
     }.also {
       asyncFunctionComponent = it
     }
@@ -167,7 +186,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -175,7 +195,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
     }.also {
       asyncFunctionComponent = it
     }
@@ -184,7 +205,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -192,7 +214,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       asyncFunctionComponent = it
     }
@@ -201,7 +224,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
       asyncFunctionComponent = it
     }
@@ -209,7 +233,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       asyncFunctionComponent = it
     }
@@ -218,7 +243,8 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {
       asyncFunctionComponent = it
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -5,8 +5,8 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.enforceType
 
-@Suppress("UNCHECKED_CAST")
 inline fun <reified T> createAsyncFunctionComponent(
   name: String,
   desiredArgsTypes: Array<AnyType>,
@@ -16,11 +16,26 @@ inline fun <reified T> createAsyncFunctionComponent(
     return AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
   }
   return when (T::class.java) {
-    Int::class.java -> IntAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Int)
-    Boolean::class.java -> BoolAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Boolean)
-    Double::class.java -> DoubleAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Double)
-    Float::class.java -> FloatAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> Float)
-    String::class.java -> StringAsyncFunctionComponent(name, desiredArgsTypes, body as (Array<out Any?>) -> String)
+    Int::class.java -> {
+      enforceType<(Array<out Any?>) -> Int>(body)
+      IntAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
+    Boolean::class.java -> {
+      enforceType<(Array<out Any?>) -> Boolean>(body)
+      BoolAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
+    Double::class.java -> {
+      enforceType<(Array<out Any?>) -> Double>(body)
+      DoubleAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
+    Float::class.java -> {
+      enforceType<(Array<out Any?>) -> Float>(body)
+      FloatAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
+    String::class.java -> {
+      enforceType<(Array<out Any?>) -> String>(body)
+      StringAsyncFunctionComponent(name, desiredArgsTypes, body)
+    }
     else -> AsyncFunctionComponent<Any?>(name, desiredArgsTypes, body)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.functions
 import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
+import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 
 class FunctionBuilder(@PublishedApi internal val name: String) {
@@ -34,7 +35,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
-      body(p0 as P0)
+      enforceType<P0>(p0)
+      body(p0)
     }.also {
       functionComponent = it
     }
@@ -45,7 +47,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      body(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
     }.also {
       functionComponent = it
     }
@@ -56,7 +59,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      body(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
     }.also {
       functionComponent = it
     }
@@ -67,7 +71,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
     }.also {
       functionComponent = it
     }
@@ -78,7 +83,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
     }.also {
       functionComponent = it
     }
@@ -89,7 +95,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
     }.also {
       functionComponent = it
     }
@@ -100,7 +107,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       functionComponent = it
     }
@@ -111,7 +119,8 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       functionComponent = it
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -18,6 +18,7 @@ import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.primaryConstructor
@@ -97,7 +98,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
-      body(p0 as P0)
+      enforceType<P0>(p0)
+      body(p0)
     }.also {
       syncFunctions[name] = it
     }
@@ -108,7 +110,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      body(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
     }.also {
       syncFunctions[name] = it
     }
@@ -119,7 +122,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      body(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
     }.also {
       syncFunctions[name] = it
     }
@@ -130,7 +134,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
     }.also {
       syncFunctions[name] = it
     }
@@ -141,7 +146,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
     }.also {
       syncFunctions[name] = it
     }
@@ -152,7 +158,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
     }.also {
       syncFunctions[name] = it
     }
@@ -163,7 +170,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       syncFunctions[name] = it
     }
@@ -174,7 +182,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
     return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       syncFunctions[name] = it
     }
@@ -207,7 +216,10 @@ open class ObjectDefinitionBuilder {
     return if (P0::class.java == Promise::class.java) {
       AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
-      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+        enforceType<P0>(p0)
+        body(p0)
+      }
     }.also {
       asyncFunctions[name] = it
     }
@@ -218,7 +230,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      body(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
     }.also {
       asyncFunctions[name] = it
     }
@@ -230,7 +243,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
-      body(p0 as P0, promise)
+      enforceType<P0>(p0)
+      body(p0, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -241,7 +255,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      body(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
     }.also {
       asyncFunctions[name] = it
     }
@@ -253,7 +268,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
-      body(p0 as P0, p1 as P1, promise)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -264,7 +280,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
     }.also {
       asyncFunctions[name] = it
     }
@@ -276,7 +293,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, promise)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -287,7 +305,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
     }.also {
       asyncFunctions[name] = it
     }
@@ -299,7 +318,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -310,7 +330,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
     }.also {
       asyncFunctions[name] = it
     }
@@ -322,7 +343,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -333,7 +355,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       asyncFunctions[name] = it
     }
@@ -345,7 +368,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -356,7 +380,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       asyncFunctions[name] = it
     }
@@ -368,7 +393,8 @@ open class ObjectDefinitionBuilder {
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {
       asyncFunctions[name] = it
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnforceType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnforceType.kt
@@ -1,0 +1,60 @@
+package expo.modules.kotlin.types
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0> enforceType(p0: Any?) {
+  contract {
+    returns() implies (p0 is P0)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1> enforceType(p0: Any?, p1: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2> enforceType(p0: Any?, p1: Any?, p2: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2, reified P3> enforceType(p0: Any?, p1: Any?, p2: Any?, p3: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2 && p3 is P3)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> enforceType(p0: Any?, p1: Any?, p2: Any?, p3: Any?, p4: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2 && p3 is P3 && p4 is P4)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> enforceType(p0: Any?, p1: Any?, p2: Any?, p3: Any?, p4: Any?, p5: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2 && p3 is P3 && p4 is P4 && p5 is P5)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> enforceType(p0: Any?, p1: Any?, p2: Any?, p3: Any?, p4: Any?, p5: Any?, p6: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2 && p3 is P3 && p4 is P4 && p5 is P5 && p6 is P6)
+  }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> enforceType(p0: Any?, p1: Any?, p2: Any?, p3: Any?, p4: Any?, p5: Any?, p6: Any?, p7: Any?) {
+  contract {
+    returns() implies (p0 is P0 && p1 is P1 && p2 is P2 && p3 is P3 && p4 is P4 && p5 is P5 && p6 is P6 && p7 is P7)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -22,6 +22,7 @@ import kotlin.reflect.KType
 import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
+import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 
 @DefinitionMarker
@@ -195,7 +196,10 @@ class ViewDefinitionBuilder<T : View>(
     return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, emptyArray()) { _, promise -> body(promise as P0) }
     } else {
-      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) -> body(p0 as P0) }
+      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+        enforceType<P0>(p0)
+        body(p0)
+      }
     }.also {
       asyncFunctions[name] = it
     }
@@ -206,7 +210,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
-      body(p0 as P0, p1 as P1)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
     }.also {
       asyncFunctions[name] = it
     }
@@ -218,7 +223,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
-      body(p0 as P0, promise)
+      enforceType<P0>(p0)
+      body(p0, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -229,7 +235,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
-      body(p0 as P0, p1 as P1, p2 as P2)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
     }.also {
       asyncFunctions[name] = it
     }
@@ -241,7 +248,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
-      body(p0 as P0, p1 as P1, promise)
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -252,7 +260,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
     }.also {
       asyncFunctions[name] = it
     }
@@ -264,7 +273,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, promise)
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -275,7 +285,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
     }.also {
       asyncFunctions[name] = it
     }
@@ -287,7 +298,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, promise)
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -298,7 +310,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
     }.also {
       asyncFunctions[name] = it
     }
@@ -310,7 +323,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, promise)
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -321,7 +335,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
       asyncFunctions[name] = it
     }
@@ -333,7 +348,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, promise)
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
       asyncFunctions[name] = it
     }
@@ -344,7 +360,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunction {
     return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, p7 as P7)
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
       asyncFunctions[name] = it
     }
@@ -356,7 +373,8 @@ class ViewDefinitionBuilder<T : View>(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
   ): AsyncFunction {
     return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
-      body(p0 as P0, p1 as P1, p2 as P2, p3 as P3, p4 as P4, p5 as P5, p6 as P6, promise)
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {
       asyncFunctions[name] = it
     }


### PR DESCRIPTION
# Why

Reduces the number of type casts needed when calling the exported function. 

# How

Introduced a new helper function that forces the compiler into thinking that received types are correct. We can do it because our API ensures received data is correct. 

# Test Plan

- bare-expo ✅ 
