### PR TITLE
[dev-menu] Fix JS Debugger not using the correct app target

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix JS Debugger not using the correct app target. ([#28373](https://github.com/expo/expo/pull/28373) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 5.0.1 — 2024-04-19

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.h
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.h
@@ -1,0 +1,18 @@
+  // Copyright 2018-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#if __has_include(<React-RCTAppDelegate/RCTRootViewFactory.h>)
+#import <React-RCTAppDelegate/RCTRootViewFactory.h>
+#elif __has_include(<React_RCTAppDelegate/RCTRootViewFactory.h>)
+// for importing the header from framework, the dash will be transformed to underscore
+#import <React_RCTAppDelegate/RCTRootViewFactory.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DevClientRootViewFactory : RCTRootViewFactory
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
@@ -1,0 +1,52 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#import "DevClientRootViewFactory.h"
+
+#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
+#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
+// for importing the header from framework, the dash will be transformed to underscore
+#import <React_RCTAppDelegate/RCTAppDelegate.h>
+#endif
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#import <reacthermes/HermesExecutorFactory.h>
+#endif
+
+#import <React/RCTCxxBridgeDelegate.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+
+@interface RCTRootViewFactory () <RCTCxxBridgeDelegate> {
+  std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;
+}
+@end
+
+@implementation DevClientRootViewFactory
+
+
+- (void)createBridgeIfNeeded:(NSDictionary *)launchOptions
+{
+  if (self.bridge != nil) {
+    return;
+  }
+
+  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+}
+
+#pragma mark - RCTCxxBridgeDelegate
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  std::unique_ptr<facebook::react::JSExecutorFactory> executorFactory  = [super jsExecutorFactoryForBridge:bridge];
+
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+  auto rawExecutorFactory = executorFactory.get();
+  auto hermesExecFactory = dynamic_cast<facebook::react::HermesExecutorFactory*>(rawExecutorFactory);
+  if (hermesExecFactory != nullptr) {
+    hermesExecFactory->setEnableDebugger(false);
+  }
+#endif
+
+  return executorFactory;
+}
+
+@end

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
@@ -23,7 +23,6 @@
 
 @implementation DevClientRootViewFactory
 
-
 - (void)createBridgeIfNeeded:(NSDictionary *)launchOptions
 {
   if (self.bridge != nil) {

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.mm
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.mm
@@ -123,9 +123,6 @@
 
 @interface DevClientAppDelegate (DevMenuRCTAppDelegate)
 
-#ifdef __cplusplus
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge;
-#endif
 @end
 
 @implementation DevMenuRCTAppDelegate
@@ -134,22 +131,6 @@
 - (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
 {
   return [[DevMenuRCTBridge alloc] initWithDelegate:delegate launchOptions:launchOptions];
-}
-
-#pragma mark - RCTCxxBridgeDelegate
-- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
-{
-    std::unique_ptr<facebook::react::JSExecutorFactory> executorFactory  = [super jsExecutorFactoryForBridge:bridge];
-
-    #if __has_include(<reacthermes/HermesExecutorFactory.h>)
-        auto rawExecutorFactory = executorFactory.get();
-        auto hermesExecFactory = dynamic_cast<facebook::react::HermesExecutorFactory*>(rawExecutorFactory);
-        if (hermesExecFactory != nullptr) {
-            hermesExecFactory->setEnableDebugger(false);
-        }
-    #endif
-
-    return executorFactory;
 }
 
 @end

--- a/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
+++ b/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
@@ -35,9 +35,7 @@ class EXDevMenuDevSettings: NSObject {
       devSettings["isRemoteDebuggingAvailable"] = bridgeSettings.isRemoteDebuggingAvailable
       devSettings["isHotLoadingAvailable"] = bridgeSettings.isHotLoadingAvailable
       devSettings["isPerfMonitorAvailable"] = isPerfMonitorAvailable
-
-      // bridge mode has the `bridge.batched` and the bridgeless mode references the later.
-      devSettings["isJSInspectorAvailable"] = bridge.batched?.isInspectable ?? bridge.isInspectable
+      devSettings["isJSInspectorAvailable"] = bridgeSettings.isDeviceDebuggingAvailable
 
       let isElementInspectorAvailable = manager.currentManifest?.isDevelopmentMode()
       devSettings["isElementInspectorAvailable"] = isElementInspectorAvailable

--- a/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
+++ b/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
@@ -47,9 +47,9 @@
     return [weakSelf createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
   };
 
-  configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> self, NSDictionary *launchOptions)
+  configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> bridge, NSDictionary *launchOptions)
   {
-    return [weakSelf createBridgeWithDelegate:self launchOptions:launchOptions];
+    return [weakSelf createBridgeWithDelegate:bridge launchOptions:launchOptions];
   };
 
   return [[DevClientRootViewFactory alloc] initWithConfiguration:configuration andTurboModuleManagerDelegate:self];

--- a/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
+++ b/packages/expo-dev-menu/ios/ReactNativeCompatibles/ReactNative/DevClientAppDelegate.mm
@@ -1,4 +1,5 @@
 #import <EXDevMenu/DevClientAppDelegate.h>
+#import <EXDevMenu/DevClientRootViewFactory.h>
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTCxxBridgeDelegate.h>
@@ -28,12 +29,31 @@
 
 @interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider, RCTTurboModuleManagerDelegate>
 
-- (RCTRootViewFactory *)createRCTRootViewFactory;
-
 @end
 
 @implementation DevClientAppDelegate
 
+- (RCTRootViewFactory *)createRCTRootViewFactory
+{
+  RCTRootViewFactoryConfiguration *configuration =
+  [[RCTRootViewFactoryConfiguration alloc] initWithBundleURL:self.bundleURL
+                                              newArchEnabled:self.fabricEnabled
+                                          turboModuleEnabled:self.turboModuleEnabled
+                                           bridgelessEnabled:self.bridgelessEnabled];
+
+  __weak __typeof(self) weakSelf = self;
+  configuration.createRootViewWithBridge = ^UIView *(RCTBridge *bridge, NSString *moduleName, NSDictionary *initProps)
+  {
+    return [weakSelf createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
+  };
+
+  configuration.createBridgeWithDelegate = ^RCTBridge *(id<RCTBridgeDelegate> self, NSDictionary *launchOptions)
+  {
+    return [weakSelf createBridgeWithDelegate:self launchOptions:launchOptions];
+  };
+
+  return [[DevClientRootViewFactory alloc] initWithConfiguration:configuration andTurboModuleManagerDelegate:self];
+}
 
 - (void)initRootViewFactory {
   RCTSetNewArchEnabled([self newArchEnabled]);


### PR DESCRIPTION
# Why

When clicking on "Open JS Debugger" sometimes DevTools would connect to the DevMenu instead of connecting to the app instance.  

# How

- Disable dev-menu hermes debugger through jsExecutorFactoryForBridge
- Remove some unused functions 

# Test Plan

Run BareExpo and FabricTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
