### PR TITLE
[image] Exclude unimplemented functions from tests

### DIFF
--- a/apps/test-suite/tests/Image.js
+++ b/apps/test-suite/tests/Image.js
@@ -212,14 +212,16 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
     });
 
-    t.describe('generateBlurhashAsync', async () => {
-      t.it('returns a correct blurhash for url', async () => {
-        const result = await Image.generateBlurhashAsync(REMOTE_KNOWN_SOURCE.uri, [4, 3]);
-        t.expect(result).toBe(REMOTE_KNOWN_SOURCE.blurhash);
+    if (Platform.OS === 'ios') {
+      t.describe('generateBlurhashAsync', async () => {
+        t.it('returns a correct blurhash for url', async () => {
+          const result = await Image.generateBlurhashAsync(REMOTE_KNOWN_SOURCE.uri, [4, 3]);
+          t.expect(result).toBe(REMOTE_KNOWN_SOURCE.blurhash);
+        });
+        t.it('rejects on a missing url', async () => {
+          await throws(Image.generateBlurhashAsync(NON_EXISTENT_SOURCE.uri, [4, 3]));
+        });
       });
-      t.it('rejects on a missing url', async () => {
-        await throws(Image.generateBlurhashAsync(NON_EXISTENT_SOURCE.uri, [4, 3]));
-      });
-    });
+    }
   });
 }


### PR DESCRIPTION
# Why

Fixes bugs that were discovered during Android QA.
Exclude unimplemented functions from tests.
