### PR TITLE
[ncl][gl] Fix PIXI example

### DIFF
--- a/apps/native-component-list/src/screens/GL/BeforePIXI.native.tsx
+++ b/apps/native-component-list/src/screens/GL/BeforePIXI.native.tsx
@@ -118,9 +118,6 @@ window.document = new DOMDocument();
 // @ts-ignore
 window.document.body = new DOMElement('body');
 
-// @ts-ignore
-window.location = 'data:'; // <- Not sure about this... or anything for that matter ¯\_(ツ)_/¯
-
 // This could be made better, but I'm not sure if it'll matter for PIXI
 // @ts-ignore
 global.navigator.userAgent = 'iPhone';


### PR DESCRIPTION
# Why

Fixes PIXI example

# How

We no longer need to set up the `window.location` field as it is now defined by React Native itself.
See https://github.com/expo/browser-polyfill/pull/81

# Test Plan

- NCL ✅ 