### PR TITLE
[dev-client] Add missing header for JSC

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - Use DevMenuRCTBridge in DevClientRootViewFactory. ([#28460](https://github.com/expo/expo/pull/28460) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add missing header that causes an error when using `JSC`.
+- Add missing header that causes an error when using `JSC`. ([#28492](https://github.com/expo/expo/pull/28492) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 5.0.6 — 2024-04-25
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Use DevMenuRCTBridge in DevClientRootViewFactory. ([#28460](https://github.com/expo/expo/pull/28460) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add missing header that causes an error when using `JSC`.
 
 ## 5.0.6 — 2024-04-25
 

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
@@ -16,6 +16,7 @@
 #import <React/RCTCxxBridgeDelegate.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+#import <jsireact/JSIExecutor.h>
 
 @interface RCTRootViewFactory () <RCTCxxBridgeDelegate> {
   std::shared_ptr<facebook::react::RuntimeScheduler> _runtimeScheduler;


### PR DESCRIPTION
# Why
Closes #28487

# How
Not explicitly including the header for `JSIExecutor` will cause a build error when using `JSC`. This is because when `HermesExecutorFactory.h` is excluded,  the header is no longer included.

# Test Plan
Tested in bare expo with `hermes` and `jsc`.