### PR TITLE
[docs] Update e2e-tests.mdx

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -524,7 +524,7 @@ describe('Home screen', () => {
 <Collapsible summary="e2e/utils/openApp.js (new file)">
 
 ```js e2e/utils/openApp.js
-const appConfig = require('../../../app.json');
+const appConfig = require('../../app.json');
 const { resolveConfig } = require('detox/internals');
 
 const platform = device.getPlatform();


### PR DESCRIPTION
Updated example code to have correct import of app.json

# Why

Documentation was not correct. `e2e` directory and `app.json` file sits on the same level so when we import `const appConfig = require('../../../app.json');` in `e2e/utils/openApp.js` it should only require `../../` rather than `../../../`

# How

N/A

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
