### PR TITLE
[video thumbnails][Android] Release the `MediaMetadataRetriever` safely

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Made sure that `MediaMetadataRetriever` is safely released.
+
 ## 8.0.0 — 2024-04-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [Android] Made sure that `MediaMetadataRetriever` is safely released.
+- [Android] Made sure that `MediaMetadataRetriever` is safely released. ([#29015](https://github.com/expo/expo/pull/29015) by [@lukmccall](https://github.com/lukmccall))
 
 ## 8.0.0 — 2024-04-18
 


### PR DESCRIPTION
# Why

Releases the `MediaMetadataRetriever` safely.

# How

The documentation mentioned that `MediaMetadataRetriever` can throw when realeaseing the underlying asset. That can lead to a crash. We can use `use` function from Kotlin to close it safely. 
