### PR TITLE
[doc] Add information in the new Sentry documentation

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -87,7 +87,10 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
 }
 ```
 
-Next, in an environment where you want to create releases and upload sourcemaps to Sentry, you will need to set the `SENTRY_AUTH_TOKEN` environment variable to your [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). If you are using EAS Build, you can set the environment variable by [creating a secret named SENTRY_AUTH_TOKEN](/build-reference/variables/#using-secrets-in-environment-variables).
+Next, in an environment where you want to create releases and upload sourcemaps to Sentry, you will need to set the `SENTRY_AUTH_TOKEN` environment variable to your [Sentry auth token](https://docs.sentry.io/product/cli/configuration/).
+
+- If you are using EAS Build, you can set the environment variable by [creating a secret named SENTRY_AUTH_TOKEN](/build-reference/variables/#using-secrets-in-environment-variables).
+- If you are using EAS Build for building on your local infraestructure (`eas build --local`), add also the `SENTRY_AUTH_TOKEN` variable in `~/.bash_profile` (or `~/.zshrc` if you use Zsh)
 
 > **warning** The Sentry auth token should be stored securely. Do not commit it to a public repository, and treat it as you would any other sensitive API key.
 


### PR DESCRIPTION
# Why
Because `eas build -p android --local` was not working without defining it in my local env, and it was not very clear in the doc.

# How
No how

# Test Plan
Naaaap

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Drink a 🍺
- [ ] Sleep well because it's already 3AM
