### PR TITLE
fix(cli): enable API routes in folders starting with `.` characters

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `TypeError: osascript(...) is not a function` when pressing "j" to open JS debugger. ([#28315](https://github.com/expo/expo/pull/28315) by [@kudo](https://github.com/kudo))
+- Fix API routes in folders starting with `.` characters. ([#28366](https://github.com/expo/expo/pull/28366) by [@byCedric](https://github.com/byCedric))
 
 ## 0.18.0 — 2024-04-18
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/router-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/router-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { getAppRouterRelativeEntryPath } from '../router';
+import { getAppRouterRelativeEntryPath, getApiRoutesForDirectory } from '../router';
 
 jest.mock('resolve-from');
 
@@ -38,5 +38,24 @@ describe(getAppRouterRelativeEntryPath, () => {
       '/'
     );
     expect(getAppRouterRelativeEntryPath('/apps/demo/')).toBe('../../app');
+  });
+});
+
+describe(getApiRoutesForDirectory, () => {
+  it('returns api routes by glob pattern', () => {
+    vol.fromJSON(
+      {
+        'app/test.tsx': 'export default () => {}',
+        'app/test+api.tsx': 'export default () => {}',
+        'app/nested/route+api.tsx': 'export default () => {}',
+        'app/.well-known/test+api.tsx': 'export default () => {}',
+      },
+      '/project'
+    );
+    expect(getApiRoutesForDirectory('/project/app')).toEqual([
+      '/project/app/.well-known/test+api.tsx',
+      '/project/app/nested/route+api.tsx',
+      '/project/app/test+api.tsx',
+    ]);
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/router.ts
+++ b/packages/@expo/cli/src/start/server/metro/router.ts
@@ -73,6 +73,7 @@ export function getApiRoutesForDirectory(cwd: string) {
   return globSync('**/*+api.@(ts|tsx|js|jsx)', {
     cwd,
     absolute: true,
+    dot: true,
   });
 }
 
@@ -80,6 +81,7 @@ export function getApiRoutesForDirectory(cwd: string) {
 export function getRoutePaths(cwd: string) {
   return globSync('**/*.@(ts|tsx|js|jsx)', {
     cwd,
+    dot: true,
   }).map((p) => './' + normalizePaths(p));
 }
 


### PR DESCRIPTION
# Why

Fixes #28364

# How

Enables `dot` files & folders on the glob we do for API routes, e.g. `.well-known`.

# Test Plan

See #28364

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
