### PR TITLE
[docs] Add `enableJavaScript` prop in SnackInline component for Tutorial > Get started

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -348,6 +348,8 @@ import SnackInline from '~/components/plugins/SnackInline';
 </SnackInline>
 ```
 
+By default, `SnackInline` component uses `.tsx` when opening an example in Snack. To use `.js` extension, add `enableJavaScript` prop.
+
 ### Add multiple code variants
 
 Sometimes it's useful to show multiple ways of doing something, for instance, maybe you'd like to have an example using a React class component, and also an example of a functional component.

--- a/docs/common/snack.ts
+++ b/docs/common/snack.ts
@@ -6,6 +6,7 @@ type Config = {
   templateId?: string;
   code?: string | null;
   files?: Record<string, string>;
+  isTypeScriptEnabled?: boolean;
 };
 
 type File = {
@@ -15,7 +16,7 @@ type File = {
 };
 
 export function getSnackFiles(config: Config) {
-  const { templateId, code, files, baseURL } = config;
+  const { templateId, code, files, baseURL, isTypeScriptEnabled } = config;
 
   const result: Record<string, File> = {};
   if (files) {
@@ -36,10 +37,23 @@ export function getSnackFiles(config: Config) {
     });
   }
 
+  // if (templateId) {
+  //   result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
+  // } else if (code) {
+  //   result['App.js'] = { type: 'CODE', contents: code };
+  // }
   if (templateId) {
-    result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
+    if (isTypeScriptEnabled) {
+      result['App.tsx'] = { type: 'CODE', url: `${baseURL}/${templateId}.tsx` };
+    } else {
+      result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
+    }
   } else if (code) {
-    result['App.js'] = { type: 'CODE', contents: code };
+    if (isTypeScriptEnabled) {
+      result['App.tsx'] = { type: 'CODE', contents: code };
+    } else {
+      result['App.js'] = { type: 'CODE', contents: code };
+    }
   }
 
   return result;

--- a/docs/common/snack.ts
+++ b/docs/common/snack.ts
@@ -37,11 +37,6 @@ export function getSnackFiles(config: Config) {
     });
   }
 
-  // if (templateId) {
-  //   result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
-  // } else if (code) {
-  //   result['App.js'] = { type: 'CODE', contents: code };
-  // }
   if (templateId) {
     if (isTypeScriptEnabled) {
       result['App.tsx'] = { type: 'CODE', url: `${baseURL}/${templateId}.tsx` };

--- a/docs/common/snack.ts
+++ b/docs/common/snack.ts
@@ -6,7 +6,7 @@ type Config = {
   templateId?: string;
   code?: string | null;
   files?: Record<string, string>;
-  isTypeScriptEnabled?: boolean;
+  enableJavaScript?: boolean;
 };
 
 type File = {
@@ -16,7 +16,7 @@ type File = {
 };
 
 export function getSnackFiles(config: Config) {
-  const { templateId, code, files, baseURL, isTypeScriptEnabled } = config;
+  const { templateId, code, files, baseURL, enableJavaScript } = config;
 
   const result: Record<string, File> = {};
   if (files) {
@@ -38,16 +38,16 @@ export function getSnackFiles(config: Config) {
   }
 
   if (templateId) {
-    if (isTypeScriptEnabled) {
-      result['App.tsx'] = { type: 'CODE', url: `${baseURL}/${templateId}.tsx` };
-    } else {
+    if (enableJavaScript) {
       result['App.js'] = { type: 'CODE', url: `${baseURL}/${templateId}.js` };
+    } else {
+      result['App.tsx'] = { type: 'CODE', url: `${baseURL}/${templateId}.tsx` };
     }
   } else if (code) {
-    if (isTypeScriptEnabled) {
-      result['App.tsx'] = { type: 'CODE', contents: code };
-    } else {
+    if (enableJavaScript) {
       result['App.js'] = { type: 'CODE', contents: code };
+    } else {
+      result['App.tsx'] = { type: 'CODE', contents: code };
     }
   }
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -99,7 +99,7 @@ const styles = StyleSheet.create({
 
 The background is dark, so the text is difficult to read. The `<Text>` component uses `#000` (black) as its default color. Let's add a style to the `<Text>` component to change the text color to `#fff` (white) in **App.js**.
 
