### PR TITLE
[dev-client] fix deep linking launch error

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
@@ -56,7 +56,10 @@ class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHost: ReactHost?) 
 
   val hasInstance: Boolean
     get() {
-      return currentReactContext?.hasActiveReactInstance() ?: false
+      if (isBridgelessMode) {
+        return currentReactContext?.hasActiveReactInstance() ?: false
+      }
+      return reactNativeHost.hasInstance() && currentReactContext?.hasActiveReactInstance() ?: false
     }
 
   val devSupportManager: DevSupportManager?


### PR DESCRIPTION
# Why

fix dev-launcher error from starting with deep links (bridge mode)
<img src="https://github.com/expo/expo/assets/46429/1622dc12-176f-432c-8da9-a83801c352bf" width="60%">

# How

the `ReactHostWrapper.hasInstance` on bridge mode will create a ReactInstanceManager if it's not created. the behavior is not correct. we should check `ReactNativeHost.hasInstance()` first.

# Test Plan

```sh
$ yarn create expo -t blank@sdk-51 sdk51
$ cd sdk51
$ npx expo install expo-dev-client
$ npx expo run:android
# if it doesn't happen, keep running the following command until it happens. assumes the applicationId is com.example
$ adb uninstall com.example && adb install -r android/app/build/outputs/apk/debug/app-debug.apk && adb shell am start -a android.intent.action.VIEW -d 'exp+sdk51://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081'
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
