### PR TITLE
[media-library] remove default ACCESS_MEDIA_LOCATION permission

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -19,6 +19,7 @@
 - drop unused web `name` property. ([#27437](https://github.com/expo/expo/pull/27437) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Migrate to expo modules. ([#25587](https://github.com/expo/expo/pull/25587) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
+- The `ACCESS_MEDIA_LOCATION` Android permission should not pulled into by default and should be pulled through Config Plugins. ([#28230](https://github.com/expo/expo/pull/28230) by [@kudo](https://github.com/kudo))
 
 ## 15.9.1 - 2023-12-19
 

--- a/packages/expo-media-library/android/src/main/AndroidManifest.xml
+++ b/packages/expo-media-library/android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
   <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
# Why

fixes #28139 
close ENG-11971

# How

the `ACCESS_MEDIA_LOCATION` permission should be added through [config-plugin](https://github.com/expo/expo/blob/a1558edf6ee17749d89907e11da7f5a65933c9d9/packages/expo-media-library/plugin/src/withMediaLibrary.ts#L49) but not pulled in by default from manifest merger

# Test Plan

based on the repro https://github.com/freddybreitenstein/expo-media-library-android-permission-bug
- build apk and use apktool to extract AndroidManifest.xml to check whether `ACCESS_MEDIA_LOCATION` is there
- add `["expo-media-library", { "isAccessMediaLocationEnabled": true }]` to app.json plugins. prebuild and build apk to check the permission again.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
