### PR TITLE
Update react-native-reanimated to 3.9.0-rc.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1892,7 +1892,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.9.0-rc.0):
+  - RNReanimated (3.9.0-rc.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2637,7 +2637,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 4f3c4dbd4f908be32ec8c93f086e8924bd4a2e07
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 4d271a5d9178403bd8dae0d853e2be21cf53743c
-  RNReanimated: 51b46231a6a323c1823d35676c55fa2347c5f52b
+  RNReanimated: b0e16e5938d510b2203a2195c4f1563de2a23e49
   RNScreens: 52f2565581af64b1b410d49784cf8342ed94ca28
   RNSVG: 55bf7e6e90717321191cde721072df87e9f8a024
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.74.0-rc.9",
     "react-native-gesture-handler": "~2.16.0",
     "react-native-pager-view": "6.2.3",
-    "react-native-reanimated": "~3.9.0-rc.0",
+    "react-native-reanimated": "~3.9.0-rc.1",
     "react-native-safe-area-context": "4.10.0-rc.1",
     "react-native-screens": "~3.31.0-rc.1",
     "react-native-svg": "15.2.0-rc.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1704,7 +1704,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.9.0-rc.0):
+  - RNReanimated (3.9.0-rc.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2376,7 +2376,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: 78909e01c02136071e1e884efea014c945c154ba
+  hermes-engine: 1b3b7ac76c699dc7773d2c50545fb8b8ce5cff81
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
@@ -2450,7 +2450,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 4f3c4dbd4f908be32ec8c93f086e8924bd4a2e07
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNGestureHandler: 4d271a5d9178403bd8dae0d853e2be21cf53743c
-  RNReanimated: 51b46231a6a323c1823d35676c55fa2347c5f52b
+  RNReanimated: b0e16e5938d510b2203a2195c4f1563de2a23e49
   RNScreens: 52f2565581af64b1b410d49784cf8342ed94ca28
   RNSVG: 55bf7e6e90717321191cde721072df87e9f8a024
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -73,7 +73,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.14.0",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.9.0-rc.0",
+    "react-native-reanimated": "~3.9.0-rc.1",
     "react-native-safe-area-context": "4.10.0-rc.1",
     "react-native-screens": "~3.31.0-rc.1",
     "react-native-svg": "15.2.0-rc.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -139,7 +139,7 @@
     "react-native-maps": "1.14.0",
     "react-native-pager-view": "6.2.3",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~3.9.0-rc.0",
+    "react-native-reanimated": "~3.9.0-rc.1",
     "react-native-safe-area-context": "4.10.0-rc.1",
     "react-native-screens": "~3.31.0-rc.1",
     "react-native-svg": "15.2.0-rc.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -89,7 +89,7 @@
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.14.0",
   "react-native-pager-view": "6.2.3",
-  "react-native-reanimated": "~3.9.0-rc.0",
+  "react-native-reanimated": "~3.9.0-rc.1",
   "react-native-screens": "~3.31.0-rc.1",
   "react-native-safe-area-context": "4.10.0-rc.1",
   "react-native-svg": "15.2.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16735,10 +16735,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~3.9.0-rc.0:
-  version "3.9.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.9.0-rc.0.tgz#f3178705ce76e14e887bf88cc92cfe25407aa5e8"
-  integrity sha512-wJdtA6//eDO1+vBFpmbO051NKog4yNQEHK9wpvc1gN8cu4v2sZbiJE+FvCzETG18x419LMZ3N5kxI+/JYHCdwg==
+react-native-reanimated@~3.9.0-rc.1:
+  version "3.9.0-rc.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.9.0-rc.1.tgz#af50c901ae5500b3a1d811f7ffd676af2907782b"
+  integrity sha512-/u1reKR6dIlirf4CXBTtjOLCT7XybPLIPB2xRgZyswptoDLRLX2BiBJS4ec0IZkT2gBv8QwSPqoDru1J8Z8lUQ==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-nullish-coalescing-operator" "^7.0.0-0"
@@ -18475,7 +18475,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18500,15 +18500,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18579,7 +18570,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18613,13 +18604,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -20801,7 +20785,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20823,15 +20807,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

New RC is out, it includes a fix for a crash when used with RN >0.74.0-rc.8

# How

Updated the dependency and reinstalled pods

# Test Plan

Works in bare-expo on both architectures