### PR TITLE
[expo-updates][android] Upgrade dependencies and remove unused ones

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
-- Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
+- [Android] Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
+- [Android] Upgrade dependencies and remove unused ones. Change multipart parser to okhttp. ([#29060](https://github.com/expo/expo/pull/29060) by [@wschurman](https://github.com/wschurman))
 
 ## 0.25.14 — 2024-05-16
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -76,6 +76,9 @@ android {
     packagingOptions {
       pickFirst "**/libfbjni.so"
       pickFirst "**/libc++_shared.so"
+
+      resources.excludes.add("META-INF/LICENSE.md")
+      resources.excludes.add("META-INF/LICENSE-notice.md")
     }
   }
   sourceSets {
@@ -100,6 +103,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   def room_version = "2.6.1"
+  def mockk_version = "1.13.11"
 
   implementation "androidx.room:room-runtime:$room_version"
   ksp "androidx.room:room-compiler:$room_version"
@@ -107,24 +111,19 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-brotli:4.9.2")
-  implementation("com.squareup.okio:okio:2.9.0")
-  implementation("commons-codec:commons-codec:1.10")
-  implementation("commons-io:commons-io:2.6")
-  implementation("commons-fileupload:commons-fileupload:1.4")
-  implementation("javax.portlet:portlet-api:3.0.1")
-  implementation("javax.servlet:javax.servlet-api:4.0.1")
-  implementation("org.apache.commons:commons-lang3:3.9")
-  implementation("org.bouncycastle:bcutil-jdk15to18:1.70")
+  implementation("commons-io:commons-io:2.16.1")
+  implementation("org.bouncycastle:bcutil-jdk15to18:1.78.1")
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.4.0'
-  testImplementation 'io.mockk:mockk:1.12.3'
+  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation "io.mockk:mockk:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion()}"
 
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:core:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+  androidTestImplementation 'com.squareup.okio:okio:2.9.0'
+  androidTestImplementation 'androidx.test:runner:1.5.2'
+  androidTestImplementation 'androidx.test:core:1.5.0'
+  androidTestImplementation 'androidx.test:rules:1.5.0'
+  androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.room:room-testing:$room_version"
   androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion()}"
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/TestUtils.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/TestUtils.kt
@@ -1,0 +1,46 @@
+package expo.modules.updates
+
+import expo.modules.updates.TestUtils.asResponseBody
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+
+object TestUtils {
+  private fun MultipartBody.asResponseBody(): ResponseBody {
+    val contentBuffer = Buffer().also { this.writeTo(it) }
+    return contentBuffer.asResponseBody(this.contentType(), this.contentLength())
+  }
+
+  fun MultipartBody.asResponse(headers: Headers? = null) = Response.Builder()
+    .request(Request.Builder().url("http://wat.com").build())
+    .protocol(Protocol.HTTP_2)
+    .message("")
+    .also {
+      if (headers != null) {
+        it.headers(headers)
+      }
+    }
+    .code(200)
+    .body(this.asResponseBody())
+    .build()
+
+  fun String.asJSONResponse(headers: Headers? = null) = Response.Builder()
+    .request(Request.Builder().url("http://wat.com").build())
+    .protocol(Protocol.HTTP_2)
+    .message("")
+    .also {
+      if (headers != null) {
+        it.headers(headers)
+      }
+    }
+    .code(200)
+    .body(this.toResponseBody("application/json".toMediaType()))
+    .build()
+}

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -3,17 +3,23 @@ package expo.modules.updates.loader
 import android.net.Uri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.updates.TestUtils.asJSONResponse
+import expo.modules.updates.TestUtils.asResponse
 import expo.modules.updates.UpdatesConfiguration
-import expo.modules.updates.codesigning.*
-import expo.modules.updates.manifest.Update
+import expo.modules.updates.codesigning.CODE_SIGNING_METADATA_KEY_ID_KEY
+import expo.modules.updates.codesigning.CertificateFixtures
 import expo.modules.updates.codesigning.TestCertificateType
 import expo.modules.updates.codesigning.getTestCertificate
-import io.mockk.every
-import io.mockk.mockk
-import okhttp3.*
+import expo.modules.updates.manifest.Update
 import okhttp3.Headers.Companion.toHeaders
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okio.Buffer
+import okhttp3.MultipartBody
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,16 +29,8 @@ class FileDownloaderManifestParsingTest {
   @Test
   fun testManifestParsing_JSONBody() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
-    val contentType = "application/json"
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType, "expo-protocol-version" to "0").toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(
-        "application/json; charset=utf-8".toMediaTypeOrNull(),
-        CertificateFixtures.testExpoUpdatesManifestBody
-      )
-    }
+
+    val response = CertificateFixtures.testExpoUpdatesManifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,
@@ -66,12 +64,11 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBody() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
     val extensions = "{}"
     val directive = CertificateFixtures.testDirectiveNoUpdateAvailable
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"").toHeaders(),
@@ -90,15 +87,7 @@ class FileDownloaderManifestParsingTest {
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType, "expo-protocol-version" to "0").toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse(mapOf("expo-protocol-version" to "0").toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,
@@ -137,26 +126,17 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodyOnlyDirective() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
     val directive = CertificateFixtures.testDirectiveNoUpdateAvailable
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"directive\"; filename=\"hello3\"").toHeaders(),
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType).toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -194,26 +174,16 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodyOnlyDirective_v0CompatibilityMode() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
-
     val directive = CertificateFixtures.testDirectiveNoUpdateAvailable
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"directive\"; filename=\"hello3\"").toHeaders(),
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType).toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -247,24 +217,15 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodyNoRelevantParts() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"fake\"; filename=\"hello3\"").toHeaders(),
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), "")
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType).toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -300,14 +261,14 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodyEmpty() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns contentType
-      every { headers } returns mapOf("content-type" to contentType).toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, "")
-    }
+    val response = Response.Builder()
+      .request(Request.Builder().url("http://wat.com").build())
+      .protocol(Protocol.HTTP_2)
+      .message("")
+      .code(200)
+      .body("".toResponseBody("${MultipartBody.MIXED}; boundary=$boundary".toMediaType()))
+      .build()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -342,11 +303,15 @@ class FileDownloaderManifestParsingTest {
   @Test
   fun testManifestParsing_NullBodyResponseProtocol1() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
-    val response = mockk<Response>().apply {
-      every { headers } returns mapOf("expo-protocol-version" to "1").toHeaders()
-      every { code } returns 200
-      every { body } returns null
-    }
+
+    val response = Response.Builder()
+      .request(Request.Builder().url("http://wat.com").build())
+      .protocol(Protocol.HTTP_2)
+      .message("")
+      .code(200)
+      .header("expo-protocol-version", "1")
+      .body(null)
+      .build()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -381,11 +346,15 @@ class FileDownloaderManifestParsingTest {
   @Test
   fun testManifestParsing_204ResponseProtocol1() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
-    val response = mockk<Response>().apply {
-      every { headers } returns mapOf("expo-protocol-version" to "1").toHeaders()
-      every { code } returns 204
-      every { body } returns null
-    }
+
+    val response = Response.Builder()
+      .request(Request.Builder().url("http://wat.com").build())
+      .protocol(Protocol.HTTP_2)
+      .message("")
+      .code(204)
+      .header("expo-protocol-version", "1")
+      .body(null)
+      .build()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -420,12 +389,14 @@ class FileDownloaderManifestParsingTest {
   @Test
   fun testManifestParsing_204ResponseNoProtocol() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
-    val response = mockk<Response>().apply {
-      every { header("content-type") } returns null
-      every { headers } returns mapOf<String, String>().toHeaders()
-      every { code } returns 204
-      every { body } returns null
-    }
+
+    val response = Response.Builder()
+      .request(Request.Builder().url("http://wat.com").build())
+      .protocol(Protocol.HTTP_2)
+      .message("")
+      .code(204)
+      .body(null)
+      .build()
 
     val configuration = UpdatesConfiguration(
       null,
@@ -456,24 +427,15 @@ class FileDownloaderManifestParsingTest {
 
   @Test
   fun testManifestParsing_JSONBodySigned() {
-    val contentType = "application/json"
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
       "expo-sfv-version" to "0",
-      "content-type" to contentType,
       "expo-signature" to CertificateFixtures.testExpoUpdatesManifestBodySignature
     )
 
     val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testExpoUpdatesManifestBody)
-    }
+    val response = CertificateFixtures.testExpoUpdatesManifestBody.asJSONResponse(headersMap.toHeaders())
 
     val testCertificate = getTestCertificate(TestCertificateType.VALID)
     val configuration = UpdatesConfiguration(
@@ -510,18 +472,16 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodySigned() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
-      "expo-sfv-version" to "0",
-      "content-type" to contentType
+      "expo-sfv-version" to "0"
     )
 
     val extensions = "{}"
     val directive = CertificateFixtures.testDirectiveNoUpdateAvailable
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"").toHeaders(),
@@ -548,17 +508,7 @@ class FileDownloaderManifestParsingTest {
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse(headersMap.toHeaders())
 
     val testCertificate = getTestCertificate(TestCertificateType.VALID)
     val configuration = UpdatesConfiguration(
@@ -597,23 +547,14 @@ class FileDownloaderManifestParsingTest {
 
   @Test
   fun testManifestParsing_JSONBodySigned_UnsignedRequest() {
-    val contentType = "application/json"
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
-      "expo-sfv-version" to "0",
-      "content-type" to contentType
+      "expo-sfv-version" to "0"
     )
 
     val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testExpoUpdatesManifestBody)
-    }
+    val response = CertificateFixtures.testExpoUpdatesManifestBody.asJSONResponse(headersMap.toHeaders())
 
     val testCertificate = getTestCertificate(TestCertificateType.VALID)
     val configuration = UpdatesConfiguration(
@@ -649,12 +590,10 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodySignedCertificateParticularExperience() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
-      "expo-sfv-version" to "0",
-      "content-type" to contentType
+      "expo-sfv-version" to "0"
     )
 
     val extensions = "{}"
@@ -664,7 +603,7 @@ class FileDownloaderManifestParsingTest {
     val intermediateCert = getTestCertificate(TestCertificateType.CHAIN_INTERMEDIATE)
     val rootCert = getTestCertificate(TestCertificateType.CHAIN_ROOT)
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"").toHeaders(),
@@ -695,17 +634,7 @@ class FileDownloaderManifestParsingTest {
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse(headersMap.toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,
@@ -761,7 +690,7 @@ class FileDownloaderManifestParsingTest {
     val intermediateCert = getTestCertificate(TestCertificateType.CHAIN_INTERMEDIATE)
     val rootCert = getTestCertificate(TestCertificateType.CHAIN_ROOT)
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"").toHeaders(),
@@ -784,17 +713,7 @@ class FileDownloaderManifestParsingTest {
         RequestBody.create("application/x-pem-file; charset=utf-8".toMediaTypeOrNull(), leafCert + intermediateCert)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse(headersMap.toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,
@@ -832,12 +751,10 @@ class FileDownloaderManifestParsingTest {
   fun testManifestParsing_MultipartBodySignedCertificateParticularExperience_IncorrectExperienceInDirective() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val boundary = "blah"
-    val contentType = "multipart/mixed; boundary=$boundary"
 
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
-      "expo-sfv-version" to "0",
-      "content-type" to contentType
+      "expo-sfv-version" to "0"
     )
 
     val directive = CertificateFixtures.testDirectiveNoUpdateAvailableIncorrectProjectId
@@ -846,7 +763,7 @@ class FileDownloaderManifestParsingTest {
     val intermediateCert = getTestCertificate(TestCertificateType.CHAIN_INTERMEDIATE)
     val rootCert = getTestCertificate(TestCertificateType.CHAIN_ROOT)
 
-    val multipartBody = MultipartBody.Builder(boundary)
+    val response = MultipartBody.Builder(boundary)
       .setType(MultipartBody.MIXED)
       .addPart(
         mapOf("Content-Disposition" to "form-data; name=\"extraneous\"; filename=\"hello1\"").toHeaders(),
@@ -865,17 +782,7 @@ class FileDownloaderManifestParsingTest {
         RequestBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), directive)
       )
       .build()
-
-    val contentBuffer = Buffer().also { multipartBody.writeTo(it) }
-
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
-    }
+      .asResponse(headersMap.toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,
@@ -911,23 +818,14 @@ class FileDownloaderManifestParsingTest {
 
   @Test
   fun testManifestParsing_JSONBodySigned_UnsignedRequest_ManifestSignatureOptional() {
-    val contentType = "application/json"
     val headersMap = mapOf(
       "expo-protocol-version" to "0",
-      "expo-sfv-version" to "0",
-      "content-type" to contentType
+      "expo-sfv-version" to "0"
     )
 
     val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-    val response = mockk<Response>().apply {
-      headersMap.forEach {
-        every { header(it.key) } returns it.value
-      }
-      every { headers } returns headersMap.toHeaders()
-      every { code } returns 200
-      every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testExpoUpdatesManifestBody)
-    }
+    val response = CertificateFixtures.testExpoUpdatesManifestBody.asJSONResponse(headersMap.toHeaders())
 
     val configuration = UpdatesConfiguration(
       null,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -23,6 +23,7 @@ import java.text.DateFormat
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
+import java.util.regex.Pattern
 import kotlin.experimental.and
 
 /**
@@ -276,5 +277,53 @@ object UpdatesUtils {
       // Throw if the second parse attempt fails
       throw e
     }
+  }
+
+  private val PARAMETER_PATTERN: Pattern by lazy {
+    val token = "([a-zA-Z0-9-!#$%&'*+.^_`{|}~]+)"
+    val quoted = "\"([^\"]*)\""
+    Pattern.compile(";\\s*(?:\\s*$token\\s*=\\s*(?:$token|$quoted))?\\s*")
+  }
+
+  /**
+   * Parse name parameter from content-disposition header value.
+   *
+   * Derived from Okhttp String.toMediaType
+   */
+  fun String.parseContentDispositionNameParameter(): String? {
+    val parameterNamesAndValues = mutableMapOf<String, String?>()
+    val parameter = PARAMETER_PATTERN.matcher(this)
+    var s = this.indexOf(';')
+    while (s < length) {
+      parameter.region(s, length)
+      require(parameter.lookingAt()) {
+        "Parameter is not formatted correctly: \"${substring(s)}\" for: \"$this\""
+      }
+
+      val name: String? = parameter.group(1)
+      if (name == null) {
+        s = parameter.end()
+        continue
+      }
+
+      val token: String? = parameter.group(2)
+      val value: String? = when {
+        token == null -> {
+          // Value is "double-quoted". That's valid and our regex group already strips the quotes.
+          parameter.group(3)
+        }
+        token.startsWith("'") && token.endsWith("'") && token.length > 2 -> {
+          // If the token is 'single-quoted' it's invalid! But we're lenient and strip the quotes.
+          token.substring(1, token.length - 1)
+        }
+        else -> token
+      }
+
+      if (!parameterNamesAndValues.containsKey(name)) {
+        parameterNamesAndValues[name] = value
+      }
+      s = parameter.end()
+    }
+    return parameterNamesAndValues["name"]
   }
 }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesConfigurationTest.kt
@@ -5,10 +5,8 @@ import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase
 import org.junit.Assert
-import org.junit.Test
 
 class UpdatesConfigurationTest : TestCase() {
-  @Test
   fun testGetNormalizedUrlOrigin_NoPort() {
     val mockedUri = mockk<Uri>()
     every { mockedUri.scheme } returns "https"
@@ -17,7 +15,6 @@ class UpdatesConfigurationTest : TestCase() {
     Assert.assertEquals("https://exp.host", getNormalizedUrlOrigin(mockedUri))
   }
 
-  @Test
   fun testGetNormalizedUrlOrigin_DefaultPort() {
     val mockedUri = mockk<Uri>()
     every { mockedUri.scheme } returns "https"
@@ -26,7 +23,6 @@ class UpdatesConfigurationTest : TestCase() {
     Assert.assertEquals("https://exp.host", getNormalizedUrlOrigin(mockedUri))
   }
 
-  @Test
   fun testGetNormalizedUrlOrigin_OtherPort() {
     val mockedUri = mockk<Uri>()
     every { mockedUri.scheme } returns "https"

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -1,31 +1,27 @@
 package expo.modules.updates
 
+import expo.modules.updates.UpdatesUtils.parseContentDispositionNameParameter
 import expo.modules.updates.db.entity.AssetEntity
 import io.mockk.mockk
 import junit.framework.TestCase
 import org.junit.Assert
-import org.junit.Test
 
 class UpdatesUtilsTest : TestCase() {
-  @Test
   fun testCreateFilenameForAsset() {
     val assetEntity = AssetEntity("key", ".png")
     Assert.assertEquals("key.png", UpdatesUtils.createFilenameForAsset(assetEntity))
   }
 
-  @Test
   fun testCreateFilenameForAssetWhenMissingDotPrefix() {
     val assetEntity = AssetEntity("key", "png")
     Assert.assertEquals("key.png", UpdatesUtils.createFilenameForAsset(assetEntity))
   }
 
-  @Test
   fun testCreateFilenameForAssetWhenMissingExtension() {
     val assetEntity = AssetEntity("key", null)
     Assert.assertEquals("key", UpdatesUtils.createFilenameForAsset(assetEntity))
   }
 
-  @Test
   fun testCreateFilenameForAsset_NullKey() {
     // asset filenames with null keys should be unique
     val asset1 = AssetEntity(null, "bundle")
@@ -38,7 +34,6 @@ class UpdatesUtilsTest : TestCase() {
     Assert.assertEquals(asset1Name.substring(asset1Name.length - 7), ".bundle")
   }
 
-  @Test
   fun testGetRuntimeVersion() {
     val baseConfig = UpdatesConfiguration(
       scopeKey = "wat",
@@ -63,5 +58,28 @@ class UpdatesUtilsTest : TestCase() {
       noRuntimeConfig.getRuntimeVersion()
     }
     Assert.assertEquals(exception.message, "No runtime version provided in configuration")
+  }
+
+  fun testParseContentDisposition() {
+    val expected = mapOf(
+      "form-data; name=\"hello\"" to "hello",
+      "form-data; name=hello" to "hello",
+
+      // from apache.commons.fileupload2.core.ParameterParserTest
+      "text/plain; Charset=UTF-8" to null,
+      "test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=\"stuff\"; name=wat" to "wat",
+      "test; test1 =  stuff   ;name=wat; test2 =  \"stuff; stuff\"; test3=\"stuff\"" to "wat",
+
+      // others
+      " form-data; name=\"field_value\"; filename=\"file_name.html\"" to "field_value",
+      " form-data; filename=\"file_name.html\"; name=\"field_value\"" to "field_value",
+      "text/plain;a=1;b=2;name=manifest-wat;c=3" to "manifest-wat",
+      "Message/Partial; number=2; total=3; name=\"oc=abc@example.com\"" to "oc=abc@example.com",
+      "multipart/mixed; name=2; name=3" to "2"
+    )
+
+    expected.forEach { (case, expectedName) ->
+      Assert.assertEquals(expectedName, case.parseContentDispositionNameParameter())
+    }
   }
 }


### PR DESCRIPTION
# Why

This removes the following dependencies:
```
implementation("javax.portlet:portlet-api:3.0.1")
implementation("javax.servlet:javax.servlet-api:4.0.1")
```
These were added in https://github.com/expo/expo/pull/24971 to satisfy them no longer being provided in react native, and failing to resolve during release builds if not added.

They are used by apache commons fileupload, which provides a lot of utilities for doing servlet and portlet stuff, which we don't need.

What we do need is a multipart parser (which okhttp now provides) and a parameter parser for parsing `content-disposition`.

Also some dependencies can be upgraded.

# Test Plan

Wait for tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
