### PR TITLE
[docs] experimentally bring back JSDoc `@link` support (internal links only)

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -27,6 +27,8 @@ export type CommentTagData = {
 export type CommentContentData = {
   kind: string;
   text: string;
+  tag?: string;
+  tsLinkText?: string;
 };
 
 export type TypeDefinitionData = {

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { shadows, theme, typography } from '@expo/styleguide';
 import { borderRadius, breakpoints, spacing } from '@expo/styleguide-base';
+import { slug } from 'github-slugger';
 import type { ComponentType } from 'react';
 import { Fragment } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
@@ -662,7 +663,12 @@ const getParamTags = (shortText?: string) => {
 
 export const getCommentContent = (content: CommentContentData[]) => {
   return content
-    .map(entry => entry.text)
+    .map(entry => {
+      if (entry.tag === '@link' && !entry.text.includes('/')) {
+        return `[${entry.tsLinkText?.length ? entry.tsLinkText : entry.text}](#${slug(entry.text)})`;
+      }
+      return entry.text;
+    })
     .join('')
     .trim();
 };


### PR DESCRIPTION
# Why

Refs #28493

In the past, we wanted to use `@link` globally, but TypeDoc lacked the degree of customization we needed to handle all possible link cases for our docs.  However, with out MD approach system gain some robustness, and  since there are some simple cases, when we can have best result for both worlds (our docs & IDE) without unwanted side-effects, let's bring back simple`@link` support tailored only for internal types at this time.

# How

Add simple `@link` tag conversion to MD hash link. This solution need way more testing until we can apply it globally for every package, and switch to it being default a pattern for internal type links, but in the simple case from Symbols API we can have a win already.

# Test Plan

I have verified that no other package JSDoc includes `@link` so there are no unexpected usages which might lead to issues (there are few use-cases in `expo-maps`, but this package is not using the autogenerated docs yet (we might put an attention to this when decide to convert the package).

The changes have been reviewed locally, all lint check and test are passing.

# Preview

https://github.com/expo/expo/assets/719641/b16e4d33-2f57-474f-bbbf-d99fa7811bbc