### PR TITLE
Update build.gradle to use annotationProcessor instead of kapt for room

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -90,7 +90,7 @@ dependencies {
   def room_version = "2.4.2"
 
   implementation "androidx.room:room-runtime:$room_version"
-  kapt "androidx.room:room-compiler:$room_version"
+  annotationProcessor "androidx.room:room-compiler:$room_version"
 
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")


### PR DESCRIPTION
Fixes an error for non admin users running build on androids. 

`> Task :expo-updates:kaptDebugKotlin
java.io.FileNotFoundException: C:\WINDOWS\sqlite-3.36.0-93068ff4-a0a7-44a0-bc91-2fc763079ab2-sqlitejdbc.dll.lck (Access is denied)`

# Why

Certain users without administrator privilege's cannot fix the underlying issue.  

https://stackoverflow.com/questions/78331211/expo-updates-failing-to-run-android-build-on-windows
https://github.com/expo/expo/issues/28240


# How

Building with kapt was failing, using annotationProcessor resolved the issue.

# Test Plan

- Open a windows user without admin priviledges. Build any project using "npx expo run:android"

# Checklist


- [X ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
