### PR TITLE
[docs] Fix `zulu` installation command for SDK 49 and below

### DIFF
--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -73,8 +73,8 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
 We recommend JDK 11 (you may encounter problems with higher JDK versions). Run the following commands in a terminal window to install it:
 
 <Terminal
-  cmd={['$ brew tap homebrew/cask-versions', '$ brew install --cask zulu11']}
-  cmdCopy="brew tap homebrew/cask-versions && brew install --cask zulu11"
+  cmd={['$ brew tap homebrew/cask-versions', '$ brew install --cask zulu@11']}
+  cmdCopy="brew tap homebrew/cask-versions && brew install --cask zulu@11"
 />
 
 After you install the JDK, add the `JAVA_HOME` environment variable in **~/.bash_profile** (or **~/.zshrc** if you use Zsh):


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #28610

It can be verified in Homebrew docs: https://formulae.brew.sh/cask/zulu@11#default

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `zulu` installation command for SDK 49 and below.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
