### PR TITLE
[tracking-transparency][ios] Fix `requestTrackingPermissionsAsync` being resolved before user makes a choice

### DIFF
--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `requestTrackingPermissionsAsync` being resolved instantly due to iOS 17.4 bug
+
 ### 💡 Others
 
 ## 4.0.2 — 2024-04-29

--- a/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
+++ b/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
@@ -4,26 +4,57 @@ import AppTrackingTransparency
 import ExpoModulesCore
 
 public class TrackingTransparencyPermissionRequester: NSObject, EXPermissionsRequester {
+  var pendingResolver: EXPromiseResolveBlock?
+  var pendingRejecter: EXPromiseRejectBlock?
+
+  override init() {
+    super.init()
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleApplicationDidBecomeActive),
+      name: UIApplication.didBecomeActiveNotification,
+      object: nil
+    )
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
   static public func permissionType() -> String {
     return "appTracking"
   }
 
-  public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: EXPromiseRejectBlock) {
+  public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
     if #available(iOS 14, *) {
-      ATTrackingManager.requestTrackingAuthorization() { [weak self] _ in
-        resolve(self?.getPermissions());
+      ATTrackingManager.requestTrackingAuthorization { [weak self] systemStatus in
+        // iOS 17.4 ATT bug https://forums.developer.apple.com/forums/thread/746432
+        // we use the didBecomeActiveNotification to recognize when the permission modal has been closed,
+        // refetch the permissions and return them to the original promise.
+        if systemStatus == .denied, ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+          self?.pendingResolver = resolve
+          self?.pendingRejecter = reject
+        } else {
+          resolve([
+            "status": systemStatus.toPermissionStatus().rawValue
+          ])
+          self?.pendingRejecter = nil
+          self?.pendingResolver = nil
+        }
       }
     } else {
-      resolve(self.getPermissions());
+      resolve(self.getPermissions())
+      self.pendingRejecter = nil
+      self.pendingResolver = nil
     }
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
     var status: EXPermissionStatus
-    
+
     if #available(iOS 14, *) {
       var systemStatus: ATTrackingManager.AuthorizationStatus
-      
+
       let trackingUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSUserTrackingUsageDescription")
       if trackingUsageDescription == nil {
         EXFatal(EXErrorWithMessage("""
@@ -34,18 +65,7 @@ public class TrackingTransparencyPermissionRequester: NSObject, EXPermissionsReq
       } else {
         systemStatus = ATTrackingManager.trackingAuthorizationStatus
       }
-
-      switch systemStatus {
-      case .authorized:
-        status = EXPermissionStatusGranted
-      case .restricted,
-           .denied:
-        status = EXPermissionStatusDenied
-      case .notDetermined:
-        fallthrough
-      @unknown default:
-        status = EXPermissionStatusUndetermined
-      }
+      status = systemStatus.toPermissionStatus()
     } else {
       status = EXPermissionStatusGranted
     }
@@ -53,5 +73,27 @@ public class TrackingTransparencyPermissionRequester: NSObject, EXPermissionsReq
     return [
       "status": status.rawValue
     ]
+  }
+
+  @objc private func handleApplicationDidBecomeActive() {
+    if let pendingResolver, let pendingRejecter {
+      requestPermissions(resolver: pendingResolver, rejecter: pendingRejecter)
+    }
+  }
+}
+
+@available(iOS 14, *)
+private extension ATTrackingManager.AuthorizationStatus {
+  func toPermissionStatus() -> EXPermissionStatus {
+    switch self {
+    case .authorized:
+      return EXPermissionStatusGranted
+    case .restricted, .denied:
+      return EXPermissionStatusDenied
+    case .notDetermined:
+      fallthrough
+    @unknown default:
+      return EXPermissionStatusUndetermined
+    }
   }
 }


### PR DESCRIPTION
# Why

On iOS 17.4 `requestTrackingPermissionsAsync` will resolve instantly (even before the modal is shown) with status `denied` due to a [known bug](https://forums.developer.apple.com/forums/thread/746432?answerId=784610022#784610022) (in our case it was `undetermined` due to implementation differences).

# How

Used a workaround which detects if the bug has appeared. In that case promise is stored until the app returns to foreground - that's when user has made a choice in the modal. After the app has returned to foreground we can call requestPermissions again to get the correct result.

# Test Plan

Tested in iOS 17.4 simulator in BareExpo

