### PR TITLE
[iOS][font] Fix some vector icons using incorrect fonts

### DIFF
--- a/apps/native-component-list/src/screens/FontScreen.tsx
+++ b/apps/native-component-list/src/screens/FontScreen.tsx
@@ -1,25 +1,10 @@
+import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Platform, ScrollView, Text, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 export default function FontScreen() {
   return (
     <ScrollView style={{ flex: 1 }}>
-      <View
-        style={{
-          paddingVertical: 10,
-          paddingHorizontal: 15,
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          flex: 1,
-        }}>
-        <Ionicons name="logo-facebook" size={25} />
-        <Ionicons name="logo-apple" size={25} />
-        <Ionicons name="logo-amazon" size={25} />
-        <Ionicons name="logo-npm" size={25} />
-        <Ionicons name="logo-google" size={25} />
-        <Ionicons name="alarm" size={25} />
-      </View>
-
       <View style={{ paddingVertical: 10, paddingHorizontal: 15, flex: 1 }}>
         <Text style={{ fontFamily: 'space-mono', fontSize: 16 }}>
           Font icons sets and other custom fonts can be loaded from the web
@@ -50,6 +35,54 @@ export default function FontScreen() {
           </Text>
         )}
       </View>
+
+      <Text style={styles.vectorIconsName}>Ionicons</Text>
+      <View style={styles.vectorIconsContainer}>
+        <View style={styles.vectorIconsRow}>
+          <Ionicons name="search-sharp" size={25} />
+          <Ionicons name="share-outline" size={25} />
+          <Ionicons name="thunderstorm-outline" size={25} />
+          <Ionicons name="volume-medium" size={25} />
+          <Ionicons name="wine-sharp" size={25} />
+          <Ionicons name="newspaper-outline" size={25} />
+        </View>
+        <View style={styles.vectorIconsRow}>
+          <Ionicons name="logo-facebook" size={25} />
+          <Ionicons name="logo-apple" size={25} />
+          <Ionicons name="logo-amazon" size={25} />
+          <Ionicons name="logo-npm" size={25} />
+          <Ionicons name="logo-google" size={25} />
+          <Ionicons name="alarm" size={25} />
+        </View>
+      </View>
+
+      <Text style={styles.vectorIconsName}>FontAwesome5</Text>
+      <View style={styles.vectorIconsContainer}>
+        <View style={styles.vectorIconsRow}>
+          <FontAwesome5 name="laugh-wink" size={25} />
+          <FontAwesome5 name="smile-beam" size={25} />
+          <FontAwesome5 name="map" size={25} />
+          <FontAwesome5 name="bacon" size={25} />
+          <FontAwesome5 name="basketball-ball" size={25} />
+          <FontAwesome5 name="biking" size={25} />
+        </View>
+        <View style={styles.vectorIconsRow}>
+          <FontAwesome5 name="home" size={25} />
+          <FontAwesome5 name="paw" size={25} />
+          <FontAwesome5 name="map" size={25} solid />
+          <FontAwesome5 name="camera" size={25} />
+          <FontAwesome5 name="cat" size={25} />
+          <FontAwesome5 name="horse" size={25} />
+        </View>
+        <View style={styles.vectorIconsRow}>
+          <FontAwesome5 name="react" size={25} />
+          <FontAwesome5 name="aws" size={25} />
+          <FontAwesome5 name="swift" size={25} />
+          <FontAwesome5 name="facebook" size={25} />
+          <FontAwesome5 name="twitter" size={25} />
+          <FontAwesome5 name="apple" size={25} />
+        </View>
+      </View>
     </ScrollView>
   );
 }
