### PR TITLE
[dev-menu] Fix DevMenu showing up before the app is loaded when using the new architecture.

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed some dev menu items like "Reload" that are not functional. ([#28578](https://github.com/expo/expo/pull/28578) by [@kudo](https://github.com/kudo))
+- Fixed DevMenu showing up before the app is loaded when using the new architecture. ([#28589](https://github.com/expo/expo/pull/28589) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -103,7 +103,8 @@ open class DevMenuManager: NSObject {
         return
       }
 
-      if bridge.isLoading {
+      // When using the proxy bridge isLoading is always false, so always add the ContentDidAppearNotification observer
+      if bridge.isLoading || bridge.isProxy() {
         NotificationCenter.default.addObserver(self, selector: #selector(DevMenuManager.autoLaunch), name: DevMenuViewController.ContentDidAppearNotification, object: nil)
       } else {
         autoLaunch()


### PR DESCRIPTION
# Why

Partially fixes ENG-12058

# How

When running new arch with bridgeless mode the RCTBridgeProxy class always returns false for `isLoading`, because of that we need to check if we're using proxy and add the ContentDidAppearNotification observer

# Test Plan

Run FabricTester locally on iOS


https://github.com/expo/expo/assets/11707729/be02072b-ae8f-434f-9639-8d2c349e9917



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
