### PR TITLE
[core][Android] Fix `field operation on NULL object` when reloading

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `field operation on NULL object` when reloading the app.
+- [Android] Fix `field operation on NULL object` when reloading the app. ([#28555](https://github.com/expo/expo/pull/28555) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `field operation on NULL object` when reloading the app.
+
 ### 💡 Others
 
 ## 1.12.5 — 2024-05-01

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -42,9 +42,9 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
   LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(
     [this, cName](jsi::Runtime &rt) {
       // Check if the installer has been deallocated.
-      // If so, return nullptr to avoid a crash.
+      // If so, return nullptr to avoid a "field operation on NULL object" crash.
       // As it's probably the best we can do in this case.
-      if (installer->isDeallocated()) {
+      if (installer->wasDeallocated()) {
         return std::shared_ptr<jsi::Object>(nullptr);
       }
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -41,6 +41,13 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
   // Create a lazy object for the specific module. It defers initialization of the final module object.
   LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(
     [this, cName](jsi::Runtime &rt) {
+      // Check if the installer has been deallocated.
+      // If so, return nullptr to avoid a crash.
+      // As it's probably the best we can do in this case.
+      if (installer->isDeallocated()) {
+        return std::shared_ptr<jsi::Object>(nullptr);
+      }
+
       auto module = installer->getModule(cName);
       return module->cthis()->getJSIObject(rt);
     });

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -359,6 +359,7 @@ void JSIContext::prepareForDeallocation() {
   runtimeHolder.reset();
   jniDeallocator.reset();
   javaPart_.reset();
+  wasDeallocated = true;
 }
 
 void JSIContext::jniSetNativeStateForSharedObject(
@@ -384,6 +385,10 @@ void JSIContext::jniSetNativeStateForSharedObject(
     ->cthis()
     ->get()
     ->setNativeState(runtimeHolder->get(), std::move(nativeState));
+}
+
+bool JSIContext::isDeallocated() const {
+  return wasDeallocated;
 }
 
 thread_local std::unordered_map<uintptr_t, JSIContext *> jsiContexts;

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -359,7 +359,7 @@ void JSIContext::prepareForDeallocation() {
   runtimeHolder.reset();
   jniDeallocator.reset();
   javaPart_.reset();
-  wasDeallocated = true;
+  wasDeallocated_ = true;
 }
 
 void JSIContext::jniSetNativeStateForSharedObject(
@@ -387,8 +387,8 @@ void JSIContext::jniSetNativeStateForSharedObject(
     ->setNativeState(runtimeHolder->get(), std::move(nativeState));
 }
 
-bool JSIContext::isDeallocated() const {
-  return wasDeallocated;
+bool JSIContext::wasDeallocated() const {
+  return wasDeallocated_;
 }
 
 thread_local std::unordered_map<uintptr_t, JSIContext *> jsiContexts;

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -145,9 +145,13 @@ public:
 
   void prepareForDeallocation();
 
+  bool isDeallocated() const;
+
 private:
   friend HybridBase;
   jni::global_ref<JSIContext::javaobject> javaPart_;
+
+  bool wasDeallocated = false;
 
   explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -145,13 +145,13 @@ public:
 
   void prepareForDeallocation();
 
-  bool isDeallocated() const;
+  bool wasDeallocated() const;
 
 private:
   friend HybridBase;
   jni::global_ref<JSIContext::javaobject> javaPart_;
 
-  bool wasDeallocated = false;
+  bool wasDeallocated_ = false;
 
   explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 


### PR DESCRIPTION
# Why

Fixes the `field operation on NULL object` when reloading the app.

```
JNI DETECTED ERROR IN APPLICATION: field operation on NULL object: 0x0
    in call to GetObjectField
    from void com.facebook.jni.NativeRunnable.run()
```
```
(facebook::jni::getHybridDataFromField(facebook::jni::JObject const*, facebook::jni::JField<facebook::jni::detail::JTypeFor<facebook::jni::detail::HybridData, facebook::jni::JObject, void>::_javaobject*> const&)+64) (BuildId: da1a18c6fd99d3c8e6e180ce9e3cfc5498a67961)
 (facebook::jni::HybridClass<expo::JavaScriptModuleObject, facebook::jni::detail::BaseHybridClass>::JavaPart::cthis() const+52) (BuildId: da1a18c6fd99d3c8e6e180ce9e3cfc5498a67961)
 (BuildId: da1a18c6fd99d3c8e6e180ce9e3cfc5498a67961)
 (expo::LazyObject::get(facebook::jsi::Runtime&, facebook::jsi::PropNameID const&)+228) (BuildId: da1a18c6fd99d3c8e6e180ce9e3cfc5498a67961)
```


# How

I think that the JS is trying to get access to the hybrid data when the native runtime is deallocated.

# Test Plan

- bare-expo ✅ 
- new app ✅ 