### PR TITLE
[docs] Update React Native, Android, iOS version on SDK 51 reference index page

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -7,6 +7,7 @@ import RedirectNotification from '~/components/plugins/RedirectNotification';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 <RedirectNotification>
   The page you are looking for does not exist in this SDK version. It may have been deprecated or
@@ -45,12 +46,14 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
       SDK packages.
     </>
   }
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
-  title="Using libraries"
+  title="Use libraries"
   description="Learn how to install Expo SDK packages in your project."
   href="/workflow/using-libraries"
+  Icon={BookOpen02Icon}
 />
 
 ## Using pre-release versions

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -59,7 +59,7 @@ New Expo SDK versions are released three times each year. Between these releases
 
 ### Canary releases
 
-Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `50.0.0-canary-20231205-250b31f`. To install the latest canary release:
+Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `51.0.0-canary-20240418-8d74597`. To install the latest canary release:
 
 <Terminal
   cmd={[
@@ -81,9 +81,9 @@ Approximately every four months there is a new Expo SDK release that typically u
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
+| 51.0.0           | 0.74                 | 0.19.10                  |
 | 50.0.0           | 0.73                 | 0.19.6                   |
 | 49.0.0           | 0.72                 | 0.19.6                   |
-| 48.0.0           | 0.71                 | 0.18.10                  |
 
 ### Support for other React Native versions
 
@@ -95,6 +95,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |
 | 49.0.0           | 5+              | 33                  | 13+         |
-| 48.0.0           | 5+              | 33                  | 13+         |

--- a/docs/pages/versions/v51.0.0/index.mdx
+++ b/docs/pages/versions/v51.0.0/index.mdx
@@ -7,6 +7,7 @@ import RedirectNotification from '~/components/plugins/RedirectNotification';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 <RedirectNotification>
   The page you are looking for does not exist in this SDK version. It may have been deprecated or
@@ -45,12 +46,14 @@ Expo apps are React Native apps, so all Expo SDK packages work in any React Nati
       SDK packages.
     </>
   }
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
-  title="Using libraries"
+  title="Use libraries"
   description="Learn how to install Expo SDK packages in your project."
   href="/workflow/using-libraries"
+  Icon={BookOpen02Icon}
 />
 
 ## Using pre-release versions

--- a/docs/pages/versions/v51.0.0/index.mdx
+++ b/docs/pages/versions/v51.0.0/index.mdx
@@ -59,7 +59,7 @@ New Expo SDK versions are released three times each year. Between these releases
 
 ### Canary releases
 
-Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `50.0.0-canary-20231205-250b31f`. To install the latest canary release:
+Canary releases represent a snapshot of the state of the `main` branch at the time they are published. Canary package versions include `-canary` in the name, along with the date and commit hash, such as `51.0.0-canary-20240418-8d74597`. To install the latest canary release:
 
 <Terminal
   cmd={[
@@ -81,9 +81,9 @@ Approximately every four months there is a new Expo SDK release that typically u
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
+| 51.0.0           | 0.74                 | 0.19.10                  |
 | 50.0.0           | 0.73                 | 0.19.6                   |
 | 49.0.0           | 0.72                 | 0.19.6                   |
-| 48.0.0           | 0.71                 | 0.18.10                  |
 
 ### Support for other React Native versions
 
@@ -95,6 +95,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 51.0.0           | 6+              | 34                  | 13.4+       |
 | 50.0.0           | 6+              | 34                  | 13.4+       |
 | 49.0.0           | 5+              | 33                  | 13+         |
-| 48.0.0           | 5+              | 33                  | 13+         |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- For SDK 51 release, this PR updates Android, iOS, React Native and React Native Web compatible version tables.
- Removes SDK 48 mention from these tables.
- Changes applied to unversioned and SDK 51 docs.
- Add missing icons on boxlinks and fix libraries guide title in one of the boxlink.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v51.0.0

## Preview

![CleanShot 2024-04-28 at 19 41 47@2x](https://github.com/expo/expo/assets/10234615/585bc597-cf23-4d2b-b747-b0b5f5cba310)

![CleanShot 2024-04-28 at 19 41 43@2x](https://github.com/expo/expo/assets/10234615/11205a96-ba3f-49f0-a846-88ff6e675bd5)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
