### PR TITLE
[docs] Only jump to anchor when pressing the anchor button

### DIFF
--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -96,9 +96,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative"
-          href="#bare-workflow"
+        <span
+          class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
         >
           <span
             class="css-1n5kx9e-TextComponent"
@@ -106,6 +105,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Bare Workflow
           </span>
+        </span>
+        <a
+          href="#bare-workflow"
+        >
           <svg
             aria-label="permalink"
             class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
@@ -238,9 +241,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative"
-          href="#expokit"
+        <span
+          class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
         >
           <span
             class="css-1n5kx9e-TextComponent"
@@ -248,6 +250,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             ExpoKit
           </span>
+        </span>
+        <a
+          href="#expokit"
+        >
           <svg
             aria-label="permalink"
             class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
@@ -313,9 +319,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative"
-          href="#bare-workflow-1"
+        <span
+          class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
         >
           <span
             class="css-1n5kx9e-TextComponent"
@@ -323,6 +328,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Bare Workflow
           </span>
+        </span>
+        <a
+          href="#bare-workflow-1"
+        >
           <svg
             aria-label="permalink"
             class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
@@ -463,9 +472,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </g>
             </svg>
           </div>
-          <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative"
-            href="#expokit-1"
+          <span
+            class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
           >
             <span
               class="css-1n5kx9e-TextComponent"
@@ -473,6 +481,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               ExpoKit
             </span>
+          </span>
+          <a
+            href="#expokit-1"
+          >
             <svg
               aria-label="permalink"
               class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"
@@ -772,9 +784,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative"
-          href="#bare-workflow-2"
+        <span
+          class="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative"
         >
           <span
             class="css-1n5kx9e-TextComponent"
@@ -782,6 +793,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Bare Workflow
           </span>
+        </span>
+        <a
+          href="#bare-workflow-2"
+        >
           <svg
             aria-label="permalink"
             class="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible"

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -10,7 +10,6 @@ import {
   useRef,
   useState,
   useEffect,
-  SyntheticEvent,
   MouseEventHandler,
 } from 'react';
 
@@ -72,8 +71,6 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
         event.preventDefault();
       }
     };
-
-    console.log({ rendering: true, isOpen });
 
     return (
       <details id={heading.current.slug} css={detailsStyle} open={isOpen} data-testid={testID}>

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -10,6 +10,8 @@ import {
   useRef,
   useState,
   useEffect,
+  SyntheticEvent,
+  MouseEventHandler,
 } from 'react';
 
 import withHeadingManager, {
@@ -58,22 +60,31 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
       }
     }, []);
 
-    function onToggle() {
-      setOpen(!isOpen);
-    }
+    const onToggle: MouseEventHandler<HTMLElement> = event => {
+      // Detect if we are clicking the PermalinkIcon. Probably a better way to do this?
+      if (event.target instanceof SVGElement) {
+        if (!isOpen) {
+          setOpen(true);
+        }
+      } else {
+        setOpen(!isOpen);
+        // Ensure that the collapsible opens nicely on the first click
+        event.preventDefault();
+      }
+    };
+
+    console.log({ rendering: true, isOpen });
 
     return (
       <details id={heading.current.slug} css={detailsStyle} open={isOpen} data-testid={testID}>
-        <summary css={summaryStyle} className="group">
-          <div css={markerWrapperStyle} onClick={onToggle}>
+        <summary css={summaryStyle} className="group" onClick={onToggle}>
+          <div css={markerWrapperStyle}>
             <TriangleDownIcon className="icon-sm text-icon-default" css={markerStyle} />
           </div>
-          <LinkBase
-            href={'#' + heading.current.slug}
-            onClick={onToggle}
-            ref={heading.current.ref}
-            className="inline-flex gap-1.5 items-center scroll-m-5 relative">
+          <span className="inline-flex gap-1.5 items-center scroll-m-5 mr-2 relative">
             <DEMI>{summary}</DEMI>
+          </span>
+          <LinkBase href={'#' + heading.current.slug} ref={heading.current.ref}>
             <PermalinkIcon className="icon-sm inline-flex invisible group-hover:visible group-focus-visible:visible" />
           </LinkBase>
         </summary>


### PR DESCRIPTION
# Why

It feels weird to open a collapsible and have it jump to the anchor at the same time. We should only do that when you explicitly press the anchor icon

## Before

https://github.com/expo/expo/assets/90494/ccaa8368-4979-4f11-88e8-79b47b41f841

## After

https://github.com/expo/expo/assets/90494/b20434d8-a43e-4c65-9383-c70331272aff

# How

Only link to the anchor from the PermalinkIcon component

# Test Plan

Run it locally