### PR TITLE
Fix: Broken link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import {
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { PlatformTags } from '~/ui/components/Tag';
 
-> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend using [`expo-camera/next`](camera-next) which has barcode scanning built-in instead.
+> **warning** **Deprecated:** This library will no longer be available from SDK 51. We recommend using [`expo-camera`](camera) which has barcode scanning built-in instead.
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 


### PR DESCRIPTION
The link for `expo-camera/next` in the docs as stated here is currently broken:

> Deprecated: This library will no longer be available from SDK 51. We recommend using [expo-camera/next](https://docs.expo.dev/versions/latest/sdk/camera-next/) which has barcode scanning built-in instead.

This PR fixes it.