### PR TITLE
[docs] Fix links in Use Google authentication guide

### DIFF
--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -20,7 +20,7 @@ See `@react-native-google-signin/google-signin` documentation for instructions o
 
 <BoxLink
   title="React Native Google Sign In: Expo installation instructions"
-  href="https://github.com/react-native-google-signin/google-signin#expo-installation"
+  href="https://react-native-google-signin.github.io/docs/setting-up/expo"
 />
 
 ## Configure Google project for Android and iOS
@@ -29,7 +29,7 @@ Below are instructions on how to configure your Google project for Android and i
 
 ### Upload app to Google Play Store
 
-We recommend uploading the app to the Google Play Store if your app still needs to be in production. It is not necessary to upload the complete app if your project is still in the development process. Upload a single instance of your app. This will allow you to sign your app with the required certificates, such as the SHA-1 certificate fingerprint, which is required to provide when configuring the Google project for Android. To learn more about the app submission process, see the guides below in the order they are specified:
+We recommend uploading the app to the Google Play Store if your app still needs to be in production. It is not necessary to upload the complete app if your project is still in the development process. Upload a single instance of your app. This will allow you to sign your app with the required certificates, such as the SHA-1 certificate fingerprint, which is required when configuring the Google project for Android. To learn more about the app submission process, see the guides below in the order they are specified:
 
 <BoxLink title="Create your first EAS Build" href="/build/setup/" />
 
@@ -51,7 +51,7 @@ For more instructions on how to configure your Google project for Android and iO
 
 <BoxLink
   title="Firebase"
-  href="https://react-native-google-signin.github.io/docs/setting-up/get-config-file#with-firebase-and-expo"
+  href="https://react-native-google-signin.github.io/docs/setting-up/expo#expo-and-firebase"
 />
 
 #### Upload google-services.json and GoogleService-Info.plist to EAS
@@ -73,7 +73,7 @@ For more instructions on how to configure your Google project for Android with G
 
 <BoxLink
   title="Configure a Google API Console project"
-  href="https://developers.google.com/identity/sign-in/android/start#configure-a-google-api-console-project"
+  href="https://developers.google.com/identity/android-credential-manager#configure-a-google-api-console-project"
 />
 
 #### iOS


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As reported in [Discord](https://discord.com/channels/695411232856997968/1012054197409165387/1224443834801328310) fix that link and other links in the Use Google authentication guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/guides/google-authentication/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
