### PR TITLE
[docs] Update TV docs for SDK 51 (including Expo Router support)

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -45,7 +45,7 @@ The fastest way to generate a new project is described in the [TV example](https
 
 <Terminal cmd={['$ npx create-expo-app MyTVProject -e with-tv']} />
 
-For SDK 51 and later, you can start with the [TV Router example](https://github.com/expo/examples/with-router-tv):
+For SDK 51 and later, you can start with the [TV Router example](https://github.com/expo/examples/tree/master/with-router-tv):
 
 <Terminal cmd={['$ npx create-expo-app MyTVProject -e with-router-tv']} />
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -9,7 +9,7 @@ import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
-> **Warning** TV development is available only in SDK 50 and later, and is still considered experimental. Not all Expo features and SDK modules are available on TV.
+> **Warning** TV development is available only in SDK 50 and later. Not all Expo features and SDK modules are available on TV; see the [**Limitations**](#limitations) section for details.
 
 React Native is supported on Android TV and Apple TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos). This technology extends beyond TV, offering a comprehensive core repo fork with support for phone and TV targets, including Hermes and Fabric.
 
@@ -27,25 +27,29 @@ The necessary changes to the native Android and iOS files are minimal and can be
   - The Xcode project is modified to target tvOS instead of iOS
   - The splash screen (**SplashScreen.storyboard**) is modified to work on tvOS
 
-## Quick start
+## System requirements for TV development
 
-The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) within the Expo examples repository.
-
-## Integration with an existing Expo project
-
-If you have an existing Expo project, the following walkthrough describes the steps required to modify an Expo project for TV.
-
-You will need:
-
-- An Expo project using SDK 50 or later.
 - **Android TV**:
+  - [Node.js (LTS)](https://nodejs.org/en/) on macOS or Linux.
+  - Android Studio (Iguana or later).
   - In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image).
   - After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as creating an Android phone emulator).
 - **Apple TV**:
+  - [Node.js (LTS)](https://nodejs.org/en/) on macOS.
   - Xcode 15 or later.
   - tvOS SDK 17 or later. (This is not installed automatically with Xcode. You can install it later with `xcodebuild -downloadAllPlatforms`).
 
-> **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
+## Quick start
+
+The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) within the Expo examples repository:
+
+<Terminal cmd={['$ yarn create expo-app MyTVProject -e with-tv']} />
+
+For SDK 51 and later, you can start with the [TV Router Example](https://github.com/expo/examples/with-router-tv):
+
+<Terminal cmd={['$ yarn create expo-app MyTVProject -e with-router-tv']} />
+
+(This creates a new project that uses [Expo Router](/router/introduction/) for file based navigation, modeled after the [**create-expo-app** default template](/get-started/create-a-project/).)
 
 ## Supported modules
 
@@ -76,20 +80,26 @@ At this time, TV applications work with the following packages and APIs listed i
 - [SplashScreen](/versions/latest/sdk/splash-screen/)
 - [Svg](/versions/latest/sdk/svg/)
 - [Updates](/versions/latest/sdk/updates/)
-- [Video](/versions/latest/sdk/video)
 
 TV also works with [react-navigation](https://reactnavigation.org/), [react-native-video](https://github.com/react-native-video/react-native-video), and many other commonly used third-party React Native libraries.
 
 ## Limitations
 
-Certain Expo packages are not supported at this time, most notably:
+The [Expo DevClient](/versions/latest/sdk/dev-client/) package is not supported at this time.
 
-- [Expo DevClient](/versions/latest/sdk/dev-client/)
-- [Expo Router](/router/introduction/)
+The [Expo Video](/versions/latest/sdk/video) package is not supported at this time. TV developers should continue to use the [Expo AV](/versions/latest/sdk/av/) package for video.
+
+The [Expo Router](/router/introduction/) package is only supported in SDK 51 and later.
+
+## Integration with an existing Expo project
+
+If you have an existing Expo project using SDK 50 or later, the following walkthrough describes the steps required to modify an Expo project for TV.
+
+> **Info** If you are starting with an SDK 49 project, you will need to [upgrade to SDK 50 or higher](/workflow/upgrading-expo-sdk-walkthrough/) before proceeding through the following steps.
 
 <Step label="1">
 
-## Modify dependencies for TV
+### Modify dependencies for TV
 
 In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from [`npx expo install` version validation](/more/expo-cli/#configuring-dependency-validation).
 
@@ -116,7 +126,7 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 
 <Step label="2">
 
-## Add the TV config plugin
+### Add the TV config plugin
 
 <Terminal cmd={['$ npx expo install --dev @react-native-tvos/config-tv']} />
 
@@ -149,7 +159,7 @@ Verify that this plugin appears in **app.json**:
 
 <Step label="3">
 
-## Run prebuild
+### Run prebuild
 
 Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifications to the project.
 
@@ -161,7 +171,7 @@ Set the `EXPO_TV` environment variable, and run prebuild to make the TV modifica
 
 <Step label="4">
 
-## Build for Android TV
+### Build for Android TV
 
 Start an Android TV emulator and use the following command to start the app on the emulator:
 
@@ -170,7 +180,7 @@ Start an Android TV emulator and use the following command to start the app on t
 </Step>
 <Step label="5">
 
-## Build for Apple TV
+### Build for Apple TV
 
 Run the following command to build and run the app on an Apple TV simulator:
 
@@ -179,7 +189,7 @@ Run the following command to build and run the app on an Apple TV simulator:
 </Step>
 <Step label="6">
 
-## Revert TV changes and build for phone
+### Revert TV changes and build for phone
 
 You can revert the changes for TV and go back to phone development by unsetting `EXPO_TV` and running prebuild again:
 
@@ -189,7 +199,7 @@ You can revert the changes for TV and go back to phone development by unsetting 
 
 <Step label="7">
 
-## Create EAS Build profiles for both TV and phone
+### Create EAS Build profiles for both TV and phone
 
 Since the TV build is driven by the value of an environment variable, it is easy to set up EAS Build profiles that build from the same source but target TV instead of phone.
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -9,7 +9,7 @@ import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
-> **Warning** TV development is available only in SDK 50 and later. Not all Expo features and SDK modules are available on TV; see the [**Limitations**](#limitations) section for details.
+> **Warning** TV development is available only in SDK 50 and later. Not all Expo features and SDK modules are available on TV. See the [**Limitations**](#limitations) section for details.
 
 React Native is supported on Android TV and Apple TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos). This technology extends beyond TV, offering a comprehensive core repo fork with support for phone and TV targets, including Hermes and Fabric.
 
@@ -41,15 +41,15 @@ The necessary changes to the native Android and iOS files are minimal and can be
 
 ## Quick start
 
-The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) within the Expo examples repository:
+The fastest way to generate a new project is described in the [TV example](https://github.com/expo/examples/tree/master/with-tv) within the Expo examples repository:
 
-<Terminal cmd={['$ yarn create expo-app MyTVProject -e with-tv']} />
+<Terminal cmd={['$ npx create-expo-app MyTVProject -e with-tv']} />
 
-For SDK 51 and later, you can start with the [TV Router Example](https://github.com/expo/examples/with-router-tv):
+For SDK 51 and later, you can start with the [TV Router example](https://github.com/expo/examples/with-router-tv):
 
-<Terminal cmd={['$ yarn create expo-app MyTVProject -e with-router-tv']} />
+<Terminal cmd={['$ npx create-expo-app MyTVProject -e with-router-tv']} />
 
-(This creates a new project that uses [Expo Router](/router/introduction/) for file based navigation, modeled after the [**create-expo-app** default template](/get-started/create-a-project/).)
+This creates a new project that uses [Expo Router](/router/introduction/) for file-based navigation, modeled after the [**create-expo-app** default template](/get-started/create-a-project/).
 
 ## Supported modules
 
@@ -85,11 +85,9 @@ TV also works with [react-navigation](https://reactnavigation.org/), [react-nati
 
 ## Limitations
 
-The [Expo DevClient](/versions/latest/sdk/dev-client/) package is not supported at this time.
-
-The [Expo Video](/versions/latest/sdk/video) package is not supported at this time. TV developers should continue to use the [Expo AV](/versions/latest/sdk/av/) package for video.
-
-The [Expo Router](/router/introduction/) package is only supported in SDK 51 and later.
+- The [Expo DevClient](/versions/latest/sdk/dev-client/) package is not supported at this time.
+- The [Expo Video](/versions/latest/sdk/video) package is not supported at this time. TV developers should continue to use the [Expo AV](/versions/latest/sdk/av/) package for video.
+- The [Expo Router](/router/introduction/) package is only supported in SDK 51 and later.
 
 ## Integration with an existing Expo project
 


### PR DESCRIPTION
# Why

Expo Router now works on TV, and there have been a few other changes that need to be mentioned in the TV doc.

This should go in after the new TV Expo Router example is merged (see https://github.com/expo/examples/pull/478).

# How

Made doc changes.

# Test Plan

- CI should pass
- Test the new example after merging

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
