### PR TITLE
[core][Android] Fix `JSIContext was prepared to be deallocated` exception

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -122,7 +122,8 @@ public:
     jni::local_ref<JavaScriptObject::javaobject> js
   );
 
-  void deleteSharedObject(
+  static void deleteSharedObject(
+    jni::global_ref<JSIContext::javaobject> javaObject,
     int objectId
   );
 


### PR DESCRIPTION
# Why

Fixes `JSIContext was prepared to be deallocated` exception reported [here](https://github.com/expo/expo/pull/28163#issuecomment-2052195963)

# How

Made sure that `JSIContext` will live long enough to remove all shared objects. 

# Test Plan

- bare-expo ✅ 
- unit tests ✅ 