### PR TITLE
[expo-image-picker][android] prevent multiple image pickers from opening on Android

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed type exports for isolatedModules option in typescript ([#28499](https://github.com/expo/expo/pull/28499) by [@megacherry](https://github.com/megacherry))
+- On Android, fixed an issue where multiple pickers could be opened, causing a crash. ([#28509](https://github.com/expo/expo/pull/28509) by [@haileyok](https://github.com/haileyok))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -34,6 +34,7 @@ import kotlin.coroutines.resumeWithException
 private const val moduleName = "ExponentImagePicker"
 
 class ImagePickerModule : Module() {
+  private var isPickerOpen = false
 
   override fun definition() = ModuleDefinition {
     Name(moduleName)
@@ -129,6 +130,11 @@ class ImagePickerModule : Module() {
     options: ImagePickerOptions
   ): Any {
     return try {
+      if (isPickerOpen) {
+        return ImagePickerResponse(canceled = true)
+      }
+
+      isPickerOpen = true
       var result = launchPicker(pickerLauncher)
       if (
         !options.allowsMultipleSelection &&
@@ -143,6 +149,8 @@ class ImagePickerModule : Module() {
       mediaHandler.readExtras(result.data, options)
     } catch (cause: OperationCanceledException) {
       return ImagePickerResponse(canceled = true)
+    } finally {
+      isPickerOpen = false
     }
   }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -34,8 +34,6 @@ import kotlin.coroutines.resumeWithException
 private const val moduleName = "ExponentImagePicker"
 
 class ImagePickerModule : Module() {
-  private var isPickerOpen = false
-
   override fun definition() = ModuleDefinition {
     Name(moduleName)
 
@@ -121,6 +119,8 @@ class ImagePickerModule : Module() {
    * The user can retrieve the data using exported `getPendingResultAsync` method.
    */
   private var pendingMediaPickingResult: PendingMediaPickingResult? = null
+
+  private var isPickerOpen = false
 
   /**
    * Calls [launchPicker] and unifies flow shared between "launchCameraAsync" and "launchImageLibraryAsync"


### PR DESCRIPTION
# Why

Currently, calling `launchImageLibraryAsync()` twice in quick succession on Android will result in two image pickers being opened. Whenever the second picker is closed, the app will crash.

[expo-image-picker-crash-before.webm](https://github.com/expo/expo/assets/153161762/a2e1b4c5-ee93-4b7f-ae43-1cd7dcc004da)

# How

We can keep track of when the picker is open by adding a variable `isPickerOpen`. Whenever we call `launchContract()` inside of `ImagePickerModule`, we will check if the picker is currently open. If it is, we will simply return with a cancelled response. Otherwise we will update `isPickerOpen` to true.

Whenever the "picking" has completed, we will set `isPickerOpen` back to false.

[expo-image-picker-crash-after.webm](https://github.com/expo/expo/assets/153161762/b17134e5-c10f-415d-94d7-2bd81fbda782)

# Test Plan

Using the sandbox app, use this code and quickly press the "Open Picker" button (or do it programmatically if you want).

```tsx
import React from 'react'
import {View, Text, Button} from 'react-native'
import * as ImagePicker from '../../../packages/expo-image-picker/src/ImagePicker'

export default function Layout() {
  return (
    <View style={{flex: 1, marginTop: 100, gap: 20, paddingHorizontal: 20}}>
      <Text style={{textAlign: 'center', fontSize: 20, fontWeight: 'bold'}}>Expo Android Image Picker Test</Text>
      <Button title="Get Permission" onPress={() => {
        ImagePicker.getMediaLibraryPermissionsAsync()
      }} />
      <Button title="Open Picker" onPress={async () => {
        const res = await ImagePicker.launchImageLibraryAsync()

        console.log(res)
      }} />
    </View>
  )
}
```

Observe the crash when opening the second picker. Next, test the same against this PR. Observe that there is one `cancelled` response immediately, and the first picker result can still complete without a crash.

https://github.com/expo/expo/assets/153161762/76e481e7-ea90-471b-98b3-69ea41b61603

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
