### PR TITLE
[cli] Filter out unavailable connected devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Filter out unavailable connected devices when running `npx expo run:ios -d`. ([#28642](https://github.com/expo/expo/pull/28642) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.18.8 — 2024-05-02

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -41,9 +41,13 @@ export interface ConnectedDevice {
 async function getConnectedDevicesUsingNativeToolsAsync(): Promise<ConnectedDevice[]> {
   return (
     (await devicectl.getConnectedAppleDevicesAsync())
-      // Filter out unpaired devices.
+      // Filter out unpaired and unavailable devices.
       // TODO: We could improve this logic in the future to attempt pairing if specified.
-      .filter((device) => device.connectionProperties.pairingState === 'paired')
+      .filter(
+        (device) =>
+          device.connectionProperties.pairingState === 'paired' &&
+          device.connectionProperties.tunnelState !== 'unavailable'
+      )
       .map((device) => {
         return {
           name: device.deviceProperties.name,


### PR DESCRIPTION
# Why

While testing `devicectl list devices` for Orbit I noticed that xcode returns iOS devices even if the device is unavailable (E.g. wifi and Bluetooth off). 

Upon testing this with Expo CLI I was faced with the following issues:

1. the iPhone was shown as connected via cable

![image](https://github.com/expo/expo/assets/11707729/e38102f1-9969-4371-87a2-cfdd8b5b5181)

2. When selecting the device the build would fail with `Unable to find a destination matching the provided destination` 

![image](https://github.com/expo/expo/assets/11707729/66240243-9aef-4f0f-9907-3a8c8ff539fe)


# How

Update `getConnectedDevicesUsingNativeToolsAsync` to check the tunnel state of the device and filter out unavailable devices.

# Test Plan

```
npx expo run:ios -d
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
