### PR TITLE
Fix expo image crash on data URIs

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed an issue where data URIs caused crashes on iOS16+.
 - Refactor web implementations of `useSourceSelection` to avoid unnecessary rerenders. ([#27569](https://github.com/expo/expo/pull/27569) by [@aleqsio](https://github.com/aleqsio))
 - Fixed an issue where `isBlurhashString` always returned `true` .([#27251](https://github.com/expo/expo/pull/27251) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix #available check to account for tvOS. ([#27272](https://github.com/expo/expo/pull/27272) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed an issue where data URIs caused crashes on iOS16+.
+- [iOS] Fixed an issue where data URIs caused crashes on iOS16+. ([#28320](https://github.com/expo/expo/pull/28320) by [@aleqsio](https://github.com/aleqsio))
 - Refactor web implementations of `useSourceSelection` to avoid unnecessary rerenders. ([#27569](https://github.com/expo/expo/pull/27569) by [@aleqsio](https://github.com/aleqsio))
 - Fixed an issue where `isBlurhashString` always returned `true` .([#27251](https://github.com/expo/expo/pull/27251) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix #available check to account for tvOS. ([#27272](https://github.com/expo/expo/pull/27272) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -256,19 +256,8 @@ public final class ImageView: ExpoView {
 
   private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
     let path: String? = {
-      if #available(iOS 16.0, tvOS 16.0, *) {
-        // .path() on iOS 16 will remove the leading slash
-#if os(tvOS)
-        // but it doesn't on tvOS 16 🙃
-        if let path = source.uri?.path() {
-          return String(path.dropFirst())
-        }
-        return nil
-#else
-        return source.uri?.path()
-#endif
-      }
-
+        // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
+        // It also crashes with EXC_BREAKPOINT when parsing data:image uris
       // manually drop the leading slash below iOS 16
       if let path = source.uri?.path {
         return String(path.dropFirst())

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -256,8 +256,8 @@ public final class ImageView: ExpoView {
 
   private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
     let path: String? = {
-        // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
-        // It also crashes with EXC_BREAKPOINT when parsing data:image uris
+      // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
+      // It also crashes with EXC_BREAKPOINT when parsing data:image uris
       // manually drop the leading slash below iOS 16
       if let path = source.uri?.path {
         return String(path.dropFirst())


### PR DESCRIPTION
# Why

I saw a crash (EXC_BREAKPOINT) occuring on "Image formats" screen due to the old code calling ".path()" with image data URIs.

# How

Used the <iOS16 fallback for all code paths instead.

# Test Plan

Tested that this fixes the crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
