### PR TITLE
[expo-font][iOS] Fix font registration failing when font was in use.

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix font registration failing when font was in use.
+- [iOS] Fix font registration failing when font was in use. ([#28989](https://github.com/expo/expo/pull/28989) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix font registration failing when font was in use.
+
 ### 💡 Others
 
 ## 12.0.5 — 2024-05-10

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -12,7 +12,9 @@ public final class FontLoaderModule: Module {
       // If the font was already registered, unregister it first. Otherwise CTFontManagerRegisterGraphicsFont
       // would fail because of a duplicated font name when the app reloads or someone wants to override a font.
       if let familyName = FontFamilyAliasManager.familyName(forAlias: fontFamilyAlias) {
-        try unregisterFont(named: familyName)
+        guard try unregisterFont(named: familyName) == true else {
+          return
+        }
       }
 
       // Create a font object from the given file

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -12,7 +12,7 @@ public final class FontLoaderModule: Module {
       // If the font was already registered, unregister it first. Otherwise CTFontManagerRegisterGraphicsFont
       // would fail because of a duplicated font name when the app reloads or someone wants to override a font.
       if let familyName = FontFamilyAliasManager.familyName(forAlias: fontFamilyAlias) {
-        guard try unregisterFont(named: familyName) == true else {
+        guard try unregisterFont(named: familyName) else {
           return
         }
       }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/28948

# How

When unregistering a font, we sometimes bump into a failure.

Now, if the failure code indicates that the font will still be available afterwards, we let the registerFont function complete instead of rethrowing this error.

# Test Plan

Tested that this works in standalone app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
