### PR TITLE
[android][media-library] fix promise resolved twice

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed promise resolved twice on denied permission. ([#28323](https://github.com/expo/expo/pull/28323) by [@mathieupost](https://github.com/mathieupost))
+
 ### 💡 Others
 
 ## 16.0.0 — 2024-04-18

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -462,8 +462,9 @@ class MediaLibraryModule : Module() {
   ) = Action { permissionsWereGranted ->
     if (!permissionsWereGranted) {
       promise.reject(PermissionsException(ERROR_USER_DID_NOT_GRANT_WRITE_PERMISSIONS_MESSAGE))
+    } else {
+      block()
     }
-    block()
   }
 
   private inner class MediaStoreContentObserver(handler: Handler, private val mMediaType: Int) :


### PR DESCRIPTION

# Why

After https://github.com/expo/expo/pull/28212 was merged, the block in actionIfUserGrantedPermission was still executed even if permission was denied, resulting in the passed promise being resolved twice.

# How

The `block` is now only evaluated if permission was granted.

# Test Plan

By running the MediaLibrary tests in the bare-app, when rejecting the permission to modify assets, no log should appear about a promise being resolved twice.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
