### PR TITLE
[gha] regenerate docs unversioned data on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Docs Website
 defaults:
   run:
     shell: bash
-    working-directory: docs
 
 on:
   workflow_dispatch: {}
@@ -36,26 +35,38 @@ jobs:
         id: expo-caches
         with:
           yarn-docs: 'true'
+          yarn-tools: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 📝 Regenerate `unversioned` data for Docs
+        run: et gdad
       - name: 🧶 Yarn install
+        working-directory: docs
         if: steps.expo-caches.outputs.yarn-docs-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧪 Run Docs tests
+        working-directory: docs
         run: yarn test
       - name: 🚨 Lint Docs website code
+        working-directory: docs
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
+        working-directory: docs
         run: yarn lint-prose
-      - run: yarn danger ci
+      - name: ⚠️ Danger check
+        working-directory: docs
+        run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗️ Build Docs website for deploy
+        working-directory: docs
         run: yarn export
         timeout-minutes: 20
       - name: 🔗 Lint pages links
+        working-directory: docs
         run: yarn lint-links --quiet
       - name: ✅ Test links (legacy)
+        working-directory: docs
         run: |
           yarn export-server &
           while ! nc -z localhost 8000; do
@@ -64,6 +75,7 @@ jobs:
           yarn test-links http://127.0.0.1:8000
         timeout-minutes: 3
       - name: 🚀 Deploy Docs website
+        working-directory: docs
         if: ${{ github.event.ref == 'refs/heads/main' }}
         run: ./deploy.sh
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📝 Regenerate `unversioned` data for Docs
-        run: et gdad
+        run: expotools generate-docs-api-data
       - name: 🧶 Yarn install
         working-directory: docs
         if: steps.expo-caches.outputs.yarn-docs-hit != 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           yarn-docs: 'true'
           yarn-tools: 'true'
+          yarn-workspace: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📝 Regenerate `unversioned` data for Docs


### PR DESCRIPTION
# Why

Usually, we regenerate the `unversioned` docs data right before cutting new SDK version, which often exposes few docs issues which need to be fixed before the final releases.

# How

An experiment with unversioned docs data generation on side deploy, so we continuously will see up to date API reference data, based on the current packages source code.

I'm still thinking if we should remove or ignore the `unversioned` data files from repository and hook up the generation script to post install or just before Next app run.

# Test Plan

Run the CI.
