### PR TITLE
[video][Android] Remove Kotlin warnings

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -49,6 +49,7 @@ class FullscreenPlayerActivity : Activity() {
     if (Build.VERSION.SDK_INT >= 34) {
       overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
     } else {
+      @Suppress("DEPRECATION")
       overridePendingTransition(0, 0)
     }
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -46,7 +46,7 @@ class FullscreenPlayerActivity : Activity() {
     VideoManager.getVideoView(videoViewId).exitFullscreen()
 
     // Disable the exit transition
-    if (Build.VERSION.SDK_INT >= 34) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
       overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
     } else {
       @Suppress("DEPRECATION")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayerAudioFocusManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayerAudioFocusManager.kt
@@ -51,6 +51,7 @@ class VideoPlayerAudioFocusManager(val context: Context, private val player: Wea
       this.currentFocusRequest = newFocusRequest
       audioManager.requestAudioFocus(newFocusRequest)
     } else {
+      @Suppress("DEPRECATION")
       audioManager.requestAudioFocus(
         this,
         AudioManager.STREAM_MUSIC,
@@ -64,6 +65,7 @@ class VideoPlayerAudioFocusManager(val context: Context, private val player: Wea
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         audioManager.abandonAudioFocusRequest(it)
       } else {
+        @Suppress("DEPRECATION")
         audioManager.abandonAudioFocus(this)
       }
     }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -146,6 +146,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
     if (Build.VERSION.SDK_INT >= 34) {
       currentActivity.overrideActivityTransition(Activity.OVERRIDE_TRANSITION_OPEN, 0, 0)
     } else {
+      @Suppress("DEPRECATION")
       currentActivity.overridePendingTransition(0, 0)
     }
     isInFullscreen = true

--- a/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
@@ -5,6 +5,7 @@ import android.graphics.Canvas
 import android.graphics.Outline
 import android.graphics.Path
 import android.graphics.RectF
+import android.os.Build
 import android.view.View
 import android.view.ViewOutlineProvider
 import com.facebook.react.modules.i18nmanager.I18nUtil
@@ -197,7 +198,11 @@ class OutlineProvider(private val mContext: Context) : ViewOutlineProvider() {
       // shadow is. For the particular case, we fallback to canvas clipping in the view
       // which is supposed to call `clipCanvasIfNeeded` in its `draw` method.
       updateConvexPathIfNeeded()
-      outline.setConvexPath(mConvexPath)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        outline.setPath(mConvexPath)
+      } else {
+        outline.setConvexPath(mConvexPath)
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Removes Kotlin warnings. 
Most of them can be just ignored because we already migrated to new APIs.

# Test Plan

- NCL ✅ 