### PR TITLE
[secure-store] Update tests snapshots

### DIFF
--- a/packages/expo-secure-store/src/__tests__/__snapshots__/SecureStore-test.ios.ts.snap.ios
+++ b/packages/expo-secure-store/src/__tests__/__snapshots__/SecureStore-test.ios.ts.snap.ios
@@ -12,4 +12,4 @@ exports[`exports accessibility options: WHEN_PASSCODE_SET_THIS_DEVICE_ONLY 1`] =
 
 exports[`exports accessibility options: WHEN_UNLOCKED 1`] = `5`;
 
-exports[`exports accessibility options: WHEN_UNLOCKED_THIS_DEVICE_ONLY 1`] = `3`;
+exports[`exports accessibility options: WHEN_UNLOCKED_THIS_DEVICE_ONLY 1`] = `6`;


### PR DESCRIPTION
# Why

Check-packages check is falling due to outdated snapshots after https://github.com/expo/expo/pull/28424

# How

`yarn test -u`

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
