### PR TITLE
[camera] Enable torch on first render

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 - On `iOS`, set previewLayer on scanner to get correct dimensions. ([#28931](https://github.com/expo/expo/pull/28931) by [@alanjhughes](https://github.com/alanjhughes))
 - On `Android`, correctly handle orientation when landscape pictures are rendered. ([#28929](https://github.com/expo/expo/pull/28929) by [@alanjhughes](https://github.com/alanjhughes))
 - On `web`, fix missing function "getCapabilities" in Firefox. ([#28947](https://github.com/expo/expo/pull/28947) by [@miso-belica](https://github.com/miso-belica))
-- Allow starting the camera with the torch enabled.
+- Allow starting the camera with the torch enabled. ([#29217](https://github.com/expo/expo/pull/29217) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 - On `iOS`, set previewLayer on scanner to get correct dimensions. ([#28931](https://github.com/expo/expo/pull/28931) by [@alanjhughes](https://github.com/alanjhughes))
 - On `Android`, correctly handle orientation when landscape pictures are rendered. ([#28929](https://github.com/expo/expo/pull/28929) by [@alanjhughes](https://github.com/alanjhughes))
 - On `web`, fix missing function "getCapabilities" in Firefox. ([#28947](https://github.com/expo/expo/pull/28947) by [@miso-belica](https://github.com/miso-belica))
+- Allow starting the camera with the torch enabled.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -127,7 +127,7 @@ class CameraViewModule : Module() {
       }
 
       Prop("enableTorch") { view, enabled: Boolean? ->
-        view.setTorchEnabled(enabled ?: false)
+        view.enableTorch = enabled ?: false
       }
 
       Prop("animateShutter") { view, animate: Boolean? ->

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -163,6 +163,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
       isSessionPaused = false
       sessionQueue.async {
         self.session.startRunning()
+        self.enableTorch()
       }
     }
   }
@@ -265,6 +266,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     sessionQueue.asyncAfter(deadline: .now() + 0.5) {
       self.barcodeScanner.maybeStartBarcodeScanning()
       self.session.startRunning()
+      self.enableTorch()
       self.onCameraReady()
     }
   }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -266,8 +266,8 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
     sessionQueue.asyncAfter(deadline: .now() + 0.5) {
       self.barcodeScanner.maybeStartBarcodeScanning()
       self.session.startRunning()
-      self.enableTorch()
       self.onCameraReady()
+      self.enableTorch()
     }
   }
 


### PR DESCRIPTION
# Why
Closes #29182
Users would like to render the camera with the torch enabled. This doesn't currently work because when the props are set the camera is null on both platforms.

# How
Call the function to enable the torch after the camera has been created. 

# Test Plan
Bare-expo with `enableTorch` set to true ✅

