### PR TITLE
[cli] Show the -s, --sso option in the login command help.

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -40,6 +40,7 @@ it('runs `npx expo login --help`', async () => {
         -u, --username <string>  Username
         -p, --password <string>  Password
         --otp <string>           One-time password from your 2FA device
+        -s, --sso                Log in with SSO
         -h, --help               Usage info
     "
   `);

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -29,8 +29,7 @@ export const expoLogin: Command = async (argv) => {
         `-u, --username <string>  Username`,
         `-p, --password <string>  Password`,
         `--otp <string>           One-time password from your 2FA device`,
-        // hiding from help until SSO is public
-        // `-s, --sso                Log in with SSO`,
+        `-s, --sso                Log in with SSO`,
         `-h, --help               Usage info`,
       ].join('\n')
     );


### PR DESCRIPTION
# Why
As noted by @jonsamp, the login info message was not clear. It was changed to  show use of 'login --help' to see more login options. However, on checking, the sso login option was hidden in the login help.

Related PR: https://github.com/expo/expo/pull/28523 

# How
Uncommented the -s, --sso flag in the login help

# Test Plan
 Ran expo cli locally 
 
##  Checked login help before making any changes:

`cli % EXPO_LOCAL=1 nexpo login --help

  Info
    Log in to an Expo account

  Usage
    $ npx expo login

  Options
    -u, --username <string>  Username
    -p, --password <string>  Password
    --otp <string>           One-time password from your 2FA device
    -h, --help               Usage info

`
## Login help after adding back the sso help option:

`cli % EXPO_LOCAL=1 nexpo login --help         

  Info
    Log in to an Expo account

  Usage
    $ npx expo login

  Options
    -u, --username <string>  Username
    -p, --password <string>  Password
    --otp <string>           One-time password from your 2FA device
    -s, --sso                Log in with SSO
    -h, --help               Usage info

`



