### PR TITLE
fix(cli): prevent overwriting Atlas data when exporting web with static renderer

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent overwriting exported Atlas data when exporting web with static renderer. ([#28502](https://github.com/expo/expo/pull/28502) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.18.6 — 2024-04-26

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -155,7 +155,7 @@
     "@types/wrap-ansi": "^8.0.1",
     "@types/ws": "^8.5.4",
     "devtools-protocol": "^0.0.1113120",
-    "expo-atlas": "^0.1.0",
+    "expo-atlas": "^0.2.0",
     "expo-module-scripts": "^3.0.0",
     "find-process": "^1.4.7",
     "jest-runner-tsd": "^6.0.0",

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -16,6 +16,7 @@ import { ConfigT } from 'metro-config';
 import path from 'path';
 
 import { isEnableHermesManaged, maybeThrowFromInconsistentEngineAsync } from './exportHermes';
+import { attachAtlasAsync } from '../start/server/metro/debugging/attachAtlas';
 import { loadMetroConfigAsync } from '../start/server/metro/instantiateMetro';
 import { getEntryWithServerRoot } from '../start/server/middleware/ManifestMiddleware';
 import {
@@ -143,6 +144,15 @@ async function bundleProductionMetroClientAsync(
   });
 
   assertMetroConfig(config);
+
+  // Attach Expo Atlas if enabled
+  await attachAtlasAsync({
+    exp: expoConfig,
+    projectRoot,
+    metroConfig: config,
+    isExporting: true,
+    resetAtlasFile: true, // NOTE(cedric): reset the Atlas file once, and reuse it for static exports
+  });
 
   const metroServer = await Metro.runMetro(config, {
     watch: false,

--- a/packages/@expo/cli/src/start/server/metro/debugging/AtlasPrerequisite.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/AtlasPrerequisite.ts
@@ -26,7 +26,7 @@ export class AtlasPrerequisite extends ProjectPrerequisite<
         warningMessage:
           'Expo Atlas is not installed in this project, unable to gather bundle information.',
         requiredPackages: [
-          { version: '^0.1.1', pkg: 'expo-atlas', file: 'expo-atlas/package.json', dev: true },
+          { version: '^0.2.0', pkg: 'expo-atlas', file: 'expo-atlas/package.json', dev: true },
         ],
       });
     } catch (error) {

--- a/packages/@expo/cli/src/start/server/metro/debugging/attachAtlas.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/attachAtlas.ts
@@ -15,68 +15,43 @@ type AttachAtlasOptions = Pick<EnsureDependenciesOptions, 'exp'> & {
   resetAtlasFile?: boolean;
 };
 
-export async function attachAtlasAsync({
-  exp,
-  isExporting,
-  projectRoot,
-  middleware,
-  metroConfig,
-  resetAtlasFile,
-}: AttachAtlasOptions): Promise<void | ReturnType<
-  typeof import('expo-atlas/cli').createExpoAtlasMiddleware
->> {
+export async function attachAtlasAsync(
+  options: AttachAtlasOptions
+): Promise<void | ReturnType<typeof import('expo-atlas/cli').createExpoAtlasMiddleware>> {
   if (!env.EXPO_UNSTABLE_ATLAS) {
     return;
   }
 
   debug('Atlas is enabled, initializing for this project...');
+  await new AtlasPrerequisite(options.projectRoot).bootstrapAsync({ exp: options.exp });
 
-  await new AtlasPrerequisite(projectRoot).bootstrapAsync({ exp });
+  return !options.isExporting
+    ? attachAtlasToDevServer(options)
+    : await attachAtlasToExport(options);
+}
 
-  // Expo CLI instantiates multiple Metro instances when exporting static web.
-  // Fully resetting this atlas file is therefore an opt-in.
-  if (isExporting && resetAtlasFile) {
-    const atlas = importAtlas(projectRoot);
-    if (!atlas) return debug('Atlas is not installed in the project, skipping initialization');
-
-    const atlasPath = atlas.getAtlasPath(projectRoot);
-    await atlas?.createAtlasFile(atlasPath);
-    debug('(Re)created Atlas file at:', atlasPath);
-  }
-
-  // Exporting only sets up Metro, without attaching middleware
-  if (isExporting) {
-    const atlas = importAtlasForExport(projectRoot);
-    if (!atlas) return debug('Atlas is not installed in the project, skipping initialization');
-
-    atlas.withExpoAtlas(metroConfig);
-    debug('Attached Atlas to Metro config for exporting');
-    return;
-  }
-
-  // Running in development mode requires middleware to be attached
-  if (!isExporting && !middleware) {
+/**
+ * Attach Atlas to the Metro bundler for development mode.
+ * This includes attaching to Metro's middleware stack to host the Atlas UI.
+ */
+function attachAtlasToDevServer(
+  options: Pick<AttachAtlasOptions, 'projectRoot' | 'middleware' | 'metroConfig'>
+): void | ReturnType<typeof import('expo-atlas/cli').createExpoAtlasMiddleware> {
+  if (!options.middleware) {
     throw new Error(
       'Expected middleware to be provided for Atlas when running in development mode'
     );
-  } else if (!isExporting && middleware) {
-    const atlas = importAtlasForDev(projectRoot);
-    if (!atlas) return debug('Atlas is not installed in the project, skipping initialization');
-
-    const instance = atlas.createExpoAtlasMiddleware(metroConfig);
-    middleware.use('/_expo/atlas', instance.middleware);
-    debug('Attached Atlas middleware for development on: /_expo/atlas');
-    return instance;
   }
-}
 
-function importAtlas(projectRoot: string): null | typeof import('expo-atlas') {
-  try {
-    return require(require.resolve('expo-atlas', { paths: [projectRoot] }));
-  } catch (error: any) {
-    debug('Failed to load Atlas from project:', error);
-    return null;
+  const atlas = importAtlasForDev(options.projectRoot);
+  if (!atlas) {
+    return debug('Atlas is not installed in the project, skipping initialization');
   }
+
+  const instance = atlas.createExpoAtlasMiddleware(options.metroConfig);
+  options.middleware.use('/_expo/atlas', instance.middleware);
+  debug('Attached Atlas middleware for development on: /_expo/atlas');
+  return instance;
 }
 
 function importAtlasForDev(projectRoot: string): null | typeof import('expo-atlas/cli') {
@@ -86,6 +61,28 @@ function importAtlasForDev(projectRoot: string): null | typeof import('expo-atla
     debug('Failed to load Atlas from project:', error);
     return null;
   }
+}
+
+/**
+ * Attach Atlas to the Metro bundler for exporting mode.
+ * This only includes attaching the custom serializer to the Metro config.
+ */
+async function attachAtlasToExport(
+  options: Pick<AttachAtlasOptions, 'projectRoot' | 'metroConfig' | 'resetAtlasFile'>
+): Promise<void> {
+  const atlas = importAtlasForExport(options.projectRoot);
+  if (!atlas) {
+    return debug('Atlas is not installed in the project, skipping initialization');
+  }
+
+  if (options.resetAtlasFile) {
+    // @ts-expect-error
+    const filePath = await atlas.resetExpoAtlasFile(options.projectRoot);
+    debug('(Re)created Atlas file at:', filePath);
+  }
+
+  atlas.withExpoAtlas(options.metroConfig);
+  debug('Attached Atlas to Metro config for exporting');
 }
 
 function importAtlasForExport(projectRoot: string): null | typeof import('expo-atlas/metro') {

--- a/packages/@expo/cli/src/start/server/metro/debugging/attachAtlas.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/attachAtlas.ts
@@ -76,7 +76,6 @@ async function attachAtlasToExport(
   }
 
   if (options.resetAtlasFile) {
-    // @ts-expect-error
     const filePath = await atlas.resetExpoAtlasFile(options.projectRoot);
     debug('(Re)created Atlas file at:', filePath);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9922,10 +9922,10 @@ expo-asset-utils@~3.0.0:
   resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-3.0.0.tgz#2c7ddf71ba9efacf7b46c159c1c650114a2f14dc"
   integrity sha512-CgIbNvTqKqQi1lrlptmwoaCMu4ZVOZf8tghmytlor23CjIOuorw6cfuOqiqWkJLz23arTt91maYEU9XLMPB23A==
 
-expo-atlas@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/expo-atlas/-/expo-atlas-0.1.1.tgz#fdf4f4cc324d631d10cc68741d0ed0ebbcafc675"
-  integrity sha512-Hav8n5DRNCUPqs/L34KUv3+lj10k8NxOnvyAfsN0lc7cUG3h8SS45xB1xXUDHx4RX5IjKBtCvocdirCmamPQWw==
+expo-atlas@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/expo-atlas/-/expo-atlas-0.2.0.tgz#b69b5475d6b46fce5dc8b86d6b18d9ecb717b2a4"
+  integrity sha512-1ygW6ouTC/twYBWXJpw4LsPCCDdBt5KYQQos2y1fTxUyF4VeYq6nMc1dfR0AwFGRo0NyI0YFMDPn3HRWjshzVQ==
   dependencies:
     "@expo/server" "^0.3.1"
     arg "^5.0.2"


### PR DESCRIPTION
# Why

When enabling static web exports, there is an issue with exporting Atlas data for all platforms. We seem to re-instantiate Metro for static exports, which will overwrite the exported data in the Atlas file.

# How

- [x] Updated e2e test to validate the contents of the Atlas file
- [x] Moved logic to (re)create Atlas file to Expo CLI, as an opt-in.
  - [x] Released Atlas `0.2.0` with this new ownership
- [x] Updated Atlas prerequisite to `0.2.0`

# Test Plan

- See added tests
- `$ EXPO_UNSTABLE_ATLAS=true expo export --platform all` (with static export)
  - Should include all platforms, not just web.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
