### PR TITLE
test(create-expo): replace outdated e2e `App.js` with `app/_layout.tsx` assertion

### DIFF
--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -113,7 +113,7 @@ it('uses npm', async () => {
   expect(results.stdout).toMatch(/npm install/);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'App.js');
+  expectFileExists(projectName, 'app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');


### PR DESCRIPTION
# Why

This is a follow-up for the failing CI of #28759, caused by [893fd06](https://github.com/expo/expo/commit/893fd060c21c3c3ec31167f37863eec185c06016).

# How

- Replace outdated e2e `App.js` with `app/_layout.tsx` assertion

# Test Plan

See e2e tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
