### PR TITLE
[tracking-transparency] Make test more resilient

### DIFF
--- a/packages/expo-tracking-transparency/plugin/src/__tests__/withTrackingTransparency-test.ts
+++ b/packages/expo-tracking-transparency/plugin/src/__tests__/withTrackingTransparency-test.ts
@@ -7,10 +7,13 @@ describe('Expo Tracking Transparency', () => {
         slug: 'testSlug',
         name: 'testName',
       })
-    ).toEqual({
+    ).toMatchObject({
       _internal: {
         pluginHistory: {
-          'expo-tracking-transparency': { name: 'expo-tracking-transparency', version: '3.3.0' },
+          'expo-tracking-transparency': {
+            name: 'expo-tracking-transparency',
+            version: expect.any(String),
+          },
         },
       },
       android: { permissions: ['com.google.android.gms.permission.AD_ID'] },


### PR DESCRIPTION
# Why

This test failed after publishing a new version.

# How

The test checks for an exact match of the package version. We don't want to update that and don't care about the version, that's not what this test is for, so we can pass the test as long as the version is any string.

# Test Plan

CI