### PR TITLE
[core][updates] fix error recovery on android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Removed the legacy interfaces for font processors as they are no longer used by `expo-font` and nothing else depends on them. ([#26380](https://github.com/expo/expo/pull/26380) by [@tsapeta](https://github.com/tsapeta))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.23. ([#28088](https://github.com/expo/expo/pull/28088) by [@kudo](https://github.com/kudo))
+- Introduced `onDidCreateDevSupportManager` handler to support error recovery from expo-updates. ([#28177](https://github.com/expo/expo/pull/28177) by [@kudo](https://github.com/kudo))
 
 ## 1.11.11 - 2024-03-11
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
 
 public interface ReactNativeHostHandler {
   /**
@@ -70,6 +71,11 @@ public interface ReactNativeHostHandler {
    * Callback before react instance creation
    */
   default void onWillCreateReactInstance(boolean useDeveloperSupport) {}
+
+  /**
+   * Callback when the {@link DevSupportManager} is available
+   */
+  default void onDidCreateDevSupportManager(@NonNull DevSupportManager devSupportManager) {}
 
   /**
    * Callback after react instance creation

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix inconsistent hashes for autolinking for fingerprint policy. ([#27390](https://github.com/expo/expo/pull/27390) by [@wschurman](https://github.com/wschurman))
 - Fixed launch crash when running on a project without expo-dev-client and debug build. ([#27780](https://github.com/expo/expo/pull/27780) by [@kudo](https://github.com/kudo))
 - Fixed bridgeless error recovery support for launch errors on Android. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
+- Fixed error recovery on Android. ([#28177](https://github.com/expo/expo/pull/28177) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
@@ -68,7 +69,9 @@ class DisabledUpdatesController(
   override val bundleAssetName: String?
     get() = launcher?.bundleAssetName
 
-  override fun onDidCreateReactInstanceManager(reactContext: ReactContext) {
+  override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {}
+
+  override fun onDidCreateReactInstance(reactContext: ReactContext) {
     weakActivity = WeakReference(reactContext.currentActivity)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
@@ -118,8 +119,11 @@ class EnabledUpdatesController(
   override val bundleAssetName: String?
     get() = startupProcedure.bundleAssetName
 
-  override fun onDidCreateReactInstanceManager(reactContext: ReactContext) {
-    startupProcedure.onDidCreateReactInstanceManager(reactContext)
+  override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {
+    startupProcedure.onDidCreateDevSupportManager(devSupportManager)
+  }
+
+  override fun onDidCreateReactInstance(reactContext: ReactContext) {
     weakActivity = WeakReference(reactContext.currentActivity)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -3,6 +3,7 @@ package expo.modules.updates
 import android.os.Bundle
 import com.facebook.react.ReactApplication
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.db.entity.AssetEntity
@@ -44,7 +45,9 @@ interface IUpdatesController {
    */
   var appContext: WeakReference<AppContext>?
 
-  fun onDidCreateReactInstanceManager(reactContext: ReactContext)
+  fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager)
+
+  fun onDidCreateReactInstance(reactContext: ReactContext)
 
   fun onReactInstanceException(exception: java.lang.Exception)
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.db.DatabaseHolder
@@ -79,7 +80,9 @@ class UpdatesDevLauncherController(
   override val bundleAssetName: String
     get() = throw Exception("IUpdatesController.bundleAssetName should not be called in dev client")
 
-  override fun onDidCreateReactInstanceManager(reactContext: ReactContext) {}
+  override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {}
+
+  override fun onDidCreateReactInstance(reactContext: ReactContext) {}
 
   override fun onReactInstanceException(exception: java.lang.Exception) {}
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -7,6 +7,7 @@ import androidx.annotation.WorkerThread
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.core.interfaces.ApplicationLifecycleListener
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityHandler
@@ -38,8 +39,12 @@ class UpdatesPackage : Package {
         UpdatesController.initialize(context)
       }
 
+      override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {
+        UpdatesController.instance.onDidCreateDevSupportManager(devSupportManager)
+      }
+
       override fun onDidCreateReactInstance(useDeveloperSupport: Boolean, reactContext: ReactContext) {
-        UpdatesController.instance.onDidCreateReactInstanceManager(reactContext)
+        UpdatesController.instance.onDidCreateReactInstance(reactContext)
       }
 
       override fun onReactInstanceException(useDeveloperSupport: Boolean, exception: Exception) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -3,7 +3,7 @@ package expo.modules.updates.procedures
 import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
-import com.facebook.react.bridge.ReactContext
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.entity.AssetEntity
@@ -220,11 +220,11 @@ class StartupProcedure(
     callback.onFinished()
   }
 
-  fun onDidCreateReactInstanceManager(reactContext: ReactContext) {
+  fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {
     if (emergencyLaunchException != null) {
       return
     }
-    errorRecovery.startMonitoring(reactContext)
+    errorRecovery.startMonitoring(devSupportManager)
   }
 
   fun onReactInstanceException(exception: Exception) {

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -718,6 +718,7 @@ export async function initAsync(
       '-dontwarn javax.lang.model.element.Modifier',
       '-dontwarn org.checkerframework.checker.nullness.qual.EnsuresNonNullIf',
       '-dontwarn org.checkerframework.dataflow.qual.Pure',
+      '-keep class com.google.common.util.concurrent.ListenableFuture { *; }',
       '',
     ].join('\n'),
     'utf-8'

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [Android] Added `ReactNativeHostHandler.onReactInstanceException()` for expo-updates to handle exceptions on bridgeless mode. ([#27815](https://github.com/expo/expo/pull/27815) by [@kudo](https://github.com/kudo))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - [Android] Do not use the workaround in the `ReactActivityDelegateWrapper` `onActivityResult` method when using the new architecture. ([#28165](https://github.com/expo/expo/pull/28165) by [@alanjhughes](https://github.com/alanjhughes))
+- Introduced `onDidCreateDevSupportManager` handler to support error recovery from expo-updates. ([#28177](https://github.com/expo/expo/pull/28177) by [@kudo](https://github.com/kudo))
 
 ## 50.0.14 - 2024-03-20
 

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -89,6 +89,10 @@ object ExpoReactHostFactory {
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)
 
+      reactNativeHost.reactNativeHostHandlers.forEach { handler ->
+        handler.onWillCreateReactInstance(useDeveloperSupport)
+      }
+
       val reactHostImpl =
         ReactHostImpl(
           context,
@@ -101,6 +105,10 @@ object ExpoReactHostFactory {
           .apply {
             jsEngineResolutionAlgorithm = reactNativeHost.jsEngineResolutionAlgorithm
           }
+
+      reactNativeHost.reactNativeHostHandlers.forEach { handler ->
+        handler.onDidCreateDevSupportManager(reactHostImpl.devSupportManager)
+      }
 
       reactHostImpl.addReactInstanceEventListener(object : ReactInstanceEventListener {
         override fun onReactContextInitialized(context: ReactContext) {

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -89,7 +89,6 @@ class ReactActivityDelegateWrapper(
       mReactDelegate.isAccessible = true
       val reactDelegate = mReactDelegate[delegate] as ReactDelegate
 
-      dispatchWillCreateReactInstanceIfNeeded()
       reactDelegate.loadApp(appKey)
       rootViewContainer.addView(reactDelegate.reactRootView, ViewGroup.LayoutParams.MATCH_PARENT)
       activity.setContentView(rootViewContainer)
@@ -106,7 +105,6 @@ class ReactActivityDelegateWrapper(
       shouldEmitPendingResume = true
       delayLoadAppHandler.whenReady {
         Utils.assertMainThread()
-        dispatchWillCreateReactInstanceIfNeeded()
         invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
         reactActivityLifecycleListeners.forEach { listener ->
           listener.onContentChanged(activity)
@@ -117,7 +115,6 @@ class ReactActivityDelegateWrapper(
       return
     }
 
-    dispatchWillCreateReactInstanceIfNeeded()
     invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onContentChanged(activity)
@@ -330,15 +327,6 @@ class ReactActivityDelegateWrapper(
       methodMap[name] = method
     }
     return method!!.invoke(delegate, *args) as T
-  }
-
-  private fun dispatchWillCreateReactInstanceIfNeeded() {
-    if (_reactHost != null) {
-      val useDeveloperSupport = _reactNativeHost.useDeveloperSupport
-      (_reactNativeHost as? ReactNativeHostWrapper)?.reactNativeHostHandlers?.forEach {
-        it.onWillCreateReactInstance(useDeveloperSupport)
-      }
-    }
   }
 
   //endregion

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapperBase.kt
@@ -28,6 +28,10 @@ open class ReactNativeHostWrapperBase(
 
     val result = super.createReactInstanceManager()
 
+    reactNativeHostHandlers.forEach { handler ->
+      handler.onDidCreateDevSupportManager(result.devSupportManager)
+    }
+
     result.addReactInstanceEventListener(object : ReactInstanceEventListener {
       override fun onReactContextInitialized(context: ReactContext) {
         reactNativeHostHandlers.forEach { handler ->


### PR DESCRIPTION
# Why

the error recovery of updates was broken since https://github.com/expo/expo/pull/27629/files#diff-b034a3a37c87b036bb0d9c0549d6701774c79fedb4892dd44807d8947d75d4fbL27-R37. apparently when ReactContext is available, it's too late for error recovery because bundle is loaded and may throw exceptions already. 

# How

- i feel #27629's change is correct for `onDidCreateReactInstance`. for error recovery we sound like need to call point between onWillCreateReactInstance and DevSupportManager available (error recovery requires DevSupportManager to detect exceptions). this pr introduces a new `onDidCreateDevSupportManager` for this purpose.
- also fix incorrect onWillCreateReactInstance timing on bridgeless mode
- seen a detox failed from proguard that i have to add an additional proguard rule to fix that.

# Test Plan

test based on #28050
i need further change to the detox e2e
  - detox does not support reload well, it will encounter [the detox error](https://github.com/wix/Detox/blob/97186a9e50aa69bf6585bd4b10ef262b6b4e9e8c/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/UIModuleIdlingResource.kt#L31) and enter infinite waiting loop. the reason is that the detox access to the old ReactContext which is not the same with the new ReactContext reloading from error recovery. i have to patch the #28050 test
    ```diff
    diff --git a/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts b/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
    index 016a204516..92b429c506 100644
    --- a/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
    +++ b/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
    @@ -19,6 +19,23 @@ const waitForAppToBecomeVisible = async () => {
         .withTimeout(2000);
     };
    
    +function launchAppWithTimeout(timeout: number) {
    +  return new Promise(async (resolve, reject) => {
    +    setTimeout(() => {
    +      reject(new Error('Launch timed out'));
    +    }, timeout);
    +
    +    try {
    +      await device.launchApp({
    +        newInstance: true,
    +      });
    +      resolve(null);  // If successful, resolve the promise.
    +    } catch (error) {
    +      reject(error);  // If the launchApp itself fails, reject the promise.
    +    }
    +  });
    +}
    +
     describe('Error recovery tests', () => {
       afterEach(async () => {
         await device.uninstallApp();
    @@ -69,9 +86,7 @@ describe('Error recovery tests', () => {
         // we don't check current update ID header or failed update IDs header since the behavior for this request is not defined
         // (we don't guarantee current update to be set during a crash or the launch failure to have been registered yet)
         await jestExpect(
    -      device.launchApp({
    -        newInstance: true,
    -      })
    +      launchAppWithTimeout(2000)
         ).rejects.toThrow();
         const request2 = await Server.waitForUpdateRequest(10000);
         const request2EmbeddedUpdateId = request2.headers['expo-embedded-update-id'];
    ```
     

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
