### PR TITLE
[sqlite] bump sqlite to 3.45.3 and enable bytecodevtab

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -490,9 +490,10 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (14.0.1):
     - ExpoModulesCore
-    - sqlite3 (~> 3.42.0)
-    - sqlite3/fts (~> 3.42.0)
-    - sqlite3/fts5 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
+    - "sqlite3/bytecodevtab (~> 3.45.3+1)"
+    - "sqlite3/fts (~> 3.45.3+1)"
+    - "sqlite3/fts5 (~> 3.45.3+1)"
   - ExpoStoreReview (7.0.0):
     - ExpoModulesCore
   - ExpoSymbols (0.1.0):
@@ -560,7 +561,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
   - EXUpdates/Tests (0.25.0):
     - DoubleConversion
@@ -589,7 +590,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
   - EXUpdatesInterface (0.16.0):
     - ExpoModulesCore
@@ -1948,12 +1949,14 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.7.0)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
-  - sqlite3/fts (3.42.0):
+  - "sqlite3 (3.45.3+1)":
+    - "sqlite3/common (= 3.45.3+1)"
+  - "sqlite3/bytecodevtab (3.45.3+1)":
     - sqlite3/common
-  - sqlite3/fts5 (3.42.0):
+  - "sqlite3/common (3.45.3+1)"
+  - "sqlite3/fts (3.45.3+1)":
+    - sqlite3/common
+  - "sqlite3/fts5 (3.45.3+1)":
     - sqlite3/common
   - UMAppLoader (4.6.0)
   - Yoga (0.0.0)
@@ -2552,7 +2555,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 0f9a83ba905a36fa79902b03ab41563edc61ab36
   ExpoSMS: e38400dbf1ef759095d74a23c9948426c4561aa6
   ExpoSpeech: 95bab00c822d58b43175df0603d668c1b442be16
-  ExpoSQLite: 54b0d0500c2479b593205c6587af52b9401d126a
+  ExpoSQLite: bb6e0e3a203f378f50a2fdb7df129d4c6d780e56
   ExpoStoreReview: 84eae5d3898b70fc7392a7f571cd5619efce68b9
   ExpoSymbols: 493a6853c3e70354daf0b365bf609967094049c3
   ExpoSystemUI: b8430b38749b5bd67ff17198efc12de48c5bc704
@@ -2563,7 +2566,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: 9ec8d990273a4dc4821e18985dc31fce62449ac8
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
   EXTaskManager: 115302bd3342bc9bfa4271bdfe216ea66eb265a3
-  EXUpdates: cadf64a410728ab99f3fd5551bc502771591b1c9
+  EXUpdates: 6381cb42f462b78d558f55eaf7cab672164828ae
   EXUpdatesInterface: 9c4a15026e8434058e0fc0cc0418e667107e0edd
   FBLazyVector: 026c8f4ae67b06e088ae01baa2271ef8a26c0e8c
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
@@ -2645,7 +2648,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
+  sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
   UMAppLoader: f17a5ee8e85b536ace0fc254b447a37ed198d57e
   Yoga: ff1d575b119f510a5de23c22a794872562078ccf
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5

--- a/apps/expo-go/android/gradle.properties
+++ b/apps/expo-go/android/gradle.properties
@@ -29,6 +29,3 @@ hermesEnabled=true
 
 # Remove this workaround when upgrading to react-native@0.72.1
 kotlin.jvm.target.validation.mode=warning
-
-# Enable SQLite bytecode vtable support
-expo.sqlite.customBuildFlags=-DSQLITE_ENABLE_BYTECODE_VTAB

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -112,14 +112,6 @@ target 'Expo Go' do
         end
       end
 
-      # Enable SQLite bytecode vtable support
-      if pod_name == 'sqlite3'
-        target_installation_result.native_target.build_configurations.each do |config|
-          config.build_settings['OTHER_CFLAGS'] ||= ['$(inherited)']
-          config.build_settings['OTHER_CFLAGS'] << '-DSQLITE_ENABLE_BYTECODE_VTAB=1'
-        end
-      end
-
       if pod_name.end_with?('EXUpdates')
         target_installation_result.native_target.build_configurations.each do |config|
           config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -202,9 +202,10 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (14.0.1):
     - ExpoModulesCore
-    - sqlite3 (~> 3.42.0)
-    - sqlite3/fts (~> 3.42.0)
-    - sqlite3/fts5 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
+    - "sqlite3/bytecodevtab (~> 3.45.3+1)"
+    - "sqlite3/fts (~> 3.45.3+1)"
+    - "sqlite3/fts5 (~> 3.45.3+1)"
   - ExpoStoreReview (7.0.0):
     - ExpoModulesCore
   - ExpoSymbols (0.1.0):
