### PR TITLE
Update app.json

### DIFF
--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -27,7 +27,13 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "expo-font",
+        {
+          "fonts": ["./assets/fonts/FontAwesome.ttf", "./assets/fonts/SpaceMono-Regular.ttf"]
+        }
+      ],
     ],
     "experiments": {
       "typedRoutes": true


### PR DESCRIPTION
# Why

I think this PR requires further discussion. Expo fonts seem to be broken when creating an app based on the `Navigation (TypeScript)` template. 

The issue arises when exporting a web application with `npx expo export -p web`. It does not appear the font assets are properly bundled on web output in the `/dist` folder. 

I'm serving my web application via Firebase Hosting. When deployed, it would result in the default error page described in this issue https://github.com/expo/vector-icons/issues/244 with vector icons. 

My changes include adding the FontAwesome.ttf file locally in my assets folder and adding the `expo-font` plugin + the path to local files. Once that was added, icons are now appearing in my web build fine. 

# How

Honestly don't know how I came this solution. Just a lot of random debugging and found a solution that works. applied it to two projects i have successfully. Expo 50 + expo-router. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
