### PR TITLE
[docs] Fix vale warning in Stripe SDK 51 reference

### DIFF
--- a/docs/pages/versions/v51.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/stripe.mdx
@@ -39,7 +39,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 }
 ```
 
-- **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
+- **merchantIdentifier**: iOS only. This is the [Apple merchant ID obtained here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
 
 ## Example


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #28354

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix Vale warning about vague link test usage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running `yarn run lint-prose` in docs repo locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
