### PR TITLE
[doctor] Don't match on stderr prefix on deep dep check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix failed deep dependency checks when using npm@~10.6+ ([#28563](https://github.com/expo/expo/pull/28563) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 💡 Others
 
 ## 1.5.2 — 2024-04-24

--- a/packages/expo-doctor/src/utils/explainDependencies.ts
+++ b/packages/expo-doctor/src/utils/explainDependencies.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 
 import { RootNodePackage, VersionSpec } from './explainDependencies.types';
+import { Log } from './log';
 
 type TargetPackage = { name: string; version?: VersionSpec };
 
@@ -31,7 +32,7 @@ async function explainAsync(
     return JSON.parse(stdout);
   } catch (error: any) {
     if (isSpawnResult(error)) {
-      if (error.stderr.match(/npm ERR! No dependencies found matching/)) {
+      if (error.stderr.match(/No dependencies found matching/)) {
         return null;
       } else if (error.stdout.match(/Usage: npm <command>/)) {
         throw new Error(
@@ -40,6 +41,9 @@ async function explainAsync(
           )} failed. This validation is only available on Node 16+ / npm 8.`
         );
       }
+    }
+    if (error.stderr) {
+      Log.debug(error.stderr);
     }
     throw new Error(`Failed to find dependency tree for ${packageName}: ` + error.message);
   }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/28545, which presents itself on the most recent NPM versions. Somewhere between 10.2 and 10.6, the stderr prefix changed from `npm ERR!` to `npm error`. The deep dependency check code was matching on `/npm ERR! No dependencies found matching/` to detect that there's no matching dependencies, so it broke all deep dep checks on these later versions.

# How
Changed the match to `/No dependencies found matching/`. Since we request the JSON output from `npm explain`, which also identifies that no results, thought about going after that, but it's really just matching against the same string, so 

Example:
```
npm explain expo-cli --json
npm error No dependencies found matching expo-cli
{
  "error": {
    "code": null,
    "summary": "No dependencies found matching expo-cli",
    "detail": ""
  }
}
```

Also added some debug logging to the `explainDependencies` code so we can get a little more info if these commands fail in the future (there's been other hard-to-detect issues before due to node setup weirdness).

# Test Plan
No more errors on those checks with npm 10.7:
<img width="658" alt="image" src="https://github.com/expo/expo/assets/8053974/43b817fc-3e60-4aff-88a4-0409eab2417b">

No errors on those checks still with npm 10.7
<img width="656" alt="image" src="https://github.com/expo/expo/assets/8053974/f2512a10-b76f-47d3-b560-f16bf817a0bc">

Also, still picks up issues if I install one of the dependencies those checks detects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
