### PR TITLE
[docs] Add Links rule to avoid vague text in Vale and update other rules

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -54,6 +54,7 @@ swap:
   vscode: VS Code
   VSCode: VS Code
   wifi: Wi-Fi
+  wi-fi: Wi-Fi
   windows: Windows
   yarn: Yarn
   youtube: YouTube

--- a/docs/.vale/writing-styles/expo-docs/Gender.yml
+++ b/docs/.vale/writing-styles/expo-docs/Gender.yml
@@ -2,7 +2,13 @@ extends: existence
 message: "Don't use %s. Use gender-neutral language instead."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#use-gender-neutral-terms'
 ignorecase: false
-level: warning
+level: error
 tokens:
-  - he
-  - she
+  - he/she
+  - s/he
+  - \(s\)he
+  - \bhe\b
+  - \bhim\b
+  - \bhis\b
+  - \bshe\b
+  - \bher\b

--- a/docs/.vale/writing-styles/expo-docs/Gender.yml
+++ b/docs/.vale/writing-styles/expo-docs/Gender.yml
@@ -1,7 +1,7 @@
 extends: existence
-message: "Don't use %s. Use gender-neutral language instead."
+message: "Don't use '%s'. Use gender-neutral pronoun instead."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#use-gender-neutral-terms'
-ignorecase: false
+ignorecase: true
 level: error
 tokens:
   - he/she

--- a/docs/.vale/writing-styles/expo-docs/Gender.yml
+++ b/docs/.vale/writing-styles/expo-docs/Gender.yml
@@ -12,3 +12,7 @@ tokens:
   - \bhis\b
   - \bshe\b
   - \bher\b
+  - \bguy\b
+  - \bgal\b
+  - \guys\b
+  - \bgals\b

--- a/docs/.vale/writing-styles/expo-docs/Gender.yml
+++ b/docs/.vale/writing-styles/expo-docs/Gender.yml
@@ -14,5 +14,5 @@ tokens:
   - \bher\b
   - \bguy\b
   - \bgal\b
-  - \guys\b
+  - \bguys\b
   - \bgals\b

--- a/docs/.vale/writing-styles/expo-docs/Gender.yml
+++ b/docs/.vale/writing-styles/expo-docs/Gender.yml
@@ -2,7 +2,7 @@ extends: existence
 message: "Don't use '%s'. Use gender-neutral pronoun instead."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#use-gender-neutral-terms'
 ignorecase: true
-level: error
+level: warning
 tokens:
   - he/she
   - s/he

--- a/docs/.vale/writing-styles/expo-docs/Links.yml
+++ b/docs/.vale/writing-styles/expo-docs/Links.yml
@@ -7,18 +7,7 @@ nonword: true
 level: warning
 
 swap:
-  # For the word 'here' in Markdown and HTML links
   '\[here\]\(.*?\)': 'here'
   '<a\s*href\s*=\s*".*?".*?>\s*here\s*</a>': 'here'
-
-  # For the word 'this' in Markdown and HTML links
   '\[this\]\(.*?\)': 'this'
   '<a\s*href\s*=\s*".*?".*?>\s*this\s*</a>': 'this'
-
-  # # For the word 'page' in Markdown and HTML links
-  # '\[page\]\(.*?\)': 'page'
-  # '<a\s*href\s*=\s*".*?".*?>\s*page\s*</a>': 'page'
-
-  # # For the phrase 'this page' in Markdown and HTML links
-  # '\[this page\]\(.*?\)': 'this page'
-  # '<a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>': 'this page'

