### PR TITLE
[docs] Fix Grid layout issue in Learn more section of home page

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -116,7 +116,7 @@ const Home = () => {
           <Row>
             <GridCell
               xl={6}
-              lg={6}
+              lg={12}
               css={css({
                 backgroundColor: palette.orange3,
                 borderColor: palette.orange7,
@@ -138,7 +138,7 @@ const Home = () => {
             </GridCell>
             <GridCell
               xl={6}
-              lg={6}
+              lg={12}
               css={css({
                 backgroundColor: palette.green3,
                 borderColor: palette.green7,
@@ -159,7 +159,7 @@ const Home = () => {
             </GridCell>
             <GridCell
               xl={6}
-              lg={6}
+              lg={12}
               css={css({
                 backgroundColor: palette.yellow3,
                 borderColor: palette.yellow8,
@@ -180,7 +180,7 @@ const Home = () => {
             </GridCell>
             <GridCell
               xl={6}
-              lg={6}
+              lg={12}
               css={css({
                 backgroundColor: palette.purple3,
                 borderColor: palette.purple7,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1713209760396989)


# How

<!--
How did you build this feature or fix this bug and why?
-->

By switching to single column layout to `lg` breakpoint.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and running `yarn test`.

## Preview

https://github.com/expo/expo/assets/10234615/deac39e5-d7c1-48e6-8435-67def81bb19d



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
