### PR TITLE
[expo-updates][cli] Improve error printing

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.23. ([#28088](https://github.com/expo/expo/pull/28088) by [@kudo](https://github.com/kudo))
 - Always initialize UpdatesController to prevent accidentally accessing the singleton instance. ([#27996](https://github.com/expo/expo/pull/27996) by [@kudo](https://github.com/kudo))
+- Improve error printing in CLI. ([#28188](https://github.com/expo/expo/pull/28188) by [@wschurman](https://github.com/wschurman))
 
 ## 0.24.12 - 2024-03-13
 

--- a/packages/expo-updates/cli/build/assetsVerify.js
+++ b/packages/expo-updates/cli/build/assetsVerify.js
@@ -33,6 +33,7 @@ const path_1 = __importDefault(require("path"));
 const assetsVerifyAsync_1 = require("./assetsVerifyAsync");
 const assetsVerifyTypes_1 = require("./assetsVerifyTypes");
 const args_1 = require("./utils/args");
+const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
 const debug = require('debug')('expo-updates:assets:verify');
 const expoAssetsVerify = async (argv) => {
@@ -67,23 +68,17 @@ Verify that all static files in an exported bundle are in either the export or a
   -h, --help                             Usage info
   `, 0);
     }
-    return (async () => {
-        const projectRoot = (0, args_1.getProjectRoot)(args);
-        const validatedArgs = resolveOptions(projectRoot, args);
-        debug(`Validated params: ${JSON.stringify(validatedArgs, null, 2)}`);
-        const { buildManifestPath, exportedManifestPath, assetMapPath, platform } = validatedArgs;
-        const missingAssets = await (0, assetsVerifyAsync_1.getMissingAssetsAsync)(buildManifestPath, exportedManifestPath, assetMapPath, platform);
-        if (missingAssets.length > 0) {
-            throw new Error(`${missingAssets.length} assets not found in either embedded manifest or in exported bundle:${JSON.stringify(missingAssets, null, 2)}`);
-        }
-        else {
-            Log.log(`All resolved assets found in either embedded manifest or in exported bundle.`);
-        }
-        process.exit(0);
-    })().catch((e) => {
-        Log.log(`${e}`);
-        process.exit(1);
-    });
+    const projectRoot = (0, args_1.getProjectRoot)(args);
+    const validatedArgs = resolveOptions(projectRoot, args);
+    debug(`Validated params: ${JSON.stringify(validatedArgs, null, 2)}`);
+    const { buildManifestPath, exportedManifestPath, assetMapPath, platform } = validatedArgs;
+    const missingAssets = await (0, assetsVerifyAsync_1.getMissingAssetsAsync)(buildManifestPath, exportedManifestPath, assetMapPath, platform);
+    if (missingAssets.length > 0) {
+        throw new errors_1.CommandError(`${missingAssets.length} assets not found in either embedded manifest or in exported bundle:${JSON.stringify(missingAssets, null, 2)}`);
+    }
+    else {
+        Log.log(`All resolved assets found in either embedded manifest or in exported bundle.`);
+    }
 };
 exports.expoAssetsVerify = expoAssetsVerify;
 function resolveOptions(projectRoot, args) {
@@ -92,7 +87,7 @@ function resolveOptions(projectRoot, args) {
     const assetMapPath = validatedPathFromArgument(projectRoot, args, '--asset-map-path');
     const platform = args['--platform'];
     if (!(0, assetsVerifyTypes_1.isValidPlatform)(platform)) {
-        throw new Error(`Platform must be one of ${JSON.stringify(assetsVerifyTypes_1.validPlatforms)}`);
+        throw new errors_1.CommandError(`Platform must be one of ${JSON.stringify(assetsVerifyTypes_1.validPlatforms)}`);
     }
     return {
         exportedManifestPath,
@@ -104,7 +99,7 @@ function resolveOptions(projectRoot, args) {
 function validatedPathFromArgument(projectRoot, args, key) {
     const maybeRelativePath = args[key];
     if (!maybeRelativePath) {
-        throw new Error(`No value for ${key}`);
+        throw new errors_1.CommandError(`No value for ${key}`);
     }
     if (maybeRelativePath.indexOf('/') === 0) {
         return maybeRelativePath; // absolute path

--- a/packages/expo-updates/cli/build/assetsVerifyAsync.js
+++ b/packages/expo-updates/cli/build/assetsVerifyAsync.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getExportedMetadataHashSet = exports.getExportedMetadataAsync = exports.getFullAssetDumpHashSet = exports.getFullAssetDumpAsync = exports.getBuildManifestHashSet = exports.getBuildManifestAsync = exports.getMissingAssetsAsync = void 0;
 const fs_1 = require("fs");
+const errors_1 = require("./utils/errors");
 const debug = require('debug')('expo-updates:assets:verify');
 /**
  * Finds any assets that will be missing from an app given a build and an exported update bundle.
@@ -116,7 +117,7 @@ exports.getExportedMetadataAsync = getExportedMetadataAsync;
 function getExportedMetadataHashSet(metadata, platform) {
     const fileMetadata = platform === 'android' ? metadata.fileMetadata.android : metadata.fileMetadata.ios;
     if (!fileMetadata) {
-        throw new Error(`Exported bundle was not exported for platform ${platform}`);
+        throw new errors_1.CommandError(`Exported bundle was not exported for platform ${platform}`);
     }
     const assets = fileMetadata?.assets ?? [];
     // Asset paths in the export metadata are of the form 'assets/<hash string>'

--- a/packages/expo-updates/cli/build/cli.js
+++ b/packages/expo-updates/cli/build/cli.js
@@ -31,6 +31,7 @@ const arg_1 = __importDefault(require("arg"));
 const chalk_1 = __importDefault(require("chalk"));
 const debug_1 = __importDefault(require("debug"));
 const getenv_1 = require("getenv");
+const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
 // Setup before requiring `debug`.
 if ((0, getenv_1.boolish)('EXPO_DEBUG', false)) {
@@ -92,4 +93,6 @@ if (!(command in commands)) {
     console.error(`Invalid command: ${command}`);
     process.exit(1);
 }
-commands[command]().then((exec) => exec(commandArgs));
+commands[command]()
+    .then((exec) => exec(commandArgs))
+    .catch(errors_1.logCmdError);

--- a/packages/expo-updates/cli/build/generateFingerprint.js
+++ b/packages/expo-updates/cli/build/generateFingerprint.js
@@ -30,6 +30,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateFingerprint = void 0;
 const chalk_1 = __importDefault(require("chalk"));
 const args_1 = require("./utils/args");
+const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
 const generateFingerprint = async (argv) => {
     const args = (0, args_1.assertArgs)({
@@ -58,11 +59,17 @@ Generate fingerprint for use in expo-updates runtime version
     ]);
     const platform = (0, args_1.requireArg)(args, '--platform');
     if (!['ios', 'android'].includes(platform)) {
-        throw new Error(`Invalid platform argument: ${platform}`);
+        throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
     const projectRoot = (0, args_1.getProjectRoot)(args);
-    const workflow = await resolveWorkflowAsync(projectRoot, platform);
-    const result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+    let result;
+    try {
+        const workflow = await resolveWorkflowAsync(projectRoot, platform);
+        result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+    }
+    catch (e) {
+        throw new errors_1.CommandError(e.message);
+    }
     console.log(JSON.stringify(result));
 };
 exports.generateFingerprint = generateFingerprint;

--- a/packages/expo-updates/cli/build/resolveRuntimeVersion.js
+++ b/packages/expo-updates/cli/build/resolveRuntimeVersion.js
@@ -30,6 +30,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.resolveRuntimeVersion = void 0;
 const chalk_1 = __importDefault(require("chalk"));
 const args_1 = require("./utils/args");
+const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
 const resolveRuntimeVersion = async (argv) => {
     const args = (0, args_1.assertArgs)({
@@ -57,13 +58,19 @@ Resolve expo-updates runtime version
     const { resolveRuntimeVersionAsync } = await import('../../utils/build/resolveRuntimeVersionAsync.js');
     const platform = (0, args_1.requireArg)(args, '--platform');
     if (!['ios', 'android'].includes(platform)) {
-        throw new Error(`Invalid platform argument: ${platform}`);
+        throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
     const debug = args['--debug'];
-    const runtimeVersionInfo = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform, {
-        silent: true,
-        debug,
-    });
+    let runtimeVersionInfo;
+    try {
+        runtimeVersionInfo = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform, {
+            silent: true,
+            debug,
+        });
+    }
+    catch (e) {
+        throw new errors_1.CommandError(e.message);
+    }
     console.log(JSON.stringify(runtimeVersionInfo));
 };
 exports.resolveRuntimeVersion = resolveRuntimeVersion;

--- a/packages/expo-updates/cli/build/syncConfigurationToNative.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNative.js
@@ -31,6 +31,7 @@ exports.syncConfigurationToNative = void 0;
 const chalk_1 = __importDefault(require("chalk"));
 const syncConfigurationToNativeAsync_1 = require("./syncConfigurationToNativeAsync");
 const args_1 = require("./utils/args");
+const errors_1 = require("./utils/errors");
 const Log = __importStar(require("./utils/log"));
 const syncConfigurationToNative = async (argv) => {
     const args = (0, args_1.assertArgs)({
@@ -56,7 +57,7 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
     }
     const platform = (0, args_1.requireArg)(args, '--platform');
     if (!['ios', 'android'].includes(platform)) {
-        throw new Error(`Invalid platform argument: ${platform}`);
+        throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
     await (0, syncConfigurationToNativeAsync_1.syncConfigurationToNativeAsync)({
         projectRoot: (0, args_1.getProjectRoot)(args),

--- a/packages/expo-updates/cli/build/utils/errors.d.ts
+++ b/packages/expo-updates/cli/build/utils/errors.d.ts
@@ -1,0 +1,10 @@
+/**
+ * General error, formatted as a message in red text when caught by expo-cli (no stack trace is printed). Should be used in favor of `log.error()` in most cases.
+ */
+export declare class CommandError extends Error {
+    code: string;
+    name: string;
+    readonly isCommandError = true;
+    constructor(code: string, message?: string);
+}
+export declare function logCmdError(error: any): never;

--- a/packages/expo-updates/cli/build/utils/errors.js
+++ b/packages/expo-updates/cli/build/utils/errors.js
@@ -1,0 +1,41 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.logCmdError = exports.CommandError = void 0;
+const assert_1 = require("assert");
+const chalk_1 = __importDefault(require("chalk"));
+const log_1 = require("./log");
+const ERROR_PREFIX = 'Error: ';
+/**
+ * General error, formatted as a message in red text when caught by expo-cli (no stack trace is printed). Should be used in favor of `log.error()` in most cases.
+ */
+class CommandError extends Error {
+    code;
+    name = 'CommandError';
+    isCommandError = true;
+    constructor(code, message = '') {
+        super('');
+        this.code = code;
+        // If e.toString() was called to get `message` we don't want it to look
+        // like "Error: Error:".
+        if (message.startsWith(ERROR_PREFIX)) {
+            message = message.substring(ERROR_PREFIX.length);
+        }
+        this.message = message || code;
+    }
+}
+exports.CommandError = CommandError;
+function logCmdError(error) {
+    if (!(error instanceof Error)) {
+        throw error;
+    }
+    if (error instanceof CommandError || error instanceof assert_1.AssertionError) {
+        // Print the stack trace in debug mode only.
+        (0, log_1.exit)(error);
+    }
+    const errorDetails = error.stack ? '\n' + chalk_1.default.gray(error.stack) : '';
+    (0, log_1.exit)(chalk_1.default.red(error.toString()) + errorDetails);
+}
+exports.logCmdError = logCmdError;

--- a/packages/expo-updates/cli/build/utils/log.d.ts
+++ b/packages/expo-updates/cli/build/utils/log.d.ts
@@ -1,7 +1,11 @@
 export declare function time(label?: string): void;
 export declare function timeEnd(label?: string): void;
 export declare function error(...message: string[]): void;
+/** Print an error and provide additional info (the stack trace) in debug mode. */
+export declare function exception(e: Error): void;
 export declare function warn(...message: string[]): void;
 export declare function log(...message: string[]): void;
+/** Clear the terminal of all text. */
+export declare function clear(): void;
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */
-export declare function exit(message: string, code?: number): never;
+export declare function exit(message: string | Error, code?: number): never;

--- a/packages/expo-updates/cli/build/utils/log.js
+++ b/packages/expo-updates/cli/build/utils/log.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.exit = exports.log = exports.warn = exports.error = exports.timeEnd = exports.time = void 0;
+exports.exit = exports.clear = exports.log = exports.warn = exports.exception = exports.error = exports.timeEnd = exports.time = void 0;
+const chalk_1 = __importDefault(require("chalk"));
 function time(label) {
     console.time(label);
 }
@@ -13,21 +17,37 @@ function error(...message) {
     console.error(...message);
 }
 exports.error = error;
+/** Print an error and provide additional info (the stack trace) in debug mode. */
+function exception(e) {
+    error(chalk_1.default.red(e.toString()) + (process.env.EXPO_DEBUG ? '\n' + chalk_1.default.gray(e.stack) : ''));
+}
+exports.exception = exception;
 function warn(...message) {
-    console.warn(...message);
+    console.warn(...message.map((value) => chalk_1.default.yellow(value)));
 }
 exports.warn = warn;
 function log(...message) {
     console.log(...message);
 }
 exports.log = log;
+/** Clear the terminal of all text. */
+function clear() {
+    process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
+}
+exports.clear = clear;
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */
 function exit(message, code = 1) {
-    if (code === 0) {
-        log(message);
+    if (message instanceof Error) {
+        exception(message);
+        process.exit(code);
     }
-    else {
-        error(message);
+    if (message) {
+        if (code === 0) {
+            log(message);
+        }
+        else {
+            error(message);
+        }
     }
     process.exit(code);
 }

--- a/packages/expo-updates/cli/src/assetsVerifyAsync.ts
+++ b/packages/expo-updates/cli/src/assetsVerifyAsync.ts
@@ -9,6 +9,7 @@ import {
   MissingAsset,
   Platform,
 } from './assetsVerifyTypes';
+import { CommandError } from './utils/errors';
 
 const debug = require('debug')('expo-updates:assets:verify') as typeof console.log;
 
@@ -145,7 +146,7 @@ export function getExportedMetadataHashSet(metadata: ExportedMetadata, platform:
   const fileMetadata =
     platform === 'android' ? metadata.fileMetadata.android : metadata.fileMetadata.ios;
   if (!fileMetadata) {
-    throw new Error(`Exported bundle was not exported for platform ${platform}`);
+    throw new CommandError(`Exported bundle was not exported for platform ${platform}`);
   }
   const assets: ExportedMetadataAsset[] = fileMetadata?.assets ?? [];
   // Asset paths in the export metadata are of the form 'assets/<hash string>'

--- a/packages/expo-updates/cli/src/cli.ts
+++ b/packages/expo-updates/cli/src/cli.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
 
+import { logCmdError } from './utils/errors';
 import * as Log from './utils/log';
 
 // Setup before requiring `debug`.
@@ -88,4 +89,6 @@ if (!(command in commands)) {
   process.exit(1);
 }
 
-commands[command]().then((exec) => exec(commandArgs));
+commands[command]()
+  .then((exec) => exec(commandArgs))
+  .catch(logCmdError);

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
+import { CommandError } from './utils/errors';
 import * as Log from './utils/log';
 
 export const generateFingerprint: Command = async (argv) => {
@@ -41,11 +42,18 @@ Generate fingerprint for use in expo-updates runtime version
 
   const platform = requireArg(args, '--platform');
   if (!['ios', 'android'].includes(platform)) {
-    throw new Error(`Invalid platform argument: ${platform}`);
+    throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
   const projectRoot = getProjectRoot(args);
-  const workflow = await resolveWorkflowAsync(projectRoot, platform);
-  const result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+
+  let result;
+  try {
+    const workflow = await resolveWorkflowAsync(projectRoot, platform);
+    result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+  } catch (e: any) {
+    throw new CommandError(e.message);
+  }
+
   console.log(JSON.stringify(result));
 };

--- a/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
+++ b/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from './cli';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
+import { CommandError } from './utils/errors';
 import * as Log from './utils/log';
 
 export const resolveRuntimeVersion: Command = async (argv) => {
@@ -42,14 +43,19 @@ Resolve expo-updates runtime version
 
   const platform = requireArg(args, '--platform');
   if (!['ios', 'android'].includes(platform)) {
-    throw new Error(`Invalid platform argument: ${platform}`);
+    throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
   const debug = args['--debug'];
 
-  const runtimeVersionInfo = await resolveRuntimeVersionAsync(getProjectRoot(args), platform, {
-    silent: true,
-    debug,
-  });
+  let runtimeVersionInfo;
+  try {
+    runtimeVersionInfo = await resolveRuntimeVersionAsync(getProjectRoot(args), platform, {
+      silent: true,
+      debug,
+    });
+  } catch (e: any) {
+    throw new CommandError(e.message);
+  }
   console.log(JSON.stringify(runtimeVersionInfo));
 };

--- a/packages/expo-updates/cli/src/syncConfigurationToNative.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNative.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { Command } from './cli';
 import { syncConfigurationToNativeAsync } from './syncConfigurationToNativeAsync';
 import { requireArg, assertArgs, getProjectRoot } from './utils/args';
+import { CommandError } from './utils/errors';
 import * as Log from './utils/log';
 
 export const syncConfigurationToNative: Command = async (argv) => {
@@ -38,7 +39,7 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
 
   const platform = requireArg(args, '--platform');
   if (!['ios', 'android'].includes(platform)) {
-    throw new Error(`Invalid platform argument: ${platform}`);
+    throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
   await syncConfigurationToNativeAsync({

--- a/packages/expo-updates/cli/src/utils/errors.ts
+++ b/packages/expo-updates/cli/src/utils/errors.ts
@@ -1,0 +1,43 @@
+import { AssertionError } from 'assert';
+import chalk from 'chalk';
+
+import { exit } from './log';
+
+const ERROR_PREFIX = 'Error: ';
+
+/**
+ * General error, formatted as a message in red text when caught by expo-cli (no stack trace is printed). Should be used in favor of `log.error()` in most cases.
+ */
+export class CommandError extends Error {
+  name = 'CommandError';
+  readonly isCommandError = true;
+
+  constructor(
+    public code: string,
+    message: string = ''
+  ) {
+    super('');
+    // If e.toString() was called to get `message` we don't want it to look
+    // like "Error: Error:".
+    if (message.startsWith(ERROR_PREFIX)) {
+      message = message.substring(ERROR_PREFIX.length);
+    }
+
+    this.message = message || code;
+  }
+}
+
+export function logCmdError(error: any): never {
+  if (!(error instanceof Error)) {
+    throw error;
+  }
+
+  if (error instanceof CommandError || error instanceof AssertionError) {
+    // Print the stack trace in debug mode only.
+    exit(error);
+  }
+
+  const errorDetails = error.stack ? '\n' + chalk.gray(error.stack) : '';
+
+  exit(chalk.red(error.toString()) + errorDetails);
+}

--- a/packages/expo-updates/cli/src/utils/log.ts
+++ b/packages/expo-updates/cli/src/utils/log.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 export function time(label?: string): void {
   console.time(label);
 }
@@ -10,20 +12,37 @@ export function error(...message: string[]): void {
   console.error(...message);
 }
 
+/** Print an error and provide additional info (the stack trace) in debug mode. */
+export function exception(e: Error): void {
+  error(chalk.red(e.toString()) + (process.env.EXPO_DEBUG ? '\n' + chalk.gray(e.stack) : ''));
+}
+
 export function warn(...message: string[]): void {
-  console.warn(...message);
+  console.warn(...message.map((value) => chalk.yellow(value)));
 }
 
 export function log(...message: string[]): void {
   console.log(...message);
 }
 
+/** Clear the terminal of all text. */
+export function clear(): void {
+  process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
+}
+
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */
-export function exit(message: string, code: number = 1): never {
-  if (code === 0) {
-    log(message);
-  } else {
-    error(message);
+export function exit(message: string | Error, code: number = 1): never {
+  if (message instanceof Error) {
+    exception(message);
+    process.exit(code);
+  }
+
+  if (message) {
+    if (code === 0) {
+      log(message);
+    } else {
+      error(message);
+    }
   }
 
   process.exit(code);


### PR DESCRIPTION
# Why

Errors thrown from the expo-updates CLI currently are very verbose (have stack traces). This makes them fairly hard to read.

# How

This copies a few utility functions from `@expo/cli` in order to improve error printing. At some point it'd probably be worth factoring out the CLI core to a new package, but not now.

# Test Plan

`yarn link` this package into a project, see:
```
$ npx expo-updates runtimeversion:resolve --platform ios
CommandError: You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions
```

whereas previously it would have much more verbose output.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
