### PR TITLE
[core][Android] Fix SEGFAULTs caused by `std::shared_ptr<JavaCalllback::CallbackContext>::__on_zero_shared`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixes SEGFAULTs caused by `std::shared_ptr<JavaCalllback::CallbackContext>::__on_zero_shared`.
+- [Android] Fixes SEGFAULTs caused by `std::shared_ptr<JavaCalllback::CallbackContext>::__on_zero_shared`. ([#28483](https://github.com/expo/expo/pull/28483) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixes SEGFAULTs caused by `std::shared_ptr<JavaCalllback::CallbackContext>::__on_zero_shared`.
+
 ### 💡 Others
 
 ## 1.12.2 — 2024-04-23

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -80,6 +80,7 @@ void JavaCallback::invokeJSFunction(
   T arg
 ) {
   const auto strongCallbackContext = this->callbackContext.lock();
+  // The context were deallocated before the callback was invoked.
   if (strongCallbackContext == nullptr) {
     return;
   }
@@ -276,6 +277,7 @@ void JavaCallback::invokeSharedRef(jni::alias_ref<SharedRef::javaobject> result)
 
 void JavaCallback::invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage) {
   const auto strongCallbackContext = this->callbackContext.lock();
+  // The context were deallocated before the callback was invoked.
   if (strongCallbackContext == nullptr) {
     return;
   }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -13,6 +13,39 @@
 
 namespace expo {
 
+#if REACT_NATIVE_TARGET_VERSION >= 75
+
+JavaCallback::CallbackContext::CallbackContext(
+  jsi::Runtime &rt,
+  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
+  std::optional<jsi::Function> resolveHolder,
+  std::optional<jsi::Function> rejectHolder
+) : react::LongLivedObject(rt),
+    rt(rt),
+    jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
+    resolveHolder(std::move(resolveHolder)),
+    rejectHolder(std::move(rejectHolder)) {}
+
+#else
+
+JavaCallback::CallbackContext::CallbackContext(
+  jsi::Runtime &rt,
+  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
+  std::optional<jsi::Function> resolveHolder,
+  std::optional<jsi::Function> rejectHolder
+) : rt(rt),
+    jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
+    resolveHolder(std::move(resolveHolder)),
+    rejectHolder(std::move(rejectHolder)) {}
+
+#endif
+
+void JavaCallback::CallbackContext::invalidate() {
+  resolveHolder.reset();
+  rejectHolder.reset();
+  allowRelease();
+}
+
 JavaCallback::JavaCallback(std::shared_ptr<CallbackContext> callbackContext)
   : callbackContext(std::move(callbackContext)) {}
 
@@ -27,6 +60,7 @@ void JavaCallback::registerNatives() {
                    makeNativeMethod("invokeNative", JavaCallback::invokeArray),
                    makeNativeMethod("invokeNative", JavaCallback::invokeMap),
                    makeNativeMethod("invokeNative", JavaCallback::invokeSharedRef),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeError),
                  });
 }
 
@@ -45,24 +79,40 @@ void JavaCallback::invokeJSFunction(
   ArgsConverter<T> argsConverter,
   T arg
 ) {
-  const auto jsInvoker = callbackContext->jsCallInvokerHolder;
+  const auto strongCallbackContext = this->callbackContext.lock();
+  if (strongCallbackContext == nullptr) {
+    return;
+  }
+
+  const auto jsInvoker = strongCallbackContext->jsCallInvokerHolder.lock();
+  // Call invoker is already released, so we cannot invoke the callback.
+  if (jsInvoker == nullptr) {
+    return;
+  }
+
   jsInvoker->invokeAsync(
     [
-      context = std::move(callbackContext),
+      context = callbackContext,
       argsConverter = std::move(argsConverter),
       arg = std::move(arg)
     ]() -> void {
-      if (!context->jsFunctionHolder.has_value()) {
+      auto strongContext = context.lock();
+      // The context were deallocated before the callback was invoked.
+      if (strongContext == nullptr) {
+        return;
+      }
+
+      if (!strongContext->resolveHolder.has_value()) {
         throw std::runtime_error(
           "JavaCallback was already settled. Cannot invoke it again"
         );
       }
 
-      jsi::Function &jsFunction = context->jsFunctionHolder.value();
-      jsi::Runtime &rt = context->rt;
+      jsi::Function &jsFunction = strongContext->resolveHolder.value();
+      jsi::Runtime &rt = strongContext->rt;
 
-      argsConverter(rt, jsFunction, std::move(arg), context->isRejectCallback);
-      context->jsFunctionHolder.reset();
+      argsConverter(rt, jsFunction, std::move(arg));
+      strongContext->invalidate();
     });
 }
 
@@ -72,8 +122,7 @@ void JavaCallback::invokeJSFunction(T arg) {
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      T arg,
-      bool isRejectCallback
+      T arg
     ) {
       jsFunction.call(rt, {jsi::Value(rt, arg)});
     },
@@ -86,8 +135,7 @@ void JavaCallback::invoke() {
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      nullptr_t arg,
-      bool isRejectCallback
+      nullptr_t arg
     ) {
       jsFunction.call(rt, {jsi::Value::null()});
     },
@@ -116,8 +164,7 @@ void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      std::string arg,
-      bool isRejectCallback
+      std::string arg
     ) {
       std::optional<jsi::Value> extendedString = convertStringToFollyDynamicIfNeeded(
         rt,
@@ -145,8 +192,7 @@ void JavaCallback::invokeArray(jni::alias_ref<react::WritableNativeArray::javaob
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      folly::dynamic arg,
-      bool isRejectCallback
+      folly::dynamic arg
     ) {
       jsi::Value convertedArg = jsi::valueFromDynamic(rt, arg);
       auto enhancedArg = decorateValueForDynamicExtension(rt, convertedArg);
@@ -169,28 +215,8 @@ void JavaCallback::invokeMap(jni::alias_ref<react::WritableNativeMap::javaobject
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      folly::dynamic arg,
-      bool isRejectCallback
+      folly::dynamic arg
     ) {
-      if (isRejectCallback) {
-        auto errorCode = arg.find("code")->second.asString();
-        auto message = arg.find("message")->second.asString();
-
-        auto codedError = makeCodedError(
-          rt,
-          jsi::String::createFromUtf8(rt, errorCode),
-          jsi::String::createFromUtf8(rt, message)
-        );
-
-        jsFunction.call(
-          rt,
-          (const jsi::Value *) &codedError,
-          (size_t) 1
-        );
-
-        return;
-      }
-
       jsi::Value convertedArg = jsi::valueFromDynamic(rt, arg);
       auto enhancedArg = decorateValueForDynamicExtension(rt, convertedArg);
       if (enhancedArg) {
@@ -212,8 +238,7 @@ void JavaCallback::invokeSharedRef(jni::alias_ref<SharedRef::javaobject> result)
     [](
       jsi::Runtime &rt,
       jsi::Function &jsFunction,
-      jni::global_ref<SharedRef::javaobject> arg,
-      bool isRejectCallback
+      jni::global_ref<SharedRef::javaobject> arg
     ) {
       const auto jsiContext = getJSIContext(rt);
       auto native = jni::make_local(arg);
@@ -247,5 +272,54 @@ void JavaCallback::invokeSharedRef(jni::alias_ref<SharedRef::javaobject> result)
     },
     jni::make_global(result)
   );
+}
+
+void JavaCallback::invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage) {
+  const auto strongCallbackContext = this->callbackContext.lock();
+  if (strongCallbackContext == nullptr) {
+    return;
+  }
+
+  const auto jsInvoker = strongCallbackContext->jsCallInvokerHolder.lock();
+  // Call invoker is already released, so we cannot invoke the callback.
+  if (jsInvoker == nullptr) {
+    return;
+  }
+
+  jsInvoker->invokeAsync(
+    [
+      context = callbackContext,
+      code = code->toStdString(),
+      errorMessage = errorMessage->toStdString()
+    ]() -> void {
+      auto strongContext = context.lock();
+      // The context were deallocated before the callback was invoked.
+      if (strongContext == nullptr) {
+        return;
+      }
+
+      if (!strongContext->rejectHolder.has_value()) {
+        throw std::runtime_error(
+          "JavaCallback was already settled. Cannot invoke it again"
+        );
+      }
+
+      jsi::Function &jsFunction = strongContext->rejectHolder.value();
+      jsi::Runtime &rt = strongContext->rt;
+
+      auto codedError = makeCodedError(
+        rt,
+        jsi::String::createFromUtf8(rt, code),
+        jsi::String::createFromUtf8(rt, errorMessage)
+      );
+
+      jsFunction.call(
+        rt,
+        (const jsi::Value *) &codedError,
+        (size_t) 1
+      );
+
+      strongContext->invalidate();
+    });
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -13,6 +13,7 @@
 #include <react/jni/WritableNativeMap.h>
 #include <fbjni/detail/CoreClasses.h>
 #include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/LongLivedObject.h>
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;
@@ -26,19 +27,27 @@ struct SharedRef : public jni::JavaClass<SharedRef> {
 
 class JSIContext;
 
-typedef std::variant<folly::dynamic, jni::global_ref<SharedRef::javaobject>> CallbackArg;
-
 class JavaCallback : public jni::HybridClass<JavaCallback, Destructible> {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaCallback;";
   static auto constexpr TAG = "JavaCallback";
 
-  struct CallbackContext {
+  class CallbackContext : public react::LongLivedObject {
+  public:
+    CallbackContext(
+      jsi::Runtime &rt,
+      std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
+      std::optional<jsi::Function> resolveHolder,
+      std::optional<jsi::Function> rejectHolder
+    );
+
     jsi::Runtime &rt;
-    std::shared_ptr<react::CallInvoker> jsCallInvokerHolder;
-    std::optional<jsi::Function> jsFunctionHolder;
-    bool isRejectCallback;
+    std::weak_ptr<react::CallInvoker> jsCallInvokerHolder;
+    std::optional<jsi::Function> resolveHolder;
+    std::optional<jsi::Function> rejectHolder;
+
+    void invalidate();
   };
 
   static void registerNatives();
@@ -49,7 +58,7 @@ public:
   );
 
 private:
-  std::shared_ptr<CallbackContext> callbackContext;
+  std::weak_ptr<CallbackContext> callbackContext;
 
   friend HybridBase;
 
@@ -73,13 +82,10 @@ private:
 
   void invokeSharedRef(jni::alias_ref<SharedRef::javaobject> result);
 
+  void invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage);
+
   template<class T>
-  using ArgsConverter = std::function<void(
-    jsi::Runtime &rt,
-    jsi::Function &jsFunction,
-    T arg,
-    bool isRejectCallback
-  )>;
+  using ArgsConverter = std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction, T arg)>;
 
   template<class T>
   inline void invokeJSFunction(

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -36,7 +36,7 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
   });
 
   loadJClass(env, "expo/modules/kotlin/jni/PromiseImpl", {
-    {"<init>", "(Lexpo/modules/kotlin/jni/JavaCallback;Lexpo/modules/kotlin/jni/JavaCallback;)V"}
+    {"<init>", "(Lexpo/modules/kotlin/jni/JavaCallback;)V"}
   });
 
   loadJClass(env, "java/lang/Object", {});

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -7,13 +7,14 @@
 #include "Exceptions.h"
 #include "JavaCallback.h"
 #include "types/JNIToJSIConverter.h"
+#include "JSReferencesCache.h"
 
 #include <utility>
 #include <functional>
 #include <unistd.h>
 #include <optional>
 
-#include "JSReferencesCache.h"
+#include <ReactCommon/LongLivedObject.h>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
@@ -21,10 +22,10 @@ namespace react = facebook::react;
 
 namespace expo {
 
-jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
-  jsi::Function &&function,
-  jsi::Runtime &rt,
-  bool isRejectCallback = false
+jni::local_ref<JavaCallback::JavaPart> createJavaCallback(
+  jsi::Function &&resolveFunction,
+  jsi::Function &&rejectFunction,
+  jsi::Runtime &rt
 ) {
   JSIContext *jsiContext = getJSIContext(rt);
   std::shared_ptr<react::CallInvoker> jsInvoker = jsiContext->runtimeHolder->jsInvoker;
@@ -32,9 +33,15 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
   std::shared_ptr<JavaCallback::CallbackContext> callbackContext = std::make_shared<JavaCallback::CallbackContext>(
     rt,
     std::move(jsInvoker),
-    std::move(function),
-    isRejectCallback
+    std::move(resolveFunction),
+    std::move(rejectFunction)
   );
+
+#if REACT_NATIVE_TARGET_VERSION >= 75
+  facebook::react::LongLivedObjectCollection::get(rt).add(callbackContext);
+#else
+  facebook::react::LongLivedObjectCollection::get().add(callbackContext);
+#endif
 
   return JavaCallback::newInstance(jsiContext, std::move(callbackContext));
 }
@@ -336,15 +343,10 @@ jsi::Function MethodMetadata::createPromiseBody(
       jsi::Function resolveJSIFn = promiseConstructorArgs[0].getObject(rt).getFunction(rt);
       jsi::Function rejectJSIFn = promiseConstructorArgs[1].getObject(rt).getFunction(rt);
 
-      jobject resolve = createJavaCallbackFromJSIFunction(
+      jobject javaCallback = createJavaCallback(
         std::move(resolveJSIFn),
-        rt
-      ).release();
-
-      jobject reject = createJavaCallbackFromJSIFunction(
         std::move(rejectJSIFn),
-        rt,
-        true
+        rt
       ).release();
 
       JNIEnv *env = jni::Environment::current();
@@ -353,15 +355,14 @@ jsi::Function MethodMetadata::createPromiseBody(
         "expo/modules/kotlin/jni/PromiseImpl");
       jmethodID jPromiseConstructor = jPromise.getMethod(
         "<init>",
-        "(Lexpo/modules/kotlin/jni/JavaCallback;Lexpo/modules/kotlin/jni/JavaCallback;)V"
+        "(Lexpo/modules/kotlin/jni/JavaCallback;)V"
       );
 
       // Creates a promise object
       jobject promise = env->NewObject(
         jPromise.clazz,
         jPromiseConstructor,
-        resolve,
-        reject
+        javaCallback
       );
 
       // Cast in this place is safe, cause we know that this function expects promise.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
@@ -33,7 +33,7 @@ interface Promise {
 fun Promise.toBridgePromise(): com.facebook.react.bridge.Promise {
   val expoPromise = this
   val resolveMethod: (value: Any?) -> Unit = if (expoPromise is PromiseImpl) {
-    expoPromise.resolveBlock::invoke
+    expoPromise.callback::invoke
   } else {
     expoPromise::resolve
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -49,6 +49,10 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
     invokeNative(result)
   }
 
+  operator fun invoke(code: String, errorMessage: String) = checkIfValid {
+    invokeNative(code, errorMessage)
+  }
+
   private external fun invokeNative()
   private external fun invokeNative(result: Int)
   private external fun invokeNative(result: Boolean)
@@ -58,6 +62,7 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
   private external fun invokeNative(result: WritableNativeArray)
   private external fun invokeNative(result: WritableNativeMap)
   private external fun invokeNative(result: SharedRef<*>)
+  private external fun invokeNative(code: String, errorMessage: String)
 
   private inline fun checkIfValid(body: () -> Unit) {
     try {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -1,8 +1,5 @@
 package expo.modules.kotlin.jni
 
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.bridge.WritableNativeArray
-import com.facebook.react.bridge.WritableNativeMap
 import expo.modules.BuildConfig
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
@@ -30,7 +27,7 @@ private const val STACK_FRAME_KEY_METHOD_NAME = "methodName"
 
 @DoNotStrip
 class PromiseImpl @DoNotStrip internal constructor(
-  @DoNotStrip internal val callback: JavaCallback,
+  @DoNotStrip internal val callback: JavaCallback
 ) : Promise {
   internal var wasSettled = false
     private set

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -30,8 +30,7 @@ private const val STACK_FRAME_KEY_METHOD_NAME = "methodName"
 
 @DoNotStrip
 class PromiseImpl @DoNotStrip internal constructor(
-  @DoNotStrip internal val resolveBlock: JavaCallback,
-  @DoNotStrip internal val rejectBlock: JavaCallback
+  @DoNotStrip internal val callback: JavaCallback,
 ) : Promise {
   internal var wasSettled = false
     private set
@@ -39,80 +38,35 @@ class PromiseImpl @DoNotStrip internal constructor(
   private var fullFunctionName: String? = null
 
   override fun resolve(value: Any?) = checkIfWasSettled {
-    resolveBlock(
+    callback.invoke(
       JSTypeConverter.convertToJSValue(value)
     )
   }
 
   override fun resolve(result: Int) = checkIfWasSettled {
-    resolveBlock.invoke(result)
+    callback.invoke(result)
   }
 
   override fun resolve(result: Boolean) = checkIfWasSettled {
-    resolveBlock.invoke(result)
+    callback.invoke(result)
   }
 
   override fun resolve(result: Double) = checkIfWasSettled {
-    resolveBlock.invoke(result)
+    callback.invoke(result)
   }
 
   override fun resolve(result: Float) = checkIfWasSettled {
-    resolveBlock.invoke(result)
+    callback.invoke(result)
   }
 
   override fun resolve(result: String) = checkIfWasSettled {
-    resolveBlock.invoke(result)
+    callback.invoke(result)
   }
 
   // Copy of the reject method from [com.facebook.react.bridge.PromiseImpl]
   override fun reject(code: String, message: String?, cause: Throwable?) = checkIfWasSettled {
-    val errorInfo = WritableNativeMap()
-
-    errorInfo.putString(ERROR_MAP_KEY_CODE, code)
-
-    // Use the custom message if provided otherwise use the throwable message.
-    if (message != null) {
-      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, message)
-    } else if (cause != null) {
-      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, cause.message)
-    } else {
-      // The JavaScript side expects a map with at least an error message.
-      // /Libraries/BatchedBridge/NativeModules.js -> createErrorFromErrorData
-      // TYPE: (errorData: { message: string })
-      errorInfo.putString(ERROR_MAP_KEY_MESSAGE, ERROR_DEFAULT_MESSAGE)
-    }
-
-    // For consistency with iOS ensure userInfo key exists, even if we null it.
-    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-    errorInfo.putNull(ERROR_MAP_KEY_USER_INFO)
-
-    // Attach a nativeStackAndroid array if a throwable was passed
-    // this matches iOS behavior - iOS adds a `nativeStackIOS` property
-    // iOS: /React/Base/RCTUtils.m -> RCTJSErrorFromCodeMessageAndNSError
-    if (cause != null) {
-      val stackTrace: Array<StackTraceElement> = cause.stackTrace
-      val nativeStackAndroid = WritableNativeArray()
-
-      // Build an an Array of StackFrames to match JavaScript:
-      // iOS: /Libraries/Core/Devtools/parseErrorStack.js -> StackFrame
-      var i = 0
-      while (i < stackTrace.size && i < ERROR_STACK_FRAME_LIMIT) {
-        val frame = stackTrace[i]
-        val frameMap: WritableMap = WritableNativeMap()
-        // NOTE: no column number exists StackTraceElement
-        frameMap.putString(STACK_FRAME_KEY_CLASS, frame.className)
-        frameMap.putString(STACK_FRAME_KEY_FILE, frame.fileName)
-        frameMap.putInt(STACK_FRAME_KEY_LINE_NUMBER, frame.lineNumber)
-        frameMap.putString(STACK_FRAME_KEY_METHOD_NAME, frame.methodName)
-        nativeStackAndroid.pushMap(frameMap)
-        i++
-      }
-      errorInfo.putArray(ERROR_MAP_KEY_NATIVE_STACK, nativeStackAndroid)
-    } else {
-      errorInfo.putArray(ERROR_MAP_KEY_NATIVE_STACK, WritableNativeArray())
-    }
-
-    rejectBlock.invoke(errorInfo)
+    // TODO(@lukmccall): Add information about the stack trace to the error message
+    callback.invoke(code, message ?: cause?.message ?: "unknown")
   }
 
   private inline fun checkIfWasSettled(body: () -> Unit) {


### PR DESCRIPTION
# Why

Fixes:
```
                  DEBUG  F  #00 pc 000000000011073c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libexpo-modules-core.so (offset 0x787000) (std::__ndk1::__shared_ptr_emplace<expo::JavaCallback::CallbackContext, std::__nd
                            k1::allocator<expo::JavaCallback::CallbackContext> >::__on_zero_shared()+52) (BuildId: 49a3c01d17881d7654f5196ac2bb4d0716df10f3)
                         F  #01 pc 00000000000e4ba8  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libexpo-modules-core.so (offset 0x787000) (std::__ndk1::__function::__func<void expo::JavaCallback::invokeJSFunction<bool>(
                            std::__ndk1::function<void (facebook::jsi::Runtime&, facebook::jsi::Function&, bool, bool)>, bool)::'lambda'(), std::__ndk1::allocator<void expo::JavaCallback::invokeJSFunction<bool>(std::__ndk1::function<void (facebook::jsi::Runtime&, faceboo
                            k::jsi::Function&, bool, bool)>, bool)::'lambda'()>, void ()>::destroy_deallocate()+124) (BuildId: 49a3c01d17881d7654f5196ac2bb4d0716df10f3)
                         F  #02 pc 00000000000dbb38  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libexpo-modules-core.so (offset 0x787000) (std::__ndk1::__function::__func<expo::BridgelessJSCallInvoker::invokeAsync(std::
                            __ndk1::function<void ()>&&)::'lambda'(facebook::jsi::Runtime&), std::__ndk1::allocator<expo::BridgelessJSCallInvoker::invokeAsync(std::__ndk1::function<void ()>&&)::'lambda'(facebook::jsi::Runtime&)>, void (facebook::jsi::Runtime&)>::destroy_
                            deallocate()+80) (BuildId: 49a3c01d17881d7654f5196ac2bb4d0716df10f3)
                         F  #03 pc 000000000044a9d8  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #04 pc 000000000044a074  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (std::__ndk1::function<void (facebook::jsi::Runtime&)>::~function()+20) (BuildId: 6699c0f
                            9a7bdbba4)
                         F  #05 pc 00000000005b72f0  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #06 pc 00000000005bcb10  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #07 pc 00000000005bcc10  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #08 pc 00000000005bd728  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #09 pc 00000000005bc67c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfabricjni.so (offset 0x8c4000) (BuildId: 6699c0f9a7bdbba4)
                         F  #10 pc 00000000000fc344  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #11 pc 00000000000f773c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (std::__ndk1::function<void (facebook::jsi::Runtime&)>::~function()+20) (BuildId: ea536
                            2671c1fcb07)
                         F  #12 pc 00000000001208dc  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #13 pc 000000000012173c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #14 pc 0000000000121854  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #15 pc 00000000001222d4  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #16 pc 00000000001212b0  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!librninstance.so (offset 0x23bb000) (BuildId: ea5362671c1fcb07)
                         F  #17 pc 00000000001e750c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #18 pc 00000000001df154  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (std::__ndk1::function<void ()>::~function()+20) (BuildId: c47ef889b966436f)
                         F  #19 pc 000000000020eed0  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #20 pc 000000000020fc4c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #21 pc 000000000020fd38  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #22 pc 0000000000210838  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #23 pc 000000000020f7c0  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #24 pc 00000000001e750c  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (BuildId: c47ef889b966436f)
                         F  #25 pc 00000000001df154  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (std::__ndk1::function<void ()>::~function()+20) (BuildId: c47ef889b966436f)
                         F  #26 pc 0000000000212bb8  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (facebook::jni::JNativeRunnable::~JNativeRunnable()+44) (BuildId: c47ef889b966436f)
                         F  #27 pc 0000000000212be8  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libreactnativejni.so (offset 0x20a1000) (facebook::jni::JNativeRunnable::~JNativeRunnable()+24) (BuildId: c47ef889b966436f)
                         F  #28 pc 00000000000215c8  /data/app/~~e8-X2lAIh5Hk12O5xY2zog==/com.example.withnewarch-cQTxG6ebvPwPwHucPyNV1w==/base.apk!libfbjni.so (offset 0x1020000) (BuildId: a22242831a7971267de570e06121acb588ce64cd)
                         F  #29 pc 0000000000377030  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #30 pc 000000000201c5f0  /memfd:jit-cache (deleted) (offset 0x2000000) (com.facebook.jni.HybridData$Destructor.destruct+96)
                         F  #31 pc 00000000003605a4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #32 pc 00000000004906b4  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, bool, art::JValue*)+1248) (BuildId: b10f5696fea1b32
                            039b162aef3850ed3)
                         F  #33 pc 0000000000509f94  /apex/com.android.art/lib64/libart.so (void art::interpreter::ExecuteSwitchImplCpp<false>(art::interpreter::SwitchImplContext*)+780) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #34 pc 00000000003797d8  /apex/com.android.art/lib64/libart.so (ExecuteSwitchImplAsm+8) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #35 pc 00000000002b46d0  <anonymous:7a0b3ca000> (com.facebook.jni.DestructorThread$1.run+0)
                         F  #36 pc 000000000037cde0  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.__uniq.112435418011751916792819755956732575238.llvm.1377403
                            774332988508)+356) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #37 pc 000000000037c560  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+672) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #38 pc 0000000000377168  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+88) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #39 pc 00000000003605a4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #40 pc 000000000034b8a4  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+144) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #41 pc 00000000004f3e30  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1888) (BuildId: b10f5696fea1b32039b162aef3850ed3)
                         F  #42 pc 00000000000cb6a8  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: a87908b48b368e6282bcc9f34bcfc28c)
                         F  #43 pc 000000000006821c  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: a87908b48b368e6282bcc9f34bcfc28c)
```

# How

There is a difference in how the call invoker and the runtime executor deallocate items that are added to the queue. The call invoker appears to be more aggressive and will deallocate all items before runtime. However, the executor seems to be more lazy and doesn't care if all items are deallocated. I assume that when I add something to the queue, it will be deallocated before we lose the runtime. This assumption seems reasonable to me. However, React Native works differently when bridgeless is on.

Also, I had to combine resolve and reject callbacks into one object. It's easier to deallocate those objects correctly when they're together. 

# Test Plan

- unit tests ✅ 
- new application ✅ 
```
$ yarn create expo-app my-app -e with-canary-new-arch
$ cd my-app
$ yarn add expo@next
$ npx expo run:android
then keep pressing "r" in terminal ui until the crash
```