### PR TITLE
ci(cli): shard e2e tests to lower workflow from `11m` to `6m`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -44,6 +44,9 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -70,7 +73,7 @@ jobs:
         run: yarn typecheck
         working-directory: packages/@expo/cli
       - name: E2E Test CLI
-        run: yarn test:e2e
+        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
         working-directory: packages/@expo/cli
       # - name: 🔔 Notify on Slack
       #   uses: 8398a7/action-slack@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Why

The CLI e2e is taking around 10m30s - 11m, this could be faster.

<details><summary>Consumed test time per test file</summary>

<img width="1112" alt="image" src="https://github.com/expo/expo/assets/1203991/6b8c5672-f0fe-4dc5-85f9-76e99a22ee61">

</details>

# How

- **Attempted to speed up bundling through minimizing the workers**
  - `--max-workers=1` → average slowdown of **1.156x** original time
  - `--max-workers=2` → average slowdown of **1.031x** original time
  - `--max-workers=3` → average slowdown of **1.017x** original time
- **Attempted to run on MacOS M1 instead of Ubuntu**
  The results were interesting and very volatile. There were improvements of 0.61x of its original time but also 3.04x slowdowns. I'm not sure if this is related to IO buildup or GHA sharing the Mac host, and another big consumer happened to be there.
- **Attempted to run tests in parallel [with sharding](https://jestjs.io/docs/next/cli#--shard)** _(see commits)_
  - `--shard x/4` → 5m9s, 5m14s, 4m0s, 4m36s _(total **5m41s**)_
  - `--shard x/2` → 7m48s, 6m6s _(total **7m57s**)_
  - `--shard x/3` → 5m52s, 4m57s, 5m12s _(total **6m1s**)_

For now, sharding with 3 parallel tasks seems to be the sweet spot for CLI e2e tests, and a quick win without changing code. It reduces the tests from 11m to 6m, which is roughly **1.83x** faster.

# Test Plan

See GHA

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
