### PR TITLE
[expo-updates][android] Use protected methods in room dao now that ksp allows it

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
 - [Android] Upgrade dependencies and remove unused ones. Change multipart parser to okhttp. ([#29060](https://github.com/expo/expo/pull/29060) by [@wschurman](https://github.com/wschurman))
+- [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
 
 ## 0.25.14 — 2024-05-16
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
@@ -12,25 +12,20 @@ import java.util.*
  */
 @Dao
 abstract class JSONDataDao {
-  /**
-   * for private use only
-   * must be marked public for Room
-   * so we use the underscore to discourage use
-   */
   @Query("SELECT * FROM json_data WHERE `key` = :key AND scope_key = :scopeKey ORDER BY last_updated DESC LIMIT 1;")
-  abstract fun _loadJSONDataForKey(key: String, scopeKey: String): List<JSONDataEntity>
+  protected abstract fun loadJSONDataForKeyInternal(key: String, scopeKey: String): List<JSONDataEntity>
 
   @Insert
-  abstract fun _insertJSONData(jsonDataEntity: JSONDataEntity)
+  protected abstract fun insertJSONDataInternal(jsonDataEntity: JSONDataEntity)
 
   @Query("DELETE FROM json_data WHERE `key` = :key AND scope_key = :scopeKey;")
-  abstract fun _deleteJSONDataForKey(key: String, scopeKey: String)
+  protected abstract fun deleteJSONDataForKeyInternal(key: String, scopeKey: String)
 
   /**
    * for public use
    */
   fun loadJSONStringForKey(key: String, scopeKey: String): String? {
-    val rows = _loadJSONDataForKey(key, scopeKey)
+    val rows = loadJSONDataForKeyInternal(key, scopeKey)
     return if (rows.isEmpty()) {
       null
     } else {
@@ -40,8 +35,8 @@ abstract class JSONDataDao {
 
   @Transaction
   open fun setJSONStringForKey(key: String, value: String, scopeKey: String) {
-    _deleteJSONDataForKey(key, scopeKey)
-    _insertJSONData(JSONDataEntity(key, value, Date(), scopeKey))
+    deleteJSONDataForKeyInternal(key, scopeKey)
+    insertJSONDataInternal(JSONDataEntity(key, value, Date(), scopeKey))
   }
 
   @Transaction
@@ -49,15 +44,15 @@ abstract class JSONDataDao {
     val iterator = fields.entries.iterator()
     while (iterator.hasNext()) {
       val entry = iterator.next()
-      _deleteJSONDataForKey(entry.key, scopeKey)
-      _insertJSONData(JSONDataEntity(entry.key, entry.value, Date(), scopeKey))
+      deleteJSONDataForKeyInternal(entry.key, scopeKey)
+      insertJSONDataInternal(JSONDataEntity(entry.key, entry.value, Date(), scopeKey))
     }
   }
 
   @Transaction
   open fun updateJSONStringForKey(key: String, scopeKey: String, updater: (previousValue: String?) -> String) {
     val previousValue = loadJSONStringForKey(key, scopeKey)
-    _deleteJSONDataForKey(key, scopeKey)
-    _insertJSONData(JSONDataEntity(key, updater(previousValue), Date(), scopeKey))
+    deleteJSONDataForKeyInternal(key, scopeKey)
+    insertJSONDataInternal(JSONDataEntity(key, updater(previousValue), Date(), scopeKey))
   }
 }


### PR DESCRIPTION
# Why

As of https://github.com/expo/expo/pull/29055 we generate kotlin code for room DAOs. This allows us to discontinue the use of the underscore naming pattern and make the access of the methods actually private (protected).

Closes ENG-12375.

# How

Rename methods, add protected access.

# Test Plan

Build. (this runs the ksp processor)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
