### PR TITLE
Correct output code

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -288,7 +288,7 @@ export default function Blog() {
 This will **export** to the following:
 
 ```html Output HTML
-<a href="/my-root/post/123">Go to blog post</a>
+<a href="/my-root/blog/123">Go to blog post</a>
 ```
 
 If you use `<a>`, React Navigation, or the `Linking` API directly, you'll need to manually prepend the `baseUrl`.


### PR DESCRIPTION
This current output of the code as described by [the docs](https://docs.expo.dev/more/expo-cli/) is confusing and hence I think it's an error:

> Expo Router has built-in support for `baseUrl`. When using the `Link` and `router` APIs, the `baseUrl` will be automatically prepended to the URL.

```ts
// app/blog/index.tsx

import { Link } from 'expo-router';

export default function Blog() {
  return <Link href="/blog/123">Go to blog post</Link>;
}
```
> This will export to the following:
```ts
// Output HTML
<a href="/my-root/post/123">Go to blog post</a>
```

I think `/blog/223` and not `/post/123` should be the output.