### PR TITLE
[CI] fix TV compile test

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -337,8 +337,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.74.0-0rc0',
-        '@react-native-tvos/config-tv': '^0.0.7',
+        'react-native': 'npm:react-native-tvos@~0.74.0-0rc2',
+        '@react-native-tvos/config-tv': '^0.0.8',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

Fix CI

# How

Move to latest RNTV 0.74 published package, which is current with the changes in RN 0.74.0-rc.8

# Test Plan

CI should pass

