### PR TITLE
[core][Android] Make `defaultAppContextMock` private

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -26,9 +26,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import java.lang.ref.WeakReference
 
-internal fun defaultAppContextMock(
-  jniDeallocator: JNIDeallocator = JNIDeallocator(shouldCreateDestructorThread = false),
-  jsiInterop: JSIContext = JSIContext()
+private fun defaultAppContextMock(
+  jniDeallocator: JNIDeallocator = JNIDeallocator(shouldCreateDestructorThread = false)
 ): AppContext {
   val appContextMock = mockk<AppContext>()
   val coreModule = run {
@@ -40,7 +39,7 @@ internal fun defaultAppContextMock(
   every { appContextMock.classRegistry } answers { ClassRegistry() }
   every { appContextMock.jniDeallocator } answers { jniDeallocator }
   every { appContextMock.findView<View>(capture(slot())) } answers { mockk() }
-  every { appContextMock.jsiInterop } answers { jsiInterop }
+
   return appContextMock
 }
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptFunctionTest.kt
@@ -1,44 +1,38 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
-import org.junit.Before
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
 class JavaScriptFunctionTest {
-  private lateinit var jsiInterop: JSIContext
-
-  @Before
-  fun before() {
-    jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock(jsiInterop = this))
-    }
-  }
 
   @Test
-  fun should_be_able_to_receive_function_instance() {
-    val jsValue = jsiInterop.evaluateScript("() => {}")
+  fun should_be_able_to_receive_function_instance() = withJSIInterop {
+    val jsValue = evaluateScript("() => {}")
     Truth.assertThat(jsValue.isFunction()).isTrue()
     val jsFunction = jsValue.getFunction()
     Truth.assertThat(jsFunction).isNotNull()
   }
 
   @Test
-  fun should_be_able_to_return_value() {
-    val function = jsiInterop.evaluateScript("() => { return 21 }").getFunction<Int>()
+  fun should_be_able_to_return_value() = withJSIInterop {
+    val function = evaluateScript("() => { return 21 }").getFunction<Int>()
     val result = function()
     Truth.assertThat(result).isEqualTo(21)
   }
 
   @Test
-  fun should_be_able_to_accept_simple_data() {
-    val function = jsiInterop.evaluateScript("(a, b) => { return a + b }").getFunction<Int>()
+  fun should_be_able_to_accept_simple_data() = withJSIInterop {
+    val function = evaluateScript("(a, b) => { return a + b }").getFunction<Int>()
     val result = function(20, 50)
     Truth.assertThat(result).isEqualTo(70)
   }
 
   @Test
-  fun should_be_able_to_accept_complex_data() {
-    val function = jsiInterop.evaluateScript("(object) => { return object.k1 }").getFunction<String>()
+  fun should_be_able_to_accept_complex_data() = withJSIInterop {
+    val function = evaluateScript("(object) => { return object.k1 }").getFunction<String>()
     val result = function(mapOf("k1" to "expo"))
     Truth.assertThat(result).isEqualTo("expo")
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -4,53 +4,43 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Before
 import org.junit.Test
 
+fun JSIContext.emptyObject(): JavaScriptObject {
+  return evaluateScript("({ })").getObject()
+}
+
 class JavaScriptObjectTest {
-  private lateinit var jsiInterop: JSIContext
-
-  private fun emptyObject(): JavaScriptObject {
-    return jsiInterop.evaluateScript("({ })").getObject()
-  }
-
-  @Before
-  fun before() {
-    jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock(jsiInterop = this))
-    }
-  }
-
   @Test
-  fun hasProperty_should_return_false_when_the_property_is_missing() {
+  fun hasProperty_should_return_false_when_the_property_is_missing() = withJSIInterop {
     val jsObject = emptyObject()
     Truth.assertThat(jsObject.hasProperty("prop")).isFalse()
   }
 
   @Test
-  fun hasProperty_should_return_true_when_the_property_exists() {
-    val jsObject = jsiInterop.evaluateScript("({ 'prop': 123 })").getObject()
+  fun hasProperty_should_return_true_when_the_property_exists() = withJSIInterop {
+    val jsObject = evaluateScript("({ 'prop': 123 })").getObject()
     Truth.assertThat(jsObject.hasProperty("prop")).isTrue()
   }
 
   @Test
-  fun getProperty_should_return_correct_value_is_the_property_exists() {
-    val jsObject = jsiInterop.evaluateScript("({ 'prop': 123 })").getObject()
+  fun getProperty_should_return_correct_value_is_the_property_exists() = withJSIInterop {
+    val jsObject = evaluateScript("({ 'prop': 123 })").getObject()
     val property = jsObject.getProperty("prop")
     Truth.assertThat(property.isNumber()).isTrue()
     Truth.assertThat(property.getDouble()).isEqualTo(123)
   }
 
   @Test
-  fun getProperty_should_return_undefined_when_the_property_is_missing() {
-    val jsObject = jsiInterop.evaluateScript("({ 'prop': 123 })").getObject()
+  fun getProperty_should_return_undefined_when_the_property_is_missing() = withJSIInterop {
+    val jsObject = evaluateScript("({ 'prop': 123 })").getObject()
     val property = jsObject.getProperty("foo")
     Truth.assertThat(property.isUndefined()).isTrue()
   }
 
   @Test
-  fun setProperty_should_work_with_bool() {
-    val jsObject = jsiInterop.evaluateScript("({ })").getObject()
+  fun setProperty_should_work_with_bool() = withJSIInterop {
+    val jsObject = evaluateScript("({ })").getObject()
     jsObject.setProperty("foo", true)
     jsObject.setProperty("bar", false)
 
@@ -62,57 +52,66 @@ class JavaScriptObjectTest {
   }
 
   @Test
-  fun setProperty_should_work_with_int() = with(emptyObject()) {
-    setProperty("foo", 123)
-    val foo = getProperty("foo").getDouble()
-    Truth.assertThat(foo).isEqualTo(123)
+  fun setProperty_should_work_with_int() = withJSIInterop {
+    with(emptyObject()) {
+      setProperty("foo", 123)
+      val foo = getProperty("foo").getDouble()
+      Truth.assertThat(foo).isEqualTo(123)
+    }
   }
 
   @Test
-  fun setProperty_should_work_with_double() = with(emptyObject()) {
-    setProperty("foo", 20.43)
-    val foo = getProperty("foo").getDouble()
-    Truth.assertThat(foo).isEqualTo(20.43)
+  fun setProperty_should_work_with_double() = withJSIInterop {
+    with(emptyObject()) {
+      setProperty("foo", 20.43)
+      val foo = getProperty("foo").getDouble()
+      Truth.assertThat(foo).isEqualTo(20.43)
+    }
   }
 
   @Test
-  fun setProperty_should_work_with_string() = with(emptyObject()) {
-    setProperty("foo", "bar")
-    setProperty("bar", null as String?)
+  fun setProperty_should_work_with_string() = withJSIInterop {
+    with(emptyObject()) {
+      setProperty("foo", "bar")
+      setProperty("bar", null as String?)
 
-    val foo = getProperty("foo").getString()
-    val bar = getProperty("bar")
+      val foo = getProperty("foo").getString()
+      val bar = getProperty("bar")
 
-    Truth.assertThat(foo).isEqualTo("bar")
-    Truth.assertThat(bar.isUndefined()).isTrue()
+      Truth.assertThat(foo).isEqualTo("bar")
+      Truth.assertThat(bar.isUndefined()).isTrue()
+    }
   }
 
   @Test
-  fun setProperty_should_work_with_js_value() = with(emptyObject()) {
-    val jsValue = jsiInterop.evaluateScript("123")
+  fun setProperty_should_work_with_js_value() = withJSIInterop {
+    with(emptyObject()) {
+      val jsValue = evaluateScript("123")
 
-    setProperty("foo", jsValue)
+      setProperty("foo", jsValue)
 
-    val foo = getProperty("foo").getDouble()
-
-    Truth.assertThat(foo).isEqualTo(123)
+      val foo = getProperty("foo").getDouble()
+      Truth.assertThat(foo).isEqualTo(123)
+    }
   }
 
   @Test
-  fun setProperty_should_work_with_js_object() = with(emptyObject()) {
-    val jsObject = jsiInterop.evaluateScript("({ 'bar': 10 })").getObject()
+  fun setProperty_should_work_with_js_object() = withJSIInterop {
+    with(emptyObject()) {
+      val jsObject = evaluateScript("({ 'bar': 10 })").getObject()
 
-    setProperty("foo", jsObject)
+      setProperty("foo", jsObject)
 
-    val foo = getProperty("foo").getObject()
-    val bar = foo.getProperty("bar").getDouble()
+      val foo = getProperty("foo").getObject()
+      val bar = foo.getProperty("bar").getDouble()
 
-    Truth.assertThat(bar).isEqualTo(10)
+      Truth.assertThat(bar).isEqualTo(10)
+    }
   }
 
   @Test
-  fun setProperty_should_work_with_untyped_null() {
-    val jsObject = jsiInterop.evaluateScript("({ 'foo': 10 })").getObject()
+  fun setProperty_should_work_with_untyped_null() = withJSIInterop {
+    val jsObject = evaluateScript("({ 'foo': 10 })").getObject()
 
     jsObject.setProperty("foo", null)
     val foo = jsObject.getProperty("foo")
@@ -121,40 +120,48 @@ class JavaScriptObjectTest {
   }
 
   @Test
-  fun defineProperty_defines_non_enumerable_property() = with(emptyObject()) {
-    defineProperty("expo", 10)
+  fun defineProperty_defines_non_enumerable_property() = withJSIInterop {
+    with(emptyObject()) {
+      defineProperty("expo", 10)
 
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
-    Truth.assertThat(getPropertyNames().toList()).doesNotContain("expo")
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
+      Truth.assertThat(getPropertyNames().toList()).doesNotContain("expo")
+    }
   }
 
   @Test
-  fun defineProperty_defines_enumerable_property() = with(emptyObject()) {
-    // When the property is enumerable, it is listed in the property names
-    defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Enumerable))
+  fun defineProperty_defines_enumerable_property() = withJSIInterop {
+    with(emptyObject()) {
+      // When the property is enumerable, it is listed in the property names
+      defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Enumerable))
 
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
-    Truth.assertThat(getPropertyNames().toList()).contains("expo")
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
+      Truth.assertThat(getPropertyNames().toList()).contains("expo")
+    }
   }
 
   @Test
-  fun defineProperty_defines_configurable_property() = with(emptyObject()) {
-    // Configurable allows to redefine the property
-    defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Configurable))
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
+  fun defineProperty_defines_configurable_property() = withJSIInterop {
+    with(emptyObject()) {
+      // Configurable allows to redefine the property
+      defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Configurable))
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
 
-    defineProperty("expo", 123)
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(123)
+      defineProperty("expo", 123)
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(123)
+    }
   }
 
   @Test
-  fun defineProperty_defines_writable_property() = with(emptyObject()) {
-    // Writable allows changing the property
-    defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Writable))
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
+  fun defineProperty_defines_writable_property() = withJSIInterop {
+    with(emptyObject()) {
+      // Writable allows changing the property
+      defineProperty("expo", 10, listOf(JavaScriptObject.PropertyDescriptor.Writable))
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(10)
 
-    setProperty("expo", 123)
-    Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(123)
+      setProperty("expo", 123)
+      Truth.assertThat(getProperty("expo").getDouble()).isEqualTo(123)
+    }
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptRuntimeTest.kt
@@ -1,55 +1,48 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
 class JavaScriptRuntimeTest {
-  private lateinit var jsiInterop: JSIContext
-
-  @Before
-  fun before() {
-    jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock(jsiInterop = this))
-    }
-  }
-
   @Test(expected = JavaScriptEvaluateException::class)
-  fun evaluate_should_throw_evaluate_exception() {
-    jsiInterop.evaluateScript("'")
+  fun evaluate_should_throw_evaluate_exception() = withJSIInterop {
+    evaluateScript("'")
   }
 
   @Test
-  fun evaluate_should_throw_evaluate_exception_with_stack() {
+  fun evaluate_should_throw_evaluate_exception_with_stack() = withJSIInterop {
     val exception = Assert.assertThrows(JavaScriptEvaluateException::class.java) {
-      jsiInterop.evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
+      evaluateScript("function x() { global.nonExistingFunction(10); }; x();")
     }
 
     Truth.assertThat(exception.jsStack).isNotEmpty()
   }
 
   @Test
-  fun evaluate_returns_undefined() {
-    val undefined = jsiInterop.evaluateScript("undefined")
+  fun evaluate_returns_undefined() = withJSIInterop {
+    val undefined = evaluateScript("undefined")
     Truth.assertThat(undefined.isUndefined()).isTrue()
     Truth.assertThat(undefined.isNull()).isFalse()
     Truth.assertThat(undefined.kind()).isEqualTo("undefined")
   }
 
   @Test
-  fun evaluate_returns_null() {
-    val `null` = jsiInterop.evaluateScript("null")
+  fun evaluate_returns_null() = withJSIInterop {
+    val `null` = evaluateScript("null")
     Truth.assertThat(`null`.isNull()).isTrue()
     Truth.assertThat(`null`.isUndefined()).isFalse()
     Truth.assertThat(`null`.kind()).isEqualTo("null")
   }
 
   @Test
-  fun evaluate_returns_bool() {
-    val boolTrue = jsiInterop.evaluateScript("true")
-    val boolFalse = jsiInterop.evaluateScript("false")
+  fun evaluate_returns_bool() = withJSIInterop {
+    val boolTrue = evaluateScript("true")
+    val boolFalse = evaluateScript("false")
 
     Truth.assertThat(boolTrue.isBool()).isTrue()
     Truth.assertThat(boolTrue.kind()).isEqualTo("boolean")
@@ -62,32 +55,32 @@ class JavaScriptRuntimeTest {
   }
 
   @Test
-  fun evaluate_returns_number() {
-    val number = jsiInterop.evaluateScript("73.12")
+  fun evaluate_returns_number() = withJSIInterop {
+    val number = evaluateScript("73.12")
     Truth.assertThat(number.isNumber()).isTrue()
     Truth.assertThat(number.kind()).isEqualTo("number")
     Truth.assertThat(number.getDouble()).isEqualTo(73.12)
   }
 
   @Test
-  fun evaluate_returns_string() {
-    val string = jsiInterop.evaluateScript("'foobar'")
+  fun evaluate_returns_string() = withJSIInterop {
+    val string = evaluateScript("'foobar'")
     Truth.assertThat(string.isString()).isTrue()
     Truth.assertThat(string.kind()).isEqualTo("string")
     Truth.assertThat(string.getString()).isEqualTo("foobar")
   }
 
   @Test
-  fun evaluate_returns_function() {
-    val function = jsiInterop.evaluateScript("(function() {})")
+  fun evaluate_returns_function() = withJSIInterop {
+    val function = evaluateScript("(function() {})")
     Truth.assertThat(function.isFunction()).isTrue()
     Truth.assertThat(function.isObject()).isTrue()
     Truth.assertThat(function.kind()).isEqualTo("function")
   }
 
   @Test
-  fun createObject_should_return_a_valid_object() {
-    val jsObject = jsiInterop.createObject()
+  fun createObject_should_return_a_valid_object() = withJSIInterop {
+    val jsObject = createObject()
 
     Truth.assertThat(jsObject.getPropertyNames()).hasLength(0)
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -1,23 +1,16 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
-import org.junit.Before
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
 class JavaScriptValueTest {
-  private lateinit var jsiInterop: JSIContext
-
-  @Before
-  fun before() {
-    jsiInterop = JSIContext().apply {
-      installJSIForTests(defaultAppContextMock(jsiInterop = this))
-    }
-  }
-
   @Test
-  fun should_wrap_numbers() {
-    val numberResult = jsiInterop.evaluateScript("21 + 37")
+  fun should_wrap_numbers() = withJSIInterop {
+    val numberResult = evaluateScript("21 + 37")
 
     Truth.assertThat(numberResult.kind()).isEqualTo("number")
     Truth.assertThat(numberResult.isNumber()).isEqualTo(true)
@@ -25,8 +18,8 @@ class JavaScriptValueTest {
   }
 
   @Test
-  fun should_wrap_strings() {
-    val stringResult = jsiInterop.evaluateScript("expo is awesome".addSingleQuotes())
+  fun should_wrap_strings() = withJSIInterop {
+    val stringResult = evaluateScript("expo is awesome".addSingleQuotes())
 
     Truth.assertThat(stringResult.kind()).isEqualTo("string")
     Truth.assertThat(stringResult.isString()).isEqualTo(true)
@@ -34,8 +27,8 @@ class JavaScriptValueTest {
   }
 
   @Test
-  fun should_wrap_booleans() {
-    val boolResult = jsiInterop.evaluateScript("true")
+  fun should_wrap_booleans() = withJSIInterop {
+    val boolResult = evaluateScript("true")
 
     Truth.assertThat(boolResult.kind()).isEqualTo("boolean")
     Truth.assertThat(boolResult.isBool()).isEqualTo(true)
@@ -43,8 +36,8 @@ class JavaScriptValueTest {
   }
 
   @Test
-  fun should_wrap_objects() {
-    val objectResult = jsiInterop.evaluateScript("({'p1':123})")
+  fun should_wrap_objects() = withJSIInterop {
+    val objectResult = evaluateScript("({'p1':123})")
 
     Truth.assertThat(objectResult.kind()).isEqualTo("object")
     Truth.assertThat(objectResult.isObject()).isEqualTo(true)


### PR DESCRIPTION
# Why

An improved version of the fixed proposed here: https://github.com/expo/expo/pull/28601.

# How

To simplify our test setups, we should use the same set of mocks for each test case. Currently, we are using different mocks to start our tests in a few places, which is not scalable. Therefore, I suggest using a universal entry point to replace it.

# Test Plan

- unit tests ✅ 
