### PR TITLE
[task-manager][android] Fix the task manager events not being sent to the JS side

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix the task manager events not being sent to the JS side. ([#29024](https://github.com/expo/expo/pull/29024) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 - Keep using the legacy event emitter as the module is not fully migrated to Expo Modules API. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/EmitEventWrapper.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/EmitEventWrapper.java
@@ -1,0 +1,9 @@
+package expo.modules.taskManager;
+
+import android.os.Bundle;
+
+// Wrapper used for passing the emit function from the EventEmitter between Kotlin and Java
+@FunctionalInterface
+interface EmitEventWrapper {
+  void emit(String name, Bundle body);
+}

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerModule.kt
@@ -3,6 +3,7 @@ package expo.modules.taskManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import expo.modules.core.errors.ModuleNotFoundException
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.interfaces.taskManager.TaskServiceInterface
@@ -39,7 +40,8 @@ class TaskManagerModule : Module() {
           // It may throw, because RN event emitter may not be available
           // we can just ignore those cases
           weakModule.get()?.sendEvent(name, body)
-        } catch (_: Throwable) {
+        } catch (error: Throwable) {
+          Log.e("ExpoTaskManager", "Failed to emit event $name using the module's event emitter: ${error.message}")
         }
         Unit
       }


### PR DESCRIPTION
# Why

Location updates wouldn't get passed to the JS side. Turns out the TaskManager is still using the old EventEmitter which doesn't work in SDK51 on Android

fixes https://github.com/expo/expo/issues/28959
fixes https://github.com/expo/expo/issues/29021

# How

Used a similar workaround to use the new EventEmitter as in `expo-av` and `expo-battery`

# Test Plan

Tested in BareExpo on Android 14 emulator
