### PR TITLE
[docs] Update Upgrade Expo SDK

### DIFF
--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -47,7 +47,7 @@ The manifest is similar to an **index.html** on the web. It is served from the r
 
 ### SDK versions
 
-Expo Go supports multiple [**SDK versions**](/versions/latest/). A new Expo SDK version is released approximately three times each year. Each time a new version is added to Expo Go, an old version is dropped. You can see the supported SDK versions in the Expo Go app by navigating to the settings page.
+Expo Go supports the latest [**SDK version**](/versions/latest/) only. Each time a new version is added to Expo Go, the previous version is dropped.
 
 <Collapsible summary="What if I open a project with an unsupported SDK version?">
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -9,7 +9,9 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **info** We recommend upgrading SDK versions incrementally, one at a time. Doing so will help you pinpoint breakages and issues that arise during the upgrade process.
 
-Expo maintains approximately 6 months of backward compatibility. Once an SDK version has been deprecated, you can no longer use it in the Expo Go app. SDK deprecations **will not** affect the standalone apps you have in production or your [development builds](/develop/development-builds/introduction/), and backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
+With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
+
+If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
 
 ## How to upgrade to the latest SDK version
 
@@ -27,8 +29,8 @@ Install the new version of the Expo package:
     '# Install latest',
     '$ npm install expo@latest',
     '',
-    '# Install a specific SDK version (for example, SDK 49)',
-    '$ npm install expo@49',
+    '# Install a specific SDK version (for example, SDK 50)',
+    '$ npm install expo@50',
   ]}
 />
 
@@ -41,8 +43,8 @@ Install the new version of the Expo package:
     '# Install latest',
     '$ yarn add expo@latest',
     '',
-    '# Install a specific SDK version (for example, SDK 49)',
-    '$ yarn add expo@49',
+    '# Install a specific SDK version (for example, SDK 50)',
+    '$ yarn add expo@50',
   ]}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-11148

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating Expo Go context to indicate that only a single version (latest SDK version) is supported. Also, add expo.dev/go information to allow installing a specific Expo Go version.
- Increment Expo package version in Terminal component to SDK 50.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/workflow/upgrading-expo-sdk-walkthrough/

## Preview

![CleanShot 2024-04-25 at 21 27 01@2x](https://github.com/expo/expo/assets/10234615/96583cae-7df5-405a-804e-28b4f2541e8f)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
