### PR TITLE
[install-expo-modules] add sdk 51 support

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added Expo SDK 51 and React Native 0.74 support. ([#28444](https://github.com/expo/expo/pull/28444) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn074-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn074-updated.kt
@@ -1,0 +1,52 @@
+package com.helloworld
+import android.content.res.Configuration
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ReactNativeHostWrapper
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost =
+      ReactNativeHostWrapper(this, object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+            }
+
+        override fun getJSMainModuleName(): String = "index"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      })
+
+  override val reactHost: ReactHost
+    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn074.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn074.kt
@@ -1,0 +1,43 @@
+package com.helloworld
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.soloader.SoLoader
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost =
+      object : DefaultReactNativeHost(this) {
+        override fun getPackages(): List<ReactPackage> =
+            PackageList(this).packages.apply {
+              // Packages that cannot be autolinked yet can be added manually here, for example:
+              // add(MyReactNativePackage())
+            }
+
+        override fun getJSMainModuleName(): String = "index"
+
+        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+
+        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      }
+
+  override val reactHost: ReactHost
+    get() = getDefaultReactHost(applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, false)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
-import semver from 'semver';
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 
+import { ExpoVersionMappings } from '../../../utils/expoVersionMappings';
 import { setModulesMainApplication } from '../withAndroidModulesMainApplication';
-import { ExpoVersionMappings } from '../../../utils/expoVersionMappings'
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -1,21 +1,39 @@
+import assert from 'assert';
+import semver from 'semver';
 import fs from 'fs';
 import path from 'path';
 
 import { setModulesMainApplication } from '../withAndroidModulesMainApplication';
+import { ExpoVersionMappings } from '../../../utils/expoVersionMappings'
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(setModulesMainApplication, () => {
+  it('should able to update from react-native@>=0.74.0 kotlin template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn074.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn074-updated.kt'), 'utf8'),
+    ]);
+
+    const sdkVersion = getSdkVersion('0.74.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should able to update from react-native@>=0.73.0 kotlin template', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn073.kt'), 'utf8'),
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn073-updated.kt'), 'utf8'),
     ]);
 
-    const contents = setModulesMainApplication(rawContents, 'kt');
+    const sdkVersion = getSdkVersion('0.73.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'kt');
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = setModulesMainApplication(contents, 'kt');
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'kt');
     expect(nextContents).toEqual(expectContents);
   });
 
@@ -25,10 +43,11 @@ describe(setModulesMainApplication, () => {
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn071-updated.java'), 'utf8'),
     ]);
 
-    const contents = setModulesMainApplication(rawContents, 'java');
+    const sdkVersion = getSdkVersion('0.71.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'java');
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = setModulesMainApplication(contents, 'java');
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'java');
     expect(nextContents).toEqual(expectContents);
   });
 
@@ -38,10 +57,11 @@ describe(setModulesMainApplication, () => {
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn068-updated.java'), 'utf8'),
     ]);
 
-    const contents = setModulesMainApplication(rawContents, 'java');
+    const sdkVersion = getSdkVersion('0.68.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'java');
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = setModulesMainApplication(contents, 'java');
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'java');
     expect(nextContents).toEqual(expectContents);
   });
 
@@ -51,10 +71,11 @@ describe(setModulesMainApplication, () => {
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064-updated.java'), 'utf8'),
     ]);
 
-    const contents = setModulesMainApplication(rawContents, 'java');
+    const sdkVersion = getSdkVersion('0.64.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'java');
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = setModulesMainApplication(contents, 'java');
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'java');
     expect(nextContents).toEqual(expectContents);
   });
 
@@ -64,10 +85,19 @@ describe(setModulesMainApplication, () => {
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn064-updated.kt'), 'utf8'),
     ]);
 
-    const contents = setModulesMainApplication(rawContents, 'kt');
+    const sdkVersion = getSdkVersion('0.64.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'kt');
     expect(contents).toEqual(expectContents);
     // Try it twice...
-    const nextContents = setModulesMainApplication(contents, 'kt');
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'kt');
     expect(nextContents).toEqual(expectContents);
   });
 });
