### PR TITLE
[workspace] Update blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 &ensp;•&ensp;
   <a aria-label="expo documentation" href="https://docs.expo.dev">Read the Documentation</a>
 &ensp;•&ensp;
-  <a aria-label="expo documentation" href="https://blog.expo.dev">Learn more on our blog</a>
+  <a aria-label="expo documentation" href="https://expo.dev/blog">Learn more on our blog</a>
 &ensp;•&ensp;
   <a aria-label="expo documentation" href="https://expo.canny.io/feature-requests">Request a feature</a>
 </p>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The link in `expo/expo/README` directs to the old blog URL. This PR updates it to the new one.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Manually change blog link in README.md

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
