### PR TITLE
feat(config-type): new test environment parameters to branch's config plugin

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -350,6 +350,14 @@ export interface IOS {
              * Your Branch API key
              */
             apiKey?: string;
+            /**
+             * Your Branch Test API key
+             */
+            testApiKey?: string;
+            /**
+             * A boolean indicating whether Branch should be initialised pointing to your Test environment
+             */
+            enableTestEnvironment?: boolean;
         };
         /**
          * Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.
@@ -572,6 +580,14 @@ export interface Android {
              * Your Branch API key
              */
             apiKey?: string;
+            /**
+             * Your Branch Test API key
+             */
+            testApiKey?: string;
+            /**
+             * A boolean indicating whether Branch should be initialised pointing to your Test environment
+             */
+            enableTestEnvironment?: boolean;
         };
         /**
          * [Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -354,6 +354,14 @@ export interface IOS {
        * Your Branch API key
        */
       apiKey?: string;
+      /**
+       * Your Branch Test API key
+       */
+      testApiKey?: string;
+      /**
+       * A boolean indicating whether Branch should be initialised pointing to your Test environment
+       */
+      enableTestEnvironment?: boolean;
     };
     /**
      * Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.
@@ -576,6 +584,14 @@ export interface Android {
        * Your Branch API key
        */
       apiKey?: string;
+      /**
+       * Your Branch Test API key
+       */
+      testApiKey?: string;
+      /**
+       * A boolean indicating whether Branch should be initialised pointing to your Test environment
+       */
+      enableTestEnvironment?: boolean;
     };
     /**
      * [Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Introduce new config values to enable Test environments when using `@config-plugin/react-native-branch` ([#28084](https://github.com/expo/expo/pull/28084) by [@rodperottoni](https://github.com/rodperottoni))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others


### PR DESCRIPTION
# Why

Branch offers developers the ability to test their integration within a "Test" environment. This is usually done by passing an extra **Test API Key** to the branch's native module bindings & instructing the SDK to initialise pointed to the Test environment. 

Unfortunately, the existing community config plugin (`@config-plugins/react-native-branch`) does not offer support for enabling the **test** environment. One of my colleagues has customised the community plugin to work for our internal purposes, and I thought it would be cool to make this available for other expo users.

# How

In this PR I'm simply expanding upon the existing config types to accept two extra values:
- `config.[android|ios].config.branch.testApiKey`: A test API key to be consumed by the config plugin.
- `config.[android|ios].config.branch.enableTestEnvironment`: A boolean value indicating whether to use the Test environment

These values will be referenced by the updated config plugin (`@config-plugins/react-native-branch`) during `prebuild`.

# Test Plan

I am adding tests to `@config-plugins/react-native-branch` to ensure these values will be correctly used.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
