### PR TITLE
[docs] Fix typo in page  descriptions for Expo Router docs

### DIFF
--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -1,6 +1,6 @@
 ---
 title: Navigate between pages
-description: Create links to move between pages.
+description: Learn how to create links to move between pages.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -193,7 +193,7 @@ export default function Root() {
 
 Create a nested [layout route](/router/layouts) that checks whether users are authenticated before rendering the child route components. This layout route redirects users to the sign-in screen if they are not authenticated.
 
-```jsx app/(app)/_layout.js
+```jsx app/(app)/_layout.js|collapseHeight=400
 import { Redirect, Stack } from 'expo-router';
 
 import { useSession } from '../../ctx';
@@ -225,7 +225,7 @@ export default function AppLayout() {
 
 Create the `/sign-in` screen. It can toggle the authentication using `signIn()`. Since this screen is outside the `(app)` group, the group's layout and authentication check do not run when rendering this screen. This lets logged-out users see this screen.
 
-```jsx app/sign-in.js
+```jsx app/sign-in.js|collapseHeight=480
 import { router } from 'expo-router';
 import { Text, View } from 'react-native';
 
@@ -255,7 +255,7 @@ export default function SignIn() {
 
 Implement an authenticated screen that lets users sign out.
 
-```jsx app/(app)/index.js
+```jsx app/(app)/index.js|collapseHeight=480
 import { Text, View } from 'react-native';
 
 import { useSession } from '../../ctx';
@@ -286,7 +286,7 @@ With Expo Router, something must be rendered to the screen while loading the ini
 
 ## Modals and per-route authentication
 
-Another common pattern is to render a sign-in modal over the top of the app. This enables you to dismiss partially preserve deep links when the authentication is complete. However, this pattern requires routes to be rendered in the background as these routes require handling data loading without authentication.
+Another common pattern is to render a sign-in modal over the top of the app. This enables you to dismiss and partially preserve deep links when the authentication is complete. However, this pattern requires routes to be rendered in the background as these routes require handling data loading without authentication.
 
 <FileTree
   files={[
@@ -303,7 +303,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
   ]}
 />
 
-```jsx app/(app)/_layout.js
+```jsx app/(app)/_layout.js|collapseHeight=480
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {

--- a/docs/pages/router/reference/redirects.mdx
+++ b/docs/pages/router/reference/redirects.mdx
@@ -1,6 +1,6 @@
 ---
 title: Redirects
-description: Learn how redirect URLs in Expo Router.
+description: Learn how to redirect URLs in Expo Router.
 ---
 
 You can redirect a request to a different URL based on some in-app criteria. Expo Router supports a number of different redirection patterns.

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -9,8 +9,6 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { APIBox } from '~/components/plugins/APIBox';
 
-> Available from Expo SDK 49 and Expo Router v2.
-
 To enable Search Engine Optimization (SEO) on the web you must statically render your app. This guide will walk you through the process of statically rendering your Expo Router app.
 
 ## Setup


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes page description in two Expo Router docs, general typos, and also fixes height of code blocks in Expo Router authentication guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
