### PR TITLE
[core][Android] Refactor how we stores information about exported functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Fixed SharedRef class names are obfuscated when R8 is enabled. ([#27965](https://github.com/expo/expo/pull/27965) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `recreateRootViewWithBundleURL` parameters. ([#27989](https://github.com/expo/expo/pull/27989) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fixed `ExpoBridgeModule.installModules()` is broken on Android and bridgeless mode. ([#28065](https://github.com/expo/expo/pull/28065) by [@kudo](https://github.com/kudo))
-- [Android] Fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`.
+- [Android] Fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`. ([#28163](https://github.com/expo/expo/pull/28163) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fixed SharedRef class names are obfuscated when R8 is enabled. ([#27965](https://github.com/expo/expo/pull/27965) by [@kudo](https://github.com/kudo))
 - [iOS] Fix `recreateRootViewWithBundleURL` parameters. ([#27989](https://github.com/expo/expo/pull/27989) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fixed `ExpoBridgeModule.installModules()` is broken on Android and bridgeless mode. ([#28065](https://github.com/expo/expo/pull/28065) by [@kudo](https://github.com/kudo))
+- [Android] Fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -24,9 +24,7 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
 #else
   facebook::react::LongLivedObjectCollection::get().clear();
 #endif
-  installer->jsRegistry.reset();
-  installer->runtimeHolder.reset();
-  installer->jniDeallocator.reset();
+  installer->prepareForDeallocation();
 }
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -48,7 +48,6 @@ void JSIContext::registerNatives() {
                    makeNativeMethod("global", JSIContext::global),
                    makeNativeMethod("createObject", JSIContext::createObject),
                    makeNativeMethod("drainJSEventLoop", JSIContext::drainJSEventLoop),
-                   makeNativeMethod("wasDeallocated", JSIContext::jniWasDeallocated),
                    makeNativeMethod("setNativeStateForSharedObject",
                                     JSIContext::jniSetNativeStateForSharedObject),
                  });
@@ -167,6 +166,10 @@ void JSIContext::prepareRuntime() {
 
 jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIContext::callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<jni::local_ref<JavaScriptModuleObject::javaobject>(
       std::string)>(
@@ -178,16 +181,23 @@ JSIContext::callGetJavaScriptModuleObjectMethod(const std::string &moduleName) c
 
 jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIContext::callGetCoreModuleObject() const {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<jni::local_ref<JavaScriptModuleObject::javaobject>()>(
       "getCoreModuleObject"
     );
-
   return method(javaPart_);
 }
 
 jni::local_ref<jni::JArrayClass<jni::JString>>
 JSIContext::callGetJavaScriptModulesNames() const {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>(
       "getJavaScriptModulesName"
@@ -196,6 +206,10 @@ JSIContext::callGetJavaScriptModulesNames() const {
 }
 
 bool JSIContext::callHasModule(const std::string &moduleName) const {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<jboolean(std::string)>(
       "hasModule"
@@ -242,6 +256,10 @@ void JSIContext::registerSharedObject(
   jni::local_ref<jobject> native,
   jni::local_ref<JavaScriptObject::javaobject> js
 ) {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<void(jni::local_ref<jobject>, jni::local_ref<JavaScriptObject::javaobject>)>(
       "registerSharedObject"
@@ -250,6 +268,10 @@ void JSIContext::registerSharedObject(
 }
 
 void JSIContext::deleteSharedObject(int objectId) {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<void(int)>(
       "deleteSharedObject"
@@ -261,6 +283,10 @@ void JSIContext::registerClass(
   jni::local_ref<jclass> native,
   jni::local_ref<JavaScriptObject::javaobject> jsClass
 ) {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<void(jni::local_ref<jclass>, jni::local_ref<JavaScriptObject::javaobject>)>(
       "registerClass"
@@ -271,6 +297,10 @@ void JSIContext::registerClass(
 jni::local_ref<JavaScriptObject::javaobject> JSIContext::getJavascriptClass(
   jni::local_ref<jclass> native
 ) {
+  if (javaPart_ == nullptr) {
+    throw std::runtime_error("JSIContext was prepared to be deallocated.");
+  }
+
   const static auto method = expo::JSIContext::javaClassLocal()
     ->getMethod<jni::local_ref<JavaScriptObject::javaobject>(jni::local_ref<jclass>)>(
       "getJavascriptClass"
@@ -278,8 +308,11 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::getJavascriptClass(
   return method(javaPart_, std::move(native));
 }
 
-void JSIContext::jniWasDeallocated() {
-  wasDeallocated = true;
+void JSIContext::prepareForDeallocation() {
+  jsRegistry.reset();
+  runtimeHolder.reset();
+  jniDeallocator.reset();
+  javaPart_.reset();
 }
 
 void JSIContext::jniSetNativeStateForSharedObject(

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -135,14 +135,14 @@ public:
   std::unique_ptr<JSReferencesCache> jsRegistry;
   jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
 
-  bool wasDeallocated = false;
-
   void registerClass(jni::local_ref<jclass> native,
                      jni::local_ref<JavaScriptObject::javaobject> jsClass);
 
   jni::local_ref<JavaScriptObject::javaobject> getJavascriptClass(jni::local_ref<jclass> native);
 
   ~JSIContext();
+
+  void prepareForDeallocation();
 
 private:
   friend HybridBase;
@@ -158,8 +158,6 @@ private:
   inline jni::local_ref<JavaScriptModuleObject::javaobject> callGetCoreModuleObject() const;
 
   inline bool callHasModule(const std::string &moduleName) const;
-
-  void jniWasDeallocated();
 
   void prepareJSIContext(
     jlong jsRuntimePointer,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -53,7 +53,6 @@ private:
 
   friend HybridBase;
 
-
   JavaCallback(std::shared_ptr<CallbackContext> callback);
 
   void invoke();

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -8,6 +8,7 @@
 #include "NativeModule.h"
 
 #include <folly/dynamic.h>
+#include <jni.h>
 #include <jsi/JSIDynamic.h>
 #include <react/jni/ReadableNativeArray.h>
 #include <fbjni/detail/Hybrid.h>
@@ -36,7 +37,7 @@ void decorateObjectWithFunctions(
     jsObject->setProperty(
       runtime,
       jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *method.toJSFunction(runtime))
+      jsi::Value(runtime, *method->toJSFunction(runtime))
     );
   }
 }
@@ -53,12 +54,12 @@ void decorateObjectWithProperties(
     descriptor.setProperty(
       runtime,
       "get",
-      jsi::Value(runtime, *getter.toJSFunction(runtime))
+      jsi::Value(runtime, *getter->toJSFunction(runtime))
     );
     descriptor.setProperty(
       runtime,
       "set",
-      jsi::Value(runtime, *setter.toJSFunction(runtime))
+      jsi::Value(runtime, *setter->toJSFunction(runtime))
     );
     common::defineProperty(runtime, jsObject, name.c_str(), std::move(descriptor));
   }
@@ -79,7 +80,7 @@ void decorateObjectWithConstants(
 
 jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
 JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
-  return makeCxxInstance(jThis);
+  return makeCxxInstance();
 }
 
 void JavaScriptModuleObject::registerNatives() {
@@ -144,16 +145,23 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
   for (auto &[name, classInfo]: classes) {
     auto &[classRef, constructor, ownerClass] = classInfo;
     auto classObject = classRef->cthis();
-
+    auto weakConstructor = std::weak_ptr(constructor);
     auto klass = SharedObject::createClass(
       runtime,
       name.c_str(),
-      [classObject, &constructor = constructor](
+      [classObject, weakConstructor = std::move(weakConstructor)](
         jsi::Runtime &runtime,
         const jsi::Value &thisValue,
         const jsi::Value *args,
         size_t count
       ) -> jsi::Value {
+        // We need to check if the constructor is still alive.
+        // If not we can just ignore the call. We're destroying the module.
+        auto ctr = weakConstructor.lock();
+        if (ctr == nullptr) {
+          return jsi::Value::undefined();
+        }
+
         auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
         decorateObjectWithProperties(runtime, thisObject.get(),
                                      classObject);
@@ -165,7 +173,7 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
           * all LocalReferences are deleted.
           */
           jni::JniLocalScope scope(env, (int) count);
-          auto result = constructor.callJNISync(
+          auto result = ctr->callJNISync(
             env,
             runtime,
             thisValue,
@@ -248,15 +256,14 @@ void JavaScriptModuleObject::registerSyncFunction(
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
   std::string cName = name->toStdString();
-
-  methodsMetadata.try_emplace(
+  auto methodMetadata = std::make_shared<MethodMetadata>(
     cName,
-    cName,
-    takesOwner,
+    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
     false,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
   );
+  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
 }
 
 void JavaScriptModuleObject::registerAsyncFunction(
@@ -266,15 +273,14 @@ void JavaScriptModuleObject::registerAsyncFunction(
   jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
 ) {
   std::string cName = name->toStdString();
-
-  methodsMetadata.try_emplace(
+  auto methodMetadata = std::make_shared<MethodMetadata>(
     cName,
-    cName,
-    takesOwner,
+    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
     true,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
   );
+  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
 }
 
 void JavaScriptModuleObject::registerClass(
@@ -286,9 +292,9 @@ void JavaScriptModuleObject::registerClass(
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
   std::string cName = name->toStdString();
-  MethodMetadata constructor(
+  auto constructor = std::make_shared<MethodMetadata>(
     "constructor",
-    takesOwner,
+    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
     false,
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
@@ -323,17 +329,17 @@ void JavaScriptModuleObject::registerProperty(
 ) {
   auto cName = name->toStdString();
 
-  auto getterMetadata = MethodMetadata(
+  auto getterMetadata = make_shared<MethodMetadata>(
     cName,
-    getterTakesOwner,
+    getterTakesOwner & 0x1, // We're unsure if getterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
     false,
     jni::make_local(getterExpectedArgsTypes),
     jni::make_global(getter)
   );
 
-  auto setterMetadata = MethodMetadata(
+  auto setterMetadata = make_shared<MethodMetadata>(
     cName,
-    setterTakesOwner,
+    setterTakesOwner & 0x1, // We're unsure if setterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
     false,
     jni::make_local(setterExpectedArgsTypes),
     jni::make_global(setter)
@@ -344,7 +350,7 @@ void JavaScriptModuleObject::registerProperty(
     std::move(setterMetadata)
   );
 
-  properties.insert({cName, std::move(functions)});
+  properties.insert_or_assign(cName, std::move(functions));
 }
 
 void JavaScriptModuleObject::emitEvent(
@@ -380,9 +386,5 @@ void JavaScriptModuleObject::emitEvent(
 
     EventEmitter::emitEvent(rt, *jsThis, name, args);
   });
-}
-
-JavaScriptModuleObject::JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
-  : javaPart_(jni::make_global(jThis)) {
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -138,9 +138,6 @@ public:
   );
 
 private:
-  explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis);
-
-private:
   friend HybridBase;
 
   friend void decorateObjectWithFunctions(
@@ -168,12 +165,11 @@ private:
    * Doing that allows the runtime to deallocate jsi::Object if it's not needed anymore.
    */
   std::weak_ptr<jsi::Object> jsiObject;
-  jni::global_ref<JavaScriptModuleObject::javaobject> javaPart_;
 
   /**
    * Metadata map that stores information about all available methods on this module.
    */
-  std::unordered_map<std::string, MethodMetadata> methodsMetadata;
+  std::unordered_map<std::string, std::shared_ptr<MethodMetadata>> methodsMetadata;
 
   /**
    * A constants map.
@@ -184,11 +180,11 @@ private:
    * A registry of properties
    * The first MethodMetadata points to the getter and the second one to the setter.
    */
-  std::map<std::string, std::pair<MethodMetadata, MethodMetadata>> properties;
+  std::map<std::string, std::pair<std::shared_ptr<MethodMetadata>, std::shared_ptr<MethodMetadata>>> properties;
 
   std::map<
     std::string,
-    std::tuple<jni::global_ref<JavaScriptModuleObject::javaobject>, MethodMetadata, jni::global_ref<jclass>>
+    std::tuple<jni::global_ref<JavaScriptModuleObject::javaobject>, std::shared_ptr<MethodMetadata>, jni::global_ref<jclass>>
   > classes;
 
   jni::global_ref<JavaScriptModuleObject::javaobject> viewPrototype;

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -25,7 +25,7 @@ class JSIContext;
 /**
  * A class that holds information about the exported function.
  */
-class MethodMetadata {
+class MethodMetadata : public std::enable_shared_from_this<MethodMetadata> {
 public:
   /**
    * Function name

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -324,9 +324,6 @@ class AppContext(
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
     backgroundCoroutineScope.cancel(ContextDestroyedException())
-    if (::jsiInterop.isInitialized) {
-      jsiInterop.wasDeallocated()
-    }
     jniDeallocator.deallocate()
     logger.info("✅ AppContext was destroyed")
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -120,11 +120,6 @@ class JSIContext : Destructible {
    */
   external fun drainJSEventLoop()
 
-  /**
-   * Informs C++ that runtime was deallocated.
-   */
-  external fun wasDeallocated()
-
   external fun setNativeStateForSharedObject(id: Int, js: JavaScriptObject)
 
   /**


### PR DESCRIPTION
# Why

Refactors the way we store information about exported functions.
Hopefully, fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`.

# How

I used to think that Java would have a longer lifespan than C++. However, it seems that C++ has outlasted Java. Even after cleaning everything, some functions are still being called on the old runtime, leading to segmentation faults. To address this issue, I had to change how and where we store information about exported functions. Previously, the data was stored inside the `JavaScriptModuleObject`, and to access it, we had to use that object. This was not ideal because we didn't have full control over the lifetime of the object. Now, the data is also stored in the module object, but each exported function has its own weak pointer. During execution, the function can handle the case where metadata was deallocated.

# Test Plan

- bare-expo ✅ 
- bare-expo with a memory profiler to check if we don't ✅ 
