### PR TITLE
[expo-update][e2e] Add error recovery e2e test

### DIFF
--- a/.github/workflows/updates-e2e-error-recovery.yml
+++ b/.github/workflows/updates-e2e-error-recovery.yml
@@ -1,0 +1,101 @@
+name: Updates e2e (error recovery) EAS
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e-error-recovery.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e-error-recovery.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+  schedule:
+    - cron: '0 20 * * SUN' # 20:00 UTC every Sunday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+        variant: [updates_testing_release] # this test only works in release mode
+    runs-on: ubuntu-22.04
+    timeout-minutes: 80
+    env:
+      UPDATES_PORT: 4747
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🔧 Install eas-cli
+        run: yarn global add eas-cli
+      - name: 🌳 Add EXPO_REPO_ROOT to environment
+        run: echo "EXPO_REPO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: 🌐 Set updates host
+        run: echo "UPDATES_HOST=localhost" >> $GITHUB_ENV
+      - name: 🌐 Set updates port
+        run: echo "UPDATES_PORT=4747" >> $GITHUB_ENV
+      - name: 📦 Set platform for updates E2E build
+        run: echo "EAS_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
+      - name: 📦 Get artifacts path
+        run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
+      - name: 📦 Get commit message
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
+      - name: 📦 Set test project location
+        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+      - name: 📦 Setup test project for updates E2E error recovery tests
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
+      - name: 🚀 Build with EAS for ${{ matrix.platform }}
+        uses: ./.github/actions/eas-build
+        id: build_eas
+        with:
+          platform: ${{ env.EAS_PLATFORM }}
+          profile: ${{ matrix.variant }}
+          projectRoot: './updates-e2e'
+          expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
+      - name: On ${{ matrix.platform }} workflow canceled
+        if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
+        run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
+        working-directory: './updates-e2e'
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -14,6 +14,9 @@ require('./includedAssets/lock-filled.svg');
 // eslint-disable-next-line no-unused-expressions
 Inter_900Black;
 
+// keep the line below for replacement in generate-test-update-bundles
+// REPLACE_WITH_CRASHING_CODE
+
 function TestValue(props: { testID: string; value: string }) {
   return (
     <View>

--- a/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
@@ -1,0 +1,101 @@
+import { by, device, element, waitFor } from 'detox';
+import jestExpect from 'expect';
+
+import Server from './utils/server';
+import Update from './utils/update';
+
+const projectRoot = process.env.PROJECT_ROOT || process.cwd();
+const platform = device.getPlatform();
+const protocolVersion = 1;
+
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
+  return attributes?.text || '';
+};
+
+const waitForAppToBecomeVisible = async () => {
+  await waitFor(element(by.id('updateString')))
+    .toBeVisible()
+    .withTimeout(2000);
+};
+
+describe('Error recovery tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+    Server.stop();
+  });
+
+  it('downloads new update before launching, but launches the last non-crashing update', async () => {
+    Server.start(Update.serverPort, protocolVersion, 1000);
+
+    await Server.serveSignedDirective(Update.getNoUpdateAvailableDirective(), projectRoot);
+
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+
+    const request1 = await Server.waitForUpdateRequest(10000);
+    const request1CurrentUpdateId = request1.headers['expo-current-update-id'];
+    const request1RecentFailedUpdateIds = request1.headers['expo-recent-failed-update-ids'];
+    const embeddedUpdateId = request1.headers['expo-embedded-update-id'];
+    jestExpect(embeddedUpdateId).toBeTruthy();
+    jestExpect(request1RecentFailedUpdateIds).toBeUndefined();
+    jestExpect(request1CurrentUpdateId).toEqual(embeddedUpdateId);
+
+    await waitForAppToBecomeVisible();
+    await device.terminateApp();
+
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-crashing';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-crashing-key',
+      bundleFilename,
+      [],
+      projectRoot
+    );
+
+    await Server.serveSignedManifest(manifest, projectRoot);
+
+    // launch and crash (restart from cache doesn't work in detox)
+    // we don't check current update ID header or failed update IDs header since the behavior for this request is not defined
+    // (we don't guarantee current update to be set during a crash or the launch failure to have been registered yet)
+    await jestExpect(
+      device.launchApp({
+        newInstance: true,
+      })
+    ).rejects.toThrow();
+    const request2 = await Server.waitForUpdateRequest(10000);
+    const request2EmbeddedUpdateId = request2.headers['expo-embedded-update-id'];
+    const request2CurrentUpdateId = request2.headers['expo-current-update-id'];
+    jestExpect(embeddedUpdateId).toEqual(request2EmbeddedUpdateId);
+
+    await device.terminateApp();
+
+    // relaunch, it should launch the embedded update since the update being served failed to launch
+    await device.launchApp({
+      newInstance: true,
+    });
+    const request3 = await Server.waitForUpdateRequest(10000);
+    const request3CurrentUpdateId = request3.headers['expo-current-update-id'];
+    const request3EmbeddedUpdateId = request3.headers['expo-embedded-update-id'];
+    const request3RecentFailedUpdateIds = request3.headers['expo-recent-failed-update-ids'];
+    jestExpect(embeddedUpdateId).toEqual(request3EmbeddedUpdateId);
+    jestExpect(embeddedUpdateId).toEqual(request3CurrentUpdateId);
+    jestExpect(request3RecentFailedUpdateIds).toEqual(`"${request2CurrentUpdateId}"`);
+
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+    jestExpect(message).toBe('test');
+
+    await device.terminateApp();
+  });
+});

