### PR TITLE
[test-suite][image-picker] Fix `expected undefined to be CAMERA_MISSING`

### DIFF
--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -1,4 +1,4 @@
-import Constants from 'expo-constants';
+import { isDevice } from 'expo-device';
 import * as ImagePicker from 'expo-image-picker';
 import { Platform } from 'react-native';
 
@@ -57,7 +57,7 @@ export async function test({ it, beforeAll, expect, jasmine, describe, afterAll 
     });
 
     describe('launchCameraAsync', () => {
-      if (Constants.isDevice) {
+      if (isDevice) {
         it('launches the camera', async () => {
           await alertAndWaitForResponse('Please take a picture for this test to pass.');
           const result = await ImagePicker.launchCameraAsync();


### PR DESCRIPTION
# Why

Closes ENG-12060
Fixes `expected undefined to be CAMERA_MISSING`

# How

Replace `Constants.isDevice` using `isDevice` from `expo-device`.
The one from constants doesn't seem to be working correctly. However, it's deprecated, so maybe we should remove it now. 

# Test Plan

- test-suite ✅ 