### PR TITLE
[core] fix installModules broken on bridgeless

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -24,7 +24,6 @@ import com.swmansion.rnscreens.RNScreensPackage
 import expo.modules.adapters.react.ReactModuleRegistryProvider
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
-import expo.modules.kotlin.ExpoBridgeModule
 import expo.modules.kotlin.ModulesProvider
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.analytics.EXL
@@ -127,7 +126,6 @@ class ExponentPackage : ReactPackage {
       try {
         val experienceKey = ExperienceKey.fromManifest(manifest)
         val scopedContext = ScopedContext(reactContext, experienceKey)
-        nativeModules.add(ExpoBridgeModule(reactContext))
         nativeModules.add(NotificationsModule(reactContext, experienceKey, manifest.getStableLegacyID(), manifest.getEASProjectID()))
         nativeModules.add(RNViewShotModule(reactContext, scopedContext))
         nativeModules.add(ExponentTestNativeModule(reactContext))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed crash from reloading on iOS and bridgeless mode. ([#27928](https://github.com/expo/expo/pull/27928) by [@kudo](https://github.com/kudo))
 - Fixed SharedRef class names are obfuscated when R8 is enabled. ([#27965](https://github.com/expo/expo/pull/27965) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `recreateRootViewWithBundleURL` parameters. ([#27989](https://github.com/expo/expo/pull/27989) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fixed `ExpoBridgeModule.installModules()` is broken on Android and bridgeless mode. ([#28065](https://github.com/expo/expo/pull/28065) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -74,7 +74,6 @@ public class ModuleRegistryAdapter implements ReactPackage {
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
-    nativeModules.add(new ExpoBridgeModule(new WeakReference<>(proxy)));
     return nativeModules;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -73,7 +74,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
     }
 
-    nativeModules.add(new ExpoBridgeModule(reactContext));
+    nativeModules.add(new ExpoBridgeModule(new WeakReference<>(proxy)));
     return nativeModules;
   }
 
@@ -97,6 +98,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       nativeModulesList.addAll(reactPackage.createNativeModules(reactContext));
     }
 
+    nativeModulesList.add(new ExpoBridgeModule(new WeakReference<>(nativeModulesProxy)));
     return nativeModulesList;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
@@ -1,21 +1,22 @@
 package expo.modules.kotlin
 
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import expo.modules.adapters.react.NativeModulesProxy
+import java.lang.ref.WeakReference
 
 /**
  * The classic bridge module that is responsible for installing the host object to the runtime.
  */
-class ExpoBridgeModule(private val context: ReactContext) : ReactContextBaseJavaModule() {
+class ExpoBridgeModule(private val nativeModulesProxy: WeakReference<NativeModulesProxy>) : ReactContextBaseJavaModule() {
   override fun getName(): String = "ExpoModulesCore"
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  fun installModules() {
-    val nativeModulesProxy = context.getUnimoduleProxy()
-    val kotlinInterop = nativeModulesProxy?.kotlinInteropModuleRegistry
+  fun installModules(): Boolean {
+    val kotlinInterop = nativeModulesProxy.get()?.kotlinInteropModuleRegistry
       ?: throw IllegalStateException("Couldn't find KotlinInteropModuleRegistry")
 
     kotlinInterop.installJSIInterop()
+    return true
   }
 }


### PR DESCRIPTION
# Why

fix `ExpoBridgeModule.installModules` broken on bridgeless mode 

# How

- because turbo module interop does not support [sync methods return void](https://github.com/facebook/react-native/blob/7facb32f30d17eb27f870dd531d3dc7ebe4532f6/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java#L97-L101). this pr tries to make the method returns boolean
- passing `NativeModulesProxy` directly to `ExpoBridgeModule` to prevent using `ReactContext.getUnimoduleProxy()`
- revert #28044 that i feel adding `ExpoBridgeModule` to `getNativeModulesFromModuleRegistry` is more correct.

# Test Plan

- fabric-tester
- expo-go

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
