### PR TITLE
[docs] Fix formatting and verbiage issues in Bare and brownfield guides

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -448,5 +448,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/customizing-webpack': '/archive/customizing-webpack',
 
   // Stop encouraging usage of Expo Go when using native modules
-  '/bare/using-expo-client': '/archive/using-expo-client',
+  '/bare/using-expo-client/': '/archive/using-expo-client/',
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -516,6 +516,7 @@ const archive = [
     makePage('archive/notification-channels.mdx'),
     makePage('archive/publishing-websites-webpack.mdx'),
     makePage('archive/customizing-webpack.mdx'),
+    makePage('archive/using-expo-client.mdx'),
     makePage('archive/glossary.mdx'),
   ]),
 ];

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -349,6 +349,9 @@ redirects[versions/latest/sdk/overview]=versions/latest
 # Deprecated webpack
 redirects[guides/customizing-webpack]=archive/customizing-webpack
 
+# Stop encouraging usage of Expo Go when using native modules
+redirects[bare/using-expo-client]=archive/using-expo-client
+
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do

--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -63,7 +63,7 @@ If you haven't configured a `scheme` for your app yet to support deep linking, t
   ]}
 />
 
-For more information, see [`uri-scheme` library](https://www.npmjs.com/package/uri-scheme).
+For more information, see the [`uri-scheme` library](https://www.npmjs.com/package/uri-scheme).
 
 </Step>
 

--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -13,7 +13,7 @@ The following guide explains how to install and configure `expo-dev-client` in a
 
 <Collapsible summary="Do you need to create a new project?">
 
-If you're starting a project, you can create a new project with the `with-dev-client` template. Run this command to initialize the project:
+If you're starting with a new project, create it using the `with-dev-client` template:
 
 <Terminal cmd={['$ npx create-expo-app -e with-dev-client']} />
 
@@ -21,15 +21,13 @@ If you're starting a project, you can create a new project with the `with-dev-cl
 
 <Collapsible summary="Do you use Continuous Native Generation (CNG) in your project?">
 
-You may be reading the wrong guide then! To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-native-generation/), see ["Create a development build"](/develop/development-builds/create-a-build/).
+You may be reading the wrong guide then. To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-native-generation/), see [Create a development build](/develop/development-builds/create-a-build/).
 
 </Collapsible>
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured**: if you created your project with `npx react-native init` and do not have any other Expo packages installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
-
-## Installation
+**The `expo` package must be installed and configured.** If you created your project with `npx react-native init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
 
 <Step label="1">
 
@@ -39,11 +37,11 @@ Add the `expo-dev-client` library to your **package.json**:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-If your project has an **ios/** directory on disk, run the following command to fully install the native code for `expo-dev-client`:
+If your project has an **ios** directory on disk, run the following command to fully install the native code for `expo-dev-client`:
 
 <Terminal cmd={['$ npx pod-install']} />
 
-If your project doesn't have an **ios/** directory, you can skip this step.
+If your project doesn't have an **ios** directory, you can skip this step.
 
 </Step>
 
@@ -51,7 +49,9 @@ If your project doesn't have an **ios/** directory, you can skip this step.
 
 ## Configure deep links
 
-Expo CLI uses a deep link to launch your project, and it's also useful if you use plan to [use `expo-dev-client` for launching preview updates](/eas-update/getting-started/) if you have added a custom deep link scheme to your project. If you haven't configured a `scheme` for your app yet to support deep linking, then you can use `uri-scheme` package to do this for you.
+Expo CLI uses a deep link to launch your project, and it's also useful if you use plan to [use `expo-dev-client` for launching preview updates](/eas-update/getting-started/) if you have added a custom deep link scheme to your project.
+
+If you haven't configured a `scheme` for your app yet to support deep linking, then use `uri-scheme` library to do this for you.
 
 <Terminal
   cmd={[
@@ -59,11 +59,11 @@ Expo CLI uses a deep link to launch your project, and it's also useful if you us
     '$ npx uri-scheme list',
     '',
     '# Add a scheme to your project',
-    '$ npx uri-scheme add <your scheme>',
+    '$ npx uri-scheme add your-scheme',
   ]}
 />
 
-For more information, see [uri-scheme package](https://www.npmjs.com/package/uri-scheme).
+For more information, see [`uri-scheme` library](https://www.npmjs.com/package/uri-scheme).
 
 </Step>
 
@@ -71,12 +71,12 @@ For more information, see [uri-scheme package](https://www.npmjs.com/package/uri
 
 ## Add additional optional configuration
 
-For certain type of errors, you can provide more helpful error messages. To turn this on, import `expo-dev-client` in the project's **index** file (in the managed workflow, you need to add this import on top of the **App.&lbrace;js|tsx&rbrace;**). Make sure that the import statement is above `import App from './App'`.
+For certain types of errors, you can provide more helpful error messages. To turn this on, import `expo-dev-client` in the project's **index** file (in the managed workflow, you need to add this import on top of the **App.&lbrace;js|tsx&rbrace;**). Make sure that the import statement is above `import App from './App'`.
 
 ```js
 import 'expo-dev-client';
