### PR TITLE
[docs] Fix formatting issue in Haptics API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/haptics.mdx
+++ b/docs/pages/versions/unversioned/sdk/haptics.mdx
@@ -11,16 +11,16 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-haptics`** provides haptic (touch) feedback for
+`expo-haptics` provides haptic (touch) feedback for:
 
-- iOS 10+ devices using the Taptic Engine
 - Android devices using Vibrator system service.
+- iOS 10+ devices using the Taptic Engine.
 
-On iOS, _the Taptic engine will do nothing if any of the following conditions are true on a user's device:_
+On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
 - Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
 - User disabled the Taptic Engine in settings.
-- iOS Camera is active (in order prevent destabilization).
+- iOS Camera is active (to prevent destabilization).
 
 ## Installation
 
@@ -28,7 +28,7 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 ## Configuration
 
-On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+On Android, this library requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
 
 ## Usage
 

--- a/docs/pages/versions/v49.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/haptics.mdx
@@ -11,16 +11,16 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-haptics`** provides haptic (touch) feedback for
+`expo-haptics` provides haptic (touch) feedback for:
 
-- iOS 10+ devices using the Taptic Engine
 - Android devices using Vibrator system service.
+- iOS 10+ devices using the Taptic Engine.
 
-On iOS, _the Taptic engine will do nothing if any of the following conditions are true on a user's device:_
+On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
 - Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
 - User disabled the Taptic Engine in settings.
-- iOS Camera is active (in order prevent destabilization).
+- iOS Camera is active (to prevent destabilization).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -30,7 +30,7 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 ## Configuration
 
-On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+On Android, this library requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
 
 ## Usage
 

--- a/docs/pages/versions/v50.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/haptics.mdx
@@ -11,16 +11,16 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-haptics`** provides haptic (touch) feedback for
+`expo-haptics` provides haptic (touch) feedback for:
 
-- iOS 10+ devices using the Taptic Engine
 - Android devices using Vibrator system service.
+- iOS 10+ devices using the Taptic Engine.
 
-On iOS, _the Taptic engine will do nothing if any of the following conditions are true on a user's device:_
+On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
 - Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
 - User disabled the Taptic Engine in settings.
-- iOS Camera is active (in order prevent destabilization).
+- iOS Camera is active (to prevent destabilization).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -30,7 +30,7 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 ## Configuration
 
-On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+On Android, this library requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
 
 ## Usage
 

--- a/docs/pages/versions/v51.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/haptics.mdx
@@ -11,16 +11,16 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-haptics`** provides haptic (touch) feedback for
+`expo-haptics` provides haptic (touch) feedback for:
 
-- iOS 10+ devices using the Taptic Engine
 - Android devices using Vibrator system service.
+- iOS 10+ devices using the Taptic Engine.
 
-On iOS, _the Taptic engine will do nothing if any of the following conditions are true on a user's device:_
+On iOS, the Taptic engine will do nothing if any of the following conditions are true on a user's device:
 
 - Low Power Mode is enabled. This can be detected with [`expo-battery`](/versions/latest/sdk/battery/).
 - User disabled the Taptic Engine in settings.
-- iOS Camera is active (in order prevent destabilization).
+- iOS Camera is active (to prevent destabilization).
 
 ## Installation
 
@@ -28,7 +28,7 @@ On iOS, _the Taptic engine will do nothing if any of the following conditions ar
 
 ## Configuration
 
-On Android, this module requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
+On Android, this library requires permission to control vibration on the device. The `VIBRATE` permission is added automatically.
 
 ## Usage
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes some writing style guide and verbiage issues in the Haptics API reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

## Preview

![CleanShot 2024-04-26 at 15 49 39@2x](https://github.com/expo/expo/assets/10234615/84970198-0339-4164-ad72-9050ecf7e692)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
