### PR TITLE
[dev-client] fix missing transform.routerRoot

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed "Missing transform.routerRoot option in Metro bundling request" error when loading the bundle. ([#28428](https://github.com/expo/expo/pull/28428) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 4.0.3 — 2024-04-23

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
@@ -1,0 +1,50 @@
+package com.facebook.react.devsupport
+
+import android.content.Context
+import android.net.Uri
+import com.facebook.react.modules.debug.interfaces.DeveloperSettings
+import com.facebook.react.packagerconnection.PackagerConnectionSettings
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+
+class DevLauncherDevServerHelper(
+  context: Context,
+  private val controller: DevLauncherControllerInterface?,
+  devSettings: DeveloperSettings,
+  packagerConnection: PackagerConnectionSettings
+) :
+  DevServerHelper(devSettings, context.packageName, packagerConnection) {
+
+  override fun getDevServerBundleURL(jsModulePath: String?): String {
+    return controller?.manifest?.getBundleURL() ?: super.getDevServerBundleURL(jsModulePath)
+  }
+
+  override fun getDevServerSplitBundleURL(jsModulePath: String?): String {
+    return controller?.manifest?.getBundleURL() ?: super.getDevServerSplitBundleURL(jsModulePath)
+  }
+
+  override fun getSourceUrl(mainModuleName: String?): String {
+    return controller?.manifest?.getBundleURL() ?: super.getSourceUrl(mainModuleName)
+  }
+
+  override fun getSourceMapUrl(mainModuleName: String?): String {
+    val defaultValue = super.getSourceMapUrl(mainModuleName)
+    val bundleURL = controller?.manifest?.getBundleURL()
+      ?: return defaultValue
+
+    val parsedURL = Uri.parse(bundleURL)
+    val customOptions = parsedURL.queryParameterNames.mapNotNull { key ->
+      if (key.startsWith("transform")) {
+        key to requireNotNull(parsedURL.getQueryParameter(key))
+      } else {
+        null
+      }
+    }.ifEmpty {
+      return defaultValue
+    }
+
+    val customOptionsString = customOptions.joinToString("&") { (key, value) ->
+      "$key=$value"
+    }
+    return "$defaultValue&$customOptionsString"
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherInternalSettings.kt
@@ -1,7 +1,7 @@
 package com.facebook.react.devsupport
 
 import android.content.Context
-import com.facebook.react.packagerconnection.PackagerConnectionSettings
+import com.facebook.react.devsupport.DevInternalSettings.Listener
 import expo.modules.devlauncher.react.DevLauncherPackagerConnectionSettings
 
 internal class DevLauncherInternalSettings(
@@ -14,17 +14,4 @@ internal class DevLauncherInternalSettings(
 
   @Suppress("FunctionName")
   fun public_getPackagerConnectionSettings() = getPackagerConnectionSettings()
-}
-
-/**
- * A wrapper of [DevInternalSettings] allows us to access the package-private [DevInternalSettings] properties
- */
-internal class DevLauncherInternalSettingsWrapper(private val devSettings: DevInternalSettings) {
-  val isStartSamplingProfilerOnInit = devSettings.isStartSamplingProfilerOnInit
-  var isRemoteJSDebugEnabled: Boolean
-    get() = devSettings.isRemoteJSDebugEnabled
-    set(value) {
-      devSettings.isRemoteJSDebugEnabled = value
-    }
-  val packagerConnectionSettings: PackagerConnectionSettings = devSettings.packagerConnectionSettings
 }

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgeDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgeDevSupportManager.kt
@@ -8,6 +8,7 @@ import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.RedBoxHandler
 import com.facebook.react.packagerconnection.RequestHandler
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.injectDevServerHelper
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.koin.optInject
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
@@ -15,7 +16,7 @@ import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
 
 class DevLauncherBridgeDevSupportManager(
-  applicationContext: Context?,
+  applicationContext: Context,
   reactInstanceDevHelper: ReactInstanceDevHelper?,
   packagerPathForJSBundleName: String?,
   enableOnCreate: Boolean,
@@ -38,10 +39,17 @@ class DevLauncherBridgeDevSupportManager(
   DevLauncherKoinComponent {
   private val controller: DevLauncherControllerInterface? by optInject()
 
+  init {
+    injectDevServerHelper(applicationContext, this, controller)
+  }
+
   override fun showNewJavaError(message: String?, e: Throwable) {
     Log.e("DevLauncher", "$message", e)
     if (!DevLauncherController.wasInitialized()) {
-      Log.e("DevLauncher", "DevLauncher wasn't initialized. Couldn't intercept native error handling.")
+      Log.e(
+        "DevLauncher",
+        "DevLauncher wasn't initialized. Couldn't intercept native error handling."
+      )
       super.showNewJavaError(message, e)
       return
     }
@@ -55,7 +63,7 @@ class DevLauncherBridgeDevSupportManager(
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
   }
 
-  override fun getUniqueTag() = "DevLauncherApp - Bridge"
+  override fun getUniqueTag() = "DevLauncherApp-Bridge"
 
   override fun startInspector() {
     // no-op for the default `startInspector` which would be implicitly called

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgelessDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgelessDevSupportManager.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.facebook.react.runtime.NonFinalBridgelessDevSupportManager
 import com.facebook.react.runtime.ReactHostImpl
 import expo.modules.devlauncher.DevLauncherController
+import expo.modules.devlauncher.helpers.injectDevServerHelper
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
 import expo.modules.devlauncher.koin.optInject
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
@@ -17,6 +18,10 @@ class DevLauncherBridgelessDevSupportManager(
   packagerPathForJSBundleName: String?
 ) : NonFinalBridgelessDevSupportManager(host, context, packagerPathForJSBundleName), DevLauncherKoinComponent {
   private val controller: DevLauncherControllerInterface? by optInject()
+
+  init {
+    injectDevServerHelper(context, this, controller)
+  }
 
   override fun showNewJavaError(message: String?, e: Throwable) {
     Log.e("DevLauncher", "$message", e)
@@ -35,7 +40,7 @@ class DevLauncherBridgelessDevSupportManager(
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
   }
 
-  override fun getUniqueTag() = "DevLauncherApp - Bridgeless"
+  override fun getUniqueTag() = "DevLauncherApp-Bridgeless"
 
   override fun startInspector() {
     // no-op for the default `startInspector` which would be implicitly called

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed "Missing transform.routerRoot option in Metro bundling request" error when loading the bundle. ([#28428](https://github.com/expo/expo/pull/28428) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 5.0.4 — 2024-04-24


### PR DESCRIPTION
# Why

close ENG-12056

# How

the fix from #26441 was accidentally removed by me during react-native 0.74 support. this pr tries to add back with a dedicated `DevLauncherDevServerHelper` so that we could work for both bridge and bridgeless.

also encounter a "missing transform.routerRoot" warning when reloading. it is because dev-menu will have a [BridgelessDevSupportManager](https://github.com/facebook/react-native/blob/972b42016ef02dc3cecf9743bad82c9fd2068805/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L184-L190) connected to localhost:8081.  we need https://github.com/facebook/react-native/pull/43673 to remove the workaround.

# Test Plan

- try repro from ENG-12056
- press "r" to reload the app

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
