### PR TITLE
[docs] Update Expo Go landing page links

### DIFF
--- a/docs/pages/archive/using-expo-client.mdx
+++ b/docs/pages/archive/using-expo-client.mdx
@@ -146,4 +146,4 @@ This method is the least reliable because there are several reasons that a `requ
 
 The `.expo.[js/json/ts/tsx]` extensions to provide Expo Go specific fallbacks are removed in favor of optional imports syntax. For more information, see [Migration off the expo file extension](https://expo.fyi/expo-extension-migration.md#after).
 
-[expo-go]: https://expo.dev/expo-go
+[expo-go]: https://expo.dev/go

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -56,7 +56,7 @@ You can also use [internal distribution](/build/internal-distribution) to share 
 
 ## Can I develop iOS apps on a Windows computer?
 
-Traditionally you needed a macOS to develop iOS apps, however, you can use [EAS Build](/build/introduction) to build your app in the cloud. You can also use [EAS Submit](/submit/introduction) to submit your app to the stores. Testing can be done on a physical iOS device using [Expo Go](https://expo.dev/expo-go) or a [development build](/develop/development-builds/introduction/).
+Traditionally you needed a macOS to develop iOS apps, however, you can use [EAS Build](/build/introduction) to build your app in the cloud. You can also use [EAS Submit](/submit/introduction) to submit your app to the stores. Testing can be done on a physical iOS device using [Expo Go](https://expo.dev/go) or a [development build](/develop/development-builds/introduction/).
 
 ## What versions of Android and iOS are supported by the Expo SDK?
 

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -321,6 +321,6 @@ You can _also_ open a URL by searching for it on the device's native browser. Fo
   href="https://reactnavigation.org/docs/configuring-links"
 />
 
-[expo-go]: https://expo.dev/expo-go
+[expo-go]: https://expo.dev/go
 [n-uri-scheme]: https://www.npmjs.com/package/uri-scheme
 [expo-linking]: /versions/latest/sdk/linking

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -103,4 +103,4 @@ Often you want to be able to test what happens when a user rejects permissions, 
 
 When testing in [Expo Go][expo-go], you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.
 
-[expo-go]: https://expo.dev/expo-go
+[expo-go]: https://expo.dev/go

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -103,4 +103,4 @@ Often you want to be able to test what happens when a user rejects permissions, 
 
 When testing in [Expo Go][expo-go], you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.
 
-[expo-go]: https://expo.dev/go
+[expo-go]: https://expo.dev/expo-go

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -21,7 +21,7 @@ Face detector does not recognize faces that aren't aligned with the interface (t
 
 ## Installation
 
-This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) because it has dependencies that break builds for iOS Simulators.
+This module is **not** available in the [Expo Go app](https://expo.dev/go) because it has dependencies that break builds for iOS Simulators.
 
 You can create a [development build](/develop/development-builds/create-a-build/) to work with this package.
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -78,8 +78,8 @@ urlScheme:
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+Google Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v48.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/in-app-purchases.mdx
@@ -17,7 +17,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-This library is **not** available in the [Expo Go app](https://expo.dev/expo-go) due to app store restrictions. You can create a [development build](/develop/development-builds/create-a-build/) to work with this library.
+This library is **not** available in the [Expo Go app](https://expo.dev/go) due to app store restrictions. You can create a [development build](/develop/development-builds/create-a-build/) to work with this library.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v48.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/stripe.mdx
@@ -80,8 +80,8 @@ urlScheme:
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+Google Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
@@ -21,7 +21,7 @@ Face detector does not recognize faces that aren't aligned with the interface (t
 
 ## Installation
 
-This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) because it has dependencies that break builds for iOS Simulators.
+This module is **not** available in the [Expo Go app](https://expo.dev/go) because it has dependencies that break builds for iOS Simulators.
 
 You can create a [development build](/develop/development-builds/create-a-build/) to work with this package.
 

--- a/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
@@ -19,7 +19,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-This library is **not** available in the [Expo Go app](https://expo.dev/expo-go) due to app store restrictions. You can create a [development build](/develop/development-builds/create-a-build/) to work with this library.
+This library is **not** available in the [Expo Go app](https://expo.dev/go) due to app store restrictions. You can create a [development build](/develop/development-builds/create-a-build/) to work with this library.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v49.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/stripe.mdx
@@ -80,8 +80,8 @@ urlScheme:
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+Google Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/facedetector.mdx
@@ -23,7 +23,7 @@ Face detector does not recognize faces that aren't aligned with the interface (t
 
 ## Installation
 
-This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) because it has dependencies that break builds for iOS Simulators.
+This module is **not** available in the [Expo Go app](https://expo.dev/go) because it has dependencies that break builds for iOS Simulators.
 
 You can create a [development build](/develop/development-builds/create-a-build/) to work with this package.
 

--- a/docs/pages/versions/v50.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/stripe.mdx
@@ -80,8 +80,8 @@ urlScheme:
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+Google Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v51.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/facedetector.mdx
@@ -21,7 +21,7 @@ Face detector does not recognize faces that aren't aligned with the interface (t
 
 ## Installation
 
-This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) because it has dependencies that break builds for iOS Simulators.
+This module is **not** available in the [Expo Go app](https://expo.dev/go) because it has dependencies that break builds for iOS Simulators.
 
 You can create a [development build](/develop/development-builds/create-a-build/) to work with this package.
 

--- a/docs/pages/versions/v51.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/stripe.mdx
@@ -78,8 +78,8 @@ urlScheme:
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+Google Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Google Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/go). To use Apple Pay, you must create a [development build](/develop/development-builds/create-a-build/). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -186,6 +186,6 @@ Alternatively, we also have a repo for [out-of-tree config plugins][config-plugi
 [native-modules]: /more/glossary-of-terms/#native-module
 [autolinking]: /more/glossary-of-terms#autolinking
 [eas]: /eas
-[expo-go]: https://expo.dev/expo-go
+[expo-go]: https://expo.dev/go
 [config-plugins]: /config-plugins/introduction/
 [expo-config]: /workflow/configuration/

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -101,7 +101,6 @@ Use Expo [development builds](/workflow/overview/#development-builds) for buildi
 
 The Expo Go app is an optional stepping stone towards development builds. You can use it to quickly test your app while you are developing it, but it does not include all of the native code required to support every library. You can check **React Native Directory** to find a library compatible with Expo Go by visiting the website and verifying that it has a "✔️ Expo Go" tag. You can also enable the [filter by Expo Go](https://reactnative.directory/?expoGo=true).
 
-
 To determine if a new dependency changes native project directories, you can check the following:
 
 - Does the library includes **android** or **ios** directories?
@@ -146,4 +145,4 @@ If the module is not supported in [Expo Go][expo-go], you can create a [developm
 />
 
 [expo-cli]: /more/expo-cli/
-[expo-go]: https://expo.dev/expo-go
+[expo-go]: https://expo.dev/go


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found a few places where the Expo Go landing page is not up to date and instead is using a redirect. This PR updates all the old Expo Go landing page links to the new one.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Going through each doc to find and update the link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
