### PR TITLE
Correction on FontAwesome Icon

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -404,7 +404,7 @@ To load and display the icon on the button, let's use `FontAwesome` from the lib
 {/* prettier-ignore */}
 ```jsx Button.js
 import { StyleSheet, View, Pressable, Text } from 'react-native';
-/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */
+/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons";/* @end */
 
 export default function Button({ label, /* @info The prop theme to detect the button variant. */theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */


### PR DESCRIPTION
When importing the FontAwesome class, the extra path to @expo/vector-icons/FontAwesome is not required and will crash the program.

# Why
Primary themed button will crash the app

# How
Looking up the documentation from https://icons.expo.fyi/Index/FontAwesome/picture-o, I found the trailing /font-awesome was incorrect in the import statement

# Test Plan
verified the tutorial will now load on the Web, iOS simulator, and an Android Physical Device

