### PR TITLE
[docs] show "Unversioned" API version in PR previews

### DIFF
--- a/.github/workflows/docs-pr-deploy.yml
+++ b/.github/workflows/docs-pr-deploy.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗️ Build Docs website for deploy
-        run: yarn export
+        run: yarn export-preview
         timeout-minutes: 20
         env:
           AWS_BUCKET: 'docs.expo.dev-pr-${{ github.event.pull_request.number }}'

--- a/docs/constants/versions.js
+++ b/docs/constants/versions.js
@@ -38,13 +38,11 @@ export const VERSIONS = versionDirectories
     return true;
   })
   .sort((a, b) => {
-    if (a === 'unversioned' || a === 'latest') return -1;
-    if (b === 'unversioned' || b === 'latest') return 1;
-
-    return semver.major(b) - semver.major(a);
-  })
-  .sort((a, b) => {
+    if (a === 'unversioned') return -1;
+    if (b === 'unversioned') return 1;
     if (a === BETA_VERSION) return -1;
     if (b === BETA_VERSION) return 1;
-    return 0;
+    if (a === 'latest') return -1;
+    if (b === 'latest') return 1;
+    return semver.major(b) - semver.major(a);
   });

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "dev": "yarn generate-static-resoures && next dev -p 3002",
     "build": "next build",
     "export": "yarn generate-static-resoures production && yarn run build && yarn run export-issue-404",
+    "export-preview": "yarn generate-static-resoures preview && yarn run build && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",

--- a/docs/scripts/generate-static-resources.js
+++ b/docs/scripts/generate-static-resources.js
@@ -10,14 +10,24 @@ const basePath = path.join(dirname, '../', 'public', 'static', 'constants');
 
 const env = process.argv.slice(2)[0] || 'development';
 
-const writeResource = (filename, data) =>
+function writeResource(filename, data) {
   fs.writeFileSync(path.join(basePath, filename), JSON.stringify(data), { flag: 'wx' });
+}
+
+function getVersionForEnvironment(environment) {
+  switch (environment) {
+    case 'production':
+      return versions.VERSIONS.filter(v => v !== 'unversioned');
+    case 'preview':
+    default:
+      return versions.VERSIONS;
+  }
+}
 
 fs.mkdirSync(basePath);
 
 writeResource('versions.json', {
   ...versions,
-  VERSIONS:
-    env === 'production' ? versions.VERSIONS.filter(v => v !== 'unversioned') : versions.VERSIONS,
+  VERSIONS: getVersionForEnvironment(env),
 });
 writeResource('navigation.json', navigation);


### PR DESCRIPTION
# Why

We always include `unversioned` docs, but we hide them in version selector on deployments.  We can do this only for production deployments, and retain the entry in PR deployments, for easier testing.

# How

Do not remove `unversioned` when deployment environment is set to `preview`, make sure beta version appears below  `unversioned` docs, update docs PR deployment workflow to use modified bild script.

# Test Plan

Tested locally via `yarn export-preview` + `yarn export-server`, let's also test this on CI.

