### PR TITLE
[dev-launcher][dev-menu] Fix DevMenu getting unresponsive after reloading bundle on iOS

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed DevMenu getting unresponsive after reloading bundle. ([#28664](https://github.com/expo/expo/pull/28664) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 4.0.11 — 2024-05-04

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -672,6 +672,8 @@
     // expo-dev-menu registers its commands here: https://github.com/expo/expo/blob/6da15324ff0b4a9cb24055e9815b8aa11f0ac3af/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift#L27-L29
     [[RCTKeyCommands sharedInstance] unregisterKeyCommandWithInput:@"d"
                                                      modifierFlags:UIKeyModifierCommand];
+    [[RCTKeyCommands sharedInstance] unregisterKeyCommandWithInput:@"r"
+                                                    modifierFlags:UIKeyModifierCommand];
   }
 }
 
@@ -722,7 +724,7 @@
 - (void)setDevMenuAppBridge
 {
   DevMenuManager *manager = [DevMenuManager shared];
-  manager.currentBridge = self.appBridge;
+  manager.currentBridge = self.appBridge.parentBridge;
 
   if (self.manifest != nil) {
     manager.currentManifest = self.manifest;

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed DevMenu getting unresponsive after reloading bundle. ([#28664](https://github.com/expo/expo/pull/28664) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 5.0.12 — 2024-05-04

--- a/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
+++ b/packages/expo-dev-menu/ios/DevClientRootViewFactory.mm
@@ -2,6 +2,8 @@
 
 #import "DevClientRootViewFactory.h"
 #import <EXDevMenu/DevMenuRCTBridge.h>
+#import <EXDevMenu/DevMenuLoadingView.h>
+#import <EXDevMenu/DevMenuRCTDevSettings.h>
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 #import <React-RCTAppDelegate/RCTAppDelegate.h>
@@ -32,6 +34,15 @@
   }
 
   self.bridge = [[DevMenuRCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  NSMutableArray<id<RCTBridgeModule>> *modules = [NSMutableArray new];
+  [modules addObject:[[DevMenuLoadingView alloc] init]];
+  [modules addObject:[[DevMenuRCTDevSettings alloc] init]];
+
+  return modules;
 }
 
 #pragma mark - RCTCxxBridgeDelegate

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -45,12 +45,6 @@ class DevMenuAppInstance: DevMenuRCTAppDelegate {
     return jsSourceUrl()
   }
 
-  override func extraModules(for bridge: RCTBridge) -> [RCTBridgeModule] {
-    var modules: [RCTBridgeModule] = [DevMenuLoadingView.init()]
-    modules.append(DevMenuRCTDevSettings.init())
-    return modules
-  }
-
   override func bridge(_ bridge: RCTBridge, didNotFindModule moduleName: String) -> Bool {
     return moduleName == "DevMenu"
   }

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.h
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.h
@@ -6,6 +6,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface RCTRootViewFactory ()
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
+
+@end
+
 @interface DevMenuRCTCxxBridge : RCTCxxBridge
 
 - (NSArray<Class> *)filterModuleList:(NSArray<Class> *)modules;

--- a/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuExtensions.swift
@@ -78,6 +78,7 @@ open class DevMenuExtensions: NSObject, DevMenuExtensionProtocol {
     reload.label = { "Reload" }
     reload.glyphName = { "reload" }
     reload.importance = DevMenuScreenItem.ImportanceHighest
+    reload.registerKeyCommand(input: "r", modifiers: []) // "r" without modifiers
     return reload
   }
 

--- a/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuAppInstanceTest.swift
@@ -51,7 +51,7 @@ class DevMenuAppInstanceTest: QuickSpec {
         bridge: mockedBridge
       )
 
-      let extraModules = appInstance.extraModules(for: mockedBridge)
+      let extraModules = appInstance.rootViewFactory.extraModules(for: mockedBridge)
 
       expect(extraModules.first { type(of: $0).moduleName() == "DevLoadingView" }).toNot(beNil())
       expect(extraModules.first { type(of: $0).moduleName() == "DevSettings" }).toNot(beNil())


### PR DESCRIPTION
# Why

Closes ENG-12256

# How

- Configure `extraModulesForBridge` inside `DevClientRootViewFactory` given that RCTRootViewFactory sets itself as the `RCTCxxBridgeDelegate`
- Unregister react-native's default "r" hotkey to reload bundle and add back our custom DevMenu reload hotkey
- Use `parentBridge` for `DevMenuManager`
 
# Test Plan

Run BareExpo on iOS Sim and real device

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
