### PR TITLE
[docs] correct npx to npm when running `reset-project`

### DIFF
--- a/docs/pages/get-started/next-steps.mdx
+++ b/docs/pages/get-started/next-steps.mdx
@@ -12,7 +12,7 @@ Here are next steps to continue building your app:
 
 You can remove the boilerplate code and start fresh with a new project. Run the following command to reset your project:
 
-<Terminal cmd={['$ npx run reset-project']} />
+<Terminal cmd={['$ npm run reset-project']} />
 
 This command will move the existing files in **app** to **app-example**, then create a new **app** directory with a new **index.tsx** file.
 


### PR DESCRIPTION
# Why

The [Next Steps doc page](https://docs.expo.dev/get-started/next-steps/) says to run `npx run reset-project`. That command fails. `npx run` installs an npm package called `run` and then can't find `reset-project`, `reset-project` is a package script runnable with `npm run`. This is a one letter change of `npx` to `npm`.

# Test Plan

I created a new Expo project with `npx create-expo-app` and then ran `npm run reset-project`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
