### PR TITLE
[docs] Add "USB" to Vale's heading case rule

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -221,6 +221,7 @@ exceptions:
   - '.*Update.*'
   - '.*Watchman.*'
   - '.*UI.*'
+  - '.*USB.*'
   - '.*URI.*'
   - '.*URL.*'
   - '.*URLs.*'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After recent doc updates, we have the following warning in Vale.

![CleanShot 2024-05-08 at 00 55 55@2x](https://github.com/expo/expo/assets/10234615/100abdb4-bd42-4bb9-9abe-e9ccad292250)


# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding `USB` to the HeadingCase rule.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running `yarn lint-prose` locally and making sure there aren't any warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
