### PR TITLE
[workspace] Fix link and remove legacy Twitter reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you like Expo and want to help make it better then check out our [contributin
 
 If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/faq/)!
 
-If you still have questions you can ask them on our [Discord and [Forums](https://chat.expo.dev) or X [@expo](https://x.com/expo)](https://x.com/expo).
+If you still have questions you can ask them on our [Discord and [Forums](https://chat.expo.dev) or X [@expo](https://x.com/expo).
 
 ## 💙 The Team
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Read the [Expo Community Guidelines](https://expo.dev/guidelines) before interac
 - [`templates`](/templates) The template projects you get when you run `npx create-expo-app`
 - [`react-native-lab`](/react-native-lab) This is our fork of `react-native` used to build Expo Go.
 - [`guides`](/guides) In-depth tutorials for advanced topics like contributing to the client.
-- [`tools`](/tools) contains build and configuration tools.
+- [`tools`](/tools) contain build and configuration tools.
 - [`template-files`](/template-files) contains templates for files that require private keys. They are populated using the keys in `template-files/keys.json`.
 - [`template-files/ios/dependencies.json`](/template-files/ios/dependencies.json) specifies the CocoaPods dependencies of the app.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you like Expo and want to help make it better then check out our [contributin
 
 If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/faq/)!
 
-If you still have questions you can ask them on our [Discord and Forums](https://chat.expo.dev) or on X.com [@expo](https://x.com/expo).
+If you still have questions you can ask them on our [Discord and [Forums](https://chat.expo.dev) or X [@expo](https://x.com/expo)](https://x.com/expo).
 
 ## 💙 The Team
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read the [Expo Community Guidelines](https://expo.dev/guidelines) before interac
 - [`packages`](/packages) All the source code for Expo modules, if you want to edit a library or just see how it works this is where you'll find it.
 - [`apps`](/apps) This is where you can find Expo projects which are linked to the development modules. You'll do most of your testing in here.
 - [`apps/expo-go`](/apps/expo-go) This is where you can find the source code for Expo Go.
-- [`apps/expo-go/ios/Exponent.xcworkspace`](/ios) is the Xcode workspace. When developing iOS, always open this instead of `Exponent.xcodeproj` because the workspace also loads the CocoaPods dependencies.
+- [`apps/expo-go/ios/Exponent.xcworkspace`](/apps/expo-go/ios) is the Xcode workspace. When developing iOS, always open this instead of `Exponent.xcodeproj` because the workspace also loads the CocoaPods dependencies.
 - [`docs`](/docs) The source code for **https://docs.expo.dev**
 - [`templates`](/templates) The template projects you get when you run `npx create-expo-app`
 - [`react-native-lab`](/react-native-lab) This is our fork of `react-native` used to build Expo Go.
@@ -114,7 +114,7 @@ If you like Expo and want to help make it better then check out our [contributin
 
 If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/faq/)!
 
-If you still have questions you can ask them on our [Discord and Forums](https://chat.expo.dev) or on Twitter [@Expo](https://twitter.com/expo).
+If you still have questions you can ask them on our [Discord and Forums](https://chat.expo.dev) or on X.com [@expo](https://x.com/expo).
 
 ## 💙 The Team
 
@@ -123,6 +123,5 @@ Curious about who makes Expo? Here are our [team members](https://expo.dev/about
 ## License
 
 The Expo source code is made available under the [MIT license](LICENSE). Some of the dependencies are licensed differently, with the BSD license, for example.
-
 
 <img alt="Star the Expo repo on GitHub to support the project" src="https://user-images.githubusercontent.com/9664363/185428788-d762fd5d-97b3-4f59-8db7-f72405be9677.gif" width="50%">

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you like Expo and want to help make it better then check out our [contributin
 
 If you have questions about Expo and want answers, then check out our [Frequently Asked Questions](https://docs.expo.dev/faq/)!
 
-If you still have questions you can ask them on our [Discord and [Forums](https://chat.expo.dev) or X [@expo](https://x.com/expo).
+If you still have questions you can ask them on our [Discord and Forums](https://chat.expo.dev) or X [@expo](https://x.com/expo).
 
 ## 💙 The Team
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR updates `expo/expo/README` to:
- Fix broken link for `apps/expo-go/ios/Exponent.xcworkspace`
- Removes mention of Twitter and update it with "X.com". Use same pattern for account handle as X does.
- Fix few grammatical typos.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
