### PR TITLE
[tools] Assigning SDK tags also on the main branch

### DIFF
--- a/tools/src/ProjectVersions.ts
+++ b/tools/src/ProjectVersions.ts
@@ -25,6 +25,13 @@ export async function sdkVersionAsync(): Promise<string> {
   return packageJson.version as string;
 }
 
+/**
+ * Returns a major version number of the `expo` package.
+ */
+export async function sdkVersionNumberAsync(): Promise<number> {
+  return semver.major(await sdkVersionAsync());
+}
+
 export async function iosAppVersionAsync(): Promise<string> {
   const infoPlistPath = path.join(EXPO_GO_IOS_DIR, 'Exponent', 'Supporting', 'Info.plist');
   const infoPlist = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));

--- a/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
+++ b/tools/src/publish-packages/tasks/assignTagForSdkRelease.ts
@@ -1,14 +1,17 @@
 import chalk from 'chalk';
+import inquirer from 'inquirer';
+import semver from 'semver';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
 import Git from '../../Git';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
+import { sdkVersionNumberAsync } from '../../ProjectVersions';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
-const { green, yellow } = chalk;
+const { green, yellow, cyan } = chalk;
 
 /**
  * Assigns the SDK tag to packages when run on the release branch.
@@ -19,52 +22,76 @@ export const assignTagForSdkRelease = new Task<TaskArgs>(
     dependsOn: [loadRequestedParcels],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
-    const sdkTag = await findSdkTag();
+    const sdkTag = await getSdkTag();
+    const shouldAssignSdkTag =
+      options.assignSdkTag || (await isReleaseBranch()) || (await askToAssignSdkTag(sdkTag));
 
-    // Skip the task when not on the SDK branch.
-    if (!sdkTag) {
-      if (options.assignSdkTag) {
-        logger.warn('SDK tag can be assigned only from the release branch.');
-      }
+    if (!shouldAssignSdkTag || options.canary) {
       return;
     }
 
     await runWithSpinner(
-      `Assigning ${yellow.bold(sdkTag)} tag to packages`,
+      `Assigning ${yellow(sdkTag)} tag to packages`,
       async (step) => {
         for (const { pkg, pkgView } of parcels) {
-          if (isPackageViewMatchingTag(pkgView, sdkTag)) {
-            // Current version of the package is already tagged.
+          const currentTagVersion = pkgView?.['dist-tags']?.[sdkTag];
+          const pkgName = pkg.packageName;
+          const pkgVersion = pkg.packageVersion;
+
+          // Skip if the currently tagged version is greater or equal to the current one.
+          if (currentTagVersion && semver.lte(pkgVersion, currentTagVersion)) {
+            logger.debug(
+              `≫ Skipped ${green(pkgName)} - the tag is already greater or equal (${cyan(
+                currentTagVersion
+              )})`
+            );
             continue;
           }
-          step.start(`Assigning ${yellow.bold(sdkTag)} tag to ${green(pkg.packageName)}`);
+
+          step.start(
+            `Assigning ${yellow.bold(sdkTag)} tag to ${green(pkgName)}@${cyan(pkgVersion)}\n`
+          );
 
           if (!options.dry) {
-            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag);
+            await Npm.addTagAsync(pkgName, pkgVersion, sdkTag);
           }
         }
       },
-      `Successfully assigned ${yellow.bold(sdkTag)} tag`
+      `Successfully assigned ${yellow(sdkTag)} tag`
     );
   }
 );
 
 /**
- * Returns a boolean value whether the package view matches the given tag.
+ * Returns the SDK tag (e.g. `sdk-50`) appropriate for the current version of the `expo` package.
  */
-function isPackageViewMatchingTag(pkgView: Npm.PackageViewType, tag: string): boolean {
-  const tags = pkgView?.['dist-tags'] ?? {};
-  return tags[tag] === pkgView?.version;
+async function getSdkTag(): Promise<string> {
+  const sdkVersion = await sdkVersionNumberAsync();
+  return `sdk-${sdkVersion}`;
 }
 
 /**
- * Returns the SDK tag (e.g. `sdk-50`) when run on the release branch or `null` otherwise.
+ * Returns a boolean whether the current branch is a release branch.
  */
-async function findSdkTag(): Promise<string | null> {
-  const branchName = await Git.getCurrentBranchNameAsync();
+async function isReleaseBranch(): Promise<boolean> {
+  return !!Git.getSDKVersionFromBranchNameAsync();
+}
 
-  if (/^sdk-\d+$/.test(branchName)) {
-    return branchName;
+/**
+ * Asks whether to assign the SDK tag to the current packages versions.
+ */
+async function askToAssignSdkTag(sdkTag: string): Promise<boolean> {
+  if (process.env.CI) {
+    return false;
   }
-  return null;
+  const { assignSdkTag } = await inquirer.prompt<{ assignSdkTag: boolean }>([
+    {
+      type: 'confirm',
+      name: 'assignSdkTag',
+      prefix: '❔',
+      message: `Do you want to assign ${yellow(sdkTag)} tag to the current versions?`,
+      default: true,
+    },
+  ]);
+  return assignSdkTag;
 }


### PR DESCRIPTION
# Why

Currently `et publish` assigns `sdk-*` tags on npm only when running on the release branch. There is a period of time when `main` and the release branch are not diverged in which case we're still publishing from `main`. It would be great to tag these versions too.

# How

- Get the proper tag based on the `expo` package version instead of the branch name
- Always assign a tag if we're on the release branch
- Prompt what to do when we're on any other branch

# Test Plan

`et publish expo-font --assign-sdk-tag` assigned the tag properly, but it only runs this specific task and not the entire flow, so I'll also need to test this change once it lands on main.