### PR TITLE
[docs] Fix syntax highlight in Task Manager API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -11,8 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
-Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background. Some features of this library are used by other libraries under the hood. Here is a list of Expo SDK libraries that use `TaskManager`:
 
 - [Location](location.mdx)
 - [BackgroundFetch](background-fetch.mdx)

--- a/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
@@ -11,8 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
-Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background. Some features of this library are used by other libraries under the hood. Here is a list of Expo SDK libraries that use `TaskManager`:
 
 - [Location](location.mdx)
 - [BackgroundFetch](background-fetch.mdx)

--- a/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/task-manager.mdx
@@ -11,8 +11,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
-Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background. Some features of this library are used by other libraries under the hood. Here is a list of Expo SDK libraries that use `TaskManager`:
 
 - [Location](location.mdx)
 - [BackgroundFetch](background-fetch.mdx)

--- a/docs/pages/versions/v51.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/task-manager.mdx
@@ -11,8 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
-Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background. Some features of this library are used by other libraries under the hood. Here is a list of Expo SDK libraries that use `TaskManager`:
 
 - [Location](location.mdx)
 - [BackgroundFetch](background-fetch.mdx)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 Fix syntax highlight and verbiage issues in Task Manager API reference. Changes backported to all SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
