### PR TITLE
[image][Android] Fix `excludeAppGlideModule` flag

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -23,11 +23,15 @@ android {
 
     buildConfigField("boolean", "ALLOW_GLIDE_LOGS", project.properties.get("EXPO_ALLOW_GLIDE_LOGS", "false"))
   }
-}
 
-if (safeExtGet("excludeAppGlideModule", false)) {
-  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
-    exclude("**/ExpoImageAppGlideModule.kt")
+  sourceSets {
+    main {
+      java {
+        if (safeExtGet("excludeAppGlideModule", false)) {
+          exclude("**/ExpoImageAppGlideModule.kt")
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Fixes `excludeAppGlideModule` flag.
I think it has been broken since we updated the Kotlin version. It wasn't published, so I added nothing to the changelog.  

# Test Plan

- expo go ✅ 
- bare expo ✅ 