### PR TITLE
feat(cli): mute watchman warnings

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent duplicate watchman warnings.
+
 ### 💡 Others
 
 ## 0.18.5 — 2024-04-25

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent duplicate watchman warnings.
+- Prevent duplicate watchman warnings. ([#28461](https://github.com/expo/expo/pull/28461) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
@@ -3,6 +3,7 @@
 import chalk from 'chalk';
 import UpstreamTerminalReporter from 'metro/src/lib/TerminalReporter';
 import { Terminal } from 'metro-core';
+import type { WatcherStatus } from 'metro-file-map';
 import util from 'util';
 
 import {
@@ -100,6 +101,15 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
    * @param duration duration of the build in milliseconds.
    */
   bundleBuildEnded(event: TerminalReportableEvent, duration: number): void {}
+
+  _logWatcherStatus(status: WatcherStatus) {
+    // Metro logs this warning twice. This helps reduce the noise.
+
+    if (status.type === 'watchman_warning') {
+      return;
+    }
+    return super._logWatcherStatus(status);
+  }
 
   /**
    * This function is exclusively concerned with updating the internal state.

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.types.ts
@@ -1,6 +1,7 @@
 import type { ReportableEvent } from 'metro';
 import type { TerminalReportableEvent } from 'metro/src/lib/TerminalReporter';
 import type { Terminal } from 'metro-core';
+import type { WatcherStatus } from 'metro-file-map';
 
 import { MetroEnvironment } from '../middleware/metroOptions';
 
@@ -99,6 +100,8 @@ export interface TerminalReporterInterface {
     }: BundleProgress,
     phase: BuildPhase
   ): string;
+
+  _logWatcherStatus(event: WatcherStatus): void;
 
   /**
    * This function is only concerned with logging and should not do state

--- a/packages/@expo/cli/src/utils/fn.ts
+++ b/packages/@expo/cli/src/utils/fn.ts
@@ -1,15 +1,15 @@
 /** `lodash.memoize` */
 export function memoize<T extends (...args: any[]) => any>(fn: T): T {
-  const cache: { [key: string]: any } = {};
+  const cache = new Map<string, any>();
   return ((...args: any[]) => {
     const key = JSON.stringify(args);
-    if (cache[key]) {
-      return cache[key];
+    if (cache.has(key)) {
+      return cache.get(key);
     }
     const result = fn(...args);
-    cache[key] = result;
+    cache.set(key, result);
     return result;
-  }) as any;
+  }) as T;
 }
 
 /** memoizes an async function to prevent subsequent calls that might be invoked before the function has finished resolving. */


### PR DESCRIPTION
# Why

- follow up with this https://github.com/facebook/metro/pull/1260
- Metro double prints the warnings, this prevents one version.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
