### PR TITLE
[dev-launcher] fix https dev server support

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed loading error when both `expo-dev-client` and `expo-updates` installed but no `runtimeVersion` configured. ([#28662](https://github.com/expo/expo/pull/28662) by [@kudo](https://github.com/kudo))
+- Fixed loading error from a https dev-server on Android. ([#28691](https://github.com/expo/expo/pull/28691) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
@@ -2,17 +2,36 @@ package com.facebook.react.devsupport
 
 import android.content.Context
 import android.net.Uri
+import com.facebook.react.devsupport.interfaces.PackagerStatusCallback
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+private const val PACKAGER_OK_STATUS = "packager-status:running"
+private const val HTTP_CONNECT_TIMEOUT_MS = 5000L
+private const val PACKAGER_STATUS_ENDPOINT = "status"
 
 class DevLauncherDevServerHelper(
   context: Context,
   private val controller: DevLauncherControllerInterface?,
   devSettings: DeveloperSettings,
   packagerConnection: PackagerConnectionSettings
-) :
-  DevServerHelper(devSettings, context.packageName, packagerConnection) {
+) : DevServerHelper(devSettings, context.packageName, packagerConnection) {
+
+  private val httpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
+      .connectTimeout(HTTP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+      .readTimeout(0, TimeUnit.MILLISECONDS)
+      .writeTimeout(0, TimeUnit.MILLISECONDS)
+      .build()
+  }
 
   override fun getDevServerBundleURL(jsModulePath: String?): String {
     return controller?.manifest?.getBundleURL() ?: super.getDevServerBundleURL(jsModulePath)
@@ -46,5 +65,36 @@ class DevLauncherDevServerHelper(
       "$key=$value"
     }
     return "$defaultValue&$customOptionsString"
+  }
+
+  /**
+   * Re-implement [PackagerStatusCheck](https://github.com/facebook/react-native/blob/958f8e2bb55ba3a2ac/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.java)
+   * to support https.
+   */
+  override fun isPackagerRunning(callback: PackagerStatusCallback) {
+    val bundleURL = controller?.manifest?.getBundleURL() ?: return super.isPackagerRunning(callback)
+    val bundleUri = Uri.parse(bundleURL)
+    val statusUrl = bundleUri.buildUpon()
+      .path(PACKAGER_STATUS_ENDPOINT)
+      .clearQuery()
+      .build()
+      .toString()
+    val request = Request.Builder().url(statusUrl).build()
+    httpClient
+      .newCall(request)
+      .enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+          callback.onPackagerStatusFetched(false)
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+          if (!response.isSuccessful) {
+            callback.onPackagerStatusFetched(false)
+            return
+          }
+          val body = response.body?.string() ?: ""
+          callback.onPackagerStatusFetched(body == PACKAGER_OK_STATUS)
+        }
+      })
   }
 }


### PR DESCRIPTION
# Why

fix https dev server support for dev-launcher on android

# How

- the loader will check if dev-server packager is running but the checker has [hardcoded http](https://github.com/facebook/react-native/blob/958f8e2bb55ba3a2ace9507a48a582f546dd3ec2/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.java#L30)
- since we have our own DevLauncherDevServerHelper now, we could re-implement the checker with https support.

# Test Plan

with expo-dev-client to load `npx expo start --tunnel` project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
