### PR TITLE
[cli] Add --reverse-port argument for run:android command

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -197,6 +197,10 @@ You can compile the Android app for production by running:
 
 <Terminal cmd={['$ npx expo run:android --variant release']} />
 
+In order to have an access to the local API using android emulator you can reverse port:
+
+<Terminal cmd={['$ npx expo run:android --reverse-port <port>']} />
+
 This build is not automatically code-signed for submission to the Google Play Store. This command should be used to test bugs that may only show up in production builds. To generate a production build that is code signed for the Play Store, we recommend using [EAS Build](/build/introduction).
 
 You can debug the native Android project using native debugging tools by opening the **android** directory in Android Studio:

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added an argument `--reverse-port` for `run:android` command. ([#28583](https://github.com/expo/expo/pull/28583) by [@Gorb1k](https://github.com/Gorb1k))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -16,6 +16,7 @@ export const expoRunAndroid: Command = async (argv) => {
     '--no-install': Boolean,
     '--no-bundler': Boolean,
     '--variant': String,
+    '--reverse-port': Number,
     // Unstable, temporary fallback to disable active archs only behavior
     // TODO: replace with better fallback option, like free-form passing gradle props
     '--all-arch': Boolean,
@@ -48,6 +49,7 @@ export const expoRunAndroid: Command = async (argv) => {
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
     --variant <name>       Build variant. {dim Default: debug}
+    --reverse-port <port>   Port to use for adb reverse.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
     -h, --help             Output usage information
@@ -72,7 +74,7 @@ export const expoRunAndroid: Command = async (argv) => {
     port: args['--port'],
     variant: args['--variant'],
     allArch: args['--all-arch'],
-
+    reversePort: args['--reverse-port'],
     // Custom parsed args
     device: parsed.args['--device'],
   }).catch(logCmdError);

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -49,7 +49,7 @@ export const expoRunAndroid: Command = async (argv) => {
     --no-install           Skip installing dependencies
     --no-bundler           Skip starting the bundler
     --variant <name>       Build variant. {dim Default: debug}
-    --reverse-port <port>   Port to use for adb reverse.
+    --reverse-port <port>  Port to use for adb reverse.
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
     -h, --help             Output usage information

--- a/packages/@expo/cli/src/run/android/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/android/resolveOptions.ts
@@ -5,6 +5,7 @@ import { AndroidDeviceManager } from '../../start/platforms/android/AndroidDevic
 import { BundlerProps, resolveBundlerPropsAsync } from '../resolveBundlerProps';
 
 export type Options = {
+  reversePort?: number;
   variant?: string;
   device?: boolean | string;
   port?: number;

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -42,7 +42,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
   }
 
   if (options.reversePort && typeof options.reversePort === 'number') {
-    startAdbReverseAsync([options.reversePort]);
+    await startAdbReverseAsync([options.reversePort]);
   }
     
   const manager = await startBundlerAsync(projectRoot, {

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -10,6 +10,7 @@ import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
 import { startBundlerAsync } from '../startBundler';
+import { startAdbReverseAsync } from '../../start/platforms/android/adbReverse';
 
 const debug = require('debug')('expo:run:android');
 
@@ -40,6 +41,10 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     props.shouldStartBundler = false;
   }
 
+  if (options.reversePort && typeof options.reversePort === 'number') {
+    startAdbReverseAsync([options.reversePort]);
+  }
+    
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
     // If a scheme is specified then use that instead of the package name.


### PR DESCRIPTION
# Why

I as a developer want to have an ability to bind API port for local android developing.

# How

- Added `--reverse-port` argument for `expo run:android` command
- Added port reversing if `--reverse-port` argument is passed

# Test Plan

1. Set up random local API
2. Set up expo project
3. Start android project using `expo run:android --reverse-port <port>` command
4. Send a request to the server using next url: `http://localhost:${port}`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
