### PR TITLE
[docs] Add a note about tests files placement in Expo Router > Testing guide

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -7,10 +7,11 @@ import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { GithubIcon, BookOpen02Icon } from '@expo/styleguide-icons';
 
 [Jest](https://jestjs.io) is the most widely used JavaScript unit testing framework. In this guide, you'll learn how to set up Jest in your project, write a unit test, write a snapshot test, and best practices for structuring your tests when using Jest with React Native.
 
-You'll also use the `jest-expo` package which is a Jest preset and mocks the native part of the Expo SDK and handles most of the configuration.
+You'll also use the `jest-expo` package, which is a Jest preset and mocks the native part of the Expo SDK and handles most of the configuration.
 
 ## Installation
 
@@ -201,10 +202,18 @@ You can also use different flows to run your tests. Below are a few example scri
 
 For more information, see [CLI Options](https://jestjs.io/docs/en/cli) in Jest documentation.
 
-## Next step
+## More
 
 <BoxLink
   title="React Native Testing library"
-  description="You can also use React Native Testing Library which provides testing utilities that encourage good testing practices and works with Jest."
+  description="You can also use React Native Testing Library that provides testing utilities that encourage good testing practices and works with Jest."
   href="https://github.com/callstack/react-native-testing-library"
+  Icon={GithubIcon}
+/>
+
+<BoxLink
+  title="Testing configuration for Expo Router"
+  description="Learn how to create integration tests for your app when using Expo Router."
+  href="/router/reference/testing/"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -11,6 +11,8 @@ Expo Router relies on your file system, which can present challenges when settin
 
 Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
+> **Note**: Since Expo router is a file-based router, do not put your test files inside the **app** directory. Instead, use the **\_\_tests\_\_** directory or a separate directory. This approach is explained in [Unit testing](/develop/unit-testing/#structure-your-tests).
+
 ### Jest Native Matchers (optional)
 
 [`@testing-library/jest-native`](https://testing-library.com/docs/ecosystem-jest-native/) provides custom Jest matchers that can be used to extend the functionality of `@testing-library/react-native`. If installed, Expo Router will automatically perform the `@testing-library/jest-native` setup.
@@ -60,8 +62,8 @@ Providing an array of strings to `renderRouter` will create an inline mock files
 import { renderRouter, screen } from 'expo-router/testing-library';
 
 it('my-test', async () => {
-  renderRouter(["index", "directory/a", "(group)/b"], {
-      initialUrl: '/directory/a',
+  renderRouter(['index', 'directory/a', '(group)/b'], {
+    initialUrl: '/directory/a',
   });
 
   expect(screen).toHavePathname('/directory/a');
@@ -104,7 +106,6 @@ it('my-test', async () => {
 ```
 
 </APIBox>
-
 
 ## Jest matchers
 

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -1,5 +1,6 @@
 ---
-title: Testing
+title: Testing configuration for Expo Router
+sidebar_title: Testing
 description: Learn how to create integration tests for your app when using Expo Router.
 ---
 
@@ -9,7 +10,7 @@ Expo Router relies on your file system, which can present challenges when settin
 
 ## Configuration
 
-Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started).
+Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started) in your project.
 
 > **Note**: Since Expo router is a file-based router, do not put your test files inside the **app** directory. Instead, use the **\_\_tests\_\_** directory or a separate directory. This approach is explained in [Unit testing](/develop/unit-testing/#structure-your-tests).
 


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #28000.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a note to avoid putting a test file inside **app** directory and run into issue like #28000.

**Other changes**
- Expand the title of the guide to "Testing configuration for Expo Router" so that it is clear in search that this guide relates to Expo Router and not general testing advice.
- Update **Unit testing** guide to change the Next step to More, update BoxLinks and add a BoxLink for Expo Router testing guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/introduction/

## Preview
**Expo Router**

![Capture-2024-04-05-232255](https://github.com/expo/expo/assets/10234615/d9a15653-a3f2-4353-ab52-4c1b96544831)

**Unit testing**

![CleanShot 2024-04-05 at 23 34 47@2x](https://github.com/expo/expo/assets/10234615/7d870f6b-485a-4d21-b231-16b5f411eeab)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
