### PR TITLE
[expo-store-review][ios] fix incorrect currentscene when multiple windowscenes opened

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fixes incorrect scene when multiple windowscenes opened, while requesting a review. ([#28577](https://github.com/expo/expo/pull/28577) by [@dylancom](https://github.com/dylancom))
+
 ### 💡 Others
 
 ## 7.0.1 — 2024-04-23

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -10,8 +10,8 @@ public class StoreReviewModule: Module {
     }
 
     AsyncFunction("requestReview") {
-      if #available(iOS 15, *) {
-        guard let currentScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+      if #available(iOS 14, *) {
+        guard let currentScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene else {
           throw MissingCurrentWindowSceneException()
         }
 


### PR DESCRIPTION
# Why

When requesting a review, the current code just grabs the first scene which might not be in foreground.
When you for e.g. have multiple WindowScenes opened, the review popup shows up in first connectedScene even if the window is in background.

I also updated the "isAvailable" check to iOS14 as SKStoreReviewController.requestReview(in: currentScene) is available since iOS14.

# How

I added a filter to the array of connected scenes to find the current scene that is active and in the foreground.
Inspired by: https://stackoverflow.com/a/63954318

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
