### PR TITLE
[dev-launcher][Android] Fixed `LogBox` isn't working on the new architecture

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `LogBox` isn't working on the new architecture.
+
 ### 💡 Others
 
 ## 4.0.8 — 2024-05-01

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `LogBox` isn't working on the new architecture.
+- [Android] Fixed `LogBox` isn't working on the new architecture. ([#28602](https://github.com/expo/expo/pull/28602) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Closes ENG-12206.

# How

It appears that the `LogBox` surface does not detach when the app reloads. This behavior is likely normal, but it causes issues with the developer menu. To address this, I have temporarily implemented a solution to detach the surface when the root view is destroyed.

I'll try to investigate what is a default for RN apps and why it doesn't work with the menu. However, for now, that fix should be enough. 

# Test Plan

- new app with new architecture enable ✅ 