### PR TITLE
[core][Android] Add `onKeyDown` and `onKeyLongPress`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added `onKeyDown` and `onKeyLongPress` to `ReactActivityHandler` on Android.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added `onKeyDown` and `onKeyLongPress` to `ReactActivityHandler` on Android.
+- Added `onKeyDown` and `onKeyLongPress` to `ReactActivityHandler` on Android. ([#28684](https://github.com/expo/expo/pull/28684) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactNativeHost;
-import com.facebook.react.ReactRootView;
 
 import androidx.annotation.Nullable;
 
@@ -39,9 +38,33 @@ public interface ReactActivityHandler {
   }
 
   /**
-   * Gives modules a chance to override the wrapped ReactActivityDelegate instance.
-   * @return a new ReactActivityDelegate instance, or null if not to override
+   * Gives modules a chance to respond to `onKeyDown` events. Every listener will receive this
+   * callback, but the delegate will not receive the event unless if any of the listeners consume it
+   * (i.e. return `true` from this method).
+   * `ReactActivityDelegateWrapper.onKeyDown` will return `true` if any module returns `true`.
+   *
+   * @return true if this module wants to return `true` from `ReactActivityDelegateWrapper.onKeyDown`
    */
+  default boolean onKeyDown(int keyCode, @Nullable KeyEvent event) {
+    return false;
+  }
+
+  /**
+   * Gives modules a chance to respond to `onKeyLongPress` events. Every listener will receive this
+   * callback, but the delegate will not receive the event unless if any of the listeners consume it
+   * (i.e. return `true` from this method).
+   * `ReactActivityDelegateWrapper.onKeyLongPress` will return `true` if any module returns `true`.
+   *
+   * @return true if this module wants to return `true` from `ReactActivityDelegateWrapper.onKeyLongPress`
+   */
+  default boolean onKeyLongPress(int keyCode, @Nullable KeyEvent event) {
+    return false;
+  }
+
+    /**
+     * Gives modules a chance to override the wrapped ReactActivityDelegate instance.
+     * @return a new ReactActivityDelegate instance, or null if not to override
+     */
   @Nullable
   default ReactActivityDelegate onDidCreateReactActivityDelegate(ReactActivity activity, ReactActivityDelegate delegate) {
     return null;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
@@ -18,6 +18,7 @@ public interface ReactActivityHandler {
   /**
    * Gives modules a chance to create a ViewGroup that is used as a container for the ReactRootView,
    * which is added as a child to the container if non-null.
+   *
    * @return a ViewGroup to be used as a container, or null if no container is needed
    */
   @Nullable
@@ -61,10 +62,11 @@ public interface ReactActivityHandler {
     return false;
   }
 
-    /**
-     * Gives modules a chance to override the wrapped ReactActivityDelegate instance.
-     * @return a new ReactActivityDelegate instance, or null if not to override
-     */
+  /**
+   * Gives modules a chance to override the wrapped ReactActivityDelegate instance.
+   *
+   * @return a new ReactActivityDelegate instance, or null if not to override
+   */
   @Nullable
   default ReactActivityDelegate onDidCreateReactActivityDelegate(ReactActivity activity, ReactActivityDelegate delegate) {
     return null;
@@ -79,6 +81,7 @@ public interface ReactActivityHandler {
   default DelayLoadAppHandler getDelayLoadAppHandler(ReactActivity activity, ReactNativeHost reactNativeHost) {
     return null;
   }
+
   interface DelayLoadAppHandler {
     void whenReady(Runnable runnable);
   }

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -242,7 +242,11 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-    return delegate.onKeyDown(keyCode, event)
+    // if any of the handlers return true, intentionally consume the event instead of passing it
+    // through to the delegate
+    return reactActivityHandlers
+      .map { it.onKeyDown(keyCode, event) }
+      .fold(false) { accu, current -> accu || current } || delegate.onKeyDown(keyCode, event)
   }
 
   override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
@@ -254,7 +258,11 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
-    return delegate.onKeyLongPress(keyCode, event)
+    // if any of the handlers return true, intentionally consume the event instead of passing it
+    // through to the delegate
+    return reactActivityHandlers
+      .map { it.onKeyLongPress(keyCode, event) }
+      .fold(false) { accu, current -> accu || current } || delegate.onKeyLongPress(keyCode, event)
   }
 
   override fun onBackPressed(): Boolean {


### PR DESCRIPTION
# Why

Adds two methods to `ReactActivityHandler`: `onKeyDown` and `onKeyLongPress`.
Internally, in SWM, we have use cases for those methods. 

# Test Plan

- bare-expo ✅ 