### PR TITLE
[android] update expo-template-bare-minimum MainApplication.kt

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -20,11 +20,11 @@ class MainApplication : Application(), ReactApplication {
   override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
         this,
         object : DefaultReactNativeHost(this) {
-          override fun getPackages(): List<ReactPackage> {
-            // Packages that cannot be autolinked yet can be added manually here, for example:
-            // packages.add(new MyReactNativePackage());
-            return PackageList(this).packages
-          }
+          override fun getPackages(): List<ReactPackage> =
+              PackageList(this).packages.apply {
+                // Packages that cannot be autolinked yet can be added manually here, for example:
+                // add(MyReactNativePackage())
+              }
 
           override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
 


### PR DESCRIPTION
# Why

- [Issue 28239](https://github.com/expo/expo/issues/28239)
- Stay up to date with react-native. Since react-native 0.73.2 the MainApplication.kt file has changed. [react-native reference](https://github.com/facebook/react-native/blob/v0.73.6/packages/react-native/template/android/app/src/main/java/com/helloworld/MainApplication.kt
)
# How
Changing the way `getPackages()` add new package

# Test Plan
Use it with `npx nexpo prebuild --skip-dependency-update react-native,react --no-install --platform=android`

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).