### PR TITLE
[android] Fix core tests

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -118,6 +118,14 @@ android {
       "**/libyoga.so",
     ]
 
+    // Required or mockk will crash
+    resources {
+      excludes += [
+          "META-INF/LICENSE.md",
+          "META-INF/LICENSE-notice.md"
+      ]
+    }
+
     // In android (instrumental) tests, we want to package all so files to enable our JSI functionality.
     // Otherwise, those files should be excluded, because will be loaded by the application.
     if (isExpoModulesCoreTests) {
@@ -160,7 +168,7 @@ dependencies {
 
   testImplementation 'androidx.test:core:1.5.0'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'io.mockk:mockk:1.13.5'
+  testImplementation 'io.mockk:mockk:1.13.10'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation "org.robolectric:robolectric:4.11.1"
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
@@ -169,7 +177,7 @@ dependencies {
   androidTestImplementation 'androidx.test:runner:1.5.2'
   androidTestImplementation 'androidx.test:core:1.5.0'
   androidTestImplementation 'androidx.test:rules:1.5.0'
-  androidTestImplementation "io.mockk:mockk-android:1.12.3"
+  androidTestImplementation "io.mockk:mockk-android:1.13.10"
   androidTestImplementation "com.google.truth:truth:1.1.2"
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -27,7 +27,8 @@ import kotlinx.coroutines.test.TestScope
 import java.lang.ref.WeakReference
 
 internal fun defaultAppContextMock(
-  jniDeallocator: JNIDeallocator = JNIDeallocator(shouldCreateDestructorThread = false)
+  jniDeallocator: JNIDeallocator = JNIDeallocator(shouldCreateDestructorThread = false),
+  jsiInterop: JSIContext = JSIContext(),
 ): AppContext {
   val appContextMock = mockk<AppContext>()
   val coreModule = run {
@@ -39,6 +40,7 @@ internal fun defaultAppContextMock(
   every { appContextMock.classRegistry } answers { ClassRegistry() }
   every { appContextMock.jniDeallocator } answers { jniDeallocator }
   every { appContextMock.findView<View>(capture(slot())) } answers { mockk() }
+  every { appContextMock.jsiInterop } answers { jsiInterop }
   return appContextMock
 }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -28,7 +28,7 @@ import java.lang.ref.WeakReference
 
 internal fun defaultAppContextMock(
   jniDeallocator: JNIDeallocator = JNIDeallocator(shouldCreateDestructorThread = false),
-  jsiInterop: JSIContext = JSIContext(),
+  jsiInterop: JSIContext = JSIContext()
 ): AppContext {
   val appContextMock = mockk<AppContext>()
   val coreModule = run {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
@@ -10,7 +10,7 @@ class JavaScriptFunctionTest {
   @Before
   fun before() {
     jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock())
+      installJSIForTests(defaultAppContextMock(jsiInterop = this))
     }
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -17,7 +17,7 @@ class JavaScriptObjectTest {
   @Before
   fun before() {
     jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock())
+      installJSIForTests(defaultAppContextMock(jsiInterop = this))
     }
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -12,7 +12,7 @@ class JavaScriptRuntimeTest {
   @Before
   fun before() {
     jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock())
+      installJSIForTests(defaultAppContextMock(jsiInterop = this))
     }
   }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -11,7 +11,7 @@ class JavaScriptValueTest {
   @Before
   fun before() {
     jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock())
+      installJSIForTests(defaultAppContextMock(jsiInterop = this))
     }
   }
 


### PR DESCRIPTION
# Why
After #28593, our tests in expo-modules-core broke. Not entirely sure of the reason yet.

# How
I added another parameter to the `defaultAppContextMock` to pass the `JSIContext` and return it from `appContext.jsiInterop`. I also needed to bump the version of `mockk`.

# Test Plan
All tests are passing locally
