### PR TITLE
[docs] add back ASC Api Key instructions for `eas build` CI

### DIFF
--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -48,7 +48,7 @@ Next, we need to ensure that we can authenticate ourselves on CI as the owner of
 
 See [personal access tokens](/accounts/programmatic-access/#personal-access-tokens) to learn how to create access tokens.
 
-### (Optional) Provide an ASC Api Token for your Apple Team
+### (Optional) Provide an ASC API Token for your Apple Team
 
 In the event your iOS credentials need to be repaired, we will need an ASC API key to authenticate ourselves to Apple in CI. A common case is when your provisioning profile needs to be re-signed.
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -48,6 +48,20 @@ Next, we need to ensure that we can authenticate ourselves on CI as the owner of
 
 See [personal access tokens](/accounts/programmatic-access/#personal-access-tokens) to learn how to create access tokens.
 
+### (Optional) Provide an ASC Api Token for your Apple Team
+
+In the event your iOS credentials need to be repaired, we will need an ASC API key to authenticate ourselves to Apple in CI. A common case is when your provisioning profile needs to be re-signed.
+
+You will need to create an [API Key](https://expo.fyi/creating-asc-api-key). Next, you will need to gather information about your [Apple Team](https://expo.fyi/apple-team).
+
+Using the information you've gathered, pass it into the build command through environment variables. You will need to pass in the following:
+
+- `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file, e.g. /path/to/key/AuthKey_SFB993FB5F.p8
+- `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key, e.g. SFB993FB5F.
+- `EXPO_ASC_ISSUER_ID`: the issuer ID of your ASC API Key, e.g. f9675cff-f45d-4116-bd2c-2372142cee09.
+- `EXPO_APPLE_TEAM_ID`: your Apple Team ID, e.g. 77KQ969CHE.
+- `EXPO_APPLE_TEAM_TYPE`: your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION`, or `INDIVIDUAL`.
+
 ### Trigger new builds
 
 Now that we're authenticated with Expo CLI, we can create the build step.

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -56,11 +56,11 @@ You will need to create an [API Key](https://expo.fyi/creating-asc-api-key). Nex
 
 Using the information you've gathered, pass it into the build command through environment variables. You will need to pass the following:
 
-- `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file, e.g. /path/to/key/AuthKey_SFB993FB5F.p8
-- `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key, e.g. SFB993FB5F.
-- `EXPO_ASC_ISSUER_ID`: the issuer ID of your ASC API Key, e.g. f9675cff-f45d-4116-bd2c-2372142cee09.
-- `EXPO_APPLE_TEAM_ID`: your Apple Team ID, e.g. 77KQ969CHE.
-- `EXPO_APPLE_TEAM_TYPE`: your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION`, or `INDIVIDUAL`.
+- `EXPO_ASC_API_KEY_PATH`: The path to your ASC API Key **.p8** file. For example, **/path/to/key/AuthKey_SFB993FB5F.p8**.
+- `EXPO_ASC_KEY_ID`: The key ID of your ASC API Key. For example, `SFB993FB5F`.
+- `EXPO_ASC_ISSUER_ID`: The issuer ID of your ASC API Key. For example, `f9675cff-f45d-4116-bd2c-2372142cee09`.
+- `EXPO_APPLE_TEAM_ID`: Your Apple Team ID. For example, `77KQ969CHE`.
+- `EXPO_APPLE_TEAM_TYPE`: Your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION`, or `INDIVIDUAL`.
 
 ### Trigger new builds
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -54,7 +54,7 @@ In the event your iOS credentials need to be repaired, we will need an ASC API k
 
 You will need to create an [API Key](https://expo.fyi/creating-asc-api-key). Next, you will need to gather information about your [Apple Team](https://expo.fyi/apple-team).
 
-Using the information you've gathered, pass it into the build command through environment variables. You will need to pass in the following:
+Using the information you've gathered, pass it into the build command through environment variables. You will need to pass the following:
 
 - `EXPO_ASC_API_KEY_PATH`: the path to your ASC API Key .p8 file, e.g. /path/to/key/AuthKey_SFB993FB5F.p8
 - `EXPO_ASC_KEY_ID`: the key ID of your ASC API Key, e.g. SFB993FB5F.


### PR DESCRIPTION
# Why

Add back the ASC Api Key instructions that was reverted in https://github.com/expo/expo/commit/b058eea7ff3a148ce0ee247c4c45101071c13b71 now that we've fixed it for provisioning profiles in https://github.com/expo/eas-cli/pull/2347

# How

Revert https://github.com/expo/expo/commit/b058eea7ff3a148ce0ee247c4c45101071c13b71 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
