### PR TITLE
[template] Updates reset-project script

### DIFF
--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -2,17 +2,18 @@
 
 /**
  * This script is used to reset the project to a blank state.
- * It moves the /app directory to /app-example and creates a new /app directory with an index.tsx and _layout.tsx file.
+ * It moves the /app, /components, /hooks, /scripts, and /constants directories to /app-example and creates a new /app directory with an index.tsx and _layout.tsx file.
  * You can remove the `reset-project` script from package.json and safely delete this file after running it.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 const root = process.cwd();
-const oldDirPath = path.join(root, 'app');
-const newDirPath = path.join(root, 'app-example');
-const newAppDirPath = path.join(root, 'app');
+const oldDirs = ["app", "components", "hooks", "constants", "scripts"];
+const newDir = "app-example";
+const newAppDir = "app";
+const newDirPath = path.join(root, newDir);
 
 const indexContent = `import { Text, View } from "react-native";
 
@@ -34,40 +35,50 @@ export default function Index() {
 const layoutContent = `import { Stack } from "expo-router";
 
 export default function RootLayout() {
-  return (
-    <Stack>
-      <Stack.Screen name="index" />
-    </Stack>
-  );
+  return <Stack />;
 }
 `;
 
-fs.rename(oldDirPath, newDirPath, (error) => {
-  if (error) {
-    return console.error(`Error renaming directory: ${error}`);
-  }
-  console.log('/app moved to /app-example.');
+const moveDirectories = async () => {
+  try {
+    // Create the app-example directory
+    await fs.promises.mkdir(newDirPath, { recursive: true });
+    console.log(`📁 /${newDir} directory created.`);
 
-  fs.mkdir(newAppDirPath, { recursive: true }, (error) => {
-    if (error) {
-      return console.error(`Error creating new app directory: ${error}`);
-    }
-    console.log('New /app directory created.');
-
-    const indexPath = path.join(newAppDirPath, 'index.tsx');
-    fs.writeFile(indexPath, indexContent, (error) => {
-      if (error) {
-        return console.error(`Error creating index.tsx: ${error}`);
+    // Move old directories to new app-example directory
+    for (const dir of oldDirs) {
+      const oldDirPath = path.join(root, dir);
+      const newDirPath = path.join(root, newDir, dir);
+      if (fs.existsSync(oldDirPath)) {
+        await fs.promises.rename(oldDirPath, newDirPath);
+        console.log(`➡️ /${dir} moved to /${newDir}/${dir}.`);
+      } else {
+        console.log(`➡️ /${dir} does not exist, skipping.`);
       }
-      console.log('app/index.tsx created.');
+    }
 
-      const layoutPath = path.join(newAppDirPath, '_layout.tsx');
-      fs.writeFile(layoutPath, layoutContent, (error) => {
-        if (error) {
-          return console.error(`Error creating _layout.tsx: ${error}`);
-        }
-        console.log('app/_layout.tsx created.');
-      });
-    });
-  });
-});
+    // Create new /app directory
+    const newAppDirPath = path.join(root, newAppDir);
+    await fs.promises.mkdir(newAppDirPath, { recursive: true });
+    console.log("\n📁 New /app directory created.");
+
+    // Create index.tsx
+    const indexPath = path.join(newAppDirPath, "index.tsx");
+    await fs.promises.writeFile(indexPath, indexContent);
+    console.log("📄 app/index.tsx created.");
+
+    // Create _layout.tsx
+    const layoutPath = path.join(newAppDirPath, "_layout.tsx");
+    await fs.promises.writeFile(layoutPath, layoutContent);
+    console.log("📄 app/_layout.tsx created.");
+
+    console.log("\n✅ Project reset complete. Next steps:");
+    console.log(
+      "1. Run `npx expo start` to start a development server.\n2. Edit app/index.tsx to edit the main screen.\n3. Delete the /app-example directory when you're done referencing it."
+    );
+  } catch (error) {
+    console.error(`Error during script execution: ${error}`);
+  }
+};
+
+moveDirectories();


### PR DESCRIPTION
# Why

In the default template, we only moved the **app** directory to the **app-example** directory, which left the **components**, **constants**, **hooks**, and **scripts** folders.

This PR moves the other template-specific directories to **app-example** to reset the project fully. It also updates the output of the script to be more descriptive and helpful.

# Screenshots

Output of the reset project script
<img width="649" alt="Screenshot 2024-05-22 at 1 44 21 PM" src="https://github.com/expo/expo/assets/6455018/4ba43336-1e82-4590-a5c4-f0b076a79e81">

Resulting directories and files
<img width="266" alt="Screenshot 2024-05-22 at 1 44 31 PM" src="https://github.com/expo/expo/assets/6455018/2f3e11b0-ca9e-498c-8ff4-3d93eefea6c2">

# Test Plan

- Make a new project with `npx create-expo-app@latest`.
- Copy in the **reset-project.js** script from this PR into **/scripts/reset-project.js**.
- Run `npm run reset-project` and make sure that the result looks like the screenshots and descriptions above.
- Then, run `npx expo start` and make sure the project runs.