### PR TITLE
[camera] Fix dead frames on initial mode switch

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fix dead frames when switching from picture to video.
+
 ### 💡 Others
 
 - Remove unused property `interval` from `BarcodeSettings`. ([#28760](https://github.com/expo/expo/pull/28760) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fix dead frames when switching from picture to video.
+- On `iOS`, fix dead frames when switching from picture to video. ([#28783](https://github.com/expo/expo/pull/28783) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -179,7 +179,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       self.session.beginConfiguration()
       let preset = self.pictureSize.toCapturePreset()
       if self.session.canSetSessionPreset(preset) {
-        self.session.sessionPreset = self.mode == .video ? preset : .photo
+        self.session.sessionPreset = preset
       }
       self.session.commitConfiguration()
     }
@@ -654,7 +654,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       if session.outputs.contains(videoFileOutput) {
         self.session.beginConfiguration()
         session.removeOutput(videoFileOutput)
-        self.session.sessionPreset = .photo
         self.videoFileOutput = nil
         self.session.commitConfiguration()
       }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -179,7 +179,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       self.session.beginConfiguration()
       let preset = self.pictureSize.toCapturePreset()
       if self.session.canSetSessionPreset(preset) {
-        self.session.sessionPreset = preset
+        self.session.sessionPreset = self.mode == .video ? preset : .photo
       }
       self.session.commitConfiguration()
     }
@@ -225,6 +225,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         if self.videoFileOutput == nil {
           self.setupMovieFileCapture()
         }
+        self.updateSessionAudioIsMuted()
       } else {
         self.cleanupMovieFileCapture()
       }
@@ -252,6 +253,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         self.photoOutput = photoOutput
       }
 
+      self.session.sessionPreset = self.mode == .video ? self.pictureSize.toCapturePreset() : .photo
       self.addErrorNotification()
       self.changePreviewOrientation()
     }
@@ -652,6 +654,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       if session.outputs.contains(videoFileOutput) {
         self.session.beginConfiguration()
         session.removeOutput(videoFileOutput)
+        self.session.sessionPreset = .photo
         self.videoFileOutput = nil
         self.session.commitConfiguration()
       }
@@ -692,10 +695,6 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
 
     videoRecordedPromise = nil
     videoCodecType = nil
-
-    if session.sessionPreset != pictureSize.toCapturePreset() {
-      updateSessionPreset(preset: pictureSize.toCapturePreset())
-    }
   }
 
   func setPresetCamera(presetCamera: AVCaptureDevice.Position) {


### PR DESCRIPTION
# Why
Closes #28739
The main purpose of this PR is to fix an issue with a seemingly common use case. Users would like to trigger video recording on the long press of a button. The issue with this currently is the switch between picture and video mode, after the first render, causes a brief but obvious flicker of dead frames during the switch. Because this use case swithes the mode and immediately starts recording these frames are captured in the output.

The reason for this is because the `sessionPreset` is not set initially and when in picture mode, it should always be set to `photo` as any other setting relates to video specifically. Setting the preset on initial setup prevents the issue of dead frames during the switch.

cc @lodev09

# How
- Set the sessionPreset in `startSession`
- Reset it back to `photo` when switching back to picture mode

# Test Plan

| Before | After |
| ----------- | ----------- |
| https://github.com/expo/expo/assets/30924086/dc63e2f1-4c79-476c-9c80-04d2565c19b0 | https://github.com/expo/expo/assets/30924086/ec12ddd1-cf56-47c9-8b41-a0d750475773 |

