### PR TITLE
[expo-updates][Android] fix possible NPE in launch asset DB query

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Android: Fix hard crash due to missing asset edge row. ([#28264](https://github.com/expo/expo/pull/28264) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.25.5 — 2024-04-24

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -38,6 +38,14 @@ abstract class AssetDao {
   abstract fun _unmarkUsedAssetsFromDeletion()
 
   @Query(
+    "UPDATE assets SET marked_for_deletion = 0 WHERE id IN (" +
+        " SELECT launch_asset_id" +
+        " FROM updates" +
+        " WHERE updates.keep);"
+  )
+  abstract fun _unmarkUsedLaunchAssetsFromDeletion()
+
+  @Query(
     "UPDATE assets SET marked_for_deletion = 0 WHERE relative_path IN (" +
       " SELECT relative_path" +
       " FROM assets" +
@@ -145,6 +153,7 @@ abstract class AssetDao {
     // this is safe since this is a transaction and will be rolled back upon failure
     _markAllAssetsForDeletion()
     _unmarkUsedAssetsFromDeletion()
+    _unmarkUsedLaunchAssetsFromDeletion()
     // check for duplicate rows representing a single file on disk
     _unmarkDuplicateUsedAssetsFromDeletion()
     val deletedAssets = _loadAssetsMarkedForDeletion()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -39,9 +39,9 @@ abstract class AssetDao {
 
   @Query(
     "UPDATE assets SET marked_for_deletion = 0 WHERE id IN (" +
-        " SELECT launch_asset_id" +
-        " FROM updates" +
-        " WHERE updates.keep);"
+      " SELECT launch_asset_id" +
+      " FROM updates" +
+      " WHERE updates.keep);"
   )
   abstract fun _unmarkUsedLaunchAssetsFromDeletion()
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -25,8 +25,8 @@ abstract class UpdateDao {
   @Query("SELECT * FROM updates WHERE id = :id;")
   abstract fun _loadUpdatesWithId(id: UUID): List<UpdateEntity>
 
-  @Query("SELECT assets.* FROM assets INNER JOIN updates ON updates.launch_asset_id = assets.id WHERE updates.id = :id;")
-  abstract fun _loadLaunchAsset(id: UUID): AssetEntity
+  @Query("SELECT assets.* FROM assets INNER JOIN updates ON updates.launch_asset_id = assets.id WHERE updates.id = :updateId;")
+  abstract fun _loadLaunchAssetForUpdate(updateId: UUID): AssetEntity?
 
   @Query("UPDATE updates SET keep = 1 WHERE id = :id;")
   abstract fun _keepUpdate(id: UUID)
@@ -67,10 +67,10 @@ abstract class UpdateDao {
     return if (updateEntities.isNotEmpty()) updateEntities[0] else null
   }
 
-  fun loadLaunchAsset(id: UUID): AssetEntity {
-    val assetEntity = _loadLaunchAsset(id)
-    assetEntity.isLaunchAsset = true
-    return assetEntity
+  fun loadLaunchAssetForUpdate(updateId: UUID): AssetEntity? {
+    return _loadLaunchAssetForUpdate(updateId)?.apply {
+      isLaunchAsset = true
+    }
   }
 
   @Insert

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
@@ -59,4 +59,6 @@ class UpdateEntity(
 
   @ColumnInfo(name = "failed_launch_count", defaultValue = "0")
   var failedLaunchCount = 0
+
+  fun debugInfo(): String = JSONObject(mapOf("id" to id.toString(), "status" to status.name)).toString()
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAware.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAware.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.selectionpolicy
 
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.db.enums.UpdateStatus
 import org.json.JSONObject
 
 /**
@@ -50,6 +51,8 @@ class ReaperSelectionPolicyFilterAware : ReaperSelectionPolicy {
     } else if (nextNewestUpdate != null) {
       updatesToDelete.remove(nextNewestUpdate)
     }
-    return updatesToDelete
+
+    // don't delete embedded update
+    return updatesToDelete.filter { it.status != UpdateStatus.EMBEDDED }
   }
 }


### PR DESCRIPTION
# Why

A customer with a large user base is seeing occasional errors happening when the query to return the launch asset from the DB returns null.

This fix will not prevent the errors from happening, but will gracefully produce a callback failure if it does occur. It also applies possible band-aids to places where this could be caused.

Fixes #28168.

Closes ENG-12190.

# How

- Make the result of the DB query nullable, and add code to check for this and call `callback.onFailure()` if it occurs.
- Don't reap embedded updates
- Don't delete assets that are referenced by direct foreign key

# Test Plan

We don't have a repro for this so we're taking guesses mostly. What we do know is that when this happens the emergency launch mechanism will kick in and the embedded update will be launched. Whether this is better than crashing is up for debate.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
