### PR TITLE
[docs] API reference rendering tweaks for Expo package page

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -63,7 +63,8 @@ export type TypeDefinitionData = {
     type: string;
   };
   indexType?: {
-    type: string;
+    name?: string;
+    type?: string;
     value: string;
   };
   qualifiedName?: string;
@@ -83,6 +84,7 @@ export type TypePropertyDataFlags = {
   isExternal?: boolean;
   isOptional?: boolean;
   isStatic?: boolean;
+  isRest?: boolean;
 };
 
 // Constants section

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -120,17 +120,20 @@ const nonLinkableTypes = [
   'ComponentType',
   'PureComponent',
   'E',
+  'EventName',
   'EventSubscription',
   'K',
   'Listener',
   'ModuleType',
   'NativeSyntheticEvent',
   'P',
+  'Parameters',
   'ParsedQs',
   'ServiceActionResult',
   'SharedObject',
   'T',
   'TaskOptions',
+  'TEventsMap',
   'Uint8Array',
   // React & React Native
   'React.FC',
@@ -443,6 +446,9 @@ export const resolveTypeName = (
           </span>
         ));
     } else if (type === 'indexedAccess') {
+      if (indexType?.name) {
+        return `${objectType?.name}[${indexType?.name}]`;
+      }
       return `${objectType?.name}['${indexType?.value}']`;
     } else if (type === 'typeOperator') {
       return operator || 'undefined';
@@ -471,7 +477,10 @@ export const renderParamRow = (
   return (
     <Row key={`param-${name}`}>
       <Cell>
-        <BOLD>{parseParamName(name)}</BOLD>
+        <BOLD>
+          {flags?.isRest ? '...' : ''}
+          {parseParamName(name)}
+        </BOLD>
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell>
@@ -539,7 +548,16 @@ export const renderParams = (parameters: MethodParamData[], sdkVersion: string) 
 );
 
 export const listParams = (parameters: MethodParamData[]) =>
-  parameters ? parameters?.map(param => parseParamName(param.name)).join(', ') : '';
+  parameters
+    ? parameters
+        ?.map(param => {
+          if (param.flags?.isRest) {
+            return `...${parseParamName(param.name)}`;
+          }
+          return parseParamName(param.name);
+        })
+        .join(', ')
+    : '';
 
 export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue && defaultValue !== '...' ? (


### PR DESCRIPTION
# Why

Tweaks and fixes for Expo package API reference rendering.

# How

Support rest params in methods, fix `indexType` type resolution, make few generic types as a non-linkable.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-05-21 at 17 08 16](https://github.com/expo/expo/assets/719641/18c0689c-fdf8-458c-a5a3-0b3c1fac5cc5)
