### PR TITLE
[updates] support default non-specified entryFile in gradle plugin

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Gradle Plugin build error when no specified `entryFile` in **android/app/build.gradle**. ([#28546](https://github.com/expo/expo/pull/28546) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.25.6 — 2024-05-01

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -10,11 +10,11 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.util.Locale
 
 abstract class ExpoUpdatesPlugin : Plugin<Project> {
@@ -23,6 +23,7 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
       logger.warn("Stop expo-updates resource generation because ReactExtension is not registered")
       return
     }
+    val entryFile = detectedEntryFile(reactExtension)
     val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
 
     if (System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1") {
@@ -33,14 +34,14 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
     androidComponents.onVariants(androidComponents.selector().all()) { variant ->
       val targetName = variant.name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
       val projectRoot = project.rootProject.projectDir.parentFile.toPath()
-      val entryFile = projectRoot.relativize(reactExtension.entryFile.get().asFile.toPath())
+      val entryFileRelativePath = projectRoot.relativize(entryFile.toPath())
       val isDebuggableVariant =
         reactExtension.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
 
       val createUpdatesResourcesTask = project.tasks.register("create${targetName}UpdatesResources", CreateUpdatesResourcesTask::class.java) {
         it.description = "expo-updates: Create updates resources for ${targetName}."
         it.projectRoot.set(projectRoot.toString())
-        it.entryFile.set(entryFile.toString())
+        it.entryFile.set(entryFileRelativePath.toString())
         it.nodeExecutableAndArgs.set(reactExtension.nodeExecutableAndArgs.get())
         it.enabled = !isDebuggableVariant
       }
@@ -106,5 +107,20 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
     internal val logger by lazy {
       LoggerFactory.getLogger(ExpoUpdatesPlugin::class.java)
     }
+  }
+}
+
+/**
+ * Synced implementation from [RNGP](https://github.com/facebook/react-native/blob/9bdd777fd766ff/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt#L20-L33)
+ */
+private fun detectedEntryFile(config: ReactExtension): File {
+  val envVariableOverride = System.getenv("ENTRY_FILE") ?: null
+  val entryFile = config.entryFile.orNull?.asFile
+  val reactRoot = config.root.get().asFile
+  return when {
+    envVariableOverride != null -> File(reactRoot, envVariableOverride)
+    entryFile != null -> entryFile
+    File(reactRoot, "index.android.js").exists() -> File(reactRoot, "index.android.js")
+    else -> File(reactRoot, "index.js")
   }
 }


### PR DESCRIPTION
# Why

close ENG-12162
fixes #28489

# How

the `reactExtensions.entryFile` is lazily evaluated. this pr refers to [RNGP's logic](https://github.com/facebook/react-native/blob/9bdd777fd766ff/packages/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt#L20-L33) to get the default EntryFile is not explicit specified.

# Test Plan

- ci passed
- tried repro from #28489

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
