### PR TITLE
[create-expo] Add expo-template-default alias

### DIFF
--- a/packages/create-expo/src/legacyTemplates.ts
+++ b/packages/create-expo/src/legacyTemplates.ts
@@ -5,6 +5,11 @@ import { env } from './utils/env';
 
 export const LEGACY_TEMPLATES = [
   {
+    title: 'Default',
+    value: 'expo-template-default',
+    description: 'includes tools recommended for most app developers',
+  },
+  {
     title: 'Blank',
     value: 'expo-template-blank',
     description: 'a minimal app as clean as an empty canvas',
@@ -20,7 +25,6 @@ export const LEGACY_TEMPLATES = [
     value: 'expo-template-tabs',
     description: 'File-based routing with TypeScript enabled',
   },
-
   {
     title: 'Blank (Bare)',
     value: 'expo-template-bare-minimum',
@@ -34,11 +38,18 @@ export async function promptTemplateAsync() {
   if (env.CI) {
     throw new Error('Cannot prompt for template in CI');
   }
+
+  // Temporarily filter out the "expo-template-default" from the list of templates
+  // that we display in the prompt. Wwe can remove this filter once we release SDK 51.
+  const publicTemplates = LEGACY_TEMPLATES.filter(
+    (template) => template.value !== 'expo-template-default'
+  );
+
   const { answer } = await prompts({
     type: 'select',
     name: 'answer',
     message: 'Choose a template:',
-    choices: LEGACY_TEMPLATES,
+    choices: publicTemplates,
   });
 
   if (!answer) {


### PR DESCRIPTION
# Why

We're introducing a new template (https://github.com/expo/expo/pull/28270), and want to provide an alias for that in create-expo[-app]

# How

- Add `expo-template-default` to "legacy" templates list to support the `--template default`
- Hide this template from the prompt for now, because there is no SDK 50 version.

# Test Plan

I ran it locally using an alias that points to the build **create-expo/build/index.js**:

```
create-expod --template default@beta
```
