### PR TITLE
[expo-updates][e2e] Add e2e for fingerprint policy

### DIFF
--- a/.github/workflows/updates-e2e-fingerprint.yml
+++ b/.github/workflows/updates-e2e-fingerprint.yml
@@ -1,0 +1,103 @@
+name: Updates e2e (fingerprint) EAS
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e-fingerprint.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/@expo/fingerprint/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e-fingerprint.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/@expo/fingerprint/**
+  schedule:
+    - cron: '0 20 * * SUN' # 20:00 UTC every Sunday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+        variant: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJson('["updates_testing_debug", "updates_testing_release"]') || fromJson('["updates_testing_debug"]') }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 80
+    env:
+      UPDATES_PORT: 4747
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🔧 Install eas-cli
+        run: yarn global add eas-cli
+      - name: 🌳 Add EXPO_REPO_ROOT to environment
+        run: echo "EXPO_REPO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: 🌐 Set updates host
+        run: echo "UPDATES_HOST=localhost" >> $GITHUB_ENV
+      - name: 🌐 Set updates port
+        run: echo "UPDATES_PORT=4747" >> $GITHUB_ENV
+      - name: 📦 Set platform for updates E2E build
+        run: echo "EAS_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
+      - name: 📦 Get artifacts path
+        run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
+      - name: 📦 Get commit message
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
+      - name: 📦 Set test project location
+        run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
+      - name: 📦 Setup test project for updates E2E fingerprint tests
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
+      - name: 🚀 Build with EAS for ${{ matrix.platform }}
+        uses: ./.github/actions/eas-build
+        id: build_eas
+        with:
+          platform: ${{ env.EAS_PLATFORM }}
+          profile: ${{ matrix.variant }}
+          projectRoot: './updates-e2e'
+          expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
+      - name: On ${{ matrix.platform }} workflow canceled
+        if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
+        run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
+        working-directory: './updates-e2e'
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/packages/expo-updates/e2e/fixtures/Updates-fingerprint.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-fingerprint.e2e.ts
@@ -1,0 +1,111 @@
+import { by, device, element, waitFor } from 'detox';
+import jestExpect from 'expect';
+
+import Server from './utils/server';
+import Update from './utils/update';
+
+const projectRoot = process.env.PROJECT_ROOT || process.cwd();
+const platform = device.getPlatform();
+const protocolVersion = 1;
+
+const debugInstructions = `
+If you are seeing this, it probably means that the fingerprint in the built e2e app does not match the one in the served manifest. To debug why:
+1. In .github/actions/eas-build/actions, add '--build-logger-level=debug' to the eas build command.
+2. In packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts, set printDebug to true
+3. Run CI on github.
+4. In EAS build page for the CI run, compare the fingerprint debug output in 'Calculate expo-updates runtime version' step with that of the 'Build success hook' step.
+`;
+
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
+  return attributes?.text || '';
+};
+
+const waitForAppToBecomeVisible = async () => {
+  await waitFor(element(by.id('updateString')))
+    .toBeVisible()
+    .withTimeout(2000);
+};
+
+describe('Basic tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+    Server.stop();
+  });
+
+  it('downloads new update before launching', async () => {
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest =
+      await Update.getUpdateManifestForBundleFilenameWithFingerprintRuntimeVersionAsync(
+        new Date(),
+        hash,
+        'test-update-1-key',
+        bundleFilename,
+        [],
+        projectRoot,
+        platform
+      );
+
+    Server.start(Update.serverPort, protocolVersion, 1000);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+
+    if (message !== 'test-update-1') {
+      console.log(debugInstructions);
+    }
+
+    jestExpect(message).toBe('test-update-1');
+
+    await device.terminateApp();
+  });
+
+  it('does not download new update when it takes longer than timeout', async () => {
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest =
+      await Update.getUpdateManifestForBundleFilenameWithFingerprintRuntimeVersionAsync(
+        new Date(),
+        hash,
+        'test-update-1-key',
+        bundleFilename,
+        [],
+        projectRoot,
+        platform
+      );
+
+    Server.start(Update.serverPort, protocolVersion, 7000);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+
+    if (message !== 'test') {
+      console.log(debugInstructions);
+    }
+
+    jestExpect(message).toBe('test');
+
+    await device.terminateApp();
+  });
+});

--- a/packages/expo-updates/e2e/fixtures/project_files/.fingerprintignore
+++ b/packages/expo-updates/e2e/fixtures/project_files/.fingerprintignore
@@ -1,0 +1,1 @@
+**/ios/Gymfile

