### PR TITLE
Add dependency array for useAnimatedStyle in tutorial

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -144,7 +144,7 @@ const imageStyle = useAnimatedStyle(() => {
     width: withSpring(scaleImage.value),
     height: withSpring(scaleImage.value),
   };
-});
+}, [scaleImage]);
 ```
 
 Next, wrap the `<Animated.Image>` component that displays the sticker on the screen with the `<GestureDetector>` component and modify the `style` prop on the `Animated.Image` to pass the `imageStyle`.
@@ -269,7 +269,7 @@ const containerStyle = useAnimatedStyle(() => {
       },
     ],
   };
-});
+}, [translateX, translateY);
 ```
 
 Then add the `containerStyle` from the above snippet on the `<Animated.View>` component to apply the transform styles.

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -269,7 +269,7 @@ const containerStyle = useAnimatedStyle(() => {
       },
     ],
   };
-}, [translateX, translateY);
+}, [translateX, translateY]);
 ```
 
 Then add the `containerStyle` from the above snippet on the `<Animated.View>` component to apply the transform styles.


### PR DESCRIPTION
# Why
The web build of StickerSmash broke with an error message on my machine:

```useAnimatedStyle was used without a dependency array or Babel plugin. Please explicitly pass a dependency array, or enable the Babel/SWC plugin.```

![image](https://github.com/expo/expo/assets/40310772/78aeb843-d880-4e32-af22-f2baa1600deb)


An example of another issue similar to this one: https://github.com/react-navigation/react-navigation/issues/11483

# How

This change is what resolved the error for me.

# Test Plan

I tested this change on the web build of my StickerSmash tutorial project.

Here's a minimal repo with the changes if you have a test setup for the mobile platforms: https://github.com/FX-Wood/StickerSmash

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
