### PR TITLE
[updates] fix fingerprint policy start error on debug build

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed launch crash when using fingerprint runtime version policy on Android with expo-dev-client. ([#28912](https://github.com/expo/expo/pull/28912) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.25.13 — 2024-05-15

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -41,9 +41,9 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
       val createUpdatesResourcesTask = project.tasks.register("create${targetName}UpdatesResources", CreateUpdatesResourcesTask::class.java) {
         it.description = "expo-updates: Create updates resources for ${targetName}."
         it.projectRoot.set(projectRoot.toString())
-        it.entryFile.set(entryFileRelativePath.toString())
         it.nodeExecutableAndArgs.set(reactExtension.nodeExecutableAndArgs.get())
-        it.enabled = !isDebuggableVariant
+        it.debuggableVariant.set(isDebuggableVariant)
+        it.entryFile.set(entryFileRelativePath.toString())
       }
       variant.sources.assets?.addGeneratedSourceDirectory(createUpdatesResourcesTask, CreateUpdatesResourcesTask::assetDir)
     }
@@ -55,6 +55,9 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
 
     @get:Input
     abstract val nodeExecutableAndArgs: ListProperty<String>
+
+    @get:Input
+    abstract val debuggableVariant: Property<Boolean>
 
     @get:Input
     abstract val entryFile: Property<String>
@@ -73,7 +76,7 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
           add("android")
           add(projectRoot.get())
           add(assetDir.get().toString())
-          add("all")
+          add(if (debuggableVariant.get()) "only-fingerprint" else "all")
           add(entryFile.get())
         }
 


### PR DESCRIPTION
# Why

fix android launch crash when a project using fingerprint runtime version policy with expo-updates and expo-dev-client
close ENG-12299

# How

the crash is because on debug build we didn't generate the fingerprint file. this pr tries to generate fingerprint on debug build. this is aligned with our implementation on ios: https://github.com/expo/expo/blob/2cf057857486f3f0668b1672aa72f0f0ed09b736/packages/expo-updates/scripts/create-updates-resources-ios.sh#L5-L16

# Test Plan

```sh
$ yarn create expo -t blank@sdk-51 sdk51
$ npx expo install expo-dev-client expo-updates
$ eas update:configure
# change runtimeVersion.policy to "fingerprint"
$ npx expo run:android
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
