### PR TITLE
[doc] Add information about local builds

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -125,6 +125,8 @@ You can create up to 100 account-wide secrets for each Expo account and 100 app-
 
 You can manage secrets through the Expo website and EAS CLI.
 
+> If you are using EAS Build for building in your local infraestructure (`eas build --local`), remember to also add the variables in `~/.bash_profile` (or `~/.zshrc` if you use Zsh)
+
 > **warning** Always remember that **anything that is included in your client side code should be considered public and readable to any individual that can run the application**.
 > EAS Secrets are intended to be used to provide values to an EAS Build job so that they may be used during the build process.
 > Examples of correct usage include setting the `NPM_TOKEN` for installing private packages from npm, or a Sentry API key to create a release and upload your sourcemaps to their service.


### PR DESCRIPTION
# Why
Because `eas build -p android --local` was not working without defining it in my local env, and it was not very clear in the doc.


# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


Reference: https://github.com/expo/expo/pull/28381