### PR TITLE
[docs] Update typed-routes.mdx

### DIFF
--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -162,7 +162,7 @@ Expo CLI will add the following global types to your project when typed routes i
 
 - Sets `process.env.NODE_ENV = "development" | "production" | "test"`
 - Allows the importing of `.[css|sass|scss]` files
-- Sets the exports of `*.module.[css|sass|scss]` to be `Record<string, string`
+- Sets the exports of `*.module.[css|sass|scss]` to be `Record<string, string>`
 - Add types for Metro's `require.context`. This is enabled by `expo/metro-config` and used for static route generation.
 
 ### React Native Web


### PR DESCRIPTION
# Why

<!--
Just a little typo I noticed in the type definition. I find it confusing.
-->

# How

<!--
I found an open type in the documents: Sets the exports of *.module.[css|sass|scss] to be Record<string, string** among what globals is inputed when using type routes. I added the closing > symbol
-->