### PR TITLE
Fix datetimepicker version in bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/metro-runtime": "~3.2.1",
   "@expo/vector-icons": "^14.0.0",
   "@react-native-async-storage/async-storage": "1.23.1",
-  "@react-native-community/datetimepicker": "7.7.0",
+  "@react-native-community/datetimepicker": "8.0.0",
   "@react-native-masked-view/masked-view": "0.3.1",
   "@react-native-community/netinfo": "11.3.1",
   "@react-native-community/slider": "4.5.2",


### PR DESCRIPTION
# Why
`bundledNativeModules.json` has the wrong version of `@react-native-community/datetimepicker`. 

# How
Change to `8.0.0`

# Test Plan

