### PR TITLE
[docs] add missing external types links for `expo-speech`

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -194,6 +194,9 @@ const hardcodedTypeLinks: Record<string, string> = {
   Required: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype',
   SFSymbol: 'https://github.com/nandorojo/sf-symbols-typescript',
   ShareOptions: 'https://reactnative.dev/docs/share#share',
+  SpeechSynthesisEvent: 'https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent',
+  SpeechSynthesisUtterance:
+    'https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisUtterance',
   SyntheticEvent: 'https://react.dev/reference/react-dom/components/common#react-event-object',
   View: 'https://reactnative.dev/docs/view',
   ViewProps: 'https://reactnative.dev/docs/view#props',

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -274,7 +274,9 @@ exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 <div>
   <a
     class="css-1na8e0o-A"
-    href="#speechsynthesisevent"
+    href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent"
+    rel="noopener noreferrer"
+    target="_blank"
   >
     SpeechSynthesisEvent
   </a>


### PR DESCRIPTION
# Why

![Screenshot 2024-04-24 at 15 43 24](https://github.com/expo/expo/assets/719641/84bbf2ab-5018-4251-9653-1b599ea29b3a)

# How

Add missing external types links for `expo-speech` package.

# Test Plan

The changes have been reviewed locally. External links are working as expected.
