### PR TITLE
docs: drop additional references to `expo-cli` from docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -407,13 +407,10 @@ import { Terminal } from '~/ui/components/Snippet';
 {/* for multiple commands: */}
 
 <Terminal cmd={[
-  "# Create a new native project",
+  "# Create a new Expo project",
   "$ npx create-expo-app --template bare-minimum",
   "",
-  "# If you don’t have expo-cli yet, get it",
-  "$ npm i -g expo-cli",
-  "",
-]} cmdCopy="npx create-expo-app --template bare-minimum && npm i -g expo-cli" />
+]} cmdCopy="npx create-expo-app --template bare-minimum" />
 ```
 
 ### Use callouts

--- a/docs/pages/troubleshooting/react-native-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.mdx
@@ -28,12 +28,12 @@ The bundler that you're running in your terminal (using `npx expo start`) is usi
 
 - If this is a managed workflow project, either remove the `sdkVersion` field from your **app.json** file, or make sure it matches the value of the `expo` dependency in your **package.json** file.
 
-- If this is a managed workflow project, you should make sure your `react-native` version is correct. Run `npx expo-doctor` will show a warning where the `react-native` version you should install. If you did upgrade to a newer SDK, make sure to run `expo-cli upgrade` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
+- If this is a managed workflow project, you should make sure your `react-native` version is correct. Run `npx expo-doctor` will show a warning where the `react-native` version you should install. If you did upgrade to a newer SDK, make sure to run `npx expo install --fix` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
 
 - If this is a bare workflow project, and this error is occurring right after upgrading your React Native version, you should double-check that you have performed each of the upgrade steps correctly.
 
 - Finally:
-  - Clear your bundler caches by running `rm -rf node_modules && npm cache clean --force && npm install && watchman watch-del-all && rm -rf $TMPDIR/haste-map-* && rm -rf $TMPDIR/metro-cache && expo start --clear`
+  - Clear your bundler caches by running `rm -rf node_modules && npm cache clean --force && npm install && watchman watch-del-all && rm -rf $TMPDIR/haste-map-* && rm -rf $TMPDIR/metro-cache && npx expo start --clear`
     - Commands if you are using npm can be found [here.](clear-cache-macos-linux)
     - Commands if you are using Windows can be found [here.](clear-cache-windows)
   - If this is a bare workflow project, run `npx pod-install`, then rebuild your native projects (run `yarn android` to rebuild for Android, and `yarn ios` to rebuild iOS)


### PR DESCRIPTION
# Why

We still had this.

# How

Dropped additional references to the classic `expo-cli` from docs.

# Test Plan

Docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
