### PR TITLE
[font][iOS] Ignore some errors when registering a font

### DIFF
--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -50,7 +50,17 @@ internal func registerFont(_ font: CGFont) throws {
   var error: Unmanaged<CFError>?
 
   if !CTFontManagerRegisterGraphicsFont(font, &error), let error = error?.takeRetainedValue() {
-    throw FontRegistrationFailedException(error)
+    let fontError = CTFontManagerError(rawValue: CFErrorGetCode(error))
+
+    switch fontError {
+    case .alreadyRegistered, .duplicatedName:
+      // Ignore the error if:
+      // - this exact font instance was already registered or
+      // - another instance already registered with the same name (assuming it's most likely the same font anyway)
+      return
+    default:
+      throw FontRegistrationFailedException(error)
+    }
   }
 }
 


### PR DESCRIPTION
# Why

In brownfield apps (such as Expo Go) it is possible that multiple React instances try to register the same font. iOS sets an error when the font is already registered. I believe we can assume that it's most likely the exact same font, so we can just ignore this error.

It's worth to mention that since #28344 the chance to enter this switch case block is much smaller because module's `loadAsync` already unregisters font when the same font alias is used. It was higher with scoped font names as they were always different per project.

# How

Ignored [alreadyRegistered](https://developer.apple.com/documentation/coretext/ctfontmanagererror/alreadyregistered) and [duplicatedName](https://developer.apple.com/documentation/coretext/ctfontmanagererror/duplicatedname) errors

# Test Plan

Tested together with #28344 