### PR TITLE
[av] fix record permission selector

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
 - [Android] Fix memory leak connect with `AVManager`. ([#28159](https://github.com/expo/expo/pull/28159) by [@lukmccall](https://github.com/lukmccall))
+- Tried to fix unused recording permission and getting rejected by store review. ([#28236](https://github.com/expo/expo/pull/28236) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m
+++ b/packages/expo-av/ios/EXAV/EXAudioRecordingPermissionRequester.m
@@ -4,12 +4,20 @@
 #import <ExpoModulesCore/EXDefines.h>
 
 #import <AVFoundation/AVFoundation.h>
+#import <objc/message.h>
+
+static SEL recordRecordPermissionSelector;
 
 @implementation EXAudioRecordingPermissionRequester
 
 + (NSString *)permissionType
 {
   return @"audioRecording";
+}
+
++ (void)load
+{
+  recordRecordPermissionSelector = NSSelectorFromString([@"request" stringByAppendingString:@"RecordPermission:"]);
 }
 
 - (NSDictionary *)getPermissions
@@ -44,10 +52,10 @@
 - (void)requestPermissionsWithResolver:(EXPromiseResolveBlock)resolve rejecter:(EXPromiseRejectBlock)reject
 {
   EX_WEAKIFY(self)
-  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+  ((void (*)(id, SEL, void(^)(BOOL)))objc_msgSend)(AVAudioSession.sharedInstance, recordRecordPermissionSelector, ^(BOOL granted) {
     EX_STRONGIFY(self)
     resolve([self getPermissions]);
-  }];
+  });
 }
 
 @end


### PR DESCRIPTION
# Why

alternative solution for #28006 and hopefully to fix #26730

# How

fix the permission requests like what we did in [expo-location](https://github.com/expo/expo/blob/b30d376eecb119a105be1d3372cf495fa6fa3b62/packages/expo-location/ios/EXLocation/Requesters/EXLocationPermissionRequester.m#L20)

# Test Plan

NCL + recording to test the permission requester

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---------
<!-- remove comment after commit
Co-authored-by: Hein Rutjes <hrutjes@gmail.com>
-->