### PR TITLE
[image][Android] Fix placeholders weren't correctly scaled down

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImagePlaceholderScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImagePlaceholderScreen.tsx
@@ -1,6 +1,6 @@
 import { Image, ImageSource } from 'expo-image';
 import { useCallback, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import Button from '../../components/Button';
 import { Colors } from '../../constants';
@@ -19,35 +19,64 @@ export default function ImagePlaceholderScreen() {
   }, [source]);
 
   return (
-    <View style={styles.container}>
-      <Image
-        style={styles.image}
-        source={source ?? []}
-        placeholder={require('../../../assets/images/expo-icon.png')}
-        cachePolicy="none"
-      />
+    <ScrollView>
+      <View style={styles.container}>
+        <Image
+          style={styles.image}
+          source={source ?? []}
+          placeholder={require('../../../assets/images/expo-icon.png')}
+          cachePolicy="none"
+        />
 
-      <View style={styles.actionsContainer}>
-        <Text style={styles.text}>
-          At first you should see only a placeholder{'\n'}
-          as the source is not defined yet
-        </Text>
+        <View style={styles.actionsContainer}>
+          <Text style={styles.text}>
+            At first you should see only a placeholder{'\n'}
+            as the source is not defined yet
+          </Text>
 
-        <Text style={styles.text}>
-          Set one below and try it multiple times{'\n'}
-          to confirm that the placeholder is not{'\n'}
-          displayed when switching the sources{'\n'}
-          👇
-        </Text>
-        <Button style={styles.actionButton} title="Set to a random source" onPress={loadAnyImage} />
+          <Text style={styles.text}>
+            Set one below and try it multiple times{'\n'}
+            to confirm that the placeholder is not{'\n'}
+            displayed when switching the sources{'\n'}
+            👇
+          </Text>
+          <Button
+            style={styles.actionButton}
+            title="Set to a random source"
+            onPress={loadAnyImage}
+          />
 
-        <Text style={styles.text}>
-          Now reset it back to the placeholder{'\n'}
-          👇
-        </Text>
-        <Button style={styles.actionButton} title="Reset the source" onPress={resetSource} />
+          <Text style={styles.text}>
+            Now reset it back to the placeholder{'\n'}
+            👇
+          </Text>
+          <Button style={styles.actionButton} title="Reset the source" onPress={resetSource} />
+
+          <View
+            style={{
+              flex: 1,
+              backgroundColor: 'gray',
+              height: 1,
+              width: '100%',
+              marginHorizontal: 5,
+            }}
+          />
+          <Text style={styles.text}>
+            The placeholder should cover the whole container (if you can see the red background,
+            something is wrong)
+            {'\n'}
+            👇
+          </Text>
+          <Image
+            style={[styles.image, { backgroundColor: 'red', width: 300, height: 200 }]}
+            source={[]}
+            placeholder={{ blurhash: 'LmLg9W-oNGt7~Cs.ofWC4:RkfRR*', width: 30, height: 20 }}
+            contentFit="contain"
+            transition={5000}
+          />
+        </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed an issue where `isBlurhashString` always returned `true` .([#27251](https://github.com/expo/expo/pull/27251) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix #available check to account for tvOS. ([#27272](https://github.com/expo/expo/pull/27272) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed jest may cause `RangeError: Invalid string length` error when generating a snapshot. ([#27354](https://github.com/expo/expo/pull/27354) by [@lukmccall](https://github.com/lukmccall))
+- Fixed placeholders weren't correctly scaled down on the Android.
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fixed an issue where `isBlurhashString` always returned `true` .([#27251](https://github.com/expo/expo/pull/27251) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix #available check to account for tvOS. ([#27272](https://github.com/expo/expo/pull/27272) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed jest may cause `RangeError: Invalid string length` error when generating a snapshot. ([#27354](https://github.com/expo/expo/pull/27354) by [@lukmccall](https://github.com/lukmccall))
-- Fixed placeholders weren't correctly scaled down on the Android.
+- Fixed placeholders weren't correctly scaled down on the Android. ([#28255](https://github.com/expo/expo/pull/28255) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
@@ -59,7 +59,7 @@ class PlaceholderDownsampleStrategy(
   }
 
   override fun getSampleSizeRounding(sourceWidth: Int, sourceHeight: Int, requestedWidth: Int, requestedHeight: Int): SampleSizeRounding {
-    return  SampleSizeRounding.QUALITY;
+    return SampleSizeRounding.QUALITY
   }
 }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
@@ -44,6 +44,25 @@ object NoopDownsampleStrategy : DownsampleStrategy() {
   ): SampleSizeRounding = SampleSizeRounding.QUALITY
 }
 
+class PlaceholderDownsampleStrategy(
+  private val target: ImageViewWrapperTarget
+) : CustomDownsampleStrategy() {
+  private var wasTriggered = false
+
+  override fun getScaleFactor(sourceWidth: Int, sourceHeight: Int, requestedWidth: Int, requestedHeight: Int): Float {
+    if (!wasTriggered) {
+      target.placeholderWidth = sourceWidth
+      target.placeholderHeight = sourceHeight
+      wasTriggered = true
+    }
+    return 1f
+  }
+
+  override fun getSampleSizeRounding(sourceWidth: Int, sourceHeight: Int, requestedWidth: Int, requestedHeight: Int): SampleSizeRounding {
+    return  SampleSizeRounding.QUALITY;
+  }
+}
+
 class ContentFitDownsampleStrategy(
   private val target: ImageViewWrapperTarget,
   private val contentFit: ContentFit

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -72,7 +72,9 @@ class ExpoImageView(
     }
 
     if (isPlaceholder) {
-      applyTransformationMatrix(drawable, placeholderContentFit,
+      applyTransformationMatrix(
+        drawable,
+        placeholderContentFit,
         sourceHeight = currentTarget?.placeholderHeight,
         sourceWidth = currentTarget?.placeholderWidth
       )
@@ -86,7 +88,7 @@ class ExpoImageView(
     contentFit: ContentFit,
     contentPosition: ContentPosition = ContentPosition.center,
     sourceWidth: Int? = currentTarget?.sourceWidth,
-    sourceHeight: Int? = currentTarget?.sourceHeight,
+    sourceHeight: Int? = currentTarget?.sourceHeight
   ) {
     val imageRect = RectF(0f, 0f, drawable.intrinsicWidth.toFloat(), drawable.intrinsicHeight.toFloat())
     val viewRect = RectF(0f, 0f, width.toFloat(), height.toFloat())

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -72,7 +72,10 @@ class ExpoImageView(
     }
 
     if (isPlaceholder) {
-      applyTransformationMatrix(drawable, placeholderContentFit)
+      applyTransformationMatrix(drawable, placeholderContentFit,
+        sourceHeight = currentTarget?.placeholderHeight,
+        sourceWidth = currentTarget?.placeholderWidth
+      )
     } else {
       applyTransformationMatrix(drawable, contentFit, contentPosition)
     }
@@ -81,7 +84,9 @@ class ExpoImageView(
   private fun applyTransformationMatrix(
     drawable: Drawable,
     contentFit: ContentFit,
-    contentPosition: ContentPosition = ContentPosition.center
+    contentPosition: ContentPosition = ContentPosition.center,
+    sourceWidth: Int? = currentTarget?.sourceWidth,
+    sourceHeight: Int? = currentTarget?.sourceHeight,
   ) {
     val imageRect = RectF(0f, 0f, drawable.intrinsicWidth.toFloat(), drawable.intrinsicHeight.toFloat())
     val viewRect = RectF(0f, 0f, width.toFloat(), height.toFloat())
@@ -89,8 +94,8 @@ class ExpoImageView(
     val matrix = contentFit.toMatrix(
       imageRect,
       viewRect,
-      currentTarget?.sourceWidth ?: -1,
-      currentTarget?.sourceHeight ?: -1
+      sourceWidth ?: -1,
+      sourceHeight ?: -1
     )
     val scaledImageRect = imageRect.transform(matrix)
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -536,7 +536,10 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
         .load(model)
         .apply {
           if (placeholder != null) {
-            thumbnail(requestManager.load(placeholder.glideData))
+            thumbnail(
+              requestManager.load(placeholder.glideData)
+                .downsample(PlaceholderDownsampleStrategy(newTarget))
+            )
             val newPlaceholderContentFit = if (bestPlaceholder.isBlurhash() || bestPlaceholder.isThumbhash()) {
               contentFit
             } else {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
@@ -52,6 +52,16 @@ class ImageViewWrapperTarget(
    */
   var sourceWidth = -1
 
+  /**
+   * The placeholder height where -1 means unknown
+   */
+  var placeholderHeight = -1
+
+  /**
+   * The placeholder width where -1 means unknown
+   */
+  var placeholderWidth = -1
+
   private var cookie = -1
 
   fun setCookie(newValue: Int) {


### PR DESCRIPTION
# Why

Fixes placeholders weren't correctly scaled down.
Adds a new test case to check if the placeholders are correctly resized.

# How

We didn't apply scaling correctly to the placeholders. 

# Test Plan

- bare-expo ✅ 