### PR TITLE
docs: fix description mistake in clear-cache-windows.mdx

### DIFF
--- a/docs/pages/troubleshooting/clear-cache-windows.mdx
+++ b/docs/pages/troubleshooting/clear-cache-windows.mdx
@@ -1,6 +1,6 @@
 ---
 title: Clear bundler caches on Windows
-description: Learn how to create the bundler cache when using Yarn or npm with Expo CLI or React Native CLI on Windows.
+description: Learn how to clear the bundler cache when using Yarn or npm with Expo CLI or React Native CLI on Windows.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';


### PR DESCRIPTION
# Why

The docs for clearing the cache (windows) have a wording mistake.