### PR TITLE
[docs] Fix typo in summary for EAS Tutorial chapter

### DIFF
--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -167,7 +167,7 @@ Start the development server by running `npx expo start` from the project direct
       emulators, and learned about <strong>.apk</strong> and <strong>.aab</strong> file formats.
     </>
   }
-  nextChapterDescription="In the next chapter, Learn how to configure a development build for iOS Simulators using EAS Build and get it running."
+  nextChapterDescription="In the next chapter, learn how to configure a development build for iOS Simulators using EAS Build and get it running."
   nextChapterTitle="Create and run a cloud build for iOS Simulator"
   nextChapterLink="/tutorial/eas/ios-development-build-for-simulators/"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Didn't catch this typo before tutorial's release.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the typo in the EAS Tutorial chapter

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
