### PR TITLE
[expo] Bump recommended react-native-get-random-values version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -86,7 +86,7 @@
   "react-native": "0.74.0-rc.8",
   "react-native-web": "~0.19.10",
   "react-native-gesture-handler": "~2.16.0",
-  "react-native-get-random-values": "~1.8.0",
+  "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.13.0",
   "react-native-pager-view": "6.2.3",
   "react-native-reanimated": "~3.9.0-rc.0",


### PR DESCRIPTION
# Why

[Version 1.8](https://github.com/LinusU/react-native-get-random-values/releases/tag/v1.8.0) is already 2 years old. All additional minor changes since then added more non-breaking functionality and better compatibility with newer Expo SDKs.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
