### PR TITLE
fix(cli): Remove export exit that breaks atlas writing.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Remove export exit that breaks atlas writing.
+- Remove export exit that breaks atlas writing. ([#28438](https://github.com/expo/expo/pull/28438) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove export exit that breaks atlas writing.
+
 ### 💡 Others
 
 ## 0.18.4 — 2024-04-24

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -22,7 +22,4 @@ export async function exportAsync(projectRoot: string, options: Options) {
 
   // Final notes
   Log.log(`App exported to: ${options.outputDir}`);
-
-  // Force exit because various threading and analytics processes could be hanging, this command needs to run as fast as possible.
-  process.exit(0);
 }


### PR DESCRIPTION
# Why

process.exit was added to prevent analytics from keeping the export process hanging but this stops the process before atlas has time to finish writing the artifact file.
