### PR TITLE
[docs] Fix broken link

### DIFF
--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -10,7 +10,7 @@ Expo Router relies on your file system, which can present challenges when settin
 
 ## Configuration
 
-Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started) in your project.
+Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/start/quick-start) in your project.
 
 > **Note**: Since Expo router is a file-based router, do not put your test files inside the **app** directory. Instead, use the **\_\_tests\_\_** directory or a separate directory. This approach is explained in [Unit testing](/develop/unit-testing/#structure-your-tests).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The link to the `@testing-library/react-native` documentation in the Expo documentation was outdated. This PR updates the link to the correct URL to ensure users can access the most up-to-date instructions.


# How

<!--
How did you build this feature or fix this bug and why?
-->
Before: https://callstack.github.io/react-native-testing-library/docs/getting-started 
**After**: https://callstack.github.io/react-native-testing-library/docs/start/quick-start 


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
You can verify the correctness by clicking the updated link in the documentation and ensuring it directs to the correct page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
