### PR TITLE
[ios] Remove warnings

### DIFF
--- a/packages/expo-camera/ios/Common/CameraPermissionsRequester.swift
+++ b/packages/expo-camera/ios/Common/CameraPermissionsRequester.swift
@@ -16,7 +16,7 @@ extension BaseCameraRequester {
     var systemStatus: AVAuthorizationStatus
     let description = Bundle.main.infoDictionary?[key] as? String
 
-    if let description {
+    if description != nil {
       systemStatus = AVCaptureDevice.authorizationStatus(for: mediaType)
     } else {
       EXFatal(EXErrorWithMessage("""
@@ -80,7 +80,6 @@ class CameraPermissionRequester: NSObject, EXPermissionsRequester, BaseCameraReq
 
   func getPermissions() -> [AnyHashable: Any] {
     var systemStatus: AVAuthorizationStatus
-    var status: EXPermissionStatus
 
     let cameraUsuageDescription = Bundle.main.infoDictionary?[cameraKey] as? String
     let microphoneUsuageDescription = Bundle.main.infoDictionary?[microphoneKey] as? String

--- a/packages/expo-camera/ios/Current/CameraEnums.swift
+++ b/packages/expo-camera/ios/Current/CameraEnums.swift
@@ -47,8 +47,6 @@ enum FocusMode: String, Enumerable {
       return .autoFocus
     case .off:
       return .continuousAutoFocus
-    default:
-      return .continuousAutoFocus
     }
   }
 }

--- a/packages/expo-camera/ios/Legacy/CameraEnumsLegacy.swift
+++ b/packages/expo-camera/ios/Legacy/CameraEnumsLegacy.swift
@@ -38,8 +38,6 @@ enum CameraTypeLegacy: Int, Enumerable {
       return .front
     case .back:
       return .back
-    default:
-      return .back
     }
   }
 }
@@ -54,8 +52,6 @@ enum AutoFocus: Int, Enumerable {
       return .autoFocus
     case .off:
       return .continuousAutoFocus
-    default:
-      return .autoFocus
     }
   }
 }

--- a/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
+++ b/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
@@ -335,7 +335,7 @@ public class CameraViewLegacy: ExpoView, EXCameraInterface, EXAppLifecycleListen
 
   private func addErrorNotification() {
     if self.errorNotification != nil {
-      NotificationCenter.default.removeObserver(self.errorNotification)
+      NotificationCenter.default.removeObserver(self.errorNotification as Any)
     }
 
     self.errorNotification = NotificationCenter.default.addObserver(

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -89,8 +89,9 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
     let firstResource = PHAssetResource.assetResources(for: asset).first
     if let firstResource {
       resourceManager.writeData(for: firstResource, toFile: toUrl, options: nil) { error in
-        if let error {
+        if error != nil {
           promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
+          return
         }
         promise.resolve()
       }

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -206,7 +206,6 @@ public final class FileSystemModule: Module {
       try ensurePathPermission(appContext, path: localUrl.path, flag: .write)
 
       let session = options.sessionType == .background ? backgroundSession : foregroundSession
-      let resumeData = resumeDataString != nil ? Data(base64Encoded: resumeDataString ?? "") : nil
       let onWrite: EXDownloadDelegateOnWriteCallback = { [weak self] _, _, totalBytesWritten, totalBytesExpectedToWrite in
         self?.sendEvent(EVENT_DOWNLOAD_PROGRESS, [
           "uuid": uuid,

--- a/packages/expo-file-system/ios/NetworkingHelpers.swift
+++ b/packages/expo-file-system/ios/NetworkingHelpers.swift
@@ -63,7 +63,7 @@ func createLocalUrl(from sourceUrl: URL) throws -> URL {
 
 func createMultipartBody(boundary: String, sourceUrl: URL, options: UploadOptions) -> Data? {
   let fieldName = options.fieldName ?? sourceUrl.lastPathComponent
-  var mimeType = options.mimeType ?? findMimeType(forAttachment: sourceUrl)
+  let mimeType = options.mimeType ?? findMimeType(forAttachment: sourceUrl)
   guard let data = try? Data(contentsOf: sourceUrl) else {
     return nil
   }

--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -11,7 +11,7 @@ internal func queryCustomNativeFonts() -> [String] {
 
   // [1] Get font family names for each font file
   let fontFamilies: [[String]] = fontFilePaths.compactMap { fontFilePath in
-    guard let fontUrl = Bundle.main.url(forResource: fontFilePath, withExtension: nil) as? URL else {
+    guard let fontUrl = Bundle.main.url(forResource: fontFilePath, withExtension: nil) else {
       return []
     }
     guard let fontDescriptors = CTFontManagerCreateFontDescriptorsFromURL(fontUrl as CFURL) as? [CTFontDescriptor] else {

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -104,7 +104,7 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
  */
 func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage {
   // If there are no image frames, only resize the main image.
-  guard let images = await image.images else {
+  guard let images = image.images else {
     return resize(image: image, toSize: size, scale: scale)
   }
 
@@ -116,7 +116,7 @@ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) as
   // Create the new animated image with the resized frames.
   // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
   // so it should never happen in our case, but let's make sure to handle it gracefully.
-  if let newAnimatedImage = await UIImage.animatedImage(with: resizedImages, duration: image.duration) {
+  if let newAnimatedImage = UIImage.animatedImage(with: resizedImages, duration: image.duration) {
     return newAnimatedImage
   }
   return resize(image: image, toSize: size, scale: scale)

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -234,7 +234,7 @@ public final class ImageView: ExpoView {
           "width": image.size.width,
           "height": image.size.height,
           "mediaType": imageFormatToMediaType(image.sd_imageFormat),
-          "isAnimated": image.sd_isAnimated ?? false
+          "isAnimated": image.sd_isAnimated
         ]
       ])
 

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -29,7 +29,7 @@ final class PhotoLibraryAssetLoader: NSObject, SDImageLoader {
 
     DispatchQueue.global(qos: .userInitiated).async {
       guard let url = url, let assetLocalIdentifier = assetLocalIdentifier(fromUrl: url) else {
-        let error = makeNSError(description: "Unable to obtain the asset identifier from the url: '\(url?.absoluteString)'")
+        let error = makeNSError(description: "Unable to obtain the asset identifier from the url: '\(String(describing: url?.absoluteString))'")
         completedBlock?(nil, nil, error, false)
         return
       }

--- a/packages/expo-image/ios/ThumbhashLoader.swift
+++ b/packages/expo-image/ios/ThumbhashLoader.swift
@@ -23,7 +23,7 @@ class ThumbhashLoader: NSObject, SDImageLoader {
     // The URI looks like this: thumbhash:/3OcRJYB4d3h\iIeHeEh3eIhw+j2w
     // ThumbHash may include slashes which could break the structure of the URL, so we replace them
     // with backslashes on the JS side and revert them back to slashes here, before generating the image.
-    var thumbhash = (url.pathComponents[1] ?? "").replacingOccurrences(of: "\\", with: "/")
+    var thumbhash = url.pathComponents[1].replacingOccurrences(of: "\\", with: "/")
 
     // Thumbhashes with transparency cause the conversion to data to fail, padding the thumbhash string to correct length fixes that
     let remainder = thumbhash.count % 4


### PR DESCRIPTION
# Why
Removes various warnings across SDK packages on `iOS`

# How
Mostly harmless but better if they are not there. One potential issue of resolving a promise twice in filesystem.

# Test Plan
Affected packages work as normal
