### PR TITLE
Fixed pauseAsync is undefined

### DIFF
--- a/packages/expo-av/tsconfig.json
+++ b/packages/expo-av/tsconfig.json
@@ -2,7 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "useDefineForClassFields": "false"
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]


### PR DESCRIPTION
# Why

`e.pauseAsync is not a function. (In 'e.pauseAsync()', 'e.pauseAsync' is undefined)` crashes in production apps.

As of ES2022 (or project with tsconfig.json target: ESNext), class fields are now valid syntax, which is a breaking change when using ESNext (Expo default) and causes issues like "pauseAsync is undefined" in expo-av. It's a broad JS ecosystem issue that should be reviewed.

Further explanation: https://github.com/react-native-maps/react-native-maps/issues/4512#issuecomment-2123597205

The motivation for this change was the error "pauseAsync is undefined" when attempting to leave a screen and then calling pauseAsync on a running video at the last minute. This caused a crash. The crash is due to the function not existing for that particular call mainly because since ES2022 it's **valid** syntax to define a type such as:
```
class Foo {
  x: string;
}
```
So because it's valid syntax, it is now transpiled as opposed to fully removed, into:
```
class Foo {
  x;
}
```
Which is unexpected behavior for most libraries (it might overwrite parent methods or otherwise misbehave). To restore the old behavior (no field definition), the flag must be set to false, or code must be rewritten to support this new behavior. 

# How

Followed the contribution guide, ran yarn build, made set the flag to false, and confirmed that public class fields were no longer output, as is expected.

# Test Plan

Only confirmed build output, did not run a runtime test.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
