### PR TITLE
[expo-updates][android] Fix tests

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
@@ -70,7 +70,7 @@ class UpdatesDatabaseTest {
     updateDao.insertUpdate(testUpdate)
 
     try {
-      assetDao._insertUpdateAsset(UpdateAssetEntity(uuid, 47))
+      assetDao.insertUpdateAssetForTest(UpdateAssetEntity(uuid, 47))
     } finally {
       updateDao.deleteUpdates(listOf(testUpdate))
     }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -160,7 +160,7 @@ class EmbeddedLoaderTest {
 
     val existingAsset = AssetEntity("54da1e9816c77e30ebc5920e256736f2", "png")
     existingAsset.relativePath = "54da1e9816c77e30ebc5920e256736f2.png"
-    db.assetDao()._insertAsset(existingAsset)
+    db.assetDao().insertAssetForTest(existingAsset)
 
     loader.start(mockCallback)
 
@@ -186,7 +186,7 @@ class EmbeddedLoaderTest {
 
     val existingAsset = AssetEntity("54da1e9816c77e30ebc5920e256736f2", "png")
     existingAsset.relativePath = "54da1e9816c77e30ebc5920e256736f2.png"
-    db.assetDao()._insertAsset(existingAsset)
+    db.assetDao().insertAssetForTest(existingAsset)
 
     loader.start(mockCallback)
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -129,7 +129,7 @@ class RemoteLoaderTest {
 
     val existingAsset = AssetEntity("489ea2f19fa850b65653ab445637a181.jpg", ".jpg")
     existingAsset.relativePath = "489ea2f19fa850b65653ab445637a181.jpg"
-    db.assetDao()._insertAsset(existingAsset)
+    db.assetDao().insertAssetForTest(existingAsset)
     loader.start(mockCallback)
 
     verify { mockCallback.onSuccess(any()) }
@@ -156,7 +156,7 @@ class RemoteLoaderTest {
     val existingAsset = AssetEntity("489ea2f19fa850b65653ab445637a181.jpg", ".jpg")
     existingAsset.relativePath = "489ea2f19fa850b65653ab445637a181.jpg"
     existingAsset.url = Uri.parse("http://example.com")
-    db.assetDao()._insertAsset(existingAsset)
+    db.assetDao().insertAssetForTest(existingAsset)
     loader.start(mockCallback)
 
     verify { mockCallback.onSuccess(any()) }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -1,5 +1,6 @@
 package expo.modules.updates.db.dao
 
+import androidx.annotation.VisibleForTesting
 import androidx.room.*
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateAssetEntity
@@ -154,5 +155,15 @@ abstract class AssetDao {
     val deletedAssets = loadAssetsMarkedForDeletionInternal()
     deleteAssetsMarkedForDeletionInternal()
     return deletedAssets
+  }
+
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+  internal fun insertAssetForTest(asset: AssetEntity): Long {
+    return insertAssetInternal(asset)
+  }
+
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+  internal fun insertUpdateAssetForTest(updateAsset: UpdateAssetEntity) {
+    insertUpdateAssetInternal(updateAsset)
   }
 }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/29080 broke a few tests but they were masked due to a unrelated test failure earlier in the test run.

# How

Fix tests by adding a opt-in annotation to some methods allowing direct call into the protected-ish methods from tests. Normally it'd be fine to subclass the class being tested, but since these are generated classes and DAOs we don't control them.

# Test Plan

Wait for CI run to verify tests are working.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
