### PR TITLE
[docs][get-started] Ensure there's a quiet zone around QR codes

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
@@ -4,7 +4,7 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the Google Play Store, or visit the Expo Go page on the [Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs).
 
-<div className="p-4 rounded-lg border border-default inline-block">
+<div className="p-4 rounded-lg border border-default inline-block bg-palette-white">
   <QRCodeReact
     value="https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs"
     size={228}

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalExpoGo.mdx
@@ -4,6 +4,6 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the App Store, or visit the Expo Go page on the [App Store](https://itunes.apple.com/app/apple-store/id982107779).
 
-<div className="p-4 rounded-lg border border-default inline-block">
+<div className="p-4 rounded-lg border border-default inline-block bg-palette-white">
   <QRCodeReact value="https://itunes.apple.com/app/apple-store/id982107779" size={228} />
 </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The QR codes on the Set up your environment page have no quiet zone when viewing the page in dark mode. This makes it impossible for many QR code scanners to detect them unless you first switch to light mode.

i.e. this is what it looks like in dark mode:

![QR code sans quiet zone](https://github.com/expo/expo/assets/4579020/c89b09f3-f0b8-4438-94fe-570f09c5800c)

and this is more like it should be:

![QR code with quiet zone](https://github.com/expo/expo/assets/4579020/44727e00-62da-4408-9024-327acbd1fd6c)

For more information, see this:
* [The 'Quiet Zone' and QR Code Performance](https://qrcodedynamic.com/blog/qr-code-size/#the-quiet-zone-and-qr-code-performance)

> [...]
> The 'Quiet Zone' is an essential part of every QR code. A white space border frames the QR code, separating it from other visual noise surrounding it. The purpose of a 'Quiet Zone' is clear: it signals the beginning and end of the QR code to scanners, helping them identify and accurately interpret the code.
> 
> Without an adequate 'Quiet Zone,' your QR code scanner might have trouble distinguishing the QR code from other visual elements close to it. This can lead to scanning errors or total scan failures, thereby harming the overall user experience.
> 
>  *Therefore, the 'Quiet Zone' is not just an empty space but a vital component of a well-functioning QR code. When designing or positioning your QR codes, ensure that they always have a sufficient 'Quiet Zone.' This consideration will improve scanning success and make your users' QR code usage experience smooth and swift.*
> [...]

I tested scanning these quiet-zone-less QR codes in several apps. The built-in Samsung camera app on my phone *can* scan them, but five other QR/barcode scanners cannot. This includes one I wrote a while ago using Expo's BarCodeScanner. All of these apps had no problem scanning the QR code when I added a quiet zone.

I am surprised that react-qr-code doesn't build a quiet zone into the QR code, at least by default. But I see that they recommend wrapping the QR code in a light-coloured container with some padding if it's going to be "next to dark objects".

![react-qr-code recommendation](https://github.com/expo/expo/assets/4579020/dbc4763b-7339-47df-afb6-c07625ad536e)

# How

<!--
How did you build this feature or fix this bug and why?
-->

I set the background of the divs in which the QR codes are contained to white, instead of leaving them transparent.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I ran `yarn run dev` and checked that the QR codes now have a quiet zone in dark mode and they look the same as before in light mode.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
