### PR TITLE
[dev-launcher][updates] fix loading error when no runtimeVersion specified

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed loading error when both `expo-dev-client` and `expo-updates` installed but no `runtimeVersion` configured. ([#28662](https://github.com/expo/expo/pull/28662) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 4.0.11 — 2024-05-04

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -41,7 +41,7 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
       val runtimeVersion = getRuntimeVersion(context)
       val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
 
-      if (updatesInterface == null || updatesInterface?.validateUpdateWithConfiguration(configuration, context) == false) {
+      if (updatesInterface?.isValidUpdatesConfiguration(configuration, context) != true) {
         manifest = manifestParser.parseManifest()
         if (!manifest!!.isUsingDeveloperTool()) {
           throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactory.kt
@@ -38,15 +38,16 @@ class DevLauncherAppLoaderFactory : DevLauncherKoinComponent, DevLauncherAppLoad
       // It's (maybe) a raw React Native bundle
       DevLauncherReactNativeAppLoader(url, appHost, context, controller)
     } else {
-      if (updatesInterface == null) {
+      val runtimeVersion = getRuntimeVersion(context)
+      val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
+
+      if (updatesInterface == null || updatesInterface?.validateUpdateWithConfiguration(configuration, context) == false) {
         manifest = manifestParser.parseManifest()
         if (!manifest!!.isUsingDeveloperTool()) {
           throw Exception("expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages.")
         }
         DevLauncherLocalAppLoader(manifest!!, appHost, context, controller)
       } else {
-        val runtimeVersion = getRuntimeVersion(context)
-        val configuration = createUpdatesConfigurationWithUrl(url, projectUrl, runtimeVersion, installationIDHelper.getOrCreateInstallationID(context))
         val update = updatesInterface!!.loadUpdate(configuration, context) {
           manifest = Manifest.fromManifestJson(it) // TODO: might be able to pass actual manifest object in here
           return@loadUpdate !manifest!!.isUsingDeveloperTool()

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -48,6 +48,11 @@ internal class DevLauncherUpdatesHelperTest {
     val updatesInterface = mockk<UpdatesInterface>()
     val slot = slot<UpdatesInterface.UpdateCallback>()
     every {
+      updatesInterface.validateUpdateWithConfiguration(any(), any())
+    } answers {
+      true
+    }
+    every {
       updatesInterface.fetchUpdateWithConfiguration(any(), any(), capture(slot))
     } answers {
       val callback = slot.captured

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelperTest.kt
@@ -48,7 +48,7 @@ internal class DevLauncherUpdatesHelperTest {
     val updatesInterface = mockk<UpdatesInterface>()
     val slot = slot<UpdatesInterface.UpdateCallback>()
     every {
-      updatesInterface.validateUpdateWithConfiguration(any(), any())
+      updatesInterface.isValidUpdatesConfiguration(any(), any())
     } answers {
       true
     }

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -13,6 +13,7 @@ import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.manifests.core.Manifest
 import expo.modules.updatesinterface.UpdatesInterface
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
@@ -94,6 +95,8 @@ internal class DevLauncherAppLoaderFactoryTest {
   fun `loads app locally if manifest indicates developer tool and updatesInterface exists`() = runBlocking<Unit> {
     mockUpdatesInterface(developmentManifestJSONString) {
       Truth.assertThat(it).isFalse()
+    }.let { updatesInterface ->
+      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -109,6 +112,8 @@ internal class DevLauncherAppLoaderFactoryTest {
   fun `loads published app if manifest is published and updatesInterface exists`() = runBlocking<Unit> {
     mockUpdatesInterface(publishedManifestJSONString) {
       Truth.assertThat(it).isTrue()
+    }.let { updatesInterface ->
+      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -120,7 +125,26 @@ internal class DevLauncherAppLoaderFactoryTest {
     Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isFalse()
   }
 
-  private fun mockUpdatesInterface(manifestJSONString: String, verifyShouldContinue: (Boolean) -> Unit) {
+  @Test
+  fun `loads app locally if manifest indicates developer tool but updates is mis-configured`() = runBlocking<Unit> {
+    mockUpdatesInterface(developmentManifestJSONString) {
+      Truth.assertThat(it).isTrue()
+    }.let { updatesInterface ->
+      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns false
+    }
+    val appLoaderFactory = DevLauncherAppLoaderFactory()
+
+    val manifestParser = mockk<DevLauncherManifestParser>()
+    val manifest = Manifest.fromManifestJson(JSONObject(developmentManifestJSONString))
+    coEvery { manifestParser.isManifestUrl() } returns true
+    coEvery { manifestParser.parseManifest() } returns manifest
+
+    val appLoader = appLoaderFactory.createAppLoader(developmentManifestURL, developmentManifestURL, manifestParser)
+    Truth.assertThat(appLoader).isInstanceOf(DevLauncherLocalAppLoader::class.java)
+    Truth.assertThat(appLoaderFactory.shouldUseDeveloperSupport()).isTrue()
+  }
+
+  private fun mockUpdatesInterface(manifestJSONString: String, verifyShouldContinue: (Boolean) -> Unit): UpdatesInterface {
     val updatesInterface = mockk<UpdatesInterface>()
     val manifest = JSONObject(manifestJSONString)
     val slot = slot<(JSONObject) -> Boolean>()
@@ -151,5 +175,7 @@ internal class DevLauncherAppLoaderFactoryTest {
         }
       )
     )
+
+    return updatesInterface
   }
 }

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherAppLoaderFactoryTest.kt
@@ -96,7 +96,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(developmentManifestJSONString) {
       Truth.assertThat(it).isFalse()
     }.let { updatesInterface ->
-      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns true
+      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -113,7 +113,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(publishedManifestJSONString) {
       Truth.assertThat(it).isTrue()
     }.let { updatesInterface ->
-      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns true
+      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns true
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 
@@ -130,7 +130,7 @@ internal class DevLauncherAppLoaderFactoryTest {
     mockUpdatesInterface(developmentManifestJSONString) {
       Truth.assertThat(it).isTrue()
     }.let { updatesInterface ->
-      every { updatesInterface.validateUpdateWithConfiguration(any(), any()) } returns false
+      every { updatesInterface.isValidUpdatesConfiguration(any(), any()) } returns false
     }
     val appLoaderFactory = DevLauncherAppLoaderFactory()
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -503,7 +503,7 @@
       return;
     }
 
-    if (!self->_updatesInterface || ![self->_updatesInterface validateUpdateWithConfiguration:updatesConfiguration]) {
+    if ([self->_updatesInterface isValidUpdatesConfiguration:updatesConfiguration] != YES) {
       [manifestParser tryToParseManifest:^(EXManifestsManifest *manifest) {
         if (!manifest.isUsingDeveloperTool) {
           onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: @"expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages."}]);

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -503,7 +503,7 @@
       return;
     }
 
-    if (!self->_updatesInterface) {
+    if (!self->_updatesInterface || ![self->_updatesInterface validateUpdateWithConfiguration:updatesConfiguration]) {
       [manifestParser tryToParseManifest:^(EXManifestsManifest *manifest) {
         if (!manifest.isUsingDeveloperTool) {
           onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: @"expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages."}]);

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed loading error when both `expo-dev-client` and `expo-updates` installed but no `runtimeVersion` configured. ([#28662](https://github.com/expo/expo/pull/28662) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.16.1 — 2024-04-29

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -31,5 +31,5 @@ interface UpdatesInterface {
 
   fun reset()
   fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback)
-  fun validateUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean
+  fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean
 }

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -31,4 +31,5 @@ interface UpdatesInterface {
 
   fun reset()
   fun fetchUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: UpdateCallback)
+  fun validateUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -33,6 +33,8 @@ public protocol UpdatesExternalInterface {
     success successBlock: @escaping UpdatesUpdateSuccessBlock,
     error errorBlock: @escaping UpdatesErrorBlock
   )
+
+  @objc func validateUpdate(withConfiguration configuration: [String: Any]) -> Bool
 }
 
 /**

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -34,7 +34,7 @@ public protocol UpdatesExternalInterface {
     error errorBlock: @escaping UpdatesErrorBlock
   )
 
-  @objc func validateUpdate(withConfiguration configuration: [String: Any]) -> Bool
+  @objc func isValidUpdatesConfiguration(_ configuration: [String: Any]) -> Bool
 }
 
 /**

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed loading error when both `expo-dev-client` and `expo-updates` installed but no `runtimeVersion` configured. ([#28662](https://github.com/expo/expo/pull/28662) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.25.9 — 2024-05-07

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -3,6 +3,7 @@ package expo.modules.updates
 import android.content.Context
 import android.os.AsyncTask
 import android.os.Bundle
+import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.AppContext
@@ -186,7 +187,8 @@ class UpdatesDevLauncherController(
     return try {
       createUpdatesConfiguration(configuration, context)
       true
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+      Log.e(TAG, "Invalid updates configuration: ${e.localizedMessage}")
       false
     }
   }
@@ -348,5 +350,9 @@ class UpdatesDevLauncherController(
     callback: IUpdatesController.ModuleCallback<Unit>
   ) {
     callback.onFailure(NotAvailableInDevClientException("Updates.setExtraParamAsync() is not supported in development builds."))
+  }
+
+  companion object {
+    private val TAG = UpdatesDevLauncherController::class.java.simpleName
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -114,7 +114,13 @@ class UpdatesDevLauncherController(
     context: Context,
     callback: UpdatesInterface.UpdateCallback
   ) {
-    val newUpdatesConfiguration = validateConfig(configuration, context)
+    val newUpdatesConfiguration: UpdatesConfiguration
+    try {
+      newUpdatesConfiguration = createUpdatesConfiguration(configuration, context)
+    } catch (e: Exception) {
+      callback.onFailure(e)
+      return
+    }
     check(updatesDirectory != null)
 
     // since controller is a singleton, save its config so we can reset to it if our request fails
@@ -176,9 +182,9 @@ class UpdatesDevLauncherController(
     })
   }
 
-  override fun validateUpdateWithConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean {
+  override fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): Boolean {
     return try {
-      validateConfig(configuration, context)
+      createUpdatesConfiguration(configuration, context)
       true
     } catch (_: Exception) {
       false
@@ -186,7 +192,7 @@ class UpdatesDevLauncherController(
   }
 
   @Throws(Exception::class)
-  private fun validateConfig(configuration: HashMap<String, Any>, context: Context): UpdatesConfiguration {
+  private fun createUpdatesConfiguration(configuration: HashMap<String, Any>, context: Context): UpdatesConfiguration {
     if (updatesDirectory == null) {
       throw updatesDirectoryException!!
     }

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -160,7 +160,13 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   }
 
   public func isValidUpdatesConfiguration(_ configuration: [String: Any]) -> Bool {
-    return (try? createUpdatesConfiguration(configuration)) != nil
+    do {
+      try createUpdatesConfiguration(configuration)
+      return true
+    } catch let error {
+      NSLog("Invalid updates configuration: %@", error.localizedDescription)
+    }
+    return false
   }
 
   public func selectionPolicy() -> SelectionPolicy {

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -102,65 +102,11 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     success successBlock: @escaping UpdatesUpdateSuccessBlock,
     error errorBlock: @escaping UpdatesErrorBlock
   ) {
-    if let directoryDatabaseException = directoryDatabaseException {
-      errorBlock(directoryDatabaseException)
-      return
-    }
-
-    // swiftlint:disable:next identifier_name
-    let updatesConfigurationValidationResult = UpdatesConfig.getUpdatesConfigurationValidationResult(mergingOtherDictionary: configuration)
-    switch updatesConfigurationValidationResult {
-    case .Valid:
-      break
-    case .InvalidNotEnabled:
-      errorBlock(NSError(
-        domain: DevLauncherAppController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object is not enabled"
-        ]
-      ))
-      return
-    case .InvalidPlistError:
-      errorBlock(NSError(
-        domain: DevLauncherAppController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: invalid Expo.plist"
-        ]
-      ))
-      return
-    case .InvalidMissingURL:
-      errorBlock(NSError(
-        domain: DevLauncherAppController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid update URL"
-        ]
-      ))
-      return
-    case .InvalidMissingRuntimeVersion:
-      errorBlock(NSError(
-        domain: DevLauncherAppController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid runtime version"
-        ]
-      ))
-      return
-    }
-
-    var updatesConfiguration: UpdatesConfig
+    let updatesConfiguration: UpdatesConfig
     do {
-      updatesConfiguration = try UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: configuration)
-    } catch {
-      errorBlock(NSError(
-        domain: DevLauncherAppController.ErrorDomain,
-        code: ErrorCode.configFailed.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
-        ]
-      ))
+      updatesConfiguration = try validateConfig(configuration)
+    } catch let error {
+      errorBlock(error)
       return
     }
 
@@ -213,6 +159,10 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     }
   }
 
+  public func validateUpdate(withConfiguration configuration: [String: Any]) -> Bool {
+    return (try? validateConfig(configuration)) != nil
+  }
+
   public func selectionPolicy() -> SelectionPolicy {
     if _selectionPolicy == nil {
       _selectionPolicy = defaultSelectionPolicy
@@ -224,6 +174,65 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   }
   public func resetSelectionPolicyToDefault() {
     _selectionPolicy = nil
+  }
+
+  private func validateConfig(_ configuration: [String: Any]) throws -> UpdatesConfig {
+    if let directoryDatabaseException = directoryDatabaseException {
+      throw directoryDatabaseException
+    }
+
+    // swiftlint:disable:next identifier_name
+    let updatesConfigurationValidationResult = UpdatesConfig.getUpdatesConfigurationValidationResult(mergingOtherDictionary: configuration)
+    switch updatesConfigurationValidationResult {
+    case .Valid:
+      break
+    case .InvalidNotEnabled:
+      throw NSError(
+        domain: DevLauncherAppController.ErrorDomain,
+        code: ErrorCode.invalidUpdateURL.rawValue,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object is not enabled"
+        ]
+      )
+    case .InvalidPlistError:
+      throw NSError(
+        domain: DevLauncherAppController.ErrorDomain,
+        code: ErrorCode.invalidUpdateURL.rawValue,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Failed to read stored updates: invalid Expo.plist"
+        ]
+      )
+    case .InvalidMissingURL:
+      throw NSError(
+        domain: DevLauncherAppController.ErrorDomain,
+        code: ErrorCode.invalidUpdateURL.rawValue,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid update URL"
+        ]
+      )
+    case .InvalidMissingRuntimeVersion:
+      throw NSError(
+        domain: DevLauncherAppController.ErrorDomain,
+        code: ErrorCode.invalidUpdateURL.rawValue,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid runtime version"
+        ]
+      )
+    }
+
+    let updatesConfiguration: UpdatesConfig
+    do {
+      updatesConfiguration = try UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: configuration)
+    } catch {
+      throw NSError(
+        domain: DevLauncherAppController.ErrorDomain,
+        code: ErrorCode.configFailed.rawValue,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+        ]
+      )
+    }
+    return updatesConfiguration
   }
 
   private func setDevelopmentSelectionPolicy() {

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -104,7 +104,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   ) {
     let updatesConfiguration: UpdatesConfig
     do {
-      updatesConfiguration = try validateConfig(configuration)
+      updatesConfiguration = try createUpdatesConfiguration(configuration)
     } catch let error {
       errorBlock(error)
       return
@@ -159,8 +159,8 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     }
   }
 
-  public func validateUpdate(withConfiguration configuration: [String: Any]) -> Bool {
-    return (try? validateConfig(configuration)) != nil
+  public func isValidUpdatesConfiguration(_ configuration: [String: Any]) -> Bool {
+    return (try? createUpdatesConfiguration(configuration)) != nil
   }
 
   public func selectionPolicy() -> SelectionPolicy {
@@ -176,7 +176,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     _selectionPolicy = nil
   }
 
-  private func validateConfig(_ configuration: [String: Any]) throws -> UpdatesConfig {
+  private func createUpdatesConfiguration(_ configuration: [String: Any]) throws -> UpdatesConfig {
     if let directoryDatabaseException = directoryDatabaseException {
       throw directoryDatabaseException
     }


### PR DESCRIPTION
# Why

fix loading error with expo-dev-client and expo-updates installed but no runtimeVersion configured

# How

add a `isValidUpdatesConfiguration()` function to validate updates configuration beforehand. if failed, just using dev-launcher's local loader to load the app.

# Test Plan

```sh
$ yarn create expo -t blank@sdk-51 sdk51
$ cd sdk51
$ npx expo install expo-dev-client expo-updates
$ npx expo run:ios
$ npx expo run:android
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
