### PR TITLE
[screen-orientation] Change var type to non-weak to fix orientation listeners.

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug with weak var type causing dropped events.
+
 ### 💡 Others
 
 ## 7.0.3 — 2024-05-01

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix bug with weak var type causing dropped events.
+- Fix bug with weak var type causing dropped events. ([#28677](https://github.com/expo/expo/pull/28677) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -18,7 +18,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   var orientationControllers: [ScreenOrientationController] = []
   var controllerInterfaceMasks: [ObjectIdentifier: UIInterfaceOrientationMask] = [:]
   @objc
-  public weak var currentTraitCollection: UITraitCollection?
+  public var currentTraitCollection: UITraitCollection?
   var lastOrientationMask: UIInterfaceOrientationMask
   var rootViewController: UIViewController? {
     let keyWindow = UIApplication


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/26813

# How

After some debugging I found that `traitCollectionDidChange` in `ScreenOrientationRegistry` was receiving a `nil` argument due to this weak ref. Not sure why this is related to light/dark mode but it did fix the issue I was able to reliably reproduce.

I think we actually want this to be a non-weak ref and for the shared controller to hold a reference to a current trait collection.

# Test Plan

Tested in simulator on Expo Go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
