### PR TITLE
[docs] Add a Usage section for Device API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/device.mdx
+++ b/docs/pages/versions/unversioned/sdk/device.mdx
@@ -9,12 +9,34 @@ platforms: ['android', 'ios', 'tvos', 'web']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
+import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
+`expo-device` provides access to system information about the physical device, such as its manufacturer and model.
 
 ## Installation
 
 <APIInstallSection />
+
+## Usage
+
+<SnackInline label='Basic Device Usage' dependencies={['expo-device']}>
+
+```jsx
+import { Text, View } from 'react-native';
+import * as Device from 'expo-device';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>
+        {Device.manufacturer}: {Device.modelName}
+      </Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v49.0.0/sdk/device.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/device.mdx
@@ -9,14 +9,36 @@ iconUrl: '/static/images/packages/expo-device.png'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
+`expo-device` provides access to system information about the physical device, such as its manufacturer and model.
 
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Usage
+
+<SnackInline label='Basic Device Usage' dependencies={['expo-device']}>
+
+```jsx
+import { Text, View } from 'react-native';
+import * as Device from 'expo-device';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>
+        {Device.manufacturer}: {Device.modelName}
+      </Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v50.0.0/sdk/device.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/device.mdx
@@ -9,14 +9,36 @@ iconUrl: '/static/images/packages/expo-device.png'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
+`expo-device` provides access to system information about the physical device, such as its manufacturer and model.
 
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Usage
+
+<SnackInline label='Basic Device Usage' dependencies={['expo-device']}>
+
+```jsx
+import { Text, View } from 'react-native';
+import * as Device from 'expo-device';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>
+        {Device.manufacturer}: {Device.modelName}
+      </Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 

--- a/docs/pages/versions/v51.0.0/sdk/device.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/device.mdx
@@ -9,12 +9,34 @@ platforms: ['android', 'ios', 'tvos', 'web']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
+import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-device`** provides access to system information about the physical device, such as its manufacturer and model.
+`expo-device` provides access to system information about the physical device, such as its manufacturer and model.
 
 ## Installation
 
 <APIInstallSection />
+
+## Usage
+
+<SnackInline label='Basic Device Usage' dependencies={['expo-device']}>
+
+```jsx
+import { Text, View } from 'react-native';
+import * as Device from 'expo-device';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>
+        {Device.manufacturer}: {Device.modelName}
+      </Text>
+    </View>
+  );
+}
+```
+
+</SnackInline>
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Expo Device API reference is missing a usage section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a usage section with a basic example to Expo Device API reference. Changes backported to SDK 51, 50, and 49.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v51.0.0/sdk/device/

## Preview

![CleanShot 2024-04-29 at 00 55 29@2x](https://github.com/expo/expo/assets/10234615/3b7a1f6a-2a4f-419a-8e9d-e23828faeb6c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
