### PR TITLE
[ios][camera] Prevent crash when rendered on the simulator

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, prevent a crash when rendering the view on a simulator.
+- On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, prevent a crash when rendering the view on a simulator.
+
 ### 💡 Others
 
 ## 15.0.8 — 2024-05-13

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -29,6 +29,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     return mm
   }()
   private var cameraShouldInit = true
+  private var isSessionRunning = false
 
   // MARK: Property Observers
 
@@ -158,7 +159,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   public func onAppForegrounded() {
-    if !session.isRunning {
+    if !session.isRunning && isSessionRunning {
+      isSessionRunning = false
       sessionQueue.async {
         self.session.startRunning()
       }
@@ -166,7 +168,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   public func onAppBackgrounded() {
-    if session.isRunning {
+    if session.isRunning && !isSessionRunning {
+      isSessionRunning = true
       sessionQueue.async {
         self.session.stopRunning()
       }
@@ -298,8 +301,9 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       }
 
       if error.code == .mediaServicesWereReset {
-        if !self.session.isRunning {
+        if self.isSessionRunning {
           self.session.startRunning()
+          self.isSessionRunning = self.session.isRunning
           self.updateSessionAudioIsMuted()
           self.onCameraReady()
         }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -29,7 +29,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     return mm
   }()
   private var cameraShouldInit = true
-  private var isSessionRunning = false
+  private var isSessionPaused = false
 
   // MARK: Property Observers
 
@@ -159,8 +159,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   public func onAppForegrounded() {
-    if !session.isRunning && isSessionRunning {
-      isSessionRunning = false
+    if !session.isRunning && isSessionPaused {
+      isSessionPaused = false
       sessionQueue.async {
         self.session.startRunning()
       }
@@ -168,8 +168,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   public func onAppBackgrounded() {
-    if session.isRunning && !isSessionRunning {
-      isSessionRunning = true
+    if session.isRunning && !isSessionPaused {
+      isSessionPaused = true
       sessionQueue.async {
         self.session.stopRunning()
       }
@@ -301,12 +301,9 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       }
 
       if error.code == .mediaServicesWereReset {
-        if self.isSessionRunning {
-          self.session.startRunning()
-          self.isSessionRunning = self.session.isRunning
-          self.updateSessionAudioIsMuted()
-          self.onCameraReady()
-        }
+        self.session.startRunning()
+        self.updateSessionAudioIsMuted()
+        self.onCameraReady()
       }
     }
   }


### PR DESCRIPTION
# Why
When the camera is rendered on the simulator, the app will crash after the permissions request. This is because iOS calls `onAppForegrounded` after a permission modal is dismissed which then attempts to start the session but we are already in the middle of configuring the session.

# How
We should only start the session in `onAppForegrounded` if `onAppBackgrounded` has been called first. Otherwise, we know `onAppForegrounded` has been called after a permission modal has been dismissed. 

# Test Plan
bare-expo ✅

