### PR TITLE
[dev-menu][iOS] Fix reloading app through "r" hotkey

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix reloading app through "r" hotkey on iOS. ([#28617](https://github.com/expo/expo/pull/28617) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 5.0.11 — 2024-05-03

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -78,7 +78,6 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
     reload.importance = DevMenuScreenItem.ImportanceHighest
-    reload.registerKeyCommand(input: "r", modifiers: []) // "r" without modifiers
     return reload
   }
 


### PR DESCRIPTION
# Why

Closes ENG-12058

Similar to the issue reported by @kudo on core (https://github.com/facebook/react-native/issues/44241), triggering two immediate reloads when running an app using the new arch in bridgeless mode will cause the app to crash on iOS as well. 

# How

Instead of registering the "r" hotkey for the DevMenu `reloadAction` we can just rely on the default react-native reload action (which also uses the "r" hotkey)

# Test Plan

Test dev-client through BareExpo and FabricTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
