### PR TITLE
[docs] Add type LottieView

### DIFF
--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -35,7 +35,7 @@ import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 
 export default function App() {
-  const animation = useRef(null);
+  const animation = useRef<LottieView>(null);
   useEffect(() => {
     // You can control the ref programmatically, rather than using autoPlay
     // animation.current?.play();


### PR DESCRIPTION
Property 'reset' does not exist on type 'never'.ts(2339) Property 'play' does not exist on type 'never'.ts(2339)

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
