### PR TITLE
[video][ios] Fix memory leak

### DIFF
--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -6,7 +6,7 @@ import ExpoModulesCore
 public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   lazy var playerViewController = AVPlayerViewController()
 
-  var player: VideoPlayer? {
+  weak var player: VideoPlayer? {
     didSet {
       playerViewController.player = player?.pointer
     }


### PR DESCRIPTION
# Why

`VideoPlayer`'s native part wouldn't release when the JS part was released on iOS. 

# How

`VideoView`, which gets deallocated much later than `VideoPlayer` was holding a strong reference to the player. This made the player keep playing after leaving screens which were playing.

# Test Plan

Tested in BareExpo on iPhone 13 with iOS 17

