### PR TITLE
[docs] Fix expo module .xcframework and .framwork ios dependency configuration example

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -104,7 +104,7 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 ```diff ios/ExpoRadialChart.podspec
     s.static_framework = true
     s.dependency 'ExpoModulesCore'
-+   s.vendored_frameworks 'Frameworks/MyFramework.framework'
++   s.vendored_frameworks = 'Frameworks/MyFramework.framework'
     # Swift/Objective-C compatibility
 ```
 


### PR DESCRIPTION
# Why

I was walking through the docs in order to integrate a third-party native lib with my expo react native app. After creating a new local module for this third-party lib, I added the dependency for the xcframework folder I had. However, when trying to run `pod install --project-directory=ios` as recommended by the docs I was running into an error `undefined method 'vendored_frameworks'`.

# How

I came across [this](https://stackoverflow.com/questions/69437773/podspec-debug-release-vendored-framework-variants) stack overflow post that had a slightly different syntax to what was in the expo docs. I tried it and it worked.