### PR TITLE
Volta pin node @ 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "node-gyp": "^10.0.1",
     "prettier": "^3.1.1",
     "yarn-deduplicate": "^6.0.2"
+  },
+  "volta": {
+    "node": "20.12.2"
   }
 }


### PR DESCRIPTION
# Why

Node 20.12 must be used with this repo since anything less (including 18.x, 20.10) produces different built files when running `et cp`.
https://exponent-internal.slack.com/archives/C1QP38NQ5/p1711462334338729
https://exponent-internal.slack.com/archives/C1QP38NQ5/p1711696048878149

# How

This pins node using volta for those of us using volta so we don't have to manually change it when moving to the repo.

`volta pin node@20` is the command I ran to generate this.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
