### PR TITLE
[ios][contacts] Fixed serialization crash for department field

### DIFF
--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -236,7 +236,7 @@ func serializeContact(person: CNContact, keys: [String]?, directory: URL?) throw
     contact[ContactsKey.jobTitle] = person.jobTitle
   }
   if fieldHasValue(field: person.departmentName) {
-    contact[ContactsKey.department] = person.dates
+    contact[ContactsKey.department] = person.departmentName
   }
 
   if keysToFetch.contains(CNContactNamePrefixKey) && fieldHasValue(field: person.namePrefix) {


### PR DESCRIPTION
# Why

Fixes #28967 - serialization crash on iOS when a contact has "Department" Field

# How
Previously when the `Department` field was requested (the expo-contacts library adds it by default to the list of fields) if a contact has `Department` in their profile, the app will crash immediately with `CNPropertyNotFetchedException`.

I changed the serialization from `.dates` to `departmentName` which fixes the exception when the application accessed a field it didn't request.

# Test Plan

Tested using bare-expo.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg:
https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style
Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build
(eg: updated a module plugin).