### PR TITLE
Update monorepos.mdx

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -168,7 +168,21 @@ registerRootComponent(App);
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
-If you are using [Expo Router](/router/introduction/), define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
+If you are using [Expo Router](/router/introduction/), your **index.js** file should have the content below instead.
+```js index.js
+import { registerRootComponent } from 'expo';
+import { ExpoRoot } from 'expo-router';
+
+// Must be exported or Fast Refresh won't update the context
+export function App() {
+  const ctx = require.context('./app');
+  return <ExpoRoot context={ctx} />;
+}
+
+registerRootComponent(App);
+```
+
+In addition, define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
 
 <Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 


### PR DESCRIPTION
Updated `index.js` entry point file to reflect instructions in the [troubleshooting guide](https://docs.expo.dev/router/reference/troubleshooting/#expo_router_app_root-not-defined) when using expo-router.

# Why
Took many hours to try to make this work in a monorepo setup. I believe having this snippet from the troubleshooting section directly here is appropriate and will save others time.
