### PR TITLE
[launcher][Android] Remove unnecessary reload when opening backgrounded app from icon

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Removes the unnecessary reload when opening the backgrounded app from the icon.
+
 ### 💡 Others
 
 ## 4.0.14 — 2024-05-09

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Removes the unnecessary reload when opening the backgrounded app from the icon.
+- [Android] Removes the unnecessary reload when opening the backgrounded app from the icon. ([#28893](https://github.com/expo/expo/pull/28893) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -253,9 +253,14 @@ class DevLauncherController private constructor() :
       }
 
     intent?.let {
+      // If the app is already open or the intent is not a main intent, we don't want to handle it.
+      if (mode == Mode.APP || intent.action != Intent.ACTION_MAIN) {
+        return@let
+      }
+
       val shouldTryToLaunchLastOpenedBundle = getMetadataValue(context, "DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE", "true").toBoolean()
       val lastOpenedApp = recentlyOpedAppsRegistry.getMostRecentApp()
-      if (shouldTryToLaunchLastOpenedBundle && lastOpenedApp != null && intent.action == Intent.ACTION_MAIN) {
+      if (shouldTryToLaunchLastOpenedBundle && lastOpenedApp != null) {
         coroutineScope.launch {
           try {
             loadApp(Uri.parse(lastOpenedApp.url), activityToBeInvalidated)


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/27073.
Closes https://github.com/expo/expo/issues/28685.

# How

If we already launched the app, we don't want to do it again and force the reload.  

# Test Plan

- created a new app and tried to open the background app from the icon ✅ 