### PR TITLE
Add bridgeless support for dev-client on iOS

### DIFF
--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -11,7 +11,209 @@ PODS:
     - ExpoModulesCore
   - Expo (51.0.0-unreleased):
     - ExpoModulesCore
+  - expo-dev-client (3.3.2):
+    - EXManifests
+    - expo-dev-launcher
+    - expo-dev-menu
+    - expo-dev-menu-interface
+    - EXUpdatesInterface
+  - expo-dev-launcher (3.6.0):
+    - DoubleConversion
+    - EXManifests
+    - expo-dev-launcher/Main (= 3.6.0)
+    - expo-dev-menu
+    - expo-dev-menu-interface
+    - ExpoModulesCore
+    - EXUpdatesInterface
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTAppDelegate
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-launcher/Main (3.6.0):
+    - DoubleConversion
+    - EXManifests
+    - expo-dev-launcher/Unsafe
+    - expo-dev-menu
+    - expo-dev-menu-interface
+    - ExpoModulesCore
+    - EXUpdatesInterface
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTAppDelegate
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-launcher/Unsafe (3.6.0):
+    - DoubleConversion
+    - EXManifests
+    - expo-dev-menu
+    - expo-dev-menu-interface
+    - ExpoModulesCore
+    - EXUpdatesInterface
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTAppDelegate
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-menu (4.5.1):
+    - DoubleConversion
+    - expo-dev-menu/Main (= 4.5.1)
+    - expo-dev-menu/ReactNativeCompatibles (= 4.5.1)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - expo-dev-menu-interface (1.7.0)
+  - expo-dev-menu/Main (4.5.1):
+    - DoubleConversion
+    - EXManifests
+    - expo-dev-menu-interface
+    - expo-dev-menu/Vendored
+    - ExpoModulesCore
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-menu/ReactNativeCompatibles (4.5.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-menu/SafeAreaView (4.5.1):
+    - DoubleConversion
+    - ExpoModulesCore
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - expo-dev-menu/Vendored (4.5.1):
+    - DoubleConversion
+    - expo-dev-menu/SafeAreaView
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - ExpoAppleAuthentication (6.3.0):
     - ExpoModulesCore
   - ExpoAsset (9.0.1):
@@ -1284,6 +1486,9 @@ DEPENDENCIES:
   - EXJSONUtils (from `../../../packages/expo-json-utils/ios`)
   - EXManifests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../packages/expo`)
+  - expo-dev-client (from `../../../packages/expo-dev-client/ios`)
+  - expo-dev-launcher (from `../../../packages/expo-dev-launcher`)
+  - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
   - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
@@ -1378,6 +1583,12 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../packages/expo"
+  expo-dev-client:
+    :path: "../../../packages/expo-dev-client/ios"
+  expo-dev-launcher:
+    :path: "../../../packages/expo-dev-launcher"
+  expo-dev-menu:
+    :path: "../../../packages/expo-dev-menu"
   expo-dev-menu-interface:
     :path: "../../../packages/expo-dev-menu-interface/ios"
   ExpoAppleAuthentication:
@@ -1518,6 +1729,9 @@ SPEC CHECKSUMS:
   EXJSONUtils: d138005ee11b84fc4e3bf7119a160034db5d5e20
   EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
   Expo: 2d88b1f9b7a511015414d8c40cc8c6af13c469eb
+  expo-dev-client: 62325d7ddd0b339eb2e50e472b2e058e222c1c2d
+  expo-dev-launcher: 855a331dd2940846481628fb00a9925db22d6918
+  expo-dev-menu: 0a1b9aae7eba3063d450e109a56ed0cef3aae9b9
   expo-dev-menu-interface: 3c36b4d5032397e022958a2041afe91a130ea74c
   ExpoAppleAuthentication: 4fc9972356977f009911f2f3a5f56319c2a5b11b
   ExpoAsset: 751d84b1c4d91a1eddf4a4e356c9e9948ae20153
@@ -1587,7 +1801,7 @@ SPEC CHECKSUMS:
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
-  SDWebImageWebPCoder: c94f09adbca681822edad9e532ac752db713eabf
+  SDWebImageWebPCoder: eb09ecbb5a65a1deb5c5f7960fdb788daae0dd43
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 553006c695f727afa3d30fdac7542f7ea6e2a4f9
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5

--- a/apps/fabric-tester/ios/fabrictester.xcodeproj/project.pbxproj
+++ b/apps/fabric-tester/ios/fabrictester.xcodeproj/project.pbxproj
@@ -291,6 +291,8 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -299,6 +301,8 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -30,11 +30,7 @@
   "private": true,
   "expo": {
     "autolinking": {
-      "exclude": [
-        "expo-dev-client",
-        "expo-dev-launcher",
-        "expo-dev-menu"
-      ]
+      "exclude": []
     }
   }
 }

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Add bridgeless support for React-Native 0.74. ([#28174](https://github.com/expo/expo/pull/28174) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo), [#28111](https://github.com/expo/expo/pull/28111) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -736,7 +736,7 @@
 - (void)setDevMenuAppBridge
 {
   DevMenuManager *manager = [DevMenuManager shared];
-  manager.currentBridge = self.appBridge;
+  manager.currentBridge = [RCTBridge currentBridge];
 
   if (self.manifest != nil) {
     manager.currentManifest = self.manifest;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -598,8 +598,6 @@
 
     [self setDevMenuAppBridge];
 
-//    [self _ensureUserInterfaceStyleIsInSyncWithTraitEnv:self.window.rootViewController];
-
     if (backgroundColor) {
       self.window.rootViewController.view.backgroundColor = backgroundColor;
       self.window.backgroundColor = backgroundColor;
@@ -641,18 +639,6 @@
     }
     #undef EXPECTED_ROOT_VIEW
   });
-}
-
-/**
- * We need that function to sync the dev-menu user interface with the main application.
- */
-- (void)_ensureUserInterfaceStyleIsInSyncWithTraitEnv:(id<UITraitEnvironment>)env
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTUserInterfaceStyleDidChangeNotification
-                                                      object:env
-                                                    userInfo:@{
-                                                      RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey : env.traitCollection
-                                                    }];
 }
 
 - (void)_applyUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle API_AVAILABLE(ios(12.0))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -598,7 +598,7 @@
 
     [self setDevMenuAppBridge];
 
-    [self _ensureUserInterfaceStyleIsInSyncWithTraitEnv:self.window.rootViewController];
+//    [self _ensureUserInterfaceStyleIsInSyncWithTraitEnv:self.window.rootViewController];
 
     if (backgroundColor) {
       self.window.rootViewController.view.backgroundColor = backgroundColor;
@@ -736,7 +736,7 @@
 - (void)setDevMenuAppBridge
 {
   DevMenuManager *manager = [DevMenuManager shared];
-  manager.currentBridge = [RCTBridge currentBridge];
+  manager.currentBridge = self.appBridge;
 
   if (self.manifest != nil) {
     manager.currentManifest = self.manifest;

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -56,7 +56,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       initialProps: self.rootViewInitialProperties,
       launchOptions: self.launchOptions
     )
-    developmentClientController.appBridge = rctAppDelegate.bridge
+    developmentClientController.appBridge = RCTBridge.current()
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white
     let window = getWindow()
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Add bridgeless support for React-Native 0.74. ([#28174](https://github.com/expo/expo/pull/28174) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fixed breaking changes from React-Native 0.74. ([#26357](https://github.com/expo/expo/pull/26357), [#26740](https://github.com/expo/expo/pull/26740), [#27118](https://github.com/expo/expo/pull/27118) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-menu/ios/DevClientAppDelegate.h
+++ b/packages/expo-dev-menu/ios/DevClientAppDelegate.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DevClientAppDelegate : RCTAppDelegate
 
-- (RCTBridge *)createBridgeAndSetAdapterWithLaunchOptions:(NSDictionary *_Nullable)launchOptions;
+- (void)initRootViewFactory;
 
 #pragma mark - Remove these method when we drop SDK 49
 

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -20,6 +20,7 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
     self.manager = manager
 
     super.init()
+    super.initRootViewFactory()
     self.rootViewFactory.bridge = bridge
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -13,7 +13,7 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
     self.manager = manager
 
     super.init()
-    self.createBridgeAndSetAdapter(launchOptions: nil)
+    super.initRootViewFactory()
   }
 
   init(manager: DevMenuManager, bridge: RCTBridge) {

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -239,6 +239,12 @@ open class DevMenuManager: NSObject {
     guard let bridge = currentBridge else {
       return nil
     }
+
+    if type(of: bridge) == RCTBridgeProxy.self {
+      // RCTBridgeProxy does not support modulesConformingToProtocol, fallback to using ExpoDevMenuExtensions only
+      return [bridge.module(forName: "ExpoDevMenuExtensions")] as? [DevMenuExtensionProtocol]
+    }
+
     let allExtensions = bridge.modulesConforming(to: DevMenuExtensionProtocol.self) as! [DevMenuExtensionProtocol]
 
     let uniqueExtensionNames = Set(

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -7,8 +7,7 @@ class DevMenuViewController: UIViewController {
   static let ContentDidAppearNotification = Notification.Name("RCTContentDidAppearNotification")
 
   private let manager: DevMenuManager
-  private var reactRootView: DevMenuRootView?
-  private var hasCalledJSLoadedNotification: Bool = false
+  private var reactRootView: UIView?
 
   init(manager: DevMenuManager) {
     self.manager = manager
@@ -23,14 +22,18 @@ class DevMenuViewController: UIViewController {
   }
 
   func updateProps() {
-    reactRootView?.appProperties = initialProps()
+    if let reactRootView = reactRootView as? RCTRootView {
+      reactRootView.appProperties = initialProps()
+    } else if let reactRootView = reactRootView as? RCTSurfaceHostingProxyRootView {
+      reactRootView.appProperties = initialProps()
+    }
   }
 
   // MARK: UIViewController
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    maybeRebuildRootView()
+    rebuildRootView()
   }
 
   override func viewWillLayoutSubviews() {
@@ -40,7 +43,6 @@ class DevMenuViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    forceRootViewToRenderHack()
     reactRootView?.becomeFirstResponder()
   }
 
@@ -62,7 +64,7 @@ class DevMenuViewController: UIViewController {
 
   private func initialProps() -> [String: Any] {
     let isSimulator = TARGET_IPHONE_SIMULATOR > 0
-    
+
     return [
       "showOnboardingView": manager.shouldShowOnboarding(),
       "appInfo": manager.getAppInfo(),
@@ -74,37 +76,14 @@ class DevMenuViewController: UIViewController {
     ]
   }
 
-  // RCTRootView assumes it is created on a loading bridge.
-  // in our case, the bridge has usually already loaded. so we need to prod the view.
-  private func forceRootViewToRenderHack() {
-    if !hasCalledJSLoadedNotification, let bridge = manager.appInstance.bridge {
-      let notification = Notification(name: DevMenuViewController.JavaScriptDidLoadNotification, object: nil, userInfo: ["bridge": bridge])
+  private func rebuildRootView() {
+    reactRootView = manager.appInstance.rootViewFactory.view(withModuleName: "main", initialProperties: initialProps())
+    reactRootView?.frame = view.bounds
+    reactRootView?.backgroundColor = UIColor.clear
 
-      reactRootView?.javaScriptDidLoad(notification)
-      hasCalledJSLoadedNotification = true
-    }
-  }
-
-  private func maybeRebuildRootView() {
-    guard let bridge = manager.appInstance.bridge else {
-      return
-    }
-    if reactRootView?.bridge != bridge {
-      if reactRootView != nil {
-        reactRootView?.removeFromSuperview()
-        reactRootView = nil
-      }
-      hasCalledJSLoadedNotification = false
-      reactRootView = DevMenuRootView(bridge: bridge, moduleName: "main", initialProperties: initialProps())
-      reactRootView?.frame = view.bounds
-      reactRootView?.backgroundColor = UIColor.clear
-
-      if isViewLoaded, let reactRootView = reactRootView {
-        view.addSubview(reactRootView)
-        view.setNeedsLayout()
-      }
-    } else {
-      updateProps()
+    if isViewLoaded, let reactRootView = reactRootView {
+      view.addSubview(reactRootView)
+      view.setNeedsLayout()
     }
   }
 }


### PR DESCRIPTION
# Why

Closes ENG-11706

# How

- Reenable dev-client on fabric-tester
- Cleanup `DevClientAppDelegate` to use the same methods as `RCTAppDelegate`
- Refactor `DevMenuViewController.swift`

# Test Plan

Run BareExpo and FabricTester on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
