### PR TITLE
[iOS] Fix media library NSSortDescriptor

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash when passing `default` as sorting key.
 - [Android] Fixed crash on denied permission to modify assets. ([#28212](https://github.com/expo/expo/pull/28212) by [@mathieupost](https://github.com/mathieupost))
 
 ### 💡 Others

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix crash when passing `default` as sorting key.
+- [iOS] Fix crash when passing `default` as sorting key. ([#28328](https://github.com/expo/expo/pull/28328) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fixed crash on denied permission to modify assets. ([#28212](https://github.com/expo/expo/pull/28212) by [@mathieupost](https://github.com/mathieupost))
 
 ### 💡 Others

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -471,7 +471,9 @@ func prepareSortDescriptors(sortBy: [String]) throws -> [NSSortDescriptor] {
 
 private func sortDescriptor(from config: String) throws -> NSSortDescriptor? {
   let parts = config.components(separatedBy: " ")
-  let key = try convertSortByKey(parts[0])
+  guard let key = try convertSortByKey(parts[0]) else {
+    return nil
+  }
 
   var ascending = false
   if parts.count > 1 && parts[1] == "ASC" {


### PR DESCRIPTION
# Why

Fixes crash in media library: “Unsupported sort descriptor in fetch options”

# How

We don't construct an `NSSortDescriptor(key: nil...`.

# Test Plan

Tested in NCL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
