### PR TITLE
Revert "Fix datetimepicker version in bundledNativeModules"

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -2,7 +2,7 @@
   "@expo/metro-runtime": "~3.2.1",
   "@expo/vector-icons": "^14.0.0",
   "@react-native-async-storage/async-storage": "1.23.1",
-  "@react-native-community/datetimepicker": "8.0.0",
+  "@react-native-community/datetimepicker": "7.7.0",
   "@react-native-masked-view/masked-view": "0.3.1",
   "@react-native-community/netinfo": "11.3.1",
   "@react-native-community/slider": "4.5.2",


### PR DESCRIPTION
Reverts expo/expo#28793

Because of merging this PR #28793, 

It created this issue in Expo SDK v51.0.5

<img width="1383" alt="Screenshot 2024-05-14 at 12 40 08 AM" src="https://github.com/expo/expo/assets/101246871/dddc1dee-ea0d-4ca7-bda8-8abab35aaa82">

Because @react-native-community/datetimepicker@8.0.0 requires RN 73. See the [release](https://github.com/react-native-datetimepicker/datetimepicker/releases/tag/v8.0.0). 

> BREAKING CHANGES
> this version requires RN 73 (see https://github.com/react-native-datetimepicker/datetimepicker/pull/888)

You can reproduce this issue by running these commands.

```
npx create-expo-app 

npx expo install @react-native-community/datetimepicker
```

I predicted this issue would arise that's why I closed this PR #28773 (same as merged one #28793).