--- a/docs/.vale/writing-styles/expo-docs/Links.yml
+++ b/docs/.vale/writing-styles/expo-docs/Links.yml
@@ -1,0 +1,24 @@
+extends: substitution
+message: "Avoid vague text in links such as '%s' unless you can pair it with more descriptive text."
+link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#linking-to-other-docs'
+ignorecase: true
+scope: raw
+nonword: true
+level: warning
+
+swap:
+  # For the word 'here' in Markdown and HTML links
+  '\[here\]\(.*?\)': 'here'
+  '<a\s*href\s*=\s*".*?".*?>\s*here\s*</a>': 'here'
+
+  # For the word 'this' in Markdown and HTML links
+  '\[this\]\(.*?\)': 'this'
+  '<a\s*href\s*=\s*".*?".*?>\s*this\s*</a>': 'this'
+
+  # # For the word 'page' in Markdown and HTML links
+  # '\[page\]\(.*?\)': 'page'
+  # '<a\s*href\s*=\s*".*?".*?>\s*page\s*</a>': 'page'
+
+  # # For the phrase 'this page' in Markdown and HTML links
+  # '\[this page\]\(.*?\)': 'this page'
+  # '<a\s*href\s*=\s*".*?".*?>\s*this page\s*</a>': 'this page'

--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -22,7 +22,7 @@ recover or reset it. Now, you can opt-in to App Signing by Google Play and simpl
 
 From the Expo build process's perspective, there is no difference between whether an app is signed with an **upload certificate** or an **app signing key**. Either way, `eas build` will generate an **.apk** or **.aab** signed with the keystore currently associated with your application. If you want to generate an upload keystore manually, you can do that the same way you created your original keystore.
 
