### PR TITLE
fix(create-expo): allow templates and examples omitting `expo` root object in `app.json`

### DIFF
--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -30,6 +30,12 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
+          # TODO(cedric): swap `latest` back once the issue is resolved
+          bun-version: latest
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -30,6 +30,10 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - name: 🏗️ Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.x
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1
         with:

--- a/packages/create-expo/.gitignore
+++ b/packages/create-expo/.gitignore
@@ -1,1 +1,2 @@
 build/
+e2e/fixtures/**/*.tgz

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Allow templates and examples omitting root `expo:` object in `app.json`. ([#28521](https://github.com/expo/expo/pull/28521) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 2.3.2 — 2024-04-24

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Allow templates and examples omitting root `expo:` object in `app.json`. ([#28521](https://github.com/expo/expo/pull/28521) by [@byCedric](https://github.com/byCedric))
+- Configure `pnpm` and `yarn` v3+ package managers when providing `--no-install`. ([#28521](https://github.com/expo/expo/pull/28521) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/create-expo/e2e/__tests__/app-json-test.ts
+++ b/packages/create-expo/e2e/__tests__/app-json-test.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  createFixtureTarball,
+  createTestPath,
+  ensureFolderExists,
+  executePassing,
+  expectFileExists,
+  projectRoot,
+} from './utils';
+
+beforeAll(async () => {
+  ensureFolderExists(projectRoot);
+});
+
+it('creates project with app.json without root `expo` object', async () => {
+  const projectName = 'flat-app-json';
+
+  // Create test path and tarball
+  createTestPath(projectName);
+  const tarballPath = await createFixtureTarball('flat-app-json');
+
+  // Create the project from tarball
+  await executePassing([projectName, '--no-install', '--template', tarballPath]);
+
+  // Ensure the app.json is written properly
+  expectFileExists(projectName, 'app.json');
+
+  const appJsonPath = path.join(projectRoot, projectName, 'app.json');
+  const appJson = JSON.parse(fs.readFileSync(appJsonPath, { encoding: 'utf8' }));
+
+  expect(appJson).toMatchObject({
+    name: projectName,
+    slug: projectName,
+  });
+});

--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -1,52 +1,27 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 
-const cli = require.resolve('../../build/index.js');
-const projectRoot = getTemporaryPath();
-
-function getTemporaryPath() {
-  return path.join(os.tmpdir(), Math.random().toString(36).substring(2));
-}
-
-function execute(args: string[], env: Record<string, string> = {}) {
-  return spawnAsync('node', [cli, ...args], {
-    cwd: projectRoot,
-    env: {
-      ...process.env,
-      ...env,
-    },
-  });
-}
-
-async function executePassingAsync(args: string[], env?: Record<string, string>) {
-  const results = await execute(args, env);
-  expect(results.status).toBe(0);
-  return results;
-}
-
-function fileExists(projectName: string, filePath: string) {
-  return fs.existsSync(path.join(projectRoot, projectName, filePath));
-}
-
-function getRoot(...args: string[]) {
-  return path.join(projectRoot, ...args);
-}
-
-// 3 minutes -- React Native takes a while to install
-const extendedTimeout = 3 * 1000 * 60;
+import {
+  createTestPath,
+  ensureFolderExists,
+  execute,
+  expectExecutePassing,
+  expectFileExists,
+  expectFileNotExists,
+  forcePackageManagerEnv,
+  getTestPath,
+  projectRoot,
+} from './utils';
 
 beforeAll(async () => {
-  jest.setTimeout(extendedTimeout);
-  fs.mkdirSync(projectRoot);
+  ensureFolderExists(projectRoot);
 });
 
 it('prevents overwriting directories with projects', async () => {
   const projectName = 'cannot-overwrite-files';
-  const projectRoot = getRoot(projectName);
-  // Create the project root aot
-  fs.mkdirSync(projectRoot);
+  const projectRoot = createTestPath(projectName);
+
   // Create a fake package.json -- this is a terminal file that cannot be overwritten.
   fs.writeFileSync(path.join(projectRoot, 'package.json'), '{ "version": "1.0.0" }');
 
@@ -58,175 +33,148 @@ it('prevents overwriting directories with projects', async () => {
   }
 });
 
-it(
-  'creates a full basic project by default',
-  async () => {
-    const projectName = 'defaults-to-basic';
-    await execute([projectName]);
+it('creates a full basic project by default', async () => {
+  const projectName = 'defaults-to-basic';
+  await execute([projectName]);
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-    // expect(fileExists(projectName, 'node_modules')).toBeTruthy();
-    expect(fileExists(projectName, 'ios/')).not.toBeTruthy();
-    expect(fileExists(projectName, 'android/')).not.toBeTruthy();
-    expect(fileExists(projectName, 'app.json')).toBeTruthy();
+  expectFileExists(projectName, 'package.json');
+  expectFileExists(projectName, 'App.js');
+  expectFileExists(projectName, '.gitignore');
+  expectFileExists(projectName, 'app.json');
+  // expect(fileExists(projectName, 'node_modules')).toBeTruthy();
+  expectFileNotExists(projectName, 'ios/');
+  expectFileNotExists(projectName, 'android/');
 
-    // Ensure the app.json is written properly
-    const appJsonPath = path.join(projectRoot, projectName, 'app.json');
-    const appJson = JSON.parse(fs.readFileSync(appJsonPath, { encoding: 'utf8' }));
-    expect(appJson.expo.name).toBe('defaults-to-basic');
-    expect(appJson.expo.slug).toBe('defaults-to-basic');
+  // Ensure the app.json is written properly
+  const appJsonPath = path.join(projectRoot, projectName, 'app.json');
+  const appJson = JSON.parse(fs.readFileSync(appJsonPath, { encoding: 'utf8' }));
+  expect(appJson.expo.name).toBe('defaults-to-basic');
+  expect(appJson.expo.slug).toBe('defaults-to-basic');
 
-    // Ensure the package.json is written properly
-    const packageJsonPath = path.join(projectRoot, projectName, 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
-    expect(packageJson.name).toBe('defaults-to-basic');
-  },
-  extendedTimeout
-);
+  // Ensure the package.json is written properly
+  const packageJsonPath = path.join(projectRoot, projectName, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+  expect(packageJson.name).toBe('defaults-to-basic');
+});
 
 describe('yes', () => {
-  it(
-    'creates a default project in the current directory',
-    async () => {
-      const projectName = 'yes-default-directory';
-      const projectRoot = getRoot(projectName);
-      // Create the project root aot
-      fs.mkdirSync(projectRoot);
+  it('creates a default project in the current directory', async () => {
+    const projectName = 'yes-default-directory';
 
-      const results = await spawnAsync('node', [cli, '--yes', '--no-install'], {
-        cwd: projectRoot,
-      });
-      expect(results.status).toBe(0);
+    expectExecutePassing(await execute(['--no-install', '--yes']));
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
-  it(
-    'creates a default project in a new directory',
-    async () => {
-      const projectName = 'yes-new-directory';
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    expectFileNotExists(projectName, 'node_modules');
+  });
 
-      const results = await spawnAsync('node', [cli, projectName, '-y', '--no-install'], {
-        cwd: projectRoot,
-      });
-      expect(results.status).toBe(0);
+  it('creates a default project in a new directory', async () => {
+    const projectName = 'yes-new-directory';
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
+    expectExecutePassing(await execute([projectName, '--no-install', '-y']));
 
-  it(
-    'uses pnpm',
-    async () => {
-      const projectName = 'uses-pnpm';
-      const results = await execute([projectName, '--no-install'], {
-        // Run: DEBUG=create-expo-app:* pnpm create expo-app
-        npm_config_user_agent: `pnpm`,
-      });
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    expectFileNotExists(projectName, 'node_modules');
+  });
 
-      // Test that the user was warned about deps
-      expect(results.stdout).toMatch(/make sure you have modules installed/);
-      expect(results.stdout).toMatch(/pnpm install/);
+  it('uses pnpm', async () => {
+    const projectName = 'uses-pnpm';
+    const results = await execute([projectName, '--no-install'], {
+      // Run: DEBUG=create-expo-app:* pnpm create expo-app
+      env: forcePackageManagerEnv('pnpm'),
+    });
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      // Check if it skipped install
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
-  it(
-    'uses Bun',
-    async () => {
-      const projectName = 'uses-bun';
-      const results = await execute([projectName, '--no-install'], {
-        // Run: DEBUG=create-expo-app:* bunx create-expo-app
-        npm_config_user_agent: `bun`,
-      });
+    expectExecutePassing(results);
 
-      // Test that the user was warned about deps
-      expect(results.stdout).toMatch(/make sure you have modules installed/);
-      expect(results.stdout).toMatch(/bun install/);
+    // Test that the user was warned about deps
+    expect(results.stdout).toMatch(/make sure you have modules installed/);
+    expect(results.stdout).toMatch(/pnpm install/);
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      // Check if it skipped install
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
-  it(
-    'uses npm',
-    async () => {
-      const projectName = 'uses-npm';
-      const results = await execute([projectName, '--no-install'], {
-        // Run: DEBUG=create-expo-app:* npm create expo-app
-        npm_config_user_agent: `npm/8.1.0 node/v16.13.0 darwin x64 workspaces/false`,
-      });
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
 
-      // Test that the user was warned about deps
-      expect(results.stdout).toMatch(/make sure you have modules installed/);
-      expect(results.stdout).toMatch(/npm install/);
+    // Check if `pnpm` node linker is set
+    expectFileExists(projectName, '.npmrc');
+    const { stdout } = expectExecutePassing(
+      await spawnAsync('pnpm', ['config', 'get', 'node-linker'], { cwd: getTestPath(projectName) })
+    );
+    expect(stdout).toContain('hoisted');
+  });
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      // Check if it skipped install
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
+  it('uses Bun', async () => {
+    const projectName = 'uses-bun';
+    const results = await execute([projectName, '--no-install'], {
+      // Run: DEBUG=create-expo-app:* bunx create-expo-app
+      env: forcePackageManagerEnv('bun'),
+    });
 
-  it(
-    'uses yarn',
-    async () => {
-      const projectName = 'uses-yarn';
-      const results = await execute([projectName, '--no-install'], {
-        // Run: DEBUG=create-expo-app:* yarn create expo-app
-        npm_config_user_agent: `yarn/1.22.17 npm/? node/v16.13.0 darwin x64`,
-      });
+    expectExecutePassing(results);
 
-      // Test that the user was warned about deps
-      expect(results.stdout).toMatch(/make sure you have modules installed/);
-      expect(results.stdout).toMatch(/yarn install/);
+    // Test that the user was warned about deps
+    expect(results.stdout).toMatch(/make sure you have modules installed/);
+    expect(results.stdout).toMatch(/bun install/);
 
-      expect(fileExists(projectName, 'package.json')).toBeTruthy();
-      expect(fileExists(projectName, 'App.js')).toBeTruthy();
-      expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-      // Check if it skipped install
-      expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
-    },
-    extendedTimeout
-  );
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
+  });
+
+  it('uses npm', async () => {
+    const projectName = 'uses-npm';
+    const results = await execute([projectName, '--no-install'], {
+      // Run: DEBUG=create-expo-app:* npm create expo-app
+      env: forcePackageManagerEnv('npm'),
+    });
+
+    // Test that the user was warned about deps
+    expect(results.stdout).toMatch(/make sure you have modules installed/);
+    expect(results.stdout).toMatch(/npm install/);
+
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
+  });
+
+  it('uses yarn', async () => {
+    const projectName = 'uses-yarn';
+    const results = await execute([projectName, '--no-install'], {
+      // Run: DEBUG=create-expo-app:* yarn create expo-app
+      env: forcePackageManagerEnv('yarn'),
+    });
+
+    // Test that the user was warned about deps
+    expect(results.stdout).toMatch(/make sure you have modules installed/);
+    expect(results.stdout).toMatch(/yarn install/);
+
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
+  });
 
   xit('creates a default project in a new directory with a custom template', async () => {
     const projectName = 'yes-custom-template';
 
-    const results = await spawnAsync(
-      'node',
-      [cli, projectName, '--yes', '--template', 'blank', '--no-install'],
-      {
-        cwd: projectRoot,
-      }
+    expectExecutePassing(
+      await execute([projectName, '--no-install', '--yes', '--template', 'blank'])
     );
-    expect(results.status).toBe(0);
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
 
     // Ensure the app.json is written properly
     const appJsonPath = path.join(projectRoot, projectName, 'app.json');
@@ -244,22 +192,26 @@ describe('yes', () => {
 xdescribe('templates', () => {
   it('allows overwriting directories with tolerable files', async () => {
     const projectName = 'can-overwrite';
-    const projectRoot = getRoot(projectName);
+    const projectRoot = createTestPath(projectName);
     // Create the project root aot
     fs.mkdirSync(projectRoot);
     // Create a fake package.json -- this is a terminal file that cannot be overwritten.
     fs.writeFileSync(path.join(projectRoot, 'LICENSE'), 'hello world');
 
-    await executePassingAsync([
-      projectName,
-      '--template',
-      'https://github.com/expo/examples/tree/master/blank',
-      '--no-install',
-    ]);
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectExecutePassing(
+      await execute([
+        projectName,
+        '--no-install',
+        '--template',
+        'https://github.com/expo/examples/tree/master/blank',
+      ])
+    );
+
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
+    // Check if it skipped install
+    expectFileNotExists(projectName, 'node_modules');
 
     // Ensure the app.json is written properly
     const appJsonPath = path.join(projectRoot, 'app.json');
@@ -285,39 +237,44 @@ xdescribe('templates', () => {
     } catch (error: any) {
       expect(error.stderr).toMatch(/Could not locate the template/i);
     }
-    expect(fs.existsSync(getRoot(projectName, 'package.json'))).toBeFalsy();
+    expect(fs.existsSync(getTestPath(projectName, 'package.json'))).toBeFalsy();
   });
 
   it('downloads a valid template', async () => {
     const projectName = 'valid-template-name';
-    await executePassingAsync([projectName, '--template', 'blank']);
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, 'README.md')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+    expectExecutePassing(await execute([projectName, '--template', 'blank']));
+
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, 'README.md');
+    expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
-    expect(fileExists(projectName, 'node_modules')).toBeTruthy();
+    expectFileNotExists(projectName, 'node_modules');
   });
 
   it(`doesn't prompt to install cocoapods in a project without an ios folder`, async () => {
     const projectName = 'no-install-no-pods-no-prompt';
-    const results = await executePassingAsync([projectName, '--template', 'blank', '--no-install']);
+    const results = await execute([projectName, '--no-install', '--template', 'blank']);
+
+    expectExecutePassing(results);
 
     // Ensure it doesn't warn to install pods since blank doesn't have an ios folder.
     expect(results.stdout).not.toMatch(/make sure you have CocoaPods installed/);
     expect(results.stdout).not.toMatch(/npx pod-install/);
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
     // Ensure it skipped install
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectFileNotExists(projectName, 'node_modules');
   });
 
   it('uses npm', async () => {
     const projectName = 'uses-npm';
-    const results = await execute([projectName, '--use-npm', '--no-install']);
+    const results = await execute([projectName, '--no-install', '--use-npm']);
+
+    expectExecutePassing(results);
 
     // Test that the user was warned about deps
     expect(results.stdout).toMatch(/make sure you have modules installed/);
@@ -327,49 +284,54 @@ xdescribe('templates', () => {
       expect(results.stdout).toMatch(/npx pod-install/);
     }
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectFileNotExists(projectName, 'node_modules');
   });
 
   it('downloads a github repo with sub-project', async () => {
     const projectName = 'full-url';
-    const results = await executePassingAsync([
+    const results = await execute([
       projectName,
+      '--no-install',
       '--template',
       'https://github.com/expo/examples/tree/master/blank',
-      '--no-install',
     ]);
+
+    expectExecutePassing(results);
 
     // Test that the user was warned about deps
     expect(results.stdout).toMatch(/make sure you have modules installed/);
     expect(results.stdout).toMatch(/yarn/);
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, 'README.md')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, 'README.md');
+    expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectFileNotExists(projectName, 'node_modules');
   });
 
   it('downloads a github repo with the template path option', async () => {
     const projectName = 'partial-url-and-path';
-    await executePassingAsync([
-      projectName,
-      '--template',
-      'https://github.com/expo/examples/tree/master',
-      '--template-path',
-      'blank',
-      '--no-install',
-    ]);
 
-    expect(fileExists(projectName, 'package.json')).toBeTruthy();
-    expect(fileExists(projectName, 'App.js')).toBeTruthy();
-    expect(fileExists(projectName, 'README.md')).toBeTruthy();
-    expect(fileExists(projectName, '.gitignore')).toBeTruthy();
+    expectExecutePassing(
+      await execute([
+        projectName,
+        '--no-install',
+        '--template',
+        'https://github.com/expo/examples/tree/master',
+        '--template-path',
+        'blank',
+      ])
+    );
+
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'App.js');
+    expectFileExists(projectName, 'README.md');
+    expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
-    expect(fileExists(projectName, 'node_modules')).not.toBeTruthy();
+    expectFileNotExists(projectName, 'node_modules');
   });
 });

--- a/packages/create-expo/e2e/__tests__/utils.ts
+++ b/packages/create-expo/e2e/__tests__/utils.ts
@@ -21,6 +21,19 @@ export function getTestPath(...args: string[]) {
   return path.join(projectRoot, ...args);
 }
 
+/** Get the path to a local fixture */
+export function getFixturePath(fixtureName: string) {
+  return path.join(__dirname, '../fixtures', fixtureName);
+}
+
+/** Create a tarball from a local fixture, and return the absolute tarball path */
+export async function createFixtureTarball(fixtureName: string) {
+  const fixturePath = getFixturePath(fixtureName);
+  const result = await spawnAsync('npm', ['pack', '--json'], { cwd: fixturePath });
+  expectExecutePassing(result);
+  return path.join(fixturePath, JSON.parse(result.stdout).pop().filename);
+}
+
 /** Get the path witihin the default project root, and ensure that folder exists */
 export function createTestPath(...args: string[]) {
   const testPath = getTestPath(...args);

--- a/packages/create-expo/e2e/__tests__/utils.ts
+++ b/packages/create-expo/e2e/__tests__/utils.ts
@@ -1,0 +1,80 @@
+import spawnAsync, { type SpawnResult } from '@expo/spawn-async';
+import { SpawnOptions } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/** The (local) binary for `create-expo` */
+export const bin = require.resolve('../../build/index.js');
+
+/** The default temporary path for all e2e tests */
+export const projectRoot = getTemporaryPath();
+
+/** Create a new temporary path for e2e tests */
+export function getTemporaryPath() {
+  return path.join(os.tmpdir(), Math.random().toString(36).substring(2));
+}
+
+/** Get the path within the default project root or temporary path */
+export function getTestPath(...args: string[]) {
+  return path.join(projectRoot, ...args);
+}
+
+/** Get the path witihin the default project root, and ensure that folder exists */
+export function createTestPath(...args: string[]) {
+  const testPath = getTestPath(...args);
+  ensureFolderExists(path.dirname(testPath));
+  return testPath;
+}
+
+/** Ensure the absolute folder path exists */
+export function ensureFolderExists(folder: string) {
+  fs.mkdirSync(folder, { recursive: true });
+}
+
+/** Run `create-expo` in the default project root */
+export function execute(args: string[], { env = {}, cwd = projectRoot }: SpawnOptions = {}) {
+  return spawnAsync('node', [bin, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      ...forcePackageManagerEnv('bun'),
+      ...env,
+    },
+  });
+}
+
+/** Generate a fake `npm_config_user_agent` environment variable, to force `create-expo` using this package manager */
+export function forcePackageManagerEnv(packageManager: string) {
+  return { npm_config_user_agent: `${packageManager}/x.x.x` };
+}
+
+/** Expect the received spawn result to be ok or "passing" */
+export function expectExecutePassing(spawn: SpawnResult) {
+  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
+  it(`Spawn result should be ok, received status: ${spawn.status}`, () => {
+    expect(spawn.status).toBe(0);
+  });
+
+  return spawn;
+}
+
+/** Expect the file to exist, using proper failure message when it does not */
+export function expectFileExists(projectName: string, ...filePath: string[]) {
+  const targetPath = getTestPath(projectName, ...filePath);
+
+  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
+  it(`File path should exist: ${targetPath}`, () => {
+    expect(fs.existsSync(targetPath)).toBe(true);
+  });
+}
+
+/** Expect the file to not-exist, using proper failure message when it does not */
+export function expectFileNotExists(projectName: string, ...filePath: string[]) {
+  const targetPath = getTestPath(projectName, ...filePath);
+
+  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
+  it(`File path should not exist: ${targetPath}`, () => {
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+}

--- a/packages/create-expo/e2e/__tests__/utils.ts
+++ b/packages/create-expo/e2e/__tests__/utils.ts
@@ -51,30 +51,18 @@ export function forcePackageManagerEnv(packageManager: string) {
 
 /** Expect the received spawn result to be ok or "passing" */
 export function expectExecutePassing(spawn: SpawnResult) {
-  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
-  it(`Spawn result should be ok, received status: ${spawn.status}`, () => {
-    expect(spawn.status).toBe(0);
-  });
-
+  expect(spawn.status).toBe(0);
   return spawn;
 }
 
 /** Expect the file to exist, using proper failure message when it does not */
 export function expectFileExists(projectName: string, ...filePath: string[]) {
   const targetPath = getTestPath(projectName, ...filePath);
-
-  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
-  it(`File path should exist: ${targetPath}`, () => {
-    expect(fs.existsSync(targetPath)).toBe(true);
-  });
+  expect(fs.existsSync(targetPath)).toBe(true);
 }
 
 /** Expect the file to not-exist, using proper failure message when it does not */
 export function expectFileNotExists(projectName: string, ...filePath: string[]) {
   const targetPath = getTestPath(projectName, ...filePath);
-
-  // NOTE(cedric): this is wrapped in an `it` statement to add a custom message
-  it(`File path should not exist: ${targetPath}`, () => {
-    expect(fs.existsSync(targetPath)).toBe(false);
-  });
+  expect(fs.existsSync(targetPath)).toBe(false);
 }

--- a/packages/create-expo/e2e/fixtures/flat-app-json/App.js
+++ b/packages/create-expo/e2e/fixtures/flat-app-json/App.js
@@ -1,0 +1,3 @@
+import React from 'react';
+import { View } from 'react-native';
+export default () => <View />;

--- a/packages/create-expo/e2e/fixtures/flat-app-json/app.json
+++ b/packages/create-expo/e2e/fixtures/flat-app-json/app.json
@@ -1,0 +1,8 @@
+{
+  "android": {
+    "package": "com.example.minimal"
+  },
+  "ios": {
+    "bundleIdentifier": "com.example.minimal"
+  }
+}

--- a/packages/create-expo/e2e/fixtures/flat-app-json/package.json
+++ b/packages/create-expo/e2e/fixtures/flat-app-json/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "flat-app-json",
+  "version": "0.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "dependencies": {
+    "expo": "^50",
+    "react": "18.2.0",
+    "react-native": "0.73.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/packages/create-expo/e2e/jest.config.js
+++ b/packages/create-expo/e2e/jest.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 /** @type {import('jest').Config} */
 module.exports = {
   testEnvironment: 'node',
+  testTimeout: 1000 * 60 * 3, // e2e tests can be slow, default to 3m
   preset: 'ts-jest',
   testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@expo/json-file": "8.3.3",
+    "@expo/config": "9.0.1",
     "@expo/package-manager": "^1.5.0",
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.7",

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -29,7 +29,7 @@
     "lint": "expo-module lint",
     "typecheck": "expo-module typecheck",
     "test": "expo-module test",
-    "test:e2e": "expo-module test --config e2e/jest.config.js",
+    "test:e2e": "expo-module test --config e2e/jest.config.js --runInBand",
     "watch": "yarn run build --watch",
     "prepublishOnly": "expo-module prepublishOnly"
   },

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -1,3 +1,4 @@
+import type { ExpoConfig } from '@expo/config';
 import JsonFile from '@expo/json-file';
 import * as PackageManager from '@expo/package-manager';
 import chalk from 'chalk';
@@ -297,25 +298,25 @@ export async function sanitizeTemplateAsync(projectRoot: string) {
     await fs.promises.copyFile(templatePath, ignorePath);
   }
 
-  const config: Record<string, any> = {
-    expo: {
-      name: projectName,
-      slug: projectName,
-    },
+  const defaultConfig: ExpoConfig = {
+    name: projectName,
+    slug: projectName,
   };
 
-  const appFile = new JsonFile(path.join(projectRoot, 'app.json'), {
-    default: { expo: {} },
-  });
-  const appJson = deepMerge(await appFile.readAsync(), config);
-  await appFile.writeAsync(appJson);
+  const appFile = new JsonFile(path.join(projectRoot, 'app.json'), { default: {} });
+  const appContent = (await appFile.readAsync()) as ExpoConfig | Record<'expo', ExpoConfig>;
+  const appJson = deepMerge(
+    appContent,
+    'expo' in appContent ? { expo: defaultConfig } : defaultConfig
+  );
 
+  await appFile.writeAsync(appJson);
   debug(`Created app.json:\n%O`, appJson);
 
   const packageFile = new JsonFile(path.join(projectRoot, 'package.json'));
   const packageJson = await packageFile.readAsync();
   // name and version are required for yarn workspaces (monorepos)
-  const inputName = 'name' in config ? config.name : config.expo.name;
+  const inputName = 'name' in appJson ? appJson.name : appJson.expo.name;
   packageJson.name = applyKnownNpmPackageNameRules(inputName) || 'app';
   // These are metadata fields related to the template package, let's remove them from the package.json.
   // A good place to start


### PR DESCRIPTION
# Why

Edit: I originally wanted to fix the first issue, but found another big one when refactoring + extending the tests.

1. `@expo/config` supports `app.json` files with, and without, the root `expo:` object. This removes a limitation in `create-expo` that prevented templates to use `app.json` without root `expo:` object.

2. In the latest `create-expo` version, we configure `pnpm` and `yarn` v2/v3/v4 with the right defaults for React Native. Unfortunately, this configuration step is disabled when using `--no-install`. This should always be configured, even when not installing the dependencies.

# How

- Conditionally apply the `name` and `slug` properties on `expo.name/expo.slug` or `name/slug` in `app.json`
- Fix `--no-install` not configuring `pnpm` and `yarn` v3+ package managers

# Test Plan

- See added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
