### PR TITLE
[dev-launcher][iOS] Prevent React Native Dev Menu from showing up on launcher screen

### DIFF
--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -3,26 +3,26 @@ PODS:
   - DoubleConversion (1.1.6)
   - EASClient (0.12.0):
     - ExpoModulesCore
-  - EXAV (14.0.2):
+  - EXAV (14.0.4):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - EXConstants (16.0.1):
     - ExpoModulesCore
   - EXJSONUtils (0.13.1)
-  - EXManifests (0.14.1):
+  - EXManifests (0.14.2):
     - ExpoModulesCore
-  - Expo (51.0.0-preview.9):
+  - Expo (51.0.5):
     - ExpoModulesCore
-  - expo-dev-client (4.0.7):
+  - expo-dev-client (4.0.13):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (4.0.7):
+  - expo-dev-launcher (4.0.14):
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 4.0.7)
+    - expo-dev-launcher/Main (= 4.0.14)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -39,6 +39,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
@@ -47,7 +48,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Main (4.0.7):
+  - expo-dev-launcher/Main (4.0.14):
     - DoubleConversion
     - EXManifests
     - expo-dev-launcher/Unsafe
@@ -67,6 +68,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
@@ -75,7 +77,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-launcher/Unsafe (4.0.7):
+  - expo-dev-launcher/Unsafe (4.0.14):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu
@@ -94,6 +96,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
@@ -102,10 +105,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu (5.0.8):
+  - expo-dev-menu (5.0.14):
     - DoubleConversion
-    - expo-dev-menu/Main (= 5.0.8)
-    - expo-dev-menu/ReactNativeCompatibles (= 5.0.8)
+    - expo-dev-menu/Main (= 5.0.14)
+    - expo-dev-menu/ReactNativeCompatibles (= 5.0.14)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -125,8 +128,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu-interface (1.8.2)
-  - expo-dev-menu/Main (5.0.8):
+  - expo-dev-menu-interface (1.8.3)
+  - expo-dev-menu/Main (5.0.14):
     - DoubleConversion
     - EXManifests
     - expo-dev-menu-interface
@@ -144,6 +147,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -151,7 +155,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (5.0.8):
+  - expo-dev-menu/ReactNativeCompatibles (5.0.14):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -172,7 +176,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/SafeAreaView (5.0.8):
+  - expo-dev-menu/SafeAreaView (5.0.14):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -194,7 +198,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - expo-dev-menu/Vendored (5.0.8):
+  - expo-dev-menu/Vendored (5.0.14):
     - DoubleConversion
     - expo-dev-menu/SafeAreaView
     - glog
@@ -218,20 +222,21 @@ PODS:
     - Yoga
   - ExpoAppleAuthentication (6.4.1):
     - ExpoModulesCore
-  - ExpoAsset (10.0.3):
+  - ExpoAsset (10.0.6):
     - ExpoModulesCore
-  - ExpoBlur (13.0.1):
+  - ExpoBlur (13.0.2):
     - ExpoModulesCore
-  - ExpoCamera (15.0.3):
+  - ExpoCamera (15.0.8):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
   - ExpoFileSystem (17.0.1):
     - ExpoModulesCore
-  - ExpoFont (12.0.4):
+  - ExpoFont (12.0.5):
     - ExpoModulesCore
-  - ExpoImage (1.12.4):
+  - ExpoImage (1.12.9):
     - ExpoModulesCore
+    - libavif/libdav1d
     - SDWebImage (~> 5.19.1)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
@@ -240,7 +245,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLinearGradient (13.0.2):
     - ExpoModulesCore
-  - ExpoModulesCore (1.12.5):
+  - ExpoModulesCore (1.12.10):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -254,6 +259,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
+    - React-jsinspector
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
@@ -262,7 +268,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - EXSplashScreen (0.27.2):
+  - EXSplashScreen (0.27.4):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -285,7 +291,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - EXStructuredHeaders (3.8.0)
-  - EXUpdates (0.25.6):
+  - EXUpdates (0.25.11):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -313,15 +319,19 @@ PODS:
     - ReactCommon/turbomodule/core
     - "sqlite3 (~> 3.45.3+1)"
     - Yoga
-  - EXUpdatesInterface (0.16.1):
+  - EXUpdatesInterface (0.16.2):
     - ExpoModulesCore
-  - FBLazyVector (0.74.1-rc.0)
+  - FBLazyVector (0.74.1)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.74.1-rc.0):
-    - hermes-engine/Pre-built (= 0.74.1-rc.0)
-  - hermes-engine/Pre-built (0.74.1-rc.0)
+  - hermes-engine (0.74.1):
+    - hermes-engine/Pre-built (= 0.74.1)
+  - hermes-engine/Pre-built (0.74.1)
   - libavif/core (0.11.1)
