### PR TITLE
[expo-go] Fix import from next

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -13,7 +13,7 @@ import expo.modules.blur.BlurModule
 import expo.modules.brightness.BrightnessModule
 import expo.modules.calendar.CalendarModule
 import expo.modules.camera.CameraViewModule
-import expo.modules.camera.next.CameraViewNextModule
+import expo.modules.camera.legacy.CameraViewLegacyModule
 import expo.modules.cellular.CellularModule
 import expo.modules.clipboard.ClipboardModule
 import expo.modules.constants.ConstantsModule
@@ -148,7 +148,7 @@ object ExperiencePackagePicker : ModulesProvider {
     BlurModule::class.java,
     CalendarModule::class.java,
     CameraViewModule::class.java,
-    CameraViewNextModule::class.java,
+    CameraViewLegacyModule::class.java,
     CellularModule::class.java,
     ClipboardModule::class.java,
     CryptoModule::class.java,


### PR DESCRIPTION
# Why

This should fix https://github.com/expo/expo/actions/runs/8714487185/job/23904809794 - failing on main

# How

Update import, now that `next` is default we need to import `legacy` here.

# Test Plan

CI