### PR TITLE
Update create-expo-app CLI help screen and README to reflect new default template in v51

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update create-expo-app CLI help screen and README to reflect new default template in v51. ([#28738](https://github.com/expo/expo/pull/28738) by [@zeckdude](https://github.com/zeckdude))
+
 ### 💡 Others
 
 ## 2.3.4 — 2024-05-01

--- a/packages/create-expo/README.md
+++ b/packages/create-expo/README.md
@@ -46,7 +46,7 @@ Once you're up and running with Create Expo App, visit [this tutorial](https://d
 
 ## Templates
 
-Create Expo App prepares the app with the `tabs` template by default. You can choose to use a project with more prepared functionality. For that, you can start Create Expo App with the `--template` flag. Use the `--help` flag to see available template options.
+Create Expo App prepares the app with the `default` template. You can run Create Expo App with the `--template` flag to choose from other templates, or with the `--example` flag to choose from [example projects](https://github.com/expo/examples). Use the `--help` flag to see available template options.
 
 ```sh
 # Pick from Expo's templates

--- a/packages/create-expo/README.md
+++ b/packages/create-expo/README.md
@@ -46,7 +46,7 @@ Once you're up and running with Create Expo App, visit [this tutorial](https://d
 
 ## Templates
 
-Create Expo App prepares an empty Expo project by default. You can choose to use a project with more prepared functionality. For that, you can start Create Expo App with the `--template` flag.
+Create Expo App prepares the app with the `tabs` template by default. You can choose to use a project with more prepared functionality. For that, you can start Create Expo App with the `--template` flag. Use the `--help` flag to see available template options.
 
 ```sh
 # Pick from Expo's templates

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -38,7 +38,7 @@ async function run() {
       [
         `-y, --yes             Use the default options for creating a project`,
         `    --no-install      Skip installing npm packages or CocoaPods`,
-        chalk`-t, --template {gray [pkg]}  NPM template to use: blank, tabs, bare-minimum. Default: tabs`,
+        chalk`-t, --template {gray [pkg]}  NPM template to use: default, blank, tabs, bare-minimum.`,
         chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -38,7 +38,7 @@ async function run() {
       [
         `-y, --yes             Use the default options for creating a project`,
         `    --no-install      Skip installing npm packages or CocoaPods`,
-        chalk`-t, --template {gray [pkg]}  NPM template to use: blank, tabs, bare-minimum. Default: blank`,
+        chalk`-t, --template {gray [pkg]}  NPM template to use: blank, tabs, bare-minimum. Default: tabs`,
         chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As mentioned at https://expo.dev/changelog/2024/05-07-sdk-51#new-default-project-template-and-%22getting-started%22-flow, the default template changed from 'blank' to 'tabs'. This change just fixes the CLI help screen and README to reflect that.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Just fixed the instructions text

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
