### PR TITLE
[docs] Remove SDK 48 specific instructions from different pages

### DIFF
--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -61,8 +61,6 @@ When building your project, you can choose a device or simulator by using the `-
 
 `npx expo run:[android|ios]` automatically starts the bundler/development server. If you want to independently start the bundler with `npx expo start` command, pass the `--no-bundler` to the `npx expo run:[android|ios]` command.
 
-> For SDK 48 and lower, use the `npx expo start --dev-client` command to start the bundler when using a development build or having `expo-dev-client` library installed in your project.
-
 ## Common questions
 
 <Collapsible summary="Can I use Expo CLI without installing the Expo Modules API?">

--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -34,7 +34,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `npx expo-doctor` to diagnose potential issues with your project configuration.
-1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. In SDK 48 and lower, you can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
+1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+.
 1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Restore the keystore (if it was included in the build request).

--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -68,7 +68,7 @@ For example, the image below lists the build of a project:
   src="/static/images/eas-build/eas-build-run-on-android.png"
 />
 
-When the build's installation is complete, it will appear on the home screen. If it's a development build, open a terminal window and start the development server by running the command `npx expo start`. For SDK 48 and lower, use the `--dev-client` flag with the command.
+When the build's installation is complete, it will appear on the home screen. If it's a development build, open a terminal window and start the development server by running the command `npx expo start`.
 
 #### Running the latest build
 

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -42,7 +42,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Write the Provisioning Profile to the **~/Library/MobileDevice/Provisioning Profiles** directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
-1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. In SDK 48 and lower, you can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
+1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+.
 1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from **package.json** if defined.

--- a/docs/pages/build-reference/simulators.mdx
+++ b/docs/pages/build-reference/simulators.mdx
@@ -50,7 +50,7 @@ For example, the image below lists two previous builds of a project:
   src="/static/images/eas-build/eas-build-run-on-ios.png"
 />
 
-When the build's installation is complete, it will appear on the home screen. If it's a development build, open a terminal window and start the development server by running the command `npx expo start`. For SDK 48 and lower, use the `--dev-client` flag with the command.
+When the build's installation is complete, it will appear on the home screen. If it's a development build, open a terminal window and start the development server by running the command `npx expo start`.
 
 ### Running the latest build
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -51,7 +51,7 @@ Then you can set the same environment variable for each build profile in **eas.j
 
 Any reference to `process.env.EXPO_PUBLIC_API_URL` will be substituted for the applicable value depending on the environment.
 
-> `EXPO_PUBLIC_` variable replacement is available in SDK 49 and higher. See notes for [SDK 48 and lower](/guides/environment-variables#environment-variables-in-sdk-48-and-lower).
+> `EXPO_PUBLIC_` variable replacement is available in SDK 49 and higher.
 
 ### For use by your Expo config
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -231,11 +231,11 @@ You can install it via the [release page](https://github.com/jhen0409/react-nati
 
 ### Startup
 
-After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>Cmd ⌘</kbd> + <kbd>t</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>t</kbd> on Linux/Windows) to `8081` (for SDK 48 and lower, the port is `19000`). After that, run your project with `npx expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
+After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>Cmd ⌘</kbd> + <kbd>t</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>t</kbd> on Linux/Windows) to `8081`. After that, run your project with `npx expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
 
 In the debugger console, you can see the Element tree, as well as the props, state, and children of whatever element you select. You also have the Chrome console on the right, and if you type `$r` in the console, you will see the breakdown of your selected element.
 
-If you right-click anywhere in the React Native Debugger, you'll get some handy short-cuts to reload your JS, enable/disable the element inspector, network inspector, and to log and clear your `AsyncStorage` content.
+If you right-click anywhere in the React Native Debugger, you'll get some handy shortcuts to reload your JS, enable/disable the element inspector, network inspector, and to log and clear your `AsyncStorage` content.
 
 <Video file="debugging/react-native-debugger.mp4" />
 

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -25,8 +25,6 @@ To start developing, run the following command to start the development server:
 
 <Terminal cmd={['$ npx expo start']} />
 
-> **Note:** For SDK 48 and lower, use `npx expo start --dev-client`.
-
 To open the project inside your development client:
 
 - Press <kbd>a</kbd> or <kbd>i</kbd> keys to open your project on an Android Emulator or an iOS Simulator.

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -64,24 +64,6 @@ No additional configuration is required for web. Make sure that `react-native-re
 
 </Tab>
 
