### PR TITLE
[docs] Updates select card UI

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -28,7 +28,7 @@ export function SelectCard({
     <ButtonBase onClick={onClick}>
       <div
         className={mergeClasses(
-          'w-[250px] shadow-xs overflow-hidden rounded-lg flex flex-col items-center border border-default transition-all',
+          'w-[250px] shadow-xs overflow-hidden rounded-lg flex flex-col border border-default transition-all',
           'hocus:scale-[102%] hocus:shadow-sm'
         )}>
         <div
@@ -45,23 +45,29 @@ export function SelectCard({
             />
           </picture>
         </div>
-        <div className="p-3 text-center flex items-center justify-center flex-col gap-2">
-          <HEADLINE className="text-center">{title}</HEADLINE>
-          {description ? <CALLOUT theme="secondary">{description}</CALLOUT> : null}
-          <div className="relative">
-            <div
-              className={mergeClasses(
-                'size-5 rounded-full border bg-default',
-                isSelected ? 'border-palette-blue9' : 'border-default'
-              )}
-            />
-            <div
-              className={mergeClasses(
-                'size-3 rounded-full absolute top-1 right-1',
-                isSelected ? 'border-palette-blue9 bg-palette-blue9' : 'bg-transparent'
-              )}
-            />
+        <div className="p-4 flex flex-col gap-2">
+          <div className="flex gap-2 items-center">
+            <div className="relative">
+              <div
+                className={mergeClasses(
+                  'size-5 rounded-full border bg-default',
+                  isSelected ? 'border-palette-blue9' : 'border-default'
+                )}
+              />
+              <div
+                className={mergeClasses(
+                  'size-3 rounded-full absolute top-1 right-1',
+                  isSelected ? 'border-palette-blue9 bg-palette-blue9' : 'bg-transparent'
+                )}
+              />
+            </div>
+            <HEADLINE>{title}</HEADLINE>
           </div>
+          {description ? (
+            <CALLOUT theme="secondary" className="text-left">
+              {description}
+            </CALLOUT>
+          ) : null}
         </div>
       </div>
     </ButtonBase>


### PR DESCRIPTION
# Why

We want the UI in the docs to better match the UI in the website. So, I updated the select card in the select a development environment doc to look more like the UI in the website.

This design is still not an exact copy of the website. What I am proposing here is what I think the website should look like. Open to feedback here.

# Screenshot

<img width="1056" alt="Screenshot 2024-05-20 at 4 47 00 PM" src="https://github.com/expo/expo/assets/6455018/7ea2a8d5-6629-4a28-822c-44bdea603c95">


# Test Plan

Go to this doc: http://localhost:3002/get-started/set-up-your-environment, and make sure that it looks better/better matches the website.