### PR TITLE
[ios][image] Fix avif images not rendering

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -369,6 +369,7 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.12.6):
     - ExpoModulesCore
+    - libavif/libdav1d
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
@@ -608,6 +609,10 @@ PODS:
     - hermes-engine/Pre-built (= 0.74.1)
   - hermes-engine/Pre-built (0.74.1)
   - libavif/core (0.11.1)
+  - libavif/libdav1d (0.11.1):
+    - libavif/core
+    - libdav1d (>= 0.6.0)
+  - libdav1d (1.2.0)
   - libwebp (1.3.2):
     - libwebp/demux (= 1.3.2)
     - libwebp/mux (= 1.3.2)
@@ -2131,6 +2136,7 @@ SPEC REPOS:
     - GoogleMaps
     - GooglePlaces
     - libavif
+    - libdav1d
     - libwebp
     - Nimble
     - OHHTTPStubs
@@ -2535,7 +2541,7 @@ SPEC CHECKSUMS:
   ExpoFont: 331cf28d549edc7b6300d3be19302fc5069d9bb1
   ExpoGL: a2d717e4b7279a075d7dff04d8d2471cb404ad2c
   ExpoHaptics: 5a3a88971af384255baf2504f38b41189cec6984
-  ExpoImage: 42ed3a89130f6bb764f63a37ef3a3b28453e9fad
+  ExpoImage: 58d066db3ac8cb4b93e24b967b2dd13c9b446290
   ExpoImageManipulator: bdfe12d8a570075fa433fa03e6c8abb05092a90f
   ExpoImagePicker: f6d9da49201ce201645366afc6be12cef47f24d7
   ExpoInsights: e88a27cb4ba1b644f8f6bbb2473a5a8204767948
@@ -2578,6 +2584,7 @@ SPEC CHECKSUMS:
   GooglePlaces: 0609463845250bbadafa1739938181e54dece439
   hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
+  libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -88,6 +88,7 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.12.6):
     - ExpoModulesCore
+    - libavif/libdav1d
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
@@ -394,6 +395,10 @@ PODS:
   - hermes-engine/Public (0.74.1)
   - JKBigInteger (0.0.6)
   - libavif/core (0.11.1)
+  - libavif/libdav1d (0.11.1):
+    - libavif/core
+    - libdav1d (>= 0.6.0)
+  - libdav1d (1.2.0)
   - libwebp (1.3.2):
     - libwebp/demux (= 1.3.2)
     - libwebp/mux (= 1.3.2)
@@ -2006,6 +2011,7 @@ SPEC REPOS:
     - GoogleMaps
     - GoogleUtilities
     - libavif
+    - libdav1d
     - libwebp
     - lottie-ios
     - MBProgressHUD
@@ -2357,7 +2363,7 @@ SPEC CHECKSUMS:
   ExpoGL: a2d717e4b7279a075d7dff04d8d2471cb404ad2c
   ExpoHaptics: 5a3a88971af384255baf2504f38b41189cec6984
   ExpoHead: e55606db85845d58e818d621499cdffab771c385
-  ExpoImage: 42ed3a89130f6bb764f63a37ef3a3b28453e9fad
+  ExpoImage: 58d066db3ac8cb4b93e24b967b2dd13c9b446290
   ExpoImageManipulator: bdfe12d8a570075fa433fa03e6c8abb05092a90f
   ExpoImagePicker: f6d9da49201ce201645366afc6be12cef47f24d7
   ExpoKeepAwake: f3a7b0ff4b4911957264dad8cb584ef688326a22
@@ -2404,6 +2410,7 @@ SPEC CHECKSUMS:
   hermes-engine: 543f364ff8a13dad19f62d9d601da0e6c615f2da
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
+  libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494
   lottie-react-native: f851c0e235f171d99083c803f728f644be1dcf65

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `avif` images not rendering.
+
 ### 💡 Others
 
 ## 1.12.6 — 2024-05-02

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `avif` images not rendering.
+- Fix `avif` images not rendering. ([#28608](https://github.com/expo/expo/pull/28608) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
   s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'
   s.dependency 'SDWebImageAVIFCoder', '~> 0.11.0'
   s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'
+  s.dependency 'libavif/libdav1d'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why
Closes #28603
Closes ENG-12223
`avif` images are no longer rendering. Seems like it could be an issue with `libavif` but it's hard to tell.

# How
I've added a [new](https://github.com/videolan/dav1d) decoder for `avif` images. Apparently it is the recommended one to use.

# Test Plan
Bare expo `avif` is now displaying

![Simulator Screenshot - iPhone 15 Pro - 2024-05-03 at 15 37 36](https://github.com/expo/expo/assets/30924086/2a707b77-6fea-4011-b902-01f1cc34f27f)

