### PR TITLE
chore: disable sharding to test offline mode for cli e2e tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -44,9 +44,9 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        shard: [1, 2, 3]
+    # strategy:
+    #   matrix:
+    #     shard: [1, 2, 3]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
         run: yarn typecheck
         working-directory: packages/@expo/cli
       - name: E2E Test CLI
-        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:e2e #--shard ${{ matrix.shard }}/${{ strategy.job-total }}
         working-directory: packages/@expo/cli
       # - name: 🔔 Notify on Slack
       #   uses: 8398a7/action-slack@v3

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -75,6 +75,8 @@ jobs:
       - name: E2E Test CLI
         run: yarn test:e2e #--shard ${{ matrix.shard }}/${{ strategy.job-total }}
         working-directory: packages/@expo/cli
+        env:
+          EXPO_OFFLINE: true
       # - name: 🔔 Notify on Slack
       #   uses: 8398a7/action-slack@v3
       #   if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -6,14 +6,17 @@ import { execute, getLoadedModulesAsync, projectRoot } from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
+const originalOffline = process.env.EXPO_OFFLINE;
 beforeAll(async () => {
   await fs.mkdir(projectRoot, { recursive: true });
   process.env.FORCE_COLOR = '0';
   process.env.CI = '1';
+  process.env.EXPO_OFFLINE = '0';
 });
 afterAll(() => {
   process.env.FORCE_COLOR = originalForceColor;
   process.env.CI = originalCI;
+  process.env.EXPO_OFFLINE = originalOffline;
 });
 
 it('loads expected modules by default', async () => {

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -18,6 +18,7 @@ import {
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
+const originalOffline = process.env.EXPO_OFFLINE;
 
 const templateFolder = path.join(__dirname, '../../../../../templates/expo-template-bare-minimum/');
 
@@ -45,11 +46,13 @@ beforeAll(async () => {
   await fs.mkdir(projectRoot, { recursive: true });
   process.env.FORCE_COLOR = '0';
   process.env.CI = '1';
+  process.env.EXPO_OFFLINE = '0';
 });
 
 afterAll(() => {
   process.env.FORCE_COLOR = originalForceColor;
   process.env.CI = originalCI;
+  process.env.EXPO_OFFLINE = originalOffline;
 });
 
 it('loads expected modules by default', async () => {


### PR DESCRIPTION
# Why

This is a test to see how much faster our CLI e2e tests work, when using offline mode for static exports.

The reason for this is that we instantiate a dedicated dev bundler for static exports, that also checks for current authenticated users _and_ tries to open/close a development session.

# How

- Disabled sharding for testing

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
