### PR TITLE
Add additional config flag to allow forcing RTL on LTR locales

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -400,7 +400,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       )
       showOrReconfigureManagedAppSplashScreen(optimisticManifest)
       setLoadingProgressStatusIfEnabled()
-      ExperienceRTLManager.setSupportsRTLFromManifest(this, optimisticManifest)
+      ExperienceRTLManager.setRTLPreferencesFromManifest(this, optimisticManifest)
     }
   }
 
@@ -499,7 +499,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
 
     BranchManager.handleLink(this, intentUri, detachSdkVersion)
 
-    ExperienceRTLManager.setSupportsRTLFromManifest(this, manifest)
+    ExperienceRTLManager.setRTLPreferencesFromManifest(this, manifest)
 
     runOnUiThread {
       if (!isInForeground) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -82,7 +82,7 @@ open class HomeActivity : BaseExperienceActivity() {
     EventBus.getDefault().registerSticky(this)
     kernel.startJSKernel(this)
 
-    ExperienceRTLManager.setSupportsRTL(this, false)
+    ExperienceRTLManager.setRTLPreferences(this, false, false)
 
     SplashScreen.show(this, SplashScreenImageResizeMode.NATIVE, ReactRootView::class.java, true)
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
@@ -6,10 +6,11 @@ import expo.modules.manifests.core.Manifest
 // must be kept in sync with https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
 private const val SHARED_PREFS_NAME = "com.facebook.react.modules.i18nmanager.I18nUtil"
 private const val KEY_FOR_PREFS_ALLOWRTL = "RCTI18nUtil_allowRTL"
+private const val KEY_FOR_PREFS_FORCERTL = "RCTI18nUtil_forceRTL"
 
 class ExperienceRTLManager {
   companion object {
-    fun setSupportsRTL(context: Context, allowRTL: Boolean) {
+    fun setRTLPreferences(context: Context, allowRTL: Boolean, forceRTL: Boolean) {
       // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
       // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
       context
@@ -17,15 +18,20 @@ class ExperienceRTLManager {
         .edit()
         .also {
           it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, allowRTL)
+          it.putBoolean(KEY_FOR_PREFS_FORCERTL, forceRTL)
           it.apply()
         }
     }
 
-    fun setSupportsRTLFromManifest(context: Context, manifest: Manifest) {
-      setSupportsRTL(
-        context,
-        (manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("supportsRTL") ?: false)
-      )
+    fun setRTLPreferencesFromManifest(context: Context, manifest: Manifest) {
+        // get supportsRTL from manifest and set it in shared preferences
+        val supportsRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("supportsRTL") ?: false
+        val forcesRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("forcesRTL") ?: false
+        if(forcesRTL) {
+            setRTLPreferences(context, true, true)
+            } else {
+            setRTLPreferences(context, supportsRTL, false)
+        }
     }
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
@@ -24,14 +24,14 @@ class ExperienceRTLManager {
     }
 
     fun setRTLPreferencesFromManifest(context: Context, manifest: Manifest) {
-        // get supportsRTL from manifest and set it in shared preferences
-        val supportsRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("supportsRTL") ?: false
-        val forcesRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("forcesRTL") ?: false
-        if(forcesRTL) {
-            setRTLPreferences(context, true, true)
-            } else {
-            setRTLPreferences(context, supportsRTL, false)
-        }
+      // get supportsRTL from manifest and set it in shared preferences
+      val supportsRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("supportsRTL") ?: false
+      val forcesRTL = manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("forcesRTL") ?: false
+      if (forcesRTL) {
+        setRTLPreferences(context, true, true)
+      } else {
+        setRTLPreferences(context, supportsRTL, false)
+      }
     }
   }
 }

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -257,12 +257,19 @@ NS_ASSUME_NONNULL_BEGIN
   return manifest.supportsRTL;
 }
 
+- (bool)_readForcesRTLFromManifest:(EXManifestsManifest *)manifest
+{
+  return manifest.forcesRTL;
+}
+
 - (void)appStateDidBecomeActive
 {
   if (_isHomeApp) {
-    [EXTextDirectionController setSupportsRTL:false];
+      [EXTextDirectionController setRTLPreferences:false :false];
   } else if(_appRecord.appLoader.manifest != nil) {
-    [EXTextDirectionController setSupportsRTL:[self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest]];
+      BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
+      BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
+      [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
   }
   dispatch_async(dispatch_get_main_queue(), ^{
     // Reset the root view background color and window color if we switch between Expo home and project

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -472,7 +472,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
   [self _showOrReconfigureManagedAppSplashScreen:manifest];
   if (!_isHomeApp) {
-    [EXTextDirectionController setSupportsRTL:[self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest]];
+    BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
+    BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
+    [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
   }
   [self _rebuildBridge];
   if (self->_appRecord.appManager.status == kEXReactAppManagerStatusBridgeLoading) {

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXTextDirectionController.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXTextDirectionController.swift
@@ -9,12 +9,19 @@ public class EXTextDirectionController: NSObject {
   }
 
   @objc
-  public class func setSupportsRTL(_ supportsRTL: Bool) {
+  public class func setRTLPreferences(_ supportsRTL: Bool, _ forceRTL: Bool) {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     // On iOS we need to set both forceRTL and allowRTL so apps don't have to include localization strings.
-    UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
-    UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+    if forceRTL {
+      // Uses required reason API based on the following reason: CA92.1
+      UserDefaults.standard.set(true, forKey: "RCTI18nUtil_allowRTL")
+      UserDefaults.standard.set(true, forKey: "RCTI18nUtil_forceRTL")
+    } else {
+      UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
+      UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+    }
+
     UserDefaults.standard.synchronize()
   }
 }

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added a `forcesRTL` manifest flag for forcing RTL to be on.
+- Added a `forcesRTL` manifest flag for forcing RTL to be on. ([#28129](https://github.com/expo/expo/pull/28129) by [@aleqsio](https://github.com/aleqsio))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added a `forcesRTL` manifest flag for forcing RTL to be on.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -22,7 +22,7 @@ import java.util.*
 // must be kept in sync with https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.java
 private const val SHARED_PREFS_NAME = "com.facebook.react.modules.i18nmanager.I18nUtil"
 private const val KEY_FOR_PREFS_ALLOWRTL = "RCTI18nUtil_allowRTL"
-
+private const val KEY_FOR_PREFS_FORCERTL = "RCTI18nUtil_forceRTL"
 private const val LOCALE_SETTINGS_CHANGED = "onLocaleSettingsChanged"
 private const val CALENDAR_SETTINGS_CHANGED = "onCalendarSettingsChanged"
 
@@ -70,14 +70,28 @@ class LocalizationModule : Module() {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     val supportsRTL = appContext.reactContext?.getString(R.string.ExpoLocalization_supportsRTL)
-    if (supportsRTL != "true" && supportsRTL != "false") return
-    context
-      .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
-      .edit()
-      .also {
-        it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, supportsRTL == "true")
-        it.apply()
+    val forcesRTL = appContext.reactContext?.getString(R.string.ExpoLocalization_forcesRTL)
+
+    if (forcesRTL == "true") {
+      context
+          .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+          .edit()
+          .also {
+            it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, "true")
+            it.putBoolean(KEY_FOR_PREFS_FORCERTL, "true")
+            it.apply()
+          }
+    } else {
+      if (supportsRTL == "true" || supportsRTL == "false") {
+        context
+          .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+          .edit()
+          .also {
+            it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, supportsRTL == "true")
+            it.apply()
+          }
       }
+    }
   }
 
   // TODO: Bacon: add set language

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -74,13 +74,13 @@ class LocalizationModule : Module() {
 
     if (forcesRTL == "true") {
       context
-          .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
-          .edit()
-          .also {
-            it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, true)
-            it.putBoolean(KEY_FOR_PREFS_FORCERTL, true)
-            it.apply()
-          }
+        .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .also {
+          it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, true)
+          it.putBoolean(KEY_FOR_PREFS_FORCERTL, true)
+          it.apply()
+        }
     } else {
       if (supportsRTL == "true" || supportsRTL == "false") {
         context

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -88,6 +88,9 @@ class LocalizationModule : Module() {
           .edit()
           .also {
             it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, supportsRTL == "true")
+            if (forcesRTL == "false") {
+              it.putBoolean(KEY_FOR_PREFS_FORCERTL, false)
+            }
             it.apply()
           }
       }

--- a/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
+++ b/packages/expo-localization/android/src/main/java/expo/modules/localization/LocalizationModule.kt
@@ -77,8 +77,8 @@ class LocalizationModule : Module() {
           .getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
           .edit()
           .also {
-            it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, "true")
-            it.putBoolean(KEY_FOR_PREFS_FORCERTL, "true")
+            it.putBoolean(KEY_FOR_PREFS_ALLOWRTL, true)
+            it.putBoolean(KEY_FOR_PREFS_FORCERTL, true)
             it.apply()
           }
     } else {

--- a/packages/expo-localization/android/src/main/res/values/strings.xml
+++ b/packages/expo-localization/android/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="ExpoLocalization_supportsRTL" translatable="false">unset</string>
+  <string name="ExpoLocalization_forcesRTL" translatable="false">unset</string>
 </resources>

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -23,8 +23,12 @@ public class LocalizationModule: Module {
       return Self.getCalendars()
     }
     OnCreate {
-      if let enableRTL = Bundle.main.object(forInfoDictionaryKey: "ExpoLocalization_supportsRTL") as? Bool {
-        self.setSupportsRTL(enableRTL)
+      if let forceRTL = Bundle.main.object(forInfoDictionaryKey: "ExpoLocalization_forcesRTL") as? Bool {
+        self.setRTLPreferences(true, forceRTL)
+      } else {
+        if let enableRTL = Bundle.main.object(forInfoDictionaryKey: "ExpoLocalization_supportsRTL") as? Bool {
+          self.setRTLPreferences(enableRTL, false)
+        }
       }
     }
 
@@ -53,13 +57,20 @@ public class LocalizationModule: Module {
     return NSLocale.characterDirection(forLanguage: NSLocale.preferredLanguages.first ?? "en-US") == NSLocale.LanguageDirection.rightToLeft
   }
 
-  func setSupportsRTL(_ supportsRTL: Bool) {
+  func setRTLPreferences(_ supportsRTL: Bool, _ forceRTL: Bool) {
     // These keys are used by React Native here: https://github.com/facebook/react-native/blob/main/React/Modules/RCTI18nUtil.m
     // We set them before React loads to ensure it gets rendered correctly the first time the app is opened.
     // On iOS we need to set both forceRTL and allowRTL so apps don't have to include localization strings.
     // Uses required reason API based on the following reason: CA92.1
-    UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
-    UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+
+    if forceRTL {
+      UserDefaults.standard.set(true, forKey: "RCTI18nUtil_allowRTL")
+      UserDefaults.standard.set(true, forKey: "RCTI18nUtil_forceRTL")
+    } else {
+      UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
+      UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+    }
+
     UserDefaults.standard.synchronize()
   }
 

--- a/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.d.ts
@@ -1,6 +1,7 @@
 import { ExpoConfig } from '@expo/config-types';
 type ConfigPluginProps = {
     supportsRTL?: boolean;
+    forcesRTL?: boolean;
     allowDynamicLocaleChangesAndroid?: boolean;
 };
 declare function withExpoLocalization(config: ExpoConfig, data?: ConfigPluginProps): ExpoConfig;

--- a/packages/expo-localization/plugin/build/withExpoLocalization.js
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.js
@@ -2,14 +2,20 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const Manifest_1 = require("@expo/config-plugins/build/android/Manifest");
 const config_plugins_1 = require("expo/config-plugins");
-function withExpoLocalizationIos(config) {
-    if (config.extra?.supportsRTL == null)
+function withExpoLocalizationIos(config, data) {
+    const mergedConfig = { ...config.extra, ...data };
+    if (mergedConfig?.supportsRTL == null && mergedConfig?.forcesRTL == null)
         return config;
     if (!config.ios)
         config.ios = {};
     if (!config.ios.infoPlist)
         config.ios.infoPlist = {};
-    config.ios.infoPlist.ExpoLocalization_supportsRTL = config.extra?.supportsRTL || false;
+    if (mergedConfig?.supportsRTL != null) {
+        config.ios.infoPlist.ExpoLocalization_supportsRTL = mergedConfig?.supportsRTL;
+    }
+    if (mergedConfig?.forcesRTL != null) {
+        config.ios.infoPlist.ExpoLocalization_forcesRTL = mergedConfig?.forcesRTL;
+    }
     return config;
 }
 function withExpoLocalizationAndroid(config, data) {
@@ -26,12 +32,23 @@ function withExpoLocalizationAndroid(config, data) {
         });
     }
     return (0, config_plugins_1.withStringsXml)(config, (config) => {
-        config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
-            {
-                $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
-                _: String(data.supportsRTL ?? config.extra?.supportsRTL),
-            },
-        ], config.modResults);
+        const mergedConfig = { ...config.extra, ...data };
+        if (mergedConfig?.supportsRTL != null) {
+            config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
+                {
+                    $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
+                    _: String(mergedConfig?.supportsRTL),
+                },
+            ], config.modResults);
+        }
+        if (mergedConfig?.supportsRTL != null) {
+            config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
+                {
+                    $: { name: 'ExpoLocalization_forcesRTL', translatable: 'false' },
+                    _: String(mergedConfig?.forcesRTL),
+                },
+            ], config.modResults);
+        }
         return config;
     });
 }

--- a/packages/expo-localization/plugin/build/withExpoLocalization.js
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.js
@@ -37,15 +37,15 @@ function withExpoLocalizationAndroid(config, data) {
             config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
                 {
                     $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
-                    _: String(mergedConfig?.supportsRTL),
+                    _: String(mergedConfig?.supportsRTL ?? 'unset'),
                 },
             ], config.modResults);
         }
-        if (mergedConfig?.supportsRTL != null) {
+        if (mergedConfig?.forcesRTL != null) {
             config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
                 {
                     $: { name: 'ExpoLocalization_forcesRTL', translatable: 'false' },
-                    _: String(mergedConfig?.forcesRTL),
+                    _: String(mergedConfig?.forcesRTL ?? 'unset'),
                 },
             ], config.modResults);
         }

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -9,14 +9,21 @@ import {
 
 type ConfigPluginProps = {
   supportsRTL?: boolean;
+  forcesRTL?: boolean;
   allowDynamicLocaleChangesAndroid?: boolean;
 };
 
-function withExpoLocalizationIos(config: ExpoConfig) {
-  if (config.extra?.supportsRTL == null) return config;
+function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
+  const mergedConfig = { ...config.extra, ...data };
+  if (mergedConfig?.supportsRTL == null && mergedConfig?.forcesRTL == null) return config;
   if (!config.ios) config.ios = {};
   if (!config.ios.infoPlist) config.ios.infoPlist = {};
-  config.ios.infoPlist.ExpoLocalization_supportsRTL = config.extra?.supportsRTL || false;
+  if (mergedConfig?.supportsRTL != null) {
+    config.ios.infoPlist.ExpoLocalization_supportsRTL = mergedConfig?.supportsRTL;
+  }
+  if (mergedConfig?.forcesRTL != null) {
+    config.ios.infoPlist.ExpoLocalization_forcesRTL = mergedConfig?.forcesRTL;
+  }
   return config;
 }
 
@@ -34,15 +41,29 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
     });
   }
   return withStringsXml(config, (config) => {
-    config.modResults = AndroidConfig.Strings.setStringItem(
-      [
-        {
-          $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
-          _: String(data.supportsRTL ?? config.extra?.supportsRTL),
-        },
-      ],
-      config.modResults
-    );
+    const mergedConfig = { ...config.extra, ...data };
+    if (mergedConfig?.supportsRTL != null) {
+      config.modResults = AndroidConfig.Strings.setStringItem(
+        [
+          {
+            $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
+            _: String(mergedConfig?.supportsRTL),
+          },
+        ],
+        config.modResults
+      );
+    }
+    if (mergedConfig?.supportsRTL != null) {
+      config.modResults = AndroidConfig.Strings.setStringItem(
+        [
+          {
+            $: { name: 'ExpoLocalization_forcesRTL', translatable: 'false' },
+            _: String(mergedConfig?.forcesRTL),
+          },
+        ],
+        config.modResults
+      );
+    }
     return config;
   });
 }

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -47,18 +47,18 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
         [
           {
             $: { name: 'ExpoLocalization_supportsRTL', translatable: 'false' },
-            _: String(mergedConfig?.supportsRTL),
+            _: String(mergedConfig?.supportsRTL ?? 'unset'),
           },
         ],
         config.modResults
       );
     }
