### PR TITLE
[navigation-bar] Fix event listeners on Android

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix event listeners on Android. ([#28260](https://github.com/expo/expo/pull/28260) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Migrated dependency from `@react-native/normalize-color` to `@react-native/normalize-colors`. ([#27736](https://github.com/expo/expo/pull/27736) by [@kudo](https://github.com/kudo))

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -50,7 +50,6 @@ class NavigationBarModule : Module() {
       }
     }
 
-
     AsyncFunction("setBackgroundColorAsync") { color: Int, promise: Promise ->
       NavigationBar.setBackgroundColor(activity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -24,6 +24,33 @@ class NavigationBarModule : Module() {
 
     Events(VISIBILITY_EVENT_NAME)
 
+    OnStartObserving {
+      val decorView = activity.window.decorView
+      decorView.post {
+        @Suppress("DEPRECATION")
+        decorView.setOnSystemUiVisibilityChangeListener { visibility: Int ->
+          val isNavigationBarVisible = (visibility and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0
+          val stringVisibility = if (isNavigationBarVisible) "visible" else "hidden"
+          sendEvent(
+            VISIBILITY_EVENT_NAME,
+            Bundle().apply {
+              putString("visibility", stringVisibility)
+              putInt("rawVisibility", visibility)
+            }
+          )
+        }
+      }
+    }
+
+    OnStopObserving {
+      val decorView = activity.window.decorView
+      decorView.post {
+        @Suppress("DEPRECATION")
+        decorView.setOnSystemUiVisibilityChangeListener(null)
+      }
+    }
+
+
     AsyncFunction("setBackgroundColorAsync") { color: Int, promise: Promise ->
       NavigationBar.setBackgroundColor(activity, color, { promise.resolve(null) }, { m -> promise.reject(NavigationBarException(m)) })
     }.runOnQueue(Queues.MAIN)
@@ -99,30 +126,6 @@ class NavigationBarModule : Module() {
 
         return@AsyncFunction behavior
       }
-    }.runOnQueue(Queues.MAIN)
-
-    // We are not using `OnStartObserving` and `OnStopObserving` here because when switching threads
-    // they will resolve the promise quicker and the JS won't wait for observer removal
-    AsyncFunction<Unit>("startObserving") {
-      val decorView = activity.window.decorView
-      @Suppress("DEPRECATION")
-      decorView.setOnSystemUiVisibilityChangeListener { visibility: Int ->
-        val isNavigationBarVisible = (visibility and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0
-        val stringVisibility = if (isNavigationBarVisible) "visible" else "hidden"
-        sendEvent(
-          VISIBILITY_EVENT_NAME,
-          Bundle().apply {
-            putString("visibility", stringVisibility)
-            putInt("rawVisibility", visibility)
-          }
-        )
-      }
-    }.runOnQueue(Queues.MAIN)
-
-    AsyncFunction<Unit>("stopObserving") {
-      val decorView = activity.window.decorView
-      @Suppress("DEPRECATION")
-      decorView.setOnSystemUiVisibilityChangeListener(null)
     }.runOnQueue(Queues.MAIN)
   }
 


### PR DESCRIPTION
# Why

Opening the NavigationBar test screen inside NCL results in a warning being thrown due to the wrong number of arguments provided (due to the way that we were handling events)

<img width="435" alt="image" src="https://github.com/expo/expo/assets/11707729/bb8311d0-a8d3-4c34-80ff-07996a13c3f9">


# How

Use `OnStartObserving` and `OnStopObserving` methods to setup listeners 

# Test Plan

Run BareExpo and FabricTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
