### PR TITLE
[cli] Fix HTTPS tunneling for usernames with dot

### DIFF
--- a/apps/fabric-tester/ios/fabrictester/PrivacyInfo.xcprivacy
+++ b/apps/fabric-tester/ios/fabrictester/PrivacyInfo.xcprivacy
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array/>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string></string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array/>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.18.10 — 2024-05-07

--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -51,7 +51,8 @@ export class AsyncNgrok {
     return [
       // NOTE: https://github.com/expo/expo/pull/16556#discussion_r822944286
       await this.getProjectRandomnessAsync(),
-      slugify(username),
+      // Strip out periods from the username to avoid subdomain issues with SSL certificates.
+      slugify(username, { remove: /\./ }),
       // Use the port to distinguish between multiple tunnels (webpack, metro).
       String(this.port),
     ];


### PR DESCRIPTION
# Why

As highlighted in https://github.com/expo/expo/issues/27027#issuecomment-2081108033, users with `.` in their usernames are unable to use HTTPS tunneling due to a limitation of our SSL certificate, where we can only have one level deep wild card domains.

# How

Update `_getIdentifyingUrlSegmentsAsync` to filter out `.` when slugifying the username. This shouldn't cause any clashes given that we concat the username with `getProjectRandomnessAsync()`

# Test Plan

`yarn start --tunnel` using an account  with `.` in the username 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
