### PR TITLE
[docs] Completing the `useFocusEffect` doc example

### DIFF
--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -34,7 +34,7 @@ export default function Route() {
 
       /* @info Return function is invoked whenever the route gets out of focus */
       return () => {
-        console.log('See you soon... I hope!');
+        console.log('This route is now unfocused.');
       }
       /* @end */
     }, []);

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -29,7 +29,13 @@ export default function Route() {
     useCallback(() => {
     /* @end */
       /* @info Invoked whenever the route is focused */
-      console.log('Hello')
+      console.log('Hello, I am focused!');
+      /* @end */
+
+      /* @info Return function is invoked whenever the route gets out of focus */
+      return () => {
+        console.log('See you soon... I hope!');
+      }
       /* @end */
     }, []);
   );


### PR DESCRIPTION
# Why

To be as exhaustive as the [react-navigation equivalent](https://reactnavigation.org/docs/function-after-focusing-screen/#:~:text=React%20Navigation%20provides%20a%20hook%20that%20returns%20a%20boolean%20indicating,on%20the%20screen%20or%20not.)

# How

Added the `return () => {}` function to the `useFocusEffect` example, to show how to trigger code when view gets **out** of focus.

# Test Plan

N/A
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
