### PR TITLE
[docs] Default to Expo Go on development environment setup docs

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
@@ -16,7 +16,7 @@ export function DevelopmentModeForm() {
         if (query.mode) {
           setMode(query.mode as DevelopmentMode);
         } else {
-          setMode('development-build');
+          setMode('expo-go');
         }
       }
     },
@@ -41,15 +41,6 @@ export function DevelopmentModeForm() {
   return (
     <div className="flex flex-wrap gap-4">
       <SelectCard
-        imgSrc="/static/images/get-started/development-build.png"
-        darkImgSrc="/static/images/get-started/development-build-dark.png"
-        title="Development build"
-        alt="Development build"
-        description="Make a build of your own app with developer tools. Supports custom native modules. Intended for production projects."
-        isSelected={mode === 'development-build'}
-        onClick={() => onRadioChange('development-build')}
-      />
-      <SelectCard
         imgSrc="/static/images/get-started/expo-go.png"
         darkImgSrc="/static/images/get-started/expo-go-dark.png"
         title="Expo Go"
@@ -57,6 +48,15 @@ export function DevelopmentModeForm() {
         description="Try out app development in a limited sandbox without custom native modules. Great for testing out Expo quickly. Not intended for long-term projects."
         isSelected={mode === 'expo-go'}
         onClick={() => onRadioChange('expo-go')}
+      />
+      <SelectCard
+        imgSrc="/static/images/get-started/development-build.png"
+        darkImgSrc="/static/images/get-started/development-build-dark.png"
+        title="Development build"
+        alt="Development build"
+        description="Make a build of your own app with developer tools. Supports custom native modules. Intended for production projects."
+        isSelected={mode === 'development-build'}
+        onClick={() => onRadioChange('development-build')}
       />
     </div>
   );


### PR DESCRIPTION
# Why

We should show Expo Go as the default choice, but instead are showing development build instructions.

# Screenshots

## Before
<img width="1763" alt="Screenshot 2024-05-31 at 10 40 03 AM" src="https://github.com/expo/expo/assets/6455018/caea5352-783b-4b03-b338-e69feea013ed">

## After
<img width="1763" alt="Screenshot 2024-05-31 at 10 39 56 AM" src="https://github.com/expo/expo/assets/6455018/d8dd46e3-dd45-497f-82b5-684a8f5dff19">


# Test Plan

- Go to /get-started/set-up-your-environment
- Make sure that Android device and Expo Go are selected by default, like in the after screenshot