### PR TITLE
docs(config-plugins): add `mods.ios.podfile` and `withPodfile` docs

### DIFF
--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -209,6 +209,7 @@ The following default mods are provided by the mod compiler for common file mani
 | `mods.ios.entitlements`      |        -        | Modify the **ios/&lt;name&gt;/&lt;product-name&gt;.entitlements** as JSON (parsed with [`@expo/plist`][expo-plist]).                |
 | `mods.ios.expoPlist`         |        -        | Modify the **ios/&lt;ame&gt;/Expo.plist** as JSON (Expo updates config for iOS) (parsed with [`@expo/plist`][expo-plist]).          |
 | `mods.ios.xcodeproj`         |        -        | Modify the **ios/&lt;name&gt;.xcodeproj** as an `XcodeProject` object (parsed with [`xcode`](https://www.npmjs.com/package/xcode)). |
+| `mods.ios.podfile`           |        -        | Modify the **ios/Podfile** as a string.                                                                                             |
 | `mods.ios.podfileProperties` |        -        | Modify the **ios/Podfile.properties.json** as JSON.                                                                                 |
 | `mods.ios.appDelegate`       | <WarningIcon /> | Modify the **ios/&lt;name&gt;/AppDelegate.m** as a string.                                                                          |
 
@@ -246,6 +247,7 @@ Instead you should use the helper mods provided by `expo/config-plugins`:
 | `mods.ios.entitlements`      | `withEntitlementsPlist` |        -        |
 | `mods.ios.expoPlist`         | `withExpoPlist`         |        -        |
 | `mods.ios.xcodeproj`         | `withXcodeProject`      |        -        |
+| `mods.ios.podfile`           | `withPodfile`           |        -        |
 | `mods.ios.podfileProperties` | `withPodfileProperties` |        -        |
 | `mods.ios.appDelegate`       | `withAppDelegate`       | <WarningIcon /> |
 


### PR DESCRIPTION
# Why

Follow-up of #27209

Merge this for SDK 51 stable release.

# How

I added the docs to this separate PR since the config plugin docs aren't versioned. This means that once I merge the other PR, the docs will deploy.

# Test Plan

Just a docs change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
