### PR TITLE
[android][media-library] Fix app crash on deny permission

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed crash on denied permission to modify assets. ([#28212](https://github.com/expo/expo/pull/28212) by [@mathieupost](https://github.com/mathieupost))
+
 ### 💡 Others
 
 - Prevent config plugin from writing permissions until prebuild. ([#28107](https://github.com/expo/expo/pull/28107) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -110,7 +110,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("addAssetsToAlbumAsync") { assetsId: List<String>, albumId: String, copyToAlbum: Boolean, promise: Promise ->
       throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
+        val action = actionIfUserGrantedPermission(promise) {
           withModuleScope(promise) {
             AddAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum, promise)
               .execute()
@@ -122,7 +122,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("removeAssetsFromAlbumAsync") { assetsId: List<String>, albumId: String, promise: Promise ->
       throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
+        val action = actionIfUserGrantedPermission(promise) {
           withModuleScope(promise) {
             RemoveAssetsFromAlbum(context, assetsId.toTypedArray(), albumId, promise)
               .execute()
@@ -134,7 +134,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
       throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
+        val action = actionIfUserGrantedPermission(promise) {
           withModuleScope(promise) {
             DeleteAssets(context, assetsId.toTypedArray(), promise)
               .execute()
@@ -171,7 +171,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("createAlbumAsync") { albumName: String, assetId: String, copyAsset: Boolean, promise: Promise ->
       throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
+        val action = actionIfUserGrantedPermission(promise) {
           withModuleScope(promise) {
             CreateAlbum(context, albumName, assetId, copyAsset, promise)
               .execute()
@@ -183,7 +183,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("deleteAlbumsAsync") { albumIds: List<String>, promise: Promise ->
       throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
+        val action = actionIfUserGrantedPermission(promise) {
           withModuleScope(promise) {
             DeleteAlbums(context, albumIds, promise)
               .execute()
@@ -237,7 +237,7 @@ class MediaLibraryModule : Module() {
         return@AsyncFunction
       }
 
-      val action = actionIfUserGrantedPermission {
+      val action = actionIfUserGrantedPermission(promise) {
         moduleCoroutineScope.launch {
           MigrateAlbum(context, assets, albumDir.name, promise)
             .execute()
@@ -451,10 +451,11 @@ class MediaLibraryModule : Module() {
   }
 
   private fun actionIfUserGrantedPermission(
+    promise: Promise,
     block: () -> Unit
   ) = Action { permissionsWereGranted ->
     if (!permissionsWereGranted) {
-      throw PermissionsException(ERROR_USER_DID_NOT_GRANT_WRITE_PERMISSIONS_MESSAGE)
+      promise.reject(PermissionsException(ERROR_USER_DID_NOT_GRANT_WRITE_PERMISSIONS_MESSAGE))
     }
     block()
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -144,18 +144,6 @@ class MediaLibraryModule : Module() {
       }
     }
 
-    AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted {
-        val action = actionIfUserGrantedPermission {
-          withModuleScope(promise) {
-            DeleteAssets(context, assetsId.toTypedArray(), promise)
-              .execute()
-          }
-        }
-        runActionWithPermissions(assetsId, action)
-      }
-    }
-
     AsyncFunction("getAssetInfoAsync") { assetId: String, _: Map<String, Any?>?/* unused on android atm */, promise: Promise ->
       throwUnlessPermissionsGranted(isWrite = false) {
         withModuleScope(promise) {


### PR DESCRIPTION
# Why

After experiencing the issue described in https://github.com/expo/expo/issues/25667, I went digging and found that an Exception was thrown that could not be gracefully handled or prevented.

# How

Instead of throwing a `PermissionException`, the `actionIfUserGrantedPermission` function now rejects the promise with that exception.

# Test Plan

By running the MediaLibrary tests in the `bare-app`, when rejecting the permission to modify assets, the test fails instead of the app crashing. When allowing the permission, the tests still succeed of course.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

(no documentation change is needed as far as I understand, since this makes the behavior the same as on iOS)