### PR TITLE
Fix #28043, crash caused by unnecessary permissions check

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent unnecessary permissions check when moving app to background (Would crash with certain configs). ([#28045](https://github.com/expo/expo/pull/28045) by [@cltnschlosser](https://github.com/cltnschlosser))
+
 ### 💡 Others
 
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -101,16 +101,15 @@ public final class PedometerModule: Module {
   }
 
   private func stopUpdates() {
-    guard let permissions = appContext?.permissions else {
+    guard watchHandler != nil,
+          let permissions = appContext?.permissions,
+          permissions.hasGrantedPermission(usingRequesterClass: EXMotionPermissionRequester.self) else {
       return
     }
-    if permissions.hasGrantedPermission(usingRequesterClass: EXMotionPermissionRequester.self) {
-      if watchHandler != nil {
-        pedometer.stopUpdates()
-        watchStartDate = nil
-        watchHandler = nil
-      }
-    }
+
+    pedometer.stopUpdates()
+    watchStartDate = nil
+    watchHandler = nil
   }
 }
 

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -102,8 +102,8 @@ public final class PedometerModule: Module {
 
   private func stopUpdates() {
     guard watchHandler != nil,
-          let permissions = appContext?.permissions,
-          permissions.hasGrantedPermission(usingRequesterClass: EXMotionPermissionRequester.self) else {
+      let permissions = appContext?.permissions,
+      permissions.hasGrantedPermission(usingRequesterClass: EXMotionPermissionRequester.self) else {
       return
     }
 


### PR DESCRIPTION
# Why

Fixes  #28043
Also minor perf improvement by skipping unnecessary work.

# Test Plan

Using bare expo project that was experiencing this crash.
