### PR TITLE
[et] Fix `update-native-dependencies`

### DIFF
--- a/tools/src/android-update-native-dependencies/androidProjectReports.ts
+++ b/tools/src/android-update-native-dependencies/androidProjectReports.ts
@@ -150,6 +150,14 @@ async function readGradleReportAndConvertIntoAndroidReport(
     if (await pathExists(gradleBuildKotlin)) {
       return gradleBuildKotlin;
     }
+    const projectGradleBuildGroovy = path.resolve(reportPath, '../../../../build.gradle');
+    const projectGradleBuildKotlin = path.resolve(reportPath, '../../../../build.gradle.kts');
+    if (await pathExists(projectGradleBuildGroovy)) {
+      return gradleBuildGroovy;
+    }
+    if (await pathExists(projectGradleBuildKotlin)) {
+      return gradleBuildKotlin;
+    }
     throw new Error(`Failed to locate gradle.build(.kts)? for report: ${reportPath}`);
   };
 
@@ -182,7 +190,11 @@ async function readAndConvertReports(): Promise<AndroidProjectReport[]> {
   const findGradleReportsFiles = async (cwd: string): Promise<string[]> => {
     const result = await glob('**/build/dependencyUpdates/report.json', {
       cwd,
-      ignore: ['**/node_modules, **/ios'],
+      ignore: [
+        '**/node_modules, **/ios',
+        '**/packages/react-native/**',
+        '**/vendored/unversioned/**',
+      ],
     });
     return Promise.all(result.map(async (el) => path.resolve(cwd, el)));
   };

--- a/tools/src/android-update-native-dependencies/initScript.gradle
+++ b/tools/src/android-update-native-dependencies/initScript.gradle
@@ -4,7 +4,7 @@ initscript {
   }
 
   dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:v0.44.0'
+    classpath 'com.github.ben-manes:gradle-versions-plugin:+'
   }
 }
 


### PR DESCRIPTION
# Why

Fixes `et update-native-dependencies`. It wasn't working because our repo structure was changed. 
Closes ENG-12062


# Test Plan

- run `et update-native-dependencies` ✅ 