### PR TITLE
[image-manipulator] Fix handling urls from the photo library

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS` correctly handle urls coming from the users photo library.
+
 ### 💡 Others
 
 ## 12.0.3 — 2024-05-01

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS` correctly handle urls coming from the users photo library.
+- On `iOS` correctly handle urls coming from the users photo library. ([#28777](https://github.com/expo/expo/pull/28777) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorModule.swift
@@ -51,8 +51,7 @@ public class ImageManipulatorModule: Module {
       }
       return callback(.success(image))
     }
-    if url.scheme == "assets-library" {
-      // TODO: ALAsset URLs are deprecated as of iOS 11, we should migrate to `ph://` soon.
+    if url.scheme == "ph" || url.scheme == "assets-library" {
       return loadImageFromPhotoLibrary(url: url, callback: callback)
     }
 
@@ -75,7 +74,7 @@ public class ImageManipulatorModule: Module {
    Loads the image from user's photo library.
    */
   internal func loadImageFromPhotoLibrary(url: URL, callback: @escaping LoadImageCallback) {
-    guard let asset = PHAsset.fetchAssets(withALAssetURLs: [url], options: nil).firstObject else {
+    guard let asset = retreiveAsset(from: url) else {
       return callback(.failure(ImageNotFoundException()))
     }
     let size = CGSize(width: asset.pixelWidth, height: asset.pixelHeight)
@@ -117,19 +116,5 @@ public class ImageManipulatorModule: Module {
       throw ImageWriteFailedException(error.localizedDescription)
     }
     return (url: fileUrl, data: data)
-  }
-}
-
-/**
- Returns pixel data representation of the image.
- */
-func imageData(from image: UIImage, format: ImageFormat, compression: Double) -> Data? {
-  switch format {
-  case .jpeg, .jpg:
-    return image.jpegData(compressionQuality: compression)
-  case .png:
-    return image.pngData()
-  case .webp:
-    return SDImageWebPCoder.shared.encodedData(with: image, format: .webP, options: [.encodeCompressionQuality: compression])
   }
 }

--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -1,0 +1,27 @@
+import SDWebImageWebPCoder
+import Photos
+
+/**
+ Returns pixel data representation of the image.
+ */
+func imageData(from image: UIImage, format: ImageFormat, compression: Double) -> Data? {
+  switch format {
+  case .jpeg, .jpg:
+    return image.jpegData(compressionQuality: compression)
+  case .png:
+    return image.pngData()
+  case .webp:
+    return SDImageWebPCoder.shared.encodedData(with: image, format: .webP, options: [.encodeCompressionQuality: compression])
+  }
+}
+
+/**
+ Checks is we are dealing with a ph asset URL and uses the correct method to fetch it.
+ */
+func retreiveAsset(from url: URL) -> PHAsset? {
+  if url.scheme == "ph" {
+    let identifier = String(url.absoluteString.dropFirst(5))
+    return PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil).firstObject
+  }
+  return PHAsset.fetchAssets(withALAssetURLs: [url], options: nil).firstObject
+}

--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -16,11 +16,11 @@ func imageData(from image: UIImage, format: ImageFormat, compression: Double) ->
 }
 
 /**
- Checks is we are dealing with a ph asset URL and uses the correct method to fetch it.
+ Checks if we are dealing with a ph asset URL and uses the correct method to fetch it.
  */
 func retreiveAsset(from url: URL) -> PHAsset? {
   if url.scheme == "ph" {
-    let identifier = String(url.absoluteString.dropFirst(5))
+    let identifier = String(url.absoluteString.dropFirst(5)) // removes ph://
     return PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil).firstObject
   }
   return PHAsset.fetchAssets(withALAssetURLs: [url], options: nil).firstObject


### PR DESCRIPTION
# Why
Closes #28772
`PHAsset.fetchAssets(withALAssetURLs:, options:)` has been deprecated since iOS 11 so we need to retrieve the image differently when it is selected from the user's photo library. 

# How
Use a different function on `PHAsset` to handle these URLs.

# Test Plan
Bare expo and the provided repro. The image is selected and resized correctly.