-...
-import App from "./App";
+/* @hide ... */ /* @end */
+import App from './App';
 ```
 
 For more information, see [Error handling](/develop/development-builds/use-development-builds/#add-error-handling).

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -7,24 +7,43 @@ description: Learn how to install and configure expo-updates in bare React Nativ
 import { Terminal } from '~/ui/components/Snippet';
 import { DiffBlock } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-The `expo-updates` library fetches and manages updates to app JavaScript and assets received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates and provides a variety of tools for managing them. It can also be configured to work with a [custom server](/eas-update/custom-updates-server/). This guide explains how set it up for use with EAS Update.
+The `expo-updates` library fetches and manages updates to an app's JavaScript and assets that are received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates and provides a variety of tools for managing them. It can also be configured to work with a [custom server](/eas-update/custom-updates-server/). This guide explains how to set it up for use with EAS Update.
 
 <Collapsible summary="Do you need to create a new project?">
 
-If you are creating a new project, we recommend using `npx create-expo-app --template bare-minimum` (or `yarn create expo-app --template bare-minimum`) because it will handle the following configuration for you automatically. It includes the `expo-updates` [config plugin](/config-plugins/introduction/), which will handle the installation steps for you.
+If you are creating a new project, we recommend using the following command:
+
+<Tabs>
+
+<Tab label="npm">
+
+<Terminal cmd={['$ npx create-expo-app --template bare-minimum']} />
+
+</Tab>
+
+<Tab label="yarn">
+
+<Terminal cmd={['$ yarn create expo-app --template bare-minimum']} />
+
+</Tab>
+
+</Tabs>
+
+Running this command will create a new project from the `bare-minimum` template that will handle configuring the `expo-updates` [config plugin](/config-plugins/introduction/) and the installation steps described in the following sections of this guide.
 
 </Collapsible>
 
 <Collapsible summary="Do you use Continuous Native Generation (CNG) in your project?">
 
-You may be reading the wrong guide then! To use `expo-updates` in a project that uses [CNG](/workflow/continuous-native-generation/), refer to the [EAS Update "Get started" guide](/eas-update/getting-started/).
+You may be reading the wrong guide then. To use `expo-updates` in a project that uses [CNG](/workflow/continuous-native-generation/), see [EAS Update "Get started"](/eas-update/getting-started/).
 
 </Collapsible>
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured**: if you created your project with `npx react-native init` and do not have any other Expo packages installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+**The `expo` package must be installed and configured.** If you created your project with `npx react-native init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
 
 ## Installation
 
@@ -32,18 +51,21 @@ To get started, install `expo-updates`:
 
 <Terminal cmd={['$ npx expo install expo-updates']} />
 
-Then, install pods:
+Then, install pods for iOS:
 
 <Terminal cmd={['$ npx pod-install']} />
 
-Once installation is complete, apply the changes from the following diffs to configure `expo-updates` in your project.
+## Configuring expo-updates library
 
-### Configuration in JavaScript and JSON
+Apply the changes from the diffs from the following sections to configure `expo-updates` in your project.
 
-Modify the `expo` section of **app.json**. (If you originally created your app using `npx react-native init`, you will need to add this section.)
-The changes below add the updates URL to the Expo configuration.
+### JavaScript and JSON
 
