### PR TITLE
[docs] Fix internal links in FileSystem API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -212,8 +212,8 @@ import * as FileSystem from 'expo-file-system';
 
 The API takes `file://` URIs pointing to local files on the device to identify files. Each app only has read and write access to locations under the following directories:
 
-- [`FileSystem.documentDirectory`](#documendirectory)
-- [`FileSystem.cacheDirectory`](#cachedirectory)
+- [`FileSystem.documentDirectory`](#filesystemdocumentdirectory)
+- [`FileSystem.cacheDirectory`](#filesystemcachedirectory)
 
 So, for example, the URI to a file named `'myFile'` under `'myDirectory'` in the app's user documents directory would be `FileSystem.documentDirectory + 'myDirectory/myFile'`.
 

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -208,8 +208,8 @@ import * as FileSystem from 'expo-file-system';
 
 The API takes `file://` URIs pointing to local files on the device to identify files. Each app only has read and write access to locations under the following directories:
 
-- [`FileSystem.documentDirectory`](#documendirectory)
-- [`FileSystem.cacheDirectory`](#cachedirectory)
+- [`FileSystem.documentDirectory`](#filesystemdocumentdirectory)
+- [`FileSystem.cacheDirectory`](#filesystemcachedirectory)
 
 So, for example, the URI to a file named `'myFile'` under `'myDirectory'` in the app's user documents directory would be `FileSystem.documentDirectory + 'myDirectory/myFile'`.
 

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -208,8 +208,8 @@ import * as FileSystem from 'expo-file-system';
 
 The API takes `file://` URIs pointing to local files on the device to identify files. Each app only has read and write access to locations under the following directories:
 
-- [`FileSystem.documentDirectory`](#documendirectory)
-- [`FileSystem.cacheDirectory`](#cachedirectory)
+- [`FileSystem.documentDirectory`](#filesystemdocumentdirectory)
+- [`FileSystem.cacheDirectory`](#filesystemcachedirectory)
 
 So, for example, the URI to a file named `'myFile'` under `'myDirectory'` in the app's user documents directory would be `FileSystem.documentDirectory + 'myDirectory/myFile'`.
 

--- a/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/filesystem.mdx
@@ -213,8 +213,8 @@ import * as FileSystem from 'expo-file-system';
 
 The API takes `file://` URIs pointing to local files on the device to identify files. Each app only has read and write access to locations under the following directories:
 
-- [`FileSystem.documentDirectory`](#documendirectory)
-- [`FileSystem.cacheDirectory`](#cachedirectory)
+- [`FileSystem.documentDirectory`](#filesystemdocumentdirectory)
+- [`FileSystem.cacheDirectory`](#filesystemcachedirectory)
 
 So, for example, the URI to a file named `'myFile'` under `'myDirectory'` in the app's user documents directory would be `FileSystem.documentDirectory + 'myDirectory/myFile'`.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1712950812522879)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix internal links to methods in directory section.
Changes applied to all SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/versions/v50.0.0/sdk/filesystem/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