@@ -272,7 +273,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
   - EXUpdates/Tests (0.25.0):
     - DoubleConversion
@@ -301,7 +302,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
   - EXUpdatesInterface (0.16.0):
     - ExpoModulesCore
@@ -1779,12 +1780,14 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.7.0)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
-  - sqlite3/fts (3.42.0):
+  - "sqlite3 (3.45.3+1)":
+    - "sqlite3/common (= 3.45.3+1)"
+  - "sqlite3/bytecodevtab (3.45.3+1)":
     - sqlite3/common
-  - sqlite3/fts5 (3.42.0):
+  - "sqlite3/common (3.45.3+1)"
+  - "sqlite3/fts (3.45.3+1)":
+    - sqlite3/common
+  - "sqlite3/fts5 (3.45.3+1)":
     - sqlite3/common
   - Stripe (23.26.0):
     - StripeApplePay (= 23.26.0)
@@ -2372,7 +2375,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 0f9a83ba905a36fa79902b03ab41563edc61ab36
   ExpoSMS: e38400dbf1ef759095d74a23c9948426c4561aa6
   ExpoSpeech: 95bab00c822d58b43175df0603d668c1b442be16
-  ExpoSQLite: 54b0d0500c2479b593205c6587af52b9401d126a
+  ExpoSQLite: bb6e0e3a203f378f50a2fdb7df129d4c6d780e56
   ExpoStoreReview: 84eae5d3898b70fc7392a7f571cd5619efce68b9
   ExpoSymbols: 493a6853c3e70354daf0b365bf609967094049c3
   ExpoSystemUI: b8430b38749b5bd67ff17198efc12de48c5bc704
@@ -2383,7 +2386,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: 9ec8d990273a4dc4821e18985dc31fce62449ac8
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
   EXTaskManager: 115302bd3342bc9bfa4271bdfe216ea66eb265a3
-  EXUpdates: a5650bbabf9c31cc51282472c65d783f4e69fbf7
+  EXUpdates: cf9d790dc53c696bc572f396fe8745699606320b
   EXUpdatesInterface: 9c4a15026e8434058e0fc0cc0418e667107e0edd
   FBLazyVector: 026c8f4ae67b06e088ae01baa2271ef8a26c0e8c
   FirebaseCore: 25c0400b670fd1e2f2104349cd3b5dcce8d9418f
@@ -2477,7 +2480,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
+  sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
   Stripe: e6f816be5a573f7ef45b82d9d843130154fd0269
   stripe-react-native: f1af0235d838495e0c209da6da321eb6f74b70b8
   StripeApplePay: d6ef43f2bf834463e1dcaaf4a61c681aec04990e
@@ -2491,6 +2494,6 @@ SPEC CHECKSUMS:
   Yoga: ff1d575b119f510a5de23c22a794872562078ccf
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 8e254aedd171796e47705c1b9624bb875f85115c
+PODFILE CHECKSUM: 08d42139077d6c9a60951d31532300d7f641d419
 
 COCOAPODS: 1.14.2

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - EASClient (0.11.0):
+  - EASClient (0.12.0):
     - ExpoModulesCore
