### PR TITLE
[android] Fix onActivityResult with bridgeless

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
 - [Android] Added `ReactNativeHostHandler.onReactInstanceException()` for expo-updates to handle exceptions on bridgeless mode. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
-- [Android] Do not use the workaround in the `ReactActivityDelegateWrapper` `onActivityResult` method when using the new architecture.
+- [Android] Do not use the workaround in the `ReactActivityDelegateWrapper` `onActivityResult` method when using the new architecture. ([#28165](https://github.com/expo/expo/pull/28165) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 50.0.14 - 2024-03-20
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] Added bridgeless support on ReactNativeHostHandler. ([#27629](https://github.com/expo/expo/pull/27629) by [@kudo](https://github.com/kudo))
 - [Android] Added `ReactNativeHostHandler.onReactInstanceException()` for expo-updates to handle exceptions on bridgeless mode. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
+- [Android] Do not use the workaround in the `ReactActivityDelegateWrapper` `onActivityResult` method when using the new architecture.
 
 ## 50.0.14 - 2024-03-20
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -225,7 +225,7 @@ class ReactActivityDelegateWrapper(
      *
      * TODO (@bbarthec): fix it upstream?
      */
-    if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && delegate.reactInstanceManager.currentReactContext == null) {
+    if (!ReactFeatureFlags.enableBridgelessArchitecture && delegate.reactInstanceManager.currentReactContext == null) {
       val reactContextListener = object : ReactInstanceEventListener {
         override fun onReactContextInitialized(context: ReactContext) {
           delegate.reactInstanceManager.removeReactInstanceEventListener(this)

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -225,7 +225,7 @@ class ReactActivityDelegateWrapper(
      *
      * TODO (@bbarthec): fix it upstream?
      */
-    if (delegate.reactInstanceManager.currentReactContext == null) {
+    if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED && delegate.reactInstanceManager.currentReactContext == null) {
       val reactContextListener = object : ReactInstanceEventListener {
         override fun onReactContextInitialized(context: ReactContext) {
           delegate.reactInstanceManager.removeReactInstanceEventListener(this)


### PR DESCRIPTION
# Why
Fixes a crash on the new architecture when `onActivityResult` is called. We're using a workaround to an old issue in the `ReactActivityDelegateWrapper`'s `onActivityResult` function. This accesses  the `reactInstanceManager` which is null. We don't need this on the new arch.

# How
Add a check to see if we are on the new arch and if so skip the workaround. I'm not sure this is still even necessary on the old arch anymore

# Test Plan
Bare expo running the new arch. `onActivityResult` dependent apis are now working.
