### PR TITLE
[docs] Add doc for fingerprint runtime version and CI/CD (beta)

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -344,6 +344,7 @@ const general = [
       makePage('eas-update/rollouts.mdx'),
       makePage('eas-update/rollbacks.mdx'),
       makePage('eas-update/asset-selection.mdx'),
+      makePage('eas-update/continuous-deployment.mdx'),
     ]),
     makeGroup('Reference', [
       makePage('eas-update/migrate-from-classic-updates.mdx'),

--- a/docs/pages/eas-update/continuous-deployment.mdx
+++ b/docs/pages/eas-update/continuous-deployment.mdx
@@ -1,0 +1,47 @@
+---
+title: Continuous Deployment
+description: Learn how to use the fingerprint runtime version for continuous deployment in production and during development.
+---
+
+> **info** This is available in beta for SDK 51 and not yet considered stable. Use may result in unexpected system behavior.
+
+## Concepts
+
+### Fingerprint runtime versioning
+
+The [`fingerprint` runtime version policy](/eas-update/runtime-versions/#fingerprint-runtime-version-policy) uses the `@expo/fingerprint` package to generate a hash of your project when making a build or publishing an update, and then uses that hash as the runtime version. The hash is calculated based on dependencies, custom native code, native project files, and configuration, amongst other things.
+
+By automatically calculating the runtime version, you don't have to be concerned about native layer compatibility with the JavaScript application when deploying updates to builds.
+
+## Continuous Integration (CI) and Continuous Deployment (CD)
+
+CI/CD for a React Native project dictates that every JS change (update) is deployed to all compatible builds over-the-air, and new builds are created when the runtime changes.
+
+It can be accomplished by performing roughly these steps:
+1. Run application tests, abort if tests fail.
+2. Calculate fingerprint for relevant platforms using the `npx expo-updates fingerprint:generate` command.
+3. Check for EAS builds with a runtime version equal to the fingerprint (`eas build:list --runtimeVersion <fingerprint>`). Create a new build if none exists yet.
+    - (optional) Submit to app stores for full continuous deployment. This has not yet been tested and is not recommended.
+4. Run `eas update` to publish an update for the current commit.
+
+### GitHub Actions
+
+Expo provides a [GitHub Action](https://github.com/expo/expo-github-action/tree/main/continuous-deploy-fingerprint) for performing the steps mentioned in the previous section within a GitHub Actions workflow.
+
+## Debugging fingerprint inconsistencies
+
+If you notice different fingerprints being generated across different machines or environments, it may mean that unanticipated files are being included in the hash calculation. `@expo/fingerprint` has a predetermined set of files to include/exclude for hash calculation, but often your project setup may require additional excludes. For projects that include native directories (**android** and **ios**) this is more common.
+
+We provide tools for identifying which files are causing fingerprint inconsistencies and mechanisms to exclude those files from fingerprint calculations for your project.
+
+To identify differences in fingerprints on different machines or environments:
+- When running fingerprint generation commands on each machine/environment (`npx expo-updates fingerprint:generate`), pass `--debug` flag.
+- Diff outputs from those command runs to determine files causing the difference. These tools may be helpful:
+    - [JSON Pretty Print](https://jsonformatter.org/json-pretty-print ) to format the output.
+    - [JSON Diff](https://www.jsondiff.com/) to compare the output and identify the files causing the discrepancies.
+
+To exclude files causing the differences, add them to the **.fingerprintignore** file as described in the [`@expo/fingerprint` README](https://www.npmjs.com/package/@expo/fingerprint).
+
+### Debugging with GitHub Actions
+
+Running the workflow in debug mode will automatically add the `--debug` flag to the commands run as part of the action, and the output will be available in the workflow run logs.

--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -100,7 +100,27 @@ It's important to know that this policy does require the developer to manage the
 
 Also, if you select a different native version between Android and iOS, you'll end up with builds and updates with separate runtime versions. When you publish an update, EAS CLI will detect that two updates are needed, and it will create two updates with the required runtime versions and publish them separately.
 
-### `"fingerprintExperimental"` runtime version policy (experimental)
+### `"fingerprint"` runtime version policy
+
+> **warning** The `fingerprint` runtime policy is still in beta as of SDK 51 and not yet considered stable. Use may result in unexpected EAS Update behavior.
+
+We provide the `"fingerprint"` runtime version policy for Expo projects that automatically calculates the runtime version for you, including through changes like SDK upgrades or adding custom native code.
+
+```json
+{
+  "expo": {
+    "runtimeVersion": {
+      "policy": "fingerprint"
+    }
+  }
+}
+```
+
+This policy works for both projects with and without custom native code. It works by using the `@expo/fingerprint` package to calculate the hash of your project during builds and updates to determine build-update compatibility (also known as the runtime).
+
+### `"fingerprintExperimental"` runtime version policy
+
+> **warning** `fingerprintExperimental`is deprecated and is removed from SDK 51 onwards.
 
 We provide the `"fingerprintExperimental"` runtime version policy for a project that has custom native code that may change between builds:
 
@@ -117,8 +137,6 @@ We provide the `"fingerprintExperimental"` runtime version policy for a project 
 This policy is well-suited for projects incorporating custom native code that require safe updates without native conflicts. Unlike the `"nativeVersion"` policy, the `"fingerprintExperimental"` option automatically scans your project's native dependencies to update the `"runtimeVersion"` accordingly.
 
 Enabling fingerprinting may lengthen build times, as the fingerprinting process can be resource-intensive.
-
-> **warning** Using the experimental `fingerprintExperimental` runtime policy may result in unexpected system behavior. This policy is still under active development as part of the `@expo/fingerprint` beta package, and its specifications may change in the future.
 
 ### `"sdkVersion"` runtime version policy (deprecated)
 


### PR DESCRIPTION
# Why

This adds documentation for the new `fingerprint` runtime version policy for expo-updates and how to use it to do CI/CD.

Closes ENG-11157.

# How

Add docs. Note that more changes are coming to the github action we provide to be up to date with this doc, but since it's in beta I think it's okay to order them this way to start dogfooding.

# Test Plan

Start docs server locally, go to page, proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
