### PR TITLE
[go][Android] Add ExpoBridgeModule to ExponentPackage in Expo Go

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -24,6 +24,7 @@ import com.swmansion.rnscreens.RNScreensPackage
 import expo.modules.adapters.react.ReactModuleRegistryProvider
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
+import expo.modules.kotlin.ExpoBridgeModule
 import expo.modules.kotlin.ModulesProvider
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.analytics.EXL
@@ -126,6 +127,7 @@ class ExponentPackage : ReactPackage {
       try {
         val experienceKey = ExperienceKey.fromManifest(manifest)
         val scopedContext = ScopedContext(reactContext, experienceKey)
+        nativeModules.add(ExpoBridgeModule(reactContext))
         nativeModules.add(NotificationsModule(reactContext, experienceKey, manifest.getStableLegacyID(), manifest.getEASProjectID()))
         nativeModules.add(RNViewShotModule(reactContext, scopedContext))
         nativeModules.add(ExponentTestNativeModule(reactContext))


### PR DESCRIPTION
# Why

After landing #27929, Expo Go on Android cannot launch local home because it tries to get `globalThis.expo.NativeModule` while our JSI bindings are not installed yet.

# How

The solution for this is to explicitly add `ExpoBridgeModule` to the `ExponentPackage`, like other RN modules

# Test Plan

- `yarn start` in `apps/expo-go`
- Build Expo Go and confirm that home launches without errors
