### PR TITLE
[docs] Add Watchman installation step for iOS local development

### DIFF
--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -19,7 +19,7 @@ This guide explains how to install the iOS Simulator on your Mac for app develop
 
 <XcodeInstructions />
 
-<Step label="3">
+<Step label="4">
 
 ### Try it out
 

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -15,7 +15,7 @@ Developing your app directly on a computer can be more convenient than constantl
 
 This guide explains how to install the iOS Simulator on your Mac for app development. Note that the iOS Simulator can only be installed on macOS. If you are developing an iOS app from a Windows or a Linux machine, you will need a physical iOS device.
 
-## Setup Xcode
+## Setup Xcode and Watchman
 
 <XcodeInstructions />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
@@ -1,5 +1,6 @@
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Step } from '~/ui/components/Step';
+import { Terminal } from '~/ui/components/Snippet';
 
 <Step label="1">
 
@@ -27,6 +28,11 @@ Open Xcode, choose **Settings...** from the Xcode menu (or press <kbd>cmd ⌘</k
 
 ### Install Watchman
 
-Watchman is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance. See [installation instructions](https://facebook.github.io/watchman/docs/install#macos) in Watchman documentation.
+[Watchman](https://facebook.github.io/watchman/docs/install#macos) is a tool for watching changes in the filesystem. Installing it will result in better performance. You can install it with:
+
+<Terminal
+  cmd={['$ brew update', '$ brew install watchman']}
+  cmdCopy="brew update && brew install watchman"
+/>
 
 </Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx
@@ -22,3 +22,11 @@ Open Xcode, choose **Settings...** from the Xcode menu (or press <kbd>cmd ⌘</k
 />
 
 </Step>
+
+<Step label="3">
+
+### Install Watchman
+
+Watchman is a tool by Facebook for watching changes in the filesystem. It is highly recommended you install it for better performance. See [installation instructions](https://facebook.github.io/watchman/docs/install#macos) in Watchman documentation.
+
+</Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -9,7 +9,7 @@ import XcodeInstructions from './_xcodeInstructions.mdx';
 
 <BuildEnvironmentSwitch />
 
-## Set up Xcode
+## Set up Xcode and Watchman
 
 <XcodeInstructions />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
@@ -9,7 +9,7 @@ import XcodeInstructions from './_xcodeInstructions.mdx';
 
 <BuildEnvironmentSwitch />
 
-## Set up Xcode
+## Set up Xcode and Watchman
 
 <XcodeInstructions />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #29096

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add Watchman installation instructions in iOS device and Simulator development build local app development process. For macOS, we already recommend installing it for Android.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
