### PR TITLE
[android][camera] Handle displaying landscape images correctly

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,7 +17,7 @@
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix incorrect orientation when taking pictures in landscape. ([#28917](https://github.com/expo/expo/pull/28917) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, set previewLayer on scanner to get correct dimensions. ([#28931](https://github.com/expo/expo/pull/28931) by [@alanjhughes](https://github.com/alanjhughes))
-- On `Android`, correctly handle orientation when taking pictures in landscape.
+- On `Android`, correctly handle orientation when landscape pictures are rendered. ([#28929](https://github.com/expo/expo/pull/28929) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 15.0.8 — 2024-05-13
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix incorrect orientation when taking pictures in landscape. ([#28917](https://github.com/expo/expo/pull/28917) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, set previewLayer on scanner to get correct dimensions. ([#28931](https://github.com/expo/expo/pull/28931) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, correctly handle orientation when taking pictures in landscape.
 
 ## 15.0.8 — 2024-05-13
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -221,6 +221,7 @@ class CameraViewModule : Module() {
       }.runOnQueue(Queues.MAIN)
 
       OnViewDestroys { view ->
+        view.orientationEventListener.disable()
         view.cancelCoroutineScope()
         view.releaseCamera()
       }


### PR DESCRIPTION
# Why
On android landscape pictures are taken correctly but not rotated  correctly when rendered to the screen.

# How
Implement the `OrientationEventListener` on Android to set the target rotation on the image.

# Test Plan
Built a test app specifically for camera 

