### PR TITLE
[ios][android] update @react-native-community/datetimepicker to 7.7.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1867,7 +1867,7 @@ PODS:
     - React-Core
   - RNCPicker (2.7.5):
     - React-Core
-  - RNDateTimePicker (7.6.4):
+  - RNDateTimePicker (7.7.0):
     - React-Core
   - RNFlashList (1.6.4):
     - React-Core
@@ -2634,7 +2634,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
-  RNDateTimePicker: 08f00a2c341bf96e4b30da15799fbdd4c5fa48a3
+  RNDateTimePicker: 4f3c4dbd4f908be32ec8c93f086e8924bd4a2e07
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 4d271a5d9178403bd8dae0d853e2be21cf53743c
   RNReanimated: 51b46231a6a323c1823d35676c55fa2347c5f52b

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "7.6.4",
+    "@react-native-community/datetimepicker": "7.7.0",
     "@react-native-community/netinfo": "11.3.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1679,7 +1679,7 @@ PODS:
     - React-Core
   - RNCPicker (2.7.5):
     - React-Core
-  - RNDateTimePicker (7.6.4):
+  - RNDateTimePicker (7.7.0):
     - React-Core
   - RNFlashList (1.6.4):
     - React-Core
@@ -2447,7 +2447,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
   RNCMaskedView: 090213d32d8b3bb83a4dcb7d12c18f0152591906
   RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
-  RNDateTimePicker: 08f00a2c341bf96e4b30da15799fbdd4c5fa48a3
+  RNDateTimePicker: 4f3c4dbd4f908be32ec8c93f086e8924bd4a2e07
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 4d271a5d9178403bd8dae0d853e2be21cf53743c
   RNReanimated: 51b46231a6a323c1823d35676c55fa2347c5f52b

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -23,7 +23,7 @@
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "^7.6.4",
+    "@react-native-community/datetimepicker": "^7.7.0",
     "@react-native-community/netinfo": "11.3.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "^0.3.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "1.23.1",
-    "@react-native-community/datetimepicker": "7.6.4",
+    "@react-native-community/datetimepicker": "7.7.0",
     "@react-native-community/netinfo": "11.3.1",
     "@react-native-community/slider": "4.5.2",
     "@react-native-masked-view/masked-view": "0.3.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^14.0.0",
   "@react-native-async-storage/async-storage": "1.23.1",
-  "@react-native-community/datetimepicker": "7.6.4",
+  "@react-native-community/datetimepicker": "7.7.0",
   "@react-native-masked-view/masked-view": "0.3.1",
   "@react-native-community/netinfo": "11.3.1",
   "@react-native-community/slider": "4.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,10 +3337,10 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@react-native-community/datetimepicker@7.6.4", "@react-native-community/datetimepicker@^7.6.4":
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.6.4.tgz#b11ae425a51234bab36ba88755cd2a430c53e862"
-  integrity sha512-mbnZ5xYl4d2dkWPumQD2mTbLrvMunxUQdbmu0CriOLn48Hy1dQLilQcFg3SfVynND0ydJXo5CRPyXWvUaVkrLQ==
+"@react-native-community/datetimepicker@7.7.0", "@react-native-community/datetimepicker@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.7.0.tgz#0d0162b0434c7b35883f8c5af846f35e23d045ec"
+  integrity sha512-nYzZy4DQLRFUzKJShWzRleCaebmCJfZ1lIcFmZgMXJoiVuGJNw3OIGHSWmHhPETh3OhP1RO3to882d7WmDIyrA==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Why
Updating for SDK51

# How
Bumped package versions 

# Test Plan
- Bare expo + NCL ✅
- Expo go + NCL ✅

