### PR TITLE
[image][Android] Fix applying loading options conditionally

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -52,10 +52,8 @@ class ExpoImageModule : Module() {
           // We added `quality` and `downsample` to create the same cache key as in final image load.
           .encodeQuality(100)
           .downsample(NoopDownsampleStrategy)
-          .apply {
-            if (cachePolicy == CachePolicy.MEMORY) {
-              diskCacheStrategy(DiskCacheStrategy.NONE)
-            }
+          .customize(`when` = cachePolicy == CachePolicy.MEMORY) {
+            diskCacheStrategy(DiskCacheStrategy.NONE)
           }
           .listener(object : RequestListener<Drawable> {
             override fun onLoadFailed(

--- a/packages/expo-image/android/src/main/java/expo/modules/image/GlideExtensions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/GlideExtensions.kt
@@ -1,0 +1,56 @@
+package expo.modules.image
+
+import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.request.RequestOptions
+
+/**
+ * Conditionally applies the block to the RequestBuilder if the condition is true.
+ */
+fun <T> RequestBuilder<T>.customize(`when`: Boolean, block: RequestBuilder<T>.() -> RequestBuilder<T>): RequestBuilder<T> {
+  if (!`when`) {
+    return this
+  }
+
+  return block()
+}
+
+/**
+ * Conditionally applies the block to the RequestBuilder if the value is not null.
+ */
+inline fun <T, P> RequestBuilder<T>.customize(value: P?, block: RequestBuilder<T>.(P) -> RequestBuilder<T>): RequestBuilder<T> {
+  if (value == null) {
+    return this
+  }
+
+  return block(value)
+}
+
+/**
+ * Conditionally applies the block to the RequestOptions if the condition is true.
+ */
+inline fun RequestOptions.customize(`when`: Boolean, block: RequestOptions.() -> RequestOptions): RequestOptions {
+  if (!`when`) {
+    return this
+  }
+
+  return block()
+}
+
+/**
+ * Conditionally applies the block to the RequestOptions if the value is not null.
+ */
+inline fun <T> RequestOptions.customize(value: T?, block: RequestOptions.(T) -> RequestOptions): RequestOptions {
+  if (value == null) {
+    return this
+  }
+
+  return block(value)
+}
+
+fun <T> RequestBuilder<T>.apply(options: RequestOptions?): RequestBuilder<T> {
+  if (options == null) {
+    return this
+  }
+
+  return apply(options)
+}


### PR DESCRIPTION
# Why

Fixes how we apply loading options conditionally.

# How

Glide can copy `ReaquestBuilder` or `RequestOptions` when applying some options. It didn't happen in our case, but I would like to avoid weird bugs in the future, so I've changed how we add some options conditionally based on the user inputs. Now, we're always using the reference returned from `Glide` rather than using the old builder when constructing a new request. 

# Test Plan

- NCL ✅ 
