### PR TITLE
[image][android] add support for animated AVIFs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -30,7 +30,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 | :--------: | :-----------------------------------------: | :---------: | :-------------------------------------------------------: |
 |    WebP    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
 | PNG / APNG |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
+|    AVIF    |                 <YesIcon />                 | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
 |    HEIC    |                 <YesIcon />                 | <YesIcon /> |  <NoIcon /> [not adopted yet](https://caniuse.com/heif)   |
 |    JPEG    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
 |    GIF     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |

--- a/docs/pages/versions/v51.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/image.mdx
@@ -30,7 +30,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 | :--------: | :-----------------------------------------: | :---------: | :-------------------------------------------------------: |
 |    WebP    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
 | PNG / APNG |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
+|    AVIF    |                 <YesIcon />                 | <YesIcon /> | <PendingIcon /> [~87% adoption](https://caniuse.com/avif) |
 |    HEIC    |                 <YesIcon />                 | <YesIcon /> |  <NoIcon /> [not adopted yet](https://caniuse.com/heif)   |
 |    JPEG    |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |
 |    GIF     |                 <YesIcon />                 | <YesIcon /> |                        <YesIcon />                        |

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for displaying animated AVIF images on Android. ([#28609](https://github.com/expo/expo/pull/28609) by [@fobos531](https://github.com/fobos531))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -18,7 +18,7 @@ android {
   namespace "expo.modules.image"
   defaultConfig {
     versionCode 1
-    versionName "1.12.4"
+    versionName "1.12.6"
     consumerProguardFiles("proguard-rules.pro")
 
     buildConfigField("boolean", "ALLOW_GLIDE_LOGS", project.properties.get("EXPO_ALLOW_GLIDE_LOGS", "false"))

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -18,7 +18,7 @@ android {
   namespace "expo.modules.image"
   defaultConfig {
     versionCode 1
-    versionName "1.12.6"
+    versionName "1.12.4"
     consumerProguardFiles("proguard-rules.pro")
 
     buildConfigField("boolean", "ALLOW_GLIDE_LOGS", project.properties.get("EXPO_ALLOW_GLIDE_LOGS", "false"))
@@ -44,7 +44,7 @@ dependencies {
   kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
   api 'com.caverock:androidsvg-aar:1.4'
 
-  implementation "com.github.penfeizhou.android.animation:glide-plugin:2.28.0"
+  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.1"
   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
 
   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Motivated by https://github.com/expo/expo/pull/28608
Fixes https://github.com/expo/expo/issues/21890

# How

<!--
How did you build this feature or fix this bug and why?
-->

Bumped the `com.github.penfeizhou.android.animation:glide-plugin` from 2.28.0 to 3.0.1. It contains a few general fixes and also animated AVIF support

# Test Plan

Tested on SDK 33 (emulator) only

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Before: 

https://github.com/expo/expo/assets/19533289/ae8861cc-8f30-46fb-b29e-8752fb0481b1

After:

https://github.com/expo/expo/assets/19533289/05f15a35-3447-40d8-8e2d-f4357bb2c9b4


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


**Note**: If you do not want to fit this into SDK 51, that's fine - I can remove the change from SDK 51 docs