-> The example `updates` URL and `projectId` shown below are for use with EAS Update. The EAS CLI sets this URL correctly for the EAS Update service when running `eas update:configure`.
+Modify the `expo` section of **app.json**. (If you created your project using `npx react-native init`, you will need to add this section.)
+
+The changes below add the [`updates` URL](/versions/latest/config/app/#url) to the Expo configuration.
+
+> The example `updates` URL and `projectId` shown below are used with EAS Update. The EAS CLI sets this URL correctly for the EAS Update service when running `eas update:configure`.
 
 ```diff app.json
  {
@@ -93,65 +115,7 @@ If you want to set up a [custom server](/eas-update/custom-updates-server) inste
  }
 ```
 
-### Configuration for iOS
-
-Add the file **Podfile.properties.json** to the **ios** directory:
-
-```json ios/Podfile.properties.json
-{
-  "expo.jsEngine": "hermes"
-}
-```
-
-Modify **ios/Podfile** to check for the JS engine configuration (JSC or Hermes) in Expo files:
-
-```diff ios/Podfile
---- a/ios/Podfile
-+++ b/ios/Podfile
-@@ -2,6 +2,9 @@ require File.join(File.dirname(`node --print "require.resolve('expo/package.json
- require_relative '../node_modules/react-native/scripts/react_native_pods'
- require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
-
-+require 'json'
-+podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
-+
- platform :ios, '13.0'
- prepare_react_native_project!
-
-@@ -41,7 +44,7 @@ target 'MyApp' do
-     # Hermes is now enabled by default. Disable by setting this flag to false.
-     # Upcoming versions of React Native may rely on get_default_flags(), but
-     # we make it explicit here to aid in the React Native upgrade process.
--    :hermes_enabled => flags[:hermes_enabled],
-+    :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
-     :fabric_enabled => flags[:fabric_enabled],
-     # Enables Flipper.
-     #
-
-```
-
-Add the **Supporting** directory containing **Expo.plist** to your project in Xcode with the following content, to match the content in **app.json**:
-
-```xml Expo.plist
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>EXUpdatesCheckOnLaunch</key>
-    <string>ALWAYS</string>
-    <key>EXUpdatesEnabled</key>
-    <true/>
-    <key>EXUpdatesLaunchWaitMs</key>
-    <integer>0</integer>
-    <key>EXUpdatesRuntimeVersion</key>
-    <string>1.0.0</string>
-    <key>EXUpdatesURL</key>
-    <string>http://localhost:3000/api/manifest</string>
-  </dict>
-</plist>
-```
-
-### Configuration for Android
+### Android
 
 Modify **android/app/build.gradle** to check for the JS engine configuration (JSC or Hermes) in Expo files:
 
@@ -209,9 +173,67 @@ Add the Expo runtime version string key to **android/app/src/main/res/values/str
 
 <DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />
 
+### iOS
+
+Add the file **Podfile.properties.json** to the **ios** directory:
+
+```json ios/Podfile.properties.json
+{
+  "expo.jsEngine": "hermes"
+}
+```
+
+Modify **ios/Podfile** to check for the JS engine configuration (JSC or Hermes) in Expo files:
+
+```diff ios/Podfile
+--- a/ios/Podfile
++++ b/ios/Podfile
+@@ -2,6 +2,9 @@ require File.join(File.dirname(`node --print "require.resolve('expo/package.json
+ require_relative '../node_modules/react-native/scripts/react_native_pods'
+ require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
++require 'json'
++podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
++
+ platform :ios, '13.0'
+ prepare_react_native_project!
+
+@@ -41,7 +44,7 @@ target 'MyApp' do
+     # Hermes is now enabled by default. Disable by setting this flag to false.
+     # Upcoming versions of React Native may rely on get_default_flags(), but
+     # we make it explicit here to aid in the React Native upgrade process.
+-    :hermes_enabled => flags[:hermes_enabled],
++    :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
+     :fabric_enabled => flags[:fabric_enabled],
+     # Enables Flipper.
+     #
+
+```
+
+Add the **Supporting** directory containing **Expo.plist** to your project in Xcode with the following content, to match the content in **app.json**:
+
+```xml Expo.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>EXUpdatesCheckOnLaunch</key>
+    <string>ALWAYS</string>
+    <key>EXUpdatesEnabled</key>
+    <true/>
+    <key>EXUpdatesLaunchWaitMs</key>
+    <integer>0</integer>
+    <key>EXUpdatesRuntimeVersion</key>
+    <string>1.0.0</string>
+    <key>EXUpdatesURL</key>
+    <string>http://localhost:3000/api/manifest</string>
+  </dict>
+</plist>
+```
+
 ## Next steps
 
-- To start trying out EAS Update with EAS Build, see the EAS Update [Getting Started](/eas-update/getting-started/).
-- See more information about usage in the [`expo-updates` README](https://github.com/expo/expo/tree/main/packages/expo-updates/README.md).
-- See [EAS Update with a local build](/eas-update/build-locally/).
-- It is also possible to use `expo-updates` with a custom server that implements the [Expo Updates protocol](/technical-specs/expo-updates-1/); see the [`custom-expo-updates-server` README](https://github.com/expo/custom-expo-updates-server#readme).
+- To start using EAS Update with EAS Build, see the EAS Update [Get started](/eas-update/getting-started/).
+- See [`expo-updates` API reference](/versions/latest/sdk/updates/) for more information on how to use the library.
+- See how to use [EAS Update with a local build directly](/eas-update/build-locally/).
+- It is also possible to use `expo-updates` with a custom server that implements the [Expo Updates protocol](/technical-specs/expo-updates-1/). See [`custom-expo-updates-server` README](https://github.com/expo/custom-expo-updates-server#readme).

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -21,7 +21,7 @@ If you have a React Native app that doesn't use any Expo tools, you might be won
 
 **All tools and services provided by Expo work great in any React Native app**.
 
-You can use [EAS](/eas) to get quickly set up with a professional CI/CD workflow for building, reviewing, deploying, and updating your apps. [Expo CLI](/more/expo-cli/) provides the best command-line experience for working with React Native. The [Expo SDK](/versions/latest/) is an extended standard library for React Native. It gives developers high-quality, well maintained native libraries that use consistent API conventions to make them easier to learn and use.
+You can use [EAS](/eas) to get quickly set up with a professional CI/CD workflow for building, reviewing, deploying, and updating your apps. [Expo CLI](/more/expo-cli/) provides the best command-line experience for working with React Native. The [Expo SDK](/versions/latest/) is an extended standard library for React Native. It gives developers high-quality, well-maintained native libraries that use consistent API conventions to make them easier to learn and use.
 
 If you've ever written a native module for React Native, you'll be surprised how much easier it is to build and maintain modules with the idiomatic Swift and Kotlin DSL provided by the [Expo Modules API](/modules/overview/).
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { DEMI } from '~/ui/components/Text';
 
-To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
+To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package, which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
 
 ## Install the `expo` package
 
@@ -51,7 +51,9 @@ Windows and macOS. If building for these platforms, you can utilize Expo CLI for
 
 After installing the `expo` package, you can use the following commands which are alternatives to `npx react-native run-android` and `npx react-native run-ios`:
 
-<Terminal cmd={['# for Android', '$ npx expo run:android', '', '# for iOS', '$ npx expo run:ios']} />
+<Terminal
+  cmd={['# for Android', '$ npx expo run:android', '', '# for iOS', '$ npx expo run:ios']}
+/>
 
 When building your project, you can choose a device or simulator by using the `--device` flag. This also applies to any iOS device that is connected to your computer.
 

--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -135,7 +135,7 @@ index a71b5e7..d6d406e 100644
 
 <Step label="4.3">
 
-If you have your own class extending `Application`, you can add the following to it:
+If you have your own class extending `Application`, you can add the following. It includes calls to `ApplicationLifecycleDispatcher` for handling events at the application startup and during device configuration changes.
 
 <DiffBlock raw={`diff --git a/android/app/src/main/java/com/<my-app-package>/MainApplication.kt b/android/app/src/main/java/com/<my-app-package>/MainApplication.kt
 new file mode 100644

--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -10,28 +10,32 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 
-> **info** If your project is a **greenfield React Native app**, primarily built with React Native from the start, then [refer to the "Install Expo modules in an existing React Native project" guide](/bare/installing-expo-modules/) instead of this page.
+> **info** If your project is a **greenfield React Native app** &mdash; primarily built with React Native from the start, then see [Install Expo modules in an existing React Native project](/bare/installing-expo-modules/) instead of this guide.
+
+This guide provides the steps to prepare your existing native project to install and use Expo modules and the module API.
 
 ## Prerequisites
 
-You should have a brownfield native project with React Native installed and configured to render a root view. If you don't have this yet, you can follow [the "Integration with Existing Apps" guide](https://reactnative.dev/docs/integration-with-existing-apps) on the React Native docs and then return here.
-
-## Installation
-
 > **warning** The following instructions may not work for all projects. Support for integrating Expo modules into existing projects is still experimental. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues).
 
-### Install the `expo` package
+You should have a brownfield native project with React Native installed and configured to render a root view. If you don't have this yet, follow the [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps) guide from the React Native documentation and then come back here once you have followed the steps.
 
-First, add the `expo` package to your project. Ensure you are using a version of the `expo` package that is compatible with the React Native version in your project. [Learn more](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
+## Install the `expo` package
+
+Add the `expo` package to your project. Ensure you are using a version of [the `expo` package that is compatible with the React Native version in your project](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
 
 <Terminal cmd={['npm install expo']} />
 
-### Configure your Android app
+## Configuring native apps
+
+### Android app
 
 <Step label="1">
-  Add the following to the `gradle.properties` file in the `android` directory:
-  <DiffBlock
-    raw={`diff --git a/android/gradle.properties b/android/gradle.properties
+
+Add the following to the **gradle.properties** file in the **android** directory:
+
+<DiffBlock
+  raw={`diff --git a/android/gradle.properties b/android/gradle.properties
 index 20e2a01..e98ad88 100644
 --- a/android/gradle.properties
 +++ b/android/gradle.properties
@@ -39,13 +43,16 @@ index 20e2a01..e98ad88 100644
 +newArchEnabled=false
 +
 +hermesEnabled=true`}
-  />
+/>
+
 </Step>
 
 <Step label="2">
-  Add the following to the `setting.gradle` file in the `android` directory:
-  <DiffBlock
-    raw={`diff --git a/android/settings.gradle b/android/settings.gradle
+
+Add the following to the **setting.gradle** file in the **android** directory:
+
+<DiffBlock
+  raw={`diff --git a/android/settings.gradle b/android/settings.gradle
 index a26c7c6..dd8802a 100644
 --- a/android/settings.gradle
 +++ b/android/settings.gradle
@@ -55,24 +62,32 @@ index a26c7c6..dd8802a 100644
 +
  include ':app'
  includeBuild("../node_modules/@react-native/gradle-plugin")`}
-  />
+/>
+
 </Step>
 
 <Step label="3">
-  From the `android` directory, run the following command:
-  <Terminal cmd={['./gradlew clean']} />
-  Once this completes, run the following command:
-  <Terminal cmd={['./gradlew assembleDebug']} />
+
+Inside the **android** directory, run the following command:
+
+<Terminal cmd={['./gradlew clean']} />
+
+Once the above command completes, run:
+
+<Terminal cmd={['./gradlew assembleDebug']} />
+
 </Step>
 
 <Step label="4">
-  **(Optional)** Complete the following steps if you would like to use [lifecycle listeners](/modules/android-lifecycle-listeners/)
-  in your app. If you do not set up lifecycle listeners, then additional setup will be required for each module that uses them.
-<Step label="1">
-If you already have a class that extends the `Application` class you can move to step 3.
-If you do not have it, we need to create one. Add a file called `MainApplication.kt` file to your `android/app/src/main/java/com/<your-app-package>` directory with the following content:
 
-<DiffBlock raw={`diff --git a/android/app/src/main/java/com/<my-app-package>/MainApplication.kt b/android/app/src/main/java/com/<my-app-package>/MainApplication.kt
+**(Optional)** Complete the following steps if you would like to use [lifecycle listeners](/modules/android-lifecycle-listeners/) in your app. If you do not set up lifecycle listeners, then additional setup will be required for each module that uses them.
+
+<Step label="4.1">
+
+If you already have a class that extends the `Application` class you can move to step 3. If you do not have it, we need to create one. Add a file called **MainApplication.kt** file to your **android/app/src/main/java/com/&lt;your-app-package&gt;** directory with the following content:
+
+<DiffBlock
+  raw={`diff --git a/android/app/src/main/java/com/<my-app-package>/MainApplication.kt b/android/app/src/main/java/com/<my-app-package>/MainApplication.kt
 new file mode 100644
 index 0000000..2c8525a
 --- /dev/null
@@ -95,11 +110,17 @@ index 0000000..2c8525a
 +        super.onConfigurationChanged(newConfig)
 +        ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
 +    }
-+}`} />
++}`}
+/>
+
 </Step>
-<Step label="2">
-Register the class in the `AndroidManifest.xml` file.
-<DiffBlock raw={`diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
+
+<Step label="4.2">
+
+Register the class in the **AndroidManifest.xml** file.
+
+<DiffBlock
+  raw={`diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
 index a71b5e7..d6d406e 100644
 --- a/android/app/src/main/AndroidManifest.xml
 +++ b/android/app/src/main/AndroidManifest.xml
@@ -107,10 +128,13 @@ index a71b5e7..d6d406e 100644
      <application
          android:allowBackup="true"
 +        android:name=".MainApplication"
-         android:fullBackupContent="@xml/backup_rules"`} />
+         android:fullBackupContent="@xml/backup_rules"`}
+/>
+
 </Step>
 
-<Step label="3">
+<Step label="4.3">
+
 If you have your own class extending `Application`, you can add the following to it:
 
 <DiffBlock raw={`diff --git a/android/app/src/main/java/com/<my-app-package>/MainApplication.kt b/android/app/src/main/java/com/<my-app-package>/MainApplication.kt
@@ -130,17 +154,21 @@ class MainApplication() : Application() {
 +       ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
 +   }
 
-}`} />
+}`}
+/>
+
 Override `onConfigurationChanged` if you have not done so already.
 
 </Step>
 </Step>
 
-### Configure your iOS app
+### iOS app
 
 <Step label="1">
-  Add the following to your `Podfile` in the `ios` directory:
-  <DiffBlock
+
+Add the following to your `Podfile` in the **ios** directory:
+
+<DiffBlock
     raw={`
 diff --git a/ios/Podfile b/ios/Podfile
 index 2d3a979..825a9d4 100644
@@ -153,46 +181,57 @@ index 2d3a979..825a9d4 100644
    "react-native/scripts/react_native_pods.rb",
 @@ -14,6 +15,7 @@ if linkage != nil
  end
- 
- target '<YourAppTarget>' do
-+  use_expo_modules!
-   config = use_native_modules!
+
+target '<YourAppTarget>' do
+
+- use_expo_modules!
+  config = use_native_modules!
   `}
   />
+
 </Step>
 
 <Step label="2">
-  Open your `ios` directory in Xcode. From the project navigator, select your project and then
-  select your app target under `TARGETS`. In `Build Settings`, using the search bar, search for
-  `ENABLE_USER_SCRIPT_SANDBOXING`. If it is not already, set its value to `No`.
+
+Open your **ios** directory in Xcode. From the project navigator, select your project and then select your app target under `TARGETS`. In `Build Settings`, using the search bar, search for `ENABLE_USER_SCRIPT_SANDBOXING`. If it is not already, set its value to `No`.
+
 </Step>
 
 <Step label="3">
-  Run `pod install` in the `ios` directory.
-  <Terminal cmd={['cd ios && pod install']} />
-  You will need to do this everytime you add a dependency that uses native code.
+
+Run `pod install` in the **ios** directory.
+
+<Terminal cmd={['cd ios && pod install']} />
+
+You will need to do this every time you add a dependency that uses native code.
+
 </Step>
 
 <Step label="4">
-  **(Optional)** Complete the following if you would like to use [AppDelegate subscribers](/modules/appdelegate-subscribers/). If you do not set up AppDelegate subscribers, then additional setup will be required for each module that uses them.
-  <DiffBlock
-    raw={`diff --git a/ios/<MyAppProject>/AppDelegate.swift b/ios/<MyAppProject>/AppDelegate.swift
+
+**(Optional)** Complete the following if you would like to use [`AppDelegate` subscribers](/modules/appdelegate-subscribers/). If you do not set up `AppDelegate` subscribers, then additional setup will be required for each module that uses them.
+
+<DiffBlock raw={`diff --git a/ios/<MyAppProject>/AppDelegate.swift b/ios/<MyAppProject>/AppDelegate.swift
 index ff83531..bd8651d 100644
 --- a/ios/<MyAppProject>/AppDelegate.swift
 +++ b/ios/<MyAppProject>/AppDelegate.swift
 @@ -1,31 +1,29 @@
  import UIKit
 +import ExpoModulesCore
- 
- @main
+
+@main
 -class AppDelegate: UIResponder, UIApplicationDelegate {
 +class AppDelegate: ExpoAppDelegate {
- 
--  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
--    return true
-+    super.application(application, didFinishLaunchingWithOptions: launchOptions)
-   }
- `}
+
+- func application(\_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+* override func application(\_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+- return true
+
+* super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+  `}
   />
+
 </Step>

--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -9,17 +9,17 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { DEMI, CODE } from '~/ui/components/Text';
 
-An existing native app that was built using another technology, whose main entry point is *not* a React Native view, is commonly referred to as a "brownfield" app. For example, if your app was built using UIKit and Swift, and you want to use React Native for a single screen then that is considered an "existing native app" and "brownfield".
+An existing native app that was built using another technology, whose main entry point is _not_ a React Native view, is commonly referred to as a "brownfield" app. For example, if your app was built using UIKit and Swift, and you want to use React Native for a single screen then that is considered an "existing native app" and "brownfield".
 
-In contrast, "greenfield" apps are those which are created using Expo or React Native from the start or where React Native is the entry point and where all other UI branches off from.
+In contrast, "greenfield" apps are created using Expo or React Native from the start or where React Native is the entry point and where all other UI branches off from.
 
 By these definitions, if you have an "existing native app" for Android or iOS and you want to learn how to use Expo and React Native in your project (perhaps on a single screen or even a single feature), then this guide is for you.
 
 ## Compatibility with existing native apps
 
-> **info** Support for integrating Expo modules into existing native projects is still experimental. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues). Not all features of the above tools/services will when used in the context of an existing native app.
+> **info** Support for integrating Expo modules into existing native projects is still experimental. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues). Not all features of the tools and services below will be available when used in the context of an existing native app.
 
-Expo is primarily built with greenfield apps in mind — not all Expo tools and services are compatible with existing native projects.
+Expo is primarily built with greenfield apps in mind. Not all Expo tools and services are compatible with existing native projects.
 
 | Tool/Service                                                                                         | Supports brownfield? |
 | ---------------------------------------------------------------------------------------------------- | -------------------- |
@@ -43,5 +43,5 @@ Expo is primarily built with greenfield apps in mind — not all Expo tools and 
 <BoxLink
   title="Install Expo modules"
   description="Install the Expo Modules API and use it to add existing Expo modules or write your own native extensions."
-  href="/brownfield/installing-expo-modules"
+  href="/brownfield/installing-expo-modules/"
 />

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -34,7 +34,7 @@ The following instructions cover both Android and iOS and physical devices and e
 
 <Collapsible summary="Are you using this library in a bare React Native app?">
 
-Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) will need to follow the ["Install expo-dev-client in bare React Native" guide](/bare/install-dev-builds-in-bare/).
+Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) need to follow instructions from [Install `expo-dev-client` in bare React Native](/bare/install-dev-builds-in-bare/).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #27608

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix redirect issues to the archived doc "
- Show the archived doc `archive/using-expo-client/` in the sidebar (by updating the navigation structure)
- Fix formatting and verbiage issues in guides under "Existing React Native apps" and "Existing native apps" sections.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and going through each guide.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
