### PR TITLE
[docs] Add a link to alternate methods to enable developer mode

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
@@ -49,6 +49,6 @@ Run the following command to create a development build:
 <Step label="5">
 ### Install the development build on your device
 
-After the build is complete, scan the QR code in your terminal or open the link on your device. Tap "Install" to download the build onto your device, then tap "Open" to install it.
+After the build is complete, scan the QR code in your terminal or open the link on your device. Tap **Install** to download the build on your device, then tap **Open** to install it.
 
 </Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
@@ -65,16 +65,18 @@ Run the following command to create a development build:
 <Step label="7">
 ### Turn on developer mode
 
-1. Open "Settings" > "Privacy & Security", scroll down to the "Developer Mode" list item and navigate into it.
-2. Tap the switch to enable "Developer Mode". After you do so, Settings presents an alert to warn you that Developer Mode reduces your device's security. To continue enabling "Developer Mode", tap the alert's "Restart" button.
-3. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap "Turn On", and enter your device passcode when prompted.
+1. Open **Settings** > **Privacy & Security**, scroll down to the **Developer Mode** list item and navigate into it.
+2. Tap the switch to enable **Developer Mode**. After you do so, Settings presents an alert to warn you that Developer Mode reduces your device's security. To continue enabling **Developer Mode**, tap the alert's **Restart** button.
+3. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap **Turn On**, and enter your device passcode when prompted.
+
+> Alternatively, if you have Xcode installed on your Mac, you can use it to [enable iOS developer mode](/guides/ios-developer-mode/#connect-an-ios-device-with-a-mac).
 
 </Step>
 
 <Step label="8">
 ### Install the development build on your device
 
-After the build is complete, scan the QR code in your terminal and tap "Open with iTunes" when it appears inside the Camera app. Alternatively, open the link displayed in the terminal on your device.
+After the build is complete, scan the QR code in your terminal and tap **Open with iTunes** when it appears inside the Camera app. Alternatively, open the link displayed in the terminal on your device.
 
 After confirming the installation, the app will appear in your device's app library.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -29,7 +29,7 @@ Run the following command in your project's root directory:
 
 ### Plug in your device via USB
 
-Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap "Trust" if prompted.
+Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on recent feedback received, there was some confusion that Developer mode setting can be enabled using Xcode and connecting an iOS device using the USB cable. In set your environment doc, we share instructions to enable this setting in case of using a development build without Xcode. However, since we cover instructions with Xcode in detail in its own guide, let's add that as callout in this to avoid confusion around this in future.

This PR also aligns referencing settings in bold since the doc (and elsewhere in docs) we prefer to use them over quotes. For consistency, let's update that.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
