### PR TITLE
[eslint-config-expo] [ENG-11850] Use explicit rules for React

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- Opt into explicit rules from eslint-plugin-react  ([#28032](https://github.com/expo/expo/pull/28032) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eslint-config-expo/utils/react.js
+++ b/packages/eslint-config-expo/utils/react.js
@@ -1,16 +1,20 @@
 module.exports = {
   parserOptions: { ecmaFeatures: { jsx: true } },
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  plugins: ['react'],
+  extends: ['plugin:react-hooks/recommended'],
   rules: {
+    'react/display-name': 'warn',
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-undef': 'error',
     'react/jsx-uses-react': 'warn',
     'react/jsx-uses-vars': 'warn',
+    'react/no-danger-with-children': 'warn',
+    'react/no-deprecated': 'warn',
     'react/no-direct-mutation-state': 'warn',
+    'react/no-string-refs': ['warn', { noTemplateLiterals: true }],
     'react/no-this-in-sfc': 'warn',
     'react/no-unknown-property': 'warn',
     'react/require-render-return': 'warn',
-    'react/react-in-jsx-scope': 'off',
   },
   settings: {
     react: { version: 'detect' },


### PR DESCRIPTION
# Why

We want to use explicit rules for React instead of just extending the recommended.

# How

Update the rules.

# Test Plan

Tested locally be installing it on an existing project with `yalc`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
