### PR TITLE
[docs] Add an example to enable `android.permissions` in Permissions guide

### DIFF
--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -15,7 +15,7 @@ Permissions in standalone and [development builds](/develop/development-builds/i
 
 Permissions are configured with the [`expo.android.permissions`](/versions/latest/config/app/#permissions) and [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) keys in your app config (**app.json**, **app.config.js**).
 
-Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `android.permissions` to add additional permissions that are not included by default in a library.
+Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `expo.android.permissions` to add additional permissions that are not included by default in a library.
 
 ```json app.json
 {

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -13,33 +13,29 @@ Permissions in standalone and [development builds](/develop/development-builds/i
 
 ## Android
 
-Permissions are configured with the [`expo.android.permissions`](/versions/latest/config/app/#permissions) and [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) keys in your app config (**app.json**, **app.config.js**).
+Permissions are configured with the [`android.permissions`](/versions/latest/config/app/#permissions) and [`android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) keys in your [app config](/workflow/configuration/).
 
-Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `expo.android.permissions` to add additional permissions that are not included by default in a library.
+Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `android.permissions` to add additional permissions that are not included by default in a library.
 
 ```json app.json
 {
-  "expo": {
-    "android": {
-      "permissions": ["android.permission.SCHEDULE_EXACT_ALARM"]
-    }
+  "android": {
+    "permissions": ["android.permission.SCHEDULE_EXACT_ALARM"]
   }
 }
 ```
 
-The only way to remove permissions that are added by package-level **AndroidManifest.xml** files is to block them with the [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) property. To do this, specify the **full permission name**. For example, if you want to remove the audio recording permissions added by `expo-av`:
+The only way to remove permissions that are added by package-level **AndroidManifest.xml** files is to block them with the [`android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) property. To do this, specify the **full permission name**. For example, if you want to remove the audio recording permissions added by `expo-av`:
 
 ```json app.json
 {
-  "expo": {
-    "android": {
-      "blockedPermissions": ["android.permission.RECORD_AUDIO"]
-    }
+  "android": {
+    "blockedPermissions": ["android.permission.RECORD_AUDIO"]
   }
 }
 ```
 
-- See [`expo.android.permissions`](/versions/latest/config/app/#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/prebuild#templates).
+- See [`android.permissions`](/versions/latest/config/app/#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/prebuild#templates).
 - Apps using _dangerous_ or _signature_ permissions without valid reasons **may be rejected by Google**. Ensure you follow the [Android permissions best practices](https://developer.android.com/training/permissions/usage-notes) when submitting your app.
 - [All available Android `Manifest.permissions`](https://developer.android.com/reference/android/Manifest.permission).
 
@@ -59,17 +55,15 @@ Modify **AndroidManifest.xml** to exclude specific permissions: add the `tools:n
 
 ## iOS
 
-Your iOS app can ask for system permissions from the user. For example, to use the device's camera, or access photos, Apple requires an explanation for how your app makes use of that data. Most packages will automatically provide a boilerplate reason for a given permission with [config plugins](/config-plugins/introduction/). These default messages will most likely need to be tailored to your specific use case in order for your app to be accepted by the App Store.
+Your iOS app can ask for system permissions from the user. For example, to use the device's camera or access photos, Apple requires an explanation for how your app makes use of that data. Most packages will automatically provide a boilerplate reason for a given permission with [config plugins](/config-plugins/introduction/). These default messages will most likely need to be tailored to your specific use case for your app to be accepted by the App Store.
 
-To set permission messages, use the [`expo.ios.infoPlist`](/versions/latest/config/app/#infoplist) key in your app config (**app.json**, **app.config.js**), for example:
+To set permission messages, use the [`ios.infoPlist`](/versions/latest/config/app/#infoplist) key in your [app config](/workflow/configuration/), for example:
 
 ```json app.json
 {
-  "expo": {
-    "ios": {
-      "infoPlist": {
-        "NSCameraUsageDescription": "This app uses the camera to scan barcodes on event tickets."
-      }
+  "ios": {
+    "infoPlist": {
+      "NSCameraUsageDescription": "This app uses the camera to scan barcodes on event tickets."
     }
   }
 }
@@ -79,17 +73,15 @@ Many of these properties are also directly configurable using the [config plugin
 
 ```json app.json
 {
-  "expo": {
-    "plugins": [
-      [
-        "expo-media-library",
-        {
-          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
-          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos."
-        }
-      ]
+  "plugins": [
+    [
+      "expo-media-library",
+      {
+        "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+        "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos."
+      }
     ]
-  }
+  ]
 }
 ```
 

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -7,7 +7,7 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 When developing a native app that requires access to potentially sensitive information on a user's device, such as their location or contacts, the app must request the user's permission first. For example, to access the user's media library, the app will need to run [`MediaLibrary.requestPermissionsAsync()`](/versions/latest/sdk/media-library#medialibraryrequestpermissionsasync).
 
-Permissions in standalone and [development builds](/develop/development-builds/introduction/) require native build-time configuration before they can be requested using runtime JavaScript code. This is not required when testing projects in the [Expo Go][expo-go] app.
+Permissions in standalone and [development builds](/develop/development-builds/introduction/) require native build-time configuration before they can be requested using runtime JavaScript code. This is not required when testing projects in the [Expo Go](https://expo.dev/go) app.
 
 > If you don't configure or explain the native permissions properly **it may result in your app getting rejected or pulled from the stores**.
 
@@ -15,9 +15,19 @@ Permissions in standalone and [development builds](/develop/development-builds/i
 
 Permissions are configured with the [`expo.android.permissions`](/versions/latest/config/app/#permissions) and [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) keys in your app config (**app.json**, **app.config.js**).
 
-Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**, so you won't often need to use `android.permissions` to add additional permissions.
+Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `android.permissions` to add additional permissions that are not included by default in a library.
 
-The only way to remove permissions that are added by package-level **AndroidManifest.xml** files is to block them with the [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) property. To do this, specify the **full permission name**; for example, if you want to remove the audio recording permissions added by `expo-av`:
+```json app.json
+{
+  "expo": {
+    "android": {
+      "permissions": ["android.permission.SCHEDULE_EXACT_ALARM"]
+    }
+  }
+}
+```
+
+The only way to remove permissions that are added by package-level **AndroidManifest.xml** files is to block them with the [`expo.android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) property. To do this, specify the **full permission name**. For example, if you want to remove the audio recording permissions added by `expo-av`:
 
 ```json app.json
 {
@@ -29,9 +39,9 @@ The only way to remove permissions that are added by package-level **AndroidMani
 }
 ```
 
-- See [`expo.android.permissions`](/versions/latest/config/app.mdx#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/prebuild#templates).
+- See [`expo.android.permissions`](/versions/latest/config/app/#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/prebuild#templates).
 - Apps using _dangerous_ or _signature_ permissions without valid reasons **may be rejected by Google**. Ensure you follow the [Android permissions best practices](https://developer.android.com/training/permissions/usage-notes) when submitting your app.
-- [All available Android Manifest.permissions](https://developer.android.com/reference/android/Manifest.permission).
+- [All available Android `Manifest.permissions`](https://developer.android.com/reference/android/Manifest.permission).
 
 <ConfigReactNative>
 
@@ -95,12 +105,10 @@ Add and modify the permission message values in **Info.plist** file directly. We
 
 ## Web
 
-On the web, permissions like the `Camera` and `Location` can only be requested from a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#When_is_a_context_considered_secure). For example, using `https://` or `http://localhost`. This limitation is similar to Android's manifest permissions and iOS's infoPlist usage messages and enforced to increase privacy.
+On the web, permissions like the `Camera` and `Location` can only be requested from a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#When_is_a_context_considered_secure). For example, using `https://` or `http://localhost`. This limitation is similar to Android's manifest permissions and iOS's **Info.plist** usage messages and is enforced to increase privacy.
 
 ## Resetting permissions
 
 Often you want to be able to test what happens when a user rejects permissions, to ensure your app reacts gracefully. An operating-system level restriction on both Android and iOS prohibits an app from asking for the same permission more than once (you can imagine how this could be annoying for the user to be repeatedly prompted for permissions after rejecting them). To test different flows involving permissions in development, you may need to uninstall and reinstall the native app.
 
-When testing in [Expo Go][expo-go], you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.
-
-[expo-go]: https://expo.dev/expo-go
+When testing in [Expo Go](https://expo.dev/go), you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-11394

# How

<!--
How did you build this feature or fix this bug and why?
-->
In Permissions guide:
- Add an example to showcase using `expo.android.permissions`.
![CleanShot 2024-04-22 at 02 00 59@2x](https://github.com/expo/expo/assets/10234615/3bda9b1f-a706-4654-ad36-d5f6435769e5)

- Fix minor verbiage issues and link to Expo Go landing page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/permissions/#android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
