### PR TITLE
[docs] Adds expo.new automated setup link

### DIFF
--- a/docs/pages/get-started/introduction.mdx
+++ b/docs/pages/get-started/introduction.mdx
@@ -14,7 +14,7 @@ We also make [Expo Application Services (EAS)](https://expo.dev/eas), a set of s
 There are two ways to get started:
 
 <BoxLink
-  title="Automated setup on expo.dev"
+  title="Automated setup with expo.new"
   description="Create a project, set up your development environment, automatically configure build and update automations, and start developing."
   href="https://expo.new/"
   Icon={Earth02Icon}

--- a/docs/pages/get-started/introduction.mdx
+++ b/docs/pages/get-started/introduction.mdx
@@ -5,14 +5,23 @@ hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon, Earth02Icon } from '@expo/styleguide-icons';
 
 Expo is a framework that makes developing Android and iOS apps easier. Our framework provides file-based routing, a standard library of native modules, and much more. Expo is open source with an active community on [GitHub](https://github.com/expo/expo) and [Discord](https://chat.expo.dev).
 
 We also make [Expo Application Services (EAS)](https://expo.dev/eas), a set of services that complement the Expo framework in each step of the development process.
 
+There are two ways to get started:
+
 <BoxLink
-  title="Quick start"
+  title="Automated setup on expo.dev"
+  description="Create a project, set up your development environment, automatically configure build and update automations, and start developing."
+  href="https://expo.new/"
+  Icon={Earth02Icon}
+/>
+
+<BoxLink
+  title="Quick start docs"
   description="Create a project, set up your development environment, and start developing."
   href="/get-started/create-a-project/"
   Icon={BookOpen02Icon}


### PR DESCRIPTION
# Why

Adds automated quick start link to /get-started/introduction

<img width="805" alt="Screenshot 2024-05-22 at 1 56 00 PM" src="https://github.com/expo/expo/assets/6455018/5fae8542-552e-4257-b31e-fb41325f873d">


# Test plan

Go to /get-started/introduction and make sure the links appear like in the screenshot above.

# Deploy plan

We need to redirect expo.new to expo.dev/hello before this PR is merged.