### PR TITLE
[location] fix unit test error

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
+- Fixed unit test errors. ([#28208](https://github.com/expo/expo/pull/28208) by [@kudo](https://github.com/kudo))
 
 ## 16.5.5 - 2024-02-29
 

--- a/packages/expo-location/src/__tests__/Location-test.native.ts
+++ b/packages/expo-location/src/__tests__/Location-test.native.ts
@@ -1,6 +1,7 @@
-import { NativeModulesProxy, Platform } from 'expo-modules-core';
+import { Platform } from 'expo-modules-core';
 import { mockProperty, unmockAllProperties } from 'jest-expo';
 
+import ExpoLocation from '../ExpoLocation';
 import * as Location from '../Location';
 
 const fakeReturnValue = {
@@ -17,12 +18,12 @@ const fakeReturnValue = {
 
 function applyMocks() {
   mockProperty(
-    NativeModulesProxy.ExpoLocation,
+    ExpoLocation,
     'getCurrentPositionAsync',
     jest.fn(async () => fakeReturnValue)
   );
   mockProperty(
-    NativeModulesProxy.ExpoLocation,
+    ExpoLocation,
     'requestPermissionsAsync',
     jest.fn(async () => {})
   );
@@ -52,11 +53,7 @@ describe('watchPositionAsync', () => {
     const watchBarrier = new Promise((resolve) => {
       resolveBarrier = resolve;
     });
-    mockProperty(
-      NativeModulesProxy.ExpoLocation,
-      'watchPositionImplAsync',
-      jest.fn(resolveBarrier)
-    );
+    mockProperty(ExpoLocation, 'watchPositionImplAsync', jest.fn(resolveBarrier));
     await Location.watchPositionAsync({}, callback);
     await watchBarrier;
 
@@ -70,7 +67,7 @@ if (Platform.OS === 'android') {
   xdescribe('geocodeAsync', () => {
     // TODO(@tsapeta): This doesn't work due to missing Google Maps API key.
     it(`falls back to Google Maps API on Android without Google Play services`, () => {
-      mockProperty(NativeModulesProxy.ExpoLocation, 'geocodeAsync', async () => {
+      mockProperty(ExpoLocation, 'geocodeAsync', async () => {
         const error = new Error();
         (error as any).code = 'E_NO_GEOCODER';
         throw error;
@@ -108,7 +105,7 @@ describe('navigator.geolocation polyfill', () => {
       });
       navigator.geolocation.getCurrentPosition(pass, pass, {});
       await barrier;
-      expect(NativeModulesProxy.ExpoLocation.getCurrentPositionAsync).toHaveBeenCalled();
+      expect(ExpoLocation.getCurrentPositionAsync).toHaveBeenCalled();
     });
   });
 
@@ -119,7 +116,7 @@ describe('navigator.geolocation polyfill', () => {
         resolveBarrier = resolve;
       });
       mockProperty(
-        NativeModulesProxy.ExpoLocation,
+        ExpoLocation,
         'watchPositionImplAsync',
         jest.fn(async () => {
           resolveBarrier();


### PR DESCRIPTION
# Why

fix check packages errors: https://github.com/expo/expo/runs/23785958661

# How

`NativeModulesProxy` is deprecated. use the direct way to mock properties

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
