### PR TITLE
[docs] Describe EAS Update rollback-on-fast-crash in debug guide

### DIFF
--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -1,5 +1,5 @@
 ---
-title: Debug EAS Update
+title: EAS Update Debugging
 sidebar_title: Basic
 description: Learn how to debug EAS Update.
 ---
@@ -81,6 +81,12 @@ The displayed deployment has the correct channel, but it is not linked to a bran
 ### Missing deployment
 
 If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](/#configure-channel), [configure our runtime version](/#configure-runtime-version) and verify our [general configuration](/eas-update/debug-advanced/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
+
+### Update is crashing and rolling back to a previous version
+
+If everything on the Deployments page looks correct, but your app is still showing the previous update or the code embedded with the build, it's possible that your app is downloading and applying the update, but the update is crashing prior to rendering your root component. EAS Update will automatically roll back to the previous version if an update crashes shortly after loading. If you do not see the update after successfully using the [`expo-updates`](/versions/latest/sdk/updates/) JS API to reload the app after an update is downloaded, this is likely the issue. [Learn more about how EAS Update detects crashes and rolls back to a previous working version](error-recovery/#explaining-the-error-recovery-flow).
+
+You can our [runtime issue troubleshooting guide](/debugging/runtime-issues/) to see the error that occurs when the update crashes. Publish a new update that fixes the crash to resolve the issue. A common reason that the embedded code may work but an update does not is due to a missing environment variable. [Learn more about how environment variables work in EAS Update](environment-variables/).
 
 ## Solutions
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -84,7 +84,7 @@ If our deployment is not displayed, it means our build is not configured properl
 
 ### Automatic roll back when an update crashes
 
-If everything looks correct on the deployments page, but your app still shows the previous update or the code embedded with the build, your new update's code may be crashing. This can happen when this new update crashes before the root component renders after the app downloads and applies the new update.
+If everything looks correct on the Deployments page, but your app still shows the previous update or the code embedded with the build, your new update's code may be crashing. This can happen when this new update crashes before the root component renders after the app downloads and applies the new update.
 
 EAS Update is designed to automatically roll back to the previous update if it detects that a new update crashed shortly after launch. See [how EAS Update detects crashes and rolls back to a previous working version](/eas-update/error-recovery/#explaining-the-error-recovery-flow) for more information.
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic EAS Update Debugging
 sidebar_title: Basic
-description: Learn how to debug EAS Update.
+description: Learn why your update may not be showing up in your app and how to fix it.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
@@ -82,19 +82,17 @@ The displayed deployment has the correct channel, but it is not linked to a bran
 
 If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](/#configure-channel), [configure our runtime version](/#configure-runtime-version) and verify our [general configuration](/eas-update/debug-advanced/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
 
-### Update is crashing and rolling back to a previous version
+### Automatic roll back when an update crashes
 
-If everything looks correct on the deployments page, but your app still shows the previous update or the code embedded with the build, it can be caused by the new update crash. This can happen when this new update crashes before the root component renders after the app downloads and applies the new update. 
+If everything looks correct on the deployments page, but your app still shows the previous update or the code embedded with the build, your new update's code may be crashing. This can happen when this new update crashes before the root component renders after the app downloads and applies the new update.
 
-Another example of a crash scenario is when the app uses the [`expo-updates`](/versions/latest/sdk/updates/) API but doesn't apply the new update. Again, the crash is most likely the culprit.
-
-EAS Update is designed to automatically roll back to the previous update after it detects an update crash. See [how EAS Update detects crashes and rolls back to a previous working version](/eas-update/error-recovery/#explaining-the-error-recovery-flow) for more information.
+EAS Update is designed to automatically roll back to the previous update if it detects that a new update crashed shortly after launch. See [how EAS Update detects crashes and rolls back to a previous working version](/eas-update/error-recovery/#explaining-the-error-recovery-flow) for more information.
 
 To diagnose the error causing the update crash:
 - See the [Troubleshooting guide on runtime issues](/debugging/runtime-issues/) to apply a strategy to identify the error.
 - After identifying the error, publish a new update that fixes the crash to resolve the issue.
 
-Another common reason a new update does not work but embedded code does is due to a missing environment variable. See [how environment variables work with EAS Update](/eas-update/environment-variables/) for more information.
+A common reason a new update does not work but embedded code does is due to a missing environment variable. See [how environment variables work with EAS Update](/eas-update/environment-variables/) for more information.
 
 ## Solutions
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -84,9 +84,17 @@ If our deployment is not displayed, it means our build is not configured properl
 
 ### Update is crashing and rolling back to a previous version
 
-If everything on the Deployments page looks correct, but your app is still showing the previous update or the code embedded with the build, it's possible that your app is downloading and applying the update, but the update is crashing prior to rendering your root component. EAS Update will automatically roll back to the previous version if an update crashes shortly after loading. If you do not see the update after successfully using the [`expo-updates`](/versions/latest/sdk/updates/) JS API to reload the app after an update is downloaded, this is likely the issue. [Learn more about how EAS Update detects crashes and rolls back to a previous working version](error-recovery/#explaining-the-error-recovery-flow).
+If everything looks correct on the deployments page, but your app still shows the previous update or the code embedded with the build, it can be caused by the new update crash. This can happen when this new update crashes before the root component renders after the app downloads and applies the new update. 
 
-You can our [runtime issue troubleshooting guide](/debugging/runtime-issues/) to see the error that occurs when the update crashes. Publish a new update that fixes the crash to resolve the issue. A common reason that the embedded code may work but an update does not is due to a missing environment variable. [Learn more about how environment variables work in EAS Update](environment-variables/).
+Another example of a crash scenario is when the app uses the [`expo-updates`](/versions/latest/sdk/updates/) API but doesn't apply the new update. Again, the crash is most likely the culprit.
+
+EAS Update is designed to automatically roll back to the previous update after it detects an update crash. See [how EAS Update detects crashes and rolls back to a previous working version](/eas-update/error-recovery/#explaining-the-error-recovery-flow) for more information.
+
+To diagnose the error causing the update crash:
+- See the [Troubleshooting guide on runtime issues](/debugging/runtime-issues/) to apply a strategy to identify the error.
+- After identifying the error, publish a new update that fixes the crash to resolve the issue.
+
+Another common reason a new update does not work but embedded code does is due to a missing environment variable. See [how environment variables work with EAS Update](/eas-update/environment-variables/) for more information.
 
 ## Solutions
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic EAS Update Debugging
 sidebar_title: Basic
-description: Learn why your update may not be showing up in your app and how to fix it.
+description: Learn how to use basic debugging techniques to fix an update issue.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -1,5 +1,5 @@
 ---
-title: EAS Update Debugging
+title: Basic EAS Update Debugging
 sidebar_title: Basic
 description: Learn how to debug EAS Update.
 ---


### PR DESCRIPTION
# Why
This is a really common question/issue about EAS Update. I thought we described it elsewhere, but I am having a hard time finding it lately. The only description I could find is in the error recovery page, but that's really technical. Most users need to know "if update crashes, your app rolls back" and not much more. The video embedded in this page covers this scenario.

# How

This issue doesn't really match the others (it's not something you can determine from the deployments page), but it's basic troubleshooting IMO. So, I added it to the list of common problems.

Also tweaked the title to match the "Advanced EAS Update debugging" page. Maybe there's a better way, but it's quite easy to find the Advanced guide while not finding the basic guide, and most users need the basic guide:

<img width="680" alt="image" src="https://github.com/expo/expo/assets/8053974/06d90f97-bb14-4e06-a8bf-5574ea007df4">


# Test Plan

looked at it, tested links
