### PR TITLE
[docs][web] Fixed jest installation terminal command

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -17,7 +17,7 @@ You'll also use the `jest-expo` package, which is a Jest preset and mocks the na
 
 To install `jest-expo` in your project, run the following command:
 
-<Terminal cmd={['$ npx expo install -- --save-dev jest-expo jest']} />
+<Terminal cmd={['$ npx expo install --save-dev jest-expo jest']} />
 
 > **info** If you are using TypeScript, then also install `@types/jest` as a dev dependency.
 


### PR DESCRIPTION
# Why


When copying the terminal command for Jest from the expo docs, It gave me an error. After removing the extra dashes from the command, the installation command works as intended. 


# How


Removed the extra dashes in the command. 


# Test Plan


Ran the installation command from expo: "npx expo install jest-expo jest -- --save-dev" -failed
Ran the edited command "npx expo install jest-expo jest --save-dev" passed


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
