### PR TITLE
[video] Fix issues with the event system

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VolumeEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VolumeEvent.kt
@@ -6,5 +6,5 @@ import java.io.Serializable
 
 internal class VolumeEvent(
   @Field var volume: Float? = null,
-  @Field var muted: Boolean? = null
+  @Field var isMuted: Boolean? = null
 ) : Record, Serializable

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -14,7 +14,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   var playbackRate: Float = 1.0 {
     didSet {
       if oldValue != playbackRate {
-        appContextSafeEmit(event: "playbackRateChange", arguments: playbackRate, oldValue)
+        safeEmit(event: "playbackRateChange", arguments: playbackRate, oldValue)
       }
       if #available(iOS 16.0, *) {
         pointer.defaultRate = playbackRate
@@ -45,7 +45,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         let oldVolumeEvent = VolumeEvent(volume: oldValue, isMuted: isMuted)
         let newVolumeEvent = VolumeEvent(volume: volume, isMuted: isMuted)
 
-        appContextSafeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
+        safeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
       }
       pointer.volume = volume
     }
@@ -57,7 +57,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         let oldVolumeEvent = VolumeEvent(volume: volume, isMuted: oldValue)
         let newVolumeEvent = VolumeEvent(volume: volume, isMuted: isMuted)
 
-        appContextSafeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
+        safeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
       }
       pointer.isMuted = isMuted
     }
@@ -118,12 +118,12 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   func onStatusChanged(player: AVPlayer, oldStatus: PlayerStatus?, newStatus: PlayerStatus, error: Exception?) {
     let errorRecord = error != nil ? PlaybackError(message: error?.localizedDescription) : nil
-    appContextSafeEmit(event: "statusChange", arguments: newStatus.rawValue, oldStatus?.rawValue, errorRecord)
+    safeEmit(event: "statusChange", arguments: newStatus.rawValue, oldStatus?.rawValue, errorRecord)
     status = newStatus
   }
 
   func onIsPlayingChanged(player: AVPlayer, oldIsPlaying: Bool?, newIsPlaying: Bool) {
-    appContextSafeEmit(event: "playingChange", arguments: newIsPlaying, oldIsPlaying)
+    safeEmit(event: "playingChange", arguments: newIsPlaying, oldIsPlaying)
     isPlaying = newIsPlaying
   }
 
