### PR TITLE
[android][contacts] Fixed back to back presentFormAsync attempt issue

### DIFF
--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -67,6 +67,7 @@ private val defaultFields = setOf(
 
 const val RC_EDIT_CONTACT = 2137
 const val RC_PICK_CONTACT = 2138
+const val RC_ADD_CONTACT = 2139
 
 // TODO: Evan: default API is confusing. Duplicate data being requested.
 private val DEFAULT_PROJECTION = listOf(
@@ -266,7 +267,7 @@ class ContactsModule : Module() {
 
     OnActivityResult { _, payload ->
       val (requestCode, resultCode, intent) = payload
-      if (requestCode == RC_EDIT_CONTACT) {
+      if (requestCode == RC_EDIT_CONTACT || requestCode == RC_ADD_CONTACT) {
         val pendingPromise = contactManipulationPromise ?: return@OnActivityResult
 
         pendingPromise.resolve(0)
@@ -308,7 +309,7 @@ class ContactsModule : Module() {
     intent.putExtra(ContactsContract.Intents.Insert.NAME, contact.getFinalDisplayName())
     intent.putParcelableArrayListExtra(ContactsContract.Intents.Insert.DATA, contact.contentValues)
     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-    activity.startActivity(intent)
+    activity.startActivityForResult(intent, RC_ADD_CONTACT)
   }
 
   private fun presentEditForm(contact: Contact, promise: Promise) {


### PR DESCRIPTION
# Why

Closes #28951


# How

After the first trigger of `presentFormAsync`, `contactManipulationPromise` doesn't get back to its initial state which is null. Managed it using `startActivityForResult`. Only occurs in Android.

# Test Plan

It also can be observed and reproducible in `apps/bare-expo`. Tested in `apps/bare-expo` in Android 14.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
