### PR TITLE
[docs] Mention Android build artifact extensions

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -50,8 +50,8 @@ export default [
     enum: ['app-bundle', 'apk'],
     description: [
       'Type of the artifact you want to build. It controls which Gradle task will be used to build the project. It can be overridden by `gradleCommand` or `developmentClient: true` option.',
-      ' - `app-bundle` - `:app:bundleRelease`',
-      ' - `apk` - `:app:assembleRelease`',
+      ' - `app-bundle` - `:app:bundleRelease` (creates `.aab` artifact)',
+      ' - `apk` - `:app:assembleRelease` (creates `.apk` artifact)',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -50,8 +50,8 @@ export default [
     enum: ['app-bundle', 'apk'],
     description: [
       'Type of the artifact you want to build. It controls which Gradle task will be used to build the project. It can be overridden by `gradleCommand` or `developmentClient: true` option.',
-      ' - `app-bundle` - `:app:bundleRelease` (creates `.aab` artifact)',
-      ' - `apk` - `:app:assembleRelease` (creates `.apk` artifact)',
+      ' - `app-bundle` - `:app:bundleRelease` (creates **.aab** artifact)',
+      ' - `apk` - `:app:assembleRelease` (creates **.apk** artifact)',
     ],
   },
   {


### PR DESCRIPTION
# Why

For a newcomer in Andrid development, like me, it was hard to figure out how to create an `.aab` artificat. That's why I propose explicity mentioning it.

# How

By putting the extensions next to their respective `buildType`.

# Test Plan

I ran `eas build` to try it out.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
