### PR TITLE
[go] Add legacy camera to HomeActivity

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -18,6 +18,7 @@ import expo.modules.barcodescanner.BarCodeScannerModule
 import expo.modules.barcodescanner.BarCodeScannerPackage
 import expo.modules.blur.BlurModule
 import expo.modules.camera.CameraViewModule
+import expo.modules.camera.legacy.CameraViewLegacyModule
 import expo.modules.clipboard.ClipboardModule
 import expo.modules.constants.ConstantsModule
 import expo.modules.constants.ConstantsPackage
@@ -168,6 +169,7 @@ open class HomeActivity : BaseExperienceActivity() {
         BarCodeScannerModule::class.java,
         BlurModule::class.java,
         CameraViewModule::class.java,
+        CameraViewLegacyModule::class.java,
         ClipboardModule::class.java,
         ConstantsModule::class.java,
         DeviceModule::class.java,


### PR DESCRIPTION
# Why
After promoting `expo-camera/next` to stable and changing the class names, I forgot to add the legacy class to the `HomeActivity`s module list

# How
Add the class

# Test Plan
Expo go now runs correctly
