### PR TITLE
[image][ios] fix resizing animated images failing to preserve animation

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue where certain images would not animate at certain sizes on `iOS`. ([#28335](https://github.com/expo/expo/pull/28335) by [@fobos531](https://github.com/fobos531))
+
 ### 💡 Others
 
 ## 1.12.1 — 2024-04-19

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -147,6 +147,8 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
     return resize(image: image, toSize: size, scale: scale)
   }
 
+  // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
+  // so it should never happen in our case, but let's handle it gracefully.
   if let animatedImage = UIImage.animatedImage(with: resizedImages, duration: image.duration) {
     return animatedImage
   }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -133,7 +133,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
     // Performs a check for each frame being valid before resizing it
     if let frame = await image.animatedImageFrame(at: index) {
       let resizedImage = resize(image: frame, toSize: size, scale: scale)
-        resizedImages.append(resizedImage)
+      resizedImages.append(resizedImage)
     } else {
       print("Warning: Frame at index \(index) could not be loaded and will be skipped.")
       continue  // Skip null frames, but could also implement some error recovery logic here

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -136,16 +136,16 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
       return resize(image: frame, toSize: size, scale: scale)
     }.compactMap { $0 }
 
-   // Check if all frames were skipped or failed to load
-   if resizedFrames.isEmpty {
-     print("Error: All frames failed to load and/or were skipped.")
-     return resize(image: image, toSize: size, scale: scale)
-   }
+    // Check if all frames were skipped or failed to load
+    if resizedFrames.isEmpty {
+      print("Error: All frames failed to load and/or were skipped.")
+      return resize(image: image, toSize: size, scale: scale)
+    }
 
-   // Create the new animated image with the resized frames
-   if let newAnimatedImage = UIImage.animatedImage(with: resizedFrames, duration: image.duration) {
-     return newAnimatedImage
-   }
+    // Create the new animated image with the resized frames
+    if let newAnimatedImage = UIImage.animatedImage(with: resizedFrames, duration: image.duration) {
+      return newAnimatedImage
+    }
   } catch {
     print("Error during concurrent image resizing: \(error)")
   }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -143,6 +143,8 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
     }
 
     // Create the new animated image with the resized frames
+    // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
+    // so it should never happen in our case, but let's make sure to handle it gracefully.
     if let newAnimatedImage = UIImage.animatedImage(with: resizedFrames, duration: image.duration) {
       return newAnimatedImage
     }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -130,7 +130,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
   do {
     let resizedFrames = try await concurrentMap(0..<frameCount) { index -> UIImage? in
       guard let frame = await image.animatedImageFrame(at: index) else {
-        print("Warning: Frame at index \(index) could not be loaded and will be skipped.")
+        log.warn("Frame at index \(index) could not be loaded and will be skipped.")
         return nil
       }
       return resize(image: frame, toSize: size, scale: scale)
@@ -138,7 +138,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
 
     // Check if all frames were skipped or failed to load
     if resizedFrames.isEmpty {
-      print("Error: All frames failed to load and/or were skipped.")
+      log.error("All frames failed to load and/or were skipped.")
       return resize(image: image, toSize: size, scale: scale)
     }
 
@@ -149,7 +149,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
       return newAnimatedImage
     }
   } catch {
-    print("Error during concurrent image resizing: \(error)")
+    log.error("Error during concurrent image resizing: \(error)")
   }
 
   return resize(image: image, toSize: size, scale: scale)

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -134,17 +134,17 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
         return nil
       }
       return resize(image: frame, toSize: size, scale: scale)
-   }.compactMap { $0 }
+    }.compactMap { $0 }
 
    // Check if all frames were skipped or failed to load
    if resizedFrames.isEmpty {
-       print("Error: All frames failed to load and/or were skipped.")
-       return resize(image: image, toSize: size, scale: scale)
+     print("Error: All frames failed to load and/or were skipped.")
+     return resize(image: image, toSize: size, scale: scale)
    }
 
    // Create the new animated image with the resized frames
    if let newAnimatedImage = UIImage.animatedImage(with: resizedFrames, duration: image.duration) {
-       return newAnimatedImage
+     return newAnimatedImage
    }
   } catch {
     print("Error during concurrent image resizing: \(error)")

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -144,8 +144,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
   if resizedImages.isEmpty {
     print("Error: All frames failed to load and/or were skipped.")
 
-    // return the usual image
-    return image
+    return resize(image: image, toSize: size, scale: scale)
   }
 
   if let animatedImage = UIImage.animatedImage(with: resizedImages, duration: image.duration) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes https://github.com/expo/expo/issues/28183

# How

<!--
How did you build this feature or fix this bug and why?
-->

### Research:

When dealing with animated images (GIFs), `expo-image` uses a `createAnimatedIfNeeded` method to properly prepare the GIF for the display. While this is all good, the problem arises in the fact that while a `SDAnimatedImage` is in fact a subclass of `UIImage`, it looks like the `SDAnimatedImage` constructor completely "loses" the `images` information on the resulting `UIImage`, which is used by standard `UIImage` to determine whether the image is animated or not. This means that in 

`func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage` 

the check for `image.images` is essentially invalid since it is guaranteed that this member will ALWAYS be `nil`. The reason this issue was not discovered before is that when `processImage` is run, downscaling will not aways run, depending on user's prop configuration vs. defaults set by `expo-image` in terms of whether the image should be downscaled or not. In events when the downscaling is indeed run, the resizing logic is also run, which means that the check for `image.images` will fail, and the method will return a still image since the that's the fallback in that specific method. When downscaling does **not** run, even though `SDAnimatedImage` constructor "lost" data about `image.images` array, the image will still render correctly since it's still an `SDAnimatedImage` in the end and no additional processing is run, which means it is unlikely that a still `UIImage` will be returned.

### Solution:

Use SDWebImage's `sd_isAnimated` extension property on `UIImage` to check whether the image is animated within the `func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage` function. We can use this since AFAIK all code paths into this function will ensure we're dealing with an instance of a SDWebImage or some of its subclasses. If the image is animated, cast it to `SDAnimatedImage` and use its instance methods/properties to perform the frame resizing logic. 

Error recovery mechanisms:
- image not animated -> return still image (resized)
- image animated but some frames failed to resize -> return animated image but with only the frames that were successfully resized
- image animated but NONE of the frames got resized -> return still image (resized)
- image animated, some other error happened with resizing - return still image (resized)


I'm not sure whether there are any negative performance implications to my implementation, but it seems to work. Happy to adjust it if you have any feedback.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See middle and right image in first row - List of GIFs screen in NCL

Before:


https://github.com/expo/expo/assets/19533289/b2cdf022-2998-4af4-9f46-ec91053e8c80



After:


https://github.com/expo/expo/assets/19533289/316ccc57-99e5-456e-9f17-e566f7154355



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
