### PR TITLE
[ios][camera] Correct orientation when taking landscape pictures

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix incorrect orientation when taking pictures in landscape.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix incorrect orientation when taking pictures in landscape.
+- On `iOS`, fix incorrect orientation when taking pictures in landscape. ([#28917](https://github.com/expo/expo/pull/28917) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -25,7 +25,7 @@ struct ExpoCameraUtils {
 
     return orientation
   }
-  
+
   // .landscapeRight and .landscapeLeft of UIInterfaceOrientation are reversed when mapped to UIDeviceOrientation
   static func physicalOrientation(
     for orientation: UIInterfaceOrientation

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -25,6 +25,26 @@ struct ExpoCameraUtils {
 
     return orientation
   }
+  
+  // .landscapeRight and .landscapeLeft of UIInterfaceOrientation are reversed when mapped to UIDeviceOrientation
+  static func physicalOrientation(
+    for orientation: UIInterfaceOrientation
+  ) -> UIDeviceOrientation {
+    switch orientation {
+    case .portrait:
+      return .portrait
+    case .landscapeLeft:
+      return .landscapeRight
+    case .landscapeRight:
+      return .landscapeLeft
+    case .portraitUpsideDown:
+      return .portraitUpsideDown
+    case .unknown:
+      return .unknown
+    default:
+      return .unknown
+    }
+  }
 
   static func videoOrientation(for interfaceOrientation: UIInterfaceOrientation) -> AVCaptureVideoOrientation {
     switch interfaceOrientation {
@@ -41,6 +61,7 @@ struct ExpoCameraUtils {
     }
   }
 
+  // .landscapeRight and .landscapeLeft need to be reversed when mapped back to AVCaptureVideoOrientation
   static func videoOrientation(for deviceOrientation: UIDeviceOrientation) -> AVCaptureVideoOrientation {
     switch deviceOrientation {
     case .portrait:
@@ -48,9 +69,9 @@ struct ExpoCameraUtils {
     case .portraitUpsideDown:
       return .portraitUpsideDown
     case .landscapeLeft:
-      return .landscapeLeft
-    case .landscapeRight:
       return .landscapeRight
+    case .landscapeRight:
+      return .landscapeLeft
     default:
       return .portrait
     }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -784,6 +784,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       // We shouldn't access the device orientation anywhere but on the main thread
       let videoOrientation = ExpoCameraUtils.videoOrientation(for: self.deviceOrientation)
       if (self.previewLayer.videoPreviewLayer.connection?.isVideoOrientationSupported) == true {
+        self.physicalOrientation = ExpoCameraUtils.physicalOrientation(for: self.deviceOrientation)
         self.previewLayer.videoPreviewLayer.connection?.videoOrientation = videoOrientation
       }
     }


### PR DESCRIPTION
# Why
Closes #28573

# How
When mapping from `UIInterfaceOrientation` to `UIDeviceOrientation`, `.landscapeLeft` and `.landscapeRight` are reversed. Similarly, when mapping from `UIDeviceOrientation` to `AVCaptureVideoOrientation` the values must be reversed. Ideally, we'd use `UIInterfaceOrientation` directly but this is only safe to access on the main thread. Instead, we store it when we correct the previews orientation and when the `orientationChanged` notification is received. We also need to use `UIDeviceOrientation` so we can provide a fallback of `UIDevice.current.orientation` as there is no way to access the current `UIInterfaceOrientation` safely on  a background thread.

# Test Plan
bare-expo using a phone and an iPad ✅

