### PR TITLE
[docs] Publish Hash support section in search parameters

### DIFF
--- a/docs/pages/router/reference/search-parameters.mdx
+++ b/docs/pages/router/reference/search-parameters.mdx
@@ -252,13 +252,11 @@ export default function User() {
 }
 ```
 
-{/* ## Hash support */}
+## Hash support
 
-{/* The URL [hash](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) is a string that follows the `#` symbol in a URL. It is commonly used on websites to link to a specific section of a page, but it can also be used to store data. Expo Router treats the hash as a special search parameter using the name `#`. It can be accessed and modified using the same hooks and APIs from [search parameters](/router/reference/search-parameters/). */}
+The URL [hash](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) is a string that follows the `#` symbol in a URL. It is commonly used on websites to link to a specific section of a page, but it can also be used to store data. Expo Router treats the hash as a special search parameter using the name `#`. It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-search-parameters).
 
 {/* prettier-ignore */}
-{/*
-
 ```tsx app/hash.tsx
 import { Text } from 'react-native';
 import { router, useLocalSearchParams, Link } from 'expo-router';
@@ -276,5 +274,3 @@ export default function User() {
   );
 }
 ```
-
-\*/}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #27660 and unhide Hash support section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/router/reference/search-parameters/#hash-support

## Preview

![CleanShot 2024-05-10 at 01 57 28@2x](https://github.com/expo/expo/assets/10234615/227a3718-16f9-4821-93d9-5b7d063d6ce1)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
