### PR TITLE
[av][android] Fix events not working

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix events being sent using a wrong event emitter. ([#28716](https://github.com/expo/expo/pull/28716) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 14.0.3 — 2024-05-01

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManagerInterface.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManagerInterface.java
@@ -1,12 +1,17 @@
 package expo.modules.av;
 
 import android.content.Context;
+import android.os.Bundle;
 
 import expo.modules.core.ModuleRegistry;
 import expo.modules.core.Promise;
 import expo.modules.core.arguments.ReadableArguments;
 import expo.modules.av.video.VideoView;
 import expo.modules.interfaces.permissions.PermissionsResponseListener;
+
+interface EmitEventWrapper {
+  void emit(String name, Bundle body);
+}
 
 public interface AVManagerInterface {
   void registerVideoViewForAudioLifecycle(final VideoView videoView);
@@ -24,6 +29,8 @@ public interface AVManagerInterface {
   void setAudioIsEnabled(final Boolean value);
 
   void setAudioMode(final ReadableArguments map);
+
+  void setEmitEventWrapper(EmitEventWrapper emitEventWrapper);
 
   void loadForSound(final ReadableArguments source, final ReadableArguments status, final Promise promise);
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVManagerInterface.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVManagerInterface.java
@@ -9,6 +9,7 @@ import expo.modules.core.arguments.ReadableArguments;
 import expo.modules.av.video.VideoView;
 import expo.modules.interfaces.permissions.PermissionsResponseListener;
 
+@FunctionalInterface
 interface EmitEventWrapper {
   void emit(String name, Bundle body);
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
@@ -1,11 +1,13 @@
 package expo.modules.av
 
 import android.Manifest
+import android.os.Bundle
 import expo.modules.core.arguments.ReadableArguments
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import java.lang.ref.WeakReference
 
 private class AVManagerModuleNotFound : CodedException(message = "AVManagerInterface not found")
 
@@ -27,6 +29,22 @@ class AVModule : Module() {
       "ExponentAV.onError",
       "Expo.Recording.recorderUnloaded"
     )
+
+    OnCreate {
+      // Slightly hacky way to be able to emit events using the new event emitter from legacy modules.
+      val weakModule = WeakReference(this@AVModule)
+      val emitEvent = { name: String, body: Bundle ->
+        try {
+          // It may thrown, because RN event emitter may not be available
+          // we can just ignore those cases
+          weakModule.get()?.sendEvent(name, body)
+        } catch (_: Throwable) {
+        }
+        Unit
+      }
+
+      appContext.legacyModule<AVManagerInterface>()?.setEmitEventWrapper(emitEvent)
+    }
 
     AsyncFunction("setAudioIsEnabled") { value: Boolean ->
       avManager.setAudioIsEnabled(value)


### PR DESCRIPTION
# Why

This PR fixes a regression introduced in SDK 51, caused by the fact that events sent using the wrong event emitter are not accepted.

Fixes https://github.com/expo/expo/issues/28698

# How

Used a solution similar to `ExpoBattery`, where the `sendEvent` function from the module is passed to the calling class instance. In this case I used additional wrapper interface, because `AVModule` is written in kotlin and `AVManager` is in java.

# Test Plan

Tested in BareExpo in Android 14 emulator.

