### PR TITLE
fix(babel-preset-expo): Fix replacement of `__DEV__` in export statement.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix replacement of `__DEV__` in export statement.
+
 ### 💡 Others
 
 ## 11.0.5 — 2024-05-02

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix replacement of `__DEV__` in export statement.
+- Fix replacement of `__DEV__` in export statement. ([#28786](https://github.com/expo/expo/pull/28786) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/define-plugin.js
+++ b/packages/babel-preset-expo/build/define-plugin.js
@@ -93,7 +93,8 @@ const plugin = ({ types }) => {
                 processNode(replacements, nodePath, memberExpressionComparator);
             },
             // const x = { version: VERSION };
-            Identifier(nodePath, state) {
+            // @ts-expect-error: Virtual type `ReferencedIdentifier` is not on types.
+            ReferencedIdentifier(nodePath, state) {
                 const binding = nodePath.scope?.getBinding(nodePath.node.name);
                 if (binding ||
                     // Don't transform import identifiers. This is meant to mimic webpack's

--- a/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
@@ -461,20 +461,92 @@ it(`removes Platform module usage on native`, () => {
   );
 });
 
-it(`removes __DEV__ usage`, () => {
-  const options = {
-    ...DEFAULT_OPTS,
-    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android', isDev: false }),
-  };
+describe('__DEV__', () => {
+  it(`removes __DEV__ usage`, () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'android', isDev: false }),
+    };
 
-  const sourceCode = `  
+    const sourceCode = `  
     if (__DEV__) {
       require('./foobar')
     }
     `;
 
-  // No minfication needed here, the babel plugin does it to ensure the imports are removed before dependencies are collected.
-  expect(babel.transform(sourceCode, options)!.code!).toEqual(``);
+    // No minfication needed here, the babel plugin does it to ensure the imports are removed before dependencies are collected.
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(``);
+  });
+
+  it('preserves __DEV__ in export alias', () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
+    };
+
+    const sourceCode = `
+      const dev = true;
+      export { dev as __DEV__ };
+    `;
+
+    // Ensure this doesn't throw
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(
+      `Object.defineProperty(exports,"__esModule",{value:true});exports.__DEV__=undefined;const dev=exports.__DEV__=true;`
+    );
+  });
+
+  it(`does not replace __DEV__ key in object`, () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
+    };
+
+    const sourceCode = `const x = { __DEV__: __DEV__ };`;
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(`const x={__DEV__:false};`);
+  });
+
+  it('preserves __DEV__ in an object shorthand method name', () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
+    };
+
+    const sourceCode = `
+  const x = {
+    __DEV__() { return __DEV__; },
+  };
+  `;
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(
+      `const x={__DEV__(){return false;}};`
+    );
+  });
+
+  it('preserves __DEV__ as the name of an optional property access', () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
+    };
+    const sourceCode = `
+    x?.__DEV__;
+    x?.__DEV__();
+  `;
+
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(`x?.__DEV__;x?.__DEV__();`);
+  });
+
+  it('preserves __DEV__ as a label of a block statement', () => {
+    const options = {
+      ...DEFAULT_OPTS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: false }),
+    };
+    const sourceCode = `
+    __DEV__: {
+      break __DEV__;
+    };
+  `;
+
+    expect(babel.transform(sourceCode, options)!.code!).toEqual(`__DEV__:{break __DEV__;};`);
+  });
 });
 
 describe('SSR window check', () => {

--- a/packages/babel-preset-expo/src/define-plugin.ts
+++ b/packages/babel-preset-expo/src/define-plugin.ts
@@ -95,7 +95,8 @@ const plugin = ({ types }: { types: typeof t }): babel.PluginObj => {
       },
 
       // const x = { version: VERSION };
-      Identifier(nodePath, state) {
+      // @ts-expect-error: Virtual type `ReferencedIdentifier` is not on types.
+      ReferencedIdentifier(nodePath, state) {
         const binding = nodePath.scope?.getBinding(nodePath.node.name);
 
         if (


### PR DESCRIPTION
# Why

Fixes a regression that we temporarily fixed in SDK 50. https://exponent-internal.slack.com/archives/C5ERY0TAR/p1715558585127549
Specifically fixes support for syntax used in `@apollo/client`.
fix https://github.com/expo/expo/issues/28785

# Test Plan

- Added tests that could reproduce the syntax issue from before.