### PR TITLE
[template-default] backport missed changes after code move

### DIFF
--- a/templates/expo-template-default/app/(tabs)/index.tsx
+++ b/templates/expo-template-default/app/(tabs)/index.tsx
@@ -1,9 +1,9 @@
 import { Image, StyleSheet, Platform } from 'react-native';
 
+import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { HelloWave } from '@/components/HelloWave';
 
 export default function HomeScreen() {
   return (
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   },
   stepContainer: {
     gap: 8,
+    marginBottom: 8,
   },
   reactLogo: {
     height: 178,

--- a/templates/expo-template-default/components/Collapsible.tsx
+++ b/templates/expo-template-default/components/Collapsible.tsx
@@ -23,7 +23,7 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
         />
         <ThemedText type="defaultSemiBold">{title}</ThemedText>
       </TouchableOpacity>
-      <ThemedView style={styles.content}>{isOpen ? children : null}</ThemedView>
+      {isOpen && <ThemedView style={styles.content}>{children}</ThemedView>}
     </ThemedView>
   );
 }
@@ -32,9 +32,10 @@ const styles = StyleSheet.create({
   heading: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 4,
+    gap: 6,
   },
   content: {
+    marginTop: 6,
     marginLeft: 24,
   },
 });

--- a/templates/expo-template-default/components/ExternalLink.tsx
+++ b/templates/expo-template-default/components/ExternalLink.tsx
@@ -1,23 +1,22 @@
 import { Link } from 'expo-router';
-import * as WebBrowser from 'expo-web-browser';
-import React from 'react';
+import { openBrowserAsync } from 'expo-web-browser';
+import { type ComponentProps } from 'react';
 import { Platform } from 'react-native';
 
-export function ExternalLink(
-  props: Omit<React.ComponentProps<typeof Link>, 'href'> & { href: string }
-) {
+type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
+
+export function ExternalLink({ href, ...rest }: Props) {
   return (
     <Link
       target="_blank"
-      {...props}
-      // @ts-expect-error: External URLs are not typed.
-      href={props.href}
-      onPress={(e) => {
+      {...rest}
+      href={href}
+      onPress={async (event) => {
         if (Platform.OS !== 'web') {
           // Prevent the default behavior of linking to the default browser on native.
-          e.preventDefault();
+          event.preventDefault();
           // Open the link in an in-app browser.
-          WebBrowser.openBrowserAsync(props.href as string);
+          await openBrowserAsync(href);
         }
       }}
     />

--- a/templates/expo-template-default/components/ParallaxScrollView.tsx
+++ b/templates/expo-template-default/components/ParallaxScrollView.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactElement } from 'react';
 import { StyleSheet, useColorScheme } from 'react-native';
 import Animated, {
   interpolate,
@@ -11,15 +11,17 @@ import { ThemedView } from '@/components/ThemedView';
 
 const HEADER_HEIGHT = 250;
 
+type Props = PropsWithChildren<{
+  headerImage: ReactElement;
+  headerBackgroundColor: { dark: string; light: string };
+}>;
+
 export default function ParallaxScrollView({
   children,
   headerImage,
   headerBackgroundColor,
-}: PropsWithChildren<{
-  headerImage: React.ReactElement;
-  headerBackgroundColor: { dark: string; light: string };
-}>) {
-  const colorScheme = useColorScheme() || 'light';
+}: Props) {
+  const colorScheme = useColorScheme() ?? 'light';
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollViewOffset(scrollRef);
 
@@ -68,9 +70,7 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     padding: 32,
-    gap: 24,
-    borderRadius: 16,
+    gap: 16,
     overflow: 'hidden',
-    marginTop: -12,
   },
 });

--- a/templates/expo-template-default/components/ThemedText.tsx
+++ b/templates/expo-template-default/components/ThemedText.tsx
@@ -1,14 +1,20 @@
-import { Text, StyleSheet } from 'react-native';
+import { Text, type TextProps, StyleSheet } from 'react-native';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
 
-export type TextProps = {
+export type ThemedTextProps = TextProps & {
   lightColor?: string;
   darkColor?: string;
-} & { type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link' } & Text['props'];
+  type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
+};
 
-export function ThemedText(props: TextProps) {
-  const { style, lightColor, darkColor, type = 'default', ...otherProps } = props;
+export function ThemedText({
+  style,
+  lightColor,
+  darkColor,
+  type = 'default',
+  ...rest
+}: ThemedTextProps) {
   const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
 
   return (
@@ -22,7 +28,7 @@ export function ThemedText(props: TextProps) {
         type === 'link' ? styles.link : undefined,
         style,
       ]}
-      {...otherProps}
+      {...rest}
     />
   );
 }
@@ -49,6 +55,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#2e78b7',
+    color: '#0a7ea4',
   },
 });

