### PR TITLE
chore: try simple yarn caching for cli job

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -110,7 +110,7 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Install Playwright Browsers
-        run: bun playwright install --with-deps
+        run: bun playwright install --with-deps chromium
         working-directory: packages/@expo/cli
       - name: E2E (playwright) Test CLI
         run: yarn test:playwright

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -58,37 +58,32 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+
+      - name: ♻️ Restore Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --prefer-offline --frozen-lockfile
+
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-workspace: 'true'
-      - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+
       - name: 🔎 Type Check CLI
         run: yarn typecheck
         working-directory: packages/@expo/cli
       - name: E2E Test CLI
         run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
         working-directory: packages/@expo/cli
-      # - name: 🔔 Notify on Slack
-      #   uses: 8398a7/action-slack@v3
-      #   if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
-      #   with:
-      #     channel: '#expo-cli'
-      #     status: ${{ job.status }}
-      #     fields: job,message,ref,eventName,author,took
-      #     author_name: Check packages
+
   web:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -128,7 +128,7 @@ jobs:
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
       - name: Install Playwright Browsers
-        run: bun playwright install-deps chromium
+        run: bun playwright install --with-deps chromium
         working-directory: packages/@expo/cli
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -118,16 +118,16 @@ jobs:
       - name: Build Expo CLI
         run: yarn workspace @expo/cli prepare
         
-      - name: Get installed Playwright version for cache key
+      - name: 🎭 Get installed Playwright version for cache key
         run: echo "PLAYWRIGHT_VERSION=$(npm info @playwright/test version)" >> $GITHUB_ENV
-      - name: Cache Playwright browser binaries
+      - name: 🎭 Cache Playwright browser binaries
         uses: actions/cache@v4
         id: playwright-browser-cache
         with:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-      - name: Install Playwright Browsers
+      - name: 🎭 Install Playwright Browsers
         run: bun playwright install --with-deps chromium
         working-directory: packages/@expo/cli
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -118,10 +118,20 @@ jobs:
       - name: Build Expo CLI
         run: yarn workspace @expo/cli prepare
         
+      - name: Get installed Playwright version for cache key
+        run: echo "PLAYWRIGHT_VERSION=$(npm info @playwright/test version)" >> $GITHUB_ENV
+      - name: Cache Playwright browser binaries
+        uses: actions/cache@v4
+        id: playwright-browser-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
       - name: Install Playwright Browsers
-        run: bun playwright install --with-deps chromium
+        run: bun playwright install-deps chromium
         working-directory: packages/@expo/cli
-        
+        if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
+
       - name: E2E (playwright) Test CLI
         run: yarn test:playwright
         working-directory: packages/@expo/cli

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -68,7 +68,10 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: YARN_IGNORE_SCRIPTS=true yarn install --prefer-offline --frozen-lockfile
+      
+      - name: Build Expo CLI
+        run: yarn workspace @expo/cli prepare
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -101,17 +104,24 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
+      - name: ♻️ Restore Yarn Cache
+        uses: actions/cache@v4
         with:
-          yarn-workspace: 'true'
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: YARN_IGNORE_SCRIPTS=true yarn install --prefer-offline --frozen-lockfile
+      
+      - name: Build Expo CLI
+        run: yarn workspace @expo/cli prepare
+        
       - name: Install Playwright Browsers
         run: bun playwright install --with-deps chromium
         working-directory: packages/@expo/cli
+        
       - name: E2E (playwright) Test CLI
         run: yarn test:playwright
         working-directory: packages/@expo/cli

--- a/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
@@ -1,16 +1,15 @@
 import execa from 'execa';
 
 import { runExportSideEffects } from './export-side-effects';
-import { bin, ensurePortFreeAsync, getRouterE2ERoot } from '../utils';
+import { bin, getRouterE2ERoot } from '../utils';
 
 runExportSideEffects();
 
 const projectRoot = getRouterE2ERoot();
-it(`asserts the server env isn't correct`, async () => {
-  await ensurePortFreeAsync(8081);
 
+it(`asserts the server env isn't correct`, async () => {
   await expect(
-    execa('node', [bin, 'start'], {
+    execa('node', [bin, 'start', '--port', '3002'], {
       cwd: projectRoot,
       env: {
         NODE_ENV: 'production',
@@ -24,7 +23,4 @@ it(`asserts the server env isn't correct`, async () => {
   ).rejects.toThrow(
     /NODE_OPTIONS="--no-experimental-fetch" is not supported with Expo server. Node.js built-in Request\/Response APIs are required to continue./
   );
-});
-afterAll(async () => {
-  await ensurePortFreeAsync(8081);
-});
+}, 10000);


### PR DESCRIPTION
# Why

- The CLI CI jobs don't appear to be having cache hits.
- The CLI CI jobs are doing extra setup that is only required for working on the native part of the SDK. Many of these checks are covered in SDK > check-packages, which always runs for CLI anyways.
- We don't cache playwright browsers and install too many browsers. This adds 30s to the E2E web tests which don't need to run.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
