### PR TITLE
[go] bump @shopify/react-native-skia to 1.2.1

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1380,7 +1380,7 @@ PODS:
     - React-Core
   - react-native-segmented-control (2.5.0):
     - React-Core
-  - react-native-skia (1.0.4):
+  - react-native-skia (1.2.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2418,7 +2418,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: c29d484f19c49ff19525a94105e4ab2c4d4ae273
   react-native-safe-area-context: 71e343069c879133ea9c194097261830f6d23478
   react-native-segmented-control: 712749e75728a736a2b8a7d7dbc8c2a3344b73e8
-  react-native-skia: 9ede31b12c287a93564a1b24db151749ae931eb4
+  react-native-skia: 4db83b2d44c0869de99b7bd00cf55b1235215224
   react-native-slider: ce295d2bf830a7990af05b0bd70ab28c133e230c
   react-native-webview: 684364aaf96cbfff9a7128ade10766ebb7d25c6f
   React-nativeconfig: cd40a0c8f2f9e7b28425b100eb7f2ac1797c5dbc

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -35,7 +35,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@shopify/flash-list": "1.6.4",
-    "@shopify/react-native-skia": "1.0.4",
+    "@shopify/react-native-skia": "1.2.1",
     "@stripe/stripe-react-native": "0.37.2",
     "@types/react-native": "~0.70.6",
     "date-fns": "^2.28.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -47,7 +47,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@shopify/flash-list": "1.6.4",
-    "@shopify/react-native-skia": "1.0.4",
+    "@shopify/react-native-skia": "1.2.1",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~51.0.0-unreleased",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.5.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "1.0.4",
+  "@shopify/react-native-skia": "1.2.1",
   "@shopify/flash-list": "1.6.4",
   "@sentry/react-native": "5.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,10 +3724,10 @@
     recyclerlistview "4.2.0"
     tslib "2.4.0"
 
-"@shopify/react-native-skia@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.0.4.tgz#17049742eed595ac2abc21c343dce5899e476f56"
-  integrity sha512-nRAtW4Xv54Eb774PPZXwgTQNevknZ/5JIh6DldzQ9te57TQbh9fP4en+6m7GK1qfN5HhC+6M8NOWdXDbd6YN4g==
+"@shopify/react-native-skia@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.2.1.tgz#9aa8a91ec0855230001e21194f771974d7de26c4"
+  integrity sha512-uTvii22umQHFgLty/K6w4yzuu3Xe6w9n6oa6+297FddCS1iZqQrk5XvOrQIYzFz+ycgI1RLtoWjL9bKrA9Hdjw==
   dependencies:
     canvaskit-wasm "0.39.1"
     react-reconciler "0.27.0"


### PR DESCRIPTION
# Why

update vendor module for sdk 51

# How

bump @shopify/react-native-skia@1.2.1

# Test Plan

ncl + skia

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
