### PR TITLE
chore(cli): add hydration test

### DIFF
--- a/apps/router-e2e/__e2e__/hydration/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/hydration/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack />;
+}

--- a/apps/router-e2e/__e2e__/hydration/app/index.tsx
+++ b/apps/router-e2e/__e2e__/hydration/app/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export default function Page() {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  return (
+    <>
+      <Text testID="index-text">Index</Text>
+      {/* Sanity to test that hydration errors are caught in the E2E test */}
+      {/* <Text testID="index-text">Index {Date.now()}</Text> */}
+      {mounted && <Text testID="index-mounted">Mounted</Text>}
+    </>
+  );
+}

--- a/packages/@expo/cli/e2e/playwright/dev/hydration.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/hydration.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import execa from 'execa';
+
+import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
+import { getRouterE2ERoot } from '../../__tests__/utils';
+import { bin, ServeStaticCommand } from '../../utils/command-instance';
+
+test.beforeAll(() => clearEnv());
+test.afterAll(() => restoreEnv());
+
+const projectRoot = getRouterE2ERoot();
+const inputDir = 'dist-hydration';
+
+test.describe(inputDir, () => {
+  test.beforeAll(async () => {
+    // Could take 45s depending on how fast the bundler resolves
+    test.setTimeout(560 * 1000);
+  });
+
+  let serveCmd: ServeStaticCommand;
+
+  test.beforeEach('bundle and serve', async () => {
+    console.time('expo export');
+    await execa('node', [bin, 'export', '-p', 'web', '--output-dir', inputDir], {
+      cwd: projectRoot,
+      env: {
+        NODE_ENV: 'production',
+        EXPO_USE_STATIC: 'static',
+        E2E_ROUTER_SRC: 'hydration',
+      },
+    });
+    console.timeEnd('expo export');
+
+    serveCmd = new ServeStaticCommand(projectRoot, {
+      NODE_ENV: 'production',
+    });
+  });
+
+  // This test generally ensures no errors are thrown during an export loading.
+  test('loads without hydration errors', async ({ page }) => {
+    console.time('npx serve');
+    await serveCmd.startAsync([inputDir]);
+    console.timeEnd('npx serve');
+    console.log('Server running:', serveCmd.url);
+
+    console.time('Open page');
+    // Navigate to the app
+    await page.goto(serveCmd.url);
+
+    console.timeEnd('Open page');
+
+    // Listen for console errors
+    const errorLogs: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errorLogs.push(msg.text());
+      }
+    });
+
+    // Listen for uncaught exceptions and console errors
+    const errors: string[] = [];
+    page.on('pageerror', (error) => {
+      errors.push(error.message);
+    });
+
+    console.time('hydrate');
+    // Wait for the app to load
+    await page.waitForSelector('[data-testid="index-text"]');
+
+    // Wait for the app to hydrate
+    await page.waitForSelector('[data-testid="index-mounted"]');
+    console.timeEnd('hydrate');
+
+    expect(errorLogs).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/@expo/cli/e2e/utils/command-instance.ts
+++ b/packages/@expo/cli/e2e/utils/command-instance.ts
@@ -203,3 +203,144 @@ export class ExpoStartCommand extends EventEmitter {
     });
   }
 }
+
+export class ServeStaticCommand extends EventEmitter {
+  protected cliOutput: string = '';
+
+  url: string;
+
+  private isStopping: boolean = false;
+  private childProcess?: import('child_process').ChildProcess;
+
+  constructor(
+    public projectRoot: string,
+
+    public env: NodeJS.ProcessEnv = {}
+  ) {
+    super();
+  }
+
+  public async stopAsync(): Promise<void> {
+    this.isStopping = true;
+    if (this.childProcess) {
+      const exitPromise = once(this.childProcess, 'exit');
+      await new Promise<void>((resolve) => {
+        treeKill(this.childProcess!.pid!, 'SIGKILL', (err) => {
+          if (err) {
+            console.error('tree-kill', err);
+          }
+          resolve();
+        });
+      });
+      this.childProcess.kill('SIGKILL');
+      await exitPromise;
+      this.childProcess = undefined;
+      console.log(`Stopped npx serve`);
+    }
+  }
+
+  private parseStdio(childProcess) {
+    childProcess.stdout.on('data', (chunk) => {
+      const msg = chunk.toString();
+      if (!process.env.CI) process.stdout.write(chunk);
+      this.cliOutput += msg;
+      this.emit('stdout', [msg]);
+    });
+    childProcess.stderr.on('data', (chunk) => {
+      const msg = chunk.toString();
+      if (!process.env.CI) process.stderr.write(chunk);
+      this.cliOutput += msg;
+      this.emit('stderr', [msg]);
+    });
+  }
+
+  getUrl(): string {
+    assert(this.url, 'npx serve not started');
+    return this.url;
+  }
+
+  fetchAsync(url: string, init?: RequestInit | undefined) {
+    const serverUrl = new URL(url, this.getUrl());
+    return fetch(serverUrl, init);
+  }
+
+  flushErrors() {
+    this.cliOutput.split('\n').forEach((line) => {
+      if (line.match(/Error:/i)) {
+        throw new Error(line);
+      }
+    });
+  }
+
+  async startAsync(args: string[] = []) {
+    if (this.childProcess) {
+      throw new Error('npx serve already started');
+    }
+    this.cliOutput = '';
+
+    const cmdArgs = ['npx', 'serve', ...args].filter(Boolean) as string[];
+
+    console.log('$', cmdArgs.join(' '));
+    await new Promise<void>((resolve, reject) => {
+      try {
+        this.childProcess = spawn(cmdArgs[0], cmdArgs.slice(1), {
+          cwd: this.projectRoot,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          shell: false,
+          env: {
+            CI: '1',
+            ...process.env,
+            ...this.env,
+            NODE_ENV: this.env.NODE_ENV || ('' as any),
+          },
+        });
+
+        this.cliOutput = '';
+
+        this.parseStdio(this.childProcess);
+
+        this.childProcess.on('close', (code, signal) => {
+          if (this.isStopping) return;
+          if (code || signal) {
+            console.error(`'${cmdArgs.join(' ')}' exited unexpectedly with: ${code || signal}`);
+          }
+        });
+        const isReadyCallback = (message) => {
+          const resolveServer = () => {
+            try {
+              new URL(this.url);
+            } catch (err) {
+              reject({
+                err,
+                msg: message,
+              });
+            }
+            resolve();
+          };
+
+          for (const rawStr of stripAnsi(message)) {
+            const tag = 'Accepting connections at ';
+            if (rawStr.includes(tag)) {
+              const matchedLine = rawStr
+                .split('\n')
+                ?.find((line) => line.includes(tag))
+                ?.split(/Accepting connections at\s+/)
+                ?.pop()
+                ?.trim();
+              if (!matchedLine) {
+                return reject(new Error('Failed to parse server URL: ' + message));
+              }
+              this.url = matchedLine;
+              callback.remove();
+              return resolveServer();
+            }
+          }
+        };
+        const callback = this.addListener('stdout', isReadyCallback);
+      } catch (err) {
+        console.error(`Failed to run ${cmdArgs.join(' ')}`, err);
+        setTimeout(() => process.exit(1), 0);
+      }
+    });
+  }
+}


### PR DESCRIPTION
# Why

- I want to refactor the router root to not use AppRegistry from RNW but the last time I tried this it caused regressions in the hydration system.
- This test will continuously ensure hydration errors don't occur in production web exports.
