### PR TITLE
[dev-menu][iOS] Fix JS Debugger not detecting correct engine in new arch

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed JS Debugger not detecting correct engine in new arch on iOS. ([#28606](https://github.com/expo/expo/pull/28606) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 5.0.10 — 2024-05-02

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -29,7 +29,15 @@
 
   NSString *engine;
   NSString *bridgeDescription = [[[manager currentBridge] batchedBridge] bridgeDescription];
-  if ([bridgeDescription containsString:@"Hermes"]) {
+
+  // In bridgeless mode the bridgeDescription always is "BridgeProxy" instead of actual engine name
+  if ([bridgeDescription containsString:@"BridgeProxy"]) {
+  #if USE_HERMES
+    engine = @"Hermes";
+  #else
+    engine = @"JSC";
+  #endif
+  } else if ([bridgeDescription containsString:@"Hermes"]) {
     engine = @"Hermes";
   } else if ([bridgeDescription containsString:@"V8"]) {
     engine = @"V8";


### PR DESCRIPTION
# Why

When using the new arch with bridgeless mode the DevMenu misidentifies the JS engine as JSC 

# How

When using new arch with bridgeless mode use the value of `USE_HERMES` to determine the JS engine. As far as I know, V8 is not supported on iOS with bridgeless so we don't need to check for that case.

# Test Plan

Run FabricTester with Hermes and JSC


https://github.com/expo/expo/assets/11707729/808fa060-4b73-489e-8d2f-5307a639175a



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
