### PR TITLE
[docs] Add config plugin info in Expo Asset

### DIFF
--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -47,12 +47,11 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
       description: [
         'An array of asset files or directories to link to the native project. The paths should be relative to the project root so that the file names, whether specified directly or using a directory, will become the resource names.',
         '',
-        'Supported file types are images, videos, sounds, and SQLite database files.'
+        'Supported file types are images, videos, sounds, and SQLite database files.',
       ].join('\n'),
       default: '[]',
     },
-
-]}
+  ]}
 />
 
 ## API

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -51,7 +51,6 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         '* Images: `.png`, `.jpg`, `.gif`',
         '* Media: `.mp4`, `.mp3`, `.lottie`',
         '* SQLite database files: `.db`'
-
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -52,7 +52,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         '* Media: `.mp4`, `.mp3`, `.lottie`',
         '* SQLite database files: `.db`',
         '',
-        '> **Note**: To import an existing  database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database).',
+        '> **Note**: To import an existing database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database). For other file types such as `.lottie`, see [how to add a file extension to `assetExts` in metro config](/guides/customizing-metro/#adding-more-file-extensions-to-assetexts)',
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -47,7 +47,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
       description: [
         'An array of asset files or directories to link to the native project. The paths should be relative to the project root so that the file names, whether specified directly or using a directory, will become the resource names.',
         '',
-        'Supported file types are images, videos, sounds, and SQLite database files.',
+        'Supported file types are images, videos, sounds, SQLite database file, JSON, and Lottie animation (`.lottie`).',
       ].join('\n'),
       default: '[]',
     },

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -9,12 +9,47 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
 
-**`expo-asset`** provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
+`expo-asset` provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-asset` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-asset",
+        {
+          "assets": ["path/to/file.png", "path/to/directory"]
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'assets',
+      description:
+        'An array of asset files or directories to link to the native project. The paths should be relative to the project root so that the file names, whether specified directly or using a directory, will become the resource names.',
+      default: '[]',
+    },
+  ]}
+/>
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -44,11 +44,15 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
   properties={[
     {
       name: 'assets',
-      description:
+      description: [
         'An array of asset files or directories to link to the native project. The paths should be relative to the project root so that the file names, whether specified directly or using a directory, will become the resource names.',
+        '',
+        'Supported file types are images, videos, sounds, and SQLite database files.'
+      ].join('\n'),
       default: '[]',
     },
-  ]}
+
+]}
 />
 
 ## API

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -50,12 +50,13 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
         'Supported file types:',
         '* Images: `.png`, `.jpg`, `.gif`',
         '* Media: `.mp4`, `.mp3`, `.lottie`',
-        '* SQLite database files: `.db`'
+        '* SQLite database files: `.db`',
+        '',
+        '> **Note**: To import an existing  database file (`.db`), see instructions in [SQLite API reference](/versions/latest/sdk/sqlite/#import-an-existing-database).',
       ].join('\n'),
       default: '[]',
     },
-
-]}
+  ]}
 />
 
 ## API

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -47,11 +47,16 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
       description: [
         'An array of asset files or directories to link to the native project. The paths should be relative to the project root so that the file names, whether specified directly or using a directory, will become the resource names.',
         '',
-        'Supported file types are images, videos, sounds, SQLite database file, JSON, and Lottie animation (`.lottie`).',
+        'Supported file types:',
+        '* Images: `.png`, `.jpg`, `.gif`',
+        '* Media: `.mp4`, `.mp3`, `.lottie`',
+        '* SQLite database files: `.db`'
+
       ].join('\n'),
       default: '[]',
     },
-  ]}
+
+]}
 />
 
 ## API


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-11786

# How

<!--
How did you build this feature or fix this bug and why?
-->

By documenting the config plugin example and properties in Expo Asset API reference. Changes applied to unversioned reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/asset/#configuration-in-appjsonappconfigjs

## Preview

![CleanShot 2024-04-17 at 23 05 11@2x](https://github.com/expo/expo/assets/10234615/3bb6bccf-3d6a-490e-8ad2-b776b41bf706)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
