### PR TITLE
[expo-calendar] [iOS] Fix missing event info on update

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix missing event info on update. ([#28825](https://github.com/expo/expo/pull/28825) by [@robertying](https://github.com/robertying))
+
 ### 💡 Others
 
 ## 13.0.4 — 2024-05-09

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -140,6 +140,9 @@ public class CalendarModule: Module {
         calendarEvent.endDate = parse(date: endDate)
       }
 
+      calendarEvent.title = event.title
+      calendarEvent.location = event.location
+      calendarEvent.notes = event.notes
       calendarEvent.isAllDay = event.allDay
       calendarEvent.availability = getAvailability(availability: event.availability)
 
@@ -257,6 +260,17 @@ public class CalendarModule: Module {
       if let completionDate {
         reminder.completionDate = completionDate
       }
+
+      if let notes = details.notes {
+        reminder.notes = notes
+      }
+
+      if let isCompleted = details.completed {
+        reminder.isCompleted = isCompleted
+      }
+
+      reminder.title = details.title
+      reminder.location = details.location
 
       try eventStore.save(reminder, commit: true)
       return reminder.calendarItemIdentifier


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up on https://github.com/expo/expo/pull/28265. Expo Calendar also doesn't properly update event info on `saveEventAsync` and `saveReminderAsync`, such as `title`, `location`, etc.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Make sure the available properties are all set and updated.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Create a new calendar event on iOS.
- Update the newly created event with a new title using Expo Calendar.
- Go to the Calendar app and see the event title is not changed.
- Apply the fix.
- Update the event title again using Expo Calendar.
- Go to the Calendar app and see the event title is correctly changed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
