### PR TITLE
Bump expo-updates-interface dependency version

### DIFF
--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -36,7 +36,7 @@
     "expo-dev-menu": "5.0.13",
     "expo-dev-menu-interface": "1.8.3",
     "expo-manifests": "~0.14.0",
-    "expo-updates-interface": "~0.16.0"
+    "expo-updates-interface": "~0.16.2"
   },
   "devDependencies": {
     "expo-module-scripts": "^3.0.0",

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -47,7 +47,7 @@
     "expo-eas-client": "~0.12.0",
     "expo-manifests": "~0.14.0",
     "expo-structured-headers": "~3.8.0",
-    "expo-updates-interface": "~0.16.0",
+    "expo-updates-interface": "~0.16.2",
     "fast-glob": "^3.3.2",
     "fbemitter": "^3.0.0",
     "ignore": "^5.3.1",


### PR DESCRIPTION
# Why

#28662 introduced interface changes and we should bump the required version to align the change

# How

bump `expo-updates-interface@~0.16.2` from both expo-dev-client and expo-updates

# Test Plan

n/a

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
