### PR TITLE
[apps] fix kotlin version

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
     compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
     targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.22'
+    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
     ndkVersion = "26.1.10909125"
   }
   repositories {
@@ -18,9 +18,9 @@ buildscript {
 
     classpath("com.facebook.react:react-native-gradle-plugin")
 
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
 
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:6.23.3"
+    classpath("com.diffplug.spotless:spotless-plugin-gradle:6.23.3")
   }
 }
 

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dbFlowVersion = '4.2.4'
     buildToolsVersion = '34.0.0'
-    kotlinVersion = '1.8.10'
+    kotlinVersion = '1.9.23'
     gradleDownloadTaskVersion = '5.0.1'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
 

--- a/apps/fabric-tester/android/build.gradle
+++ b/apps/fabric-tester/android/build.gradle
@@ -6,9 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-        if (findProperty('android.kotlinVersion')) {
-            kotlinVersion = findProperty('android.kotlinVersion')
-        }
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
         // for expo-dev-client
         expoUpdatesVersion = null
 
@@ -19,9 +17,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.4.2')
+        classpath('com.android.tools.build:gradle')
         classpath('com.facebook.react:react-native-gradle-plugin')
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
     }
 }
 

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     dependencies {
         classpath('com.android.tools.build:gradle')
         classpath('com.facebook.react:react-native-gradle-plugin')
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
     }
 }
 


### PR DESCRIPTION
# Why

align kotlin version to 1.9.23 for apps

# How

fix some misaligned kotlin configurations

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