+  - libavif/libdav1d (0.11.1):
+    - libavif/core
+    - libdav1d (>= 0.6.0)
+  - libdav1d (1.2.0)
   - libwebp (1.3.2):
     - libwebp/demux (= 1.3.2)
     - libwebp/mux (= 1.3.2)
@@ -350,28 +360,28 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.74.1-rc.0)
-  - RCTRequired (0.74.1-rc.0)
-  - RCTTypeSafety (0.74.1-rc.0):
-    - FBLazyVector (= 0.74.1-rc.0)
-    - RCTRequired (= 0.74.1-rc.0)
-    - React-Core (= 0.74.1-rc.0)
+  - RCTDeprecation (0.74.1)
+  - RCTRequired (0.74.1)
+  - RCTTypeSafety (0.74.1):
+    - FBLazyVector (= 0.74.1)
+    - RCTRequired (= 0.74.1)
+    - React-Core (= 0.74.1)
   - ReachabilitySwift (5.2.2)
-  - React (0.74.1-rc.0):
-    - React-Core (= 0.74.1-rc.0)
-    - React-Core/DevSupport (= 0.74.1-rc.0)
-    - React-Core/RCTWebSocket (= 0.74.1-rc.0)
-    - React-RCTActionSheet (= 0.74.1-rc.0)
-    - React-RCTAnimation (= 0.74.1-rc.0)
-    - React-RCTBlob (= 0.74.1-rc.0)
-    - React-RCTImage (= 0.74.1-rc.0)
-    - React-RCTLinking (= 0.74.1-rc.0)
-    - React-RCTNetwork (= 0.74.1-rc.0)
-    - React-RCTSettings (= 0.74.1-rc.0)
-    - React-RCTText (= 0.74.1-rc.0)
-    - React-RCTVibration (= 0.74.1-rc.0)
-  - React-callinvoker (0.74.1-rc.0)
-  - React-Codegen (0.74.1-rc.0):
+  - React (0.74.1):
+    - React-Core (= 0.74.1)
+    - React-Core/DevSupport (= 0.74.1)
+    - React-Core/RCTWebSocket (= 0.74.1)
+    - React-RCTActionSheet (= 0.74.1)
+    - React-RCTAnimation (= 0.74.1)
+    - React-RCTBlob (= 0.74.1)
+    - React-RCTImage (= 0.74.1)
+    - React-RCTLinking (= 0.74.1)
+    - React-RCTNetwork (= 0.74.1)
+    - React-RCTSettings (= 0.74.1)
+    - React-RCTText (= 0.74.1)
+    - React-RCTVibration (= 0.74.1)
+  - React-callinvoker (0.74.1)
+  - React-Codegen (0.74.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -391,12 +401,12 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.74.1-rc.0):
+  - React-Core (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.1-rc.0)
+    - React-Core/Default (= 0.74.1)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -408,58 +418,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.74.1-rc.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.74.1-rc.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.74.1-rc.0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.74.1-rc.0)
-    - React-Core/RCTWebSocket (= 0.74.1-rc.0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.74.1-rc.0):
+  - React-Core/CoreModulesHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -476,7 +435,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.74.1-rc.0):
+  - React-Core/Default (0.74.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.74.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.1)
+    - React-Core/RCTWebSocket (= 0.74.1)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -493,7 +486,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.74.1-rc.0):
+  - React-Core/RCTAnimationHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -510,7 +503,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.74.1-rc.0):
+  - React-Core/RCTBlobHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -527,7 +520,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.74.1-rc.0):
+  - React-Core/RCTImageHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -544,7 +537,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.74.1-rc.0):
+  - React-Core/RCTLinkingHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -561,7 +554,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.74.1-rc.0):
+  - React-Core/RCTNetworkHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -578,7 +571,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.74.1-rc.0):
+  - React-Core/RCTSettingsHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -595,7 +588,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.74.1-rc.0):
+  - React-Core/RCTTextHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -612,12 +605,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.74.1-rc.0):
+  - React-Core/RCTVibrationHeaders (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.1-rc.0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -629,36 +622,53 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.74.1-rc.0):
+  - React-Core/RCTWebSocket (0.74.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.1)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.74.1-rc.0)
+    - RCTTypeSafety (= 0.74.1)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
+    - React-Core/CoreModulesHeaders (= 0.74.1)
+    - React-jsi (= 0.74.1)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.74.1-rc.0)
+    - React-RCTImage (= 0.74.1)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.74.1-rc.0):
+  - React-cxxreact (0.74.1):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.1-rc.0)
-    - React-debug (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
+    - React-callinvoker (= 0.74.1)
+    - React-debug (= 0.74.1)
+    - React-jsi (= 0.74.1)
     - React-jsinspector
-    - React-logger (= 0.74.1-rc.0)
-    - React-perflogger (= 0.74.1-rc.0)
-    - React-runtimeexecutor (= 0.74.1-rc.0)
-  - React-debug (0.74.1-rc.0)
-  - React-Fabric (0.74.1-rc.0):
+    - React-logger (= 0.74.1)
+    - React-perflogger (= 0.74.1)
+    - React-runtimeexecutor (= 0.74.1)
+  - React-debug (0.74.1)
+  - React-Fabric (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -669,20 +679,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.74.1-rc.0)
-    - React-Fabric/attributedstring (= 0.74.1-rc.0)
-    - React-Fabric/componentregistry (= 0.74.1-rc.0)
-    - React-Fabric/componentregistrynative (= 0.74.1-rc.0)
-    - React-Fabric/components (= 0.74.1-rc.0)
-    - React-Fabric/core (= 0.74.1-rc.0)
-    - React-Fabric/imagemanager (= 0.74.1-rc.0)
-    - React-Fabric/leakchecker (= 0.74.1-rc.0)
-    - React-Fabric/mounting (= 0.74.1-rc.0)
-    - React-Fabric/scheduler (= 0.74.1-rc.0)
-    - React-Fabric/telemetry (= 0.74.1-rc.0)
-    - React-Fabric/templateprocessor (= 0.74.1-rc.0)
-    - React-Fabric/textlayoutmanager (= 0.74.1-rc.0)
-    - React-Fabric/uimanager (= 0.74.1-rc.0)
+    - React-Fabric/animations (= 0.74.1)
+    - React-Fabric/attributedstring (= 0.74.1)
+    - React-Fabric/componentregistry (= 0.74.1)
+    - React-Fabric/componentregistrynative (= 0.74.1)
+    - React-Fabric/components (= 0.74.1)
+    - React-Fabric/core (= 0.74.1)
+    - React-Fabric/imagemanager (= 0.74.1)
+    - React-Fabric/leakchecker (= 0.74.1)
+    - React-Fabric/mounting (= 0.74.1)
+    - React-Fabric/scheduler (= 0.74.1)
+    - React-Fabric/telemetry (= 0.74.1)
+    - React-Fabric/templateprocessor (= 0.74.1)
+    - React-Fabric/textlayoutmanager (= 0.74.1)
+    - React-Fabric/uimanager (= 0.74.1)
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -691,26 +701,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.74.1-rc.0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.74.1-rc.0):
+  - React-Fabric/animations (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -729,7 +720,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.74.1-rc.0):
+  - React-Fabric/attributedstring (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -748,7 +739,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.74.1-rc.0):
+  - React-Fabric/componentregistry (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -767,37 +758,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.74.1-rc.0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.74.1-rc.0)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.1-rc.0)
-    - React-Fabric/components/modal (= 0.74.1-rc.0)
-    - React-Fabric/components/rncore (= 0.74.1-rc.0)
-    - React-Fabric/components/root (= 0.74.1-rc.0)
-    - React-Fabric/components/safeareaview (= 0.74.1-rc.0)
-    - React-Fabric/components/scrollview (= 0.74.1-rc.0)
-    - React-Fabric/components/text (= 0.74.1-rc.0)
-    - React-Fabric/components/textinput (= 0.74.1-rc.0)
-    - React-Fabric/components/unimplementedview (= 0.74.1-rc.0)
-    - React-Fabric/components/view (= 0.74.1-rc.0)
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.74.1-rc.0):
+  - React-Fabric/componentregistrynative (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -816,7 +777,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.74.1-rc.0):
+  - React-Fabric/components (0.74.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.74.1)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.1)
+    - React-Fabric/components/modal (= 0.74.1)
+    - React-Fabric/components/rncore (= 0.74.1)
+    - React-Fabric/components/root (= 0.74.1)
+    - React-Fabric/components/safeareaview (= 0.74.1)
+    - React-Fabric/components/scrollview (= 0.74.1)
+    - React-Fabric/components/text (= 0.74.1)
+    - React-Fabric/components/textinput (= 0.74.1)
+    - React-Fabric/components/unimplementedview (= 0.74.1)
+    - React-Fabric/components/view (= 0.74.1)
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -835,7 +826,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.74.1-rc.0):
+  - React-Fabric/components/legacyviewmanagerinterop (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -854,7 +845,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.74.1-rc.0):
+  - React-Fabric/components/modal (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -873,7 +864,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.74.1-rc.0):
+  - React-Fabric/components/rncore (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -892,7 +883,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.74.1-rc.0):
+  - React-Fabric/components/root (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -911,7 +902,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.74.1-rc.0):
+  - React-Fabric/components/safeareaview (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -930,7 +921,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.74.1-rc.0):
+  - React-Fabric/components/scrollview (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -949,7 +940,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.74.1-rc.0):
+  - React-Fabric/components/text (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -968,7 +959,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.74.1-rc.0):
+  - React-Fabric/components/textinput (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -987,7 +978,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.74.1-rc.0):
+  - React-Fabric/components/unimplementedview (0.74.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1007,7 +1017,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.74.1-rc.0):
+  - React-Fabric/core (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1026,7 +1036,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.74.1-rc.0):
+  - React-Fabric/imagemanager (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1045,7 +1055,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.74.1-rc.0):
+  - React-Fabric/leakchecker (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1064,7 +1074,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.74.1-rc.0):
+  - React-Fabric/mounting (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1083,7 +1093,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.74.1-rc.0):
+  - React-Fabric/scheduler (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1102,7 +1112,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.74.1-rc.0):
+  - React-Fabric/telemetry (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1121,7 +1131,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.74.1-rc.0):
+  - React-Fabric/templateprocessor (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1140,7 +1150,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.74.1-rc.0):
+  - React-Fabric/textlayoutmanager (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1160,7 +1170,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.74.1-rc.0):
+  - React-Fabric/uimanager (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1179,45 +1189,45 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.74.1-rc.0):
+  - React-FabricImage (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.74.1-rc.0)
-    - RCTTypeSafety (= 0.74.1-rc.0)
+    - RCTRequired (= 0.74.1)
+    - RCTTypeSafety (= 0.74.1)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.74.1-rc.0)
+    - React-jsiexecutor (= 0.74.1)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.74.1-rc.0)
-  - React-graphics (0.74.1-rc.0):
+  - React-featureflags (0.74.1)
+  - React-graphics (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - React-Core/Default (= 0.74.1-rc.0)
+    - React-Core/Default (= 0.74.1)
     - React-utils
-  - React-hermes (0.74.1-rc.0):
+  - React-hermes (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.1-rc.0)
+    - React-cxxreact (= 0.74.1)
     - React-jsi
-    - React-jsiexecutor (= 0.74.1-rc.0)
+    - React-jsiexecutor (= 0.74.1)
     - React-jsinspector
-    - React-perflogger (= 0.74.1-rc.0)
+    - React-perflogger (= 0.74.1)
     - React-runtimeexecutor
-  - React-ImageManager (0.74.1-rc.0):
+  - React-ImageManager (0.74.1):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1226,45 +1236,45 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.74.1-rc.0):
+  - React-jserrorhandler (0.74.1):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.74.1-rc.0):
+  - React-jsi (0.74.1):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.74.1-rc.0):
+  - React-jsiexecutor (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
+    - React-cxxreact (= 0.74.1)
+    - React-jsi (= 0.74.1)
     - React-jsinspector
-    - React-perflogger (= 0.74.1-rc.0)
-  - React-jsinspector (0.74.1-rc.0):
+    - React-perflogger (= 0.74.1)
+  - React-jsinspector (0.74.1):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-runtimeexecutor (= 0.74.1-rc.0)
-  - React-jsitracing (0.74.1-rc.0):
+    - React-runtimeexecutor (= 0.74.1)
+  - React-jsitracing (0.74.1):
     - React-jsi
-  - React-logger (0.74.1-rc.0):
+  - React-logger (0.74.1):
     - glog
-  - React-Mapbuffer (0.74.1-rc.0):
+  - React-Mapbuffer (0.74.1):
     - glog
     - React-debug
-  - React-nativeconfig (0.74.1-rc.0)
-  - React-NativeModulesApple (0.74.1-rc.0):
+  - React-nativeconfig (0.74.1)
+  - React-NativeModulesApple (0.74.1):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1275,10 +1285,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.74.1-rc.0)
-  - React-RCTActionSheet (0.74.1-rc.0):
-    - React-Core/RCTActionSheetHeaders (= 0.74.1-rc.0)
-  - React-RCTAnimation (0.74.1-rc.0):
+  - React-perflogger (0.74.1)
+  - React-RCTActionSheet (0.74.1):
+    - React-Core/RCTActionSheetHeaders (= 0.74.1)
+  - React-RCTAnimation (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1286,7 +1296,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.74.1-rc.0):
+  - React-RCTAppDelegate (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1310,7 +1320,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.74.1-rc.0):
+  - React-RCTBlob (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1323,7 +1333,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.74.1-rc.0):
+  - React-RCTFabric (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1343,7 +1353,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.74.1-rc.0):
+  - React-RCTImage (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1352,14 +1362,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.74.1-rc.0):
+  - React-RCTLinking (0.74.1):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
+    - React-Core/RCTLinkingHeaders (= 0.74.1)
+    - React-jsi (= 0.74.1)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.74.1-rc.0)
-  - React-RCTNetwork (0.74.1-rc.0):
+    - ReactCommon/turbomodule/core (= 0.74.1)
+  - React-RCTNetwork (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1367,7 +1377,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.74.1-rc.0):
+  - React-RCTSettings (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1375,23 +1385,23 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.74.1-rc.0):
-    - React-Core/RCTTextHeaders (= 0.74.1-rc.0)
+  - React-RCTText (0.74.1):
+    - React-Core/RCTTextHeaders (= 0.74.1)
     - Yoga
