### PR TITLE
[cli] add navigate to Router type

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add missing type-safe navigation with router.navigate. ([#28034](https://github.com/expo/expo/pull/28034) by [@youssdevx](https://github.com/youssdevx))
 - Add source map outputs when exporting API route bundles. ([#27913](https://github.com/expo/expo/pull/27913) by [@kitten](https://github.com/kitten))
 - Add experimental support for using a canary build of the React Native renderer. ([#27303](https://github.com/expo/expo/pull/27303) by [@EvanBacon](https://github.com/EvanBacon))
 - Add basic `react-server` support. ([#27264](https://github.com/expo/expo/pull/27264) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -517,8 +517,10 @@ declare module "expo-router" {
    * Expo Router Exports *
    ***********************/
 
-  export type Router = Omit<OriginalRouter, 'push' | 'replace' | 'setParams'> & {
+  export type Router = Omit<OriginalRouter, 'push' | 'replace' | 'setParams' | 'navigate'> & {
     /** Navigate to the provided href. */
+    navigate: <T>(href: Href<T>) => void;
+    /** Navigate by adding another route regardless of the existing navigation history. */
     push: <T>(href: Href<T>) => void;
     /** Navigate to route without appending to the history. */
     replace: <T>(href: Href<T>) => void;


### PR DESCRIPTION
# Why

- `router.navigate` was not type-safe
- navigate was missing from the types in Router

# How

- add navigate to Router in type generation