### PR TITLE
[docs]  Update Orbit guide's structure, add Windows installation instructions

### DIFF
--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -13,7 +13,7 @@ Expo Orbit for macOS and Windows enables faster to install and launch builds or 
 
 ## Why Orbit
 
-Before Orbit, installing builds from EAS (Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible.
+Before Orbit, installing builds or updates from EAS (Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible.
 
 ## Highlights
 

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -1,34 +1,53 @@
 ---
 title: Expo Orbit
-maxHeadingDepth: 4
-description: Accelerate your development workflow with one-click build launches and simulator management.
+description: Accelerate your development workflow with one-click build and update launches and simulator management.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-Expo Orbit for macOS makes it faster to install and run builds from EAS, local files, or run Snack projects, on simulators and physical devices.
+Expo Orbit for macOS and Windows makes it faster to install and run builds from EAS, local files, or run Snack projects, on simulators and physical devices.
 
 <Video file="orbit/basic-features.mp4" />
+
+## Why Orbit
 
 Before Orbit, installing builds from EAS (Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible.
 
 ## Highlights
 
 - List and launch simulators, including running Android emulators without audio.
-- Install and launch builds from EAS to your simulators and real devices in one click.
+- Install and launch builds from EAS on simulators and real devices in one click.
+- Install and open updates from EAS on Android Emulators or iOS Simulators.
 - Launch Snack projects in your simulators in one click.
 - Install and launch apps from local files using Finder or drag and drop a file into the menu bar app. Orbit supports any Android **.apk**, iOS Simulator compatible **.app**, or ad hoc signed apps.
 - See pinned projects from your EAS dashboard and quickly launch your latest builds.
 
 ## Installation
 
-You can download Orbit with Homebrew, or directly from the [GitHub releases](https://github.com/expo/orbit/releases).
+<Tabs>
+
+<Tab label="macOS">
+
+You can download Orbit with Homebrew for macOS, or directly from the [GitHub releases](https://github.com/expo/orbit/releases).
 
 <Terminal cmd={['$ brew install expo-orbit']} />
 
+</Tab>
+
+<Tab label="Windows">
+
+> **Note**: Orbit for Windows is in preview and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
+
+You can download Orbit for Windows directly from the [GitHub releases](https://github.com/expo/orbit/releases).
+
+</Tab>
+
+</Tabs>
+
+## Usage
+
 If you want Orbit to start when you log in automatically, click on the Orbit icon in the menu bar, then **Settings** and select the **Launch on Login** option.
 
-> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
-
-Right now, Orbit is compatible only with macOS. However, we have exciting plans to integrate it further into the Expo ecosystem and add even more features. Try out Expo Orbit now, explore its capabilities, and share your feedback.
+> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode for macOS](/workflow/ios-simulator/).

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -19,7 +19,7 @@ Before Orbit, installing builds from EAS (Android and iOS physical devices or em
 
 - List and launch simulators, including running Android emulators without audio.
 - Install and launch builds from EAS on simulators and real devices in one click.
-- Install and open updates from EAS on Android Emulators or iOS Simulators.
+- [Install and open updates from EAS](/review/with-orbit/) on Android Emulators or iOS Simulators.
 - Launch Snack projects in your simulators in one click.
 - Install and launch apps from local files using Finder or drag and drop a file into the menu bar app. Orbit supports any Android **.apk**, iOS Simulator compatible **.app**, or ad hoc signed apps.
 - See pinned projects from your EAS dashboard and quickly launch your latest builds.

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -13,7 +13,7 @@ Expo Orbit for macOS and Windows enables faster to install and launch builds or 
 
 ## Why Orbit
 
-Before Orbit, installing builds or updates from EAS (Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible.
+Before Orbit, installing builds or updates from EAS (on Android and iOS physical devices or emulator/simulator) or running Snack projects on simulators was manual. You had to run `eas build:run` command and select a build for your chosen device or download the archive and then drag and drop it to the simulator (in the case of iOS). Also, for Snack projects, additional steps included installing Expo Go on the virtual device, logging in, and then selecting the Snack from the list. Orbit makes all of these steps as seamless as possible.
 
 ## Highlights
 

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -34,6 +34,8 @@ You can download Orbit with Homebrew for macOS, or directly from the [GitHub rel
 
 <Terminal cmd={['$ brew install expo-orbit']} />
 
+If you want Orbit to start when you log in automatically, click on the Orbit icon in the menu bar, then **Settings** and select the **Launch on Login** option.
+
 </Tab>
 
 <Tab label="Windows">
@@ -46,8 +48,4 @@ You can download Orbit for Windows directly from the [GitHub releases](https://g
 
 </Tabs>
 
-## Usage
-
-If you want Orbit to start when you log in automatically, click on the Orbit icon in the menu bar, then **Settings** and select the **Launch on Login** option.
-
-> **info** Orbit relies on the Android SDK and `xcrun` for device management, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode for macOS](/workflow/ios-simulator/).
+> **info** Orbit relies on the Android SDK on both macOS and Windows and `xcrun` for device management only on macOS, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-Expo Orbit for macOS and Windows makes it faster to install and run builds from EAS, local files, or run Snack projects, on simulators and physical devices.
+Expo Orbit for macOS and Windows enables faster to install and launch builds or updates from EAS, local files, or run Snack projects, on simulators and physical devices.
 
 <Video file="orbit/basic-features.mp4" />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This PR:
- Add context about Windows (that it is in preview) and installation instructions for Windows (link to release page)
- Also add a highlight about launching updates and link to the relevant doc where we describe the steps
- Organize the current information and divide them into sections.
- Update callout at the end of the page to include Windows instructions too.
- Update doc's description to add "update" part.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2024-04-11 at 00 05 37@2x](https://github.com/expo/expo/assets/10234615/60da3c37-3a54-4ce2-adda-cc4376252e58)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
