### PR TITLE
[docs] Enhance doubletap gesture in tutorial

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -125,6 +125,8 @@ const doubleTap = Gesture.Tap()
   .onStart(() => {
     if (scaleImage.value !== imageSize * 2) {
       scaleImage.value = scaleImage.value * 2;
+    } else {
+      scaleImage.value = Math.round(scaleImage.value / 2)
     }
   });
 ```


### PR DESCRIPTION
# Why

The doubletap gesture in the StickerSmash repository felt incomplete. After the first doubletap results in a 2x increase in size, subsequent doubletaps had no effect.

# How

This change makes it so that doubletap gestures on 'stickers' alternately enlarges and shrinks them. 

# Test Plan

I tested this on the web build of my StickerSmash project.

Perhaps there could be some float equality issues on mobile, but I don't have a test setup for that.

Here's a minimal repo for anyone with a mobile test setup: https://github.com/FX-Wood/StickerSmash
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
