### PR TITLE
Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr'

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event. ([#29012](https://github.com/expo/expo/pull/29012) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
-- [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' [#29075](https://github.com/expo/expo/pull/29075)
+- [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' ([#29075](https://github.com/expo/expo/pull/29075) by [@rafi16jan](https://github.com/rafi16jan))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event. ([#29012](https://github.com/expo/expo/pull/29012) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
+- [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' [#29075](https://github.com/expo/expo/pull/29075)
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Android] `OnStartObserving` and `OnStopObserving` can now be attached to a specific event. ([#29012](https://github.com/expo/expo/pull/29012) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
+
 - [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' ([#29075](https://github.com/expo/expo/pull/29075) by [@rafi16jan](https://github.com/rafi16jan))
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -145,7 +145,7 @@ void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *module
   for (auto &[name, classInfo]: classes) {
     auto &[classRef, constructor, ownerClass] = classInfo;
     auto classObject = classRef->cthis();
-    auto weakConstructor = std::weak_ptr(constructor);
+    auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
     auto klass = SharedObject::createClass(
       runtime,
       name.c_str(),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This is an error that occurs on Expo 51

# How

<!--
How did you build this feature or fix this bug and why?
-->
This is what I patched in my project to make apk building works

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I test with the original code and fails with `error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr'`. And the error is gone when I replace the line with the fix.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
