### PR TITLE
[docs] Make development builds default

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/DevelopmentEnvironmentInstructions.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/DevelopmentEnvironmentInstructions.tsx
@@ -21,7 +21,7 @@ export function DevelopmentEnvironmentInstructions() {
   const query = {
     platform: 'android',
     device: 'physical',
-    mode: 'expo-go',
+    mode: 'development-build',
     buildEnv: null,
     ..._query,
   };

--- a/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/DevelopmentModeForm.tsx
@@ -16,7 +16,7 @@ export function DevelopmentModeForm() {
         if (query.mode) {
           setMode(query.mode as DevelopmentMode);
         } else {
-          setMode('expo-go');
+          setMode('development-build');
         }
       }
     },
@@ -41,15 +41,6 @@ export function DevelopmentModeForm() {
   return (
     <div className="flex flex-wrap gap-4">
       <SelectCard
-        imgSrc="/static/images/get-started/expo-go.png"
-        darkImgSrc="/static/images/get-started/expo-go-dark.png"
-        title="Expo Go"
-        alt="Expo Go"
-        description="Try out app development in a limited sandbox without custom native modules. Great for testing out Expo quickly. Not intended for long-term projects."
-        isSelected={mode === 'expo-go'}
-        onClick={() => onRadioChange('expo-go')}
-      />
-      <SelectCard
         imgSrc="/static/images/get-started/development-build.png"
         darkImgSrc="/static/images/get-started/development-build-dark.png"
         title="Development build"
@@ -57,6 +48,15 @@ export function DevelopmentModeForm() {
         description="Make a build of your own app with developer tools. Supports custom native modules. Intended for production projects."
         isSelected={mode === 'development-build'}
         onClick={() => onRadioChange('development-build')}
+      />
+      <SelectCard
+        imgSrc="/static/images/get-started/expo-go.png"
+        darkImgSrc="/static/images/get-started/expo-go-dark.png"
+        title="Expo Go"
+        alt="Expo Go"
+        description="Try out app development in a limited sandbox without custom native modules. Great for testing out Expo quickly. Not intended for long-term projects."
+        isSelected={mode === 'expo-go'}
+        onClick={() => onRadioChange('expo-go')}
       />
     </div>
   );


### PR DESCRIPTION
# Why

Make development builds default, based on a conversation with Simek, Alan, and Brent.

# How

<img width="1000" alt="Screenshot 2024-05-31 at 11 03 47 AM" src="https://github.com/expo/expo/assets/6455018/e92687c2-c3e7-43ee-a6dd-b13af16b8ef1">


# Test Plan

Make sure that development builds are now the default in /get-started/set-up-your-environment, like in the screenshot.