### PR TITLE
[docs] Fix expo-updates tech spec

### DIFF
--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -20,8 +20,8 @@ A conforming implementation of this protocol MAY provide additional functionalit
 
 Conforming servers and client libraries MUST follow the HTTP spec as described in [RFC 7231](https://tools.ietf.org/html/rfc7231) as well as the more precise guidance described in this spec.
 
-- An _update_ is defined as a [_manifest_](#manifest-response) together with the assets referenced inside the manifest.
-- A [_directive_](#directive-response) is defined as a message from the server that instructs clients to perform an action.
+- An _update_ is defined as a [_manifest_](#manifest-body) together with the assets referenced inside the manifest.
+- A [_directive_](#directive-body) is defined as a message from the server that instructs clients to perform an action.
 
 Expo Updates is a protocol for assembling and delivering updates and directives to clients.
 
@@ -50,7 +50,7 @@ A conformant client library MUST make a GET request with the headers:
    - Android MUST be `expo-platform: android`.
    - If it is not one of these platforms, the server SHOULD return a 400 or a 404
 3. `expo-runtime-version` MUST be a runtime version compatible with the client. A runtime version stipulates the native code setup a client is running. It should be set when the client is built. For example, in an iOS client, the value may be set in a plist file.
-4. Any headers stipulated by a previous responses' [server defined headers](#manifest-response-headers).
+4. Any headers stipulated by a previous responses' [server defined headers](#response).
 
 A conformant client library MAY send one of `accept: application/expo+json`, `accept: application/json`, or `accept: multipart/mixed` based on the [supported response structures](#response), though it SHOULD send `accept: application/expo+json, application/json, multipart/mixed`. A conformant client library MAY express preference using "q" parameters as specified in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1), which default to `1`.
 
@@ -122,16 +122,16 @@ Part order is not strict. A multipart response with no parts (zero-length body) 
 Each part is defined as follows:
 
 1. OPTIONAL `"manifest"` part:
-   - MUST have part header `content-disposition: inline; name="manifest"`.
+   - MUST have part header `content-disposition: form-data; name="manifest"`. The first parameter (`form-data`) does not need to be `form-data`, but the `name` parameter must have `manifest` as a value.
    - MUST have part header `content-type: application/json` or `application/expo+json`.
    - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
    - The [manifest body](#manifest-body) MUST be sent in the part body.
 2. OPTIONAL `"extensions"` part:
-   - MUST have part header `content-disposition: inline; name="extensions"`.
+   - MUST have part header `content-disposition: form-data; name="extensions"`. The first parameter (`form-data`) does not need to be `form-data`, but the `name` parameter must have `extensions` as a value.
    - MUST have part header `content-type: application/json`.
    - The [extensions-body](#extensions-body) MUST be sent in the part body.
 3. OPTIONAL `"directive"` part:
-   - MUST have part header `content-disposition: inline; name="directive"`.
+   - MUST have part header `content-disposition: form-data; name="directive"`. The first parameter (`form-data`) does not need to be `form-data`, but the `name` parameter must have `directive` as a value.
    - MUST have part header `content-type: application/json` or `application/expo+json`.
    - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
    - The [directive body](#directive-body) MUST be sent in the part body.


### PR DESCRIPTION
# Why

This part of the spec was incorrect. The first parameter doesn't need to be anything in particular. The only thing that is required is the name parameter to identify it.

Closes ENG-12377.

# Test Plan

`yarn dev` in docs directory, open it locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
