### PR TITLE
[core][Android] Fix crashes during the deallocation of shared objects

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed gziped payload does not correctly shown in network inspector. ([#28486](https://github.com/expo/expo/pull/28486) by [@kudo](https://github.com/kudo))
+- [Android] Fixed crashes during the deallocation of shared objects.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed gziped payload does not correctly shown in network inspector. ([#28486](https://github.com/expo/expo/pull/28486) by [@kudo](https://github.com/kudo))
-- [Android] Fixed crashes during the deallocation of shared objects.
+- [Android] Fixed crashes during the deallocation of shared objects. ([#28491](https://github.com/expo/expo/pull/28491) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -123,7 +123,7 @@ public:
   );
 
   static void deleteSharedObject(
-    jni::global_ref<JSIContext::javaobject> javaObject,
+    jni::alias_ref<JSIContext::javaobject> javaObject,
     int objectId
   );
 


### PR DESCRIPTION
# Why

Fixes crashes during the deallocation of shared objects. 
```
2024-04-25 17:10:51.732 10991-11072 libc++abi               dev.expo.payments                    E  terminating with uncaught exception of type std::runtime_error: Unable to retrieve jni environment. Is the thread attached?
2024-04-25 17:10:51.732 10991-11072 libc                    dev.expo.payments                    A  Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 11072 (hades), pid 10991 (v.expo.payments)
```

# How

We attached the Hades thread to the JVM to call a method. However, this approach was insufficient as the default destructor for `jni::global_ref` was called outside of the added thread scope. To address this issue, I modified the way the global ref is passed to the shared object native state.


# Test Plan

- NCL ✅ 
- double-check if video player is deallocated correctly ✅ 