### PR TITLE
[camera][scanner] Set previewLayer on scanner

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix incorrect orientation when taking pictures in landscape. ([#28917](https://github.com/expo/expo/pull/28917) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, set previewLayer on scanner to get correct dimensions.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - On `iOS`, prevent a crash when rendering the view on a simulator. ([#28911](https://github.com/expo/expo/pull/28911) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix incorrect orientation when taking pictures in landscape. ([#28917](https://github.com/expo/expo/pull/28917) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, set previewLayer on scanner to get correct dimensions.
+- On `iOS`, set previewLayer on scanner to get correct dimensions. ([#28931](https://github.com/expo/expo/pull/28931) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -20,7 +20,7 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     AVMetadataObject.ObjectType.pdf417: ZXPDF417Reader(),
     AVMetadataObject.ObjectType.code39: ZXCode39Reader()
   ]
-
+  private var previewLayer: AVCaptureVideoPreviewLayer?
   private var zxingFPSProcessed = 6.0
   private var zxingEnabled = true
 
@@ -46,6 +46,10 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
         }
       }
     }
+  }
+
+  func setPreviewLayer(layer: AVCaptureVideoPreviewLayer) {
+    self.previewLayer = layer
   }
 
   func setIsEnabled(_ enabled: Bool) {
@@ -182,7 +186,11 @@ class BarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptur
     }
 
     for metadata in metadataObjects {
-      let codeMetadata = metadata as? AVMetadataMachineReadableCodeObject
+      var codeMetadata = metadata as? AVMetadataMachineReadableCodeObject
+      if let previewLayer {
+        codeMetadata = previewLayer.transformedMetadataObject(for: metadata) as? AVMetadataMachineReadableCodeObject
+      }
+
       for barcodeType in settings {
         if zxingBarcodeReaders[barcodeType] != nil {
           continue

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -792,6 +792,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
 
   private func createBarcodeScanner() -> BarcodeScanner {
     let scanner = BarcodeScanner(session: session, sessionQueue: sessionQueue)
+    scanner.setPreviewLayer(layer: previewLayer.videoPreviewLayer)
     scanner.onBarcodeScanned = { [weak self] body in
       guard let self else {
         return


### PR DESCRIPTION
# Why
Set the `previewLayer` on the barcode scanner to allow it to get the correct corner points and bounds from the scanned barcode

# How
Added as a property to the `BarcodeScanner`

# Test Plan
bare-expo ✅

