### PR TITLE
[expo-calendar] [iOS] Don't check calendar permissions for saving reminders, and fix missing details when saving calendar events

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Don't check calendar permissions for saving reminders, and fix missing details when saving calendar events. ([#28265](https://github.com/expo/expo/pull/28265) by [@robertying](https://github.com/robertying))
 - Fix the problem that stringifyDateValues is not compatible with simple type arrays. ([#27147](https://github.com/expo/expo/pull/27147) by [@XHFkindergarten](https://github.com/XHFkindergarten))
 
 ### 💡 Others

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -49,7 +49,15 @@ public class CalendarModule: Module {
     }
 
     AsyncFunction("saveCalendarAsync") { (details: CalendarRecord) -> String in
-      try checkCalendarPermissions()
+      switch details.entityType {
+        case .event:
+          try checkCalendarPermissions()
+        case .reminder:
+          try checkRemindersPermissions()
+        case .none:
+          break
+      }
+
       let calendar = try getCalendar(from: details)
       try eventStore.saveCalendar(calendar, commit: true)
       return calendar.calendarIdentifier
@@ -128,7 +136,7 @@ public class CalendarModule: Module {
       if let startDate = event.startDate {
         calendarEvent.startDate = parse(date: startDate)
       }
-      if let endDate = event.startDate {
+      if let endDate = event.endDate {
         calendarEvent.endDate = parse(date: endDate)
       }
 
@@ -438,6 +446,7 @@ public class CalendarModule: Module {
     }
 
     calendar.title = record.title
+    calendar.cgColor = EXUtilities.uiColor(record.color)?.cgColor
 
     return calendar
   }
@@ -462,6 +471,7 @@ public class CalendarModule: Module {
 
     let calendarEvent = EKEvent(eventStore: eventStore)
     calendarEvent.calendar = calendar
+    calendarEvent.title = event.title
     calendarEvent.location = event.location
     calendarEvent.notes = event.notes
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -50,12 +50,12 @@ public class CalendarModule: Module {
 
     AsyncFunction("saveCalendarAsync") { (details: CalendarRecord) -> String in
       switch details.entityType {
-        case .event:
-          try checkCalendarPermissions()
-        case .reminder:
-          try checkRemindersPermissions()
-        case .none:
-          break
+      case .event:
+        try checkCalendarPermissions()
+      case .reminder:
+        try checkRemindersPermissions()
+      case .none:
+        break
       }
 
       let calendar = try getCalendar(from: details)


### PR DESCRIPTION
# Why

expo-calendar is broken on iOS with the latest canary build. Issues I have found so far:

- Calendar event title and color is not being saved properly.
- Calendar event endDate is always the same as startDate.
- The module checks for calendar permissions even when saving reminders.

# How

Added the missing code and fixes.

# Test Plan

- Call `createEventAsync` or `createReminderAsync` with all the details and the correct events/reminders are saved in Calendar or Reminders.
- Request only for reminder permissions and try to call `createReminderAsync` doesn't throw with the missing permission error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
