### PR TITLE
[sensors] Fix ios 17.4 barometer issue

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Prevent unnecessary permissions check when moving app to background (Would crash with certain configs). ([#28045](https://github.com/expo/expo/pull/28045) by [@cltnschlosser](https://github.com/cltnschlosser))
+- Fix barometer updates not starting on iOS 17.4.
 
 ### 💡 Others
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Prevent unnecessary permissions check when moving app to background (Would crash with certain configs). ([#28045](https://github.com/expo/expo/pull/28045) by [@cltnschlosser](https://github.com/cltnschlosser))
-- Fix barometer updates not starting on iOS 17.4.
+- Fix barometer updates not starting on iOS 17.4. ([#28253](https://github.com/expo/expo/pull/28253) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/ios/BarometerModule.swift
+++ b/packages/expo-sensors/ios/BarometerModule.swift
@@ -23,6 +23,10 @@ public final class BarometerModule: Module {
     }
 
     OnStartObserving {
+      if CMAltimeter.authorizationStatus() == .notDetermined {
+        CMSensorRecorder().recordAccelerometer(forDuration: 0.1)
+      }
+
       altimeter.startRelativeAltitudeUpdates(to: operationQueue) { [weak self] data, _ in
         guard let data else {
           return


### PR DESCRIPTION
# Why
Closes #28187
There's a bug on iOS 17.4 where the motion permissions popup won't display even when the `NSMotionUsageDescription` is in the plist while using the altimeter. Currently it silently fails and the listener is never attached.

# How
We can use any of the other sensors to trigger the dialog. This is a hack but it fixes the problem until it is resolved by apple.

# Test Plan
Tested in the provided repro. The dialog now displays and updates are sent.