### PR TITLE
[docs] add Jon's podcast, small tweak for talk tiles

### DIFF
--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -67,6 +67,13 @@ export const TALKS = [
 
 export const PODCASTS = [
   {
+    title: 'Expo EAS and 100 Snakes ',
+    event: 'Rocket Ship #038',
+    description: "Jon Samp",
+    videoId: "JKU9JC4nX1k",
+    link: "https://podcast.galaxies.dev/episodes/038-expo-eas-and-100-snakes-with-jon-samp"
+  },
+  {
     title: 'Expo Router & Universal React Native Apps',
     event: 'Rocket Ship #028',
     description: "Evan Bacon",

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -86,22 +86,24 @@ export const TalkGridCell = ({
     <A
       openInNewTab
       href={link ?? `https://www.youtube.com/watch?v=${videoId}`}
-      css={[cellStyle, cellAPIStyle, cellHoverStyle]}
+      css={[cellStyle, cellTalkStyle, cellHoverStyle]}
       className={className}
       isStyled>
-      <div
-        style={{
-          backgroundImage: `url(${
-            thumbnail
-              ? `/static/thumbnails/${thumbnail}`
-              : `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`
-          })`,
-        }}
-        className="border-b border-b-default bg-cover bg-center h-[138px]"
-      />
-      <div css={cellTitleWrapperStyle} className="!py-3 gap-1">
-        <LABEL className="block leading-normal">{title}</LABEL>
-        <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />
+      <div>
+        <div
+          style={{
+            backgroundImage: `url(${
+              thumbnail
+                ? `/static/thumbnails/${thumbnail}`
+                : `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`
+            })`,
+          }}
+          className="border-b border-b-default bg-cover bg-center h-[138px]"
+        />
+        <div css={cellTitleWrapperStyle} className="!py-3 gap-1">
+          <LABEL className="block leading-normal">{title}</LABEL>
+          <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />
+        </div>
       </div>
       <div className="px-4 pb-2 bg-default flex flex-col gap-0.5">
         <CALLOUT theme="secondary" className="flex gap-2 items-center">
@@ -218,6 +220,15 @@ const cellAPIStyle = css({
   padding: 0,
   overflow: 'hidden',
   textDecoration: 'none',
+});
+
+const cellTalkStyle = css({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 266,
+  backgroundColor: theme.background.default,
+  justifyContent: 'space-between',
+  padding: 0,
 });
 
 const cellIconWrapperStyle = css({


### PR DESCRIPTION
# Why

Routinely update on podcasts with the team.

# How

Add the latets Jon's podcast, tweak talk tile component appearance and ensure minimal height.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-04-18 at 18 18 53](https://github.com/expo/expo/assets/719641/2e1668cb-c66c-4202-88e4-1efdaef38d8d)