--- a/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.ts
@@ -12,6 +12,7 @@ const notifyStrings = [
   'test-update-invalid-hash',
   'test-update-older',
   'test-assets-1',
+  'test-update-crashing',
 ];
 
 const platform = process.argv[2];
@@ -47,10 +48,15 @@ async function createTestUpdateBundles(
   const testUpdateJson: { [k: string]: any } = {};
   for (const notifyString of ['test', ...notifyStrings]) {
     console.log(`Creating bundle for string '${notifyString}'...`);
-    const modifiedAppJs = originalAppJs.replace(
+    let modifiedAppJs = originalAppJs.replace(
       /testID="updateString" value="test"/g,
       `testID="updateString" value="${notifyString}"`
     );
+
+    if (notifyString === 'test-update-crashing') {
+      modifiedAppJs = modifiedAppJs.replace('// REPLACE_WITH_CRASHING_CODE', 'blah.blah;');
+    }
+
     await fs.rm(appJsPath);
     await fs.writeFile(appJsPath, modifiedAppJs, 'utf-8');
     await createUpdateBundleAsync(projectRoot, platform);

--- a/packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import {
+  initAsync,
+  setupUpdatesErrorRecoveryE2EAppAsync,
+  transformAppJsonForE2EWithFallbackToCacheTimeout,
+} from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: true,
+    transformAppJson: transformAppJsonForE2EWithFallbackToCacheTimeout,
+  });
+
+  await setupUpdatesErrorRecoveryE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -48,7 +48,17 @@ function getExpoDependencyChunks({
       ? [['expo-dev-menu-interface'], ['expo-dev-menu'], ['expo-dev-launcher'], ['expo-dev-client']]
       : []),
     ...(includeTV
-      ? [['expo-av', 'expo-blur', 'expo-image', 'expo-linear-gradient', 'expo-localization', 'expo-crypto', 'expo-network']]
+      ? [
+          [
+            'expo-av',
+            'expo-blur',
+            'expo-image',
+            'expo-linear-gradient',
+            'expo-localization',
+            'expo-crypto',
+            'expo-network',
+          ],
+        ]
       : []),
   ];
 }
@@ -816,6 +826,29 @@ export async function setupUpdatesDisabledE2EAppAsync(
   // Copy Detox test file to e2e/tests directory
   await fs.copyFile(
     path.resolve(dirName, '..', 'fixtures', 'Updates-disabled.e2e.ts'),
+    path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
+  );
+}
+
+export async function setupUpdatesErrorRecoveryE2EAppAsync(
+  projectRoot: string,
+  { localCliBin, repoRoot }: { localCliBin: string; repoRoot: string }
+) {
+  await copyCommonFixturesToProject(
+    projectRoot,
+    ['tsconfig.json', '.detoxrc.json', 'eas.json', 'eas-hooks', 'e2e', 'includedAssets', 'scripts'],
+    { appJsFileName: 'App.tsx', repoRoot, isTV: false }
+  );
+
+  // install extra fonts package
+  await spawnAsync(localCliBin, ['install', '@expo-google-fonts/inter'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  // Copy Detox test file to e2e/tests directory
+  await fs.copyFile(
+    path.resolve(dirName, '..', 'fixtures', 'Updates-error-recovery.e2e.ts'),
     path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
   );
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -260,7 +260,7 @@ public final class FileDownloader {
       let failedUpdateIDs = try database.recentUpdateIdsWithFailedLaunch()
       if !failedUpdateIDs.isEmpty {
         let structuredHeaderList = try StringList(value: failedUpdateIDs.map({ item in
-          try StringItem(value: item.uuidString)
+          try StringItem(value: item.uuidString.lowercased())
         }))
         extraHeaders["Expo-Recent-Failed-Update-IDs"] = structuredHeaderList.serialize()
       }


### PR DESCRIPTION
# Why

We need to test basic error recovery functionality. This PR tests it as best we can in release builds in update e2e.

Closes ENG-11840.

# How

Unfortunately we can't test the "reloadFromCache" error recovery step inside the app since detox doesn't support restarting the react native instance (see other test for how we simulate restarting).

So we can just test that it crashes and that the next launch doesn't try to launch it.

This also tests the new header added in https://github.com/expo/expo/pull/27991

# Test Plan

Run new workflow in CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
