### PR TITLE
feat(create-expo): support using `github.com/` URLs without protocol

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- support GitHub URLs that don't have a protocol.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- support GitHub URLs that don't have a protocol.
+- support GitHub URLs that don't have a protocol. ([#28435](https://github.com/expo/expo/pull/28435) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -53,21 +53,28 @@ function deepMerge(target: any, source: any) {
   return target;
 }
 
+function coerceUrl(urlString: string) {
+  try {
+    return new URL(urlString);
+  } catch (e) {
+    if (!/^(https?:\/\/)/.test(urlString)) {
+      return new URL(`https://${urlString}`);
+    }
+    throw e;
+  }
+}
+
 export function resolvePackageModuleId(moduleId: string) {
   if (
     // Supports github repository URLs
-    moduleId.startsWith('https://github.com')
+    /^(https?:\/\/)?github\.com\//.test(moduleId)
   ) {
     try {
-      const uri = new URL(moduleId);
+      const uri = coerceUrl(moduleId);
       debug('Resolved moduleId to repository path:', moduleId);
       return { type: 'repository', uri } as const;
-    } catch (error: any) {
-      if (error.code === 'ERR_INVALID_URL') {
-        throw new Error(`Invalid URL: "${moduleId}" provided`);
-      } else {
-        throw error;
-      }
+    } catch {
+      throw new Error(`Invalid URL: "${moduleId}" provided`);
     }
   }
 


### PR DESCRIPTION
# Why

- make the github template option a bit more resilient.
- this PR also improves the error messages so you never see a "Only GitHub repositories are supported." when you provide a github URL.

# Test Plan

- This works `cead -t github.com/evanbacon/apr24-template --no-install`
- This throws a reasonable error: `cead -t github.com/evanbacon/test-missing-repo --no-install`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
