### PR TITLE
[docs] Update error-handling.mdx

### DIFF
--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -18,7 +18,7 @@ This guide specifies how to handle unmatched routes and errors in your app when 
 
 Native apps don't have a server so there are technically no 404s. However, if you're implementing a router universally, then it makes sense to handle missing routes. This is done automatically for each app, but you can also customize it.
 
-```js app/[...unmatched].js
+```js app/+not-found.js
 import { Unmatched } from 'expo-router';
 export default Unmatched;
 ```


### PR DESCRIPTION
Fix the filename of not found route

# Why

[As per documentation in another place](https://docs.expo.dev/router/reference/not-found/), the filename for the `Not Found` page has been changed in the newer version of Expo Router
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
