### PR TITLE
[docs] [ENG-11602] Update Android image docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -82,7 +82,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-11-ndk-r23b` (`sdk-49`)
+#### `ubuntu-22.04-jdk-11-ndk-r23b`
 
 <Collapsible summary="Details">
 
@@ -146,7 +146,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r23b`
+#### `ubuntu-20.04-jdk-11-ndk-r23b` (`sdk-49`)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

Updated the docs for available Android images after changing the image mapped to the `sdk-49` tag
https://linear.app/expo/issue/ENG-11602/preinstall-gradle-and-ndks-used-in-the-3-latests-sdks-on-android

# How

Moved the tag annotation from `ubuntu-22.04-jdk-11-ndk-r23b` to `ubuntu-20.04-jdk-11-ndk-r23b`

# Test Plan

Checked locally

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
