### PR TITLE
[cli] Filter architectures to valid values only

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Prevent overwriting exported Atlas data when exporting web with static renderer. ([#28502](https://github.com/expo/expo/pull/28502) by [@byCedric](https://github.com/byCedric))
 - Improve login info message for other login options. ([#28523](https://github.com/expo/expo/pull/28523) by [@wschurman](https://github.com/wschurman))
-- Filter out invalid architectures before passing `-PreactNativeArchitectures` to `gradle`.
+- Filter out invalid architectures before passing `-PreactNativeArchitectures` to `gradle`. ([#28548](https://github.com/expo/expo/pull/28548) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.18.6 — 2024-04-26
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Prevent overwriting exported Atlas data when exporting web with static renderer. ([#28502](https://github.com/expo/expo/pull/28502) by [@byCedric](https://github.com/byCedric))
 - Improve login info message for other login options. ([#28523](https://github.com/expo/expo/pull/28523) by [@wschurman](https://github.com/wschurman))
+- Filter out invalid architectures before passing `-PreactNativeArchitectures` to `gradle`.
 
 ## 0.18.6 — 2024-04-26
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
@@ -52,27 +52,28 @@ describe(resolveGradlePropsAsync, () => {
 
   it(`returns the device architectures in a comma separated string`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([testDevice]);
-    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.arm64, DeviceABI.x86]);
+    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.armeabiV7a, DeviceABI.x86]);
 
     expect(await resolveGradlePropsAsync('/', {}, testDevice)).toEqual({
       apkVariantDirectory: '/android/app/build/outputs/apk/debug',
       appName: 'app',
       buildType: 'debug',
       flavors: [],
-      architectures: 'arm64,x86',
+      architectures: 'armeabi-v7a,x86',
     });
   });
 
+  const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
   it(`should filter out duplicate abis`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([testDevice]);
     jest
       .mocked(getDeviceABIsAsync)
       .mockResolvedValueOnce([
-        DeviceABI.arm64,
         DeviceABI.x86,
-        DeviceABI.x86,
-        DeviceABI.arm64,
-        DeviceABI.armeabiV7a,
+        DeviceABI.arm64v8a,
+        DeviceABI.arm64v8a,
+        DeviceABI.x8664,
+        DeviceABI.x8664
       ]);
 
     expect(await resolveGradlePropsAsync('/', {}, testDevice)).toEqual({
@@ -80,7 +81,7 @@ describe(resolveGradlePropsAsync, () => {
       appName: 'app',
       buildType: 'debug',
       flavors: [],
-      architectures: 'arm64,x86,armeabi-v7a',
+      architectures: 'x86,arm64-v8a,x86_64',
     });
   });
 });

--- a/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
@@ -63,7 +63,6 @@ describe(resolveGradlePropsAsync, () => {
     });
   });
 
-  const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
   it(`should filter out duplicate abis`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([testDevice]);
     jest
@@ -73,7 +72,7 @@ describe(resolveGradlePropsAsync, () => {
         DeviceABI.arm64v8a,
         DeviceABI.arm64v8a,
         DeviceABI.x8664,
-        DeviceABI.x8664
+        DeviceABI.x8664,
       ]);
 
     expect(await resolveGradlePropsAsync('/', {}, testDevice)).toEqual({

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { Device, DeviceABI, getDeviceABIsAsync } from '../../start/platforms/android/adb';
+import { Device, getDeviceABIsAsync } from '../../start/platforms/android/adb';
 import { CommandError } from '../../utils/errors';
 
 const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { Device, getDeviceABIsAsync } from '../../start/platforms/android/adb';
 import { CommandError } from '../../utils/errors';
 
+const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
+
 export type GradleProps = {
   /** Directory for the APK based on the `variant`. */
   apkVariantDirectory: string;
@@ -60,5 +62,8 @@ async function getConnectedDeviceABIS(
   }
 
   const abis = await getDeviceABIsAsync(device);
-  return abis.filter((abi, i, arr) => arr.indexOf(abi) === i).join(',');
+  const validArchitectures = new Set(VALID_ARCHITECTURES);
+
+  const validAbis = abis.filter((abi) => validArchitectures.has(abi));
+  return validAbis.filter((abi, i, arr) => arr.indexOf(abi) === i).join(',');
 }

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { Device, getDeviceABIsAsync } from '../../start/platforms/android/adb';
 import { CommandError } from '../../utils/errors';
 
+// Supported ABIs for Android. see https://developer.android.com/ndk/guides/abis
 const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
 
 export type GradleProps = {

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { Device, getDeviceABIsAsync } from '../../start/platforms/android/adb';
+import { Device, DeviceABI, getDeviceABIsAsync } from '../../start/platforms/android/adb';
 import { CommandError } from '../../utils/errors';
 
 const VALID_ARCHITECTURES = ['armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'];
@@ -62,8 +62,7 @@ async function getConnectedDeviceABIS(
   }
 
   const abis = await getDeviceABIsAsync(device);
-  const validArchitectures = new Set(VALID_ARCHITECTURES);
 
-  const validAbis = abis.filter((abi) => validArchitectures.has(abi));
+  const validAbis = abis.filter((abi) => VALID_ARCHITECTURES.includes(abi));
   return validAbis.filter((abi, i, arr) => arr.indexOf(abi) === i).join(',');
 }

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -18,6 +18,7 @@ export enum DeviceABI {
   arm64 = 'arm64',
   x64 = 'x64',
   x86 = 'x86',
+  x8664 = 'x86_64',
   arm64v8a = 'arm64-v8a',
   armeabiV7a = 'armeabi-v7a',
   armeabi = 'armeabi',

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -18,6 +18,7 @@ export enum DeviceABI {
   arm64 = 'arm64',
   x64 = 'x64',
   x86 = 'x86',
+  arm64v8a = 'arm64-v8a',
   armeabiV7a = 'armeabi-v7a',
   armeabi = 'armeabi',
   universal = 'universal',


### PR DESCRIPTION
# Why
Closes #28541

# How
Older android devices may return deprecated architectures causing build errors. We should filter these out. It's fine if the returned string ends up empty as we won't add the architecture argument it in that case.

# Test Plan
I can't repro the issue myself as I don't have an old enough device but the existing behaviour is unaffected. Maybe @jonsamp or @brentvatne can test this?

