### PR TITLE
[video][android] Improve HLS compatibility

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Improve HLS compatibility. ([#28997](https://github.com/expo/expo/pull/28997) by [@behenate](https://github.com/behenate))
+
 ## 1.1.9 — 2024-05-13
 
 ### 🎉 New features

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${androidxMedia3Version}"
+  implementation "androidx.media3:media3-exoplayer-hls:${androidxMedia3Version}"
   implementation "androidx.media3:media3-ui:${androidxMedia3Version}"
 
   def fragment_version = "1.6.2"


### PR DESCRIPTION
# Why

ExoPlayer has a special dependency that is required to stream HLS content, we should include it by default in `expo-video` to improve out-of-the-box media compatibility

# How

Added the `media3-exoplayer-hls` dependency to `build.gradle`

# Test Plan

Tested in BareExpo on android emulator. HLS live streams work now, where they weren't working before.

