### PR TITLE
chore(cli): display iOS device model name for connected devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Reduce export code paths. ([#29218](https://github.com/expo/expo/pull/29218) by [@EvanBacon](https://github.com/EvanBacon))
+- Display the iOS device model for connected devices. ([#29227](https://github.com/expo/expo/pull/29227) by [@michalzuk](https://github.com/michalzuk))
 - Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
 - Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused dependencies. ([#29177](https://github.com/expo/expo/pull/29177) by [@Simek](https://github.com/Simek))

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -28,6 +28,8 @@ export interface ConnectedDevice {
   name: string;
   /** @example `iPhone13,4` */
   model: string;
+  /** @example `iPhone 12 mini` */
+  modelName: string;
   /** @example `device` */
   deviceType: 'device' | 'catalyst';
   /** @example `USB` */
@@ -52,6 +54,7 @@ async function getConnectedDevicesUsingNativeToolsAsync(): Promise<ConnectedDevi
         return {
           name: device.deviceProperties.name,
           model: device.hardwareProperties.productType,
+          modelName: device.hardwareProperties.marketingName,
           osVersion: device.deviceProperties.osVersionNumber,
           udid: device.hardwareProperties.udid,
           deviceType: 'device',
@@ -122,6 +125,7 @@ async function getConnectedDevicesUsingCustomToolingAsync(): Promise<ConnectedDe
         // TODO(EvanBacon): Better name
         name: deviceValues.DeviceName ?? deviceValues.ProductType ?? 'unknown iOS device',
         model: deviceValues.ProductType,
+        modelName: deviceValues.ProductName,
         osVersion: deviceValues.ProductVersion,
         deviceType: 'device',
         connectionType: device.Properties.ConnectionType,

--- a/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
@@ -3,72 +3,104 @@ import { formatDeviceChoice } from '../promptDevice';
 
 describe(formatDeviceChoice, () => {
   it(`formats USB connected device`, () => {
-    const option = formatDeviceChoice({
-      name: "Evan's phone",
-      model: 'iPhone13,4',
-      modelName: "iPhone 12 mini",
-      osVersion: '15.4.1',
-      deviceType: 'device',
-      connectionType: 'USB',
-      udid: '00008101-001964A22629003A',
-      osType: "iOS"
-    });
+    const option = formatDeviceChoice(
+      {
+        name: "Evan's phone",
+        model: 'iPhone13,4',
+        modelName: 'iPhone 12 mini',
+        osVersion: '15.4.1',
+        deviceType: 'device',
+        connectionType: 'USB',
+        udid: '00008101-001964A22629003A',
+        osType: 'iOS',
+      },
+      false
+    );
+
+    expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
+  });
+
+  it(`formats USB connected device with duplicated name`, () => {
+    const option = formatDeviceChoice(
+      {
+        name: "Evan's phone",
+        model: 'iPhone13,4',
+        modelName: 'iPhone 12 mini',
+        osVersion: '15.4.1',
+        deviceType: 'device',
+        connectionType: 'USB',
+        udid: '00008101-001964A22629003A',
+        osType: 'iOS',
+      },
+      true
+    );
 
     expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone - iPhone 12 mini (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
-  it(`formats network connected device`, () => {
-    const option = formatDeviceChoice({
-      name: "Evan's phone",
-      model: 'iPhone13,4',
-      modelName: "iPhone 12 mini",
-      osVersion: '15.4.1',
-      deviceType: 'device',
-      connectionType: 'Network',
-      udid: '00008101-001964A22629003A',
-      osType: "iOS"
-    });
 
-    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone - iPhone 12 mini (15.4.1)`);
+  it(`formats network connected device`, () => {
+    const option = formatDeviceChoice(
+      {
+        name: "Evan's phone",
+        model: 'iPhone13,4',
+        modelName: 'iPhone 12 mini',
+        osVersion: '15.4.1',
+        deviceType: 'device',
+        connectionType: 'Network',
+        udid: '00008101-001964A22629003A',
+        osType: 'iOS',
+      },
+      false
+    );
+
+    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats active simulator`, () => {
-    const option = formatDeviceChoice({
-      dataPath:
-        '/Users/evanbacon/Library/Developer/CoreSimulator/Devices/ADEF1A93-5D20-40C3-826C-5A4E04DBBB52/data',
-      dataPathSize: 2811236352,
-      logPath: '/Users/evanbacon/Library/Logs/CoreSimulator/ADEF1A93-5D20-40C3-826C-5A4E04DBBB52',
-      udid: 'ADEF1A93-5D20-40C3-826C-5A4E04DBBB52',
-      isAvailable: true,
-      logPathSize: 479232,
-      deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-8',
-      state: 'Booted',
-      name: 'iPhone 8',
-      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-15-4',
-      osVersion: '15.4',
-      windowName: 'iPhone 8 (15.4)',
-      osType: 'iOS',
-    });
+    const option = formatDeviceChoice(
+      {
+        dataPath:
+          '/Users/evanbacon/Library/Developer/CoreSimulator/Devices/ADEF1A93-5D20-40C3-826C-5A4E04DBBB52/data',
+        dataPathSize: 2811236352,
+        logPath: '/Users/evanbacon/Library/Logs/CoreSimulator/ADEF1A93-5D20-40C3-826C-5A4E04DBBB52',
+        udid: 'ADEF1A93-5D20-40C3-826C-5A4E04DBBB52',
+        isAvailable: true,
+        logPathSize: 479232,
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-8',
+        state: 'Booted',
+        name: 'iPhone 8',
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-15-4',
+        osVersion: '15.4',
+        windowName: 'iPhone 8 (15.4)',
+        osType: 'iOS',
+      },
+      false
+    );
 
     expect(stripAnsi(option.title)).toEqual(`iPhone 8 (15.4)`);
     expect(stripAnsi(option.value)).toEqual('ADEF1A93-5D20-40C3-826C-5A4E04DBBB52');
   });
   it(`formats closed simulator`, () => {
-    const option = formatDeviceChoice({
-      dataPath:
-        '/Users/evanbacon/Library/Developer/CoreSimulator/Devices/4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066/data',
-      dataPathSize: 13316096,
-      logPath: '/Users/evanbacon/Library/Logs/CoreSimulator/4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066',
-      udid: '4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066',
-      isAvailable: true,
-      deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus',
-      state: 'Shutdown',
-      name: 'iPhone 8 Plus',
-      runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-15-4',
-      osVersion: '15.4',
-      windowName: 'iPhone 8 Plus (15.4)',
-      osType: 'iOS',
-    });
+    const option = formatDeviceChoice(
+      {
+        dataPath:
+          '/Users/evanbacon/Library/Developer/CoreSimulator/Devices/4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066/data',
+        dataPathSize: 13316096,
+        logPath: '/Users/evanbacon/Library/Logs/CoreSimulator/4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066',
+        udid: '4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066',
+        isAvailable: true,
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus',
+        state: 'Shutdown',
+        name: 'iPhone 8 Plus',
+        runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-15-4',
+        osVersion: '15.4',
+        windowName: 'iPhone 8 Plus (15.4)',
+        osType: 'iOS',
+      },
+      false
+    );
 
     expect(stripAnsi(option.title)).toEqual(`iPhone 8 Plus (15.4)`);
     expect(stripAnsi(option.value)).toEqual('4DE5F2E1-C6FF-4CCE-BD27-7D40E2674066');

--- a/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
@@ -6,26 +6,30 @@ describe(formatDeviceChoice, () => {
     const option = formatDeviceChoice({
       name: "Evan's phone",
       model: 'iPhone13,4',
+      modelName: "iPhone 12 mini",
       osVersion: '15.4.1',
       deviceType: 'device',
       connectionType: 'USB',
       udid: '00008101-001964A22629003A',
+      osType: "iOS"
     });
 
-    expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone - iPhone 12 mini (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats network connected device`, () => {
     const option = formatDeviceChoice({
       name: "Evan's phone",
       model: 'iPhone13,4',
+      modelName: "iPhone 12 mini",
       osVersion: '15.4.1',
       deviceType: 'device',
       connectionType: 'Network',
       udid: '00008101-001964A22629003A',
+      osType: "iOS"
     });
 
-    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone - iPhone 12 mini (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats active simulator`, () => {

--- a/packages/@expo/cli/src/run/ios/options/promptDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/promptDevice.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 
 import * as SimControl from '../../../start/platforms/ios/simctl';
+import { setOfDuplicatedValues } from '../../../utils/array';
 import prompt from '../../../utils/prompts';
 import { ConnectedDevice } from '../appleDevice/AppleDevice';
 
@@ -15,7 +16,10 @@ function isSimControlDevice(item: AnyDevice): item is SimControl.Device {
 }
 
 /** Format a device for the prompt list. Exposed for testing. */
-export function formatDeviceChoice(item: AnyDevice): { title: string; value: string } {
+export function formatDeviceChoice(
+  item: AnyDevice,
+  isDeviceNameDuplicated: boolean
+): { title: string; value: string } {
   const isConnected = isConnectedDevice(item) && item.deviceType === 'device';
   const isActive = isSimControlDevice(item) && item.state === 'Booted';
   const symbol =
@@ -27,10 +31,11 @@ export function formatDeviceChoice(item: AnyDevice): { title: string; value: str
           : '🔌 '
         : '';
   const format = isActive ? chalk.bold : (text: string) => text;
+  const deviceName = format(
+    `${item.name}${isDeviceNameDuplicated && isConnected ? ` - ${item.modelName}` : ''}`
+  );
   return {
-    title: `${symbol}${format(item.name)}${isConnected ? ` - ${item.modelName}` : ''}${
-      item.osVersion ? chalk.dim(` (${item.osVersion})`) : ''
-    }`,
+    title: `${symbol}${deviceName}${item.osVersion ? chalk.dim(` (${item.osVersion})`) : ''}`,
     value: item.udid,
   };
 }
@@ -43,7 +48,10 @@ export async function promptDeviceAsync(devices: AnyDevice[]): Promise<AnyDevice
     name: 'value',
     limit: 11,
     message: 'Select a device',
-    choices: devices.map((item) => formatDeviceChoice(item)),
+    choices: () => {
+      const duplicatedDeviceNames = setOfDuplicatedValues(devices, (item) => item.name);
+      return devices.map((item) => formatDeviceChoice(item, duplicatedDeviceNames.has(item.name)));
+    },
     suggest: (input: any, choices: any) => {
       const regex = new RegExp(input, 'i');
       return choices.filter((choice: any) => regex.test(choice.title));

--- a/packages/@expo/cli/src/run/ios/options/promptDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/promptDevice.ts
@@ -28,7 +28,7 @@ export function formatDeviceChoice(item: AnyDevice): { title: string; value: str
         : '';
   const format = isActive ? chalk.bold : (text: string) => text;
   return {
-    title: `${symbol}${format(item.name)}${
+    title: `${symbol}${format(item.name)}${isConnected ? ` - ${item.modelName}` : ''}${
       item.osVersion ? chalk.dim(` (${item.osVersion})`) : ''
     }`,
     value: item.udid,

--- a/packages/@expo/cli/src/utils/array.ts
+++ b/packages/@expo/cli/src/utils/array.ts
@@ -59,3 +59,26 @@ export function groupBy<T, K extends keyof any>(list: T[], getKey: (item: T) => 
     {} as Record<K, T[]>
   );
 }
+
+/** Returns a set of duplicated values in an array */
+export function setOfDuplicatedValues<T extends object>(
+  array: T[],
+  key: (item: T) => string
+): Set<string> {
+  const valueCounts = new Map<string, number>();
+
+  array.forEach((item) => {
+    const value = key(item);
+
+    valueCounts.set(value, (valueCounts.get(value) || 0) + 1);
+  });
+
+  const duplicates = new Set<string>();
+  valueCounts.forEach((count, value) => {
+    if (count > 1) {
+      duplicates.add(value);
+    }
+  });
+
+  return duplicates;
+}


### PR DESCRIPTION
# Why
At the moment, it is impossible to distinguish one of the connected devices with the same system version.
<img width="300" alt="image" src="https://github.com/expo/expo/assets/18529692/0f644725-f9c1-4b8c-a772-7a0b7798871c">

# How
Use `modelName` property delivered by iOS to display it for connected device.
<img width="383" alt="image" src="https://github.com/expo/expo/assets/18529692/5881be9b-5370-45f2-a1fe-d68df6fafd20">


# Test Plan

- Used `nexpo run:ios --device` to verify if device model is displayed correctly
- Updated and verified related tests

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
