### PR TITLE
[docs] Fix installation step's command in Unit testing guide

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -17,7 +17,15 @@ You'll also use the `jest-expo` package, which is a Jest preset and mocks the na
 
 To install `jest-expo` in your project, run the following command:
 
-<Terminal cmd={['$ npx expo install -- --save-dev jest-expo jest']} />
+<Terminal
+  cmd={[
+    '# For all other package managers',
+    '$ npx expo install -- --save-dev jest-expo jest',
+    '',
+    '# For yarn',
+    '$ yarn add -D jest-expo jest',
+  ]}
+/>
 
 > **info** If you are using TypeScript, then also install `@types/jest` as a dev dependency.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the [installation section in Unit testing guide](https://docs.expo.dev/develop/unit-testing/#installation) does not consider if one using yarn. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the Installation section to recommend `npx expo install...` for other package managers and include Yarn specific command.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/unit-testing/

## Preview

![CleanShot 2024-05-08 at 01 29 27@2x](https://github.com/expo/expo/assets/10234615/d74f44d5-f3d8-4360-b9fb-fe5988f3f55f)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
