### PR TITLE
[docs] reorder the development mode tiles on the setup environment page

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
@@ -16,7 +16,7 @@ export function DevelopmentModeForm() {
         if (query.mode) {
           setMode(query.mode as DevelopmentMode);
         } else {
-          setMode('expo-go');
+          setMode('development-build');
         }
       }
     },
@@ -41,15 +41,6 @@ export function DevelopmentModeForm() {
   return (
     <div className="flex flex-wrap gap-4">
       <SelectCard
-        imgSrc="/static/images/get-started/expo-go.png"
-        darkImgSrc="/static/images/get-started/expo-go-dark.png"
-        title="Expo Go"
-        alt="Expo Go"
-        description="Try out app development in a limited sandbox without custom native modules. Great for testing out Expo quickly. Not intended for long-term projects."
-        isSelected={mode === 'expo-go'}
-        onClick={() => onRadioChange('expo-go')}
-      />
-      <SelectCard
         imgSrc="/static/images/get-started/development-build.png"
         darkImgSrc="/static/images/get-started/development-build-dark.png"
         title="Development build"
@@ -57,6 +48,15 @@ export function DevelopmentModeForm() {
         description="Make a build of your own app with developer tools. Supports custom native modules. Intended for production projects."
         isSelected={mode === 'development-build'}
         onClick={() => onRadioChange('development-build')}
+      />
+      <SelectCard
+        imgSrc="/static/images/get-started/expo-go.png"
+        darkImgSrc="/static/images/get-started/expo-go-dark.png"
+        title="Expo Go"
+        alt="Expo Go"
+        description="Try out app development in a limited sandbox without custom native modules. Great for testing out Expo quickly. Not intended for long-term projects."
+        isSelected={mode === 'expo-go'}
+        onClick={() => onRadioChange('expo-go')}
       />
     </div>
   );


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EBFAVCEA/p1716979016083609

# How

Move the Development build tile before Expo Go on the Set up environment develop method selection section. Set development client as a default.

# Test Plan

The changes have been reviewed locally. All lint checks are passing.

# Preview

![Screenshot 2024-05-29 at 14 12 02](https://github.com/expo/expo/assets/719641/c9470ebe-07e1-4487-b339-3bf7dfd0e400)

