### PR TITLE
[tools] Fix publishing with node 20

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -112,9 +112,13 @@ export async function downloadPackageTarballAsync(
  * Creates a tarball from a package.
  */
 export async function packToTarballAsync(packageDir: string): Promise<PackResult> {
-  const [result] = await spawnJSONCommandAsync<PackResult[]>('npm', ['pack', '--json'], {
-    cwd: packageDir,
-  });
+  const [result] = await spawnJSONCommandAsync<PackResult[]>(
+    'npm',
+    ['pack', '--json', '--foreground-scripts=false'],
+    {
+      cwd: packageDir,
+    }
+  );
   return result;
 }
 

--- a/tools/src/publish-packages/tasks/packPackageToTarball.ts
+++ b/tools/src/publish-packages/tasks/packPackageToTarball.ts
@@ -31,7 +31,7 @@ export const packPackageToTarball = new Task<TaskArgs>(
           return;
         } catch (error) {
           step.fail();
-          logger.error(error.stderr);
+          logger.error(error);
           return Task.STOP;
         }
       },


### PR DESCRIPTION
# Why

We're hitting https://github.com/npm/cli/issues/7354 in our publish script now that we use node 20.

# How

Apply the workaround for now.

Also show a more full error when this fails for future failures if any.

# Test Plan

`et publish --canary --dry` and see it no longer gets stuck.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
