### PR TITLE
[cli] Remove extra newline in Expo Go version prompt

### DIFF
--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -84,10 +84,9 @@ export class ExpoGoInstaller<IDevice> {
         initial: true,
         message: `Expo Go ${expectedExpoGoVersion} is recommended for SDK ${this.sdkVersion} (${
           deviceManager.name
-        }
-          is using ${installedExpoGoVersion}). ${learnMore(
-            'https://docs.expo.dev/get-started/expo-go/#sdk-versions'
-          )}. Install the recommended Expo Go version?`,
+        } is using ${installedExpoGoVersion}). ${learnMore(
+          'https://docs.expo.dev/get-started/expo-go/#sdk-versions'
+        )}. Install the recommended Expo Go version?`,
       });
 
       if (confirm) {


### PR DESCRIPTION
# Why

Fixes ENG-11750

# How

Remove newline