### PR TITLE
[iOS] Add NULL check before dereferencing error in EXFileSystemAssetLibraryHandler

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add NULL check before dereferencing pointer to error pointer in `EXFileSystemAssetLibraryHandler`. ([#29091](https://github.com/expo/expo/pull/29091) by [@hakonk](https://github.com/hakonk))
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystemAssetLibraryHandler.m
@@ -121,9 +121,11 @@
   }
 
   NSString *description = [NSString stringWithFormat:@"Invalid URL provided, expected scheme to be either 'ph' or 'assets-library', was '%@'.", url.scheme];
-  *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
-                                      code:NSURLErrorUnsupportedURL
-                                  userInfo:@{NSLocalizedDescriptionKey: description}];
+  if (error != NULL) {
+    *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
+                                        code:NSURLErrorUnsupportedURL
+                                    userInfo:@{NSLocalizedDescriptionKey: description}];
+  }
   return nil;
 }
 


### PR DESCRIPTION
# Why

When running Analyze in Xcode, a warning popped up denoting that if a NULL pointer is passed, the code would crash because one is dereferencing a potential NULL pointer.

# How

Check that the `error` pointer is not `NULL` before dereferencing. 

# Test Plan

NB! I have not tested this, nor do I know the correct test regime to employ. Please provide me some feedback and I will revise the PR.