### PR TITLE
[expo-go] Improve error messaging with snack

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -20,7 +20,7 @@ class ManifestException : ExponentException {
   private var fixInstructions: String? = null
   private val isSnackURL: Boolean
     get() =
-    manifestUrl.contains(SNACK_STAGING) || manifestUrl.contains(SNACK_PROD)
+      manifestUrl.contains(SNACK_STAGING) || manifestUrl.contains(SNACK_PROD)
 
   var canRetry: Boolean = true
   val errorHeader: String?
@@ -105,11 +105,11 @@ class ManifestException : ExponentException {
               "• The $projectType you opened uses <b>SDK $sdkVersionRequired</b>."
             fixInstructions = if (isSnackURL) {
               "Either select SDK ${supportedSdksString("or")} on <a href='https:/snack.expo.dev/'>https:/snack.expo.dev/</a> or install an older version of Expo Go that is compatible with your project." +
-                      "<br>If your required SDK version is not listed on Snack, use an emulator or one of the online emulators inside of Snack<br><br>"
+                "<br>If your required SDK version is not listed on Snack, use an emulator or one of the online emulators inside of Snack<br><br>"
             } else {
               "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>"
             } + "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
-                    "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
+              "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
             canRetry = false
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -107,9 +107,9 @@ class ManifestException : ExponentException {
               "Either select SDK ${supportedSdksString("or")} on <a href='https:/snack.expo.dev/'>https:/snack.expo.dev/</a> or install an older version of Expo Go that is compatible with your project." +
                 "<br>If your required SDK version is not listed on Snack, use an emulator or one of the online emulators inside of Snack<br><br>"
             } else {
-              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with ${if (isSnackURL) "this" else "your"} $projectType.<br><br>"
-            } + "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
-              "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
+              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with ${if (isSnackURL) "this" else "your"} $projectType.<br><br>" +
+                "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>"
+            } + "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
             canRetry = false
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -10,18 +10,27 @@ import java.lang.Exception
 import java.lang.NumberFormatException
 import expo.modules.core.utilities.EmulatorUtilities.isRunningOnEmulator
 
+private const val SNACK_STAGING = "2dce2748-c51f-4865-bae0-392af794d60a"
+private const val SNACK_PROD = "933fd9c0-1666-11e7-afca-d980795c5824"
+
 class ManifestException : ExponentException {
   private val manifestUrl: String
   private var errorJSON: JSONObject? = null
   private lateinit var errorMessage: String
   private var fixInstructions: String? = null
+  private val isSnackURL: Boolean
+    get() =
+    manifestUrl.contains(SNACK_STAGING) || manifestUrl.contains(SNACK_PROD)
 
   var canRetry: Boolean = true
   val errorHeader: String?
     get() = errorJSON?.let {
       try {
         when (it.getString("errorCode")) {
-          "EXPERIENCE_SDK_VERSION_OUTDATED" -> "Project is incompatible with this version of Expo Go"
+          "EXPERIENCE_SDK_VERSION_OUTDATED" -> {
+            val projectType = if (isSnackURL) "This Snack" else "Project"
+            "$projectType is incompatible with this version of Expo Go"
+          }
           "EXPERIENCE_SDK_VERSION_TOO_NEW" -> "Project is incompatible with this version of Expo Go"
           "SNACK_NOT_FOUND_FOR_SDK_VERSION" -> "This Snack is incompatible with this version of Expo Go"
           else -> null
@@ -85,17 +94,22 @@ class ManifestException : ExponentException {
             val expoDevLink =
               "https://expo.dev/go?sdkVersion=$sdkVersionRequired&platform=android&device=${!isRunningOnEmulator()}"
 
+            val projectType = if (isSnackURL) "snack" else "project"
+
             formattedMessage =
               "• The installed version of Expo Go is for <b>$maybePluralSDKsString ${
                 supportedSdksString(
                   "and"
                 )
               }</b>.<br>" +
-              "• The project you opened uses <b>SDK $sdkVersionRequired</b>."
-            fixInstructions =
-              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>" +
-              "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
-              "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
+              "• The $projectType you opened uses <b>SDK $sdkVersionRequired</b>."
+            fixInstructions = if (isSnackURL) {
+              "Either select SDK ${supportedSdksString("or")} on <a href='https:/snack.expo.dev/'>https:/snack.expo.dev/</a> or install an older version of Expo Go that is compatible with your project." +
+                      "<br>If your required SDK version is not listed on Snack, use an emulator or one of the online emulators inside of Snack<br><br>"
+            } else {
+              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>"
+            } + "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
+                    "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
             canRetry = false
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -107,7 +107,7 @@ class ManifestException : ExponentException {
               "Either select SDK ${supportedSdksString("or")} on <a href='https:/snack.expo.dev/'>https:/snack.expo.dev/</a> or install an older version of Expo Go that is compatible with your project." +
                 "<br>If your required SDK version is not listed on Snack, use an emulator or one of the online emulators inside of Snack<br><br>"
             } else {
-              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with your project.<br><br>"
+              "Either upgrade this project to SDK ${supportedSdksString("or")} or install an older version of Expo Go that is compatible with ${if (isSnackURL) "this" else "your"} $projectType.<br><br>"
             } + "<a href='https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/'>Learn how to upgrade to SDK ${supportedSdks.last()}.</a><br><br>" +
               "<a href='$expoDevLink'>Learn how to install Expo Go for SDK $sdkVersionRequired</a>."
             canRetry = false

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -224,10 +224,6 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
 
 - (NSString *)supportedSdkVersionsConjunctionString:(nonnull NSString *)conjunction {
   NSArray *supportedSDKVersionInts = [self supportedSdkVersionInts];
-  NSString *stringBeginning = [[supportedSDKVersionInts subarrayWithRange:NSMakeRange(0, supportedSDKVersionInts.count - 1)] componentsJoinedByString:@", "];
-  if (supportedSDKVersionInts.count > 1) {
-    return [NSString stringWithFormat:@"%@ %@ %@", stringBeginning, conjunction, [supportedSDKVersionInts lastObject]];
-  }
   return [NSString stringWithFormat:@"%d", [[supportedSDKVersionInts firstObject] intValue]];
 }
 
@@ -245,7 +241,10 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
           errorCode = @"EXPERIENCE_SDK_VERSION_OUTDATED";
           // since we are spoofing this error, we put the SDK version of the project as the
           // "available" SDK version -- it's the only one available from the server
-          metadata = @{@"availableSDKVersions": @[maybeManifest.expoGoSDKVersion]};
+          metadata = @{
+            @"availableSDKVersions": @[maybeManifest.expoGoSDKVersion],
+            @"isSnackURL": [NSNumber numberWithBool:self.isSnackURL]
+          };
         }
         if (manifestSdkVersion > newestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_TOO_NEW";
@@ -326,35 +325,45 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
     NSString * expoDevLink = [NSString stringWithFormat:@"https://expo.dev/go?sdkVersion=%d&platform=ios&device=false", requiredVersionNum];
     NSArray *supportedSDKVersionInts = [self supportedSdkVersionInts];
 
-    NSString *maybePluralSdkString = [supportedSDKVersions count] == 1 ? @"SDK" : @"SDKs";
-
     showTryAgainButton = false;
     formattedMessage = [NSString stringWithFormat:
-                          @"• The installed version of Expo Go is for **%@ %@**.\n"
-                        @"• The project you opened uses **SDK %d**.",
-                        maybePluralSdkString,
+                          @"• The installed version of Expo Go is for **SDK %@**.\n"
+                        @"• The %@ you opened uses **SDK %d**.",
                         [self supportedSdkVersionsConjunctionString:@"and"],
+                        self.isSnackURL ? @"snack" : @"project",
                         requiredVersionNum
     ];
 
 #if (TARGET_OS_SIMULATOR)
-    fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@ or install a version of Expo Go that is compatible with your project.\n\n"
+    fixInstructions = [NSString stringWithFormat:@"Either upgrade this %@ to SDK %@ or install a version of Expo Go that is compatible with your project.\n\n"
                        @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
                        @"[%@](Learn how to install Expo Go for SDK %d.)",
+                       self.isSnackURL ? @"snack" : @"project",
                        [self supportedSdkVersionsConjunctionString:@"or"],
                        [[supportedSDKVersionInts lastObject] intValue],
                        expoDevLink,
                        requiredVersionNum
     ];
 #else
-    fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
-                       @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
-                       @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
-                       [self supportedSdkVersionsConjunctionString:@"or"],
-                       [[supportedSDKVersionInts lastObject] intValue],
-                       expoDevLink,
-                       requiredVersionNum
-    ];
+    if (self.isSnackURL) {
+      fixInstructions = [NSString stringWithFormat:@"Either select SDK %@ on https://snack.expo.dev, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
+                         @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
+                         @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
+                         [self supportedSdkVersionsConjunctionString:@"or"],
+                         [[supportedSDKVersionInts lastObject] intValue],
+                         expoDevLink,
+                         requiredVersionNum
+      ];
+    } else {
+      fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
+                         @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
+                         @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
+                         [self supportedSdkVersionsConjunctionString:@"or"],
+                         [[supportedSDKVersionInts lastObject] intValue],
+                         expoDevLink,
+                         requiredVersionNum
+      ];
+    }
 #endif
   } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
     NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];
@@ -400,11 +409,18 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
   return [NSError errorWithDomain:EXRuntimeErrorDomain code:error.code userInfo:userInfo];
 }
 
