### PR TITLE
[docs] Add url to suggested @sentry/react-native/expo config object as per sentry docs. npx sentry-expo-upload-sourcemaps fails without url specified

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -92,6 +92,8 @@ Next, in an environment where you want to create releases and upload sourcemaps 
 
 > **warning** The Sentry auth token should be stored securely. Do not commit it to a public repository, and treat it as you would any other sensitive API key.
 
+<ConfigReactNative>
+
 If you do not use [Continuous Native Generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation/), then you should use the [`@sentry/wizard`](https://docs.sentry.io/platforms/react-native/#install).
 
 </ConfigReactNative>

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -79,7 +79,8 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
         "@sentry/react-native/expo",
         {
           "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
-          "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable"
+          "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable",
+          "url": "https://sentry.io/ (or if you are using a self-hosted instance, the url of that e.g. https://self-hosted.example.com/)"
         }
       ]
     ]
@@ -90,31 +91,6 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
 Next, in an environment where you want to create releases and upload sourcemaps to Sentry, you will need to set the `SENTRY_AUTH_TOKEN` environment variable to your [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). If you are using EAS Build, you can set the environment variable by [creating a secret named SENTRY_AUTH_TOKEN](/build-reference/variables/#using-secrets-in-environment-variables).
 
 > **warning** The Sentry auth token should be stored securely. Do not commit it to a public repository, and treat it as you would any other sensitive API key.
-
-<Collapsible summary={<>When to add <CODE>url</CODE> to <CODE>@sentry/react-native/expo</CODE> config plugin?</>}>
-
-If you are using a self-hosted instance, you need to add the `url` property to the `@sentry/react-native/expo` config plugin.
-
-{/* prettier-ignore */}
-```json app.json
-{
-  "expo": {
-    "plugins": [
-      [
-        "@sentry/react-native/expo",
-        {
-          /*@hide ...*/ /*@end*/
-          "url": "https://self-hosted.example.com"
-        }
-      ]
-    ]
-  }
-}
-```
-
-</Collapsible>
-
-<ConfigReactNative>
 
 If you do not use [Continuous Native Generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation/), then you should use the [`@sentry/wizard`](https://docs.sentry.io/platforms/react-native/#install).
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -80,7 +80,9 @@ Configuring `@sentry/react-native` can be done through the config plugin. Add th
         {
           "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
           "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable",
-          "url": "https://sentry.io/ (or if you are using a self-hosted instance, the url of that e.g. https://self-hosted.example.com/)"
+          // If you are using a self-hosted instance, update the value of the url property
+          // to point towards your self-hosted instance. For example, https://self-hosted.example.com/.
+          "url": "https://sentry.io/"
         }
       ]
     ]


### PR DESCRIPTION
Update to correspond with docs on https://docs.sentry.io/platforms/react-native/sourcemaps/uploading/expo/#add-the-sentry-expo-plugin

I noticed this was missing from the expo docs after I saw `npx sentry-expo-upload-sourcemaps` fails when I did not set url as it was on the public instance:

```
🐕 Fetching from expo config...
SENTRY_ORG resolved to XXX from expo config.
Could not resolve sentry url, set it in the environment variable SENTRY_URL or in the '@sentry/react-native' plugin properties in your expo config.
SENTRY_PROJECT resolved to XXX from expo config.
```

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
