### PR TITLE
docs: pin `eslint` to `v8`

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -24,13 +24,12 @@ Install ESLint, Prettier, and [`eslint-config-universe`](https://github.com/expo
 
 <Tabs>
     <Tab label="npm">
-        <Terminal cmd={['$ npm install eslint prettier eslint-config-universe --save-dev']} />
+        <Terminal cmd={['$ npm install eslint@8 prettier eslint-config-universe --save-dev']} />
     </Tab>
 
     <Tab label="yarn">
-        <Terminal cmd={['$ yarn add -D eslint prettier eslint-config-universe']} />
+        <Terminal cmd={['$ yarn add -D eslint@8 prettier eslint-config-universe']} />
     </Tab>
-
 </Tabs>
 
 The `eslint-config-universe` library provides shared ESLint configurations for Node.js, web and universal Expo apps.

--- a/packages/eslint-config-universe/README.md
+++ b/packages/eslint-config-universe/README.md
@@ -10,7 +10,7 @@ yarn add --dev eslint-config-universe
 You will also need to install `eslint` and `prettier`:
 
 ```sh
-yarn add --dev eslint prettier
+yarn add --dev eslint@8 prettier
 ```
 
 ## Usage


### PR DESCRIPTION
# Why

Fixes #28144

# How

- Updated "Using ESLint" docs page
- Updated `eslint-config-universe` **README.md**

# Test Plan

Just a docs change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
