### PR TITLE
[camera] Fix scanning ean13 barcodes

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fix `ean13` barcodes not returning data.
+
 ### 💡 Others
 
 ## 15.0.3 — 2024-04-29

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fix `ean13` barcodes not returning data.
+- On `iOS`, fix `ean13` barcodes not returning data. ([#28674](https://github.com/expo/expo/pull/28674) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -41,7 +41,7 @@ class BarcodeScannerUtils {
         result["data"] = value.dropFirst()
       }
     }
-    
+
     if !barcodeScannerResult.corners.isEmpty {
       var cornerPointsResult = [[String: Any]]()
       for point in barcodeScannerResult.corners {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -32,6 +32,7 @@ class BarcodeScannerUtils {
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = barcodeScannerResult.type
+    result["data"] = barcodeScannerResult.stringValue
 
     // iOS converts upc_a to ean13 and appends a leading 0
     if barcodeScannerResult.type == AVMetadataObject.ObjectType.ean13 {
@@ -39,10 +40,8 @@ class BarcodeScannerUtils {
       if !value.isEmpty && value.hasPrefix("0") {
         result["data"] = value.dropFirst()
       }
-    } else {
-      result["data"] = barcodeScannerResult.stringValue
     }
-
+    
     if !barcodeScannerResult.corners.isEmpty {
       var cornerPointsResult = [[String: Any]]()
       for point in barcodeScannerResult.corners {


### PR DESCRIPTION
# Why
Closes #28671
Fixes a small regression from #28233 where `ean13` barcodes would not have the `data` value set. This was caused by the workaround needed to return correct values for `upc_a` barcodes.

# How
Set this value regardless.

# Test Plan
Bare-expo scanning `ean13` barcodes works as expected
