### PR TITLE
[docs] Promote `expo-camera/next` to stable

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -20,7 +20,7 @@ The Expo SDK provides access to device and system functionality such as contacts
 After installing one or more packages, you can import them into your JavaScript code:
 
 ```js
-import { Camera } from 'expo-camera';
+import { CameraView } from 'expo-camera';
 import * as Contacts from 'expo-contacts';
 import { Gyroscope } from 'expo-sensors';
 ```

--- a/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Camera (Next)
+title: Camera (legacy)
 description: A React component that renders a preview for the device's front or back camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-camera'
 packageName: 'expo-camera'
@@ -9,7 +9,7 @@ platforms: ['android*', 'ios*', 'web']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PrereleaseNotice from '~/components/PrereleaseNotice';
+import { SnackInline } from '~/ui/components/Snippet';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,12 +17,9 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-<PrereleaseNotice>
-  This page documents an upcoming version of the Camera library. **To try it, switch to
-  `expo-camera/next` imports in your code.**
-</PrereleaseNotice>
+`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
-`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
+> **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
 
 ## Installation
 
@@ -87,14 +84,16 @@ Learn how to configure the native projects in the [installation instructions in 
 
 > **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
+<SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
+
 ```jsx
-import { CameraView, useCameraPermissions } from 'expo-camera/next';
+import { Camera, CameraType } from 'expo-camera/legacy';
 import { useState } from 'react';
 import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [facing, setFacing] = useState('back');
-  const [permission, requestPermission] = useCameraPermissions();
+  const [type, setType] = useState(CameraType.back);
+  const [permission, requestPermission] = Camera.useCameraPermissions();
 
   /* @hide if (!permission) ... */
   if (!permission) {
@@ -115,19 +114,19 @@ export default function App() {
   }
   /* @end */
 
-  function toggleCameraFacing() {
-    setFacing(current => (current === 'back' ? 'front' : 'back'));
+  function toggleCameraType() {
+    setType(current => (current === CameraType.back ? CameraType.front : CameraType.back));
   }
 
   return (
     <View style={styles.container}>
-      <CameraView style={styles.camera} facing={facing}>
+      <Camera style={styles.camera} type={type}>
         <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.button} onPress={toggleCameraFacing}>
+          <TouchableOpacity style={styles.button} onPress={toggleCameraType}>
             <Text style={styles.text}>Flip Camera</Text>
           </TouchableOpacity>
         </View>
-      </CameraView>
+      </Camera>
     </View>
   );
 }
@@ -159,6 +158,8 @@ const styles = StyleSheet.create({
 });
 ```
 
+</SnackInline>
+
 ## Web support
 
 Most browsers support a version of web camera functionality, you can check out the [web camera browser support here](https://caniuse.com/#feat=stream). Image URIs are always returned as base64 strings because local file system paths are unavailable in the browser.
@@ -169,17 +170,17 @@ When using **Chrome versions 64+**, if you try to use a web camera in a cross-or
 
 ```html
 <iframe src="..." allow="microphone; camera;">
-  <!-- <CameraView /> -->
+  <!-- <Camera /> -->
 </iframe>
 ```
 
 ## API
 
 ```js
-import { CameraView } from 'expo-camera/next';
+import { Camera } from 'expo-camera/legacy';
 ```
 
-<APISection packageName="expo-camera-next" apiName="Camera" exposeAllClassPropsInSidebar={true} />
+<APISection packageName="expo-camera-legacy" apiName="Camera" />
 
 ## Permissions
 

--- a/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
@@ -17,6 +17,8 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
+> **warning** This is the legacy version of the `expo-camera` package which will no longer be receiving updates. If you are starting a new project, we recommend using the latest version. You can find it [here](/versions/latest/sdk/camera).
+
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 > **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.

--- a/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
@@ -17,7 +17,7 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-> **warning** This is the legacy version of the `expo-camera` package which will no longer be receiving updates. If you are starting a new project, we recommend using the latest version. You can find it [here](/versions/latest/sdk/camera).
+> **warning** This is the legacy version of the `expo-camera` package which will no longer be receiving updates. If you are starting a new project, we recommend using the latest version. You can find it [here](/versions/unversioned/sdk/camera).
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 

--- a/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera-legacy.mdx
@@ -17,7 +17,7 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-> **warning** This is the legacy version of the `expo-camera` package which will no longer be receiving updates. If you are starting a new project, we recommend using the latest version. You can find it [here](/versions/unversioned/sdk/camera).
+> **warning** This is the legacy version of the `expo-camera` package which will no longer be receiving updates. If you are starting a new project, we recommend using [the latest version of expo-camera](/versions/v51.0.0/sdk/camera).
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -9,7 +9,6 @@ platforms: ['android*', 'ios*', 'web']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { SnackInline } from '~/ui/components/Snippet';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -17,9 +16,7 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, auto focus, white balance and flash mode are adjustable. Using `Camera`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
-
-> **info** Android devices can use one of two available Camera APIs: you can opt-in to using [`Camera2`](https://developer.android.com/reference/android/hardware/camera2/package-summary) with the `useCamera2Api` prop.
+`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 ## Installation
 
@@ -84,16 +81,14 @@ Learn how to configure the native projects in the [installation instructions in 
 
 > **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
-<SnackInline label='Basic Camera usage' dependencies={['expo-camera']}>
-
 ```jsx
-import { Camera, CameraType } from 'expo-camera';
+import { CameraView, useCameraPermissions } from 'expo-camera';
 import { useState } from 'react';
 import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [type, setType] = useState(CameraType.back);
-  const [permission, requestPermission] = Camera.useCameraPermissions();
+  const [facing, setFacing] = useState('back');
+  const [permission, requestPermission] = useCameraPermissions();
 
   /* @hide if (!permission) ... */
   if (!permission) {
@@ -114,19 +109,19 @@ export default function App() {
   }
   /* @end */
 
-  function toggleCameraType() {
-    setType(current => (current === CameraType.back ? CameraType.front : CameraType.back));
+  function toggleCameraFacing() {
+    setFacing(current => (current === 'back' ? 'front' : 'back'));
   }
 
   return (
     <View style={styles.container}>
-      <Camera style={styles.camera} type={type}>
+      <CameraView style={styles.camera} facing={facing}>
         <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.button} onPress={toggleCameraType}>
+          <TouchableOpacity style={styles.button} onPress={toggleCameraFacing}>
             <Text style={styles.text}>Flip Camera</Text>
           </TouchableOpacity>
         </View>
-      </Camera>
+      </CameraView>
     </View>
   );
 }
@@ -158,8 +153,6 @@ const styles = StyleSheet.create({
 });
 ```
 
-</SnackInline>
-
 ## Web support
 
 Most browsers support a version of web camera functionality, you can check out the [web camera browser support here](https://caniuse.com/#feat=stream). Image URIs are always returned as base64 strings because local file system paths are unavailable in the browser.
@@ -170,17 +163,17 @@ When using **Chrome versions 64+**, if you try to use a web camera in a cross-or
 
 ```html
 <iframe src="..." allow="microphone; camera;">
-  <!-- <Camera /> -->
+  <!-- <CameraView /> -->
 </iframe>
 ```
 
 ## API
 
 ```js
-import { Camera } from 'expo-camera';
+import { CameraView } from 'expo-camera';
 ```
 
-<APISection packageName="expo-camera" apiName="Camera" />
+<APISection packageName="expo-camera" apiName="Camera" exposeAllClassPropsInSidebar={true} />
 
 ## Permissions
 


### PR DESCRIPTION
# Why
`expo-camera/next` has now been promoted to stable. Changing the docs to reflect this.

# How
Removed `next` from the new package and added `legacy` to the old one. 

# Test Plan
n/a
