### PR TITLE
[expo] bump skia version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.5.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "0.1.221",
+  "@shopify/react-native-skia": "1.0.4",
   "@shopify/flash-list": "1.6.3",
   "@sentry/react-native": "5.5.0"
 }


### PR DESCRIPTION
# Why

i forgot to bump the skia version in bundledNativeModules.json from #27973

# How

bump the skia version to 1.0.4

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
