### PR TITLE
fix(env,cli): stale env variables after env files change

### DIFF
--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `.load(_, { strict: true })`. As expected, now it overwrites env variables after second call. ([#28935](https://github.com/expo/expo/pull/28935) by [@XantreDev](https://github.com/XantreDev))
+
 ### 💡 Others
 
 ## 0.3.0 — 2024-04-18


### PR DESCRIPTION
# Why

Expo cli do not respond on env file update
#28891 

# How

Started to clean up env vars before using dotenvExtend

# Test Plan

I wrote unit test env is updated

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