-See [here](https://developer.android.com/studio/publish/app-signing) to find more information about this process.
+See [Android's documentation](https://developer.android.com/studio/publish/app-signing) to find more information about this process.
 
 ### App signing by Google Play
 

--- a/docs/pages/archive/classic-updates/advanced-release-channels.mdx
+++ b/docs/pages/archive/classic-updates/advanced-release-channels.mdx
@@ -6,7 +6,7 @@ title: Advanced release channels
 
 ## Introduction
 
-For a quick introduction to release channels, read [this](./release-channels.mdx).
+For a quick introduction to release channels, [read this](./release-channels.mdx).
 
 When you publish your app by running `expo publish --release-channel staging`, it creates:
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -559,7 +559,7 @@ functions:
     # @end #
 ```
 
-Learn more about building and using custom TypeScript/JavaScript functions [here](/custom-builds/functions/).
+> [Learn more about building and using custom TypeScript/JavaScript functions](/custom-builds/functions/).
 
 ### `functions.[function_name].shell`
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -22,6 +22,8 @@ In this guide, you'll find information on creating a development build with EAS 
 
 You will need a React Native Android and/or iOS project that is configured to build with EAS Build. If you haven't configured your project yet, see [Create your first build](/build/setup/).
 
+We should add [this](/some-link) link [here](https://docs.expo.dev).
+
 ## Instructions
 
 The following instructions cover both Android and iOS and physical devices and emulators. You can use whichever instructions are relevant to your project. If you would prefer a video over text, skip to [Video walkthroughs](#video-walkthroughs).

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -22,8 +22,6 @@ In this guide, you'll find information on creating a development build with EAS 
 
 You will need a React Native Android and/or iOS project that is configured to build with EAS Build. If you haven't configured your project yet, see [Create your first build](/build/setup/).
 
-We should add [this](/some-link) link [here](https://docs.expo.dev).
-
 ## Instructions
 
 The following instructions cover both Android and iOS and physical devices and emulators. You can use whichever instructions are relevant to your project. If you would prefer a video over text, skip to [Video walkthroughs](#video-walkthroughs).

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -8,7 +8,7 @@ import { Tab, Tabs, TabsGroup } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
-> **warning** In SDK 50 and above, `metro` is the default bundler for web apps. The previous documentation for publishing with `webpack` is available [here](/archive/publishing-websites-webpack/).
+> **warning** In SDK 50 and above, `metro` is the default bundler for web apps. The previous [guide for publishing with `webpack` is available here](/archive/publishing-websites-webpack/).
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -65,7 +65,7 @@ In this section, let's discuss if it is possible to have a feature complete rich
 
 React Native allows nested `<Text>` components and allows them to be used as children of `<TextInput>` to render and edit styled text. It is synchronous with the new React Native architecture (the `onChange` event fires immediately after a new character is typed into the text input field).
 
-Unfortunately, the `<TextInput>` component is built towards working with regular text, and it only returns a string in it’s `onTextChange` callback. This is a significant limitation.
+Unfortunately, the `<TextInput>` component is built towards working with regular text, and it only returns a string in it's `onTextChange` callback. This is a significant limitation.
 
 Here is a quick example. Let's start by rendering a text input with the following bold text:
 
@@ -102,7 +102,7 @@ You can also wrap any native rich text editor using [Expo Modules](/modules/over
 
 > Rich text is usually represented using [abstract syntax trees](https://en.wikipedia.org/wiki/Abstract_syntax_tree). For example, a bullet list can be a node of type `bulleted-list` with several children of type `list-item`. You can convert both HTML and markdown to a suitable AST format.
 
-There is also an effort to port the lexical editor to Android and iOS and provide a React Native wrapper, track it [here](https://github.com/facebook/lexical/discussions/2410).
+There is also an effort to port the lexical editor to Android and iOS and provide a React Native wrapper, [track it here](https://github.com/facebook/lexical/discussions/2410).
 
 ## Summary
 

--- a/docs/pages/guides/troubleshooting-proxies.mdx
+++ b/docs/pages/guides/troubleshooting-proxies.mdx
@@ -9,7 +9,7 @@ description: Learn about troubleshooting proxies with a set of recommended tools
 
 ### Overview
 
-To run this in the local iOS Simulator while on your corporate wi-fi network, a local proxy manager is required. This local proxy application, named [Charles](http://charlesproxy.com), is what our iOS Dev Team uses. Meet Charles, and get to know him. He is your friend.
+To run this in the local iOS Simulator while on your corporate Wi-Fi network, a local proxy manager is required. You can use a local proxy application such as [Charles](http://charlesproxy.com).
 
 #### Open macOS network preferences
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -438,7 +438,7 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 }
 ```
 
-To upload the source map to Sentry, you must create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](/build-reference/variables/#using-secrets-in-environment-variables).
+To upload the source map to Sentry, you must create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your Sentry auth token [in your account's settings here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](/build-reference/variables/#using-secrets-in-environment-variables).
 
 > **warning** The Sentry auth token should be stored securely. Do not commit it to a public repository, and treat it as you would any other sensitive API key.
 

--- a/docs/pages/regulatory-compliance/privacy-shield.mdx
+++ b/docs/pages/regulatory-compliance/privacy-shield.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 ## Is Expo Privacy Shield certified?
 
-**Yes! [Here](https://www.privacyshield.gov/participant?id=a2zt00000004ooyAAA&status=Active) is our Privacy Shield participant page**.
+**Yes! [Here is our Privacy Shield participant page](https://www.privacyshield.gov/participant?id=a2zt00000004ooyAAA&status=Active)**.
 
 Because we are Privacy Shield certified, all of our users have the right to obtain our confirmation of whether we maintain personal information relating to you, and the right to access, correct, amend, or delete that data. Any requests for alteration of data should be sent to secure@expo.dev, and all requests **must come from the email associated with that Expo account**.
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -39,7 +39,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 }
 ```
 
-- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **merchantIdentifier**: iOS only. This is the [Apple merchant ID obtained here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
 
 ## Example

--- a/docs/pages/versions/v48.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/stripe.mdx
@@ -41,7 +41,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 }
 ```
 
-- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **merchantIdentifier**: iOS only. This is the [Apple merchant ID obtained here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
 
 ## Example

--- a/docs/pages/versions/v49.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/stripe.mdx
@@ -41,7 +41,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 }
 ```
 
-- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **merchantIdentifier**: iOS only. This is the [Apple merchant ID obtained here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
 
 ## Example

--- a/docs/pages/versions/v50.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/stripe.mdx
@@ -41,7 +41,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 }
 ```
 
-- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **merchantIdentifier**: iOS only. This is the [Apple merchant ID obtained here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
 
 ## Example


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR
- Adds a Links rule to avoid using vague text when adding a link in `.mdx` files.
- Fixes Gender rule.
- Add "wi-fi" as term to avoid in Concistency.
- 
- Fixes issues in doc files after adding and updating above rules.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running `yarn run lint-prose` locally in the docs repo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
