### PR TITLE
docs: add `--bun` to `npx expo install` docs

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -444,7 +444,7 @@ To exclude packages from version checking, set the `expo.install` config object 
 
 You can force the package manager using a named argument:
 
-- `--bun`: use `bun` to install dependencies. Default when **bun.lockb** exists.
+- `--bun`: Use `bun` to install dependencies. Default when **bun.lockb** exists.
 - `--npm`: Use `npm` to install dependencies. Default when **package-lock.json** exists.
 - `--pnpm`: Use `pnpm` to install dependencies. Default when **pnpm-lock.yaml** exists.
 - `--yarn`: Use `yarn` to install dependencies. Default when **yarn.lock** exists.

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -440,13 +440,14 @@ To exclude packages from version checking, set the `expo.install` config object 
 
 ### Install package managers
 
-`npx expo install` has support for `yarn`, `npm`, and `pnpm`.
+`npx expo install` has support for `bun`, `npm`, `pnpm`, and `yarn`.
 
 You can force the package manager using a named argument:
 
+- `--bun`: use `bun` to install dependencies. Default when **bun.lockb** exists.
 - `--npm`: Use `npm` to install dependencies. Default when **package-lock.json** exists.
-- `--yarn`: Use `yarn` to install dependencies. Default when **yarn.lock** exists.
 - `--pnpm`: Use `pnpm` to install dependencies. Default when **pnpm-lock.yaml** exists.
+- `--yarn`: Use `yarn` to install dependencies. Default when **yarn.lock** exists.
 
 ## Authentication
 


### PR DESCRIPTION
# Why

This was missing.

# How

- Added `--bun`
- Sorted package managers alphabetical

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
