### PR TITLE
[docs] Fix verbiage in Secrets on Expo Website section

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -132,9 +132,9 @@ You can manage secrets through the Expo website and EAS CLI.
 
 ### Secrets on the Expo website
 
-To create **account-wide secrets**, navigate to [the "Secrets" tab in your account or organization settings](https://expo.dev/accounts/[account]/settings/secrets).
+To create **account-wide secrets**, navigate to [Secrets tab](https://expo.dev/accounts/[account]/settings/secrets) in your account's settings.
 
-To create **app-specific secrets**, navigate to [the "Secrets" tab in your project dashboard](https://expo.dev/accounts/[account]/projects/[project]/secrets). If you haven't published your project yet and it isn't visible on the website, you can create it on the website from this link.
+To create **app-specific secrets**, navigate to the [Secrets tab](https://expo.dev/accounts/[account]/projects/[project]/secrets) in your project's dashboard.
 
 ### Adding secrets with EAS CLI
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -82,7 +82,7 @@ If you're experiencing issues with environment variables, you can try disabling 
 
 ### EAS Build
 
-[EAS Build](/build/introduction/) uses Metro Bundler to build the JavaScript bundle embedded within your app binary, so it will use **.env** files uploaded with your build job to inline `EXPO_PUBLIC_` variables into your code. EAS Build also lets you define environment variables within build profiles in **eas.json** and via EAS Secrets. Check out the EAS Build documentation on [environment variables and build secrets](/build-reference/variables.mdx) for more information.
+[EAS Build](/build/introduction/) uses Metro Bundler to build the JavaScript bundle embedded within your app binary, so it will use **.env** files uploaded with your build job to inline `EXPO_PUBLIC_` variables into your code. EAS Build also lets you define environment variables within build profiles in **eas.json** and via EAS Secrets. Check out the EAS Build documentation on [environment variables and build secrets](/build-reference/variables/) for more information.
 
 ### EAS Update
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes the verbiage when describing how to access account wide and project wide secrets settings.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
