### PR TITLE
fix(cli): parse npm view tarball objects instead of strings

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Parse full tarball object instead of quoted string with `npm view` for Linux. ([#28919](https://github.com/expo/expo/pull/28919) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.18.12 — 2024-05-14

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Parse full tarball object instead of quoted string with `npm view` for Linux. ([#28919](https://github.com/expo/expo/pull/28919) by [@byCedric](https://github.com/byCedric))
+- Parse full tarball object instead of quoted string with `npm view` for `npm@10.8.0+`. ([#28919](https://github.com/expo/expo/pull/28919) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/npm.ts
+++ b/packages/@expo/cli/src/utils/npm.ts
@@ -69,22 +69,26 @@ export async function npmViewAsync(...props: string[]): Promise<JSONValue> {
 
 /** Given a package name like `expo` or `expo@beta`, return the registry URL if it exists. */
 export async function getNpmUrlAsync(packageName: string): Promise<string> {
-  const results = await npmViewAsync(packageName, 'dist.tarball');
+  const results = await npmViewAsync(packageName, 'dist');
 
   assert(results, `Could not get npm url for package "${packageName}"`);
 
-  // Fully qualified url returns a string.
+  // Fully qualified url returns an object.
   // Example:
-  // 𝝠 npm view expo-template-bare-minimum@sdk-33 dist.tarball --json
-  if (typeof results === 'string') {
-    return results;
+  // 𝝠 npm view expo-template-bare-minimum@sdk-33 dist --json
+  if (typeof results === 'object' && !Array.isArray(results)) {
+    return results.tarball as string;
   }
 
-  // When the tag is arbitrary, the tarball url is an array, return the last value as it's the most recent.
+  // When the tag is arbitrary, the tarball is an array, return the last value as it's the most recent.
   // Example:
-  // 𝝠 npm view expo-template-bare-minimum@33 dist.tarball --json
+  // 𝝠 npm view expo-template-bare-minimum@33 dist --json
   if (Array.isArray(results)) {
-    return results[results.length - 1] as string;
+    const lastResult = results[results.length - 1];
+
+    if (lastResult && typeof lastResult === 'object' && !Array.isArray(lastResult)) {
+      return lastResult.tarball as string;
+    }
   }
 
   throw new CommandError(


### PR DESCRIPTION
# Why

Fixes #28916

# How

Instead of relying on the (escaped) quotes to be included in `npm view` output, this just parses the full object instead.

Unfortunately, this seems to be caused by npm 10.8.0. Starting from this version, the output of `npm view <package> dist.tarball --json` is not wrapped in quotes anymore, meaning that the value is not a JSON value anymore (and can't be parsed by `JSON.parse`).

See: https://github.com/npm/cli/issues/7537

# Test Plan

See prebuild e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
