### PR TITLE
[expo-modules-core][iOS] include application support directory in FileSystemUtilities

### DIFF
--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
@@ -10,17 +10,22 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
   @objc
   public var cachesDirectory: String
 
+  @objc
+  public var applicationSupportDirectory: String
+
   var isScoped: Bool = false
 
   @objc
-  public init(documentDirectory: String, cachesDirectory: String) {
+  public init(documentDirectory: String, cachesDirectory: String, applicationSupportDirectory: String) {
     self.documentDirectory = documentDirectory
     self.cachesDirectory = cachesDirectory
+    self.applicationSupportDirectory = applicationSupportDirectory
     self.isScoped = true
 
     super.init()
     ensureDirExists(withPath: self.cachesDirectory)
     ensureDirExists(withPath: self.documentDirectory)
+    ensureDirExists(withPath: self.applicationSupportDirectory)
   }
 
   required public override init() {
@@ -30,9 +35,14 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
     let cachesPaths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
     self.cachesDirectory = cachesPaths[0]
 
+    let applicationSupportDirectoryPaths =
+    NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)
+    self.applicationSupportDirectory = applicationSupportDirectoryPaths[0]
+
     super.init()
     ensureDirExists(withPath: self.cachesDirectory)
     ensureDirExists(withPath: self.documentDirectory)
+    ensureDirExists(withPath: self.applicationSupportDirectory)
   }
 
   public static func exportedInterfaces() -> [Protocol] {
@@ -84,7 +94,7 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
 
   @objc
   public func getInternalPathPermissions(_ url: URL) -> EXFileSystemPermissionFlags {
-    let scopedDirs: [String] = [cachesDirectory, documentDirectory]
+    let scopedDirs: [String] = [cachesDirectory, documentDirectory, applicationSupportDirectory]
     let standardizedPath = url.standardized.path
     for scopedDirectory in scopedDirs {
       if standardizedPath.hasPrefix(scopedDirectory + "/") || standardizedPath == scopedDirectory {

--- a/packages/expo-modules-core/ios/Interfaces/FileSystem/EXFileSystemInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/FileSystem/EXFileSystemInterface.h
@@ -13,6 +13,7 @@ typedef NS_OPTIONS(unsigned int, EXFileSystemPermissionFlags) {
 
 @property (nonatomic, readonly) NSString *documentDirectory;
 @property (nonatomic, readonly) NSString *cachesDirectory;
+@property (nonatomic, readonly) NSString *applicationSupportDirectory;
 
 // TODO: Move permissionsForURI to EXFileSystemManagerInterface
 - (EXFileSystemPermissionFlags)permissionsForURI:(NSURL *)uri;


### PR DESCRIPTION
# Why

Fixes #29058 .

# How

`expo-file-system` internally uses `FileSystemLegacyUtilities.swift`, which was including the cache and documents directories in its permission checks, but not the application support directory where the updates directory is located. This PR adds that directory to the appropriate files.


# Test Plan

- CI should pass
- Bug repro in #29058 should be fixed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
