### PR TITLE
chore(cli): display iOS device model name for connected devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Display the iOS device model for connected devices. ([#29225](https://github.com/expo/expo/pull/29225) by [@michalzuk](https://github.com/michalzuk))
 - Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
 - Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -28,6 +28,8 @@ export interface ConnectedDevice {
   name: string;
   /** @example `iPhone13,4` */
   model: string;
+  /** @example `iPhone 12 mini` */
+  modelName: string;
   /** @example `device` */
   deviceType: 'device' | 'catalyst';
   /** @example `USB` */
@@ -52,6 +54,7 @@ async function getConnectedDevicesUsingNativeToolsAsync(): Promise<ConnectedDevi
         return {
           name: device.deviceProperties.name,
           model: device.hardwareProperties.productType,
+          modelName: device.hardwareProperties.marketingName,
           osVersion: device.deviceProperties.osVersionNumber,
           udid: device.hardwareProperties.udid,
           deviceType: 'device',
@@ -122,6 +125,7 @@ async function getConnectedDevicesUsingCustomToolingAsync(): Promise<ConnectedDe
         // TODO(EvanBacon): Better name
         name: deviceValues.DeviceName ?? deviceValues.ProductType ?? 'unknown iOS device',
         model: deviceValues.ProductType,
+        modelName: deviceValues.ProductName,
         osVersion: deviceValues.ProductVersion,
         deviceType: 'device',
         connectionType: device.Properties.ConnectionType,

--- a/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
@@ -6,26 +6,30 @@ describe(formatDeviceChoice, () => {
     const option = formatDeviceChoice({
       name: "Evan's phone",
       model: 'iPhone13,4',
+      modelName: "iPhone 12 mini",
       osVersion: '15.4.1',
       deviceType: 'device',
       connectionType: 'USB',
       udid: '00008101-001964A22629003A',
+      osType: "iOS"
     });
 
-    expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone - iPhone 12 mini (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats network connected device`, () => {
     const option = formatDeviceChoice({
       name: "Evan's phone",
       model: 'iPhone13,4',
+      modelName: "iPhone 12 mini",
       osVersion: '15.4.1',
       deviceType: 'device',
       connectionType: 'Network',
       udid: '00008101-001964A22629003A',
+      osType: "iOS"
     });
 
-    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone - iPhone 12 mini (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats active simulator`, () => {

--- a/packages/@expo/cli/src/run/ios/options/promptDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/promptDevice.ts
@@ -28,7 +28,7 @@ export function formatDeviceChoice(item: AnyDevice): { title: string; value: str
         : '';
   const format = isActive ? chalk.bold : (text: string) => text;
   return {
-    title: `${symbol}${format(item.name)}${
+    title: `${symbol}${format(item.name)}${isConnected ? ` - ${item.modelName}` : ''}${
       item.osVersion ? chalk.dim(` (${item.osVersion})`) : ''
     }`,
     value: item.udid,


### PR DESCRIPTION
# Why
At the moment, it is impossible to distinguish one of the connected devices with the same system version.
<img width="300" alt="image" src="https://github.com/expo/expo/assets/18529692/0f644725-f9c1-4b8c-a772-7a0b7798871c">

# How
Use `modelName` property delivered by iOS to display it for connected device.
<img width="383" alt="image" src="https://github.com/expo/expo/assets/18529692/5881be9b-5370-45f2-a1fe-d68df6fafd20">


# Test Plan

- Used `nexpo run:ios --device` to verify if device model is displayed correctly
- Updated and verified related tests

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
