### PR TITLE
[expo-updates][iOS] Fix embedded manifest for native debug builds

### DIFF
--- a/packages/expo-updates/utils/build/createManifestForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createManifestForBuildAsync.js
@@ -32,7 +32,7 @@ async function createManifestForBuildAsync(platform, possibleProjectRoot, destin
         platform,
         entryFile,
         minify: false,
-        dev: false,
+        dev: process.env.CONFIGURATION === 'Debug', // ensures debug assets packaged correctly for iOS and native debug
         sourcemapUseAbsolutePath: false,
     };
     const { server, bundleRequest } = (await (0, exportEmbedAsync_1.createMetroServerAndBundleRequestAsync)(projectRoot, options));

--- a/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
@@ -44,7 +44,7 @@ export async function createManifestForBuildAsync(
     platform,
     entryFile,
     minify: false,
-    dev: false,
+    dev: process.env.CONFIGURATION === 'Debug', // ensures debug assets packaged correctly for iOS and native debug
     sourcemapUseAbsolutePath: false,
   };
 


### PR DESCRIPTION
# Why

In testing with current canary packages, running a native debug build for updates (EX_UPDATES_NATIVE_DEBUG=1), it is possible for the app to lock up on iOS if a LogBox warning occurs.

The root cause is that the embedded manifest is built with dev=false, so does not include the LogBox image assets. Asset resolution then retrieves these with empty URIs, leading to an infinite loop of console.warn() calls inside React Native Image code.

# How

Modify the embedded manifest generation to set dev=true if CONFIGURATION=Debug (set for iOS debug builds only).

# Test Plan

- Tested with a local project using latest canary packages.
- CI should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).