### PR TITLE
[cli] fix react devtools inspector error

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed broken React DevTools since SDK 51. ([#29181](https://github.com/expo/expo/pull/29181) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.18.13 — 2024-05-16

--- a/packages/@expo/cli/static/react-devtools-page/index.html
+++ b/packages/@expo/cli/static/react-devtools-page/index.html
@@ -52,10 +52,11 @@
   <script type="importmap">
       {
         "imports": {
-          "react-devtools-core/standalone": "https://ga.jspm.io/npm:react-devtools-core@4.27.2/standalone.js"
+          "react-devtools-core/standalone": "https://ga.jspm.io/npm:react-devtools-core@5.2.0/standalone.js"
         },
         "scopes": {
           "https://ga.jspm.io/": {
+            "base64-js": "https://ga.jspm.io/npm:base64-js@1.5.1/index.js",
             "buffer": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/buffer.js",
             "child_process": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/child_process.js",
             "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/crypto.js",
@@ -63,6 +64,7 @@
             "fs": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/fs.js",
             "http": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/http.js",
             "https": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/https.js",
+            "ieee754": "https://ga.jspm.io/npm:ieee754@1.2.1/index.js",
             "net": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/net.js",
             "path": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/path.js",
             "process": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/process-production.js",
@@ -77,13 +79,47 @@
       }
     </script>
 
+  <script type="module">
+    import { Buffer } from "https://ga.jspm.io/npm:buffer@6.0.3/index.js";
+    import buffer from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/buffer.js";
+    import child_process from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/child_process.js";
+    import crypto from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/crypto.js";
+    import events from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/events.js";
+    import fs from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/fs.js";
+    import http from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/http.js";
+    import https from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/https.js";
+    import net from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/net.js";
+    import path from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/path.js";
+    import process from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/process-production.js";
+    import stream from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/stream.js";
+    import tls from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/tls.js";
+    import url from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/url.js";
+    import util from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/util.js";
+    import vm from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/vm.js";
+    import zlib from "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/zlib.js";
+
+    window.module = {};
+    Object.defineProperty(window.module, 'exports', {
+      set(module) {
+        window.DevTools = module.default;
+      }
+    });
+    window.Buffer = Buffer;
+    window.require = (module) => {
+      if (['bufferutil', 'utf-8-validate'].includes(module)) {
+        return false;
+      }
+      return eval(module);
+    }
+  </script>
+
   <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
   <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
     crossorigin="anonymous"></script>
 
   <script type="module">
-    import { default as DevToolsUIWrapper } from "react-devtools-core/standalone";
-    const DevTools = DevToolsUIWrapper.default;
+    import "react-devtools-core/standalone";
+    const DevTools = window.DevTools;
 
     /**
      * Private command to support DevTools frontend reload


### PR DESCRIPTION
# Why

an alternative solution than #29162 where #29162 increased 1MB resource to @expo/cli package

# How

a tricky solution that to use latest `react-devtools-core/standalone` which is built by webpack 5 and cjs. in the next sdk, we could migrate to newer react-devtools without keeping this tricky solution

# Test Plan

running react-conf-app with react-devtools with local cli

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
