### PR TITLE
[image][Android] Clean blurhash cache when the memory is running low

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Use `typeof window` checks for removing server code. ([#27514](https://github.com/expo/expo/pull/27514) by [@EvanBacon](https://github.com/EvanBacon))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - [iOS] Bump SDWebImageWebPCoder to `0.14.6`. ([#28273](https://github.com/expo/expo/pull/28273) by [@alanjhughes](https://github.com/alanjhughes))
-- Automatically clean blurhash cache when the app's memory is running low.
+- Automatically clean blurhash cache when the app's memory is running low. ([#28276](https://github.com/expo/expo/pull/28276) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.11.0 — 2024-02-05
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Use `typeof window` checks for removing server code. ([#27514](https://github.com/expo/expo/pull/27514) by [@EvanBacon](https://github.com/EvanBacon))
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - [iOS] Bump SDWebImageWebPCoder to `0.14.6`. ([#28273](https://github.com/expo/expo/pull/28273) by [@alanjhughes](https://github.com/alanjhughes))
+- Automatically clean blurhash cache when the app's memory is running low.
 
 ## 1.11.0 — 2024-02-05
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageComponentCallbacks.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageComponentCallbacks.kt
@@ -1,0 +1,22 @@
+package expo.modules.image
+
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+import expo.modules.image.blurhash.BlurhashDecoder
+
+/**
+ * Clears the Blurhash cache when the memory is low.
+ */
+object ExpoImageComponentCallbacks : ComponentCallbacks2 {
+  override fun onConfigurationChanged(newConfig: Configuration) = Unit
+
+  override fun onLowMemory() {
+      BlurhashDecoder.clearCache()
+  }
+
+  override fun onTrimMemory(level: Int) {
+    if (level == ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+      onLowMemory()
+    }
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -31,6 +31,14 @@ class ExpoImageModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoImage")
 
+    OnCreate {
+      appContext.reactContext?.registerComponentCallbacks(ExpoImageComponentCallbacks)
+    }
+
+    OnDestroy {
+      appContext.reactContext?.unregisterComponentCallbacks(ExpoImageComponentCallbacks)
+    }
+
     AsyncFunction("prefetch") { urls: List<String>, cachePolicy: CachePolicy, headersMap: Map<String, String>?, promise: Promise ->
       val context = appContext.reactContext ?: return@AsyncFunction false
 


### PR DESCRIPTION
# Why

Automatically clean blurhash cache when the app's memory is running low.

# How

Glide is doing a similar thing, and we can assist by clearing the blurhash cache which appears to be increasing rapidly when decoding several images.

# Test Plan

- bare-expo ✅ 