+- (BOOL)isSnackURL {
+  return [[self.originalUrl query] containsString:@"snack"] || [[self.originalUrl query] containsString:@"snack-channel"];
+}
+
 + (NSString * _Nonnull)formatHeader:(NSError * _Nonnull)error {
   NSString *errorCode = error.userInfo[@"errorCode"];
+  NSDictionary *metadata = error.userInfo[@"metadata"];
+  BOOL isSnackURL = [metadata[@"isSnackURL"] boolValue];
 
   if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_OUTDATED"]) {
-    return @"Project is incompatible with this version of Expo Go" ;
+    NSString *type = isSnackURL ? @"This Snack" : @"Project";
+    return [NSString stringWithFormat: @"%@ is incompatible with this version of Expo Go", type];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
     return @"Project is incompatible with this version of Expo Go";
   } else if ([errorCode isEqualToString:@"SNACK_NOT_FOUND_FOR_SDK_VERSION"]) {

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -345,25 +345,22 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
                        requiredVersionNum
     ];
 #else
+    NSString *instructions;
     if (self.isSnackURL) {
-      fixInstructions = [NSString stringWithFormat:@"Either select SDK %@ on https://snack.expo.dev, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
-                         @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
-                         @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
-                         [self supportedSdkVersionsConjunctionString:@"or"],
-                         [[supportedSDKVersionInts lastObject] intValue],
-                         expoDevLink,
-                         requiredVersionNum
+      instructions = [NSString stringWithFormat:@"Either select SDK %@ on https://snack.expo.dev, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n",
+                      [self supportedSdkVersionsConjunctionString:@"or"]
       ];
     } else {
-      fixInstructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
-                         @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
-                         @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
-                         [self supportedSdkVersionsConjunctionString:@"or"],
-                         [[supportedSDKVersionInts lastObject] intValue],
-                         expoDevLink,
-                         requiredVersionNum
+      instructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n",
+                      [self supportedSdkVersionsConjunctionString:@"or"]
       ];
     }