--- a/templates/expo-template-default/components/ThemedView.tsx
+++ b/templates/expo-template-default/components/ThemedView.tsx
@@ -1,14 +1,13 @@
-import { View } from 'react-native';
+import { View, type ViewProps } from 'react-native';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
 
-export type ViewProps = {
+export type ThemedViewProps = ViewProps & {
   lightColor?: string;
   darkColor?: string;
-} & View['props'];
+};
 
-export function ThemedView(props: ViewProps) {
-  const { style, lightColor, darkColor, ...otherProps } = props;
+export function ThemedView({ style, lightColor, darkColor, ...otherProps }: ThemedViewProps) {
   const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
 
   return <View style={[{ backgroundColor }, style]} {...otherProps} />;

--- a/templates/expo-template-default/components/navigation/TabBarIcon.tsx
+++ b/templates/expo-template-default/components/navigation/TabBarIcon.tsx
@@ -1,11 +1,9 @@
 // You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
 
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { type IconProps } from '@expo/vector-icons/build/createIconSet';
 import { type ComponentProps } from 'react';
 
-export function TabBarIcon(props: {
-  name: ComponentProps<typeof Ionicons>['name'];
-  color: string;
-}) {
-  return <Ionicons size={28} style={{ marginBottom: -3 }} {...props} />;
+export function TabBarIcon({ style, ...rest }: IconProps<ComponentProps<typeof Ionicons>['name']>) {
+  return <Ionicons size={28} style={[{ marginBottom: -3 }, style]} {...rest} />;
 }

--- a/templates/expo-template-default/hooks/useThemeColor.ts
+++ b/templates/expo-template-default/hooks/useThemeColor.ts
@@ -1,9 +1,10 @@
 /**
  * Learn more about light and dark modes:
- * https://docs.expo.io/guides/color-schemes/
+ * https://docs.expo.dev/guides/color-schemes/
  */
 
 import { useColorScheme } from 'react-native';
+
 import { Colors } from '@/constants/Colors';
 
 export function useThemeColor(


### PR DESCRIPTION
# Why

Backport missing changes in default template:
* https://github.com/expo/new-eas-template-exploration/pull/16

# How

Move missing UI and code tweaks/fixes.

# Test Plan

Run the template locally.

# Preview

<img src="https://private-user-images.githubusercontent.com/719641/323710969-af2407b4-e30e-401b-bb4f-1ededc211f71.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTQxMjY2MTksIm5iZiI6MTcxNDEyNjMxOSwicGF0aCI6Ii83MTk2NDEvMzIzNzEwOTY5LWFmMjQwN2I0LWUzMGUtNDAxYi1iYjRmLTFlZGVkYzIxMWY3MS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNDI2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDQyNlQxMDExNTlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01OTU2MTZlMjQ0MDEzZTA4YjQ5OWU1OTFiYzQzOGE2NTgyOWQzMDE0MWYwZTdhOTNjNDkxNTBhZTU5NjM5NTcyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.B1fGXvv2qSM0zxaU2cmUF-3WD_gNwBacB0w01qDEEC0" />