### PR TITLE
fix(expo-contacts): #29198 store full url & remove useless restrictio…

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed an issue where only paths of urls were stored in contacts and social profiles were only stored when all fields were filled. ([#29199](https://github.com/expo/expo/pull/29199) by [@mlecoq](https://github.com/mlecoq))
+
 ### 💡 Others
 
 ## 13.0.3 — 2024-05-01

--- a/packages/expo-contacts/ios/Decoding.swift
+++ b/packages/expo-contacts/ios/Decoding.swift
@@ -68,7 +68,7 @@ func decodeUrlAddresses(_ input: [UrlAddress]?) -> [CNLabeledValue<NSString>]? {
   var output = [CNLabeledValue<NSString>]()
   for item in input {
     let label = decodeUrlAddressLabel(item.label)
-    if let urlString = item.url?.formatted() {
+    if let urlString = item.url?.absoluteString {
       output.append(CNLabeledValue(label: label, value: urlString as NSString))
     }
   }

--- a/packages/expo-contacts/ios/Decoding.swift
+++ b/packages/expo-contacts/ios/Decoding.swift
@@ -34,13 +34,12 @@ func decodeSocialProfiles(_ input: [SocialProfile]?) -> [CNLabeledValue<CNSocial
   var output = [CNLabeledValue<CNSocialProfile>]()
   for item in input {
     let label = decodeLabel(label: item.label)
-    if let urlString = item.url,
-    let username = item.username,
-    let userId = item.userId,
-    let service = item.service {
-      let profile = CNSocialProfile(urlString: urlString.path, username: username, userIdentifier: userId, service: service)
-      output.append(CNLabeledValue(label: label, value: profile))
-    }
+    let urlString = item.url
+    let username = item.username
+    let userId = item.userId
+    let service = item.service
+    let profile = CNSocialProfile(urlString: urlString?.path(), username: username, userIdentifier: userId, service: service)
+    output.append(CNLabeledValue(label: label, value: profile))
   }
   return output
 }
@@ -69,7 +68,7 @@ func decodeUrlAddresses(_ input: [UrlAddress]?) -> [CNLabeledValue<NSString>]? {
   var output = [CNLabeledValue<NSString>]()
   for item in input {
     let label = decodeUrlAddressLabel(item.label)
-    if let urlString = item.url?.path {
+    if let urlString = item.url?.formatted() {
       output.append(CNLabeledValue(label: label, value: urlString as NSString))
     }
   }

--- a/packages/expo-contacts/ios/Decoding.swift
+++ b/packages/expo-contacts/ios/Decoding.swift
@@ -38,7 +38,7 @@ func decodeSocialProfiles(_ input: [SocialProfile]?) -> [CNLabeledValue<CNSocial
     let username = item.username
     let userId = item.userId
     let service = item.service
-    let profile = CNSocialProfile(urlString: urlString?.path(), username: username, userIdentifier: userId, service: service)
+    let profile = CNSocialProfile(urlString: urlString?.path, username: username, userIdentifier: userId, service: service)
     output.append(CNLabeledValue(label: label, value: profile))
   }
   return output


### PR DESCRIPTION
…n on social profiles

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

to fix #29198 

# How

<!--
How did you build this feature or fix this bug and why?
-->

I am using expo-contacts to store contacts and I have remarked that urls and social profiles are partially stored or missing

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
storing a contact with urls and social profiles


before modifications
![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 21 26 18](https://github.com/expo/expo/assets/3649784/c997499c-beb8-4baa-be7b-fd7cd8a7f658)

after modifications

![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 21 25 10](https://github.com/expo/expo/assets/3649784/31f17325-2997-4b31-bd3e-a06048caaccb)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
