### PR TITLE
[template-default] fix project reset on Windows

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -4,7 +4,7 @@
   "version": "51.0.24",
   "scripts": {
     "start": "expo start",
-    "reset-project": "./scripts/reset-project.js",
+    "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",


### PR DESCRIPTION
# Why

Fixes ENG-12272

# How

Add `node` to `reset-project` command so Windows know how to run the script.

# Test Plan

Reset project worked on Windows.

# Preview

<img width="838" alt="Screenshot 2024-05-09 105902" src="https://github.com/expo/expo/assets/719641/f763560c-3889-46cb-9b3d-37d5ea761639">
