### PR TITLE
[docs] Update using-sentry.mdx

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -193,7 +193,7 @@ If your app uses [Expo Router](/router/introduction), then you can configure Sen
 import { Slot, useNavigationContainerRef } from 'expo-router';
 import React from 'react';
 import * as Sentry from '@sentry/react-native';
-import Constants from 'expo-constants';
+import { isRunningInExpoGo } from 'expo';
 
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
 const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -193,6 +193,7 @@ If your app uses [Expo Router](/router/introduction), then you can configure Sen
 import { Slot, useNavigationContainerRef } from 'expo-router';
 import React from 'react';
 import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
 
 // Construct a new instrumentation instance. This is needed to communicate between the integration and React
 const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
@@ -204,6 +205,7 @@ Sentry.init({
     new Sentry.ReactNativeTracing({
       // Pass instrumentation to be used as `routingInstrumentation`
       routingInstrumentation,
+      enableNativeFramesTracking: Constants.appOwnership !== 'expo', // Only in native builds, not in Expo Go.
       // ...
     }),
   ],

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -205,7 +205,7 @@ Sentry.init({
     new Sentry.ReactNativeTracing({
       // Pass instrumentation to be used as `routingInstrumentation`
       routingInstrumentation,
-      enableNativeFramesTracking: Constants.appOwnership !== 'expo', // Only in native builds, not in Expo Go.
+      enableNativeFramesTracking: !isRunningInExpoGo(),
       // ...
     }),
   ],


### PR DESCRIPTION
added conditional for enableNativeFramesTracking when in Expo Go

# Why
Cause noobs like myself blindly copy-paste Expo's docs and if the examples provided in the docs do not work, we give up.

# How
I cross referenced the instructions given by the Expo docs with the ones given by Sentry:
https://docs.sentry.io/platforms/react-native/performance/instrumentation/expo-router/

# Test Plan
1. Followed the instructions on Expo docs for integrating Sentry with Expo-Router
2. I was getting the infamous: `Error while fetching native frames: SentryError: Native is disabled` exception
3. I added conditional native frames tracking as per the Sentry docs's Expo-Router integration
4. I haz no error

# Checklist

- [] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

this is s doc change not a code change :shrug: