### PR TITLE
Fix wrong homepage links in some packages

### DIFF
--- a/packages/expo-dev-client-components/package.json
+++ b/packages/expo-dev-client-components/package.json
@@ -26,7 +26,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev",
   "dependencies": {
     "@expo/styleguide-native": "^1.0.1",
     "expo-module-scripts": "^3.0.0"

--- a/packages/expo-json-utils/package.json
+++ b/packages/expo-json-utils/package.json
@@ -18,5 +18,5 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template"
+  "homepage": "https://docs.expo.dev"
 }

--- a/packages/expo-manifests/package.json
+++ b/packages/expo-manifests/package.json
@@ -29,7 +29,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/manifests/",
   "jest": {
     "preset": "expo-module-scripts"
   },

--- a/packages/expo-maps/package.json
+++ b/packages/expo-maps/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev",
   "dependencies": {
     "expo-asset": "^10.0.0"
   },

--- a/packages/expo-tracking-transparency/package.json
+++ b/packages/expo-tracking-transparency/package.json
@@ -28,7 +28,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/tracking-transparency",
   "devDependencies": {
     "expo-module-scripts": "^3.0.0"
   },

--- a/packages/expo-updates-interface/package.json
+++ b/packages/expo-updates-interface/package.json
@@ -18,7 +18,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/module-template",
+  "homepage": "https://docs.expo.dev",
   "dependencies": {},
   "peerDependencies": {
     "expo": "*"


### PR DESCRIPTION
# Why

I was using `expo-tracking-transparency` and noticed wrong `homepage` in `package.json`
