### PR TITLE
[docs] Update implementing-a-checkbox.mdx

### DIFF
--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
   },
   checkboxLabel: {
     marginLeft: 8,
-    fontWeight: 500,
+    fontWeight: '500',
     fontSize: 18,
   },
 });


### PR DESCRIPTION
# Why
Android throws an exception because it's unable to cast fontWeight to a string.

<img width="471" alt="image" src="https://github.com/expo/expo/assets/620454/966cfc28-b04a-4763-8166-e29c8553255a">

# How

I changed it from an integer to a string.

# Test Plan

I refreshed my Android emulator and the exception went away.
