### PR TITLE
[docs] change the API pages ToC display

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { forwardRef, useState, type MouseEvent } from 'react';
 
 import { BASE_HEADING_LEVEL, Heading, HeadingType } from '~/common/headingManager';
-import { Tag } from '~/ui/components/Tag';
 import { MONOSPACE, CALLOUT, FOOTNOTE } from '~/ui/components/Text';
 import * as Tooltip from '~/ui/components/Tooltip';
 
@@ -29,8 +28,9 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
     const displayTitle = shortenCode && isCode ? trimCodedTitle(title) : title;
 
     const [tooltipVisible, setTooltipVisible] = useState(false);
+
     const onMouseOver = (event: MouseEvent<HTMLAnchorElement>) => {
-      setTooltipVisible(isOverflowing(event.currentTarget) || Boolean(tags?.length));
+      setTooltipVisible(isOverflowing(event.currentTarget));
     };
 
     const onMouseOut = () => {
@@ -38,7 +38,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
     };
 
     const TitleElement = isCodeOrFilePath ? MONOSPACE : CALLOUT;
-    const tagsToDisplay = tags && tags.length > 0 ? tags.filter(tag => tag === 'deprecated') : [];
+    const isDeprecated = tags && tags.length > 0 ? tags.find(tag => tag === 'deprecated') : null;
 
     return (
       <Tooltip.Root open={tooltipVisible}>
@@ -58,33 +58,20 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
               className={mergeClasses(
                 'w-full !text-secondary hocus:!text-link',
                 isCodeOrFilePath && 'truncate !text-2xs',
-                isActive && '!text-link'
+                isActive && '!text-link',
+                isDeprecated && 'opacity-80 line-through'
               )}>
               {displayTitle}
             </TitleElement>
-            {tagsToDisplay.length > 0 && (
-              <div className="inline-flex">
-                {tagsToDisplay.map(tag => (
-                  <Tag name={tag} type="toc" key={`${displayTitle}-${tag}`} />
-                ))}
-              </div>
-            )}
           </Link>
         </Tooltip.Trigger>
         <Tooltip.Content
           side="bottom"
-          className="min-w-[232px]"
+          align="start"
           collisionPadding={{
             right: 22,
           }}>
           <FOOTNOTE tag={isCode ? 'code' : undefined}>{displayTitle}</FOOTNOTE>
-          {tags && tags.length > 0 && (
-            <div className="flex flex-row my-1 gap-2">
-              {tags.map(tag => (
-                <Tag name={tag} className="!m-0" type="toc" key={`${displayTitle}-${tag}`} />
-              ))}
-            </div>
-          )}
         </Tooltip.Content>
       </Tooltip.Root>
     );

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -30,7 +30,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
 
     const [tooltipVisible, setTooltipVisible] = useState(false);
     const onMouseOver = (event: MouseEvent<HTMLAnchorElement>) => {
-      setTooltipVisible(isOverflowing(event.currentTarget));
+      setTooltipVisible(isOverflowing(event.currentTarget) || Boolean(tags?.length));
     };
 
     const onMouseOut = () => {
@@ -38,6 +38,7 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
     };
 
     const TitleElement = isCodeOrFilePath ? MONOSPACE : CALLOUT;
+    const tagsToDisplay = tags && tags.length > 0 ? tags.filter(tag => tag === 'deprecated') : [];
 
     return (
       <Tooltip.Root open={tooltipVisible}>
@@ -55,27 +56,35 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
             )}>
             <TitleElement
               className={mergeClasses(
-                '!text-secondary hocus:!text-link',
+                'w-full !text-secondary hocus:!text-link',
                 isCodeOrFilePath && 'truncate !text-2xs',
                 isActive && '!text-link'
               )}>
               {displayTitle}
             </TitleElement>
-            {tags && tags.length ? (
+            {tagsToDisplay.length > 0 && (
               <div className="inline-flex">
-                {tags.map(tag => (
+                {tagsToDisplay.map(tag => (
                   <Tag name={tag} type="toc" key={`${displayTitle}-${tag}`} />
                 ))}
               </div>
-            ) : undefined}
+            )}
           </Link>
         </Tooltip.Trigger>
         <Tooltip.Content
           side="bottom"
+          className="min-w-[232px]"
           collisionPadding={{
             right: 22,
           }}>
-          <FOOTNOTE tag="code">{displayTitle}</FOOTNOTE>
+          <FOOTNOTE tag={isCode ? 'code' : undefined}>{displayTitle}</FOOTNOTE>
+          {tags && tags.length > 0 && (
+            <div className="flex flex-row my-1 gap-2">
+              {tags.map(tag => (
+                <Tag name={tag} className="!m-0" type="toc" key={`${displayTitle}-${tag}`} />
+              ))}
+            </div>
+          )}
         </Tooltip.Content>
       </Tooltip.Root>
     );
@@ -106,7 +115,7 @@ const isOverflowing = (el: HTMLElement) => {
 
   const childrenWidth = Array.from(el.children).reduce((sum, child) => sum + child.scrollWidth, 0);
   const indent = parseInt(window.getComputedStyle(el).paddingLeft, 10);
-  return childrenWidth >= el.scrollWidth - indent;
+  return childrenWidth > 220 && childrenWidth >= el.scrollWidth - indent;
 };
 
 export default DocumentationSidebarRightLink;

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#base-level-heading"
     >
       <p
-        class="!text-secondary hocus:!text-link css-1yjys1n-TextComponent"
+        class="w-full !text-secondary hocus:!text-link css-1yjys1n-TextComponent"
         data-text="true"
       >
         Base level heading
@@ -80,7 +80,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       style="padding-left: 12px;"
     >
       <p
-        class="!text-secondary hocus:!text-link css-1yjys1n-TextComponent"
+        class="w-full !text-secondary hocus:!text-link css-1yjys1n-TextComponent"
         data-text="true"
       >
         Level 3 subheading
@@ -93,7 +93,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       style="padding-left: 12px;"
     >
       <code
-        class="!text-secondary hocus:!text-link truncate !text-2xs css-yszm2s-TextComponent"
+        class="w-full !text-secondary hocus:!text-link truncate !text-2xs css-yszm2s-TextComponent"
         data-text="true"
       >
         Code heading depth 1


### PR DESCRIPTION
# Why

An attempt to improve the API pages ToC readability.

# How

Hide all tags from ToC, show tooltip only when entry name overflows.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-05-17 at 17 09 52](https://github.com/expo/expo/assets/719641/af29389b-b14b-440b-a272-e8b6945130cf)
