### PR TITLE
update @react-native-community/datetimepicker to 8.0.0

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/metro-runtime": "~3.2.1",
   "@expo/vector-icons": "^14.0.0",
   "@react-native-async-storage/async-storage": "1.23.1",
-  "@react-native-community/datetimepicker": "7.7.0",
+  "@react-native-community/datetimepicker": "8.0.0",
   "@react-native-masked-view/masked-view": "0.3.1",
   "@react-native-community/netinfo": "11.3.1",
   "@react-native-community/slider": "4.5.2",


### PR DESCRIPTION
# Why

Update react-native-community/datetimepicker to 8.0.0

Follow up PR #28462

<img width="1101" alt="Screenshot 2024-05-12 at 9 05 29 AM" src="https://github.com/expo/expo/assets/101246871/ebf3fd62-1d09-4dcd-9b78-374efa2c63be">

