### PR TITLE
Return 404 if API route file not found

### DIFF
--- a/packages/@expo/server/src/index.ts
+++ b/packages/@expo/server/src/index.ts
@@ -70,9 +70,12 @@ export function createRequestHandler(
 
       debug(`Handling API route: ${route.page}: ${filePath}`);
 
-      // TODO: What's the standard behavior for malformed projects?
       if (!fs.existsSync(filePath)) {
-        return null;
+        console.error(`API route file not found: ${filePath}`);
+        return new Response('API route file not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        });
       }
 
       if (/\.[cj]s$/.test(filePath)) {


### PR DESCRIPTION
# Why

This PR addresses the issue of handling missing API route files more gracefully. Currently, if an API route file does not exist, the server does not provide a clear response. This change ensures that a 404 status code and a descriptive message are returned, improving the developer experience and aiding in debugging. This update aligns with standard web practices for handling non-existent resources.

# How

The change was made by updating the createRequestHandler function within the `expo/packages/@expo/server/src/index.ts` file. Specifically, a check was added to verify the existence of the API route file. If the file does not exist, a 404 response with a descriptive message is returned. This ensures that developers are immediately informed about the missing route file, facilitating easier debugging and development.

# Test Plan

- Created an API route configuration pointing to a non-existent file.
- Sent a request to the server for the non-existent API route.
- Verified that the server returned a 404 status code and the message "API route file not found".
- Confirmed that existing API routes with valid files continue to function as expected.
- Checked that other parts of the request handler are not affected by this change.

# Checklist

- [✔️] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [✔️] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [✔️] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
