### PR TITLE
[updates] fix e2e errors on ios

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Suppressed `Error: Cannot find module 'expo-dev-client/package.json'` from `pod install` on iOS. ([#28611](https://github.com/expo/expo/pull/28611) by [@kudo](https://github.com/kudo))
+
 ## 0.25.7 — 2024-05-02
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -710,6 +710,9 @@ export async function initAsync(
     stdio: 'inherit',
   });
 
+  // Applying patches for 3rd party dependencies
+  await patchReactNativeAsync(projectRoot);
+
   // enable proguard on Android
   await fs.appendFile(
     path.join(projectRoot, 'android', 'gradle.properties'),
@@ -897,4 +900,24 @@ export async function setupUpdatesDevClientE2EAppAsync(
     path.resolve(dirName, '..', 'fixtures', 'Updates-dev-client.e2e.ts'),
     path.join(projectRoot, 'e2e', 'tests', 'Updates.e2e.ts')
   );
+}
+
+/**
+ * Apply temporary fix from https://github.com/facebook/react-native/pull/44402
+ */
+export async function patchReactNativeAsync(projectRoot: string) {
+  const packageJson = require(path.join(projectRoot, 'package.json'));
+  let postInstallScript = packageJson.scripts?.postinstall ?? '';
+  const reactNativeRoot = path.join(projectRoot, 'node_modules', 'react-native');
+  const reactNativeVersion = require(path.join(reactNativeRoot, 'package.json')).version;
+  if (reactNativeVersion === '0.74.1') {
+    if (postInstallScript !== '') {
+      postInstallScript += ' && ';
+    }
+    postInstallScript +=
+      'curl -sL https://patch-diff.githubusercontent.com/raw/facebook/react-native/pull/44402.diff \
+| patch -p3 -d node_modules/react-native';
+  }
+  packageJson.scripts.postinstall = postInstallScript;
+  await fs.writeFile(path.join(projectRoot, 'package.json'), JSON.stringify(packageJson, null, 2));
 }

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
 use_dev_client = false
 begin
-  use_dev_client = !!`node --print "require('expo-dev-client/package.json').version"`
+  use_dev_client = `node --print "require('expo-dev-client/package.json').version" 2>/dev/null`.length > 0
 rescue
   use_dev_client = false
 end


### PR DESCRIPTION
# Why

fix https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/b9722d1c-b4d6-4d0a-aaaa-09e519875b9c

# How

- temporarily apply fix for https://github.com/facebook/react-native/issues/44401
- suppress expo-dev-client lookup warning

# Test Plan

- updates e2e should pass on ios
- no strange `Error: Cannot find module 'expo-dev-client/package.json'` from updates e2e

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
