### PR TITLE
[sensors][Android] Start using `OnStopObserving`

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `NPE` in `DeviceMotionListener`.
+- [Android] Fixed `NPE` in `DeviceMotionListener`. ([#29022](https://github.com/expo/expo/pull/29022) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `NPE` in `DeviceMotionListener`.
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -12,7 +12,6 @@ import android.view.Surface
 import android.view.WindowManager
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.kotlin.exception.Exceptions
-import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.sensors.SensorSubscription

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -74,6 +74,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
     OnStartObserving {
       subscriptions.forEach { it.startObserving() }
       isObserving = true
+      currentFrameCallback.maybePostFromNonUI()
     }
 
     OnActivityEntersForeground {
@@ -88,13 +89,12 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
       }
     }
 
-    // We can't use `OnStopObserving`, because we need access to change the queue.
-    AsyncFunction("stopObserving") { _: String? ->
+    OnStopObserving {
       if (isObserving) {
         subscriptions.forEach { it.stopObserving() }
       }
       currentFrameCallback.stop()
-    }.runOnQueue(Queues.MAIN)
+    }
 
     AsyncFunction<Boolean>("isAvailableAsync") {
       val mSensorManager = appContext.reactContext?.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
@@ -128,13 +128,16 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
     @Volatile
     private var mIsPosted = false
 
+    @Volatile
     private var mShouldStop = false
 
     override fun doFrame(frameTimeNanos: Long) {
-      if (mShouldStop) {
-        mIsPosted = false
-      } else {
-        post()
+      synchronized(this) {
+        if (mShouldStop) {
+          mIsPosted = false
+        } else {
+          post()
+        }
       }
       val curTime = System.currentTimeMillis()
       if (curTime - lastUpdate > updateInterval) {
@@ -143,11 +146,13 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
       }
     }
 
-    fun stop() {
+    fun stop() = synchronized(this) {
       mShouldStop = true
     }
 
-    fun maybePost() {
+    fun maybePost() = synchronized(this) {
+      mShouldStop = false
+
       if (!mIsPosted) {
         mIsPosted = true
         post()
@@ -203,7 +208,7 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
           putDouble("alpha", Math.toDegrees(rotationRateEvent!!.values[0].toDouble()))
           putDouble("beta", Math.toDegrees(rotationRateEvent!!.values[1].toDouble()))
           putDouble("gamma", Math.toDegrees(rotationRateEvent!!.values[2].toDouble()))
-          putDouble("timestamp", rotationEvent!!.timestamp / 1_000_000_000.0)
+          putDouble("timestamp", rotationRateEvent!!.timestamp / 1_000_000_000.0)
         }
       )
     }


### PR DESCRIPTION
# Why

Migrates from `AsyncFunction("stopObserving")` to `OnStopObserving`.
Makes sure that everything is in sync.
Fixes NPE which was thrown by device motion listener.
 
# Test Plan

- bare-expo ✅ 