### PR TITLE
[core][Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Switched exported `EventEmitter` to the C++ implementation. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
-- [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event.
+- [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event. ([#29012](https://github.com/expo/expo/pull/29012) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Switched exported `EventEmitter` to the C++ implementation. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
+- [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
@@ -13,7 +13,7 @@ class EventObservingDefinition(
 
   enum class Type(val value: String) {
     StartObserving("startObserving"),
-    StopObserving("stopObserving"),
+    StopObserving("stopObserving")
   }
 
   private fun shouldBeInvoked(eventType: Type, eventName: String): Boolean {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/EventObservingDefinition.kt
@@ -1,0 +1,35 @@
+package expo.modules.kotlin.objects
+
+class EventObservingDefinition(
+  private val type: Type,
+  private val filer: Filter,
+  private val body: () -> Unit
+) {
+  sealed class Filter
+
+  data object AllEventsFilter : Filter()
+
+  class SelectedEventFiler(val event: String) : Filter()
+
+  enum class Type(val value: String) {
+    StartObserving("startObserving"),
+    StopObserving("stopObserving"),
+  }
+
+  private fun shouldBeInvoked(eventType: Type, eventName: String): Boolean {
+    if (eventType != type) {
+      return false
+    }
+
+    return when (filer) {
+      is AllEventsFilter -> true
+      is SelectedEventFiler -> filer.event == eventName
+    }
+  }
+
+  fun invokedIfNeed(eventType: Type, eventName: String) {
+    if (shouldBeInvoked(eventType, eventName)) {
+      body()
+    }
+  }
+}


### PR DESCRIPTION
# Why

A followup to the https://github.com/expo/expo/pull/27766.

# How

With this PR, the following DSL will become possible on Android:

```
OnStartObserving("batteryLevelChange") {
  // start observing the battery level, without the need to observe battery state or power mode too
}

OnStopObserving("batteryLevelChange") {
  // stop observing only the battery level
}
```

# Test Plan

- tests ✅ 