### PR TITLE
[dev-menu] Use DevMenuRCTBridge in DevClientRootViewFactory

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use DevMenuRCTBridge in DevClientRootViewFactory. ([#28460](https://github.com/expo/expo/pull/28460) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 5.0.6 — 2024-04-25

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import "DevClientRootViewFactory.h"
+#import <EXDevMenu/DevMenuRCTBridge.h>
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 #import <React-RCTAppDelegate/RCTAppDelegate.h>
@@ -29,7 +30,7 @@
     return;
   }
 
-  self.bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  self.bridge = [[DevMenuRCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
 }
 
 #pragma mark - RCTCxxBridgeDelegate


### PR DESCRIPTION
# Why

Closes ENG-12143

# How

Update `DevClientRootViewFactory` to ensure we use `DevMenuRCTBridge` and filter out modules like Reanimated and Screens

# Test Plan

Run BareExpo locally on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