-  - EASClient/Tests (0.11.0):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
-  - EXJSONUtils (0.12.0)
-  - EXJSONUtils/Tests (0.12.0)
-  - EXManifests (0.13.0):
-    - ExpoModulesCore
-  - EXManifests/Tests (0.13.0):
+  - EASClient/Tests (0.12.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - expo-dev-launcher (3.6.0):
+  - EXJSONUtils (0.13.0)
+  - EXJSONUtils/Tests (0.13.0)
+  - EXManifests (0.14.0):
+    - ExpoModulesCore
+  - EXManifests/Tests (0.14.0):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+  - expo-dev-launcher (4.0.1):
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 3.6.0)
+    - expo-dev-launcher/Main (= 4.0.1)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -41,7 +41,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Main (3.6.0):
+  - expo-dev-launcher/Main (4.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-launcher/Unsafe
@@ -69,7 +69,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Tests (3.6.0):
+  - expo-dev-launcher/Tests (4.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -101,7 +101,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Unsafe (3.6.0):
+  - expo-dev-launcher/Unsafe (4.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -128,10 +128,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu (4.5.1):
+  - expo-dev-menu (5.0.1):
     - DoubleConversion
-    - expo-dev-menu/Main (= 4.5.1)
-    - expo-dev-menu/ReactNativeCompatibles (= 4.5.1)
+    - expo-dev-menu/Main (= 5.0.1)
+    - expo-dev-menu/ReactNativeCompatibles (= 5.0.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -151,11 +151,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu-interface (1.7.0)
-  - expo-dev-menu-interface/Tests (1.7.0):
+  - expo-dev-menu-interface (1.8.1)
+  - expo-dev-menu-interface/Tests (1.8.1):
     - Nimble
     - Quick
-  - expo-dev-menu/Main (4.5.1):
+  - expo-dev-menu/Main (5.0.1):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu-interface
@@ -180,7 +180,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (4.5.1):
+  - expo-dev-menu/ReactNativeCompatibles (5.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -201,7 +201,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/SafeAreaView (4.5.1):
+  - expo-dev-menu/SafeAreaView (5.0.1):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -223,7 +223,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Tests (4.5.1):
+  - expo-dev-menu/Tests (5.0.1):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -248,7 +248,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/UITests (4.5.1):
+  - expo-dev-menu/UITests (5.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -271,7 +271,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Vendored (4.5.1):
+  - expo-dev-menu/Vendored (5.0.1):
     - DoubleConversion
     - expo-dev-menu/SafeAreaView
     - glog
@@ -293,17 +293,17 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoClipboard (5.0.0):
+  - ExpoClipboard (6.0.0):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (5.0.0):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
-  - ExpoFileSystem (16.0.1):
-    - ExpoModulesCore
-  - ExpoFileSystem/Tests (16.0.1):
+  - ExpoClipboard/Tests (6.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoModulesCore (1.11.2):
+  - ExpoFileSystem (17.0.0):
+    - ExpoModulesCore
+  - ExpoFileSystem/Tests (17.0.0):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+  - ExpoModulesCore (1.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -325,7 +325,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesCore/Tests (1.11.2):
+  - ExpoModulesCore/Tests (1.12.0):
     - DoubleConversion
     - ExpoModulesTestCore
     - glog
@@ -348,14 +348,14 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoModulesTestCore (0.17.0):
+  - ExpoModulesTestCore (0.18.0):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
     - Quick (~> 7.3.0)
     - React-hermes
-  - EXStructuredHeaders (3.7.0)
-  - EXStructuredHeaders/Tests (3.7.0)
-  - EXUpdates (0.24.3):
+  - EXStructuredHeaders (3.8.0)
+  - EXStructuredHeaders/Tests (3.8.0)
+  - EXUpdates (0.25.0):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -381,9 +381,9 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
-  - EXUpdates/Tests (0.24.3):
+  - EXUpdates/Tests (0.25.0):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -410,9 +410,9 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - sqlite3 (~> 3.42.0)
+    - "sqlite3 (~> 3.45.3+1)"
     - Yoga
-  - EXUpdatesInterface (0.15.0):
+  - EXUpdatesInterface (0.16.0):
     - ExpoModulesCore
   - FBLazyVector (0.74.0-rc.9)
   - fmt (9.1.0)
@@ -1593,9 +1593,9 @@ PODS:
     - React-perflogger (= 0.74.0-rc.9)
     - React-utils (= 0.74.0-rc.9)
   - SocketRocket (0.7.0)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
+  - "sqlite3 (3.45.3+1)":
+    - "sqlite3/common (= 3.45.3+1)"
+  - "sqlite3/common (3.45.3+1)"
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1841,19 +1841,19 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  EASClient: b550a8d3d3d9d1211ba71eabf789cb46c7e92b3c
-  EXJSONUtils: d138005ee11b84fc4e3bf7119a160034db5d5e20
-  EXManifests: 2355abd4aeacfb75eec5b43393c0aef9c2789fcf
-  expo-dev-launcher: 83f33847420011309008ea4cbf83a9c0d98c9f4b
-  expo-dev-menu: 3f87f2b892d4dd30f2ab3fe2a356a72fe0e3de11
-  expo-dev-menu-interface: 3c36b4d5032397e022958a2041afe91a130ea74c
-  ExpoClipboard: ecbf3edb5dcb460fdefca945923c38f8ad6c7859
-  ExpoFileSystem: d77b9a51d734890d4ce82a0fc7c4a10948a0be22
-  ExpoModulesCore: 39172e342cd3015c0b2ece5e71986d96211b21af
-  ExpoModulesTestCore: 0fe626daae71122fbc305d7fbb87b1afd283e4c5
-  EXStructuredHeaders: 3b8ec10c65a4607dc976b6cdfa5136d2ea2ece19
-  EXUpdates: b7e617f1c7f821ee96063f7ccaf6e877ef1f768d
-  EXUpdatesInterface: 431fbb833aefbc9b7252b24a6a563209ff94f87d
+  EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
+  EXJSONUtils: fe9e2688bdcbbd3adfd3323b19b0406c56acb471
+  EXManifests: 9099018ae9786e67a347c2f1e1441b8878774d1b
+  expo-dev-launcher: 462d558b8236351d4247a2f29cc26dfda1f5cae3
+  expo-dev-menu: bd8bf44b9f8d7296d2ec3f545d63e8b6026f2463
+  expo-dev-menu-interface: 4923b0bbaadd37467c511f7f875fd38d27685dc3
+  ExpoClipboard: 790ffdda543f33bf2aa97dfdb1a8477f4da7c299
+  ExpoFileSystem: 0830ca53664917b4b6cf43e4b52f616ebcd74aea
+  ExpoModulesCore: 754f151ea2715c9e5f6628d6f158be2287218a90
+  ExpoModulesTestCore: 3d1007a5db579e867829b0f9cd4be07e29cf7c0c
+  EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
+  EXUpdates: 6381cb42f462b78d558f55eaf7cab672164828ae
+  EXUpdatesInterface: 9c4a15026e8434058e0fc0cc0418e667107e0edd
   FBLazyVector: 7cdfba8b4fbe5a1d8ffade8c926ddcbd7ef7547f
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
@@ -1910,7 +1910,7 @@ SPEC CHECKSUMS:
   React-utils: ab1d0edc4d9725b9979c192ffd6062365c898d7b
   ReactCommon: 5448e997e7732e230daebf51eb9996727b4a66b9
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
+  sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
   Yoga: 86380678e6a08c6fa2215fd252543ff375d441d1
 
 PODFILE CHECKSUM: 784ae161137d8dda06e54cb14a2f2efb8933b69b

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Bumped SQLite version to 3.45.3 and enabled the [bytecodevtab](https://www.sqlite.org/bytecodevtab.html) feature. ([#28358](https://github.com/expo/expo/pull/28358) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -21,13 +21,13 @@ String toPlatformIndependentPath(File path) {
   return result
 }
 
-def SQLITE_VERSION = '3420000'
+def SQLITE_VERSION = '3450300'
 def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
 def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
 def SQLITE3_SRC_DIR = new File("$buildDir/sqlite3_src")
 
 def getSQLiteBuildFlags() {
-  def buildFlags = ''
+  def buildFlags = '-DSQLITE_ENABLE_BYTECODE_VTAB=1'
   if (findProperty('expo.sqlite.enableFTS') !== 'false') {
     buildFlags <<= '-DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
   }
@@ -89,7 +89,7 @@ def createNativeDepsDirectories = tasks.register('createNativeDepsDirectories') 
 
 def downloadSQLite = tasks.register('downloadSQLite', Download) {
   dependsOn(createNativeDepsDirectories)
-  src("https://www.sqlite.org/2023/sqlite-amalgamation-${SQLITE_VERSION}.zip")
+  src("https://www.sqlite.org/2024/sqlite-amalgamation-${SQLITE_VERSION}.zip")
   onlyIfNewer(true)
   overwrite(false)
   dest(new File(downloadsDir, "sqlite-amalgamation-${SQLITE_VERSION}.zip"))

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
-sqliteVersion = '3.42.0'
+sqliteVersion = '3.45.3+1'
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoSQLite'
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.dependency 'sqlite3', "~> #{sqliteVersion}"
+  s.dependency 'sqlite3/bytecodevtab', "~> #{sqliteVersion}"
   unless podfile_properties['expo.sqlite.enableFTS'] === 'false'
     s.dependency 'sqlite3/fts', "~> #{sqliteVersion}"
     s.dependency 'sqlite3/fts5', "~> #{sqliteVersion}"

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Bumped the underlying SQLite version to 3.45.3 on iOS. ([#28358](https://github.com/expo/expo/pull/28358) by [@kudo](https://github.com/kudo))
+
 ## 0.25.0 — 2024-04-18
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
-  s.dependency 'sqlite3', '~> 3.42.0'
+  s.dependency 'sqlite3', '~> 3.45.3+1'
 
   unless defined?(install_modules_dependencies)
     # `install_modules_dependencies` is defined from react_native_pods.rb.


### PR DESCRIPTION
# Why

since sqlite3.podspec `3.45.3+1` has the `sqlite3/bytecodevtab` subspec support. we can now enable `SQLITE_ENABLE_BYTECODE_VTAB` for all sqlite libs

# How

- bump sqlite to 3.45.3
- enable [bytecodevtab](https://www.sqlite.org/bytecodevtab.html) for sqlite

# Test Plan

launch expo-go/bare-expo and call the function to check whether `{"compile_options": "ENABLE_BYTECODE_VTAB"}` is existed
```ts
async function loadBuildFlagsAsync() {
  const db = await SQLite.openDatabaseAsync('test.db');
  const result = await db.getAllAsync<any>('PRAGMA compile_options');
  console.log('SQLite compile options:', result);
}
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
