### PR TITLE
[notifications][Android] Fix events not being sent to js

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix notifications events were using an incorrect event emitter.
+- [Android] Fix notifications events were using an incorrect event emitter. ([#28207](https://github.com/expo/expo/pull/28207) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix notifications events were using an incorrect event emitter.
+
 ### 💡 Others
 
 - [iOS] Add privacy manifest describing required reason API usage. ([#27770](https://github.com/expo/expo/pull/27770) by [@aleqsio](https://github.com/aleqsio))
@@ -347,9 +349,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import expo.modules.core.interfaces.services.EventEmitter
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.notifications.ModuleNotFoundException
 import expo.modules.notifications.notifications.NotificationSerializer
 import expo.modules.notifications.notifications.interfaces.NotificationListener
 import expo.modules.notifications.notifications.interfaces.NotificationManager

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
@@ -30,9 +30,6 @@ open class NotificationsEmitter : Module(), NotificationListener {
     )
 
     OnCreate {
-      eventEmitter = appContext.legacyModule<EventEmitter>()
-        ?: throw ModuleNotFoundException(EventEmitter::class)
-
       // Register the module as a listener in NotificationManager singleton module.
       // Deregistration happens in onDestroy callback.
       notificationManager = requireNotNull(appContext.legacyModuleRegistry.getSingletonModule("NotificationManager", NotificationManager::class.java))
@@ -55,7 +52,7 @@ open class NotificationsEmitter : Module(), NotificationListener {
    * @param notification Notification received
    */
   override fun onNotificationReceived(notification: Notification) {
-    eventEmitter?.emit(NEW_MESSAGE_EVENT_NAME, NotificationSerializer.toBundle(notification))
+    sendEvent(NEW_MESSAGE_EVENT_NAME, NotificationSerializer.toBundle(notification))
   }
 
   /**
@@ -67,11 +64,8 @@ open class NotificationsEmitter : Module(), NotificationListener {
    */
   override fun onNotificationResponseReceived(response: NotificationResponse): Boolean {
     lastNotificationResponse = response
-    eventEmitter?.let {
-      it.emit(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response))
-      return true
-    }
-    return false
+    sendEvent(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response))
+    return true
   }
 
   /**
@@ -79,6 +73,6 @@ open class NotificationsEmitter : Module(), NotificationListener {
    * Emits a [MESSAGES_DELETED_EVENT_NAME] event.
    */
   override fun onNotificationsDropped() {
-    eventEmitter?.emit(MESSAGES_DELETED_EVENT_NAME, Bundle.EMPTY)
+    sendEvent(MESSAGES_DELETED_EVENT_NAME, Bundle.EMPTY)
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/NotificationsHandler.kt
@@ -115,7 +115,13 @@ open class NotificationsHandler : Module(), NotificationListener {
    */
   override fun onNotificationReceived(notification: Notification) {
     val context = appContext.reactContext ?: return
-    val task = SingleNotificationHandlerTask(context, handler, moduleRegistry, notification, this)
+    val task = SingleNotificationHandlerTask(
+      context,
+      appContext.eventEmitter(this),
+      handler,
+      notification,
+      this
+    )
     tasksMap[task.identifier] = task
     task.start()
   }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
@@ -5,10 +5,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.ResultReceiver;
 
-import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;
 import expo.modules.core.interfaces.services.EventEmitter;
-
 import expo.modules.notifications.notifications.NotificationSerializer;
 import expo.modules.notifications.notifications.model.Notification;
 import expo.modules.notifications.notifications.model.NotificationBehavior;
@@ -42,10 +40,16 @@ public class SingleNotificationHandlerTask {
 
   private Runnable mTimeoutRunnable = SingleNotificationHandlerTask.this::handleTimeout;
 
-  /* package */ SingleNotificationHandlerTask(Context context, Handler handler, ModuleRegistry moduleRegistry, Notification notification, NotificationsHandler delegate) {
+  /* package */ SingleNotificationHandlerTask(
+    Context context,
+    EventEmitter eventEmitter,
+    Handler handler,
+    Notification notification,
+    NotificationsHandler delegate
+  ) {
     mContext = context;
     mHandler = handler;
-    mEventEmitter = moduleRegistry.getModule(EventEmitter.class);
+    mEventEmitter = eventEmitter;
     mNotification = notification;
     mDelegate = delegate;
   }


### PR DESCRIPTION
# Why

Fixes events not being sent to js because native code uses the incorrect emitter.
Closes ENG-11898.

# Test plan

- https://github.com/douglowder/NotificationsTest/tree/canary ✅ 