### PR TITLE
[av][Android] Fix `HashMap cannot be cast to ReadableNativeMap` error

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
 - [Android] Fix memory leak connect with `AVManager`. ([#28159](https://github.com/expo/expo/pull/28159) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fix `HashMap cannot be cast to ReadableNativeMap` error on Android.
+- [Android] Fix `HashMap cannot be cast to ReadableNativeMap` error on Android. ([#28317](https://github.com/expo/expo/pull/28317) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [Android] Fix recording audio on Android after converting to Expo Modules ([#26657](https://github.com/expo/expo/pull/26657) by [@jpudysz](https://github.com/jpudysz))
 - [Android] Fix memory leak connect with `AVManager`. ([#28159](https://github.com/expo/expo/pull/28159) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix `HashMap cannot be cast to ReadableNativeMap` error on Android.
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManager.java
@@ -680,8 +680,7 @@ public class AVManager implements LifecycleEventListener, AudioManager.OnAudioFo
 
     removeAudioRecorder();
 
-    final ReadableNativeMap androidMap = (ReadableNativeMap) options.get(RECORDING_OPTIONS_KEY);
-    final ReadableArguments androidOptions = new MapArguments(androidMap.toHashMap());
+    final ReadableArguments androidOptions = options.getArguments(RECORDING_OPTIONS_KEY);
 
     final String filename = "recording-" + UUID.randomUUID().toString()
       + androidOptions.getString(RECORDING_OPTION_EXTENSION_KEY);


### PR DESCRIPTION
# Why

Fixed the `HashMap cannot be cast to ReadableNativeMap` error

# How

It was caused by changes in the way we convert legacy argument types.

# Test Plan

- NCL ✅ 
- test suite ✅ 