### PR TITLE
[ios][camera] Allow removing NSMicrophoneUsageDescription from plist

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add ability to disable permissions in config plugin by passing `false` instead of permission messages. ([#28107](https://github.com/expo/expo/pull/28107) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `pictureSize` prop to `CameraView` component. ([#27664](https://github.com/expo/expo/pull/27664) by [@alanjhughes](https://github.com/alanjhughes))
+- Allow user to remove `NSMicrophoneUsageDescription` and ignore the `mute` prop if they don't intend to use video.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add ability to disable permissions in config plugin by passing `false` instead of permission messages. ([#28107](https://github.com/expo/expo/pull/28107) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `pictureSize` prop to `CameraView` component. ([#27664](https://github.com/expo/expo/pull/27664) by [@alanjhughes](https://github.com/alanjhughes))
-- Allow user to remove `NSMicrophoneUsageDescription` and ignore the `mute` prop if they don't intend to use video.
+- Allow user to remove `NSMicrophoneUsageDescription` and ignore the `mute` prop if they don't intend to use video. ([#28156](https://github.com/expo/expo/pull/28156) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-camera/ios/CameraViewNextModule.swift
+++ b/packages/expo-camera/ios/CameraViewNextModule.swift
@@ -23,7 +23,6 @@ public final class CameraViewNextModule: Module, ScannerResultHandler {
       let permissionsManager = self.appContext?.permissions
       EXPermissionsMethodsDelegate.register(
         [
-          CameraPermissionRequester(),
           CameraOnlyPermissionRequester(),
           CameraMicrophonePermissionRequester()
         ],

--- a/packages/expo-camera/ios/Next/CameraViewNext.swift
+++ b/packages/expo-camera/ios/Next/CameraViewNext.swift
@@ -197,6 +197,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       if self.mode == .video {
         if self.videoFileOutput == nil {
           self.setupMovieFileCapture()
+          self.updateSessionAudioIsMuted()
         }
       } else {
         self.cleanupMovieFileCapture()
@@ -228,6 +229,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
       self.addErrorNotification()
       self.changePreviewOrientation()
       self.updateSessionAudioIsMuted()
+      self.session.commitConfiguration()
 
       // Delay starting the scanner
       self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
@@ -605,7 +607,7 @@ public class CameraViewNext: ExpoView, EXCameraInterface, EXAppLifecycleListener
         }
       }
 
-      if !self.isMuted {
+      if !self.isMuted && self.mode == .video {
         if let audioCapturedevice = AVCaptureDevice.default(for: .audio) {
           do {
             let audioDeviceInput = try AVCaptureDeviceInput(device: audioCapturedevice)


### PR DESCRIPTION
# Why
Users may want to remove `NSMicrophoneUsageDescription` from their app if they don't intend to have video with audio or offer video at all. This makes app review a bit easier also. 

Currently, if this is done the app will crash unless they explicitly pass `mute` to the `CameraView` which is annoying because it's only relevant to video. 

# How
- Removed the `CameraPermissionRequester` that checked for both permissions in the plist.
- When adding the audio inputs we check if we are in video mode. Adding them without permission will still cause a crash but this is the same as with any other permission. Users can check if they have it and pass the correct value to the `mute` prop when using video.

# Test Plan
Test project with `NSMicrophoneUsageDescription` removed. The app will continue to work without passing the `mute` prop if you are only using the camera for pictures.
