### PR TITLE
[expo-updates][android] Change from kapt to ksp for room

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
+- Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
 
 ## 0.25.14 — 2024-05-16
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -1,5 +1,19 @@
+buildscript {
+  def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+  apply from: expoModulesCorePlugin
+  applyKotlinExpoModulesCorePlugin()
+
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:${kspVersion()}"
+  }
+}
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 
 group = 'host.exp.exponent'
 version = '0.25.14'
@@ -55,14 +69,6 @@ android {
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", exUpdatesNativeDebug)
     buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", exUpdatesAndroidDelayLoadApp)
     buildConfigField("boolean", "USE_DEV_CLIENT", useDevClient.toString())
-
-    // uncomment below to export the database schema when making changes
-    /* javaCompileOptions {
-      annotationProcessorOptions {
-        arguments += ["room.schemaLocation":
-                      "$projectDir/src/androidTest/schemas".toString()]
-      }
-    } */
   }
   testOptions {
     unitTests.includeAndroidResources = true
@@ -79,6 +85,12 @@ android {
   }
 }
 
+ksp {
+  arg("room.generateKotlin", "true")
+  // uncomment below to export the database schema when making changes
+  // arg("room.schemaLocation", "$projectDir/src/androidTest/schemas".toString())
+}
+
 dependencies {
   implementation project(':expo-structured-headers')
   implementation project(':expo-updates-interface')
@@ -90,7 +102,7 @@ dependencies {
   def room_version = "2.6.1"
 
   implementation "androidx.room:room-runtime:$room_version"
-  kapt "androidx.room:room-compiler:$room_version"
+  ksp "androidx.room:room-compiler:$room_version"
 
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")


### PR DESCRIPTION
# Why

It looks like https://github.com/expo/expo/pull/28806 wasn't sufficient to fix https://github.com/expo/expo/pull/28657. This changes expo-updates to use ksp instead of kapt, which is the suggested method going forward anyways.

Closes ENG-12257.

# How

Update to ksp. Copy the strategy of adding ksp to a library (versus a project) from react-native-async-storage.

# Test Plan

Build app. Updates e2e tests as well.

Also test uncommenting the schema generation for tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
