### PR TITLE
fix(expo-contacts): handle Android contact picker result

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Fixed an issue where the `presentContactPickerAsync` promise doesn't resolve when using the Android back button. ([#29202](https://github.com/expo/expo/pull/29202) by [@jp1987](https://github.com/jp1987))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -276,14 +276,12 @@ class ContactsModule : Module() {
       if (requestCode == RC_PICK_CONTACT) {
         val pendingPromise = contactPickingPromise ?: return@OnActivityResult
 
-        if (resultCode == Activity.RESULT_CANCELED) {
-          pendingPromise.resolve()
-        }
-
         if (resultCode == Activity.RESULT_OK) {
           val contactId = intent?.data?.lastPathSegment
           val contact = getContactById(contactId, defaultFields)
           pendingPromise.resolve(contact?.toMap(defaultFields))
+        } else {
+          pendingPromise.resolve();
         }
 
         contactPickingPromise = null

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -281,7 +281,7 @@ class ContactsModule : Module() {
           val contact = getContactById(contactId, defaultFields)
           pendingPromise.resolve(contact?.toMap(defaultFields))
         } else {
-          pendingPromise.resolve();
+          pendingPromise.resolve()
         }
 
         contactPickingPromise = null


### PR DESCRIPTION
# Why

Closes #29191

# How

When opening the picker on an Android physical device and using the back button, the `resultCode` is `1100` for some reason, causing the promise to never resolve. I simplified the logic to always resolve the promise if the `ActivityResult` was not `RESULT_OK`.

# Test Plan

Manually tested on physical device and simulator.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