-  - React-RCTVibration (0.74.1-rc.0):
+  - React-RCTVibration (0.74.1):
     - RCT-Folly (= 2024.01.01.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.74.1-rc.0):
+  - React-rendererdebug (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.74.1-rc.0)
-  - React-RuntimeApple (0.74.1-rc.0):
+  - React-rncore (0.74.1)
+  - React-RuntimeApple (0.74.1):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1409,7 +1419,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - React-utils
-  - React-RuntimeCore (0.74.1-rc.0):
+  - React-RuntimeCore (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1422,9 +1432,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.74.1-rc.0):
-    - React-jsi (= 0.74.1-rc.0)
-  - React-RuntimeHermes (0.74.1-rc.0):
+  - React-runtimeexecutor (0.74.1):
+    - React-jsi (= 0.74.1)
+  - React-RuntimeHermes (0.74.1):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1435,7 +1445,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.74.1-rc.0):
+  - React-runtimescheduler (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1447,51 +1457,51 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.74.1-rc.0):
+  - React-utils (0.74.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.74.1-rc.0)
-  - ReactCommon (0.74.1-rc.0):
-    - ReactCommon/turbomodule (= 0.74.1-rc.0)
-  - ReactCommon/turbomodule (0.74.1-rc.0):
+    - React-jsi (= 0.74.1)
+  - ReactCommon (0.74.1):
+    - ReactCommon/turbomodule (= 0.74.1)
+  - ReactCommon/turbomodule (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.1-rc.0)
-    - React-cxxreact (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
-    - React-logger (= 0.74.1-rc.0)
-    - React-perflogger (= 0.74.1-rc.0)
-    - ReactCommon/turbomodule/bridging (= 0.74.1-rc.0)
-    - ReactCommon/turbomodule/core (= 0.74.1-rc.0)
-  - ReactCommon/turbomodule/bridging (0.74.1-rc.0):
+    - React-callinvoker (= 0.74.1)
+    - React-cxxreact (= 0.74.1)
+    - React-jsi (= 0.74.1)
+    - React-logger (= 0.74.1)
+    - React-perflogger (= 0.74.1)
+    - ReactCommon/turbomodule/bridging (= 0.74.1)
+    - ReactCommon/turbomodule/core (= 0.74.1)
+  - ReactCommon/turbomodule/bridging (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.1-rc.0)
-    - React-cxxreact (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
-    - React-logger (= 0.74.1-rc.0)
-    - React-perflogger (= 0.74.1-rc.0)
-  - ReactCommon/turbomodule/core (0.74.1-rc.0):
+    - React-callinvoker (= 0.74.1)
+    - React-cxxreact (= 0.74.1)
+    - React-jsi (= 0.74.1)
+    - React-logger (= 0.74.1)
+    - React-perflogger (= 0.74.1)
+  - ReactCommon/turbomodule/core (0.74.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.1-rc.0)
-    - React-cxxreact (= 0.74.1-rc.0)
-    - React-debug (= 0.74.1-rc.0)
-    - React-jsi (= 0.74.1-rc.0)
-    - React-logger (= 0.74.1-rc.0)
-    - React-perflogger (= 0.74.1-rc.0)
-    - React-utils (= 0.74.1-rc.0)
+    - React-callinvoker (= 0.74.1)
+    - React-cxxreact (= 0.74.1)
+    - React-debug (= 0.74.1)
+    - React-jsi (= 0.74.1)
+    - React-logger (= 0.74.1)
+    - React-perflogger (= 0.74.1)
+    - React-utils (= 0.74.1)
   - SDWebImage (5.19.1):
     - SDWebImage/Core (= 5.19.1)
   - SDWebImage/Core (5.19.1)
@@ -1599,6 +1609,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - libavif
+    - libdav1d
     - libwebp
     - ReachabilitySwift
     - SDWebImage
@@ -1772,92 +1783,93 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
-  EXAV: d363e6d671d61f40c33fe4ee095f7e69ee4db385
+  EXAV: 774288fbb6d1f5e51c22a79401faa5b622af68b3
   EXConstants: 9a008dbf262550884e6280dea95b81b51f65ea6f
   EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
-  EXManifests: 7832a9a6562afc89e57190d5a8702affc0cfe77e
-  Expo: 1a8e87db075b3aa49e0dcc9dd22ef53f1df4eb2e
-  expo-dev-client: 93bc3c56bdb9a6a704e3fef01fdb588d69bbc93e
-  expo-dev-launcher: 5d3fd3b052ddcc96529e3f08b8ec8af5ad8218d4
-  expo-dev-menu: 1e1f387033155781ed4df834ea6156f658a2266e
-  expo-dev-menu-interface: 97705186cf710d42ff42b285cf97f5877be377c6
+  EXManifests: 866d0c365eb46835d48be2c7a0e00418312992b4
+  Expo: a3177f18e97260de9ec29802d28d29c130871e94
+  expo-dev-client: a4fbaa4a68a09abc4dabf25038b77f8f845b8433
+  expo-dev-launcher: 5acdee82668840b111adb8e189775a402ad22f69
+  expo-dev-menu: c2a473ef4478a775eb6f52d6c516141529ce2d33
+  expo-dev-menu-interface: be32c09f1e03833050f0ee290dcc86b3ad0e73e4
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
-  ExpoAsset: e0db7ae7bd48b077640d8d8071ad5526d9320c3d
-  ExpoBlur: 2a80440a81040ab3575bc78f7c5234d40c110c58
-  ExpoCamera: 61ab6839230b0b8a9634f371fc377ddcb73fb4c5
+  ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
+  ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
+  ExpoCamera: 304f53e32faf8ed18b2199abba346f85ca395aff
   ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
-  ExpoFont: 331cf28d549edc7b6300d3be19302fc5069d9bb1
-  ExpoImage: 80a5b14f9e0d845f2c2877cee1c2b1038ba276a6
+  ExpoFont: 690b76008be824e47907f200cb0764870108dfd1
+  ExpoImage: eab004b9363e388d3f6a118f18716de6dcfb8e8d
   ExpoKeepAwake: f3a7b0ff4b4911957264dad8cb584ef688326a22
   ExpoLinearGradient: 8cec4a09426d8934c433e83cb36262d72c667fce
-  ExpoModulesCore: 20ee85eae7586fb1b72d2c9df404f1f0ca944d9e
-  EXSplashScreen: 97934a7b9670972938602014742b733ac96097ec
+  ExpoModulesCore: 00313a5d81b010b03fc78bab8e8e3594d4d53d19
+  EXSplashScreen: 4e1d5c1b3371f7e72c1f158f04bbba6eb61dbd93
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
-  EXUpdates: 5e179c5a7bf0a6caa03ce051a264a50affd3f71d
-  EXUpdatesInterface: e5ec53f49ac304d173471f15e70abf8723f00fe5
-  FBLazyVector: 1e1d791ce842b9012435e3cd0429078fa1f1c43b
+  EXUpdates: 3f0093216134c08f8965ef5c200da25b74801b7f
+  EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
+  FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 00dd4470ffd262ad3c8dfcc848001bb61074fe74
+  hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
+  libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
-  RCTDeprecation: e69ff938a56f950f500eaf12cd4e2d335e4a0a53
-  RCTRequired: 2c520d0858ed22c806821898ee3e7a4d59acf149
-  RCTTypeSafety: a34a1f7e4cd7e295e3f971e247fb0bc0eea65080
+  RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
+  RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
+  RCTTypeSafety: a11979ff0570d230d74de9f604f7d19692157bc4
   ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
-  React: a7c9c6c2db6f18f227a56a6a3fb3cbad34c41cdc
-  React-callinvoker: c451c45fd622249adc5190628294f8361e97384c
-  React-Codegen: 873e84e60339a40e9c33ed4e6b77fba5ba456089
-  React-Core: 7ceaa879856708a24224107683d973d465adac48
-  React-CoreModules: 5efe6cee5c719e120a48724e163fcbe6db79c4e0
-  React-cxxreact: 22eb8cf584ce71da8f9f285bb4dabb9ee04c812f
-  React-debug: 53a9da27099450efe34bf6f70c46ec017fc4f9d5
-  React-Fabric: 740eae8f28dc7c9bfa9f15208fafd3612c54349f
-  React-FabricImage: 3f68c768dbb8924600b101dd40c5f8526a2a179b
-  React-featureflags: 2fb348ceb6abbc4c8404a52be9fa3055698fa7fc
-  React-graphics: 4f5c9ec608255ad52f25ddcaeab6e2d988e58d80
-  React-hermes: 0ef9161a9b3a8584fd2ce9073ee83d4b0d92fa55
-  React-ImageManager: da15932ff68456004a2224a3f914803a3bce2cd1
-  React-jserrorhandler: e72c7713a27102a8e6aaf9d9ae0975bb250967d3
-  React-jsi: cceb083f53082dca4da61fa0c53472fbc88433e9
-  React-jsiexecutor: c99b26ef3c91a91c49b7a3428d53a3496793e99c
-  React-jsinspector: 489ac70efc5e2994b318f3e4163ef4d5c5f222a0
-  React-jsitracing: 903a4a58130deabd27a4d9af436e91dcd079d5a3
-  React-logger: a02c1bc3b6befe1e09a014fb9edbd6cc79929ca6
-  React-Mapbuffer: d3aaeb7e63d8454c4bb74e596de2bd1f827055b8
-  React-nativeconfig: b908fa3e3a3b326bc4c32f2455b3cbc0e544ef43
-  React-NativeModulesApple: 807cb41a594252a829697a0f7161022116c86c1f
-  React-perflogger: 27ab9a9ade8a0a338739891c41b3ca8ea6302073
-  React-RCTActionSheet: e582dec312e9afe801dbd9095fdf7c4add8fe5e3
-  React-RCTAnimation: 4aa781670b10d10303b09130e5c8fba1f2484695
-  React-RCTAppDelegate: 939d7f74b8ab1f83433bd7182445e406006e6cea
-  React-RCTBlob: 82cd36a4483bebffbe4d2496eb98eb0cff4a2ea1
-  React-RCTFabric: 8d5923899c5d79fdbfc33ccd61e571628b2cf8e8
-  React-RCTImage: dcf1c39707690d1d8f1451449edd449e4e80790f
-  React-RCTLinking: 1eb7a1f624591bd744a3b9f07ba58c3e91e8c30d
-  React-RCTNetwork: 0588799141ed37e07534aa96b13507057f71ac19
-  React-RCTSettings: 77b74076a18720fda6daa4093c3225d12d764d36
-  React-RCTText: 027987cd59088f9031c26ac90c48af9ee70c4f2c
-  React-RCTVibration: 3ccc8f91116b80d30c0c3c5b29ddad413162090c
-  React-rendererdebug: 60bdc059dd5faa4162394ecef3c9ac19f79fc020
-  React-rncore: be00190384125cb822dd10b20f2c51126247ad00
-  React-RuntimeApple: 44dfb10c9ff79e1acfa69601eddb3e7612acddcd
-  React-RuntimeCore: 453e2bc299d7ec409709244634b57bc2b1adf72f
-  React-runtimeexecutor: 0eb92c4d0b3dd54532ce84044a2194cfad586fd3
-  React-RuntimeHermes: a9c810f936f19d81f9de500767cadcf96819cad9
-  React-runtimescheduler: f58e915301a2d97813c23d5a26af460ff3b85bdd
-  React-utils: 42af5ec8a248e1c0cb25eb4e72b1ba14eb626c88
-  ReactCommon: 4a67837d0e49766cd728110632ca7a4bc0fbd42e
+  React: 88794fad7f460349dbc9df8a274d95f37a009f5d
+  React-callinvoker: 7a7023e34a55c89ea2aa62486bb3c1164ab0be0c
+  React-Codegen: f824dfd08f6c0e021580225427ae2fac6ec15f24
+  React-Core: 60075333bc22b5a793d3f62e207368b79bff2e64
+  React-CoreModules: 147c314d6b3b1e069c9ad64cbbbeba604854ff86
+  React-cxxreact: 5de27fd8bff4764acb2eac3ee66001e0e2b910e7
+  React-debug: 6397f0baf751b40511d01e984b01467d7e6d8127
+  React-Fabric: 6fa475e16e0a37b38d462cec32b70fd5cf886305
+  React-FabricImage: 7e09b3704e3fa084b4d44b5b5ef6e2e3d3334ec0
+  React-featureflags: 2eb79dd9df4095bff519379f2a4c915069e330bb
+  React-graphics: 82a482a3aa5d9659b74cdf2c8b57faf67eaa10fb
+  React-hermes: d93936b02de2fd7e67c11e92c16d4278a14d0134
+  React-ImageManager: ebb3c4812e2c5acba5a89728c2d77729471329ad
+  React-jserrorhandler: a08e0adcf1612900dde82b8bf8e93e7d2ad953b3
+  React-jsi: f46d09ee5079a4f3b637d30d0e59b8ea6470632c
+  React-jsiexecutor: e73579560957aa3ca9dc02ab90e163454279d48c
+  React-jsinspector: e8ba20dde269c7c1d45784b858fa1cf4383f0bbb
+  React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
+  React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
+  React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
+  React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
+  React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
+  React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a
+  React-RCTActionSheet: c4a3a134f3434c9d7b0c1054f1a8cfed30c7a093
+  React-RCTAnimation: 0e5d15320eeece667fcceb6c785acf9a184e9da1
+  React-RCTAppDelegate: 3ab57e497300ec1c54b798ba2d0834ee048229f4
+  React-RCTBlob: c46aaaee693d371a1c7cae2a8c8ee2aa7fbc1adb
+  React-RCTFabric: 82f15dc5a981288bfa806545f943cbd18e794ad7
+  React-RCTImage: a04dba5fcc823244f5822192c130ecf09623a57f
+  React-RCTLinking: 533bf13c745fcb2a0c14e0e49fd149586a7f0d14
+  React-RCTNetwork: a29e371e0d363d7b4c10ab907bc4d6ae610541e9
+  React-RCTSettings: 127813224780861d0d30ecda17a40d1dfebe7d73
+  React-RCTText: 8a823f245ecf82edb7569646e3c4d8041deb800a
+  React-RCTVibration: 46b5fae74e63f240f22f39de16ad6433da3b65d9
+  React-rendererdebug: 4653f8da6ab1d7b01af796bdf8ca47a927539e39
+  React-rncore: 4f1e645acb5107bd4b4cf29eff17b04a7cd422f3
+  React-RuntimeApple: 013b606e743efb5ee14ef03c32379b78bfe74354
+  React-RuntimeCore: 7205be45a25713b5418bbf2db91ddfcca0761d8b
+  React-runtimeexecutor: a278d4249921853d4a3f24e4d6e0ff30688f3c16
+  React-RuntimeHermes: 44c628568ce8feedc3acfbd48fc07b7f0f6d2731
+  React-runtimescheduler: e2152ed146b6a35c07386fc2ac4827b27e6aad12
+  React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
+  ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
-  Yoga: dd642d55c0a38b978824b1fcfbe396722c4d4601
+  Yoga: b9a182ab00cf25926e7f79657d08c5d23c2d03b0
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: dd2d9c24a31d324229810819d040f3b11cd50d8c
+PODFILE CHECKSUM: 25935755ed1c35429ec96bdebc2a729def741e31
 
 COCOAPODS: 1.14.2

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Prevent React Native Dev Menu from showing up on launcher screen. ([#28936](https://github.com/expo/expo/pull/28936) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 4.0.14 — 2024-05-09

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -330,14 +330,26 @@
   [self _removeInitModuleObserver];
 
   _appDelegate.rootViewFactory = [_appDelegate createRCTRootViewFactory];
-  UIView *rootView = [[_appDelegate rootViewFactory] viewWithModuleName:@"main"
-                                                     initialProperties:nil
-                                                     launchOptions:_launchOptions];
 
+#if RCT_DEV
+  NSURL *url = [self devLauncherURL];
+  if (url != nil) {
+    // Connect to the websocket
+    [[RCTPackagerConnection sharedPackagerConnection] setSocketConnectionURL:url];
+  }
+
+  [self _addInitModuleObserver];
+#endif
+
+  UIView *rootView;
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(onAppContentDidAppear)
                                                name:RCTContentDidAppearNotification
                                              object:rootView];
+
+  rootView = [[_appDelegate rootViewFactory] viewWithModuleName:@"main"
+                                                     initialProperties:nil
+                                                     launchOptions:_launchOptions];
 
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
@@ -345,15 +357,6 @@
   rootViewController.view = rootView;
   _window.rootViewController = rootViewController;
 
-#if RCT_DEV
-  NSURL *url = [self devLauncherURL];
-  if (url != nil) {
-    // Connect to the websocket
-    [[RCTPackagerConnection sharedPackagerConnection] setSocketConnectionURL:url];
-  } else {
-    [self _addInitModuleObserver];
-  }
-#endif
 
   [_window makeKeyAndVisible];
 }


### PR DESCRIPTION
# Why

This PR fixes two main issues on the new arch on iOS, cmd+d in dev launcher opening the React Native Dev Menu and the app getting stuck into the splash screen when navigating to the launcher

Closes ENG-12221

# How

When initiating a react native instance using the new architecture the `RCTDidInitializeModuleNotification` notification is sent synchronously when calling `rootViewFactory.viewWithModuleName` which was not the case when using the old arch, and because of that we need to call `_addInitModuleObserver` earlier then navigating to the launcher.

# Test Plan

Test dev-client through BareExpo and FabricTester 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
