### PR TITLE
fix(cli): add `iPhone` as usbmux platform to os type

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Force exit the export command to prevent hanging processes. ([#28735](https://github.com/expo/expo/pull/28735) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix HTTPS tunneling for accounts with dots in their username. ([#28692](https://github.com/expo/expo/pull/28692) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix missing usbmux platform for platform to os conversion. ([#28802](https://github.com/expo/expo/pull/28802) by [@byCedric](https://github.com/byCedric))
 
 ## 0.18.10 — 2024-05-07
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -78,6 +78,7 @@ function coercePlatformToOsType(platform: string): OSType {
 function coerceUsbmuxdPlatformToOsType(platform: string): OSType {
   // The only connectable device I have to test against...
   switch (platform) {
+    case 'iPhone':
     case 'iPhone OS':
       return 'iOS';
     default:


### PR DESCRIPTION
# Why

Fixes #28781

# How

In the logs of #28781, you can see the following debug logs. The last log line shows that this is missing.

```
  expo:apple-device:client:usbmuxd connectUsbmuxdSocket +0ms
  expo:apple-device:client:usbmuxd getDevices +1ms
  expo:apple-device:protocol:usbmux socket write: {"messageType":"ListDevices"} +0ms
  expo:apple-device:protocol:usbmux Response: {"DeviceList":[{"DeviceID":2,"MessageType":"Attached","Properties":{"ConnectionSpeed":480000000,"ConnectionType":"USB","DeviceID":2,"LocationID":*******,"ProductID":4776,"SerialNumber":"****************************************","UDID":"****************************************","USBSerialNumber":"****************************************"}}]} +23ms
  expo:apple-device:client:usbmuxd connectUsbmuxdSocket +23ms
  expo:apple-device:client:usbmuxd connect: 2 on port 62078 +0ms
  expo:apple-device:client:usbmuxd connect:device: {
  expo:apple-device:client:usbmuxd   DeviceID: 2,
  expo:apple-device:client:usbmuxd   MessageType: 'Attached',
  expo:apple-device:client:usbmuxd   Properties: {
  expo:apple-device:client:usbmuxd     ConnectionSpeed: 480000000,
  expo:apple-device:client:usbmuxd     ConnectionType: 'USB',
  expo:apple-device:client:usbmuxd     DeviceID: 2,
  expo:apple-device:client:usbmuxd     LocationID: *******,
  expo:apple-device:client:usbmuxd     ProductID: 4776,
  expo:apple-device:client:usbmuxd     SerialNumber: '****************************************',
  expo:apple-device:client:usbmuxd     UDID: '****************************************',
  expo:apple-device:client:usbmuxd     USBSerialNumber: '****************************************'
  expo:apple-device:client:usbmuxd   }
  expo:apple-device:client:usbmuxd } +0ms
  expo:apple-device:protocol:usbmux socket write: {"messageType":"Connect","extraFields":{"DeviceID":2,"PortNumber":32498}} +2ms
  expo:apple-device:protocol:usbmux Response: {"MessageType":"Result","Number":0} +2ms
  expo:apple-device:client:usbmuxd connect:device:response: { MessageType: 'Result', Number: 0 } +4ms
  expo:apple-device:client:lockdownd getAllValues +0ms
  expo:apple-device:protocol:lockdown socket write: {"Request":"GetValue"} +0ms
  expo:apple-device:protocol:lockdown Response: {"Request":"GetValue","Value":{"BasebandCertId":*********,"BasebandKeyHashInformation":{"AKeyStatus":*,"SKeyHash":{"type":"Buffer","data":[*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*]},"SKeyStatus":*},"BasebandSerialNumber":{"type":"Buffer","data":[*,*,*,*,*,*,*,*,*,*,*,*]},"BasebandVersion":"6.01.01","BoardId":*,"BuildVersion":"20H330","CPUArchitecture":"arm64","ChipID":*****,"DeviceClass":"iPhone","DeviceColor":"1","DeviceName":"iPhone","DieID":****************,"HardwareModel":"D211AP","HasSiDP":true,"HumanReadableProductVersionString":"16.7.7","PartitionType":"GUID_partition_scheme","ProductName":"iPhone OS","ProductType":"iPhone10,5","ProductVersion":"16.7.7","ProductionSOC":true,"ProtocolVersion":"2","SupportedDeviceFamilies":[1],"TelephonyCapability":true,"UniqueChipID":****************,"UniqueDeviceID":"****************************************","WiFiAddress":"**:**:**:**:**:**"}} +50ms
  expo:apple-device Unknown usbmuxd platform (needs to be added to Expo CLI): iPhone +0ms
```

# Test Plan

See #28781

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
