### PR TITLE
[core] Fix getting the runtime in expo-gl and expo-av

### DIFF
--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -200,11 +200,7 @@ EX_REGISTER_MODULE();
 
 - (void *)javaScriptRuntimePointer
 {
-  if ([_bridge respondsToSelector:@selector(runtime)]) {
-    return _bridge.runtime;
-  } else {
-    return nil;
-  }
+  return _bridge.runtime;
 }
 
 # pragma mark - App state observing


### PR DESCRIPTION
# Why

In bridgeless mode, `expo-av` is logging a warning like this:

> Failed to set up Audio Sample Buffer callback. Do you have 'Remote Debugginer' enable in your app's developer menu?

The problem is that `respondsToSelector:` method on the bridge object no longer works when bridgeless is enabled. It's because the bridge is then a `RCTBridgeProxy` that inherits from `NSProxy` that has slightly different behavior that results in returning `false` when asking for the `runtime` selector.

The same problem exists in `expo-gl` that also uses `EXJavaScriptContextProvider` interface (from the legacy module registry).

# How

It seems safe to just return the runtime property, without that check. We added this check as it was a hacky way to get the runtime, so it was a bit easier to detect some breaking changes or when the remote debugger was enabled (no longer supported).

# Test Plan

`expo-gl` examples work as expected. I couldn't check `expo-av` because its example crashes on reanimated 😅 I believe it works now as the root cause was the same in these two modules.