### PR TITLE
fix(cli): Update Links to docs.expo.dev

### DIFF
--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -149,7 +149,7 @@ export async function installPackagesAsync(
         )} because ${
           alreadyExcluded.length > 1 ? 'they are' : 'it is'
         } listed in {bold expo.install.exclude} in package.json. ${learnMore(
-          'https://expo.dev/more/expo-cli/#configuring-dependency-validation'
+          'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
         )}`
       );
     }
@@ -164,7 +164,7 @@ export async function installPackagesAsync(
         )} because ${
           specifiedExactVersion.length > 1 ? 'these versions' : 'this version'
         } was explicitly provided. Packages excluded from dependency validation should be listed in {bold expo.install.exclude} in package.json. ${learnMore(
-          'https://expo.dev/more/expo-cli/#configuring-dependency-validation'
+          'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
         )}`
       );
     }


### PR DESCRIPTION
# Why

Old links return a 404. 
Maybe there should be a redirect as well?

# Test Plan

Links opened in Browser

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
