### PR TITLE
[docs] APISection: fix type signatures with multiple params

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -564,11 +564,12 @@ export const renderTypeOrSignatureType = ({
       <CODE key={`signature-type-${signatures[0].name}`}>
         <span className="text-quaternary">(</span>
         {signatures?.map(({ parameters }) =>
-          parameters?.map(param => (
+          parameters?.map((param, index) => (
             <span key={`signature-param-${param.name}`}>
               {param.name}
               {param.flags?.isOptional && '?'}
               <span className="text-quaternary">:</span> {resolveTypeName(param.type, sdkVersion)}
+              {parameters?.length !== index + 1 ? <span className="text-quaternary">, </span> : ''}
             </span>
           ))
         )}


### PR DESCRIPTION
# Why

![Screenshot 2024-05-20 at 16 53 52](https://github.com/expo/expo/assets/719641/18f8a720-6b98-442c-b83c-75c85186aa38)

# How

Add missing spacer character for type signatures with multiple params.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-05-20 at 16 49 18](https://github.com/expo/expo/assets/719641/8fe53575-2aa7-490a-a980-4c4ed780b7fd)
