### PR TITLE
[core] Fix bad access in EventEmitter on JSC

### DIFF
--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -209,56 +209,61 @@ void installClass(jsi::Runtime &runtime) {
   jsi::HostFunctionType addListenerHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
     jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
 
     // `this` might be an object that is representing a host object, in which case it's not possible to get the native state.
     // For native modules we need to unwrap it to get the object used under the hood by `LazyObject` host object.
-    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
+    const jsi::Object &emitter = LazyObject::unwrapObjectIfNecessary(runtime, thisObject);
 
-    addListener(runtime, thisObject, eventName, listener);
-    return createEventSubscription(runtime, eventName, thisObject, listener);
+    addListener(runtime, emitter, eventName, listener);
+    return createEventSubscription(runtime, eventName, emitter, listener);
   };
 
   jsi::HostFunctionType removeListenerHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
     jsi::Function listener = args[1].asObject(runtime).asFunction(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
 
     // Unwrap `this` object if it's a lazy object (e.g. native module).
-    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
+    const jsi::Object &emitter = LazyObject::unwrapObjectIfNecessary(runtime, thisObject);
 
-    removeListener(runtime, thisObject, eventName, listener);
+    removeListener(runtime, emitter, eventName, listener);
     return jsi::Value::undefined();
   };
 
   jsi::HostFunctionType removeAllListenersHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
 
     // Unwrap `this` object if it's a lazy object (e.g. native module).
-    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
+    const jsi::Object &emitter = LazyObject::unwrapObjectIfNecessary(runtime, thisObject);
 
-    removeAllListeners(runtime, thisObject, eventName);
+    removeAllListeners(runtime, emitter, eventName);
     return jsi::Value::undefined();
   };
 
   jsi::HostFunctionType emit = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
 
     // Unwrap `this` object if it's a lazy object (e.g. native module).
-    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
+    const jsi::Object &emitter = LazyObject::unwrapObjectIfNecessary(runtime, thisObject);
 
     // Make a new pointer that skips the first argument which is the event name.
     const jsi::Value *eventArgs = count > 1 ? &args[1] : nullptr;
 
-    emitEvent(runtime, thisObject, eventName, eventArgs, count - 1);
+    emitEvent(runtime, emitter, eventName, eventArgs, count - 1);
     return jsi::Value::undefined();
   };
 
   jsi::HostFunctionType listenerCountHost = [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
     std::string eventName = args[0].asString(runtime).utf8(runtime);
+    jsi::Object thisObject = thisValue.getObject(runtime);
 
     // Unwrap `this` object if it's a lazy object (e.g. native module).
-    const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
+    const jsi::Object &emitter = LazyObject::unwrapObjectIfNecessary(runtime, thisObject);
 
-    return jsi::Value((int)getListenerCount(runtime, thisObject, eventName));
+    return jsi::Value((int)getListenerCount(runtime, emitter, eventName));
   };
 
   // Added for compatibility with the old EventEmitter API.


### PR DESCRIPTION
# Why

The EventEmitter crashes with EXC_BAD_ACCESS on JSC on this line: https://github.com/expo/expo/blob/729a59e274675d83e2984335e0b964b5c00321f0/packages/expo-modules-core/common/cpp/EventEmitter.cpp#L87
It seems that in JSC the underlying pointer to `jsi::Object` is being invalidated on a call to `LazyObject::unwrapObjectIfNecessary`, apparently it's the `thisValue.getObject(runtime)` part.

To illustrate this better, this works:
```cpp
jsi::Object tmpObject = thisValue.getObject(runtime);
const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, tmpObject);
removeAllListeners(runtime, thisObject, eventName); // doesn't crash inside
```

but this doesn't:

```cpp
const jsi::Object &thisObject = LazyObject::unwrapObjectIfNecessary(runtime, thisValue.getObject(runtime));
removeAllListeners(runtime, thisObject, eventName); // EXC_BAD_ACCESS inside on hasNativeState
```
# How

Instead of passing `thisValue.getObject(runtime)` to the unwrap function as a reference to a temporary object, I'm assigning it beforehand that is safer and will not cause the underlying pointer invalidation.

# Test Plan

Followed steps described by Alek in the QA doc, i.e. opened an example for `expo-video` in NCL on JSC and then changed the source.