@@ -149,7 +149,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onPlayedToEnd(player: AVPlayer) {
-    appContextSafeEmit(event: "playToEnd")
+    safeEmit(event: "playToEnd")
     if loop {
       self.pointer.seek(to: .zero)
       self.pointer.play()
@@ -157,10 +157,10 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onItemChanged(player: AVPlayer, oldVideoPlayerItem: VideoPlayerItem?, newVideoPlayerItem: VideoPlayerItem?) {
-    appContextSafeEmit(event: "sourceChange", arguments: newVideoPlayerItem?.videoSource, oldVideoPlayerItem?.videoSource)
+    safeEmit(event: "sourceChange", arguments: newVideoPlayerItem?.videoSource, oldVideoPlayerItem?.videoSource)
   }
 
-  func appContextSafeEmit<each A: AnyArgument>(event: String, arguments: repeat each A) {
+  func safeEmit<each A: AnyArgument>(event: String, arguments: repeat each A) {
     if self.appContext != nil {
       self.emit(event: event, arguments: repeat each arguments)
     }

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -14,7 +14,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   var playbackRate: Float = 1.0 {
     didSet {
       if oldValue != playbackRate {
-        self.emit(event: "playbackRateChange", arguments: playbackRate, oldValue)
+        appContextSafeEmit(event: "playbackRateChange", arguments: playbackRate, oldValue)
       }
       if #available(iOS 16.0, *) {
         pointer.defaultRate = playbackRate
@@ -45,7 +45,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         let oldVolumeEvent = VolumeEvent(volume: oldValue, isMuted: isMuted)
         let newVolumeEvent = VolumeEvent(volume: volume, isMuted: isMuted)
 
-        self.emit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
+        appContextSafeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
       }
       pointer.volume = volume
     }
@@ -57,7 +57,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         let oldVolumeEvent = VolumeEvent(volume: volume, isMuted: oldValue)
         let newVolumeEvent = VolumeEvent(volume: volume, isMuted: isMuted)
 
-        self.emit(event: "volumeChange", arguments: newVolumeEvent.isMuted, oldVolumeEvent.isMuted)
+        appContextSafeEmit(event: "volumeChange", arguments: newVolumeEvent, oldVolumeEvent)
       }
       pointer.isMuted = isMuted
     }
@@ -118,12 +118,12 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   func onStatusChanged(player: AVPlayer, oldStatus: PlayerStatus?, newStatus: PlayerStatus, error: Exception?) {
     let errorRecord = error != nil ? PlaybackError(message: error?.localizedDescription) : nil
-    self.emit(event: "statusChange", arguments: newStatus.rawValue, oldStatus?.rawValue, errorRecord)
+    appContextSafeEmit(event: "statusChange", arguments: newStatus.rawValue, oldStatus?.rawValue, errorRecord)
     status = newStatus
   }
 
   func onIsPlayingChanged(player: AVPlayer, oldIsPlaying: Bool?, newIsPlaying: Bool) {
-    self.emit(event: "playingChange", arguments: newIsPlaying, oldIsPlaying)
+    appContextSafeEmit(event: "playingChange", arguments: newIsPlaying, oldIsPlaying)
     isPlaying = newIsPlaying
   }
 
@@ -149,7 +149,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onPlayedToEnd(player: AVPlayer) {
-    self.emit(event: "playToEnd")
+    appContextSafeEmit(event: "playToEnd")
     if loop {
       self.pointer.seek(to: .zero)
       self.pointer.play()
@@ -157,7 +157,13 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onItemChanged(player: AVPlayer, oldVideoPlayerItem: VideoPlayerItem?, newVideoPlayerItem: VideoPlayerItem?) {
-    self.emit(event: "sourceChange", arguments: newVideoPlayerItem?.videoSource, oldVideoPlayerItem?.videoSource)
+    appContextSafeEmit(event: "sourceChange", arguments: newVideoPlayerItem?.videoSource, oldVideoPlayerItem?.videoSource)
+  }
+
+  func appContextSafeEmit<each A: AnyArgument>(event: String, arguments: repeat each A) {
+    if self.appContext != nil {
+      self.emit(event: event, arguments: repeat each arguments)
+    }
   }
 
   // MARK: - Hashable

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -104,7 +104,8 @@ class VideoPlayerObserver {
   // MARK: - VideoPlayerObserverDelegate
 
   private func onPlayerCurrentItemChanged(_ player: AVPlayer, _ change: NSKeyValueObservedChange<AVPlayerItem?>) {
-    let newPlayerItem = change.newValue
+    // Unwraps Optional<Optional<AVPlayerItem>> into Optional<AVPlayerItem>
+    let newPlayerItem = change.newValue?.flatMap({ $0 })
 
     invalidateCurrentPlayerItemObservers()
 
@@ -120,7 +121,7 @@ class VideoPlayerObserver {
       status = .idle
     } else {
       log.warn(
-        "VideoPlayer's AVPlayer has been initialized with a `AVPlayerItem` instead of a `VideoPlayerItem`." +
+        "VideoPlayer's AVPlayer has been initialized with a `AVPlayerItem` instead of a `VideoPlayerItem`. " +
         "Always use `VideoPlayerItem` as a wrapper for media played in `VideoPlayer`."
       )
     }


### PR DESCRIPTION
# Why

Fixes a few issues I encountered with the `expo-video` event system.

# How

- `VolumeEvent` on android used `muted` instead of `isMuted` property name
- Due to double optional the warning `VideoPlayer's AVPlayer has been initialized with a AVPlayerItem instead of a VideoPlayerItem ` was thrown when it wasn't necessary
- The events can be sent before the `AppContext` is initialised as the video is loaded early. This would lead to warnings. For now the player won't send events when `AppContext` is not present. In the future we should consider a more robust solution.

# Test Plan

Tested in BareExpo on Android 14 emulatore and iOS 17 device.

