### PR TITLE
[video][ios] Improve audio session management

### DIFF
--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -26,9 +26,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   var staysActiveInBackground = false {
     didSet {
       if staysActiveInBackground {
-        VideoManager.shared.switchToActiveAudioSessionOrWarn(
-          warning: "Failed to set the audio session category. This might affect background playback functionality"
-        )
+        VideoManager.shared.setAppropriateAudioSessionOrWarn()
       }
     }
   }
@@ -60,6 +58,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         self.emit(event: "volumeChange", arguments: newVolumeEvent.isMuted, oldVolumeEvent.isMuted)
       }
       pointer.isMuted = isMuted
+      VideoManager.shared.setAppropriateAudioSessionOrWarn()
     }
   }
 
@@ -125,6 +124,8 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   func onIsPlayingChanged(player: AVPlayer, oldIsPlaying: Bool?, newIsPlaying: Bool) {
     self.emit(event: "playingChange", arguments: newIsPlaying, oldIsPlaying)
     isPlaying = newIsPlaying
+
+    VideoManager.shared.setAppropriateAudioSessionOrWarn()
   }
 
   func onRateChanged(player: AVPlayer, oldRate: Float?, newRate: Float) {

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -24,13 +24,8 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   var allowPictureInPicture: Bool = false {
     didSet {
-      if allowPictureInPicture {
-        // We need to set the audio session when the prop first changes to allow, because the PiP button in the native
-        // controls shows up automatically only when a correct audioSession category is set.
-        VideoManager.shared.switchToActiveAudioSessionOrWarn(
-          warning: "Failed to set the audio session category. This might break Picture in Picture functionality"
-        )
-      }
+      // PiP requires `.playback` audio session category in `.moviePlayback` mode
+      VideoManager.shared.setAppropriateAudioSessionOrWarn()
       playerViewController.allowsPictureInPicturePlayback = allowPictureInPicture
     }
   }


### PR DESCRIPTION
# Why

- Fixes the audio being broken when `allowPictureInPicture` option is initially set to `false` 
- When all of the players are muted, or no players are playing audio from other apps won't be interrupted. 

# How

Used correct audio session category to fix the issues. Every time an option, which relies on correct audio session is toggled, the `VideoManager. setAppropriateAudioSessionOrWarn` is called to make sure that functionality works.

# Test Plan

Tested in BareExpo on a physical iOS 17 device
