### PR TITLE
fix(expo-image-picker): cancel event on web

### DIFF
--- a/packages/expo-image-picker/src/ExponentImagePicker.web.ts
+++ b/packages/expo-image-picker/src/ExponentImagePicker.web.ts
@@ -114,6 +114,10 @@ function openFileBrowserAsync({
       document.body.removeChild(input);
     });
 
+    input.addEventListener('cancel', () => {
+      resolve({ canceled: true, assets: null });
+    });
+
     const event = new MouseEvent('click');
     input.dispatchEvent(event);
   });


### PR DESCRIPTION
Fixes #28481

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://github.com/expo/expo/issues/28481

# How

<!--
How did you build this feature or fix this bug and why?
-->

To fix the issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Here's a simple repro snack: https://snack.expo.dev/@simon-cookin/bug-expo-image-picker-web-cancel

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
