### PR TITLE
[docs] Fix examples formatting, code language, & missing type error in Localization Snack examples

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -83,7 +83,7 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = getLocales()[0].languageCode as string;
+i18n.locale = getLocales()[0].languageCode ?? 'en';
 
 // When a value is missing from a language it'll fall back to another language with the key present.
 i18n.enableFallback = true;

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -83,7 +83,7 @@ const translations = {
 const i18n = new I18n(translations);
 
 // Set the locale once at the beginning of your app.
-i18n.locale = getLocales()[0].languageCode;
+i18n.locale = getLocales()[0].languageCode as string;
 
 // When a value is missing from a language it'll fall back to another language with the key present.
 i18n.enableFallback = true;
@@ -210,10 +210,9 @@ label="Overriding RTL settings"
 dependencies={['expo-updates', 'expo-constants']}
 >
 
-```jsx
+```tsx
 import { Text, View, StyleSheet, I18nManager, Platform } from 'react-native';
 import Constants from 'expo-constants';
-
 import * as Updates from 'expo-updates';
 
 export default function App() {


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
![CleanShot 2024-05-30 at 20 23 09@2x](https://github.com/expo/expo/assets/10234615/c8e45c22-1712-43c9-88d1-1ec7838db539)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix examples formatting, code language, & missing type error in Localization Snack examples

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and verifying the Snack examples.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
