### PR TITLE
[updates] fix error recovery e2e test

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -23,6 +23,7 @@ _This version does not introduce any user-facing changes._
 ### 💡 Others
 
 - Bumped the underlying SQLite version to 3.45.3 on iOS. ([#28358](https://github.com/expo/expo/pull/28358) by [@kudo](https://github.com/kudo))
+- Fixed error recovery E2E test on iOS. ([#28372](https://github.com/expo/expo/pull/28372) by [@kudo](https://github.com/kudo))
 
 ## 0.25.0 — 2024-04-18
 

--- a/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-error-recovery.e2e.ts
@@ -68,11 +68,13 @@ describe('Error recovery tests', () => {
     // launch and crash (restart from cache doesn't work in detox)
     // we don't check current update ID header or failed update IDs header since the behavior for this request is not defined
     // (we don't guarantee current update to be set during a crash or the launch failure to have been registered yet)
-    await jestExpect(
-      device.launchApp({
+    // Detox may or may not catch the crash, we don't expect the launch to succeed or fail in this case.
+    try {
+      await device.launchApp({
         newInstance: true,
-      })
-    ).rejects.toThrow();
+      });
+    } catch {}
+
     const request2 = await Server.waitForUpdateRequest(10000);
     const request2EmbeddedUpdateId = request2.headers['expo-embedded-update-id'];
     const request2CurrentUpdateId = request2.headers['expo-current-update-id'];


### PR DESCRIPTION
# Why

tries to fix error recovery e2e test error: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/d1b819e5-eed3-463a-92f1-b620e4bf6417

# How

detox does not reliable catch to crash and throw exception from launchApp. use try-catch and not make any assumption for the launchApp result

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
