### PR TITLE
[image][iOS] Fix maintaining animated images duration after resizing

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed an issue where certain images would not animate at certain sizes on `iOS`. ([#28335](https://github.com/expo/expo/pull/28335) by [@fobos531](https://github.com/fobos531))
+- Fixed an issue where certain images would not animate at certain sizes on `iOS`. ([#28335](https://github.com/expo/expo/pull/28335) by [@fobos531](https://github.com/fobos531), [#28371](https://github.com/expo/expo/pull/28371) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/AnimatedImage.swift
+++ b/packages/expo-image/ios/AnimatedImage.swift
@@ -1,0 +1,37 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SDWebImage
+
+/**
+ Custom `SDAnimatedImage` that fixes issues with `images` and `duration` not being available.
+ */
+final class AnimatedImage: SDAnimatedImage {
+  var frames: [SDImageFrame]?
+
+  // MARK: - UIImage
+
+  override var images: [UIImage]? {
+    preloadAllFrames()
+    return frames?.map({ $0.image })
+  }
+
+  override var duration: TimeInterval {
+    preloadAllFrames()
+    return frames?.reduce(0, { $0 + $1.duration }) ?? 0.0
+  }
+
+  // MARK: - SDAnimatedImage
+
+  override func preloadAllFrames() {
+    if frames != nil {
+      return
+    }
+    frames = [UInt](0..<animatedImageFrameCount).compactMap { index in
+      guard let image = animatedImageFrame(at: index) else {
+        return nil
+      }
+      let duration = animatedImageDuration(at: index)
+      return SDImageFrame(image: image, duration: duration)
+    }
+  }
+}

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -129,6 +129,10 @@ public final class ImageView: ExpoView {
     context[.cacheKeyFilter] = createCacheKeyFilter(source.cacheKey)
     context[.imageTransformer] = createTransformPipeline()
 
+    // Tell SDWebImage to use our own class for animated formats,
+    // which has better compatibility with the UIImage and fixes issues with the image duration.
+    context[.animatedImageClass] = AnimatedImage.self
+
     // Assets from the bundler have `scale` prop which needs to be passed to the context,
     // otherwise they would be saved in cache with scale = 1.0 which may result in
     // incorrectly rendered images for resize modes that don't scale (`center` and `repeat`).
@@ -222,8 +226,7 @@ public final class ImageView: ExpoView {
       return
     }
 
-    // Create an SDAnimatedImage if needed then handle the image
-    if let image = createAnimatedIfNeeded(image: image, data: data) {
+    if let image {
       onLoad([
         "cacheType": cacheTypeToString(cacheType),
         "source": [
@@ -320,6 +323,7 @@ public final class ImageView: ExpoView {
 
     context[.imageScaleFactor] = placeholder.scale
     context[.cacheKeyFilter] = createCacheKeyFilter(placeholder.cacheKey)
+    context[.animatedImageClass] = AnimatedImage.self
 
     // Cache placeholders on the disk. Should we let the user choose whether
     // to cache them or apply the same policy as with the proper image?


### PR DESCRIPTION
# Why

Fixes a regression in the duration of animated images introduced by #28335 (described in https://github.com/expo/expo/issues/28183#issuecomment-2068200612)
Unfortunately, `SDAnimatedImage` doesn't handle `duration` and `images` properties from `UIImage` pretty well. 

# How

- Added our own `AnimatedImage` class that inherits from `SDAnimatedImage` and tries to maintain the duration of the original image
- Accordingly changed the `animatedImageClass` context option, so we'll be sure that the image that is returned from the load request will be its instance if the format supports animations
- Because of the above, we no longer need the `createAnimatedIfNeeded` function
- Some animated image resizing logic could be simplified too

# Test Plan

- Issues reported in https://github.com/expo/expo/issues/28183 seem to be solved
- GIFs in our examples are working as expected
- Other animated images (WebP, APNG, ...) work as well