### PR TITLE
[calendar] Workaround iOS 15 bug

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, workaround a bug in iOS 15 where an invalid `EKCalendarType` is returned in the calendar object when siri suggestions are enabled.
+- On `iOS`, workaround a bug in iOS 15 where an invalid `EKCalendarType` is returned in the calendar object when siri suggestions are enabled. ([#28714](https://github.com/expo/expo/pull/28714) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, workaround a bug in iOS 15 where an invalid `EKCalendarType` is returned in the calendar object when siri suggestions are enabled.
+
 ### 💡 Others
 
 ## 13.0.3 — 2024-05-01

--- a/packages/expo-calendar/ios/Conversions/Conversions.swift
+++ b/packages/expo-calendar/ios/Conversions/Conversions.swift
@@ -66,7 +66,7 @@ func serializeCalendar(calendar: EKCalendar) -> [String: Any?] {
     "source": serialize(ekSource: calendar.source),
     "entityType": entity(type: calendar.allowedEntityTypes),
     "color": calendar.cgColor != nil ? EXUtilities.hexString(with: calendar.cgColor) : nil,
-    "type": calendarTypeToString(type: calendar.type),
+    "type": calendarTypeToString(type: calendar.type, source: calendar.source.sourceType),
     "allowsModifications": calendar.allowsContentModifications,
     "allowedAvailabilities": calendarSupportedAvailabilities(fromMask: calendar.supportedEventAvailabilities)
   ]

--- a/packages/expo-calendar/ios/Conversions/EnumConversions.swift
+++ b/packages/expo-calendar/ios/Conversions/EnumConversions.swift
@@ -123,7 +123,7 @@ func recurrenceToString(frequency: EKRecurrenceFrequency) -> String {
   }
 }
 
-func calendarTypeToString(type: EKCalendarType) -> String {
+func calendarTypeToString(type: EKCalendarType, source: EKSourceType) -> String {
   switch type {
   case .local:
     return "local"
@@ -135,5 +135,7 @@ func calendarTypeToString(type: EKCalendarType) -> String {
     return "subscribed"
   case .birthday:
     return "birthdays"
+  default:
+    return sourceToString(type: source)
   }
 }


### PR DESCRIPTION
# Why
Closes #28686
There is a bug in iOS 15 where an invalid `EKCalendarType` with a raw value of 5 is returned when Siri suggestions are enabled in the calendar. This type does not exist and causes the app to crash when we try to convert it to a string. 

# How
When we don't have a valid `calendar.type` fallback to using the `sourceType`

# Test Plan
Bare-expo on iOS 15 and iOS 17 ✅ The crash no longer occurs and the event data is correct.