+
+function getSdkVersion(reactNativeVersion: string): string {
+  const versionInfo = ExpoVersionMappings.find((info) =>
+    semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
+  );
+  assert(versionInfo, `Unsupported react-native version: ${reactNativeVersion}`);
+  return versionInfo?.expoSdkVersion;
+}

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+import semver from 'semver';
 import { ConfigPlugin, withMainApplication } from '@expo/config-plugins';
 import {
   addImports,
@@ -8,7 +10,9 @@ import { replaceContentsWithOffset } from '@expo/config-plugins/build/utils/comm
 
 export const withAndroidModulesMainApplication: ConfigPlugin = (config) => {
   return withMainApplication(config, (config) => {
+    assert(config.sdkVersion)
     config.modResults.contents = setModulesMainApplication(
+      config.sdkVersion,
       config.modResults.contents,
       config.modResults.language
     );
@@ -17,12 +21,14 @@ export const withAndroidModulesMainApplication: ConfigPlugin = (config) => {
 };
 
 export function setModulesMainApplication(
+  sdkVersion: string,
   mainApplication: string,
   language: 'java' | 'kt'
 ): string {
   const isJava = language === 'java';
 
   mainApplication = addDefaultReactNativeHostWrapperIfNeeded(mainApplication, language, isJava);
+  mainApplication = addReactHostWrapperIfNeeded(sdkVersion, mainApplication, language, isJava);
   mainApplication = addReactNativeHostWrapperIfNeeded(mainApplication, language, isJava);
   mainApplication = addReactNativeNewArchHostWrapperIfNeeded(mainApplication, language, isJava);
   mainApplication = addApplicationLifecycleDispatchImportIfNeeded(
@@ -79,6 +85,23 @@ function addDefaultReactNativeHostWrapperIfNeeded(
     newInstanceCodeBlock.end
   );
   return mainApplication;
+}
+
+/**
+ * Replace `ReactNativeHostWrapper.create()` for `getDefaultReactHost()`.
+ * For react-native@>=0.74 and SDK >= 51.0.0
+ */
+function addReactHostWrapperIfNeeded(
+  sdkVersion: string,
+  mainApplication: string,
+  language: 'java' | 'kt',
+  isJava: boolean
+): string {
+  if (semver.lt(sdkVersion, '51.0.0')) {
+    return mainApplication;
+  };
+
+  return mainApplication.replace(/(\s+)getDefaultReactHost\(/gm, '$1ReactNativeHostWrapper.createReactHost(');
 }
 
 function addReactNativeHostWrapperIfNeeded(

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
@@ -1,5 +1,3 @@
-import assert from 'assert';
-import semver from 'semver';
 import { ConfigPlugin, withMainApplication } from '@expo/config-plugins';
 import {
   addImports,
@@ -7,10 +5,12 @@ import {
   findNewInstanceCodeBlock,
 } from '@expo/config-plugins/build/android/codeMod';
 import { replaceContentsWithOffset } from '@expo/config-plugins/build/utils/commonCodeMod';
+import assert from 'assert';
+import semver from 'semver';
 
 export const withAndroidModulesMainApplication: ConfigPlugin = (config) => {
   return withMainApplication(config, (config) => {
-    assert(config.sdkVersion)
+    assert(config.sdkVersion);
     config.modResults.contents = setModulesMainApplication(
       config.sdkVersion,
       config.modResults.contents,
@@ -99,9 +99,12 @@ function addReactHostWrapperIfNeeded(
 ): string {
   if (semver.lt(sdkVersion, '51.0.0')) {
     return mainApplication;
-  };
+  }
 
-  return mainApplication.replace(/(\s+)getDefaultReactHost\(/gm, '$1ReactNativeHostWrapper.createReactHost(');
+  return mainApplication.replace(
+    /(\s+)getDefaultReactHost\(/gm,
+    '$1ReactNativeHostWrapper.createReactHost('
+  );
 }
 
 function addReactNativeHostWrapperIfNeeded(

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -12,6 +12,12 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoSdkVersion: '51.0.0',
+    iosDeploymentTarget: '13.4',
+    reactNativeVersionRange: '>= 0.74.0',
+    supportCliIntegration: true,
+  },
+  {
     expoSdkVersion: '50.0.0',
     iosDeploymentTarget: '13.4',
     reactNativeVersionRange: '>= 0.73.0',


### PR DESCRIPTION
# Why

prepare install-expo-modules for sdk 51 and react-native 0.74

# How

- update ExpoVersionMappings for sdk 51 and react-native 0.74
- migrate MainApplication for `getDefaultReactHost() -> `ReactNativeHostWrapper.createReactHost()`. the getDefaultReactHost() was there from react-native 0.73, so we need to further check that for sdk>=51 only.

# Test Plan

- unit tests passed
- `npx @react-native-community/cli@latest init RN074 --version 0.74` + install-expo-modules test
- `npx @react-native-community/cli@latest init RN073 --version 0.73` + install-expo-modules test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