-<Tab label="SDK 48 and lower">
-
-Install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
-
-{/* prettier-ignore */}
-```js babel.config.js
-plugins: [
-  '@babel/plugin-proposal-export-namespace-from',
-  'react-native-reanimated/plugin',
-],
-```
-
-Next, restart your development server and clear the bundler cache using the command:
-
-<Terminal cmd={['$ npx expo start --clear']} />
-
-</Tab>
-
 </Tabs>
 
 ## Minimal example

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -11,7 +11,7 @@ Environment variables are key-value pairs configured outside your source code th
 
 The Expo CLI will automatically load environment variables with an `EXPO_PUBLIC_` prefix from **.env** files for use within your JavaScript code whenever you use the Expo CLI, such as when running `npx expo start` to start your app in local development mode.
 
-> Available in SDK 49 and higher. See notes for [SDK 48 and lower](#environment-variables-in-sdk-48-and-lower).
+> Available in SDK 49 and higher.
 
 ## Reading environment variables from .env files
 
@@ -48,7 +48,9 @@ Expo CLI loads **.env** files according to the [standard .env file resolution](h
 
 ### How to read from environment variables
 
-- <YesIcon small /> **Every environment variable must be statically referenced as a property of `process.env` using JavaScript's dot notation for it to be inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY` is valid and will be inlined.
+- <YesIcon small /> **Every environment variable must be statically referenced as a property of `process.env`
+  using JavaScript's dot notation for it to be inlined.** For example, the expression `process.env.EXPO_PUBLIC_KEY`
+  is valid and will be inlined.
 
 - <NoIcon small /> **Alternative versions of the expression are not supported**. For example, `process.env['EXPO_PUBLIC_KEY']`
   or `const {EXPO_PUBLIC_X} = process.env` is invalid and will not be inlined.
@@ -149,7 +151,3 @@ Previously with `direnv`, you would need to use a [dynamic app config](/versions
 ## Security considerations
 
 Never store sensitive secrets in environment variables that are prefixed with `EXPO_PUBLIC_`. When an end-user runs your app, they have access to all of the code and embedded environment variables in your app. Read more about [storing sensitive info](https://reactnative.dev/docs/security#storing-sensitive-info).
-
-## Environment variables in SDK 48 and lower
-
-Due to its ability to automatically load and unload environment variables in your shell depending on your current directory, we recommend [`direnv`](https://direnv.net/) for the highest level of compatibility with all Expo and EAS CLI tooling for SDK versions that do not support Expo environment variables. Since variables loaded with `direnv` are available in Node processes but not your application code itself, you can load it into the `extra` field of your [dynamic Expo config](/versions/latest/config/app/#app-config) and then access it in your JavaScript code via [`expo-constants`](/versions/latest/sdk/constants).

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -110,7 +110,6 @@ To save you the trouble of inserting a bunch of conditionals based on the enviro
 
 - **Production and development builds**: `myapp://` (see [#linking-to-your-app](#linking-to-your-app))
 - **Development in Expo Go**: `exp://127.0.0.1:8081`.
-  <CALLOUT theme="secondary">For SDK 48 and lower, the port number is `19000`.</CALLOUT>
 
 When loading published updates in Expo Go, the URL that is created by `Linking.createURL()` depends on how the project was launched and shouldn't be relied upon to be consistent or stable. For applications that require a stable URL (authorization provider redirects, for example), you should use a development build with a custom scheme instead (see [#linking-to-your-app](#linking-to-your-app)).
 
@@ -130,7 +129,6 @@ This will resolve into the following, depending on the environment:
 
 - **Production and development builds**: `myapp://path/into/app?hello=world`
 - **Development in Expo Go**: `exp://127.0.0.1:8081/--/path/into/app?hello=world`.
-  <CALLOUT theme="secondary">For SDK 48 and lower, the port number is `19000`.</CALLOUT>
 
 Again, when loading published updates in Expo Go this behavior is variable, but may look something like the following:
 
@@ -231,7 +229,7 @@ You can test it to ensure it works like this:
 
 [Expo Go][expo-go] uses the `exp://` scheme, however, if we link to `exp://` without any address afterward, it will open the app to the home screen.
 
-In development, your app will live at a url like `exp://127.0.0.1:8081` (for SDK 48 and lower, the port number is `19000`). When published, an experience will be hosted at a URL like `exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]`, where `u.expo.dev/[project-id]` is the hosted URL that Expo Go fetches from.
+In development, your app will live at a url like `exp://127.0.0.1:8081`. When published, an experience will be hosted at a URL like `exp://u.expo.dev/[project-id]?channel-name=[channel-name]&runtime-version=[runtime-version]`, where `u.expo.dev/[project-id]` is the hosted URL that Expo Go fetches from.
 
 You can test this mechanism in your mobile browser by searching `exp://u.expo.dev/F767ADF57-B487-4D8F-9522-85549C39F43F?channel-name=main&runtime-version=exposdk:45.0.0`, this will redirect to your experience in the Expo Go app.
 
@@ -294,8 +292,6 @@ You can open a URL like:
     '',
     '# Expo Go in development (adjust the `127.0.0.1:8081` to match your dev server URL)',
     '$ npx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios',
-    '',
-    '# For SDK 48 and lower, use 19000 as the port number',
   ]}
 />
 

--- a/docs/pages/guides/using-flipper.mdx
+++ b/docs/pages/guides/using-flipper.mdx
@@ -94,16 +94,7 @@ To configure and install a development build, follow the instructions below:
 
 After installing the build, run the following command to start a development server:
 
-<Terminal
-  cmd={[
-    '# For SDK 49 and higher',
-    '$ npx expo start',
-    '',
-    '# For SDK 48 and lower',
-    '$ npx expo start --dev-client',
-  ]}
-  cmdCopy="npx expo start"
-/>
+<Terminal cmd={['$ npx expo start']} />
 
 Once the development server is running, open the Flipper desktop app and select your device or simulator under **App Inspect**:
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -63,7 +63,7 @@ Start a development server to work on your project by running:
 
 > You can also run `npx expo` as an alias to `npx expo start`.
 
-This command starts a server on `http://localhost:8081` (for SDK 48 and lower, the port number is `19000`) that a client can use to interact with the bundler. The default bundler is [Metro](https://metrobundler.dev/).
+This command starts a server on `http://localhost:8081` that a client can use to interact with the bundler. The default bundler is [Metro](https://metrobundler.dev/).
 
 The UI that shows up in the process is referred to as the **Terminal UI**. It contains a QR code (for the dev server URL) and a list of keyboard shortcuts you can press:
 
@@ -100,7 +100,7 @@ By default, the project is served over a LAN connection. You can change this beh
 
 Other available options are:
 
-- `--port`: Port to start the dev server on (does not apply to webpack or [tunnel URLs](#tunneling)). Default: **8081**. For SDK 48 and lower, defaults to `19000`.
+- `--port`: Port to start the dev server on (does not apply to webpack or [tunnel URLs](#tunneling)). Default: **8081**.
 - `--https`: Start the dev server using a secure origin. This is currently only supported on web.
 
 You can force the URL to be any value with the `EXPO_PACKAGER_PROXY_URL` environment variable. For example:

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -228,33 +228,5 @@ After updating the Babel config file, run the following command to clear the bun
 
   </Tab>
 
-  <Tab label="SDK 48 and below">
-
-    Expo Router requires at least `metro@0.76.0`. If you are using Expo SDK version below 49, you will need to force upgrade your `metro` version by setting a Yarn resolution or npm override.
-
-    <Tabs>
-      <Tab label="Yarn">
-        ```json package.json
-        {
-          "resolutions": {
-            "metro": "0.76.0",
-            "metro-resolver": "0.76.0"
-          }
-        }
-        ```
-      </Tab>
-      <Tab label="npm">
-          ```json package.json
-          {
-            "overrides": {
-              "metro": "0.76.0",
-              "metro-resolver": "0.76.0"
-            }
-          }
-          ```
-      </Tab>
-    </Tabs>
-
-  </Tab>
 </Tabs>
 </Step>

--- a/docs/pages/workflow/prebuild.mdx
+++ b/docs/pages/workflow/prebuild.mdx
@@ -103,9 +103,6 @@ In addition to generating the native folders, prebuild also makes the following 
 
 - Modifies the `scripts` field in the **package.json**.
 - Modifies the `dependencies` field in the **package.json**.
-- For SDK 48 and below, removes the `main` field in the **package.json**.
-- For SDK 48 and below, generates an **index.js** file (if it doesn't exist).
-- For SDK 48 and below generates a **metro.config.js** file (if it doesn't exist).
 
 The convenience change to the `scripts` field is the only side effect that alters how a developer works on their app before/after prebuild. All other changes can be left in place and committed to git to minimize the diff when running prebuild.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove SDK 48 specific instructions from multiple documents.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
