### PR TITLE
fix(cli): export process exit

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Force exit the export command to prevent hanging processes.
 - Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Force exit the export command to prevent hanging processes.
+- Force exit the export command to prevent hanging processes. ([#28735](https://github.com/expo/expo/pull/28735) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -22,4 +22,7 @@ export async function exportAsync(projectRoot: string, options: Options) {
 
   // Final notes
   Log.log(`App exported to: ${options.outputDir}`);
+
+  // Exit the process to stop any hanging processes from reading the app.config.js or server rendering.
+  process.exit(0);
 }

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 
+import { exportAsync } from './exportAsync.js';
+import { resolveOptionsAsync } from './resolveOptions.js';
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
 import { logCmdError } from '../utils/errors';
@@ -61,9 +63,12 @@ export const expoExport: Command = async (argv) => {
   }
 
   const projectRoot = getProjectRoot(args);
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
-  const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
-  const { exportAsync } = await import('./exportAsync.js');
-  return exportAsync(projectRoot, options).catch(logCmdError);
+  try {
+    const options = await resolveOptionsAsync(projectRoot, args);
+
+    await exportAsync(projectRoot, options);
+  } catch (error) {
+    logCmdError(error);
+  }
 };

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 
-import { exportAsync } from './exportAsync.js';
-import { resolveOptionsAsync } from './resolveOptions.js';
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
 import { logCmdError } from '../utils/errors';
@@ -63,12 +61,9 @@ export const expoExport: Command = async (argv) => {
   }
 
   const projectRoot = getProjectRoot(args);
+  const { resolveOptionsAsync } = await import('./resolveOptions.js');
+  const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
-  try {
-    const options = await resolveOptionsAsync(projectRoot, args);
-
-    await exportAsync(projectRoot, options);
-  } catch (error) {
-    logCmdError(error);
-  }
+  const { exportAsync } = await import('./exportAsync.js');
+  return exportAsync(projectRoot, options).catch(logCmdError);
 };


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo/issues/27938

# How

- Add process exit back to the end of export command. This may break atlas, cc @byCedric 
