### PR TITLE
[core] fix installModules random crash

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [iOS] Fix `recreateRootViewWithBundleURL` parameters. ([#27989](https://github.com/expo/expo/pull/27989) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fixed `ExpoBridgeModule.installModules()` is broken on Android and bridgeless mode. ([#28065](https://github.com/expo/expo/pull/28065) by [@kudo](https://github.com/kudo))
 - [Android] Fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`. ([#28163](https://github.com/expo/expo/pull/28163) by [@lukmccall](https://github.com/lukmccall))
+- Fixed random `TypeError: Cannot read property 'NativeModule' of undefined` exceptions on Android. ([#28200](https://github.com/expo/expo/pull/28200) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -97,7 +97,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       nativeModulesList.addAll(reactPackage.createNativeModules(reactContext));
     }
 
-    nativeModulesList.add(new ExpoBridgeModule(new WeakReference<>(nativeModulesProxy)));
+    nativeModulesList.add(new ExpoBridgeModule(reactContext, new WeakReference<>(nativeModulesProxy)));
     return nativeModulesList;
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import expo.modules.adapters.react.NativeModulesProxy
@@ -8,15 +9,33 @@ import java.lang.ref.WeakReference
 /**
  * The classic bridge module that is responsible for installing the host object to the runtime.
  */
-class ExpoBridgeModule(private val nativeModulesProxy: WeakReference<NativeModulesProxy>) : ReactContextBaseJavaModule() {
+class ExpoBridgeModule(
+  reactContext: ReactApplicationContext,
+  private val nativeModulesProxy: WeakReference<NativeModulesProxy>
+) :
+  ReactContextBaseJavaModule(reactContext) {
   override fun getName(): String = "ExpoModulesCore"
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   fun installModules(): Boolean {
+    // Bridgeless ReactHostImpl may have BridgelessReactContext ready but not ReactInstance.
+    // Try to busy wait until ReactInstance is available so we could get the javaScriptContextHolder.
+    tryWaitSync(waitMs = 100, retries = 10) {
+      reactApplicationContext.hasActiveReactInstance()
+    }
     val kotlinInterop = nativeModulesProxy.get()?.kotlinInteropModuleRegistry
       ?: throw IllegalStateException("Couldn't find KotlinInteropModuleRegistry")
 
     kotlinInterop.installJSIInterop()
     return true
+  }
+
+  private fun tryWaitSync(waitMs: Long, retries: Int, predicate: () -> Boolean) {
+    repeat(retries) inner@{
+      if (predicate()) {
+        return
+      }
+      Thread.sleep(waitMs)
+    }
   }
 }


### PR DESCRIPTION
# Why

the `TypeError: Cannot read property 'NativeModule' of undefined` still happens occasionally. the problem is that installModules may happen right after the [block](https://github.com/facebook/react-native/blob/a5eeea814de57cd307a6625c6991f48b778d356b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L1008-L1055). the `JavaScriptContextHolder` may be ready after that on the [second block](https://github.com/facebook/react-native/blob/a5eeea814de57cd307a6625c6991f48b778d356b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L1060-L1109). we are not able to install expo global object when JavaScriptContextHolder is not ready 

# How

it's not clear to me whether it should be an issue from react native core. but to unblock our testing, let's add a busy waiting workaround first.

# Test Plan

```sh
$ git clone https://github.com/brentvatne/test-updates.git
$ cd test-updates
# remove expo-updates from package.json to make the repro minimal
$ yarn
$ npx expo run:android --variant release

# try the following command many times until the app stucking at white screen
$ adb shell am force-stop com.example.withnewarch && adb shell am start -n com.example.withnewarch/.MainActivity
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
