### PR TITLE
chore(cli): temporarily disable macos builds pending more testing

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Disable macos builds for now.
+- Disable macos builds for now. ([#28441](https://github.com/expo/expo/pull/28441) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.18.4 — 2024-04-24
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Disable macos builds for now.
+
 ## 0.18.4 — 2024-04-24
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/run/ios/options/resolveDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveDevice.ts
@@ -1,4 +1,4 @@
-import { resolveDestinationsAsync } from './appleDestinations';
+// import { resolveDestinationsAsync } from './appleDestinations';
 import { promptDeviceAsync } from './promptDevice';
 import * as Log from '../../../log';
 import {
@@ -27,7 +27,7 @@ type AnyDevice = {
 /** Get a list of devices (called destinations) that are connected to the host machine. Filter by `osType` if defined. */
 async function getDevicesAsync({
   osType,
-  ...buildProps
+  // ...buildProps
 }: { osType?: OSType } & Pick<BuildProps, 'xcodeProject' | 'scheme' | 'configuration'>): Promise<
   AnyDevice[]
 > {
@@ -37,7 +37,7 @@ async function getDevicesAsync({
         await Promise.all([
           AppleDevice.getConnectedDevicesAsync(),
           await profile(SimControl.getDevicesAsync)(),
-          resolveDestinationsAsync(buildProps),
+          // resolveDestinationsAsync(buildProps),
         ])
       ).flat(),
       (item) => item.udid


### PR DESCRIPTION
# Why

I noticed during beta testing that certain conditions were failing in a clean build. It appears that state from building via xcode had been preserved between sessions and caused the macos build to work when it otherwise wouldn't have.

The launching command for example, is ignoring the path and opening purely based on the bundle identifier. This implies an additional install step is being run, but the app isn't present in the applications folder, rather a generated `.XCInstall` folder. Since I couldn't figure out how to replicate this in the last 15 minutes, it seems safer if we disable the feature entirely.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
