### PR TITLE
Revert "[expo-updates] Fix embedded manifest for native debug builds"

### DIFF
--- a/packages/expo-updates/utils/build/createManifestForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createManifestForBuildAsync.js
@@ -32,7 +32,7 @@ async function createManifestForBuildAsync(platform, possibleProjectRoot, destin
         platform,
         entryFile,
         minify: false,
-        dev: process.env.EX_UPDATES_NATIVE_DEBUG === '1',
+        dev: false,
         sourcemapUseAbsolutePath: false,
     };
     const { server, bundleRequest } = (await (0, exportEmbedAsync_1.createMetroServerAndBundleRequestAsync)(projectRoot, options));

--- a/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
@@ -44,7 +44,7 @@ export async function createManifestForBuildAsync(
     platform,
     entryFile,
     minify: false,
-    dev: process.env.EX_UPDATES_NATIVE_DEBUG === '1',
+    dev: false,
     sourcemapUseAbsolutePath: false,
   };
 


### PR DESCRIPTION
Reverts expo/expo#28042

This is causing android e2e tests to fail I think (bisected locally): https://github.com/expo/expo/actions/runs/8560572933/job/23459880899