### PR TITLE
[docs] Fix status-bar.mdx example snack

### DIFF
--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -28,7 +28,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ```js collapseHeight=310
 import React from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
 export default function App() {


### PR DESCRIPTION
Update `status-bar.mdx` example to include the missing `StyleSheet` import.

# Why

The `status-bar.mdx` snack example is missing the `StyleSheet` import from `react-native` which is causing it to crash on load.

# How

I noticed this was failing when testing it out.

# Test Plan

Validated that after I made the change that the snack loaded properly by default.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
