### PR TITLE
[calendar][Android] Return events sorted by startDate

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Standardize `getEventsAsync` to return events sorted by start date ([#28353](https://github.com/expo/expo/pull/28353) by [@demfabris](https://github.com/demfabris))
+
 ### 💡 Others
 
 ## 13.0.5 — 2024-05-14

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -256,12 +256,13 @@ class CalendarModule : Module() {
       selection += calendarQuery
     }
     selection += ")"
+    val sortOrder = "${CalendarContract.Instances.BEGIN} ASC"
     val cursor = contentResolver.query(
       uri,
       findEventsQueryParameters,
       selection,
       null,
-      null
+      sortOrder
     )
 
     requireNotNull(cursor) { "Cursor shouldn't be null" }


### PR DESCRIPTION
# Why

A rebase version of https://github.com/expo/expo/pull/28353.

