### PR TITLE
[go] Fix a typo in the incompatible Expo Go version screen

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -358,7 +358,7 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
       ];
     }
     
-    fixInstructions = [instructions stringByAppendingFormat:@"[%@](Learn how to install Expo Go for SDK %d in an OS Simulator.)",
+    fixInstructions = [instructions stringByAppendingFormat:@"[%@](Learn how to install Expo Go for SDK %d in an iOS Simulator.)",
                        expoDevLink,
                        requiredVersionNum];
 #endif


### PR DESCRIPTION
# Why

Small typo has sneaked into the incompatible version screen
