### PR TITLE
[docs] Fix internal links after for new Get Started section and other minor fixes

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -144,7 +144,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/introduction/faq/': '/faq/',
   '/next-steps/community/': '/',
   '/introduction/managed-vs-bare/': '/archive/managed-vs-bare/',
-  '/workflow/expo-go/': '/get-started/expo-go/',
+  '/workflow/expo-go/': '/get-started/set-up-your-environment/',
   '/guides/splash-screens/': '/develop/user-interface/splash-screen/',
   '/guides/app-icons/': '/develop/user-interface/app-icons/',
   '/guides/color-schemes/': '/develop/user-interface/color-themes/',
@@ -209,7 +209,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/publishing/': '/archive/classic-updates/publishing/',
   '/workflow/publishing/': '/archive/classic-updates/publishing/',
   '/guides/linking/': '/workflow/linking/',
-  '/guides/up-and-running/': '/get-started/installation/',
+  '/guides/up-and-running/': '/get-started/create-a-project/',
   '/guides/debugging/': '/debugging/runtime-issues/',
   '/guides/logging/': '/workflow/logging/',
   '/introduction/troubleshooting-proxies/': '/guides/troubleshooting-proxies/',
@@ -218,14 +218,14 @@ const RENAMED_PAGES: Record<string, string> = {
     'https://dev.to/evanbacon/making-desktop-apps-with-electron-react-native-and-expo-5e36',
 
   // Changes from redoing the getting started workflow, SDK35+
-  '/workflow/up-and-running/': '/get-started/installation/',
+  '/workflow/up-and-running/': '/get-started/create-a-project/',
   '/introduction/additional-resources/': '/next-steps/additional-resources/',
   '/introduction/already-used-react-native/':
     '/faq/#what-is-the-difference-between-expo-and-react-native',
   '/introduction/community/': '/next-steps/community/',
-  '/introduction/installation/': '/get-started/installation/',
+  '/introduction/installation/': '/get-started/create-a-project/',
   '/versions/latest/overview/': '/versions/latest/',
-  '/versions/latest/introduction/installation/': '/get-started/installation/',
+  '/versions/latest/introduction/installation/': '/get-started/create-a-project/',
   '/workflow/exploring-managed-workflow/': '/tutorial/introduction/',
   '/introduction/walkthrough/': '/tutorial/introduction/',
 
@@ -249,13 +249,13 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/account-permissions/': '/accounts/personal/',
 
   // Redirects based on Sentry reports
-  '/next-steps/installation/': '/get-started/installation/',
+  '/next-steps/installation/': '/get-started/create-a-project/',
   '/guides/release-channels/': '/archive/classic-updates/release-channels/',
   '/guides/push-notifications/': '/push-notifications/overview/',
   '/push-notifications/': '/push-notifications/overview/',
   '/distribution/hosting-your-app/': '/distribution/publishing-websites/',
   '/build-reference/how-tos/': '/build-reference/private-npm-packages/',
-  '/get-started/': '/get-started/installation/',
+  '/get-started/': '/get-started/create-a-project/',
   '/guides/detach/': '/archive/glossary/#detach',
   '/workflow/snack/': '/more/glossary-of-terms/#snack',
   '/eas/submit/': '/submit/introduction/',
@@ -454,8 +454,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/bare/using-expo-client/': '/archive/using-expo-client/',
 
   // May 2024 home / get started section
-  '/overview': '/get-started/introduction',
-  '/get-started/installation': '/get-started/create-a-project',
-  '/get-started/expo-go': '/get-started/set-up-your-environment',
-  '/get-started/create-a-project': '/get-started/create-a-project',
+  '/overview/': '/get-started/introduction/',
+  '/get-started/installation/': '/get-started/create-a-project/',
+  '/get-started/expo-go/': '/get-started/set-up-your-environment/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -357,7 +357,6 @@ redirects[bare/using-expo-client]=archive/using-expo-client
 redirects[/overview]=get-started/introduction
 redirects[/get-started/installation]=get-started/create-a-project
 redirects[/get-started/expo-go]=get-started/set-up-your-environment
-redirects[/get-started/create-a-project]=get-started/create-a-project
 
 
 echo "::group::[5/6] Add custom redirects"

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -68,7 +68,7 @@ You may want to create a plugin in a different file, here's how:
 - The root file can be any JS file or a file named **app.plugin.js** in the root of a Node module.
 - The file should export a function that satisfies the [`ConfigPlugin`](https://github.com/expo/expo-cli/blob/3a0ef962a27525a0fe4b7e5567fb7b3fb18ec786/packages/config-plugins/src/Plugin.types.ts#L76) type.
 - Plugins should be transpiled for Node environments ahead of time!
-  - They should support the versions of Node that [Expo supports](/get-started/installation/#requirements) (LTS).
+  - They should support the versions of Node that [Expo supports](/get-started/create-a-project/) (LTS).
   - No `import/export` keywords, use `module.exports` in the shipped plugin file.
   - Expo only transpiles the user's initial `app.config` file, anything more would require a bundler which would add too many "opinions" for a config file.
 

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -47,7 +47,7 @@ The `expo` npm package enables a suite of incredible features for React Native a
 <BoxLink
   title="Expo Go"
   description="Learn React by trying it on your simulator or device."
-  href="/get-started/expo-go/"
+  href="/get-started/set-up-your-environment/"
   Icon={ExpoGoLogo}
 />
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -10,7 +10,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { BookOpen02Icon, VideoRecorderIcon } from '@expo/styleguide-icons';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-A **development build** is a debug build of your app that contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. By using development builds instead of [Expo Go](/get-started/expo-go/), you gain full control over the native runtime, so you can [install any native libraries](/workflow/using-libraries/#determining-third-party-library-compatibility), [modify any project configuration](/config-plugins/introduction/), or [write your own native code](/modules/get-started/). With Expo development builds, you are building your own native app, while with Expo Go you are running your project in a sandboxed native app environment.
+A **development build** is a debug build of your app that contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. By using development builds instead of [Expo Go](/get-started/set-up-your-environment/), you gain full control over the native runtime, so you can [install any native libraries](/workflow/using-libraries/#determining-third-party-library-compatibility), [modify any project configuration](/config-plugins/introduction/), or [write your own native code](/modules/get-started/). With Expo development builds, you are building your own native app, while with Expo Go you are running your project in a sandboxed native app environment.
 
 <ImageSpotlight
   alt="expo-dev-client launcher and menu UIs on Android and iOS"
@@ -60,7 +60,7 @@ The launcher UI makes it possible to switch between development servers without 
 
 <Collapsible summary="How are development builds different from Expo Go?">
 
-When you start a new project with Expo, the fastest and easiest way to get to "Hello, world!" is with [Expo Go](/get-started/expo-go/) on your device because you don't need to compile any native code or install any native tooling.
+When you start a new project with Expo, the fastest and easiest way to get to "Hello, world!" is with [Expo Go](/get-started/set-up-your-environment/) on your device because you don't need to compile any native code or install any native tooling.
 
 Beyond "Hello, world!" and prototypes, you'll quickly encounter limitations and need to build a development build of your app. For example, the Expo Go sandbox environment is limited to only the native packages included in the [Expo SDK](/versions/latest/), while you can include any library in a development build because it's just a normal native app.
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -90,7 +90,7 @@ In the same way React.js frameworks help users create larger websites with ease,
 
 React Native uses a JavaScript intepreter (JSC, V8, or Hermes) to run your application code. Refer to the [Google Play Policy Center](https://play.google/developer-content-policy/) and [Apple Developer Program License Agreement](https://developer.apple.com/support/terms/apple-developer-program-license-agreement) directly for the most up-to-date policy information.
 
-*The following are excerpts of related policies, as of April 25, 2024.*
+_The following are excerpts of related policies, as of April 25, 2024._
 
 ### Google Play Store
 
@@ -106,7 +106,6 @@ must not allow potential violations of Google Play policies.
 ```
 
 Source: [Google Play Policy Center](https://support.google.com/googleplay/android-developer/answer/9888379?hl=en).
-
 
 ### Apple App Store
 
@@ -185,7 +184,7 @@ EAS Build is compatible with bare workflow projects if you check in the native d
 
 ### Expo Go
 
-[Expo Go](/get-started/expo-go/) provides a quick way to get started with your app development. It comes with a pre-configured set of libraries known as the Expo SDK. This makes experimentation much faster and brings the mobile development experience much closer to the web development experience.
+[Expo Go](/get-started/set-up-your-environment/?redirected=#how-would-you-like-to-develop) provides a quick way to get started with your app development. It comes with a pre-configured set of libraries known as the Expo SDK. This makes experimentation much faster and brings the mobile development experience much closer to the web development experience.
 
 Like any other tool, it too has its limitations:
 

--- a/docs/pages/get-started/introduction.mdx
+++ b/docs/pages/get-started/introduction.mdx
@@ -13,7 +13,7 @@ We also make [Expo Application Services (EAS)](https://expo.dev/eas), a set of s
 
 <BoxLink
   title="Quick start"
-  description="Create a project, set up youre development environment, and start developing."
+  description="Create a project, set up your development environment, and start developing."
   href="/get-started/create-a-project/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -39,7 +39,7 @@ It supports services such as [Authentication](https://firebase.google.com/docs/a
 
 You can consider using the Firebase JS SDK when you:
 
-- Want to use Firebase services such as Authentication, Firestore, Realtime Database, and Storage in your app and want to develop your app with [**Expo Go**](/get-started/expo-go/).
+- Want to use Firebase services such as Authentication, Firestore, Realtime Database, and Storage in your app and want to develop your app with [**Expo Go**](/get-started/set-up-your-environment/).
 - Want a quick start with Firebase services.
 - Want to create a universal app for Android, iOS, and the web.
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -233,7 +233,7 @@ The package `@expo/cli` is installed with the `expo` package. This is sometimes 
 
 ### Manifest
 
-An Expo app manifest is similar to a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest). It provides information that Expo Go needs to know how to run the app and other relevant data. For more information, see [Expo Go](/get-started/expo-go/#manifest).
+An Expo app manifest is similar to a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest). It provides information that Expo Go needs to know how to run the app and other relevant data.
 
 ### Meta
 

--- a/docs/pages/preview/dev-process-overview.mdx
+++ b/docs/pages/preview/dev-process-overview.mdx
@@ -64,7 +64,7 @@ Yes! We think EAS is a great fit for any React Native project.
 
 <Collapsible summary={`Expo Go: an optional tool for learning, experimenting, and prototyping`}>
 
-There's no faster way to spin up a React Native project and run it on your device or emulator than [Expo Go](/get-started/expo-go/), especially when combined with [Snack](https://snack.expo.dev/).
+There's no faster way to spin up a React Native project and run it on your device or emulator than [Expo Go](https://expo.dev/go), especially when combined with [Snack](https://snack.expo.dev/).
 
 However, **Expo Go and Snack are not intended for building production apps**. They are great when you're getting started on a project or for prototypes. **If you plan on deploying your app to the store, then [development builds](#development-builds) will provide a more flexible, reliable, and complete development environment.** This guide does not go into any detail about Expo Go, and this is the only section that mentions it.
 
@@ -157,7 +157,7 @@ Learn more about [cloud-based workflows with EAS Build](/build/introduction/) an
 
 ## Initialize and run a project
 
-The easiest way to [create a new project is with `create-expo-app`](/get-started/create-a-project/#initialize-a-new-project). After creating your project, you can immediately launch it directly in Expo Go on your physical device or in an emulator/simulator if you want to experiment or build a quick prototype.
+The easiest way to [create a new project is with `create-expo-app`](/get-started/create-a-project/). After creating your project, you can immediately launch it directly in Expo Go on your physical device or in an emulator/simulator if you want to experiment or build a quick prototype.
 
 In most cases, you will create and use a development build of your project. You will install the [`expo-dev-client`](/develop/development-builds/introduction/#what-is-expo-dev-client) library. Development builds can be created with EAS Build or locally on your machine:
 
@@ -201,8 +201,9 @@ The core development loop described in the diagram above is a cycle of four main
   config file.
 
 - <Highlight isBlue>**Write native code or modify native project configuration**</Highlight>: This
-  includes writing native code directly or modifying native code configuration. You either need access to
-  the native code project directories to make these changes, or you can write native code with a [local Expo Module](/modules/get-started/#adding-a-new-module-to-an-existing-application).
+  includes writing native code directly or modifying native code configuration. You either need
+  access to the native code project directories to make these changes, or you can write native code
+  with a [local Expo Module](/modules/get-started/#adding-a-new-module-to-an-existing-application).
 
 - <Highlight isBlue>**Install a library that requires native code modifications**</Highlight>: This
   includes that a library requires making changes to the native code project configuration. Either

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -26,7 +26,7 @@ Now, you can start your project by running:
 
 <Terminal cmd={['$ npx expo start']} />
 
-- To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/expo-go). As your application grows in complexity and you need more control, you can create a [development build](/develop/development-builds/introduction/).
+- To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/set-up-your-environment/#how-would-you-like-to-develop). As your application grows in complexity and you need more control, you can create a [development build](/develop/development-builds/introduction/).
 - Open the project in a web browser by pressing <kbd>w</kbd> in the Terminal UI. Press <kbd>a</kbd> for Android (Android Studio is required), or <kbd>i</kbd> for iOS (macOS with Xcode is required).
 
 </Step>
@@ -43,7 +43,7 @@ Ensure the version of Expo Router is compatible with the Expo SDK version your p
 
 ### Prerequisites
 
-Make sure your computer is [set up for running an Expo app](/get-started/installation/).
+Make sure your computer is [set up for running an Expo app](/get-started/create-a-project/).
 
 <Step label="1">
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -17,7 +17,7 @@ In this chapter, let's learn how to create a new Expo project and how to get it 
 We'll need the following tools to get started:
 
 - Install [Expo Go](https://expo.dev/client) on a physical device.
-- Prepare for development by [installing the required tools](/get-started/installation/#requirements).
+- Prepare for development by [installing the required tools](/get-started/create-a-project/).
 
 This tutorial also assumes that you have a basic knowledge of JavaScript and React. If you have never written React code, go through [the official React tutorial](https://react.dev/learn).
 
@@ -79,14 +79,14 @@ In the project directory, run the following command to start a <A href="/more/gl
 
 <Terminal cmd={['$ npx expo start']} />
 
-Once the development server is running, the easiest way to launch the app is on a physical device with Expo Go. For more information, see <A href="/get-started/create-a-project/#open-the-app-on-your-device">Open app on a device</A>.
+Once the development server is running, the easiest way to launch the app is on a physical device with Expo Go. For more information, see <A href="/get-started/start-developing/#open-the-app-on-your-device">Open app on a device</A>.
 
 To see the web app in action, press <kbd>w</kbd> in the terminal. It will open the web app in the default web browser.
 
 Once it is running on all platforms, the project should look like this:
 
 <ImageSpotlight
-  alt="App running on an all platforms"
+  alt="App running on all platforms"
   src="/static/images/tutorial/01-app-running-on-all-platforms.jpg"
   style={{ maxWidth: 720 }}
 />

--- a/docs/pages/versions/unversioned/sdk/captureRef.mdx
+++ b/docs/pages/versions/unversioned/sdk/captureRef.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -12,7 +12,7 @@ import { APIBox } from '~/components/plugins/APIBox';
 import { CALLOUT } from '~/ui/components/Text';
 import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `@shopify/react-native-skia` brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 

--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'macos', 'web', 'tvos']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import Video from '~/components/plugins/Video';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 

--- a/docs/pages/versions/v48.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/svg.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/v48.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/view-pager.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 

--- a/docs/pages/versions/v49.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/captureRef.mdx
@@ -8,7 +8,7 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 

--- a/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
@@ -8,7 +8,7 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v49.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/map-view.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 

--- a/docs/pages/versions/v49.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/picker.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
 

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 

--- a/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
@@ -12,7 +12,7 @@ import { APIBox } from '~/components/plugins/APIBox';
 import { CALLOUT } from '~/ui/components/Text';
 import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
@@ -59,8 +59,10 @@ function SomeComponent() {
 
 <APIBox header="edges">
 
-<CALLOUT theme="secondary">Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`</CALLOUT>
-<br/>
+<CALLOUT theme="secondary">
+  Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
+</CALLOUT>
+<br />
 
 Sets the edges to apply the safe area insets to.
 
@@ -69,7 +71,7 @@ Sets the edges to apply the safe area insets to.
 <APIBox header="emulateUnlessSupported">
 
 <CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
-<br/>
+<br />
 
 On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
 

--- a/docs/pages/versions/v49.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/skia.mdx
@@ -8,7 +8,7 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `@shopify/react-native-skia` brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 

--- a/docs/pages/versions/v49.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/slider.mdx
@@ -11,7 +11,7 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 

--- a/docs/pages/versions/v49.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/svg.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 

--- a/docs/pages/versions/v50.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/captureRef.mdx
@@ -8,7 +8,7 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 

--- a/docs/pages/versions/v50.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/flash-list.mdx
@@ -8,7 +8,7 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v50.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/map-view.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 

--- a/docs/pages/versions/v50.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/picker.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
 

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -12,7 +12,7 @@ import { APIBox } from '~/components/plugins/APIBox';
 import { CALLOUT } from '~/ui/components/Text';
 import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 

--- a/docs/pages/versions/v50.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/skia.mdx
@@ -8,7 +8,7 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `@shopify/react-native-skia` brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 

--- a/docs/pages/versions/v50.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/slider.mdx
@@ -11,7 +11,7 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 

--- a/docs/pages/versions/v50.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/svg.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 

--- a/docs/pages/versions/v51.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/captureRef.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 

--- a/docs/pages/versions/v51.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/flash-list.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 

--- a/docs/pages/versions/v51.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/lottie.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v51.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/map-view.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 

--- a/docs/pages/versions/v51.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/picker.mdx
@@ -11,7 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
 

--- a/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -12,7 +12,7 @@ import { APIBox } from '~/components/plugins/APIBox';
 import { CALLOUT } from '~/ui/components/Text';
 import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 

--- a/docs/pages/versions/v51.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/skia.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 `@shopify/react-native-skia` brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 

--- a/docs/pages/versions/v51.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/slider.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 {/* todo: add video */}
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 

--- a/docs/pages/versions/v51.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/svg.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'macos', 'web', 'tvos']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import Video from '~/components/plugins/Video';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -64,7 +64,7 @@ Yes! We think EAS is a great fit for any React Native project.
 
 <Collapsible summary={`Expo Go: an optional tool for learning, experimenting, and prototyping`}>
 
-There's no faster way to spin up a React Native project and run it on your device or emulator than [Expo Go](/get-started/expo-go/), especially when combined with [Snack](https://snack.expo.dev/).
+There's no faster way to spin up a React Native project and run it on your device or emulator than [Expo Go](https://expo.dev/go), especially when combined with [Snack](https://snack.expo.dev/).
 
 However, **Expo Go and Snack are not intended for building production apps**. They are great when you're getting started on a project or for prototypes. **If you plan on deploying your app to the store, then [development builds](#development-builds) will provide a more flexible, reliable, and complete development environment.** This guide does not go into any detail about Expo Go, and this is the only section that mentions it.
 
@@ -159,7 +159,7 @@ Learn more about [cloud-based workflows with EAS Build](/build/introduction/) an
 
 ## Initialize and run a project
 
-The easiest way to [create a new project is with `create-expo-app`](/get-started/create-a-project/#initialize-a-new-project). After creating your project, you can immediately launch it directly in Expo Go on your physical device or in an emulator/simulator if you want to experiment or build a quick prototype.
+The easiest way to [create a new project is with `create-expo-app`](/get-started/create-a-project/). After creating your project, you can immediately launch it directly in Expo Go on your physical device or in an emulator/simulator if you want to experiment or build a quick prototype.
 
 In most cases, you will create and use a development build of your project. You will install the [`expo-dev-client`](/develop/development-builds/introduction/#what-is-expo-dev-client) library. Development builds can be created with EAS Build or locally on your machine:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #28511

Fixes in this PR:
- Update links of Expo Go doc to either Expo Go landing page (in API references) and in some niche cases, different guides inside the new Get started section
- Remove duplicate redirects
- Use trailing slash (using `.../expo-go` didn't work but `.../expo-go/ worked as a rediect, might related to Next.js trailing slash behavior)
- Apply docs prettier formatting to some of the docs
- Update some old redirects to directly redirect to the new get started pages
- Fix typo in Get started > Introduction > BoxLink

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