-<SnackInline label="Change the text color" dependencies={['expo-status-bar']}>
+<SnackInline label="Change the text color" dependencies={['expo-status-bar']} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx
@@ -149,7 +149,7 @@ Next, import and use the `<Image>` component from React Native and `background-i
 
 <SnackInline label="Display placeholder image" dependencies={['expo-status-bar']} files={{
   'assets/images/background-image.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/503001f14bb7b8fe48a4e318ad07e910'
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx
@@ -456,7 +456,7 @@ Now, modify the **App.js** file to use the `theme="primary"` prop on the first b
     'assets/images/background-image.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/503001f14bb7b8fe48a4e318ad07e910',
     'components/ImageViewer.js': 'tutorial/01-layout/ImageViewer.js',
     'components/Button.js': 'tutorial/01-layout/Button.js'
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -192,7 +192,7 @@ files={{
   'components/Button.js': 'tutorial/03-button-options/Button.js',
   'components/CircleButton.js': 'tutorial/03-button-options/CircleButton.js',
   'components/IconButton.js': 'tutorial/03-button-options/IconButton.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx
@@ -356,7 +356,7 @@ files={{
   'components/CircleButton.js': 'tutorial/03-button-options/CircleButton.js',
   'components/IconButton.js': 'tutorial/03-button-options/IconButton.js',
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx
@@ -556,7 +556,7 @@ files={{
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
   'components/EmojiList.js': 'tutorial/05-emoji-list/EmojiList.js',
   'components/EmojiSticker.js': 'tutorial/05-emoji-list/EmojiSticker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -168,7 +168,7 @@ files={{
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
   'components/EmojiList.js': 'tutorial/05-emoji-list/EmojiList.js',
   'components/EmojiSticker.js': 'tutorial/06-gestures/EmojiSticker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx
@@ -294,7 +294,7 @@ files={{
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
   'components/EmojiList.js': 'tutorial/05-emoji-list/EmojiList.js',
   'components/EmojiSticker.js': 'tutorial/06-gestures/CompleteEmojiSticker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -214,7 +214,7 @@ files={{
 'assets/images/background-image.png': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/503001f14bb7b8fe48a4e318ad07e910',
 'components/ImageViewer.js': 'tutorial/02-image-picker/ImageViewer.js',
 'components/Button.js': 'tutorial/02-image-picker/Button.js'
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -44,7 +44,7 @@ Throughout the tutorial, any important code or code that has changed between exa
 <SnackInline label="Hello world">
 
 {/* prettier-ignore */}
-```tsx collapseHeight=425
+```jsx collapseHeight=425
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -41,10 +41,10 @@ We believe in [learning by doing](https://en.wikipedia.org/wiki/Learning-by-doin
 
 Throughout the tutorial, any important code or code that has changed between examples will be <Highlight>highlighted in yellow</Highlight>. You can hover over the highlights (on desktop) or tap them (on mobile) to see more context on the change. For example, the code highlighted in the snippet below explains what it does:
 
-<SnackInline label="Hello world">
+<SnackInline label="Hello world" isTypeScriptEnabled>
 
 {/* prettier-ignore */}
-```jsx collapseHeight=425
+```tsx collapseHeight=425
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -41,7 +41,7 @@ We believe in [learning by doing](https://en.wikipedia.org/wiki/Learning-by-doin
 
 Throughout the tutorial, any important code or code that has changed between examples will be <Highlight>highlighted in yellow</Highlight>. You can hover over the highlights (on desktop) or tap them (on mobile) to see more context on the change. For example, the code highlighted in the snippet below explains what it does:
 
-<SnackInline label="Hello world" isTypeScriptEnabled>
+<SnackInline label="Hello world">
 
 {/* prettier-ignore */}
 ```tsx collapseHeight=425

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -41,7 +41,7 @@ We believe in [learning by doing](https://en.wikipedia.org/wiki/Learning-by-doin
 
 Throughout the tutorial, any important code or code that has changed between examples will be <Highlight>highlighted in yellow</Highlight>. You can hover over the highlights (on desktop) or tap them (on mobile) to see more context on the change. For example, the code highlighted in the snippet below explains what it does:
 
-<SnackInline label="Hello world">
+<SnackInline label="Hello world" enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx collapseHeight=425

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -72,7 +72,7 @@ files={{
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
   'components/EmojiList.js': 'tutorial/05-emoji-list/EmojiList.js',
   'components/EmojiSticker.js': 'tutorial/06-gestures/CompleteEmojiSticker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -145,7 +145,7 @@ files={{
   'components/EmojiPicker.js': 'tutorial/04-modal/EmojiPicker.js',
   'components/EmojiList.js': 'tutorial/05-emoji-list/EmojiList.js',
   'components/EmojiSticker.js': 'tutorial/06-gestures/CompleteEmojiSticker.js',
-}}>
+}} enableJavaScript>
 
 {/* prettier-ignore */}
 ```jsx collapseHeight=440

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -26,7 +26,7 @@ type Props = PropsWithChildren<{
   platforms?: string[];
   buttonTitle?: string;
   contentHidden?: boolean;
-  isTypeScriptEnabled?: boolean;
+  enableJavaScript?: boolean;
 }>;
 
 export const SnackInline = ({
@@ -39,7 +39,7 @@ export const SnackInline = ({
   buttonTitle,
   contentHidden,
   children,
-  isTypeScriptEnabled,
+  enableJavaScript,
 }: Props) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isReady, setReady] = useState(false);
@@ -97,7 +97,7 @@ export const SnackInline = ({
                   code: getCode(),
                   files,
                   baseURL: getExamplesPath(),
-                  isTypeScriptEnabled,
+                  enableJavaScript,
                 })
               )}
             />

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -26,6 +26,7 @@ type Props = PropsWithChildren<{
   platforms?: string[];
   buttonTitle?: string;
   contentHidden?: boolean;
+  isTypeScriptEnabled?: boolean;
 }>;
 
 export const SnackInline = ({
@@ -38,6 +39,7 @@ export const SnackInline = ({
   buttonTitle,
   contentHidden,
   children,
+  isTypeScriptEnabled,
 }: Props) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isReady, setReady] = useState(false);
@@ -95,6 +97,7 @@ export const SnackInline = ({
                   code: getCode(),
                   files,
                   baseURL: getExamplesPath(),
+                  isTypeScriptEnabled,
                 })
               )}
             />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #29052

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `enableJavaScript` prop in SnackInline components used in Tutorial > Get started because the source files also use `.js` extension.



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By manually checking that each SnackInline example opens using `.js` extension.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
