### PR TITLE
[Android] Fix memory leak connect with `AVManager` and global ref

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
-- [Android] Fix memory leak connect with `AVManager`.
+- [Android] Fix memory leak connect with `AVManager`. ([#28159](https://github.com/expo/expo/pull/28159) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
+- [Android] Fix memory leak connect with `AVManager`.
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -269,6 +269,9 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
     removeAudioRecorder();
     abandonAudioFocus();
+
+    mHybridData.resetNative();
+    getUIManager().unregisterLifecycleEventListener(this);
   }
 
   // Global audio state control API


### PR DESCRIPTION
# Why

Fixes memory leaks caused by `AVManager`. The CPP code stores the global ref to the `AVManager` which isn't clean, so it stays in the memory forever. 

# How

Deallocate the global ref when the module is destroyed. 

# Test Plan

- bare-expo ✅ 
