### PR TITLE
[docs] Don't use the deprecated `Localization.locale` in the Localization guide

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -72,7 +72,7 @@ On iOS, when a user changes the device's language, the app will reset. This mean
 
 ```tsx
 import { View, StyleSheet, Text } from 'react-native';
-import * as Localization from 'expo-localization';
+import { getLocales } from 'expo-localization';
 import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
@@ -83,7 +83,7 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
+i18n.locale = getLocales()[0].languageCode;
 
 // When a value is missing from a language it'll fall back to another language with the key present.
 i18n.enableFallback = true;
@@ -97,7 +97,7 @@ export default function App() {
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
       <Text>Current locale: {i18n.locale}</Text>
-      <Text>Device locale: {Localization.getLocales()[0].languageCode}</Text>
+      <Text>Device locale: {getLocales()[0].languageCode}</Text>
     </View>
   );
 }


### PR DESCRIPTION
# Why

https://docs.expo.dev/versions/latest/sdk/localization/#localizationlocale

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
