### PR TITLE
[docs] Add missing import statement in code examples for Navigation section

### DIFF
--- a/docs/pages/develop/dynamic-routes.mdx
+++ b/docs/pages/develop/dynamic-routes.mdx
@@ -49,6 +49,7 @@ Navigating from one route to a dynamic route is done by providing query paramete
 For example, the following code allows you to navigate to the dynamic route statically using query parameters:
 
 ```tsx app/(home)/index.tsx|collapseHeight=300
+import { Link } from 'expo-router';
 import { View, Text, StyleSheet } from 'react-native';
 
 export default function HomeScreen() {
@@ -73,6 +74,7 @@ const styles = StyleSheet.create({
 You can also use the `href` object to provide a `pathname` which takes the value of the dynamic route and passes `params`:
 
 ```tsx app/(home)/index.tsx
+import { Link } from 'expo-router';
 import { View, Text, StyleSheet } from 'react-native';
 
 export default function HomeScreen() {

--- a/docs/pages/develop/file-based-routing.mdx
+++ b/docs/pages/develop/file-based-routing.mdx
@@ -5,7 +5,7 @@ description: Learn about Expo Router which is a file-based routing system and ho
 
 import { FileTree } from '~/ui/components/FileTree';
 
-This guide provides basic conventions and guidance for Expo Router and navigation patterns (stack and tabs). To follow along, you can  [create a project by using the default template](/get-started/create-a-project/) or install [Expo Router library manually](/router/installation/#manual-installation) in your existing project.
+This guide provides basic conventions and guidance for Expo Router and navigation patterns (stack and tabs). To follow along, you can [create a project by using the default template](/get-started/create-a-project/) or install [Expo Router library manually](/router/installation/#manual-installation) in your existing project.
 
 ## What is Expo Router?
 
@@ -160,6 +160,7 @@ Expo Router uses a built-in component called `Link` to move between routes in an
 You can use it by importing it from Expo Router library and then passing the `href` prop with the route to navigate as the value of the prop. For example, to navigate from `/` to `/details`, add a `Link` component in the **index.tsx** file:
 
 ```tsx app/index.tsx|collapseHeight=300
+import { Link } from 'expo-router';
 import { View, Text, StyleSheet } from 'react-native';
 
 export default function HomeScreen() {


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix missing `Link` component import statement for code snippets in Home > Navigation section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
