### PR TITLE
[docs] removed `facebookScheme` from docs since it's not available in SDK 48+

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -139,7 +139,6 @@ import * as Facebook from 'expo-auth-session/providers/facebook';
 - See the guide for more info on usage: [Facebook Authentication](/guides/authentication.mdx#facebook).
 - Enforces minimum scopes to `['public_profile', 'email']` for optimal usage with services like Firebase and Auth0.
 - Uses `display=popup` for better UI results.
-- The URI redirect must be added to your **app.config.js** or **app.json** as `facebookScheme: 'fb<YOUR FBID>'`.
 - Disables PKCE for implicit auth response.
 - On web, the popup is presented with the dimensions `{ width: 700, height: 600 }`
 

--- a/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
@@ -141,7 +141,6 @@ import * as Facebook from 'expo-auth-session/providers/facebook';
 - See the guide for more info on usage: [Facebook Authentication](/guides/authentication.mdx#facebook).
 - Enforces minimum scopes to `['public_profile', 'email']` for optimal usage with services like Firebase and Auth0.
 - Uses `display=popup` for better UI results.
-- The URI redirect must be added to your **app.config.js** or **app.json** as `facebookScheme: 'fb<YOUR FBID>'`.
 - Disables PKCE for implicit auth response.
 - On web, the popup is presented with the dimensions `{ width: 700, height: 600 }`
 

--- a/docs/pages/versions/v50.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/auth-session.mdx
@@ -141,7 +141,6 @@ import * as Facebook from 'expo-auth-session/providers/facebook';
 - See the guide for more info on usage: [Facebook Authentication](/guides/authentication.mdx#facebook).
 - Enforces minimum scopes to `['public_profile', 'email']` for optimal usage with services like Firebase and Auth0.
 - Uses `display=popup` for better UI results.
-- The URI redirect must be added to your **app.config.js** or **app.json** as `facebookScheme: 'fb<YOUR FBID>'`.
 - Disables PKCE for implicit auth response.
 - On web, the popup is presented with the dimensions `{ width: 700, height: 600 }`
 

--- a/docs/pages/versions/v51.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/auth-session.mdx
@@ -139,7 +139,6 @@ import * as Facebook from 'expo-auth-session/providers/facebook';
 - See the guide for more info on usage: [Facebook Authentication](/guides/authentication.mdx#facebook).
 - Enforces minimum scopes to `['public_profile', 'email']` for optimal usage with services like Firebase and Auth0.
 - Uses `display=popup` for better UI results.
-- The URI redirect must be added to your **app.config.js** or **app.json** as `facebookScheme: 'fb<YOUR FBID>'`.
 - Disables PKCE for implicit auth response.
 - On web, the popup is presented with the dimensions `{ width: 700, height: 600 }`
 


### PR DESCRIPTION
# Why

Closes this #22026. Follow up #21018

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
