### PR TITLE
[docs] Add a usage section to link to Assets guide

### DIFF
--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -59,6 +59,10 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
   ]}
 />
 
+### Usage
+
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in the [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time) section.
+
 ## API
 
 ```js

--- a/docs/pages/versions/unversioned/sdk/asset.mdx
+++ b/docs/pages/versions/unversioned/sdk/asset.mdx
@@ -61,7 +61,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in the [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time) section.
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
 
 ## API
 

--- a/docs/pages/versions/v51.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/asset.mdx
@@ -59,6 +59,10 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
   ]}
 />
 
+### Usage
+
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in the [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time) section.
+
 ## API
 
 ```js

--- a/docs/pages/versions/v51.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/asset.mdx
@@ -61,7 +61,7 @@ You can configure `expo-asset` using its built-in [config plugin](/config-plugin
 
 ### Usage
 
-Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in the [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time) section.
+Learn more about how to use the `expo-asset` config plugin to embed an asset file in your project in [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time).
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #28331

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a sub section called Usage under Config plugins section of the Asset API reference to link to [Load an asset at build time](/develop/user-interface/assets/#load-an-asset-at-build-time) section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2024-05-07 at 04 42 47@2x](https://github.com/expo/expo/assets/10234615/32e90400-9def-4b1f-a908-a1285ad89c20)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
