### PR TITLE
[expo-updates][cli] Add --debug option to fingerprint:generate command

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add --debug option to fingerprint:generate command. ([#28311](https://github.com/expo/expo/pull/28311) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/cli/build/generateFingerprint.js
+++ b/packages/expo-updates/cli/build/generateFingerprint.js
@@ -37,6 +37,7 @@ const generateFingerprint = async (argv) => {
         // Types
         '--help': Boolean,
         '--platform': String,
+        '--debug': Boolean,
         // Aliases
         '-h': '--help',
     }, argv ?? []);
@@ -50,6 +51,7 @@ Generate fingerprint for use in expo-updates runtime version
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
+  --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `, 0);
     }
@@ -61,11 +63,12 @@ Generate fingerprint for use in expo-updates runtime version
     if (!['ios', 'android'].includes(platform)) {
         throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
+    const debug = args['--debug'];
     const projectRoot = (0, args_1.getProjectRoot)(args);
     let result;
     try {
         const workflow = await resolveWorkflowAsync(projectRoot, platform);
-        result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+        result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
     }
     catch (e) {
         throw new errors_1.CommandError(e.message);

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -12,6 +12,7 @@ export const generateFingerprint: Command = async (argv) => {
       // Types
       '--help': Boolean,
       '--platform': String,
+      '--debug': Boolean,
       // Aliases
       '-h': '--help',
     },
@@ -29,6 +30,7 @@ Generate fingerprint for use in expo-updates runtime version
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
+  --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `,
       0
@@ -45,12 +47,14 @@ Generate fingerprint for use in expo-updates runtime version
     throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
+  const debug = args['--debug'];
+
   const projectRoot = getProjectRoot(args);
 
   let result;
   try {
     const workflow = await resolveWorkflowAsync(projectRoot, platform);
-    result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true });
+    result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
   } catch (e: any) {
     throw new CommandError(e.message);
   }


### PR DESCRIPTION
# Why

This implements the flag as described in the debugging portion of https://github.com/expo/expo/pull/28310.

Closes ENG-12032.

# How

Add debug flag to output more verbose fingerprint debug info to this command, same as we have for the `runtimeversion:resolve` command.

# Test Plan

`yarn link expo-updates` in a project.
`npx expo-updates fingerprint:generate --platform ios --debug`, see full debug info.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
