### PR TITLE
[expo-updates][e2e] Attempt to fix nonderministic compilation error

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -20,14 +20,8 @@ function getExpoDependencyChunks({
   return [
     ['@expo/config-types', '@expo/env'],
     ['@expo/config'],
-    [
-      '@expo/cli',
-      '@expo/config-plugins',
-      'expo',
-      'expo-asset',
-      'expo-modules-core',
-      'expo-modules-autolinking',
-    ],
+    ['@expo/config-plugins'],
+    ['@expo/cli', 'expo', 'expo-asset', 'expo-modules-core', 'expo-modules-autolinking'],
     ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants', 'expo-manifests'],
     [
       'babel-preset-expo',


### PR DESCRIPTION
# Why

Seeing this failure nondeterministically: https://github.com/expo/expo/actions/runs/9070445697/job/24922248987

This is just a guess at a fix.

# How

Reorder so that config plugins is packed before asset, not in parallel with asset.

# Test Plan

CI run of e2e, but it'll take a while to know whether this fixes it since it's nondeterministic.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
