### PR TITLE
[core][iOS] Fix accessing the view registry to avoid infinite loop

### DIFF
--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -11,11 +11,11 @@ import { waitFor, retryForStatus, mountAndWaitFor as originalMountAndWaitFor } f
 export const name = 'Video';
 const imageRemoteSource = { uri: 'https://via.placeholder.com/350x150' };
 const videoRemoteSource = { uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4' };
-const redirectingVideoRemoteSource = { uri: 'https://bit.ly/2mcW40Q' };
+const redirectingVideoRemoteSource = { uri: 'https://bit.ly/3Qld7fa' };
 const mp4Source = require('../assets/big_buck_bunny.mp4');
 const hlsStreamUri =
   'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8';
-const hlsStreamUriWithRedirect = 'https://t.ly/fg37A';
+const hlsStreamUriWithRedirect = 'https://bit.ly/3xXhpTT';
 let source = null; // Local URI of the downloaded default source is set in a beforeAll callback.
 let portraitVideoSource = null;
 let imageSource = null;

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Fixed gziped payload does not correctly shown in network inspector. ([#28486](https://github.com/expo/expo/pull/28486) by [@kudo](https://github.com/kudo))
 - [Android] Fixed crashes during the deallocation of shared objects. ([#28491](https://github.com/expo/expo/pull/28491) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix accessing the view registry to avoid infinite loop crash.
+- [iOS] Fix accessing the view registry to avoid infinite loop crash. ([#28531](https://github.com/expo/expo/pull/28531) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fixed gziped payload does not correctly shown in network inspector. ([#28486](https://github.com/expo/expo/pull/28486) by [@kudo](https://github.com/kudo))
 - [Android] Fixed crashes during the deallocation of shared objects. ([#28491](https://github.com/expo/expo/pull/28491) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix accessing the view registry to avoid infinite loop crash.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -296,7 +296,7 @@ EX_REGISTER_MODULE();
       UIView<RCTComponentViewProtocol> *componentView = [uiManager viewForReactTag:(NSNumber *)viewId];
       UIView *view = [(ExpoFabricViewObjC *)componentView contentView];
 #else
-      UIView *view = viewRegistry[viewId];
+      UIView *view = [uiManager viewForReactTag:(NSNumber *)viewId];
 #endif
       block(view);
     }];
@@ -313,7 +313,7 @@ EX_REGISTER_MODULE();
       UIView<RCTComponentViewProtocol> *componentView = [uiManager viewForReactTag:(NSNumber *)viewId];
       UIView *view = [(ExpoFabricViewObjC *)componentView contentView];
 #else
-      UIView *view = viewRegistry[viewId];
+      UIView *view = [uiManager viewForReactTag:(NSNumber *)viewId];
 #endif
       block(view);
     }];


### PR DESCRIPTION
# Why

Fixes infinite loop crash on iOS found during QA.

![view registry crash](https://github.com/expo/expo/assets/1714764/3ca11751-b43b-47b7-abd4-08ba18192326)

# How

As of RN 0.74, `viewRegistry` that we receive in `addUIBlock` is not a plain `NSDictionary<NSNumber *, UIView *>` as it is typed in the closure. Under the hood it's a `RCTComposedViewRegistry` that re-implements `objectForKey:` (used for subscript access) in a wrong manner that may lead to an infinite loop when the view cannot be found.
Using `viewForReactTag` directly seems to be a better option.

I also updated bit.ly urls so that they redirect to HTTPS content – this should fix a few tests.

# Test Plan

It was reproducible on the test-suite tests for video (expo-av) which is probably the only one module that uses this API. Now it works perfectly, besides a few tests that are failing intermittently 😅 