+    
+    fixInstructions = [instructions stringByAppendingFormat:@"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
+                       @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
+                       [[supportedSDKVersionInts lastObject] intValue],
+                       expoDevLink,
+                       requiredVersionNum];
 #endif
   } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
     NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -330,7 +330,7 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
                           @"• The installed version of Expo Go is for **SDK %@**.\n"
                         @"• The %@ you opened uses **SDK %d**.",
                         [self supportedSdkVersionsConjunctionString:@"and"],
-                        self.isSnackURL ? @"snack" : @"project",
+                        self.isSnackURL ? @"Snack" : @"project",
                         requiredVersionNum
     ];
 
@@ -338,7 +338,7 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
     fixInstructions = [NSString stringWithFormat:@"Either upgrade this %@ to SDK %@ or install a version of Expo Go that is compatible with your project.\n\n"
                        @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
                        @"[%@](Learn how to install Expo Go for SDK %d.)",
-                       self.isSnackURL ? @"snack" : @"project",
+                       self.isSnackURL ? @"Snack" : @"project",
                        [self supportedSdkVersionsConjunctionString:@"or"],
                        [[supportedSDKVersionInts lastObject] intValue],
                        expoDevLink,
@@ -351,14 +351,14 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
                       [self supportedSdkVersionsConjunctionString:@"or"]
       ];
     } else {
-      instructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n",
-                      [self supportedSdkVersionsConjunctionString:@"or"]
+      instructions = [NSString stringWithFormat:@"Either upgrade this project to SDK %@, or launch it in an iOS simulator. It is not possible to install an older version of Expo Go for iOS devices, only the latest version is supported.\n\n"
+                      @"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n",
+                      [self supportedSdkVersionsConjunctionString:@"or"],
+                      [[supportedSDKVersionInts lastObject] intValue]
       ];
     }
     
-    fixInstructions = [instructions stringByAppendingFormat:@"[https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/](Learn how to upgrade to SDK %d.)\n\n"
-                       @"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
-                       [[supportedSDKVersionInts lastObject] intValue],
+    fixInstructions = [instructions stringByAppendingFormat:@"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
                        expoDevLink,
                        requiredVersionNum];
 #endif

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.xib
@@ -113,7 +113,7 @@
                                 <constraint firstItem="Mh8-u0-LCN" firstAttribute="leading" secondItem="3xg-me-cwE" secondAttribute="leading" constant="16" id="h5v-QT-WL1"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https::/expo.dev" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-n9-0bf" userLabel="URL">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="https::/expo.dev" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uZA-n9-0bf" userLabel="URL">
                             <rect key="frame" x="16" y="193.5" width="382" height="17"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.34509803919999998" green="0.37254901959999998" blue="0.41176470590000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
# Why
Closes ENG-12176
Currently when running an incompatible snack in expo go the error messages do not differentiate between a snack and a normal project.

# How
Added a check for snack URLs and provided different messaging based on this.

# Test Plan
Tested with compatible and incompatible snacks also did the same with projects. Screen behaves correctly for each case.

| iOS | Android |
| -------- | ------- |
|![iosSnack](https://github.com/expo/expo/assets/30924086/d4c419a3-8399-408a-9ff7-21def87a74b8)| ![androidSnack](https://github.com/expo/expo/assets/30924086/322ff277-3514-4983-a036-862a2f5c9c4c)
|