@@ -57,3 +90,20 @@ export default function FontScreen() {
 FontScreen.navigationOptions = {
   title: 'Font',
 };
+
+const styles = StyleSheet.create({
+  vectorIconsContainer: {
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    flex: 1,
+  },
+  vectorIconsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    padding: 15,
+  },
+  vectorIconsName: {
+    margin: 15,
+    fontSize: 22,
+  },
+});

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed some vector icons not rendering correctly. ([#28747](https://github.com/expo/expo/pull/28747) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 12.0.4 — 2024-04-24

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -39,15 +39,9 @@ internal struct FontFamilyAliasManager {
 }
 
 /**
- Swizzles ``UIFont.fontNames(forFamilyName:)`` and ``UIFont(name:size:)`` to support font family aliases.
+ Swizzles ``UIFont.fontNames(forFamilyName:)`` to support font family aliases.
  This is necessary because the user provides a custom family name that is then used in stylesheets,
  however the font usually has a different name encoded in the binary, thus the system may use a different name.
-
- ``UIFont(name:size:)`` covers cases where there the font family has variants. For example, the ``CGFont fullName``
- value for "Helvetica-Light-Oblique.ttf" would be something like "Helvetica Light Oblique", which
- ``UIFont.fullNames`` won't recognize, because that is a font name rather than a font family name. We have to use
- ``UIFont(name:size:)`` instead, because it accepts a font name. React Native does this looking up / falling back
- for us, we just need to ensure both methods are swizzled so they both support aliasing.
  */
 private func maybeSwizzleUIFont() {
   if hasSwizzled {
@@ -60,14 +54,6 @@ private func maybeSwizzleUIFont() {
     method_exchangeImplementations(originalFontNamesMethod, newFontNamesMethod)
   } else {
     log.error("expo-font is unable to swizzle `UIFont.fontNames(forFamilyName:)`")
-  }
-  let originalInitMethod = class_getClassMethod(UIFont.self, #selector(UIFont.init(name:size:)))
-  let newInitMethod = class_getClassMethod(UIFont.self, #selector(UIFont._expo_init(name:size:)))
-
-  if let originalInitMethod, let newInitMethod {
-    method_exchangeImplementations(originalInitMethod, newInitMethod)
-  } else {
-    log.error("expo-font is unable to swizzle `UIFont.init(name:size:)`")
   }
   hasSwizzled = true
 }

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -7,21 +7,20 @@ public extension UIFont {
    */
   @objc
   static dynamic func _expo_fontNames(forFamilyName familyName: String) -> [String] {
+    // Get font names from the original function.
     let fontNames = UIFont._expo_fontNames(forFamilyName: familyName)
 
+    // If no font names were found, let's try with the alias.
     if fontNames.isEmpty, let aliasedFamilyName = FontFamilyAliasManager.familyName(forAlias: familyName) {
-      // Note that this actually calls the original method implementation (if swizzled).
-      return UIFont._expo_fontNames(forFamilyName: aliasedFamilyName)
+      let fontNames = UIFont._expo_fontNames(forFamilyName: aliasedFamilyName)
+
+      // If we still don't find any font names, we can assume it was not a family name but a font name.
+      // In that case we can safely return the original font name.
+      if fontNames.isEmpty {
+        return [aliasedFamilyName]
+      }
+      return fontNames
     }
     return fontNames
-  }
-  @objc
-  static dynamic func _expo_init(name fontName: String, size fontSize: CGFloat) -> UIFont? {
-    let font = UIFont._expo_init(name: fontName, size: fontSize)
-
-    if let aliasedFamilyName = FontFamilyAliasManager.familyName(forAlias: fontName) {
-      return UIFont._expo_init(name: aliasedFamilyName, size: fontSize)
-    }
-    return font
   }
 }


### PR DESCRIPTION
# Why

Fixes #28693 

# How

When the swizzled `UIFont.fontNames(forFamilyName:)` function cannot find any font names for the aliased font family, we can assume it was not a family name but a font name in which case we can return an array with this font name instead of an empty array. Thanks to this, the font resolution in RN will not enter this if: https://github.com/facebook/react-native/blob/00b251b8ee8752b82a536faabc424d92f7034ebe/packages/react-native/React/Views/RCTFont.mm#L448 but will enter this one: https://github.com/facebook/react-native/blob/00b251b8ee8752b82a536faabc424d92f7034ebe/packages/react-native/React/Views/RCTFont.mm#L471 which is the expected behavior as it would bypass the unwanted logic.
In other words, this change shifts the responsibility of handling font names passed as family names to us.

I also reverted #28407 which is no longer necessary and added some FontAwesome icons to our expo-font examples in native-component-list app.

# Test Plan

Tested repros from #28693, #28407 and the new examples on both old and new architectures

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-10 at 15 40 19](https://github.com/expo/expo/assets/1714764/0d6bb933-3ddb-40d7-a1a3-45a425e6d15f)

Also thanks for @alanjhughes for helping me investigate this issue and test various cases and fonts.