### PR TITLE
fix(cli): add missing nested externals

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing nested Node.js externals.
+- Add missing nested Node.js externals. ([#28092](https://github.com/expo/expo/pull/28092) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix issue with fast resolver. ([#27686](https://github.com/expo/expo/pull/27686) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix using array syntax `(a,b)` with server output. ([#27462](https://github.com/expo/expo/pull/27462) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `console.log` statements from colliding with Metro logs. ([#27217](https://github.com/expo/expo/pull/27217) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Add missing nested Node.js externals.
 - Fix issue with fast resolver. ([#27686](https://github.com/expo/expo/pull/27686) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix using array syntax `(a,b)` with server output. ([#27462](https://github.com/expo/expo/pull/27462) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `console.log` statements from colliding with Metro logs. ([#27217](https://github.com/expo/expo/pull/27217) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/externals.ts
+++ b/packages/@expo/cli/src/start/server/metro/externals.ts
@@ -13,7 +13,20 @@ import { copyAsync } from '../../../utils/dir';
 // A list of the Node.js standard library modules that are currently
 // available,
 export const NODE_STDLIB_MODULES: string[] = [
+  // Add all nested imports...
+  'assert/strict',
+  'dns/promises',
+  'inspector/promises',
   'fs/promises',
+  'stream/web',
+  'stream/promises',
+  'path/posix',
+  'path/win32',
+  'readline/promises',
+  'stream/consumers',
+  'timers/promises',
+  'util/types',
+  // Collect all builtin modules...
   ...(
     builtinModules ||
     // @ts-expect-error


### PR DESCRIPTION
# Why

- [Reported in the discord](https://discord.com/channels/695411232856997968/813967490430402591/1226936808412282982), some node.js externals are missing. This is a temporary workaround to fix them by adding from a list used by [Webpack](https://github.com/webpack/webpack/blob/7090328ba33f8887db2dcf41767ba72f7bfb90bd/lib/node/NodeTargetPlugin.js#L12-L72) 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
