### PR TITLE
[expo-updates][cli] Fix CLI VCS detection and add workflow override ability

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix CLI VCS detection in CLI and add workflow override ability. ([#28403](https://github.com/expo/expo/pull/28403) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.25.2 — 2024-04-23

--- a/packages/expo-updates/cli/build/generateFingerprint.js
+++ b/packages/expo-updates/cli/build/generateFingerprint.js
@@ -37,6 +37,7 @@ const generateFingerprint = async (argv) => {
         // Types
         '--help': Boolean,
         '--platform': String,
+        '--workflow': String,
         '--debug': Boolean,
         // Aliases
         '-h': '--help',
@@ -51,6 +52,7 @@ Generate fingerprint for use in expo-updates runtime version
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
+  --workflow <string>                  Workflow to use for fingerprint generation, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `, 0);
@@ -63,11 +65,15 @@ Generate fingerprint for use in expo-updates runtime version
     if (!['ios', 'android'].includes(platform)) {
         throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
+    const workflowArg = args['--workflow'];
+    if (workflowArg && !['generic', 'managed'].includes(workflowArg)) {
+        throw new errors_1.CommandError(`Invalid workflow argument: ${workflowArg}. Must be either 'managed' or 'generic'`);
+    }
     const debug = args['--debug'];
     const projectRoot = (0, args_1.getProjectRoot)(args);
     let result;
     try {
-        const workflow = await resolveWorkflowAsync(projectRoot, platform);
+        const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
         result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
     }
     catch (e) {

--- a/packages/expo-updates/cli/build/resolveRuntimeVersion.js
+++ b/packages/expo-updates/cli/build/resolveRuntimeVersion.js
@@ -37,6 +37,7 @@ const resolveRuntimeVersion = async (argv) => {
         // Types
         '--help': Boolean,
         '--platform': String,
+        '--workflow': String,
         '--debug': Boolean,
         // Aliases
         '-h': '--help',
@@ -51,6 +52,7 @@ Resolve expo-updates runtime version
 
   Options
   --platform <string>                  Platform to resolve runtime version for
+  --workflow <string>                  Workflow to use for runtime version resolution, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `, 0);
@@ -60,12 +62,18 @@ Resolve expo-updates runtime version
     if (!['ios', 'android'].includes(platform)) {
         throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
+    const workflow = args['--workflow'];
+    if (workflow && !['generic', 'managed'].includes(workflow)) {
+        throw new errors_1.CommandError(`Invalid workflow argument: ${workflow}. Must be either 'managed' or 'generic'`);
+    }
     const debug = args['--debug'];
     let runtimeVersionInfo;
     try {
         runtimeVersionInfo = await resolveRuntimeVersionAsync((0, args_1.getProjectRoot)(args), platform, {
             silent: true,
             debug,
+        }, {
+            workflowOverride: workflow,
         });
     }
     catch (e) {

--- a/packages/expo-updates/cli/build/syncConfigurationToNative.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNative.js
@@ -38,6 +38,7 @@ const syncConfigurationToNative = async (argv) => {
         // Types
         '--help': Boolean,
         '--platform': String,
+        '--workflow': String,
         // Aliases
         '-h': '--help',
     }, argv ?? []);
@@ -52,6 +53,7 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
 
   Options
   --platform <string>                  Platform to sync
+  --workflow <string>                  Workflow to use for configuration sync
   -h, --help                           Output usage information
     `, 0);
     }
@@ -59,9 +61,14 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
     if (!['ios', 'android'].includes(platform)) {
         throw new errors_1.CommandError(`Invalid platform argument: ${platform}`);
     }
+    const workflow = (0, args_1.requireArg)(args, '--workflow');
+    if (!['generic', 'managed'].includes(workflow)) {
+        throw new errors_1.CommandError(`Invalid workflow argument: ${workflow}. Must be either 'managed' or 'generic'`);
+    }
     await (0, syncConfigurationToNativeAsync_1.syncConfigurationToNativeAsync)({
         projectRoot: (0, args_1.getProjectRoot)(args),
         platform,
+        workflow,
     });
 };
 exports.syncConfigurationToNative = syncConfigurationToNative;

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.d.ts
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.d.ts
@@ -1,6 +1,8 @@
+import { Workflow } from '../../utils/build/workflow';
 type SyncConfigurationToNativeOptions = {
     projectRoot: string;
     platform: 'ios' | 'android';
+    workflow: Workflow;
 };
 /**
  * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`

--- a/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
+++ b/packages/expo-updates/cli/build/syncConfigurationToNativeAsync.js
@@ -9,13 +9,11 @@ const config_plugins_1 = require("@expo/config-plugins");
 const plist_1 = __importDefault(require("@expo/plist"));
 const fs_extra_1 = __importDefault(require("fs-extra"));
 const path_1 = __importDefault(require("path"));
-const workflow_1 = require("../../utils/build/workflow");
 /**
  * Synchronize updates configuration to native files. This needs to do essentially the same thing as `withUpdates`
  */
 async function syncConfigurationToNativeAsync(options) {
-    const workflow = await (0, workflow_1.resolveWorkflowAsync)(options.projectRoot, options.platform);
-    if (workflow !== 'generic') {
+    if (options.workflow !== 'generic') {
         // not applicable to managed workflow
     }
     switch (options.platform) {

--- a/packages/expo-updates/cli/src/generateFingerprint.ts
+++ b/packages/expo-updates/cli/src/generateFingerprint.ts
@@ -12,6 +12,7 @@ export const generateFingerprint: Command = async (argv) => {
       // Types
       '--help': Boolean,
       '--platform': String,
+      '--workflow': String,
       '--debug': Boolean,
       // Aliases
       '-h': '--help',
@@ -30,6 +31,7 @@ Generate fingerprint for use in expo-updates runtime version
 
   Options
   --platform <string>                  Platform to generate a fingerprint for
+  --workflow <string>                  Workflow to use for fingerprint generation, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `,
@@ -47,13 +49,20 @@ Generate fingerprint for use in expo-updates runtime version
     throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
+  const workflowArg = args['--workflow'];
+  if (workflowArg && !['generic', 'managed'].includes(workflowArg)) {
+    throw new CommandError(
+      `Invalid workflow argument: ${workflowArg}. Must be either 'managed' or 'generic'`
+    );
+  }
+
   const debug = args['--debug'];
 
   const projectRoot = getProjectRoot(args);
 
   let result;
   try {
-    const workflow = await resolveWorkflowAsync(projectRoot, platform);
+    const workflow = workflowArg ?? (await resolveWorkflowAsync(projectRoot, platform));
     result = await createFingerprintAsync(projectRoot, platform, workflow, { silent: true, debug });
   } catch (e: any) {
     throw new CommandError(e.message);

--- a/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
+++ b/packages/expo-updates/cli/src/resolveRuntimeVersion.ts
@@ -12,6 +12,7 @@ export const resolveRuntimeVersion: Command = async (argv) => {
       // Types
       '--help': Boolean,
       '--platform': String,
+      '--workflow': String,
       '--debug': Boolean,
       // Aliases
       '-h': '--help',
@@ -30,6 +31,7 @@ Resolve expo-updates runtime version
 
   Options
   --platform <string>                  Platform to resolve runtime version for
+  --workflow <string>                  Workflow to use for runtime version resolution, and auto-detected if not provided
   --debug                              Whether to include verbose debug information in output
   -h, --help                           Output usage information
     `,
@@ -46,14 +48,28 @@ Resolve expo-updates runtime version
     throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
+  const workflow = args['--workflow'];
+  if (workflow && !['generic', 'managed'].includes(workflow)) {
+    throw new CommandError(
+      `Invalid workflow argument: ${workflow}. Must be either 'managed' or 'generic'`
+    );
+  }
+
   const debug = args['--debug'];
 
   let runtimeVersionInfo;
   try {
-    runtimeVersionInfo = await resolveRuntimeVersionAsync(getProjectRoot(args), platform, {
-      silent: true,
-      debug,
-    });
+    runtimeVersionInfo = await resolveRuntimeVersionAsync(
+      getProjectRoot(args),
+      platform,
+      {
+        silent: true,
+        debug,
+      },
+      {
+        workflowOverride: workflow,
+      }
+    );
   } catch (e: any) {
     throw new CommandError(e.message);
   }

--- a/packages/expo-updates/cli/src/syncConfigurationToNative.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNative.ts
@@ -13,6 +13,7 @@ export const syncConfigurationToNative: Command = async (argv) => {
       // Types
       '--help': Boolean,
       '--platform': String,
+      '--workflow': String,
       // Aliases
       '-h': '--help',
     },
@@ -31,6 +32,7 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
 
   Options
   --platform <string>                  Platform to sync
+  --workflow <string>                  Workflow to use for configuration sync
   -h, --help                           Output usage information
     `,
       0
@@ -42,8 +44,16 @@ only needs to be used by the EAS CLI for generic projects that do't use continuo
     throw new CommandError(`Invalid platform argument: ${platform}`);
   }
 
+  const workflow = requireArg(args, '--workflow');
+  if (!['generic', 'managed'].includes(workflow)) {
+    throw new CommandError(
+      `Invalid workflow argument: ${workflow}. Must be either 'managed' or 'generic'`
+    );
+  }
+
   await syncConfigurationToNativeAsync({
     projectRoot: getProjectRoot(args),
     platform,
+    workflow,
   });
 };

--- a/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
+++ b/packages/expo-updates/cli/src/syncConfigurationToNativeAsync.ts
@@ -4,11 +4,12 @@ import plist from '@expo/plist';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { resolveWorkflowAsync } from '../../utils/build/workflow';
+import { Workflow } from '../../utils/build/workflow';
 
 type SyncConfigurationToNativeOptions = {
   projectRoot: string;
   platform: 'ios' | 'android';
+  workflow: Workflow;
 };
 
 /**
@@ -17,8 +18,7 @@ type SyncConfigurationToNativeOptions = {
 export async function syncConfigurationToNativeAsync(
   options: SyncConfigurationToNativeOptions
 ): Promise<void> {
-  const workflow = await resolveWorkflowAsync(options.projectRoot, options.platform);
-  if (workflow !== 'generic') {
+  if (options.workflow !== 'generic') {
     // not applicable to managed workflow
   }
 

--- a/packages/expo-updates/utils/build/createFingerprintAsync.d.ts
+++ b/packages/expo-updates/utils/build/createFingerprintAsync.d.ts
@@ -1,2 +1,3 @@
 import * as Fingerprint from '@expo/fingerprint';
-export declare function createFingerprintAsync(projectRoot: string, platform: 'ios' | 'android', workflow: 'managed' | 'generic', options: Fingerprint.Options): Promise<Fingerprint.Fingerprint>;
+import { Workflow } from './workflow';
+export declare function createFingerprintAsync(projectRoot: string, platform: 'ios' | 'android', workflow: Workflow, options: Fingerprint.Options): Promise<Fingerprint.Fingerprint>;

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
@@ -36,13 +36,16 @@ async function createFingerprintForBuildAsync(platform, possibleProjectRoot, des
         return;
     }
     let fingerprint;
-    const override = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
-    if (override) {
-        console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${override}`);
-        fingerprint = { hash: override };
+    const fingerprintOverride = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
+    if (fingerprintOverride) {
+        console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${fingerprintOverride}`);
+        fingerprint = { hash: fingerprintOverride };
     }
     else {
-        const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
+        const workflowOverride = process.env.EXPO_UPDATES_WORKFLOW_OVERRIDE;
+        const workflow = workflowOverride
+            ? (0, workflow_1.validateWorkflow)(workflowOverride)
+            : await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
         const createdFingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, {});
         console.log(JSON.stringify(createdFingerprint.sources));
         fingerprint = createdFingerprint;

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.d.ts
@@ -1,5 +1,8 @@
 import * as Fingerprint from '@expo/fingerprint';
-export declare function resolveRuntimeVersionAsync(projectRoot: string, platform: 'ios' | 'android', options: Fingerprint.Options): Promise<{
+import { Workflow } from './workflow';
+export declare function resolveRuntimeVersionAsync(projectRoot: string, platform: 'ios' | 'android', fingerprintOptions: Fingerprint.Options, otherOptions: {
+    workflowOverride?: Workflow;
+}): Promise<{
     runtimeVersion: string | null;
     fingerprintSources: Fingerprint.FingerprintSource[] | null;
     workflow: 'managed' | 'generic';

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
@@ -5,19 +5,19 @@ const config_1 = require("@expo/config");
 const config_plugins_1 = require("@expo/config-plugins");
 const createFingerprintAsync_1 = require("./createFingerprintAsync");
 const workflow_1 = require("./workflow");
-async function resolveRuntimeVersionAsync(projectRoot, platform, options) {
+async function resolveRuntimeVersionAsync(projectRoot, platform, fingerprintOptions, otherOptions) {
     const { exp: config } = (0, config_1.getConfig)(projectRoot, {
         isPublicConfig: true,
         skipSDKVersionRequirement: true,
     });
-    const workflow = await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
+    const workflow = otherOptions.workflowOverride ?? (await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform));
     const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
     if (!runtimeVersion || typeof runtimeVersion === 'string') {
         return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null, workflow };
     }
     const policy = runtimeVersion.policy;
     if (policy === 'fingerprint') {
-        const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, options);
+        const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, fingerprintOptions);
         return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources, workflow };
     }
     if (workflow !== 'managed') {

--- a/packages/expo-updates/utils/build/vcs.js
+++ b/packages/expo-updates/utils/build/vcs.js
@@ -9,7 +9,7 @@ const promises_1 = __importDefault(require("fs/promises"));
 const ignore_1 = __importDefault(require("ignore"));
 const path_1 = __importDefault(require("path"));
 async function getVCSClientAsync(projectDir) {
-    if (await isGitInstalledAsync()) {
+    if (await isGitInstalledAndConfiguredAsync()) {
         return new GitClient();
     }
     else {
@@ -47,7 +47,7 @@ class NoVCSClient {
         return ignore.ignores(filePath);
     }
 }
-async function isGitInstalledAsync() {
+async function isGitInstalledAndConfiguredAsync() {
     try {
         await (0, spawn_async_1.default)('git', ['--help']);
     }
@@ -56,6 +56,12 @@ async function isGitInstalledAsync() {
             return false;
         }
         throw error;
+    }
+    try {
+        await (0, spawn_async_1.default)('git', ['rev-parse', '--show-toplevel']);
+    }
+    catch {
+        return false;
     }
     return true;
 }

--- a/packages/expo-updates/utils/build/workflow.d.ts
+++ b/packages/expo-updates/utils/build/workflow.d.ts
@@ -1,1 +1,3 @@
-export declare function resolveWorkflowAsync(projectDir: string, platform: 'ios' | 'android'): Promise<'managed' | 'generic'>;
+export type Workflow = 'managed' | 'generic';
+export declare function resolveWorkflowAsync(projectDir: string, platform: 'ios' | 'android'): Promise<Workflow>;
+export declare function validateWorkflow(possibleWorkflow: string): Workflow;

--- a/packages/expo-updates/utils/build/workflow.js
+++ b/packages/expo-updates/utils/build/workflow.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.resolveWorkflowAsync = void 0;
+exports.validateWorkflow = exports.resolveWorkflowAsync = void 0;
 const config_plugins_1 = require("@expo/config-plugins");
 const fs_extra_1 = __importDefault(require("fs-extra"));
 const path_1 = __importDefault(require("path"));
@@ -33,3 +33,10 @@ async function resolveWorkflowAsync(projectDir, platform) {
     return 'managed';
 }
 exports.resolveWorkflowAsync = resolveWorkflowAsync;
+function validateWorkflow(possibleWorkflow) {
+    if (possibleWorkflow === 'managed' || possibleWorkflow === 'generic') {
+        return possibleWorkflow;
+    }
+    throw new Error(`Invalid workflow: ${possibleWorkflow}. Must be either 'managed' or 'generic'`);
+}
+exports.validateWorkflow = validateWorkflow;

--- a/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
+++ b/packages/expo-updates/utils/src/__tests__/resolveRuntimeVersionAsync-test.ts
@@ -21,7 +21,7 @@ describe(resolveRuntimeVersionAsync, () => {
       exp: { name: 'test', slug: 'test', runtimeVersion: '3' },
     } as any);
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
-    await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
+    await expect(resolveRuntimeVersionAsync('.', 'ios', {}, {})).resolves.toEqual({
       runtimeVersion: '3',
       fingerprintSources: null,
       workflow: 'managed',
@@ -33,7 +33,7 @@ describe(resolveRuntimeVersionAsync, () => {
       exp: { name: 'test', slug: 'test', runtimeVersion: '3', ios: { runtimeVersion: '4' } },
     } as any);
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
-    await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
+    await expect(resolveRuntimeVersionAsync('.', 'ios', {}, {})).resolves.toEqual({
       runtimeVersion: '4',
       fingerprintSources: null,
       workflow: 'managed',
@@ -46,9 +46,20 @@ describe(resolveRuntimeVersionAsync, () => {
     } as any);
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('generic');
 
-    await expect(resolveRuntimeVersionAsync('.', 'ios', {})).rejects.toThrow(
+    await expect(resolveRuntimeVersionAsync('.', 'ios', {}, {})).rejects.toThrow(
       `You're currently using the bare workflow, where runtime version policies are not supported. You must set your runtime version manually. For example, define your runtime version as "1.0.0", not {"policy": "appVersion"} in your app config. https://docs.expo.dev/eas-update/runtime-versions`
     );
+  });
+
+  it('supports workflow override', async () => {
+    jest.mocked(getConfig).mockReturnValue({
+      exp: { name: 'test', slug: 'test', runtimeVersion: { policy: 'nativeVersion' } },
+    } as any);
+    jest.mocked(resolveWorkflowAsync).mockResolvedValue('generic');
+
+    await expect(
+      resolveRuntimeVersionAsync('.', 'ios', {}, { workflowOverride: 'managed' })
+    ).resolves.not.toThrow();
   });
 
   it('returns a fingerprint when fingerprint policy', async () => {
@@ -58,7 +69,7 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     jest.mocked(createFingerprintAsync).mockResolvedValue({ hash: 'hello', sources: [] });
 
-    await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
+    await expect(resolveRuntimeVersionAsync('.', 'ios', {}, {})).resolves.toEqual({
       runtimeVersion: 'hello',
       fingerprintSources: [],
       workflow: 'managed',
@@ -73,7 +84,7 @@ describe(resolveRuntimeVersionAsync, () => {
     jest.mocked(resolveWorkflowAsync).mockResolvedValue('managed');
     jest.mocked(Updates.resolveRuntimeVersionPolicyAsync).mockResolvedValue('what');
 
-    await expect(resolveRuntimeVersionAsync('.', 'ios', {})).resolves.toEqual({
+    await expect(resolveRuntimeVersionAsync('.', 'ios', {}, {})).resolves.toEqual({
       runtimeVersion: 'what',
       fingerprintSources: null,
       workflow: 'managed',

--- a/packages/expo-updates/utils/src/createFingerprintAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintAsync.ts
@@ -1,9 +1,11 @@
 import * as Fingerprint from '@expo/fingerprint';
 
+import { Workflow } from './workflow';
+
 export async function createFingerprintAsync(
   projectRoot: string,
   platform: 'ios' | 'android',
-  workflow: 'managed' | 'generic',
+  workflow: Workflow,
   options: Fingerprint.Options
 ): Promise<Fingerprint.Fingerprint> {
   if (workflow === 'generic') {

--- a/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { createFingerprintAsync } from './createFingerprintAsync';
-import { resolveWorkflowAsync } from './workflow';
+import { resolveWorkflowAsync, validateWorkflow } from './workflow';
 
 export async function createFingerprintForBuildAsync(
   platform: 'ios' | 'android',
@@ -40,12 +40,15 @@ export async function createFingerprintForBuildAsync(
 
   let fingerprint: { hash: string };
 
-  const override = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
-  if (override) {
-    console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${override}`);
-    fingerprint = { hash: override };
+  const fingerprintOverride = process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE;
+  if (fingerprintOverride) {
+    console.log(`Using fingerprint from EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${fingerprintOverride}`);
+    fingerprint = { hash: fingerprintOverride };
   } else {
-    const workflow = await resolveWorkflowAsync(projectRoot, platform);
+    const workflowOverride = process.env.EXPO_UPDATES_WORKFLOW_OVERRIDE;
+    const workflow = workflowOverride
+      ? validateWorkflow(workflowOverride)
+      : await resolveWorkflowAsync(projectRoot, platform);
     const createdFingerprint = await createFingerprintAsync(projectRoot, platform, workflow, {});
     console.log(JSON.stringify(createdFingerprint.sources));
     fingerprint = createdFingerprint;

--- a/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
+++ b/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
@@ -3,12 +3,13 @@ import { Updates } from '@expo/config-plugins';
 import * as Fingerprint from '@expo/fingerprint';
 
 import { createFingerprintAsync } from './createFingerprintAsync';
-import { resolveWorkflowAsync } from './workflow';
+import { Workflow, resolveWorkflowAsync } from './workflow';
 
 export async function resolveRuntimeVersionAsync(
   projectRoot: string,
   platform: 'ios' | 'android',
-  options: Fingerprint.Options
+  fingerprintOptions: Fingerprint.Options,
+  otherOptions: { workflowOverride?: Workflow }
 ): Promise<{
   runtimeVersion: string | null;
   fingerprintSources: Fingerprint.FingerprintSource[] | null;
@@ -19,7 +20,8 @@ export async function resolveRuntimeVersionAsync(
     skipSDKVersionRequirement: true,
   });
 
-  const workflow = await resolveWorkflowAsync(projectRoot, platform);
+  const workflow =
+    otherOptions.workflowOverride ?? (await resolveWorkflowAsync(projectRoot, platform));
 
   const runtimeVersion = config[platform]?.runtimeVersion ?? config.runtimeVersion;
   if (!runtimeVersion || typeof runtimeVersion === 'string') {
@@ -29,7 +31,12 @@ export async function resolveRuntimeVersionAsync(
   const policy = runtimeVersion.policy;
 
   if (policy === 'fingerprint') {
-    const fingerprint = await createFingerprintAsync(projectRoot, platform, workflow, options);
+    const fingerprint = await createFingerprintAsync(
+      projectRoot,
+      platform,
+      workflow,
+      fingerprintOptions
+    );
     return { runtimeVersion: fingerprint.hash, fingerprintSources: fingerprint.sources, workflow };
   }
 

--- a/packages/expo-updates/utils/src/vcs.ts
+++ b/packages/expo-updates/utils/src/vcs.ts
@@ -10,7 +10,7 @@ export interface Client {
 }
 
 export default async function getVCSClientAsync(projectDir: string): Promise<Client> {
-  if (await isGitInstalledAsync()) {
+  if (await isGitInstalledAndConfiguredAsync()) {
     return new GitClient();
   } else {
     return new NoVCSClient(projectDir);
@@ -48,7 +48,7 @@ class NoVCSClient implements Client {
   }
 }
 
-async function isGitInstalledAsync(): Promise<boolean> {
+async function isGitInstalledAndConfiguredAsync(): Promise<boolean> {
   try {
     await spawnAsync('git', ['--help']);
   } catch (error: any) {
@@ -57,6 +57,13 @@ async function isGitInstalledAsync(): Promise<boolean> {
     }
     throw error;
   }
+
+  try {
+    await spawnAsync('git', ['rev-parse', '--show-toplevel']);
+  } catch {
+    return false;
+  }
+
   return true;
 }
 

--- a/packages/expo-updates/utils/src/workflow.ts
+++ b/packages/expo-updates/utils/src/workflow.ts
@@ -4,10 +4,12 @@ import path from 'path';
 
 import getVCSClientAsync from './vcs';
 
+export type Workflow = 'managed' | 'generic';
+
 export async function resolveWorkflowAsync(
   projectDir: string,
   platform: 'ios' | 'android'
-): Promise<'managed' | 'generic'> {
+): Promise<Workflow> {
   const vcsClient = await getVCSClientAsync(projectDir);
 
   let platformWorkflowMarkers: string[];
@@ -33,4 +35,12 @@ export async function resolveWorkflowAsync(
     }
   }
   return 'managed';
+}
+
+export function validateWorkflow(possibleWorkflow: string): Workflow {
+  if (possibleWorkflow === 'managed' || possibleWorkflow === 'generic') {
+    return possibleWorkflow;
+  }
+
+  throw new Error(`Invalid workflow: ${possibleWorkflow}. Must be either 'managed' or 'generic'`);
 }


### PR DESCRIPTION
# Why

When there's no `.git` folder uploaded as part of the build (when `requireCommit` is false or not present in eas.json), even though git is installed, we also need to make sure we're working in a valid repo before deciding to use the `GitClient` as opposed to the `NoVCSClient` for workflow detection.

Part 2 of this is adding the ability to override workflow detection so that in EAS Build we can do workflow detection before running prebuild (which invalidates workflow detection since workflow detection depends on the presence of the native folders and their gitignore status).

Closes ENG-11995.

# How

When deciding which vcs system to use to detect workflow, also check if the root path detection command will work.

# Test Plan

For VCS fix:

1. Create a canary project, configure eas and eas-updates
2. `npm pack` expo-updates
3. add to project, use in project's package.json
4. run eas build

before:
https://staging.expo.dev/accounts/real-org-will/projects/test-normal-build-norequirecommit/builds/f8d5512b-32c6-40b6-8842-4d9ccbd1c8f0

after:
https://staging.expo.dev/accounts/real-org-will/projects/test-normal-build-norequirecommit/builds/c7e38a7b-9b0c-4e80-b5d7-85fc6a8c4430

(note that it's still broken, but for a reason related to the second part which will require multiple fixes to fix)

For workflow override:

1. `yarn link expo-updates` in project above locally

```
npx expo-updates runtimeversion:resolve --platform android --workflow managed
npx expo-updates runtimeversion:resolve --platform android --workflow generic
npx expo-updates fingerprint:generate --platform android --workflow managed
npx expo-updates fingerprint:generate --platform android --workflow generic
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
