### PR TITLE
[core] fix build.gradle backward compatibility for previous expo modules

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `AppContext.onHostResume()` sometimes getting null `currentActivity` on Android. ([#28338](https://github.com/expo/expo/pull/28338) by [@kudo](https://github.com/kudo))
+- Fixed backward compatibility in the **build.gradle** from third party Expo modules. ([#28359](https://github.com/expo/expo/pull/28359) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -39,9 +39,13 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
 }
 
 ext.applyKotlinExpoModulesCorePlugin = {
-  if (!project.plugins.hasPlugin('kotlin-android') && !project.plugins.hasPlugin('kotlin')) {
+  try {
+    // Tries to apply the kotlin-android plugin if the client project does not apply yet.
+    // On previous `applyKotlinExpoModulesCorePlugin`, it is inside the `project.buildscript` block.
+    // We cannot use `project.plugins.hasPlugin()` yet but only to try-catch instead.
     apply plugin: 'kotlin-android'
-  }
+  } catch (e) {}
+
   apply plugin: KotlinExpoModulesCorePlugin
 }
 


### PR DESCRIPTION
# Why

fix backward compatibility for previous expo modules.

# How

supposedly for #28083, previous expo modules are backward compatible and not necessary for any changes. but there is an error actually.

previous `applyKotlinExpoModulesCorePlugin()` is inside `buildscript {` and executed before any `apply plugins:` from build.gradle. the `project.plugins.hasPlugin` will always return false and will have error if `apply plugin: 'kotlin-android'` twice.

this pr uses try-catch to deal with the problem for that.

# Test Plan

```sh
$ yarn create expo-module
$ cd my-module/example
$ yarn add expo@next
$ npx expo prebuild -p android --clean
$ cd android
$ ./gradlew :app:assembleDebug
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
