### PR TITLE
[sensors][android] Fix crash when using `DeviceMotion` module

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix crash when using `DeviceMotion` module. ([#28839](https://github.com/expo/expo/pull/28839) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 13.0.5 — 2024-05-06

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -223,7 +223,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
   private fun getOrientation(): Int {
     val windowManager = appContext.reactContext?.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
     val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      appContext.reactContext?.applicationContext?.display?.rotation
+      appContext.activityProvider?.currentActivity?.display?.rotation
     } else {
       @Suppress("DEPRECATION")
       windowManager?.defaultDisplay?.rotation


### PR DESCRIPTION
# Why

Currently `DeviceMotion` module crashes with 

```
Tried to obtain display from a Context not associated with  one.
```

Fixes https://github.com/expo/expo/issues/28820

# How

The orientation is now obtained from the current activity instead of `reactContext.applicationContext`

# Test Plan

Tested in BareExpo 

