### PR TITLE
refactor(cli): use same icons for adb-over-wifi connected devices as ios prompt

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add microsecond format for bundling. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `.eslintrc.js` to `expo customize`. ([#29570](https://github.com/expo/expo/pull/29570) by [@EvanBacon](https://github.com/EvanBacon))
 - Support web imports of `react-native/Libraries/Image/resolveAssetSource` in Metro. ([#29685](https://github.com/expo/expo/pull/29685) by [@EvanBacon](https://github.com/EvanBacon))
+- Unify Android device prompts with iOS prompts for `npx expo run:android -d`. ([#28622](https://github.com/expo/expo/pull/28622) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 
@@ -21,94 +22,6 @@
 - Ensure Metro dev server closes fully when clients are connected. ([#30067](https://github.com/expo/expo/pull/30067) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
-
-- Add robot export e2e test. ([#30049](https://github.com/expo/expo/pull/30049) by [@EvanBacon](https://github.com/EvanBacon))
-- Add internal externals to prevent bundling `source-map-support` in development. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
-- Remove webpack dependency in repo. ([#29840](https://github.com/expo/expo/pull/29840) by [@EvanBacon](https://github.com/EvanBacon))
-- Add "more tools" to terminal UI all the time. ([#29837](https://github.com/expo/expo/pull/29837) by [@EvanBacon](https://github.com/EvanBacon))
-- Remove unused `serve.json` file from `expo customize`. ([#29571](https://github.com/expo/expo/pull/29571) by [@EvanBacon](https://github.com/EvanBacon))
-- Add more tests for export:embed. ([#29811](https://github.com/expo/expo/pull/29811) by [@EvanBacon](https://github.com/EvanBacon))
-- Reduce unused server code in exports. ([#29619](https://github.com/expo/expo/pull/29619) by [@EvanBacon](https://github.com/EvanBacon))
-- Remove unused dependencies. ([#29177](https://github.com/expo/expo/pull/29177) by [@Simek](https://github.com/Simek))
-- Update `tar` dependency. ([#29663](https://github.com/expo/expo/pull/29663) by [@Simek](https://github.com/Simek))
-
-## 0.18.19 - 2024-06-13
-
-_This version does not introduce any user-facing changes._
-
-## 0.18.18 - 2024-06-12
-
-_This version does not introduce any user-facing changes._
-
-## 0.18.17 - 2024-06-10
-
-### 🎉 New features
-
-- Add experimental React Compiler support. ([#29168](https://github.com/expo/expo/pull/29168) by [@EvanBacon](https://github.com/EvanBacon))
-- Support passing `--port 0` to use any free port. ([#29466](https://github.com/expo/expo/pull/29466) by [@EvanBacon](https://github.com/EvanBacon))
-- Deep link to simulators without prompting for permissions first. ([#29468](https://github.com/expo/expo/pull/29468) by [@EvanBacon](https://github.com/EvanBacon))
-
-### 🐛 Bug fixes
-
-- Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
-
-### 💡 Others
-
-- Reduce export code paths. ([#29218](https://github.com/expo/expo/pull/29218) by [@EvanBacon](https://github.com/EvanBacon))
-- Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
-- Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
-
-## 0.18.16 - 2024-06-06
-
-_This version does not introduce any user-facing changes._
-
-## 0.18.15 — 2024-06-05
-
-### 🐛 Bug fixes
-
-- Fixed broken React DevTools since SDK 51. ([#29181](https://github.com/expo/expo/pull/29181) by [@kudo](https://github.com/kudo))
-
-### 💡 Others
-
-- Pin @react-native subpackage versions to 0.74.83. ([#29441](https://github.com/expo/expo/pull/29441) by [@kudo](https://github.com/kudo))
-
-## 0.18.14 — 2024-05-29
-
-_This version does not introduce any user-facing changes._
-
-## 0.18.13 — 2024-05-16
-
-### 🐛 Bug fixes
-
-- Resolve real path of entry file for `expo export:embed`. ([#28926](https://github.com/expo/expo/pull/28926) by [@byCedric](https://github.com/byCedric))
-- Parse full tarball object instead of quoted string with `npm view` for `npm@10.8.0+`. ([#28919](https://github.com/expo/expo/pull/28919) by [@byCedric](https://github.com/byCedric))
-
-## 0.18.12 — 2024-05-14
-
-_This version does not introduce any user-facing changes._
-
-## 0.18.11 — 2024-05-10
-
-### 🐛 Bug fixes
-
-- Force exit the export command to prevent hanging processes. ([#28735](https://github.com/expo/expo/pull/28735) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Avoid `<root>/node_modules` as extraneous `watchFolder`. ([#28778](https://github.com/expo/expo/pull/28778) by [@byCedric](https://github.com/byCedric))
-- Fix `findUp` utilities for Windows by aborting when `path.dirname(cwd)` returns `cwd`. ([#28801](https://github.com/expo/expo/pull/28801) by [@byCedric](https://github.com/byCedric))
-- Fix missing usbmux platform for platform to os conversion. ([#28802](https://github.com/expo/expo/pull/28802) by [@byCedric](https://github.com/byCedric))
-- Prevent exit the export command until Atlas is ready. ([#28759](https://github.com/expo/expo/pull/28759) by [@byCedric](https://github.com/byCedric))
-
-## 0.18.10 — 2024-05-07
-
-### 🐛 Bug fixes
-
-- Filter out unavailable connected devices when running `npx expo run:ios -d`. ([#28642](https://github.com/expo/expo/pull/28642) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-
-## 0.18.9 — 2024-05-06
-
-### 💡 Others
-
-- Bump `experiments.reactCanary` to React 19 beta [commit](https://github.com/facebook/react/commit/4508873393058e86bed308b56e49ec883ece59d1). ([#28592](https://github.com/expo/expo/pull/28592) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.18.8 — 2024-05-02
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,94 @@
 
 ### 💡 Others
 
+- Add robot export e2e test. ([#30049](https://github.com/expo/expo/pull/30049) by [@EvanBacon](https://github.com/EvanBacon))
+- Add internal externals to prevent bundling `source-map-support` in development. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove webpack dependency in repo. ([#29840](https://github.com/expo/expo/pull/29840) by [@EvanBacon](https://github.com/EvanBacon))
+- Add "more tools" to terminal UI all the time. ([#29837](https://github.com/expo/expo/pull/29837) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove unused `serve.json` file from `expo customize`. ([#29571](https://github.com/expo/expo/pull/29571) by [@EvanBacon](https://github.com/EvanBacon))
+- Add more tests for export:embed. ([#29811](https://github.com/expo/expo/pull/29811) by [@EvanBacon](https://github.com/EvanBacon))
+- Reduce unused server code in exports. ([#29619](https://github.com/expo/expo/pull/29619) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove unused dependencies. ([#29177](https://github.com/expo/expo/pull/29177) by [@Simek](https://github.com/Simek))
+- Update `tar` dependency. ([#29663](https://github.com/expo/expo/pull/29663) by [@Simek](https://github.com/Simek))
+
+## 0.18.19 - 2024-06-13
+
+_This version does not introduce any user-facing changes._
+
+## 0.18.18 - 2024-06-12
+
+_This version does not introduce any user-facing changes._
+
+## 0.18.17 - 2024-06-10
+
+### 🎉 New features
+
+- Add experimental React Compiler support. ([#29168](https://github.com/expo/expo/pull/29168) by [@EvanBacon](https://github.com/EvanBacon))
+- Support passing `--port 0` to use any free port. ([#29466](https://github.com/expo/expo/pull/29466) by [@EvanBacon](https://github.com/EvanBacon))
+- Deep link to simulators without prompting for permissions first. ([#29468](https://github.com/expo/expo/pull/29468) by [@EvanBacon](https://github.com/EvanBacon))
+
+### 🐛 Bug fixes
+
+- Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
+
+### 💡 Others
+
+- Reduce export code paths. ([#29218](https://github.com/expo/expo/pull/29218) by [@EvanBacon](https://github.com/EvanBacon))
+- Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
+- Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
+
+## 0.18.16 - 2024-06-06
+
+_This version does not introduce any user-facing changes._
+
+## 0.18.15 — 2024-06-05
+
+### 🐛 Bug fixes
+
+- Fixed broken React DevTools since SDK 51. ([#29181](https://github.com/expo/expo/pull/29181) by [@kudo](https://github.com/kudo))
+
+### 💡 Others
+
+- Pin @react-native subpackage versions to 0.74.83. ([#29441](https://github.com/expo/expo/pull/29441) by [@kudo](https://github.com/kudo))
+
+## 0.18.14 — 2024-05-29
+
+_This version does not introduce any user-facing changes._
+
+## 0.18.13 — 2024-05-16
+
+### 🐛 Bug fixes
+
+- Resolve real path of entry file for `expo export:embed`. ([#28926](https://github.com/expo/expo/pull/28926) by [@byCedric](https://github.com/byCedric))
+- Parse full tarball object instead of quoted string with `npm view` for `npm@10.8.0+`. ([#28919](https://github.com/expo/expo/pull/28919) by [@byCedric](https://github.com/byCedric))
+
+## 0.18.12 — 2024-05-14
+
+_This version does not introduce any user-facing changes._
+
+## 0.18.11 — 2024-05-10
+
+### 🐛 Bug fixes
+
+- Force exit the export command to prevent hanging processes. ([#28735](https://github.com/expo/expo/pull/28735) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Avoid `<root>/node_modules` as extraneous `watchFolder`. ([#28778](https://github.com/expo/expo/pull/28778) by [@byCedric](https://github.com/byCedric))
+- Fix `findUp` utilities for Windows by aborting when `path.dirname(cwd)` returns `cwd`. ([#28801](https://github.com/expo/expo/pull/28801) by [@byCedric](https://github.com/byCedric))
+- Fix missing usbmux platform for platform to os conversion. ([#28802](https://github.com/expo/expo/pull/28802) by [@byCedric](https://github.com/byCedric))
+- Prevent exit the export command until Atlas is ready. ([#28759](https://github.com/expo/expo/pull/28759) by [@byCedric](https://github.com/byCedric))
+
+## 0.18.10 — 2024-05-07
+
+### 🐛 Bug fixes
+
+- Filter out unavailable connected devices when running `npx expo run:ios -d`. ([#28642](https://github.com/expo/expo/pull/28642) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
+## 0.18.9 — 2024-05-06
+
+### 💡 Others
+
+- Bump `experiments.reactCanary` to React 19 beta [commit](https://github.com/facebook/react/commit/4508873393058e86bed308b56e49ec883ece59d1). ([#28592](https://github.com/expo/expo/pull/28592) by [@EvanBacon](https://github.com/EvanBacon))
+
 ## 0.18.8 — 2024-05-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -197,6 +197,7 @@ describe(getAttachedDevicesAsync, () => {
         name: 'Device FA8251A00719',
         pid: 'FA8251A00719',
         type: 'device',
+        connectionType: 'USB',
       },
       {
         isAuthorized: true,
@@ -204,6 +205,7 @@ describe(getAttachedDevicesAsync, () => {
         name: 'Pixel_2',
         pid: 'FA8251A00720',
         type: 'device',
+        connectionType: 'USB',
       },
       {
         isAuthorized: true,

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -217,6 +217,65 @@ describe(getAttachedDevicesAsync, () => {
     ]);
   });
 
+  it(`gets network connected devices`, async () => {
+    jest
+      .mocked(getServer().runAsync)
+      .mockResolvedValueOnce(
+        [
+          'List of devices attached',
+          // unauthorized
+          'adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp. offline transport_id:1',
+          // authorized & online
+          'adb-00000XXX000XXX-YzXxxx._adb-tls-connect._tcp. device product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
+          // authorized & offline
+          'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp. offline product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
+          // Emulator
+          'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
+          '',
+        ].join('\n')
+      )
+      .mockResolvedValueOnce(
+        // Return the emulator name
+        ['Pixel_4_XL_API_30', 'OK'].join('\n')
+      );
+
+    const devices = await getAttachedDevicesAsync();
+
+    expect(devices).toEqual([
+      {
+        isAuthorized: false,
+        isBooted: false,
+        name: 'Device adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp.',
+        pid: 'adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp.',
+        type: 'device',
+        connectionType: 'Network',
+      },
+      {
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_7_Pro',
+        pid: 'adb-00000XXX000XXX-YzXxxx._adb-tls-connect._tcp.',
+        type: 'device',
+        connectionType: 'Network',
+      },
+      {
+        isAuthorized: true,
+        isBooted: false,
+        name: 'Pixel_7_Pro',
+        pid: 'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp.',
+        type: 'device',
+        connectionType: 'Network',
+      },
+      {
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_4_XL_API_30',
+        pid: 'emulator-5554',
+        type: 'emulator',
+      },
+    ]);
+  });
+
   it(`gets devices when ADB_TRACE is set`, async () => {
     jest
       .mocked(getServer().runAsync)

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/promptAndroidDevice-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/promptAndroidDevice-test.ts
@@ -1,0 +1,86 @@
+import { stripAnsi } from '../../../../utils/ansi';
+import { formatDeviceChoice } from '../promptAndroidDevice';
+
+describe(formatDeviceChoice, () => {
+  it('formats Network connected authorized device', () => {
+    const choice = formatDeviceChoice({
+      pid: 'adb-99999XXX999XXX-XxXxxx._adb-tls-connect._tcp.',
+      name: `Pixel_7_Pro`,
+      type: `device`,
+      connectionType: `Network`,
+      isBooted: true,
+      isAuthorized: true,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`🌐 Pixel_7_Pro (device)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_7_Pro`);
+  });
+
+  it('formats Network connected unauthorized device', () => {
+    const choice = formatDeviceChoice({
+      pid: 'adb-99999XXX999XXX-XxXxxx._adb-tls-connect._tcp.',
+      name: `Pixel_7_Pro`,
+      type: `device`,
+      connectionType: `Network`,
+      isBooted: true,
+      isAuthorized: false,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`🌐 Pixel_7_Pro (unauthorized)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_7_Pro`);
+  });
+
+  it('formats USB connected authorized device', () => {
+    const choice = formatDeviceChoice({
+      pid: '99999XXX999XXX',
+      name: `Pixel_7_Pro`,
+      type: `device`,
+      connectionType: `USB`,
+      isBooted: true,
+      isAuthorized: true,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`🔌 Pixel_7_Pro (device)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_7_Pro`);
+  });
+
+  it('formats USB connected unauthorized device', () => {
+    const choice = formatDeviceChoice({
+      pid: '99999XXX999XXX',
+      name: `Pixel_7_Pro`,
+      type: `device`,
+      connectionType: `USB`,
+      isBooted: true,
+      isAuthorized: false,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`🔌 Pixel_7_Pro (unauthorized)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_7_Pro`);
+  });
+
+  it('formats booted emulator', () => {
+    const choice = formatDeviceChoice({
+      pid: 'emulator-5554',
+      name: `Pixel_6_API_33`,
+      type: `emulator`,
+      isBooted: true,
+      isAuthorized: true,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`Pixel_6_API_33 (emulator)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_6_API_33`);
+  });
+
+  it('formats non-booted emulator', () => {
+    const choice = formatDeviceChoice({
+      pid: 'emulator-5554',
+      name: `Pixel_6_API_33`,
+      type: `emulator`,
+      isBooted: false,
+      isAuthorized: true,
+    });
+
+    expect(stripAnsi(choice.title)).toBe(`Pixel_6_API_33 (emulator)`);
+    expect(stripAnsi(choice.value)).toBe(`Pixel_6_API_33`);
+  });
+});

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -249,6 +249,7 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
     props: string[];
     type: Device['type'];
     isAuthorized: Device['isAuthorized'];
+    isBooted: Device['isBooted'];
     connectionType?: Device['connectionType'];
   }[] = splitItems
     .slice(1, splitItems.length)
@@ -257,18 +258,22 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
       // authorized: ['FA8251A00719', 'device', 'usb:336592896X', 'product:walleye', 'model:Pixel_2', 'device:walleye', 'transport_id:4']
       // emulator: ['emulator-5554', 'offline', 'transport_id:1']
       const props = line.split(' ').filter(Boolean);
-
-      const isAuthorized = props[1] !== 'unauthorized';
       const type = line.includes('emulator') ? 'emulator' : 'device';
 
-      let connectionType = undefined;
-      if (type === 'device' && line.includes('_adb-tls-connect.')) {
-        connectionType = 'Network';
-      } else if (type === 'device' && line.includes('usb:')) {
+      let connectionType;
+      if (type === 'device' && line.includes('usb:')) {
         connectionType = 'USB';
+      } else if (type === 'device' && line.includes('_adb-tls-connect.')) {
+        connectionType = 'Network';
       }
 
-      return { props, type, isAuthorized, connectionType };
+      const isBooted = type === 'emulator' || props[1] !== 'offline';
+      const isAuthorized =
+        connectionType === 'Network'
+          ? line.includes('model:') // Network connected devices show `model:<name>` when authorized
+          : props[1] !== 'unauthorized';
+
+      return { props, type, isAuthorized, isBooted, connectionType };
     })
     .filter(({ props: [pid] }) => !!pid);
 
@@ -277,6 +282,7 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
       type,
       props: [pid, ...deviceInfo],
       isAuthorized,
+      isBooted,
     } = props;
 
     let name: string | null = null;
@@ -301,8 +307,8 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
     }
 
     return props.connectionType
-      ? { pid, name, type, isAuthorized, isBooted: true, connectionType: props.connectionType }
-      : { pid, name, type, isAuthorized, isBooted: true };
+      ? { pid, name, type, isAuthorized, isBooted, connectionType: props.connectionType }
+      : { pid, name, type, isAuthorized, isBooted };
   });
 
   return Promise.all(devicePromises);

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -300,14 +300,9 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
       name = (await getAdbNameForDeviceIdAsync({ pid })) ?? '';
     }
 
-    return {
-      pid,
-      name,
-      type,
-      isAuthorized,
-      isBooted: true,
-      connectionType: props.connectionType,
-    };
+    return props.connectionType
+      ? { pid, name, type, isAuthorized, isBooted: true, connectionType: props.connectionType }
+      : { pid, name, type, isAuthorized, isBooted: true };
   });
 
   return Promise.all(devicePromises);


### PR DESCRIPTION
# Why

This applies the same (icon) styling for Android devices connected through ADB-over-wifi, as the iOS device prompts.

USB-only | Network-only | USB & Network
--- | --- | ---
![USB-only prompt](https://github.com/expo/expo/assets/1203991/32657849-ae97-4154-ac6b-e12b7e9a578a) | ![Network-only prompt](https://github.com/expo/expo/assets/1203991/1cc31193-cf52-43a3-9354-bf16d67ec50c) | ![USB & Network prompt](https://github.com/expo/expo/assets/1203991/f739df2e-95b1-4e0a-9ef9-5fdecb526160)

# How

- Copied icon from `expo run:ios -d` (`🌐`)
- Added `connectionType` to Android devices based on the check:
  - If device is an actual device, and includes `_adb-tls-connect`, its network ([see here](https://stackoverflow.com/a/72987868))
  - If device is an actual device, and includes `usb:`, its USB _(see `devices -l` when using usb/wifi adb connections)_

# Test Plan

See tests for: 
1. discovered wifi devices (unauthorized)
2. paired wifi devices and booted (available)
3. paired wifi devices and NOT booted (unavailable)

To pair devices:
- Open your device developer settings
- Go to "Wireless debugging"
- Enable "Use wireless debugging"

Either [pair through Android Studio](https://developer.android.com/studio/run/device#wireless), or the CLI:

- Go to "Wireless debugging"
- Go to "Pair device with pairing code", keep it open
- `$ adb pair <ip>:<port> <pairing-code>`
  - You can find the pairing code on "Pair device with pairing code".
- `$ adb devices -l`
  - This should list the Android device, when not connected through USB
- `$ expo run:android -d`
  - Should show the wifi-connected device as option too    

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
