### PR TITLE
[ios][camera] Reduce initialization frequency

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fixed regression where recording a video captures dark frames. Reduced frequency of camera initialization.
+- On `iOS`, fixed regression where recording a video captures dark frames. Reduced frequency of camera initialization. ([#28427](https://github.com/expo/expo/pull/28427) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fixed regression where recording a video captures dark frames. Reduced frequency of camera initialization.
+
 ### 💡 Others
 
 ## 15.0.1 — 2024-04-23

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -106,7 +106,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
           view.responsiveWhenOrientationLocked = responsiveOrientation
         }
       }
-      
+
       OnViewDidUpdateProps { view in
         view.initCamera()
       }

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -88,9 +88,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
 
       Prop("mute") { (view, muted: Bool?) in
-        if let muted, view.isMuted != muted {
-          view.isMuted = muted
-        }
+        view.isMuted = muted ?? false
       }
 
       Prop("animateShutter") { (view, animate: Bool?) in
@@ -107,6 +105,10 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         if let responsiveOrientation, view.responsiveWhenOrientationLocked != responsiveOrientation {
           view.responsiveWhenOrientationLocked = responsiveOrientation
         }
+      }
+      
+      OnViewDidUpdateProps { view in
+        view.initCamera()
       }
 
       AsyncFunction("getAvailablePictureSizes") { (_: String?) in

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -28,6 +28,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     mm.gyroUpdateInterval = 0.2
     return mm
   }()
+  private var cameraShouldInit = true
 
   // MARK: Property Observers
 
@@ -124,8 +125,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     setupPreview()
     #endif
     UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-    initializeCaptureSessionInput()
-    startSession()
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(orientationChanged(notification:)),
@@ -139,14 +138,17 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     previewLayer.videoPreviewLayer.videoGravity = .resizeAspectFill
     previewLayer.videoPreviewLayer.needsDisplayOnBoundsChange = true
   }
+  
+  func initCamera() {
+    guard cameraShouldInit else {
+      return
+    }
+    cameraShouldInit = false
+    self.initializeCaptureSessionInput()
+  }
 
   private func updateType() {
-    sessionQueue.async {
-      self.initializeCaptureSessionInput()
-      if !self.session.isRunning {
-        self.startSession()
-      }
-    }
+    cameraShouldInit = true
   }
 
   public func onAppForegrounded() {
@@ -199,7 +201,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       if self.mode == .video {
         if self.videoFileOutput == nil {
           self.setupMovieFileCapture()
-          self.updateSessionAudioIsMuted()
         }
       } else {
         self.cleanupMovieFileCapture()
@@ -230,16 +231,13 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
 
       self.addErrorNotification()
       self.changePreviewOrientation()
-      self.session.commitConfiguration()
-
-      // Delay starting the scanner
-      self.sessionQueue.asyncAfter(deadline: .now() + 0.5) {
-        self.barcodeScanner.maybeStartBarcodeScanning()
-        if !self.session.isRunning {
-          self.session.startRunning()
-        }
-        self.onCameraReady()
-      }
+    }
+    
+    // Delay starting the scanner
+    sessionQueue.asyncAfter(deadline: .now() + 0.5) {
+      self.barcodeScanner.maybeStartBarcodeScanning()
+      self.session.startRunning()
+      self.onCameraReady()
     }
   }
 