-    if (mergedConfig?.supportsRTL != null) {
+    if (mergedConfig?.forcesRTL != null) {
       config.modResults = AndroidConfig.Strings.setStringItem(
         [
           {
             $: { name: 'ExpoLocalization_forcesRTL', translatable: 'false' },
-            _: String(mergedConfig?.forcesRTL),
+            _: String(mergedConfig?.forcesRTL ?? 'unset'),
           },
         ],
         config.modResults

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -301,6 +301,16 @@ public class Manifest: NSObject {
     return supportsRTL
   }
 
+  public func forcesRTL() -> Bool {
+    guard let expoClientConfigRootObject = expoClientConfigRootObject(),
+      let extra: [String: Any]? = expoClientConfigRootObject.optionalValue(forKey: "extra"),
+      let forcesRTL: Bool = extra?.optionalValue(forKey: "forcesRTL") else {
+      return false
+    }
+
+    return forcesRTL
+  }
+
   public func jsEngine() -> String {
     let jsEngine = expoClientConfigRootObject().let { it in
       Manifest.string(fromManifest: it, atPaths: [


### PR DESCRIPTION
# Why and how

There's this issue that has been going on for some time 😅 
https://github.com/expo/expo/issues/26532

It's due to two things:
- first, the plugin on iOS still sets config keys even if there's no extra config – this is a bug that this PR fixes.
- second, some apps are targeted for RTL markets and require an additional option to always force RTL, and our locale detection messes with that – I added a new field to the extra manifest field and config plugin options.

New key is:

```
app.json > expo > extra > forcesRTL
```

# Test Plan

Performed the following tests:

|         | prebuild app                                                                                                                                                                                                                                         | expo go                                                                                                                                                                                       |
|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| ios     | if none set:<br><br>LTR/RTL depend on calling I18nManager.(force/allow)RTL – built in react-native behavior<br><br>if extra.forcesRTL true:<br><br>app RTL, I18nManager.isRTL true<br><br>if extra.supportsRTL true:<br><br>LTR/RTL depend on locale | if none set:<br><br>app LTR, I18nManager.isRTL false<br><br>if extra.forcesRTL true:<br><br>app RTL, I18nManager.isRTL true<br><br>if extra.supportsRTL true:<br><br>LTR/RTL depend on locale |
| android | if none set:<br><br>LTR/RTL depend on calling I18nManager.(force/allow)RTL – built in react-native behavior<br><br>if extra.forcesRTL true:<br><br>app RTL, I18nManager.isRTL true<br><br>if extra.supportsRTL true:<br><br>LTR/RTL depend on locale | if none set:<br><br>app LTR, I18nManager.isRTL false<br><br>if extra.forcesRTL true:<br><br>app RTL, I18nManager.isRTL true<br><br>if extra.supportsRTL true:<br><br>LTR/RTL depend on locale |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
