### PR TITLE
[fabric-tester] Disable privacy file aggregation on iOS

### DIFF
--- a/apps/fabric-tester/ios/Podfile
+++ b/apps/fabric-tester/ios/Podfile
@@ -26,6 +26,8 @@ target 'fabrictester' do
     :fabric_enabled => true,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/..",
+    # Temporary workaround for failing post-install hook
+    privacy_file_aggregation_enabled: false,
   )
 
   post_install do |installer|


### PR DESCRIPTION
# Why

As mentioned on https://github.com/expo/expo/pull/28593, fabric-tester fails to install pods on iOS due to a post-install hook error in core when aggregating the privacy file

# How

Disable privacy file aggregation for fabric-tester on iOS

# Test Plan

Run fabric-tester locally on iOS 
<img width="546" alt="image" src="https://github.com/expo/expo/assets/11707729/2f3a4d38-36d0-437e-a11f-dc0a4e38a916">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
