### PR TITLE
[docs] Unarchive relevant info about EAS Update asset caching

### DIFF
--- a/docs/pages/archive/classic-updates/preloading-and-caching-assets.mdx
+++ b/docs/pages/archive/classic-updates/preloading-and-caching-assets.mdx
@@ -116,11 +116,3 @@ To use the local image asset, you can continue referencing the source of the ima
 ```
 
 See the complete working example in [Expo's tabs template project](https://github.com/expo/expo/blob/main/templates/expo-template-tabs/App.tsx). You can also run `npx create-expo-app --template tabs` to set up a local project with the same template.
-
-### Publishing assets
-
-When you publish your project, it will upload your assets to the CDN so that they may be fetched when users run your app. However, in order for assets to be uploaded to the CDN they must be explicitly required somewhere in your application's code. Conditionally requiring assets will result in the bundler being unable to detect them and therefore they will not be uploaded when you publish your project.
-
-### Optimizing assets
-
-You can manually optimize your assets by running the command `npx expo-optimize` which will use the [sharp](https://sharp.pixelplumbing.com/en/stable/) library to compress your assets. You can set the quality of the compression by passing the `--quality [number]` option to the command. For example, to compress to `90%` you would run `npx expo-optimize --quality 90`.

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -1,22 +1,24 @@
 ---
 title: Asset selection and exclusion
-description: Select which assets should be included in updates.
-hideTOC: true
+description: Learn how to use the asset selection feature and verify that an update includes all required app assets.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
+import { CODE } from '~/ui/components/Text';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server. The new experimental asset selection feature in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
+In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server. The new experimental **asset selection feature** in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
 
-To use this feature, include the new property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, suppose your **app.json** file has the patterns defined this way:
+## Using asset selection
+
+To use the asset selection, include the property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
 
 ```json app.json
   "expo": {
-    /* @hide ... your existing configuration */ /* @end */
+    /* @hide ... */ /* @end */
     "extra": {
       "updates": {
         "assetPatternsToBeBundled": [
@@ -27,37 +29,41 @@ To use this feature, include the new property `extra.updates.assetPatternsToBeBu
   }
 ```
 
-In this case, all **.png** files in all subdirectories of **app/images** will be included in updates.
+After adding this configuration all **.png** files in all subdirectories of **app/images** will be included in updates. You have to also ensure that these assets need to be required in your JavaScript code
 
-If this new property is not in your app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
+If `assetPatternsToBeBundled` isn't included in the app config, all assets resolved by the bundler will be included in updates (as per SDK 49 and earlier behavior).
 
 ## Verifying that an update includes all required app assets
 
-When using this feature, assets that do not match any file patterns will resolve in the Metro bundler. However, these assets will not be uploaded to the updates server. You have to be certain that assets not included in updates are built into the native build of the app.
+When using the asset selection, assets that do not match any file patterns will resolve in the Metro bundler. However, these assets will not be uploaded to the updates server. You have to be certain that assets not included in updates are built into the native build of the app.
 
-If you are building your app locally or have access to the correct build for publishing updates (with the same [runtime version](/eas-update/runtime-versions/)), then you can use the `npx expo-updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
+If you are building your app locally or have access to the correct build for publishing updates (with the same [runtime version](/eas-update/runtime-versions/)), then use the `npx expo-updates assets:verify` command. It allows you to check whether all required assets will be included when you publish an update:
 
 <Terminal cmd={['$ npx expo-updates assets:verify <dir>']} />
-> **info** This new command is part of the `expo-updates` CLI, which also supports [EAS Update code signing](/eas-update/code-signing/). It is not part of the [Expo CLI](/more/expo-cli/) or the [EAS CLI](https://github.com/expo/eas-cli). It is available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
 
+> **info** This new command is part of the `expo-updates` CLI, which also supports [EAS Update code signing](/eas-update/code-signing/). It is not part of the [Expo CLI](/more/expo-cli/) or the [EAS CLI](https://github.com/expo/eas-cli). Only available for ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.24.10).
 
-You can also use `--help` with the command to see the available options:
+You can also use the `--help` option with the command to see the available options:
 
-```sh
-Options
-  <dir>                                  Directory of the Expo project. Default: Current working directory
-  -a, --asset-map-path <path>            Path to the `assetmap.json` in an export produced by the command `npx expo export --dump-assetmap`
-  -e, --exported-manifest-path <path>    Path to the `metadata.json` in an export produced by the command `npx expo export --dump-assetmap`
-  -b, --build-manifest-path <path>       Path to the `app.manifest` file created by expo-updates in an Expo application build (either ios or android)
-  -p, --platform <platform>              Options: ["android","ios"]
-  -h, --help                             Usage info
-```
+| Option                                | Description                                                                                                               |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `<dir>`                               | Directory of the Expo project. Default: Current working directory.                                                        |
+| `-a, --asset-map-path <path>`         | Path to the **assetmap.json** in an export produced by the command `npx expo export --dump-assetmap` .                    |
+| `-e, --exported-manifest-path <path>` | Path to the **metadata.json** in an export produced by the command `npx expo export --dump-assetmap`.                     |
+| `-b, --build-manifest-path <path>`    | Path to the **app.manifest** file created by `expo-updates` in an Expo application build (either **android** or **ios**). |
+| `-p, --platform <platform>`           | Options: ["android", "ios"]                                                                                               |
+| `-h, --help`                          | Usage info.                                                                                                               |
 
 ## Example
 
 <BoxLink
   title="Working example"
-  description="See a working example on using asset selection, the assets:verify CLI command, and other EAS update features."
+  description={
+    <>
+      See a working example of using asset selection, the <CODE>assets:verify</CODE> command, and
+      other EAS Update features.
+    </>
+  }
   Icon={GithubIcon}
   href="https://github.com/expo/UpdatesAPIDemo"
 />

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -10,7 +10,7 @@ import { CODE } from '~/ui/components/Text';
 
 > **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
 
-In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server. The new experimental **asset selection feature** in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
+In SDK 49 and earlier, all assets resolved in the Metro bundler are included in every update and are uploaded to the update server. The experimental **asset selection feature** in SDK 50 allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
 
 ## Using asset selection
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -55,9 +55,9 @@ For assets like GIFs or movies, or non-code and non-image assets, it's up to the
 
 > **Note**: GIFs are a very inefficient format. Modern video codecs can produce smaller file sizes by over an order of magnitude.
 
-## Publishing assets
+## Ensuring assets are included in updates
 
-When you publish your project, it will upload your assets to the CDN so that they may be fetched when users run your app. However, for assets to be uploaded to the CDN they must be explicitly required somewhere in your application's code. Conditionally requiring assets will result in the bundler being unable to detect them and therefore they will not be uploaded when you publish your project.
+When you publish an update, EAS will upload your assets to the CDN so that they may be fetched when users run your app. However, for assets to be uploaded to the CDN they must be explicitly required somewhere in your application's code. Conditionally requiring assets will result in the bundler being unable to detect them and therefore they will not be uploaded when you publish your project.
 
 ## Further considerations
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -17,28 +17,46 @@ Many users running Android and iOS apps are using mobile connections that are no
 
 ## Code assets
 
-When publishing an update, EAS CLI runs Expo CLI to bundle the project into an update. The update will appear in our project's **./dist** folder.
+When publishing an update, EAS CLI runs Expo CLI to bundle the project into an update. The update will appear in our project's **./dist** directory.
 
-In **./dist/bundles**, we can see the size of the **index.ios.js** and **index.android.js** files that will be part of the Android and iOS updates, respectively. Note that these are uncompressed file sizes; EAS Update uses Brotli and gzip compression, which can significantly reduce download sizes. Nevertheless, these files will be downloaded to a user's device when getting the new update if the device has not downloaded them before. Making these file sizes as small as possible helps end-users download updates quickly.
+In **./dist/bundles**, we can see the size of the **index.android.js** and **index.ios.js** files that will be part of the Android and iOS updates, respectively. Note that these are uncompressed file sizes; EAS Update uses Brotli and gzip compression, which can significantly reduce download sizes. Nevertheless, these files will be downloaded to a user's device when getting the new update if the device has not downloaded them before. Making these file sizes as small as possible helps end-users download updates quickly.
 
 ## Image assets
 
-Users will have to download any new images or other assets when they detect a new update, if those assets are not already a part of their build. You can view all the assets uploaded to EAS servers in **./dist/assets**. The assets there are hashed with their extensions removed, so it is difficult to know what assets are there. To see a pretty-printed list of assets, we can run:
+App users will have to download any new images or other assets when they detect a new update if those assets are not already a part of their build. You can view all the assets uploaded to EAS servers in **./dist/assets**. The assets there are hashed with their extensions removed, so it is difficult to know what assets are there. To see a pretty-printed list of assets, we can run:
 
 <Terminal cmd={['$ npx expo export']} />
 
-You can compress images using tools such as [guetzli](https://github.com/google/guetzli), [pngcrush](https://pmt.sourceforge.io/pngcrush/), or [optipng](http://optipng.sourceforge.net/). [imagemin](https://github.com/imagemin/imagemin) is another program and JS library that supports plugins for various optimizers. There are also many online services that can optimize your images for you.
+### Optimizing image assets
 
-Some image optimizers are lossless. This means they re-encode your image to be smaller without any change, or loss, in the pixels that are displayed. When you need each pixel to be untouched from the original image, a lossless optimizer and a lossless image format like PNG is a good choice.
+To manually optimize image assets in your project, you can use the `npx expo-optimize` command. It uses [sharp](https://sharp.pixelplumbing.com/) library to compress images.
 
-Other image optimizers are lossy, which means the optimized image is different than the original image. Often, lossy optimizers are more efficient because they discard visual information that reduces file size while making the image look nearly the same to humans. Tools like `imagemagick` can use comparison algorithms like [SSIM](https://en.wikipedia.org/wiki/Structural_similarity) to give a sense of how similar two images look. It's quite common for an optimized image that is over 95% similar to the original image to be far less than 95% of the original file size!
+<Terminal cmd={['$ npx expo-optimize']} />
+
+After running the command, all image assets are compressed except the ones that are already optimized. You can adjust the compression quality by including the `--quality [number]` option with the command. For example, to compress to 90%, run:
+
+<Terminal cmd={['$ npx expo-optimize --quality 90']} />
+
+### Other manual optimization methods
+
+You can also compress images using any other online service or a tool such as:
+
+- [`guetzli`](https://github.com/google/guetzli)
+- [`pngcrush`](https://pmt.sourceforge.io/pngcrush/)
+- [`optipng`](http://optipng.sourceforge.net/)
+
+Some image optimizers are lossless. They re-encode your image to be smaller without any change or loss in the pixels displayed. When you need each pixel to be untouched from the original image, a lossless optimizer and a lossless image format like PNG are a good choice.
+
+Other image optimizers are lossy. The optimized image differs from the original image. Often, lossy optimizers are more efficient because they discard visual information that reduces file size while making the image look nearly identical to humans. Tools like `imagemagick` can use comparison algorithms like [SSIM](https://en.wikipedia.org/wiki/Structural_similarity) to show how similar two images look. It's quite common for an optimized image that is over 95% similar to the original image to be far less than 95% of the original file size.
 
 ## Other assets
 
-For assets like GIFs or movies, or non-code and non-image assets, it's up to the developer to optimize and minify those assets. (Note: GIFs are a very inefficient format. Modern video codecs can produce smaller file sizes by over an order of magnitude.)
+For assets like GIFs or movies, or non-code and non-image assets, it's up to the developer to optimize and minify those assets.
+
+> **Note**: GIFs are a very inefficient format. Modern video codecs can produce smaller file sizes by over an order of magnitude.
 
 ## Further considerations
 
-It's important to point out that a user's app will only download new or updated assets. It will not re-download unchanged assets that already exist inside the app.
+It's important to note that a user's app will only download new or updated assets. It will not re-download unchanged assets that already exist inside the app.
 
-One way to make sure that updates stay as slim as possible is to build and submit the app frequently to the app stores so that users can download a new app binary that includes more up-to-date assets. Generally, it's a good practice to build and submit an app when adding large or many assets, and good to use updates to fix small bugs and make minor changes between app store releases.
+One way to make sure that updates stay as slim as possible is to build and submit the app frequently to the app stores so that users can download a new app binary that includes more up-to-date assets. Generally, it's a good practice to build and submit an app when adding large or multiple assets, and it's good to use updates to fix small bugs and make minor changes between app store releases.

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -55,6 +55,10 @@ For assets like GIFs or movies, or non-code and non-image assets, it's up to the
 
 > **Note**: GIFs are a very inefficient format. Modern video codecs can produce smaller file sizes by over an order of magnitude.
 
+## Publishing assets
+
+When you publish your project, it will upload your assets to the CDN so that they may be fetched when users run your app. However, for assets to be uploaded to the CDN they must be explicitly required somewhere in your application's code. Conditionally requiring assets will result in the bundler being unable to detect them and therefore they will not be uploaded when you publish your project.
+
 ## Further considerations
 
 It's important to note that a user's app will only download new or updated assets. It will not re-download unchanged assets that already exist inside the app.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-5993

# How

<!--
How did you build this feature or fix this bug and why?
-->


This PR has the following updates:

1. Remove Publishing assets and optimizing assets sections from the archived guide

2. Update verbiage, fix code comment in the code block and other minor fixes (including updating the description for SEO) in Asset selection and exclusion guide

![Capture-2024-04-08-192234](https://github.com/expo/expo/assets/10234615/307321e5-2497-43a6-a1f1-c79505971d03)

3. Add publishing assets section Optimize assets for EAS Update

4. Add optimizing image assets section (`npx expo-optimize`) in Optimize assets for EAS Update and improve doc's formatting, create a new section for other optimization tools and techniques, fix callout not used for a note.
 
![Capture-2024-04-08-184856](https://github.com/expo/expo/assets/10234615/8b6b2a02-eb87-413a-a345-5010104431a1)

![Capture-2024-04-08-185729](https://github.com/expo/expo/assets/10234615/610e9104-d4b2-4193-a0c7-39cc0e624c4a)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting:
- http://localhost:3002/eas-update/asset-selection/
- http://localhost:3002/eas-update/optimize-assets/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
