### PR TITLE
[video][ios] Fix native controls not showing when inside a stack navigator

### DIFF
--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -61,6 +61,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     playerViewController.updatesNowPlayingInfoCenter = false
 
     addSubview(playerViewController.view)
+    playerViewController.beginAppearanceTransition(true, animated: true)
   }
 
   deinit {

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -61,7 +61,6 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     playerViewController.updatesNowPlayingInfoCenter = false
 
     addSubview(playerViewController.view)
-    playerViewController.beginAppearanceTransition(true, animated: true)
   }
 
   deinit {
@@ -149,5 +148,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   public func playerViewControllerDidStopPictureInPicture(_ playerViewController: AVPlayerViewController) {
     isInPictureInPicture = false
     onPictureInPictureStop()
+  }
+
+  public override func didMoveToWindow() {
+    playerViewController.beginAppearanceTransition(self.window != nil, animated: true)
   }
 }


### PR DESCRIPTION
# Why

Then the screen with video is nested inside of a stack navigator the controls won't show
This issue didn't appear in BareExpo, because it uses a non-native stack navigator.

# How

Used `ViewController.beginAppearanceTransition` [after the player view is added to our hierarchy](https://forums.developer.apple.com/forums/thread/711360?answerId=759286022#759286022).

# Test Plan

Tested in a separate app, which uses `expo-router` for navigation.
