### PR TITLE
[docs] Install jest-expo and jest as dev dependencies

### DIFF
--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -20,7 +20,7 @@ This guide shows how to create and use a custom build config with EAS. It follow
 
 To create a build config that runs tests, you have to prepare your project by installing `jest-expo` and `jest` as dependencies. Run the following command:
 
-<Terminal cmd={['$ npx expo install jest-expo jest react-test-renderer']} />
+<Terminal cmd={['$ npx expo install jest-expo jest react-test-renderer -- --save-dev']} />
 
 Next, add a `test` script in **package.json**:
 

--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -20,7 +20,7 @@ This guide shows how to create and use a custom build config with EAS. It follow
 
 To create a build config that runs tests, you have to prepare your project by installing `jest-expo` and `jest` as dependencies. Run the following command:
 
-<Terminal cmd={['$ npx expo install jest-expo jest react-test-renderer -- --save-dev']} />
+<Terminal cmd={['$ npx expo install -- --save-dev jest-expo jest react-test-renderer']} />
 
 Next, add a `test` script in **package.json**:
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -17,7 +17,7 @@ You'll also use the `jest-expo` package, which is a Jest preset and mocks the na
 
 To install `jest-expo` in your project, run the following command:
 
-<Terminal cmd={['$ npx expo install jest-expo jest']} />
+<Terminal cmd={['$ npx expo install jest-expo jest -- --save-dev']} />
 
 > **info** If you are using TypeScript, then also install `@types/jest` as a dev dependency.
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -17,7 +17,7 @@ You'll also use the `jest-expo` package, which is a Jest preset and mocks the na
 
 To install `jest-expo` in your project, run the following command:
 
-<Terminal cmd={['$ npx expo install jest-expo jest -- --save-dev']} />
+<Terminal cmd={['$ npx expo install -- --save-dev jest-expo jest']} />
 
 > **info** If you are using TypeScript, then also install `@types/jest` as a dev dependency.
 


### PR DESCRIPTION
# Why

The current installation commands reported in the doc install `jest-expo` and `jest` as dependencies instead of dev dependencies.
