### PR TITLE
[template] Fix reset script

### DIFF
--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -6,12 +6,13 @@
  * You can remove the `reset-project` script from package.json and safely delete this file after running it.
  */
 
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
-const oldDirPath = path.join(__dirname, "app");
-const newDirPath = path.join(__dirname, "app-example");
-const newAppDirPath = path.join(__dirname, "app");
+const root = path.join(__dirname, '../');
+const oldDirPath = path.join(root, 'app');
+const newDirPath = path.join(root, 'app-example');
+const newAppDirPath = path.join(root, 'app');
 
 const indexContent = `import { Text, View } from "react-native";
 
@@ -45,27 +46,27 @@ fs.rename(oldDirPath, newDirPath, (error) => {
   if (error) {
     return console.error(`Error renaming directory: ${error}`);
   }
-  console.log("/app moved to /app-example.");
+  console.log('/app moved to /app-example.');
 
   fs.mkdir(newAppDirPath, { recursive: true }, (error) => {
     if (error) {
       return console.error(`Error creating new app directory: ${error}`);
     }
-    console.log("New /app directory created.");
+    console.log('New /app directory created.');
 
-    const indexPath = path.join(newAppDirPath, "index.tsx");
+    const indexPath = path.join(newAppDirPath, 'index.tsx');
     fs.writeFile(indexPath, indexContent, (error) => {
       if (error) {
         return console.error(`Error creating index.tsx: ${error}`);
       }
-      console.log("app/index.tsx created.");
+      console.log('app/index.tsx created.');
 
-      const layoutPath = path.join(newAppDirPath, "_layout.tsx");
+      const layoutPath = path.join(newAppDirPath, '_layout.tsx');
       fs.writeFile(layoutPath, layoutContent, (error) => {
         if (error) {
           return console.error(`Error creating _layout.tsx: ${error}`);
         }
-        console.log("app/_layout.tsx created.");
+        console.log('app/_layout.tsx created.');
       });
     });
   });

--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -9,10 +9,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const currentDir = process.cwd();
-const oldDirPath = path.join(currentDir, 'app');
-const newDirPath = path.join(currentDir, 'app-example');
-const newAppDirPath = path.join(currentDir, 'app');
+const root = process.cwd();
+const oldDirPath = path.join(root, 'app');
+const newDirPath = path.join(root, 'app-example');
+const newAppDirPath = path.join(root, 'app');
 
 const indexContent = `import { Text, View } from "react-native";
 

--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -9,10 +9,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const root = path.join(__dirname, '../');
-const oldDirPath = path.join(root, 'app');
-const newDirPath = path.join(root, 'app-example');
-const newAppDirPath = path.join(root, 'app');
+const currentDir = process.cwd();
+const oldDirPath = path.join(currentDir, 'app');
+const newDirPath = path.join(currentDir, 'app-example');
+const newAppDirPath = path.join(currentDir, 'app');
 
 const indexContent = `import { Text, View } from "react-native";
 


### PR DESCRIPTION
# Why
The reset script currently looks for the `app` directory inside the `scripts` directory because we are using `__dirname` and fails.
 
# How
Added the path to the root and used that to create the other directory paths.

# Test Plan
The reset script completes successfully
