### PR TITLE
[iOS] Add missing imports

### DIFF
--- a/packages/expo-maps/ios/ExpoMaps/ExpoAppleMapsModule.swift
+++ b/packages/expo-maps/ios/ExpoMaps/ExpoAppleMapsModule.swift
@@ -1,5 +1,5 @@
+import React
 import ExpoModulesCore
-import simd
 
 public class ExpoAppleMapsModule: Module {
   public func definition() -> ModuleDefinition {

--- a/packages/expo-maps/ios/ExpoMaps/Records/LatLngRecord.swift
+++ b/packages/expo-maps/ios/ExpoMaps/Records/LatLngRecord.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import ExpoModulesCore
 
 struct LatLngRecord: Record {

--- a/packages/expo-maps/ios/ExpoMaps/Records/PointOfInterestRecord.swift
+++ b/packages/expo-maps/ios/ExpoMaps/Records/PointOfInterestRecord.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import ExpoModulesCore
 
 struct PointOfInterestRecord: Record {

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -1,3 +1,5 @@
+import React
+
 /**
  The app context is an interface to a single Expo app.
  */

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
@@ -1,3 +1,5 @@
+import React
+
 public protocol AnyExpoView: RCTView {
   var appContext: AppContext? { get }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import React
+
 internal enum RemoteUpdateError: Error {
   case directiveParsingError
   case invalidDirectiveType

--- a/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
+++ b/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
@@ -11,6 +11,7 @@
 // swiftlint:disable force_unwrapping
 
 import Foundation
+import React
 
 // swiftlint:disable identifier_name
 @objc(EXUpdatesRemoteLoadStatus)

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RecreateReactContextProcedure.swift
@@ -1,5 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+import React
 import ExpoModulesCore
 
 final class RecreateReactContextProcedure: StateMachineProcedure {

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -1,5 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
+import React
 import ExpoModulesCore
 
 final class RelaunchProcedure: StateMachineProcedure {

--- a/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 import Foundation
+import React
 import EXManifests
 
 public final class ExpoUpdatesUpdate: Update {


### PR DESCRIPTION
# Why

I have no idea why, but I started getting compilation errors in a few places where some imports are missing. Probably since I enabled the new architecture in bare-expo 🤔 

# How

Added missing imports that prevented me to compile bare-expo

# Test Plan

bare-expo compiles
