### PR TITLE
[android][image-picker] fix getting filename and filesize from cropped images

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue where cropped images were not returning file size and file name on Android. ([#28352](https://github.com/expo/expo/pull/28352) by [@fobos531](https://github.com/fobos531))
+
 ### 💡 Others
 
 ## 15.0.0 — 2024-04-18

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
@@ -57,14 +57,15 @@ internal class MediaHandler(
     val exif = options.exif.takeIf { it }
       ?.let { exportedImage.exif(context.contentResolver) }
 
+    val fileData = getAdditionalFileData(sourceUri)
 
     return ImagePickerAsset(
       type = MediaType.IMAGE,
       uri = Uri.fromFile(outputFile).toString(),
       width = exportedImage.width,
       height = exportedImage.height,
-      fileName = outputFile.name,
-      fileSize = outputFile.length(),
+      fileName = fileData?.fileName ?: outputFile.name,
+      fileSize = fileData?.fileSize ?: outputFile.length(),
       mimeType = mimeType,
       base64 = base64,
       exif = exif,

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
@@ -57,15 +57,14 @@ internal class MediaHandler(
     val exif = options.exif.takeIf { it }
       ?.let { exportedImage.exif(context.contentResolver) }
 
-    val fileData = getAdditionalFileData(sourceUri)
 
     return ImagePickerAsset(
       type = MediaType.IMAGE,
       uri = Uri.fromFile(outputFile).toString(),
       width = exportedImage.width,
       height = exportedImage.height,
-      fileName = fileData?.fileName,
-      fileSize = fileData?.fileSize,
+      fileName = outputFile.name,
+      fileSize = outputFile.length(),
       mimeType = mimeType,
       base64 = base64,
       exif = exif,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes https://github.com/expo/expo/issues/27554

# How

<!--
How did you build this feature or fix this bug and why?
-->

It seems like the current method for fetching filename and file size via contentResolver method results in null values. However, it seems like accessing the File object directly that is acquired via outputFile produces the desired result both with cropped images and original images.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested on Pixel 8 Pro simulator with API 33. Untested on other API levels, but I believe this method should work on other API levels as well. Please let me know if that is not the case.

Note the filename and filesize values for both images with allowsEditing: false and allowsEditing: true

Before

https://github.com/expo/expo/assets/19533289/ca22ab26-1090-4198-9584-268903148d34

After


https://github.com/expo/expo/assets/19533289/0182fc8b-4b6a-49f2-9ed1-67dfb3e37b08




# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
