### PR TITLE
fix(template): use same placeholder values from `tabs` for `default` template

### DIFF
--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "Hello Expo",
+    "name": "HelloWorld",
     "slug": "expo-template-default",
-    "scheme": "expo-template-default",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
+    "scheme": "myapp",
     "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/images/splash.png",
@@ -26,7 +26,9 @@
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
-    "plugins": ["expo-router"],
+    "plugins": [
+      "expo-router"
+    ],
     "experiments": {
       "typedRoutes": true
     }


### PR DESCRIPTION
# Why

This syncs the `expo-template-default` `app.json` placeholder values with the ones from `expo-template-tabs` template.

# How

- There are a few "magic strings" that should be used for templates with `create-expo`, [they are documented here](https://github.com/expo/expo/tree/main/packages/create-expo#app-name-customization)
- For the tabs template, we default to `myapp` as scheme, but we could also default to the sluggified version of the project's name instead. For that, we just need `"slug": "helloworld"` and it should be replaced through `create-expo(-app)`

# Test Plan

- `$ bun create expo ./MyCoolApp --template default@sdk-51`
- Should have the same properties in `app.json` as `expo-template-tabs`:
  - `"name": "MyCoolApp"`
  - `"slug": "MyCoolApp"`
  - `"scheme": "myapp"`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