--- a/packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import {
+  initAsync,
+  setupUpdatesFingerprintE2EAppAsync,
+  transformAppJsonForE2EWithFingerprint,
+} from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT);
+const workingDir = path.resolve(repoRoot, '..');
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion: 'unused',
+    localCliBin,
+    configureE2E: true,
+    transformAppJson: transformAppJsonForE2EWithFingerprint,
+  });
+
+  await setupUpdatesFingerprintE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -494,6 +494,32 @@ function transformAppJsonForE2E(
 }
 
 /**
+ * Modifies app.json in the E2E test app to add the properties we need, and sets the runtime version policy to fingerprint
+ */
+export function transformAppJsonForE2EWithFingerprint(
+  appJson: any,
+  projectName: string,
+  runtimeVersion: string,
+  isTV: boolean
+) {
+  const transformedForE2E = transformAppJsonForE2EWithFallbackToCacheTimeout(
+    appJson,
+    projectName,
+    runtimeVersion,
+    isTV
+  );
+  return {
+    ...transformedForE2E,
+    expo: {
+      ...transformedForE2E.expo,
+      runtimeVersion: {
+        policy: 'fingerprint',
+      },
+    },
+  };
+}
+
+/**
  * Modifies app.json in the E2E test app to add the properties we need, plus a fallback to cache timeout for testing startup procedure
  */
 export function transformAppJsonForE2EWithFallbackToCacheTimeout(
@@ -852,6 +878,38 @@ export async function setupUpdatesErrorRecoveryE2EAppAsync(
   // Copy Detox test file to e2e/tests directory
   await fs.copyFile(
     path.resolve(dirName, '..', 'fixtures', 'Updates-error-recovery.e2e.ts'),
+    path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
+  );
+}
+
+export async function setupUpdatesFingerprintE2EAppAsync(
+  projectRoot: string,
+  { localCliBin, repoRoot }: { localCliBin: string; repoRoot: string }
+) {
+  await copyCommonFixturesToProject(
+    projectRoot,
+    [
+      'tsconfig.json',
+      '.fingerprintignore',
+      '.detoxrc.json',
+      'eas.json',
+      'eas-hooks',
+      'e2e',
+      'includedAssets',
+      'scripts',
+    ],
+    { appJsFileName: 'App.tsx', repoRoot, isTV: false }
+  );
+
+  // install extra fonts package
+  await spawnAsync(localCliBin, ['install', '@expo-google-fonts/inter'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+
+  // Copy Detox test file to e2e/tests directory
+  await fs.copyFile(
+    path.resolve(dirName, '..', 'fixtures', 'Updates-fingerprint.e2e.ts'),
     path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
   );
 }

--- a/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
+++ b/packages/expo-updates/utils/build/createFingerprintForBuildAsync.js
@@ -47,7 +47,7 @@ async function createFingerprintForBuildAsync(platform, possibleProjectRoot, des
             ? (0, workflow_1.validateWorkflow)(workflowOverride)
             : await (0, workflow_1.resolveWorkflowAsync)(projectRoot, platform);
         const createdFingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, {});
-        console.log(JSON.stringify(createdFingerprint.sources));
+        console.log(JSON.stringify(createdFingerprint));
         fingerprint = createdFingerprint;
     }
     fs_1.default.writeFileSync(path_1.default.join(destinationDir, 'fingerprint'), fingerprint.hash);

--- a/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createFingerprintForBuildAsync.ts
@@ -50,7 +50,7 @@ export async function createFingerprintForBuildAsync(
       ? validateWorkflow(workflowOverride)
       : await resolveWorkflowAsync(projectRoot, platform);
     const createdFingerprint = await createFingerprintAsync(projectRoot, platform, workflow, {});
-    console.log(JSON.stringify(createdFingerprint.sources));
+    console.log(JSON.stringify(createdFingerprint));
     fingerprint = createdFingerprint;
   }
 


### PR DESCRIPTION
# Why

This adds an e2e test for the fingerprint runtime version policy in a generic project (the e2e project). The runtime version is calculated during the build and during the manifest serving.

Closes ENG-12110.

# How

Add test and workflow.

# Test Plan

Run generation and test locally, see it works.
Wait for CI to ensure it works in CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
