### PR TITLE
[dev-menu] fix crash on release build

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `java.lang.IllegalStateException: DevMenu isn't available in release builds` when running dev-menu on Android release builds. ([#28607](https://github.com/expo/expo/pull/28607) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 5.0.10 — 2024-05-02

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -72,9 +72,7 @@ object DevMenuManager : DevMenuManagerInterface {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
-  override fun registerExtensionInterface(extensionInterface: DevMenuExtensionInterface) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
+  override fun registerExtensionInterface(extensionInterface: DevMenuExtensionInterface) = Unit
 
   override fun serializedItems(): List<Bundle> {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)


### PR DESCRIPTION
# Why

fix crash when running dev-client on release build
```
05-02 20:52:35.457  5716  5733 E AndroidRuntime: java.lang.IllegalStateException: DevMenu isn't available in release builds
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.devmenu.DevMenuManager.registerExtensionInterface(DevMenuManager.kt:76)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.devmenu.extensions.DevMenuExtension.<init>(DevMenuExtension.kt:26)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.devmenu.DevMenuPackage.createNativeModules(DevMenuPackage.kt:24)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.adapters.react.ModuleRegistryAdapter.getNativeModulesFromModuleRegistry(ModuleRegistryAdapter.java:97)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.adapters.react.ModuleRegistryAdapter.createNativeModules(ModuleRegistryAdapter.java:71)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at expo.modules.ExpoModulesPackage.createNativeModules(ExpoModulesPackage.kt:35)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactPackageHelper.getNativeModuleIterator(ReactPackageHelper.java:35)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.NativeModuleRegistryBuilder.processPackage(NativeModuleRegistryBuilder.java:40)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager.processPackage(ReactInstanceManager.java:1467)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager.processPackages(ReactInstanceManager.java:1438)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1350)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager.lambda$runCreateReactContextOnNewThread$2(ReactInstanceManager.java:1121)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager.$r8$lambda$AwGS8CysOZmWJw3kRVARHQvw9Ew(Unknown Source:0)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at com.facebook.react.ReactInstanceManager$$ExternalSyntheticLambda5.run(Unknown Source:4)
05-02 20:52:35.457  5716  5733 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:1012)
```
close ENG-12222

# How

i was wrong that debugOnly autolinking is only available on ios but not on android.
let's turn the code as no-op than exception.

# Test Plan

test bare-expo on release build

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