@@ -513,6 +511,13 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
 
   func record(options: CameraRecordingOptions, promise: Promise) {
     sessionQueue.async {
+      let preset = options.quality?.toPreset()
+      if let preset {
+        self.updateSessionPreset(preset: preset)
+      }
+    }
+    
+    sessionQueue.async {
       if let videoFileOutput = self.videoFileOutput, !videoFileOutput.isRecording && self.videoRecordedPromise == nil {
         if let connection = videoFileOutput.connection(with: .video) {
           if !connection.isVideoStabilizationSupported {
@@ -532,8 +537,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
           }
         }
 
-        let preset = options.quality?.toPreset() ?? .high
-        self.updateSessionPreset(preset: preset)
+//        let preset = options.quality?.toPreset() ?? .high
+//        self.updateSessionPreset(preset: preset)
 
         if !self.isValidVideoOptions {
           return
@@ -582,13 +587,13 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   func updateSessionAudioIsMuted() {
     sessionQueue.async {
       self.session.beginConfiguration()
-      for input in self.session.inputs {
-        if let deviceInput = input as? AVCaptureDeviceInput {
-          if deviceInput.device.hasMediaType(.audio) {
-            if self.isMuted {
+      if self.isMuted {
+        for input in self.session.inputs {
+          if let deviceInput = input as? AVCaptureDeviceInput {
+            if deviceInput.device.hasMediaType(.audio) {
               self.session.removeInput(input)
+              return
             }
-            return
           }
         }
       }
@@ -687,9 +692,11 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   func updateSessionPreset(preset: AVCaptureSession.Preset) {
 #if !targetEnvironment(simulator)
     if self.session.canSetSessionPreset(preset) {
-      self.session.beginConfiguration()
-      self.session.sessionPreset = preset
-      self.session.commitConfiguration()
+      if self.session.sessionPreset != preset {
+        self.session.beginConfiguration()
+        self.session.sessionPreset = preset
+        self.session.commitConfiguration()
+      }
     }
 #endif
   }
@@ -722,6 +729,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         self.onMountError(["message": "Camera could not be started - \(error.localizedDescription)"])
       }
       self.session.commitConfiguration()
+      self.startSession()
     }
   }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -138,7 +138,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     previewLayer.videoPreviewLayer.videoGravity = .resizeAspectFill
     previewLayer.videoPreviewLayer.needsDisplayOnBoundsChange = true
   }
-  
+
   func initCamera() {
     guard cameraShouldInit else {
       return
@@ -232,7 +232,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       self.addErrorNotification()
       self.changePreviewOrientation()
     }
-    
+
     // Delay starting the scanner
     sessionQueue.asyncAfter(deadline: .now() + 0.5) {
       self.barcodeScanner.maybeStartBarcodeScanning()
@@ -516,7 +516,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         self.updateSessionPreset(preset: preset)
       }
     }
-    
+
     sessionQueue.async {
       if let videoFileOutput = self.videoFileOutput, !videoFileOutput.isRecording && self.videoRecordedPromise == nil {
         if let connection = videoFileOutput.connection(with: .video) {

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -537,9 +537,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
           }
         }
 
-//        let preset = options.quality?.toPreset() ?? .high
-//        self.updateSessionPreset(preset: preset)
-
         if !self.isValidVideoOptions {
           return
         }


### PR DESCRIPTION
# Why
Closes #28408

Similar to  #27952, this PR attempts to reduce the number of times the camera must be reconfigured. Before, we had been initializing the camera and starting the session in the initializer. This was fine if you were using the defaults.  If, for example, you wanted to start in `video` mode then the camera would start, configure for `picture`, the default, and then immediately reconfigure for video. This also caused lifecycle problems as the camera session was started on init and then immediately began reconfiguring for `video` which will occasionally cause a crash because `startSession` cannot be called between configuration calls.

This also fixes a regression where dark frames were captured at the start of a video recording. 

# How
- We are using a serial queue to manage the camera. Nesting calls inside the blocks was a mistake. We should instead push blocks onto the queue in the order we need them to run. This leads to much more consistent and predictable setup
- The call to `updateSessionAudioIsMuted` was happening too often and was causing lifecycle issues because of this. It was also doing too much work as we didn't need to iterate through the inputs unless they needed to be removed.
- Added `OnViewDidUpdateProps` and only configure the camera when the initial group of props have been updated.

# Test Plan
Bare-expo ✅ Tested with various starting configurations. `picture`, `video`, muted, unmuted etc. Dead frames on videos have been removed.
