### PR TITLE
[iOS] Add null check before release of textureRef in EXGLCameraObject

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add NULL check before releasing `textureRef` in `EXGLCameraObject`. ([#29092](https://github.com/expo/expo/pull/29092) by [@hakonk](https://github.com/hakonk))
+
 ### 💡 Others
 
 ## 14.0.2 — 2024-04-24

--- a/packages/expo-gl/ios/EXGLCameraObject.mm
+++ b/packages/expo-gl/ios/EXGLCameraObject.mm
@@ -93,7 +93,9 @@
   CVOpenGLESTextureCacheFlush(_cameraTextureCache, 0);
   CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
   CVPixelBufferRelease(pixelBuffer);
-  CFRelease(textureRef);
+  if (textureRef != NULL) {
+    CFRelease(textureRef);
+  }
 
   [EAGLContext setCurrentContext:nil];
 }


### PR DESCRIPTION
# Why

One can potentially release a NULL pointer. Thus, one should check for this first. 

# How

Add NULL check

# Test Plan

Could not find automated tests for this, thus I'm unsure what kind of test regime to employ. Please provide me some feedback and I can alter the PR.
