### PR TITLE
[expo] reexport expo-asset

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Removed deprecated backward compatible Gradle settings. ([#28083](https://github.com/expo/expo/pull/28083) by [@kudo](https://github.com/kudo))
 - [Android] Do not use the workaround in the `ReactActivityDelegateWrapper` `onActivityResult` method when using the new architecture. ([#28165](https://github.com/expo/expo/pull/28165) by [@alanjhughes](https://github.com/alanjhughes))
 - Introduced `onDidCreateDevSupportManager` handler to support error recovery from expo-updates. ([#28177](https://github.com/expo/expo/pull/28177) by [@kudo](https://github.com/kudo))
+- Re-export `expo-asset` for other libraries to integrate without adding `expo-asset` as dependencies.
 
 ## 50.0.14 - 2024-03-20
 

--- a/packages/expo/asset.d.ts
+++ b/packages/expo/asset.d.ts
@@ -1,0 +1,1 @@
+export * from 'expo-asset';

--- a/packages/expo/asset.js
+++ b/packages/expo/asset.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-asset');

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -23,6 +23,8 @@
     "expo-module.config.json",
     "metro-config.js",
     "metro-config.d.ts",
+    "asset.js",
+    "asset.d.ts",
     "config.js",
     "config.d.ts",
     "config-plugins.js",


### PR DESCRIPTION
# Why

for other library to integrate with expo-asset without adding expo-asset as its dependency.

# How

re-export `expo-asset` as `expo/asset`

# Test Plan

test on #28291

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
