### PR TITLE
[go] fix NPE from ExpoNetworkInterceptor

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
@@ -69,7 +69,7 @@ internal class InspectorPackagerConnectionWrapper {
 
   fun sendWrappedEventToAllPages(reactInstanceManager: ReactInstanceManager, event: String) {
     val devServerHelper = devServerHelperField[reactInstanceManager.devSupportManager]
-    val inspectorPackagerConnection = inspectorPackagerConnectionField[devServerHelper] as? InspectorPackagerConnection
+    val inspectorPackagerConnection = inspectorPackagerConnectionField[devServerHelper] as? InspectorPackagerConnection ?: return
     for (page in Inspector.getPages()) {
       if (!page.title.contains("Reanimated")) {
         sendWrappedEventMethod.invoke(inspectorPackagerConnection, page.id.toString(), event)


### PR DESCRIPTION
# Why

fix NPE from ExpoNetworkInterceptor because the inspectorPackagerConnection is not ready yet.

# How

early return if inspectorPackagerConnection is not ready

# Test Plan

launch android expo-go and test network inspector

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
