### PR TITLE
feat(cli): symbolicate react stack in ssr

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Symbolicate React component stacks in SSR.
+- Symbolicate React component stacks in SSR. ([#28443](https://github.com/expo/expo/pull/28443) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove export exit that breaks atlas writing. ([#28438](https://github.com/expo/expo/pull/28438) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Symbolicate React component stacks in SSR.
 - Remove export exit that breaks atlas writing. ([#28438](https://github.com/expo/expo/pull/28438) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -140,7 +140,7 @@ function augmentLogsInternal(projectRoot: string) {
               });
 
               // Replace args[1] with the formatted stack.
-              args[1] = '\n' + formatParsedStackLikeMetro(projectRoot, symbolicatedStack);
+              args[1] = '\n' + formatParsedStackLikeMetro(projectRoot, symbolicatedStack, true);
             } catch {
               // If symbolication fails, log the original stack.
               args.push('\n' + formatStackLikeMetro(projectRoot, customStack));
@@ -177,7 +177,8 @@ export function formatStackLikeMetro(projectRoot: string, stack: string) {
 
 function formatParsedStackLikeMetro(
   projectRoot: string,
-  stackTrace: stackTraceParser.StackFrame[]
+  stackTrace: stackTraceParser.StackFrame[],
+  isComponentStack = false
 ) {
   // Remove `Error: ` from the beginning of the stack trace.
   // Dim traces that match `INTERNAL_CALLSITES_REGEX`
@@ -186,14 +187,13 @@ function formatParsedStackLikeMetro(
     .filter(
       (line) =>
         line.file &&
-        line.file !== '<anonymous>' &&
         // Ignore unsymbolicated stack frames. It's not clear how this is possible but it sometimes happens when the graph changes.
         !/^https?:\/\//.test(line.file)
     )
     .map((line) => {
       // Use the same regex we use in Metro config to filter out traces:
       const isCollapsed = INTERNAL_CALLSITES_REGEX.test(line.file!);
-      if (isCollapsed && !env.EXPO_DEBUG) {
+      if (!isComponentStack && isCollapsed && !env.EXPO_DEBUG) {
         return null;
       }
       // If a file is collapsed, print it with dim styling.

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -188,7 +188,8 @@ function formatParsedStackLikeMetro(
       (line) =>
         line.file &&
         // Ignore unsymbolicated stack frames. It's not clear how this is possible but it sometimes happens when the graph changes.
-        !/^https?:\/\//.test(line.file)
+        !/^https?:\/\//.test(line.file) &&
+        (isComponentStack ? true : line.file !== '<anonymous>')
     )
     .map((line) => {
       // Use the same regex we use in Metro config to filter out traces:

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -124,11 +124,17 @@ function augmentLogsInternal(projectRoot: string) {
                   name: string | null;
                 };
 
+                const fallbackName = mapped.name ?? '<unknown>';
                 return {
                   file: mapped.source,
                   lineNumber: mapped.line,
                   column: mapped.column,
-                  methodName: mapped.name ?? '<unknown>',
+                  // Attempt to preserve the react component name if possible.
+                  methodName: line.methodName
+                    ? line.methodName === '<unknown>'
+                      ? fallbackName
+                      : line.methodName
+                    : fallbackName,
                   arguments: line.arguments ?? [],
                 };
               });

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -7,6 +7,9 @@
 import { INTERNAL_CALLSITES_REGEX } from '@expo/metro-config';
 import chalk from 'chalk';
 import path from 'path';
+import resolveFrom from 'resolve-from';
+// @ts-expect-error
+import { mapSourcePosition } from 'source-map-support';
 import * as stackTraceParser from 'stacktrace-parser';
 
 import { env } from '../../utils/env';
@@ -88,10 +91,59 @@ function augmentLogsInternal(projectRoot: string) {
       const stack = new Error().stack;
       // Check if the log originates from the server.
       const isServerLog = !!stack?.match(SERVER_STACK_MATCHER);
+
       if (isServerLog) {
         if (name === 'error' || name === 'warn') {
-          args.push('\n' + formatStackLikeMetro(projectRoot, stack!));
+          if (
+            args.length === 2 &&
+            typeof args[1] === 'string' &&
+            args[1].trim().startsWith('at ')
+          ) {
+            // react-dom custom stacks which are always broken.
+            // A stack string like:
+            //    at div
+            //    at http://localhost:8081/node_modules/expo-router/node/render.bundle?platform=web&dev=true&hot=false&transform.engine=hermes&transform.routerRoot=app&resolver.environment=node&transform.environment=node:38008:27
+            //    at Background (http://localhost:8081/node_modules/expo-router/node/render.bundle?platform=web&dev=true&hot=false&transform.engine=hermes&transform.routerRoot=app&resolver.environment=node&transform.environment=node:151009:7)
+            const customStack = args[1];
+            const { parseErrorStack } = require(
+              resolveFrom(projectRoot, '@expo/metro-runtime/symbolicate')
+            );
+            try {
+              const parsedStack = parseErrorStack(customStack);
+              const symbolicatedStack = parsedStack.map((line: any) => {
+                const mapped = mapSourcePosition({
+                  source: line.file,
+                  line: line.lineNumber,
+                  column: line.column,
+                }) as {
+                  // '/Users/evanbacon/Documents/GitHub/lab/sdk51-beta/node_modules/react-native-web/dist/exports/View/index.js',
+                  source: string;
+                  line: number;
+                  column: number;
+                  // 'hrefAttrs'
+                  name: string | null;
+                };
+
+                return {
+                  file: mapped.source,
+                  lineNumber: mapped.line,
+                  column: mapped.column,
+                  methodName: mapped.name ?? '<unknown>',
+                  arguments: line.arguments ?? [],
+                };
+              });
+
+              // Replace args[1] with the formatted stack.
+              args[1] = '\n' + formatParsedStackLikeMetro(projectRoot, symbolicatedStack);
+            } catch {
+              // If symbolication fails, log the original stack.
+              args.push('\n' + formatStackLikeMetro(projectRoot, customStack));
+            }
+          } else {
+            args.push('\n' + formatStackLikeMetro(projectRoot, stack!));
+          }
         }
+
         logLikeMetro(originalFn, name, 'λ', ...args);
       } else {
         originalFn(...args);
@@ -114,6 +166,16 @@ export function formatStackLikeMetro(projectRoot: string, stack: string) {
   // Dim traces that match `INTERNAL_CALLSITES_REGEX`
 
   const stackTrace = stackTraceParser.parse(stack);
+  return formatParsedStackLikeMetro(projectRoot, stackTrace);
+}
+
+function formatParsedStackLikeMetro(
+  projectRoot: string,
+  stackTrace: stackTraceParser.StackFrame[]
+) {
+  // Remove `Error: ` from the beginning of the stack trace.
+  // Dim traces that match `INTERNAL_CALLSITES_REGEX`
+
   return stackTrace
     .filter(
       (line) =>


### PR DESCRIPTION
# Why

React adds a custom stack trace system which is often broken in SSR due to the way we evaluate modules. This PR adds a super fragile and complex hack to reconcile the stack to make it more readable.


## Before

<img width="1224" alt="Screenshot 2024-04-24 at 11 09 01 PM" src="https://github.com/expo/expo/assets/9664363/396933f7-b294-4968-b81b-35e807b3a545">

## After

<img width="911" alt="Screenshot 2024-04-24 at 11 12 06 PM" src="https://github.com/expo/expo/assets/9664363/2f7c4938-61c6-447d-a1f5-c83537e4c7f5">

# Test Plan

- Open the new default template on web, then reload the page. It should throw this error twice.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
