### PR TITLE
[docs] Amendment to reference correct function name

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -303,7 +303,7 @@ export default function Settings() {
   return (
     <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
       /* @info Trigger the handler method on a touchable/button component */
-      <Button title="Go to first screen" onPress={() => dismiss(3)} />
+      <Button title="Go to first screen" onPress={() => handleDismiss(3)} />
       /* @end */
     </View>
   );


### PR DESCRIPTION
# Why

I noticed the documentation referred to a function as 'dismiss', whereas it should be 'handleDismiss'.
