### PR TITLE
fix: autolinking and custom configurations

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Support custom debug build configuration for debugOnly pods (expo-dev-client for example) ([#28085](https://github.com/expo/expo/pull/28085) by [@Titozzz](https://github.com/Titozzz))
+
 ### 💡 Others
 
 ## 1.10.3 - 2024-02-06

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -62,8 +62,8 @@ module Expo
 
             podspec_dir_path = Pathname.new(pod.podspec_dir).relative_path_from(project_directory).to_path
 
-            debug_configurations = @target_definition.build_configurations.select { |config| config.include?('Debug') }.keys
-
+            debug_configurations = @target_definition.build_configurations ? @target_definition.build_configurations.select { |config| config.include?('Debug') }.keys : ['Debug']
+            
             pod_options = {
               :path => podspec_dir_path,
               :configuration => package.debugOnly ? debug_configurations : [] # An empty array means all configurations

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -62,9 +62,11 @@ module Expo
 
             podspec_dir_path = Pathname.new(pod.podspec_dir).relative_path_from(project_directory).to_path
 
+            debug_configurations = @target_definition.build_configurations.select { |config| config.include?('Debug') }.keys
+
             pod_options = {
               :path => podspec_dir_path,
-              :configuration => package.debugOnly ? ['Debug'] : [] # An empty array means all configurations
+              :configuration => package.debugOnly ? debug_configurations : [] # An empty array means all configurations
             }.merge(global_flags, package.flags)
 
             if tests_only || include_tests


### PR DESCRIPTION
Fixed debugOnly packages with custom configurations

# Why

Today if you have custom build configs, pod install with fail if one of your deps is debugOnly (hello dev-client)
```
[!] Unknown configuration whitelisted: debug. CocoaPods found demodebug, demorelease, productiondebug, productionrelease, stagingdebug, and stagingrelease, did you mean one of these?
```

Fixes: https://github.com/expo/expo/issues/25009

# How

Fixes that by matching with all configs including `*Debug*`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
