### PR TITLE
[docs] Fix Android Sensorlimits in Expo Sensors API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -40,9 +40,9 @@ import {
 
 ### Android
 
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v49.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sensors.mdx
@@ -42,9 +42,9 @@ import {
 
 ### Android
 
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v50.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sensors.mdx
@@ -42,9 +42,9 @@ import {
 
 ### Android
 
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 

--- a/docs/pages/versions/v51.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sensors.mdx
@@ -40,9 +40,9 @@ import {
 
 ### Android
 
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+Starting in Android 12 (API level 31), the system has a 200Hz limit for each sensor updates.
 
-If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+If you need an update interval of less than 200Hz, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
 
 <AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
 


### PR DESCRIPTION
# Why

The Expo doc does not meet the android doc

# How

According to https://developer.android.com/develop/sensors-and-location/sensors/sensors_overview#sensors-rate-limiting limits are 200Hz which means an update interval of 5ms, and not 200ms.

# Test Plan

This is a documentation-only update.
1Hz = 1times per second => interval of 1000ms
200Hz = 200 times per second => interval of 1000ms/200 = 5ms

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). --> not relevant for documentation changes
