### PR TITLE
[core] fix AppContext null currentActivity

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `AppContext.onHostResume()` sometimes getting null `currentActivity` on Android. ([#28338](https://github.com/expo/expo/pull/28338) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 1.12.0 — 2024-04-18

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -417,6 +417,7 @@ class AppContext(
   override val currentActivity: Activity?
     get() {
       return activityProvider?.currentActivity
+        ?: (reactContext as? ReactApplicationContext)?.currentActivity
     }
 
 // endregion


### PR DESCRIPTION
# Why

close ENG-12055

# How

on new architecture mode, the legacy UIManagerModuleWrapper sometimes does not ready on time. this will cause the AppContext.onHostResume (Actvitiy.onResume) getting null Activity. this pr tries to get currentActivity from ReactContext as a fallback.

# Test Plan

this issue is only about 10% reproducible for me. the steps are
```sh
$ yarn create expo-app my-app -e with-canary-new-arch
$ cd my-app
$ yarn expo install expo-dev-client
$ yarn expo run:android
# open another terminal and keep running the following command until the redbox happens
$ adb uninstall com.example.withnewarch && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell am start -a android.intent.action.VIEW -d 'exp+my-app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081'
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
