### PR TITLE
[expo-go] Change tap behavior for project with single branch

### DIFF
--- a/apps/expo-go/graphql.schema.json
+++ b/apps/expo-go/graphql.schema.json
@@ -3777,8 +3777,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "AuthProviderIdentifier",
                 "ofType": null
               }
             },
@@ -3916,8 +3916,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "AuthProviderIdentifier",
                 "ofType": null
               }
             },
@@ -4149,8 +4149,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "AuthProviderIdentifier",
                 "ofType": null
               }
             },
@@ -6936,6 +6936,18 @@
             "deprecationReason": null
           },
           {
+            "name": "loggerLevel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerLoggerLevel",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mode",
             "description": null,
             "type": {
@@ -7242,6 +7254,18 @@
             "deprecationReason": null
           },
           {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "developmentClient",
             "description": null,
             "type": {
@@ -7271,6 +7295,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "loggerLevel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerLoggerLevel",
               "ofType": null
             },
             "defaultValue": null,
@@ -9100,6 +9136,18 @@
             "deprecationReason": "'likes' have been deprecated."
           },
           {
+            "name": "lastDeletionAttemptTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "lastPublishedTime",
             "description": null,
             "args": [],
@@ -9421,6 +9469,22 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Classic updates have been deprecated."
+          },
+          {
+            "name": "pushNotifications",
+            "description": "App query field for querying details about an app's push notifications",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppPushNotifications",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "pushSecurityEnabled",
@@ -11270,6 +11334,109 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppPushNotifications",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insights",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppPushNotificationsInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppPushNotificationsInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationsSentOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationsSentOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -15306,6 +15473,18 @@
             "deprecationReason": null
           },
           {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSONObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "targetEntityId",
             "description": null,
             "args": [],
@@ -15518,6 +15697,41 @@
         "enumValues": [
           {
             "name": "OIDC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AuthProviderIdentifier",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GOOGLE_WS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MS_ENTRA_ID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OKTA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ONE_LOGIN",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -25657,6 +25871,39 @@
         "description": null,
         "fields": [
           {
+            "name": "configureEAS",
+            "description": "Configure EAS by pushing a commit to the default branch which updates or creates app.json, eas.json, and installs necessary dependencies.",
+            "args": [
+              {
+                "name": "githubRepositoryId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createGitHubRepository",
             "description": "Create a GitHub repository for an App",
             "args": [
@@ -28382,6 +28629,18 @@
             "deprecationReason": null
           },
           {
+            "name": "loggerLevel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerLoggerLevel",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mode",
             "description": null,
             "type": {
@@ -28653,6 +28912,18 @@
             "deprecationReason": null
           },
           {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "developmentClient",
             "description": null,
             "type": {
@@ -28682,6 +28953,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "loggerLevel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "WorkerLoggerLevel",
               "ofType": null
             },
             "defaultValue": null,
@@ -30876,6 +31159,33 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationsSentOverTimeData",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LineChartData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -43495,6 +43805,53 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkerLoggerLevel",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DEBUG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FATAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INFO",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TRACE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WARN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/apps/expo-go/src/HomeApp.tsx
+++ b/apps/expo-go/src/HomeApp.tsx
@@ -14,6 +14,7 @@ import url from 'url';
 import ApolloClient from './api/ApolloClient';
 import { ColorTheme } from './constants/Colors';
 import {
+  AppPlatform,
   HomeScreenDataDocument,
   HomeScreenDataQuery,
   HomeScreenDataQueryVariables,
@@ -167,6 +168,7 @@ export default function HomeApp() {
             query: HomeScreenDataDocument,
             variables: {
               accountName: firstLoadAccountName,
+              platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
             },
             context: { headers: { 'expo-session': storedSession?.sessionSecret } },
           });

--- a/apps/expo-go/src/components/ProjectsListItem.tsx
+++ b/apps/expo-go/src/components/ProjectsListItem.tsx
@@ -34,12 +34,13 @@ export function ProjectsListItem({ name, subtitle, firstTwoBranches, id, first, 
   const navigation = useNavigation<StackNavigationProp<HomeStackRoutes>>();
 
   function onPress() {
-    // if there's only one branch for the project and the latest update on that branch is compatible
-    // with this version of Expo Go, just launch it upon tapping the row instead of entering
+    // if there's only one branch for the project and there's only one update on that branch and
+    // it is compatible with this version of Expo Go, just launch it upon tapping the row instead of entering
     // a drill-down UI for exploring branches/updates.
     if (firstTwoBranches.length === 1) {
-      const updateToOpen = firstTwoBranches[0].updates[0];
-      if (updateToOpen) {
+      const branch = firstTwoBranches[0];
+      if (branch.updates.length === 1) {
+        const updateToOpen = branch.updates[0];
         const isCompatibleWithThisExpoGo = isUpdateCompatibleWithThisExpoGo(updateToOpen);
         if (isCompatibleWithThisExpoGo) {
           openUpdateManifestPermalink(updateToOpen);

--- a/apps/expo-go/src/components/ProjectsListItem.tsx
+++ b/apps/expo-go/src/components/ProjectsListItem.tsx
@@ -5,12 +5,18 @@ import { Row, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-component
 import React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
+import { CommonAppDataFragment } from 'src/graphql/types';
+import {
+  isUpdateCompatibleWithThisExpoGo,
+  openUpdateManifestPermalink,
+} from 'src/utils/UpdateUtils';
 
 import { HomeStackRoutes } from '../navigation/Navigation.types';
 import { AppIcon } from '../screens/HomeScreen/AppIcon';
 
 type Props = {
   name: string;
+  firstTwoBranches: CommonAppDataFragment['firstTwoBranches'];
   subtitle?: string;
   id: string;
   first: boolean;
@@ -22,13 +28,30 @@ type Props = {
  * the projects list page for an account.
  */
 
-export function ProjectsListItem({ name, subtitle, id, first, last }: Props) {
+export function ProjectsListItem({ name, subtitle, firstTwoBranches, id, first, last }: Props) {
   const theme = useExpoTheme();
 
   const navigation = useNavigation<StackNavigationProp<HomeStackRoutes>>();
 
   function onPress() {
-    navigation.push('ProjectDetails', { id });
+    // if there's only one branch for the project and the latest update on that branch is compatible
+    // with this version of Expo Go, just launch it upon tapping the row instead of entering
+    // a drill-down UI for exploring branches/updates.
+    if (firstTwoBranches.length === 1) {
+      const updateToOpen = firstTwoBranches[0].updates[0];
+      if (updateToOpen) {
+        const isCompatibleWithThisExpoGo = isUpdateCompatibleWithThisExpoGo(updateToOpen);
+        if (isCompatibleWithThisExpoGo) {
+          openUpdateManifestPermalink(updateToOpen);
+        } else {
+          navigation.push('ProjectDetails', { id });
+        }
+      } else {
+        navigation.push('ProjectDetails', { id });
+      }
+    } else {
+      navigation.push('ProjectDetails', { id });
+    }
   }
 
   const showSubtitle = subtitle && name.toLowerCase() !== subtitle.toLowerCase();

--- a/apps/expo-go/src/components/UpdateListItem.tsx
+++ b/apps/expo-go/src/components/UpdateListItem.tsx
@@ -2,13 +2,14 @@ import { UpdateIcon, iconSize, ChevronDownIcon } from '@expo/styleguide-native';
 import format from 'date-fns/format';
 import { Row, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-components';
 import React from 'react';
-import { Linking } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { BranchDetailsQuery } from 'src/graphql/types';
+import {
+  isUpdateCompatibleWithThisExpoGo,
+  openUpdateManifestPermalink,
+} from 'src/utils/UpdateUtils';
 
 import { DateFormats } from '../constants/DateFormats';
-import * as Kernel from '../kernel/Kernel';
-import * as UrlUtils from '../utils/UrlUtils';
 
 type Props = {
   update: NonNullable<BranchDetailsQuery['app']['byId']['updateBranchByName']>['updates'][0];
@@ -17,15 +18,14 @@ type Props = {
 };
 
 export function UpdateListItem({ update, first, last }: Props) {
-  const { id, message, createdAt, manifestPermalink, expoGoSDKVersion } = update;
+  const { id, message, createdAt } = update;
 
-  const isCompatibleWithThisExpoGo =
-    !!expoGoSDKVersion && Kernel.sdkVersionsArray.includes(expoGoSDKVersion);
+  const isCompatibleWithThisExpoGo = isUpdateCompatibleWithThisExpoGo(update);
 
   const theme = useExpoTheme();
 
   const handlePress = () => {
-    Linking.openURL(UrlUtils.toExp(UrlUtils.normalizeUrl(manifestPermalink)));
+    openUpdateManifestPermalink(update);
   };
 
   return (

--- a/apps/expo-go/src/graphql/fragments/CommonAppData.fragment.graphql
+++ b/apps/expo-go/src/graphql/fragments/CommonAppData.fragment.graphql
@@ -5,4 +5,12 @@ fragment CommonAppData on App {
   ownerAccount {
     name
   }
+  firstTwoBranches: updateBranches(limit: 2, offset: 0) {
+    id
+    name
+    updates(limit: 1, offset: 0, filter: { platform: $platform }) {
+      id
+      ...UpdateData
+    }
+  }
 }

--- a/apps/expo-go/src/graphql/fragments/UpdateData.fragment.graphql
+++ b/apps/expo-go/src/graphql/fragments/UpdateData.fragment.graphql
@@ -1,0 +1,10 @@
+fragment UpdateData on Update {
+  id
+  group
+  message
+  createdAt
+  runtimeVersion
+  expoGoSDKVersion
+  platform
+  manifestPermalink
+}

--- a/apps/expo-go/src/graphql/queries/AccountDataQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/AccountDataQuery.query.graphql
@@ -1,4 +1,4 @@
-query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!) {
+query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id

--- a/apps/expo-go/src/graphql/queries/BranchDetails.query.graphql
+++ b/apps/expo-go/src/graphql/queries/BranchDetails.query.graphql
@@ -14,13 +14,7 @@ query BranchDetails(
         name
         updates(limit: 100, offset: 0, filter: { platform: $platform }) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          expoGoSDKVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }

--- a/apps/expo-go/src/graphql/queries/BranchesForProjectQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/BranchesForProjectQuery.query.graphql
@@ -14,12 +14,7 @@ query BranchesForProject(
         name
         updates(limit: 1, offset: 0, filter: { platform: $platform }) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }

--- a/apps/expo-go/src/graphql/queries/ProfileDataQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/ProfileDataQuery.query.graphql
@@ -1,4 +1,4 @@
-query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
+query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!, $platform: AppPlatform!) {
   meUserActor {
     id
     username

--- a/apps/expo-go/src/graphql/queries/ProfileProjectsQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/ProfileProjectsQuery.query.graphql
@@ -1,4 +1,4 @@
-query Home_MyApps($limit: Int!, $offset: Int!) {
+query Home_MyApps($limit: Int!, $offset: Int!, $platform: AppPlatform!) {
   meUserActor {
     id
     appCount

--- a/apps/expo-go/src/graphql/queries/ProjectsListQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/ProjectsListQuery.query.graphql
@@ -1,4 +1,4 @@
-query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!) {
+query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id

--- a/apps/expo-go/src/graphql/queries/ProjectsQuery.query.graphql
+++ b/apps/expo-go/src/graphql/queries/ProjectsQuery.query.graphql
@@ -16,12 +16,7 @@ query ProjectsQuery(
         name
         updates(limit: 1, offset: 0, filter: { platform: $platform }) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }

--- a/apps/expo-go/src/graphql/types.ts
+++ b/apps/expo-go/src/graphql/types.ts
@@ -656,7 +656,7 @@ export type AccountQueryByNameArgs = {
 export type AccountSsoConfiguration = {
   __typename?: 'AccountSSOConfiguration';
   authProtocol: AuthProtocolType;
-  authProviderIdentifier: Scalars['String'];
+  authProviderIdentifier: AuthProviderIdentifier;
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
   createdAt: Scalars['DateTime'];
@@ -667,7 +667,7 @@ export type AccountSsoConfiguration = {
 
 export type AccountSsoConfigurationData = {
   authProtocol: AuthProtocolType;
-  authProviderIdentifier: Scalars['String'];
+  authProviderIdentifier: AuthProviderIdentifier;
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
   issuer: Scalars['String'];
@@ -704,7 +704,7 @@ export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
 export type AccountSsoConfigurationPublicData = {
   __typename?: 'AccountSSOConfigurationPublicData';
   authProtocol: AuthProtocolType;
-  authProviderIdentifier: Scalars['String'];
+  authProviderIdentifier: AuthProviderIdentifier;
   authorizationUrl: Scalars['String'];
   id: Scalars['ID'];
   issuer: Scalars['String'];
@@ -1094,6 +1094,7 @@ export type AndroidJobInput = {
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  loggerLevel?: InputMaybe<WorkerLoggerLevel>;
   mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
@@ -1122,9 +1123,11 @@ export type AndroidJobOverridesInput = {
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  loggerLevel?: InputMaybe<WorkerLoggerLevel>;
   mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<AndroidJobSecretsInput>;
@@ -1281,6 +1284,7 @@ export type App = Project & {
   isDeprecated: Scalars['Boolean'];
   /** @deprecated 'likes' have been deprecated. */
   isLikedByMe: Scalars['Boolean'];
+  lastDeletionAttemptTime?: Maybe<Scalars['DateTime']>;
   /** @deprecated No longer supported */
   lastPublishedTime: Scalars['DateTime'];
   /** Time of the last user activity (update, branch, submission). */
@@ -1316,6 +1320,8 @@ export type App = Project & {
    * @deprecated Classic updates have been deprecated.
    */
   published: Scalars['Boolean'];
+  /** App query field for querying details about an app's push notifications */
+  pushNotifications: AppPushNotifications;
   pushSecurityEnabled: Scalars['Boolean'];
   /**
    * Classic update release channel names (to be removed)
@@ -1729,6 +1735,23 @@ export enum AppPrivacy {
   Public = 'PUBLIC',
   Unlisted = 'UNLISTED'
 }
+
+export type AppPushNotifications = {
+  __typename?: 'AppPushNotifications';
+  id: Scalars['ID'];
+  insights: AppPushNotificationsInsights;
+};
+
+export type AppPushNotificationsInsights = {
+  __typename?: 'AppPushNotificationsInsights';
+  id: Scalars['ID'];
+  notificationsSentOverTime: NotificationsSentOverTimeData;
+};
+
+
+export type AppPushNotificationsInsightsNotificationsSentOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
 
 export type AppQuery = {
   __typename?: 'AppQuery';
@@ -2297,6 +2320,7 @@ export type AuditLog = {
   actor?: Maybe<Actor>;
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
+  metadata?: Maybe<Scalars['JSONObject']>;
   targetEntityId: Scalars['ID'];
   targetEntityMutationType: TargetEntityMutationType;
   targetEntityTableName: Scalars['String'];
@@ -2326,6 +2350,13 @@ export type AuditLogQueryByIdArgs = {
 
 export enum AuthProtocolType {
   Oidc = 'OIDC'
+}
+
+export enum AuthProviderIdentifier {
+  GoogleWs = 'GOOGLE_WS',
+  MsEntraId = 'MS_ENTRA_ID',
+  Okta = 'OKTA',
+  OneLogin = 'ONE_LOGIN'
 }
 
 export type BackgroundJobReceipt = {
@@ -3750,10 +3781,17 @@ export type GitHubRepositoryMetadata = {
 
 export type GitHubRepositoryMutation = {
   __typename?: 'GitHubRepositoryMutation';
+  /** Configure EAS by pushing a commit to the default branch which updates or creates app.json, eas.json, and installs necessary dependencies. */
+  configureEAS: BackgroundJobReceipt;
   /** Create a GitHub repository for an App */
   createGitHubRepository: GitHubRepository;
   /** Delete a GitHub repository by ID */
   deleteGitHubRepository: GitHubRepository;
+};
+
+
+export type GitHubRepositoryMutationConfigureEasArgs = {
+  githubRepositoryId: Scalars['ID'];
 };
 
 
@@ -4126,6 +4164,7 @@ export type IosJobInput = {
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  loggerLevel?: InputMaybe<WorkerLoggerLevel>;
   mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
@@ -4151,10 +4190,12 @@ export type IosJobOverridesInput = {
   buildType?: InputMaybe<IosBuildType>;
   builderEnvironment?: InputMaybe<IosBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  loggerLevel?: InputMaybe<WorkerLoggerLevel>;
   mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
   resign?: InputMaybe<BuildResignInput>;
@@ -4489,6 +4530,11 @@ export enum NotificationType {
   Email = 'EMAIL',
   Web = 'WEB'
 }
+
+export type NotificationsSentOverTimeData = {
+  __typename?: 'NotificationsSentOverTimeData';
+  data: LineChartData;
+};
 
 export type Offer = {
   __typename?: 'Offer';
@@ -6329,6 +6375,15 @@ export type WebsiteNotificationsConnection = {
   pageInfo: PageInfo;
 };
 
+export enum WorkerLoggerLevel {
+  Debug = 'DEBUG',
+  Error = 'ERROR',
+  Fatal = 'FATAL',
+  Info = 'INFO',
+  Trace = 'TRACE',
+  Warn = 'WARN'
+}
+
 export type DeleteAndroidAppBuildCredentialsResult = {
   __typename?: 'deleteAndroidAppBuildCredentialsResult';
   id: Scalars['ID'];
@@ -6349,7 +6404,7 @@ export type DeleteApplePushKeyResult = {
   id: Scalars['ID'];
 };
 
-export type CommonAppDataFragment = { __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } };
+export type CommonAppDataFragment = { __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> };
 
 export type CommonSnackDataFragment = { __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean };
 
@@ -6359,14 +6414,17 @@ type CurrentUserActorData_User_Fragment = { __typename: 'User', id: string, user
 
 export type CurrentUserActorDataFragment = CurrentUserActorData_SsoUser_Fragment | CurrentUserActorData_User_Fragment;
 
+export type UpdateDataFragment = { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string };
+
 export type Home_AccountDataQueryVariables = Exact<{
   accountName: Scalars['String'];
   appLimit: Scalars['Int'];
   snackLimit: Scalars['Int'];
+  platform: AppPlatform;
 }>;
 
 
-export type Home_AccountDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
+export type Home_AccountDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
 export type BranchDetailsQueryVariables = Exact<{
   name: Scalars['String'];
@@ -6385,7 +6443,7 @@ export type BranchesForProjectQueryVariables = Exact<{
 }>;
 
 
-export type BranchesForProjectQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, fullName: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
+export type BranchesForProjectQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, fullName: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> } } };
 
 export type Home_CurrentUserActorQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6395,18 +6453,20 @@ export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor
 export type Home_ProfileData2QueryVariables = Exact<{
   appLimit: Scalars['Int'];
   snackLimit: Scalars['Int'];
+  platform: AppPlatform;
 }>;
 
 
-export type Home_ProfileData2Query = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
+export type Home_ProfileData2Query = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
 
 export type Home_MyAppsQueryVariables = Exact<{
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+  platform: AppPlatform;
 }>;
 
 
-export type Home_MyAppsQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }> } | { __typename?: 'User', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }> } | null };
+export type Home_MyAppsQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }> } | { __typename?: 'User', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }> } | null };
 
 export type Home_ProfileSnacksQueryVariables = Exact<{
   limit: Scalars['Int'];
@@ -6420,10 +6480,11 @@ export type Home_AccountAppsQueryVariables = Exact<{
   accountName: Scalars['String'];
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+  platform: AppPlatform;
 }>;
 
 
-export type Home_AccountAppsQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }> } } };
+export type Home_AccountAppsQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }> } } };
 
 export type ProjectsQueryVariables = Exact<{
   appId: Scalars['String'];
@@ -6431,7 +6492,7 @@ export type ProjectsQueryVariables = Exact<{
 }>;
 
 
-export type ProjectsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
+export type ProjectsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> } } };
 
 export type Home_AccountSnacksQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -6470,11 +6531,24 @@ export type UserPermissionDataFragment = { __typename?: 'UserPermission', permis
 
 export type HomeScreenDataQueryVariables = Exact<{
   accountName: Scalars['String'];
+  platform: AppPlatform;
 }>;
 
 
-export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string } }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
+export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, bestContactEmail?: string | null, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, name: string, fullName: string, ownerAccount: { __typename?: 'Account', name: string }, firstTwoBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, expoGoSDKVersion?: string | null, platform: string, manifestPermalink: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
+export const UpdateDataFragmentDoc = gql`
+    fragment UpdateData on Update {
+  id
+  group
+  message
+  createdAt
+  runtimeVersion
+  expoGoSDKVersion
+  platform
+  manifestPermalink
+}
+    `;
 export const CommonAppDataFragmentDoc = gql`
     fragment CommonAppData on App {
   id
@@ -6483,8 +6557,16 @@ export const CommonAppDataFragmentDoc = gql`
   ownerAccount {
     name
   }
+  firstTwoBranches: updateBranches(limit: 2, offset: 0) {
+    id
+    name
+    updates(limit: 1, offset: 0, filter: {platform: $platform}) {
+      id
+      ...UpdateData
+    }
+  }
 }
-    `;
+    ${UpdateDataFragmentDoc}`;
 export const CommonSnackDataFragmentDoc = gql`
     fragment CommonSnackData on Snack {
   id
@@ -6543,7 +6625,7 @@ export const UserPermissionDataFragmentDoc = gql`
 }
     `;
 export const Home_AccountDataDocument = gql`
-    query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!) {
+    query Home_AccountData($accountName: String!, $appLimit: Int!, $snackLimit: Int!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id
@@ -6576,6 +6658,7 @@ ${CommonSnackDataFragmentDoc}`;
  *      accountName: // value for 'accountName'
  *      appLimit: // value for 'appLimit'
  *      snackLimit: // value for 'snackLimit'
+ *      platform: // value for 'platform'
  *   },
  * });
  */
@@ -6606,19 +6689,13 @@ export const BranchDetailsDocument = gql`
         name
         updates(limit: 100, offset: 0, filter: {platform: $platform}) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          expoGoSDKVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }
   }
 }
-    `;
+    ${UpdateDataFragmentDoc}`;
 
 /**
  * __useBranchDetailsQuery__
@@ -6664,18 +6741,13 @@ export const BranchesForProjectDocument = gql`
         name
         updates(limit: 1, offset: 0, filter: {platform: $platform}) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }
   }
 }
-    `;
+    ${UpdateDataFragmentDoc}`;
 
 /**
  * __useBranchesForProjectQuery__
@@ -6748,7 +6820,7 @@ export function refetchHome_CurrentUserActorQuery(variables?: Home_CurrentUserAc
       return { query: Home_CurrentUserActorDocument, variables: variables }
     }
 export const Home_ProfileData2Document = gql`
-    query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
+    query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!, $platform: AppPlatform!) {
   meUserActor {
     id
     username
@@ -6785,6 +6857,7 @@ ${CommonSnackDataFragmentDoc}`;
  *   variables: {
  *      appLimit: // value for 'appLimit'
  *      snackLimit: // value for 'snackLimit'
+ *      platform: // value for 'platform'
  *   },
  * });
  */
@@ -6803,7 +6876,7 @@ export function refetchHome_ProfileData2Query(variables: Home_ProfileData2QueryV
       return { query: Home_ProfileData2Document, variables: variables }
     }
 export const Home_MyAppsDocument = gql`
-    query Home_MyApps($limit: Int!, $offset: Int!) {
+    query Home_MyApps($limit: Int!, $offset: Int!, $platform: AppPlatform!) {
   meUserActor {
     id
     appCount
@@ -6828,6 +6901,7 @@ export const Home_MyAppsDocument = gql`
  *   variables: {
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      platform: // value for 'platform'
  *   },
  * });
  */
@@ -6888,7 +6962,7 @@ export function refetchHome_ProfileSnacksQuery(variables: Home_ProfileSnacksQuer
       return { query: Home_ProfileSnacksDocument, variables: variables }
     }
 export const Home_AccountAppsDocument = gql`
-    query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!) {
+    query Home_AccountApps($accountName: String!, $limit: Int!, $offset: Int!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id
@@ -6916,6 +6990,7 @@ export const Home_AccountAppsDocument = gql`
  *      accountName: // value for 'accountName'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      platform: // value for 'platform'
  *   },
  * });
  */
@@ -6949,18 +7024,13 @@ export const ProjectsQueryDocument = gql`
         name
         updates(limit: 1, offset: 0, filter: {platform: $platform}) {
           id
-          group
-          message
-          createdAt
-          runtimeVersion
-          platform
-          manifestPermalink
+          ...UpdateData
         }
       }
     }
   }
 }
-    `;
+    ${UpdateDataFragmentDoc}`;
 
 /**
  * __useProjectsQuery__
@@ -7210,7 +7280,7 @@ export type SendSmsotpToSecondFactorDeviceMutationHookResult = ReturnType<typeof
 export type SendSmsotpToSecondFactorDeviceMutationMutationResult = Apollo.MutationResult<SendSmsotpToSecondFactorDeviceMutation>;
 export type SendSmsotpToSecondFactorDeviceMutationMutationOptions = Apollo.BaseMutationOptions<SendSmsotpToSecondFactorDeviceMutation, SendSmsotpToSecondFactorDeviceMutationVariables>;
 export const HomeScreenDataDocument = gql`
-    query HomeScreenData($accountName: String!) {
+    query HomeScreenData($accountName: String!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id
@@ -7246,6 +7316,7 @@ ${CommonSnackDataFragmentDoc}`;
  * const { data, loading, error } = useHomeScreenDataQuery({
  *   variables: {
  *      accountName: // value for 'accountName'
+ *      platform: // value for 'platform'
  *   },
  * });
  */

--- a/apps/expo-go/src/screens/BranchDetailsScreen/BranchHeader.tsx
+++ b/apps/expo-go/src/screens/BranchDetailsScreen/BranchHeader.tsx
@@ -1,12 +1,12 @@
 import { BranchIcon, iconSize, spacing } from '@expo/styleguide-native';
 import { Row, useExpoTheme, View, Text, Spacer } from 'expo-dev-client-components';
 import * as React from 'react';
-import { Linking } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { BranchDetailsQuery } from 'src/graphql/types';
-
-import * as Kernel from '../../kernel/Kernel';
-import * as UrlUtils from '../../utils/UrlUtils';
+import {
+  isUpdateCompatibleWithThisExpoGo,
+  openUpdateManifestPermalink,
+} from 'src/utils/UpdateUtils';
 
 type Props = {
   name: string;
@@ -18,12 +18,10 @@ export function BranchHeader(props: Props) {
 
   const latestUpdate = props.latestUpdate;
   const openButton =
-    latestUpdate &&
-    latestUpdate.expoGoSDKVersion &&
-    Kernel.sdkVersionsArray.includes(latestUpdate.expoGoSDKVersion) ? (
+    latestUpdate && isUpdateCompatibleWithThisExpoGo(latestUpdate) ? (
       <TouchableOpacity
         onPress={() => {
-          Linking.openURL(UrlUtils.toExp(UrlUtils.normalizeUrl(latestUpdate.manifestPermalink)));
+          openUpdateManifestPermalink(latestUpdate);
         }}
         style={{
           backgroundColor: theme.button.tertiary.background,

--- a/apps/expo-go/src/screens/HomeScreen/HomeScreenData.query.graphql
+++ b/apps/expo-go/src/screens/HomeScreen/HomeScreenData.query.graphql
@@ -1,4 +1,4 @@
-query HomeScreenData($accountName: String!) {
+query HomeScreenData($accountName: String!, $platform: AppPlatform!) {
   account {
     byName(accountName: $accountName) {
       id

--- a/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
@@ -31,6 +31,7 @@ import { SectionHeader } from '../../components/SectionHeader';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
 import UserReviewSection from '../../components/UserReviewSection';
 import {
+  AppPlatform,
   HomeScreenDataDocument,
   HomeScreenDataQuery,
   HomeScreenDataQueryVariables,
@@ -252,6 +253,7 @@ export class HomeScreenView extends React.Component<Props, State> {
               query: HomeScreenDataDocument,
               variables: {
                 accountName,
+                platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
               },
               fetchPolicy: 'network-only',
             })

--- a/apps/expo-go/src/screens/HomeScreen/ProjectsSection.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/ProjectsSection.tsx
@@ -33,6 +33,7 @@ export function ProjectsSection({ apps, showMore, accountName }: Props) {
             <ProjectsListItem
               id={project.id}
               name={project.name}
+              firstTwoBranches={project.firstTwoBranches}
               subtitle={project.fullName}
               first={i === 0}
               last={i === apps.length - 1 && !showMore}

--- a/apps/expo-go/src/screens/ProjectsListScreen/ProjectList.tsx
+++ b/apps/expo-go/src/screens/ProjectsListScreen/ProjectList.tsx
@@ -133,6 +133,7 @@ function ProjectListView({ data, loadMoreAsync }: Props) {
           key={app.id}
           id={app.id}
           name={app.name}
+          firstTwoBranches={app.firstTwoBranches}
           subtitle={app.fullName}
           first={index === 0}
           last={index === (data.apps ?? []).length - 1}

--- a/apps/expo-go/src/screens/ProjectsListScreen/index.tsx
+++ b/apps/expo-go/src/screens/ProjectsListScreen/index.tsx
@@ -1,8 +1,9 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
+import { Platform } from 'react-native';
 
 import { ProjectList } from './ProjectList';
-import { useHome_AccountAppsQuery } from '../../graphql/types';
+import { AppPlatform, useHome_AccountAppsQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
 function useProjectsForAccountQuery({ accountName }: { accountName: string }) {
@@ -11,6 +12,7 @@ function useProjectsForAccountQuery({ accountName }: { accountName: string }) {
       accountName,
       limit: 15,
       offset: 0,
+      platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
     },
     fetchPolicy: 'cache-and-network',
   });

--- a/apps/expo-go/src/utils/UpdateUtils.ts
+++ b/apps/expo-go/src/utils/UpdateUtils.ts
@@ -1,0 +1,20 @@
+import { Linking } from 'react-native';
+
+import * as Kernel from '../kernel/Kernel';
+import * as UrlUtils from '../utils/UrlUtils';
+
+export function isUpdateCompatibleWithThisExpoGo({
+  expoGoSDKVersion,
+}: {
+  expoGoSDKVersion?: string | null | undefined;
+}): boolean {
+  return !!expoGoSDKVersion && Kernel.sdkVersionsArray.includes(expoGoSDKVersion);
+}
+
+export function openUpdateManifestPermalink({
+  manifestPermalink,
+}: {
+  manifestPermalink: string;
+}): void {
+  Linking.openURL(UrlUtils.toExp(UrlUtils.normalizeUrl(manifestPermalink)));
+}


### PR DESCRIPTION
# Why

When projects are displayed in a list, we want the behavior of tapping a project in that list to be the following:
- when the project has zero branches or greater than 1 branch, drill down into the project detail interface. This has the empty state as well as further drill-downs for branches/updates.
- when the project has 1 branch, and the latest update on that branch is compatible with this version of Expo Go, launch directly into that update instead.

Closes ENG-12108.

# How

Update a bunch of graphql fragments and utils to change the behavior.

# Test Plan

- Tested existing projects with multiple/no branches and/or incompatible updates. It still navigates to project permalink page.
- Tested a new project with a single update (group). See that it launches the update.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
