### PR TITLE
[camera] fix barcode types

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - Allow users using xcode 14 to still build when including camera. ([#27873](https://github.com/expo/expo/pull/27873) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix an issue where the permission functions were being imported from the wrong file. ([#27988](https://github.com/expo/expo/pull/27988) by [@alanjhughes](https://github.com/alanjhughes))
-- Fix an issue on `iOS` where the barcode types did not match the typescript representation. Also enabled scanning `upc_a` codes on `iOS`.
+- Fix an issue on `iOS` where the barcode types did not match the typescript representation. Also enabled scanning `upc_a` codes on `iOS`. ([#28233](https://github.com/expo/expo/pull/28233) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Allow users using xcode 14 to still build when including camera. ([#27873](https://github.com/expo/expo/pull/27873) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix an issue where the permission functions were being imported from the wrong file. ([#27988](https://github.com/expo/expo/pull/27988) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix an issue on `iOS` where the barcode types did not match the typescript representation. Also enabled scanning `upc_a` codes on `iOS`.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -18,14 +18,14 @@ enum BarcodeType: String, Enumerable {
   case ean8
   case qr
   case pdf417
-  case upce
+  case upc_e
   case datamatrix
   case code39
   case code93
   case itf14
   case codabar
   case code128
-  case upca
+  case upc_a
 
   func toMetadataObjectType() -> AVMetadataObject.ObjectType {
     if #available(iOS 15.4, *) {
@@ -46,9 +46,9 @@ enum BarcodeType: String, Enumerable {
       return .pdf417
     case .itf14:
       return .itf14
-    case .upca:
-      return .upce
-    case .upce:
+    case .upc_a:
+      return .ean13
+    case .upc_e:
       return .upce
     case .code39:
       return .code39
@@ -70,14 +70,14 @@ enum VNBarcodeType: String, Enumerable {
   case ean8
   case qr
   case pdf417
-  case upce
+  case upc_e
   case datamatrix
   case code39
   case code93
   case itf14
   case codabar
   case code128
-  case upca
+  case upc_a
 
   @available(iOS 16.0, *)
   func toSymbology() -> VNBarcodeSymbology {
@@ -96,9 +96,9 @@ enum VNBarcodeType: String, Enumerable {
       return .pdf417
     case .itf14:
       return .itf14
-    case .upca:
-      return .upce
-    case .upce:
+    case .upc_a:
+      return .ean13
+    case .upc_e:
       return .upce
     case .code39:
       return .code39

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -32,7 +32,7 @@ class BarcodeScannerUtils {
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = barcodeScannerResult.type
-    
+
     // iOS converts upc_a to ean13 an appends a leading 0
     if barcodeScannerResult.type == AVMetadataObject.ObjectType.ean13 {
       let value = barcodeScannerResult.stringValue ?? ""
@@ -70,7 +70,7 @@ class BarcodeScannerUtils {
     var result = [String: Any]()
     result["type"] = item.observation.symbology.rawValue
     result["data"] = item.payloadStringValue
-    
+
     // iOS converts upc_a to ean13 an appends a leading 0
     if item.observation.symbology == VNBarcodeSymbology.ean13 {
       let value = item.payloadStringValue ?? ""

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -33,7 +33,7 @@ class BarcodeScannerUtils {
     var result = [String: Any]()
     result["type"] = barcodeScannerResult.type
 
-    // iOS converts upc_a to ean13 an appends a leading 0
+    // iOS converts upc_a to ean13 and appends a leading 0
     if barcodeScannerResult.type == AVMetadataObject.ObjectType.ean13 {
       let value = barcodeScannerResult.stringValue ?? ""
       if !value.isEmpty && value.hasPrefix("0") {
@@ -71,7 +71,7 @@ class BarcodeScannerUtils {
     result["type"] = item.observation.symbology.rawValue
     result["data"] = item.payloadStringValue
 
-    // iOS converts upc_a to ean13 an appends a leading 0
+    // iOS converts upc_a to ean13 and appends a leading 0
     if item.observation.symbology == VNBarcodeSymbology.ean13 {
       let value = item.payloadStringValue ?? ""
       if !value.isEmpty && value.hasPrefix("0") {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -1,11 +1,13 @@
 import AVFoundation
 import ZXingObjC
 import VisionKit
+import Vision
 
 class BarcodeScannerUtils {
   static func getDefaultSettings() -> [String: [AVMetadataObject.ObjectType]] {
     var validTypes = [
       "upc_e": AVMetadataObject.ObjectType.upce,
+      "upc_a": AVMetadataObject.ObjectType.ean13,
       "code39": AVMetadataObject.ObjectType.code39,
       "code39mod43": AVMetadataObject.ObjectType.code39Mod43,
       "ean13": AVMetadataObject.ObjectType.ean13,
@@ -30,7 +32,16 @@ class BarcodeScannerUtils {
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = barcodeScannerResult.type
-    result["data"] = barcodeScannerResult.stringValue
+    
+    // iOS converts upc_a to ean13 an appends a leading 0
+    if barcodeScannerResult.type == AVMetadataObject.ObjectType.ean13 {
+      let value = barcodeScannerResult.stringValue ?? ""
+      if !value.isEmpty && value.hasPrefix("0") {
+        result["data"] = value.dropFirst()
+      }
+    } else {
+      result["data"] = barcodeScannerResult.stringValue
+    }
 
     if !barcodeScannerResult.corners.isEmpty {
       var cornerPointsResult = [[String: Any]]()
@@ -59,6 +70,16 @@ class BarcodeScannerUtils {
     var result = [String: Any]()
     result["type"] = item.observation.symbology.rawValue
     result["data"] = item.payloadStringValue
+    
+    // iOS converts upc_a to ean13 an appends a leading 0
+    if item.observation.symbology == VNBarcodeSymbology.ean13 {
+      let value = item.payloadStringValue ?? ""
+      if !value.isEmpty && value.hasPrefix("0") {
+        result["data"] = value.dropFirst()
+      }
+    } else {
+      result["data"] = item.payloadStringValue
+    }
 
     let bounds = item.bounds
     let cornerPoints: [[String: Any]] = [bounds.bottomLeft, bounds.bottomRight, bounds.topLeft, bounds.topRight].map { point in


### PR DESCRIPTION
# Why
Closes #28100
This did not actually repro on `android` and on `iOS` `upc_a` codes were never supported. I did notice that some of the types in swift were not cased correctly though which would cause casting them to fail. I also added a workaround to allow `iOS` to scan `upc_a` correctly. 

# How
`iOS` will convert these `upc_a` barcodes to `ean13` and append a leading `0`. We can check if we are dealing with an `ean13` and remove it. 

Fixed the casing issue in the barcode record.

# Test Plan
Bare-expo scanning a `upc_a` barcode.
