### PR TITLE
[dev-menu] fix broken DevMenuExtension functionalities

### DIFF
--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuExtensionInterface.kt
@@ -9,6 +9,11 @@ interface DevMenuExtensionSettingsInterface {
   val manager: DevMenuManagerInterface
 }
 
+/**
+ * A native extension to provide extra dev-menu items.
+ * The implementation should call [DevMenuManagerInterface.registerExtensionInterface]
+ * to register its instance to the manager.
+ */
 interface DevMenuExtensionInterface {
   /**
    * Returns a name of the module and the extension. Also required by [com.facebook.react.bridge.ReactContextBaseJavaModule].

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/DevMenuManagerInterface.kt
@@ -58,6 +58,11 @@ interface DevMenuManagerInterface {
   fun dispatchCallable(actionId: String, args: ReadableMap?)
 
   /**
+   * Registers an extra [DevMenuExtensionInterface] to the manager.
+   */
+  fun registerExtensionInterface(extensionInterface: DevMenuExtensionInterface)
+
+  /**
    * @return a list of dev menu items serialized to the [Bundle].
    */
   fun serializedItems(): List<Bundle>

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed some dev menu items like "Reload" that are not functional. ([#28578](https://github.com/expo/expo/pull/28578) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Update Menu background color in dark mode. ([#28549](https://github.com/expo/expo/pull/28549) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -22,6 +22,10 @@ class DevMenuExtension(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext), DevMenuExtensionInterface {
   override fun getName() = "ExpoDevMenuExtensions"
 
+  init {
+    DevMenuManager.registerExtensionInterface(this)
+  }
+
   override fun devMenuItems(settings: DevMenuExtensionSettingsInterface) = DevMenuItemsContainer.export {
     if (!settings.wasRunOnDevelopmentBridge()) {
       return@export

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import com.facebook.react.bridge.ReadableMap
 import expo.interfaces.devmenu.DevMenuDelegateInterface
+import expo.interfaces.devmenu.DevMenuExtensionInterface
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.interfaces.devmenu.DevMenuPreferencesInterface
 import expo.interfaces.devmenu.ReactHostWrapper
@@ -68,6 +69,10 @@ object DevMenuManager : DevMenuManagerInterface {
   override fun initializeWithReactHost(reactHost: ReactHostWrapper) = Unit
 
   override fun dispatchCallable(actionId: String, args: ReadableMap?) {
+    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
+  }
+
+  override fun registerExtensionInterface(extensionInterface: DevMenuExtensionInterface) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 


### PR DESCRIPTION
# Why

fix the "reload" from dev-menu item doesn't work.
close ENG-12203

# How

on new architecture mode, native modules are lazily loaded. the `ReactContext.getNativeModules()` only returns the loaded modules. that's why we cannot find the correct `DevMenuExtensionInterface` instances.
this pr tries not to rely on react native modules registration but uses a manual registration. that would also decouple from bridge/bridgeless implementations.

# Test Plan

try "reload" on the dev-menu

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
