### PR TITLE
[screencapture][Android] Fix memory leaks caused by event emitter

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Reverse api level constraint on the `DETECT_SCREEN_CAPTURE` permission. ([#27148](https://github.com/expo/expo/pull/27148) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fixes memory leaks caused by the event emitter.
+- [Android] Fixes memory leaks caused by the event emitter. ([#28161](https://github.com/expo/expo/pull/28161) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Reverse api level constraint on the `DETECT_SCREEN_CAPTURE` permission. ([#27148](https://github.com/expo/expo/pull/27148) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fixes memory leaks caused by the event emitter.
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes memory leaks caused by event emitter.

# How

We didn't correctly unsubscribe from the `contentResolver`. 

# Test Plan

- bare-expo ✅ 
