### PR TITLE
fix link to contributing guide in README.md

### DIFF
--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -42,4 +42,4 @@ No additional set up necessary for basic usage.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
# Why
fix link to contributing guide in expo-sensors' README.md