### PR TITLE
[docs] remove GitHub builds feature preview disclaimer

### DIFF
--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -8,7 +8,6 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
-> **info** This feature is in early access and may change significantly. Its performance might not be as polished or reliable as our established features during this early access period. We appreciate your understanding and welcome any feedback to help us improve!
 
 ## Prerequisites
 


### PR DESCRIPTION
# Why

It's time 🚀 

# How

I removed the disclaimer note from the top of the page.

# Test Plan

Before/after:

<img width="1840" alt="Screenshot 2024-05-02 at 18 39 31" src="https://github.com/expo/expo/assets/12488826/f941b53c-62a3-4cf4-a59c-a8e2b154ec13">

