### PR TITLE
[eslint-config-expo] Add android build directory to ignore

### DIFF
--- a/packages/eslint-config-expo/utils/expo.js
+++ b/packages/eslint-config-expo/utils/expo.js
@@ -1,5 +1,10 @@
 module.exports = {
   plugins: ['expo'],
+  ignorePatterns: [
+    // JS files can end up in build intermediates, eg:
+    // android/app/build/intermediates/assets/debug/EXDevMenuApp.android.js
+    'android/app/build',
+  ],
   rules: {
     'expo/no-env-var-destructuring': ['error'],
     'expo/no-dynamic-env-var': ['error'],


### PR DESCRIPTION
# Why

Without this, eslint attempts to validate the expo-dev-client bundle in build intermediates:

```
yarn eslint .
yarn run v1.22.21
$ /Users/brent/code/new-default-template/node_modules/.bin/eslint .

/Users/brent/code/new-default-template/android/app/build/intermediates/assets/debug/EXDevMenuApp.android.js
    1:5       warning  '__BUNDLE_START_TIME__' is assigned a value but never used             no-unused-vars
    1:53      error    'nativePerformanceNow' is not defined                                  no-undef
    1:87      warning  '__DEV__' is assigned a value but never used                           no-unused-vars
    2:1       warning  Expected an assignment or function call and instead saw an expression  no-unused-expressions
```

# How

Add to `ignorePatterns`

# Test Plan

Ran it in a new project with the `default` template, after running a build with expo-dev-client