### PR TITLE
[templates] Remove assetBundlePatterns config

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "HelloWorld",
     "slug": "expo-template-bare",
-    "version": "1.0.0",
-    "assetBundlePatterns": ["**/*"]
+    "version": "1.0.0"
   }
 }

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -11,7 +11,6 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -11,7 +11,6 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -12,9 +12,6 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
# Why

Fixes ENG-9323

This field was used by classic updates and as far as I know is not used by EAS Update and we use `extra.updates.assetPatternsToBeBundled` instead (can you confirm @douglowder / @wschurman?).

# How

Removed from template

# Test Plan

...?
