### PR TITLE
[splash-screen] fix white screen when updates using delay load app

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fixed `ExpoBridgeModule.installModules()` is broken on Android and bridgeless mode. ([#28065](https://github.com/expo/expo/pull/28065) by [@kudo](https://github.com/kudo))
 - [Android] Fixed segfaults in `expo::MethodMetadata::convertJSIArgsToJNI`. ([#28163](https://github.com/expo/expo/pull/28163) by [@lukmccall](https://github.com/lukmccall))
 - Fixed random `TypeError: Cannot read property 'NativeModule' of undefined` exceptions on Android. ([#28200](https://github.com/expo/expo/pull/28200) by [@kudo](https://github.com/kudo))
+- Fixed white screen flickering when using expo-updates with longer `fallbackToCacheTimeout`. ([#28227](https://github.com/expo/expo/pull/28227) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/ModulePriorities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/ModulePriorities.kt
@@ -20,6 +20,7 @@ object ModulePriorities {
     // {key} to {value}
     // key: full qualified class name
     // value: priority value, the higher value takes precedence
+    "expo.modules.splashscreen.SplashScreenPackage" to 11,
     "expo.modules.updates.UpdatesPackage" to 10
   )
 }

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed white screen flickering when using expo-updates with longer `fallbackToCacheTimeout`. ([#28227](https://github.com/expo/expo/pull/28227) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenPackage.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenPackage.kt
@@ -1,10 +1,11 @@
 package expo.modules.splashscreen
 
 import android.content.Context
-import expo.modules.splashscreen.singletons.SplashScreen
 import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.core.interfaces.SingletonModule
+import expo.modules.splashscreen.singletons.SplashScreen
 
 class SplashScreenPackage : Package {
   override fun createSingletonModules(context: Context?): List<SingletonModule> {
@@ -13,5 +14,9 @@ class SplashScreenPackage : Package {
 
   override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
     return listOf(SplashScreenReactActivityLifecycleListener(activityContext))
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> {
+    return listOf(SplashScreenReactActivityHandler())
   }
 }

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -1,29 +1,45 @@
-@file:Suppress("UnusedImport")
-
 package expo.modules.splashscreen
 
 import android.app.Activity
 import android.content.Context
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
+import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.splashscreen.singletons.SplashScreen
 
 class SplashScreenReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
   override fun onContentChanged(activity: Activity) {
-    SplashScreen.show(
+    SplashScreen.ensureShown(
       activity,
       getResizeMode(activity),
       ReactRootView::class.java,
       getStatusBarTranslucent(activity)
     )
   }
-
-  private fun getResizeMode(context: Context): SplashScreenImageResizeMode =
-    SplashScreenImageResizeMode.fromString(
-      context.getString(R.string.expo_splash_screen_resize_mode).lowercase()
-    )
-      ?: SplashScreenImageResizeMode.CONTAIN
-
-  private fun getStatusBarTranslucent(context: Context): Boolean =
-    context.getString(R.string.expo_splash_screen_status_bar_translucent).toBoolean()
 }
+
+class SplashScreenReactActivityHandler : ReactActivityHandler {
+  override fun getDelayLoadAppHandler(
+    activity: ReactActivity,
+    reactNativeHost: ReactNativeHost
+  ): ReactActivityHandler.DelayLoadAppHandler? {
+    SplashScreen.ensureShown(
+      activity,
+      getResizeMode(activity),
+      ReactRootView::class.java,
+      getStatusBarTranslucent(activity)
+    )
+    return null
+  }
+}
+
+private fun getResizeMode(context: Context): SplashScreenImageResizeMode =
+  SplashScreenImageResizeMode.fromString(
+    context.getString(R.string.expo_splash_screen_resize_mode).lowercase()
+  )
+    ?: SplashScreenImageResizeMode.CONTAIN
+
+private fun getStatusBarTranslucent(context: Context): Boolean =
+  context.getString(R.string.expo_splash_screen_status_bar_translucent).toBoolean()

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/singletons/SplashScreen.kt
@@ -149,4 +149,21 @@ object SplashScreen : SingletonModule {
   fun hide(activity: Activity) {
     hide(activity, {}, {})
   }
+
+  /**
+   * An internal helper to make sure splash screen is shown when startup.
+   */
+  internal fun ensureShown(
+    activity: Activity,
+    resizeMode: SplashScreenImageResizeMode,
+    rootViewClass: Class<out ViewGroup>,
+    statusBarTranslucent: Boolean
+  ) {
+    val controller = controllers[activity]
+    if (controller == null) {
+      show(activity, resizeMode, rootViewClass, statusBarTranslucent)
+    } else {
+      controller.showSplashScreen { }
+    }
+  }
 }


### PR DESCRIPTION
# Why

fixes #26811. specifically obvious white screen when update's fallbackToCacheTimeout has a large value.

# How

the white screen is coming between activity finishing startup and loadApp(). we should show splash at this stage. this pr tries to ensure splash screen is shown from `getDelayLoadAppHandler()` stage. it should go before expo-updates since `getDelayLoadAppHandler()` is a lazy first-matched stream.

# Test Plan

i reused the repro from #27692 to test splash screen without white screen flickering
- [x] removed expo-updates
- [x] with expo-updates
- [x] with expo-updates + fallbackToCacheTimeout=30000
- [x] with expo-updates + EX_UPDATES_ANDROID_DELAY_LOAD_APP=false
- [x] with expo-updates + manually add `Thread.sleep(5000)` [here](https://github.com/expo/expo/blob/da5a31f26ee2cd09d237db0cce9a88da6d959052/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt#L86-L87)
   
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
