### PR TITLE
[docs] Add a redirect for `/learn` to point towards Tutorial > Introduction page

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -457,4 +457,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/overview/': '/get-started/introduction/',
   '/get-started/installation/': '/get-started/create-a-project/',
   '/get-started/expo-go/': '/get-started/set-up-your-environment/',
+
+  // Redirect for /learn URL
+  '/learn/': '/tutorial/introduction/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -358,6 +358,8 @@ redirects[/overview]=get-started/introduction
 redirects[/get-started/installation]=get-started/create-a-project
 redirects[/get-started/expo-go]=get-started/set-up-your-environment
 
+# Redirect for /learn URL
+redirects[/learn]=tutorial/introduction
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Noticed that in the new template's README file generated has link to `/learn` section but the we use `/tutorial`. 

![CleanShot 2024-05-08 at 18 16 39@2x](https://github.com/expo/expo/assets/10234615/4a6175d7-78f2-416b-9036-739740dfb593)


This PR adds a redirect for `/learn` to direct users to `/tutorial/introduction/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
