### PR TITLE
[core] fix use_frameworks with new arch

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed building error when use_frameworks on new architecture. ([#28451](https://github.com/expo/expo/pull/28451) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 1.12.7 — 2024-05-02


### PR DESCRIPTION
# Why

fix header not found issue when using frameworks on new architecture
fixes #28209

# How

the header search path is from `EXJavaScriptRuntime.mm -> HermesExecutorFactory.h -> <jsinspector-modern/InspectorInterfaces.h>`. the correct import should be underlined "jsinspector_modern" in the import. the code is inside react-native core that we cannot touch.
this pr tries to use the `add_dependency()` from react-native core that we specify extra ":framework_name".

also cleanup some unused search paths that are added through `install_modules_dependencies()`.
we also have to wait 0.74.1 for https://github.com/facebook/react-native/pull/44252

# Test Plan

- [x] use_frameworks=static + hermes + newArchEnabled=true
- [x] use_frameworks=static + jsc + newArchEnabled=true
- [x] hermes + newArchEnabled=true
- [x] jsc + newArchEnabled=true
- [x] hermes + newArchEnabled=false
- [x] jsc + newArchEnabled=false
- [x] use_frameworks=static + hermes + newArchEnabled=false

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
