### PR TITLE
[core][Android] Add the method name to unexpected exception

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -104,7 +104,8 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
       auto stringRepresentation = arg.toString(rt).utf8(rt);
       throwNewJavaException(
         UnexpectedException::create(
-          "Cannot convert '" + stringRepresentation + "' to a Kotlin type.").get()
+          "[" + this->name + "] Cannot convert '" + stringRepresentation +
+          "' to a Kotlin type.").get()
       );
     }
   }


### PR DESCRIPTION
# Why

Adds a method name to the unexpected exception. 

# How

That will help debug problems in production. Currently, errors that are thrown from cpp are very cryptic. We need to figure out a better way of providing more helpful information, but that would have to be enough for now.
