### PR TITLE
[doctor] check if native files in local Expo modules are being ignored

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Check if local modules native code is unintentionally gitignored ([#28484](https://github.com/expo/expo/pull/28484) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -16,13 +16,17 @@ export class ProjectSetupCheck implements DoctorCheck {
     // ** check that expo modules native projects aren't getting gitignored **
 
     if (fs.existsSync(path.join(projectRoot, 'modules'))) {
+      // Glob returns matching files and `git check-ignore` checks files, as well, but we want to check if the path is gitignored,
+      // so we pick vital files to match off of (e.g., .podspec, build.gradle).
       const keyFilePathsForModules = [
         path.join(projectRoot, 'modules', '**', 'ios', '*.podspec'),
         path.join(projectRoot, 'modules', '**', 'android', 'build.gradle'),
       ];
 
       if (
-        (await Promise.all(keyFilePathsForModules.map(isPathIgnoredAsync))).find((result) => result)
+        (await Promise.all(keyFilePathsForModules.map(areAnyMatchingPathsIgnoredAsync))).find(
+          (result) => result
+        )
       ) {
         issues.push(
           'This project contains local Expo modules, but the android/ios folders inside the modules are gitignored. These files are required to build your native module into your app. Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level android and ios folders.'
@@ -89,11 +93,7 @@ async function getRootPathAsync(): Promise<string> {
   return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
 }
 
-/**
- * Glob returns matching files and `git check-ignore` checks files, as well, but we want to check if the path is gitignored,
- * so we pick vital files to match off of (e.g., .podspec, build.gradle).
- */
-async function isPathIgnoredAsync(filePath: string): Promise<boolean> {
+async function areAnyMatchingPathsIgnoredAsync(filePath: string): Promise<boolean> {
   const matchingNativeFiles = await glob(filePath);
   if (!matchingNativeFiles.length) return false;
   // multiple matches may occur if there are multiple modules

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -96,5 +96,9 @@ async function getRootPathAsync(): Promise<string> {
 async function isPathIgnoredAsync(filePath: string): Promise<boolean> {
   const matchingNativeFiles = await glob(filePath);
   if (!matchingNativeFiles.length) return false;
-  return await isFileIgnoredAsync(matchingNativeFiles[0]);
+  // multiple matches may occur if there are multiple modules
+  return (
+    (await Promise.all(matchingNativeFiles.map(isFileIgnoredAsync))).find((result) => result) ||
+    false
+  );
 }


### PR DESCRIPTION
# Why
An issue we've run into a few times is where someone creates a local module, but set their gitignore file to ignore their app's native project folders, but they made that match too greedy, so it ignores **all** android and ios folders.

The errors can be a little confusing when this happens... you'll get all the way to Fastlane and it'll be like, "I can't find this Cocoapod".

Matches like `/ios` or `ios/**` are fine, but `ios` is not.

# How
Check for:
a) does the **modules** folder exist?
b) if so, do any files match `modules/**/ios/*.podspec` or `modules/**/android/buld.gradle`?
c) if so, are any of those files gitignored?

Optimally, I'd check .easignore, as well, but this should catch most cases. AFAIK, checking .easignore would require reading the file and using `minimatch`, so a completely different mechanism than the existing gitignore check, which is pretty thorough because it uses `git check-ignore` from the top level. A good long-term goal would be to refactor into a general-purpose ignore check that reports back what exactly is ignoring a file and can be used by multiple checks..

# Test Plan
<img width="708" alt="image" src="https://github.com/expo/expo/assets/8053974/22ebd5ba-41f0-4fd2-ab01-cf8d21f0995b">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
