### PR TITLE
[ci] add workflow for syncing new template code with template repository

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -25,3 +25,4 @@ jobs:
           user-name: Expo Bot
           user-email: expo-bot@users.noreply.github.com
           target-branch: main
+          commit-message: Sync the default project template from ORIGIN_COMMIT

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 🚀 Push changes to the template repository
         uses: cpina/github-action-push-to-another-repository@main
         env:
-          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         with:
           source-directory: 'templates/expo-template-default'
           destination-github-username: 'expo'

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main]
     paths:
+      - .github/workflows/sync-template.yml
+      - templates/expo-template-default/**
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/sync-template.yml
       - templates/expo-template-default/**
 
 jobs:

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -7,11 +7,6 @@ on:
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/workflows/sync-template.yml
-      - templates/expo-template-default/**
 
 jobs:
   build:

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -22,5 +22,6 @@ jobs:
           source-directory: 'templates/expo-template-default'
           destination-github-username: 'expo'
           destination-repository-name: 'expo-template-default'
-          user-name: Expo Sync Bot
+          user-name: Expo Bot
+          user-email: expo-bot@users.noreply.github.com
           target-branch: main

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -1,0 +1,25 @@
+name: Sync App Template Repository
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - templates/expo-template-default/**
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: 🚀 Push changes to the template repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source-directory: 'templates/expo-template-default'
+          destination-github-username: 'expo'
+          destination-repository-name: 'expo-template-default'
+          user-name: Expo Sync Bot
+          target-branch: main


### PR DESCRIPTION
# Why

Fixes ENG-12187

We need to sync the new template code with a dedicated GitHub template repository.

# How

Add workflow which pushes the changes to the destination repository, when we change anything about the template in core repository.

# Test Plan

Temporarily run workflow on PRs, make sure that already performed changes are synced up:
* https://github.com/expo/expo-template-default/commit/aaafd2bd6e6084422019bcb179248b398b742722
* https://github.com/expo/expo/actions/runs/8896072645/job/24427882676
