### PR TITLE
fix(expo-server): issue with nested headers with Vercel deployment.

### DIFF
--- a/packages/@expo/server/CHANGELOG.md
+++ b/packages/@expo/server/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `ExpoResponse` using incorrect object. ([#29154](https://github.com/expo/expo/pull/29154) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix nested headers array. ([#29259](https://github.com/expo/expo/pull/29259) by (@younes200](https://github.com/younes200))
 
 ### 💡 Others
 

--- a/packages/@expo/server/src/vendor/vercel.ts
+++ b/packages/@expo/server/src/vendor/vercel.ts
@@ -67,7 +67,7 @@ export function convertRequest(req: http.IncomingMessage, res: http.ServerRespon
 
 export async function respond(res: http.ServerResponse, expoRes: Response): Promise<void> {
   res.statusMessage = expoRes.statusText;
-  res.writeHead(expoRes.status, expoRes.statusText, [...expoRes.headers.entries()]);
+  res.writeHead(expoRes.status, expoRes.statusText, ...expoRes.headers.entries());
 
   if (expoRes.body) {
     await writeReadableStreamToWritable(expoRes.body, res);

--- a/packages/@expo/server/src/vendor/vercel.ts
+++ b/packages/@expo/server/src/vendor/vercel.ts
@@ -67,7 +67,7 @@ export function convertRequest(req: http.IncomingMessage, res: http.ServerRespon
 
 export async function respond(res: http.ServerResponse, expoRes: Response): Promise<void> {
   res.statusMessage = expoRes.statusText;
-  res.writeHead(expoRes.status, expoRes.statusText, ...expoRes.headers.entries());
+  res.writeHead(expoRes.status, expoRes.statusText, [...expoRes.headers.entries()].flat());
 
   if (expoRes.body) {
     await writeReadableStreamToWritable(expoRes.body, res);


### PR DESCRIPTION
# Why

The most recent vercel deployment resulted in the server crashing: 
```
Unhandled Rejection: TypeError: The argument 'headers' is invalid. Received [ [ 'content-type', 'text/plain' ] ]
at ServerResponse.writeHead (node:_http_server:373:15)
at ServerResponse.n.writeHead (/opt/rust/nodejs.js:7:2831)
at respond (/var/task/node_modules/@expo/server/build/vendor/vercel.js:62:9)
at /var/task/node_modules/@expo/server/build/vendor/vercel.js:16:16
at processTicksAndRejections (node:internal/process/task_queues:95:5)
at Server.<anonymous> (/opt/rust/nodejs.js:1:10455)
at Server.<anonymous> (/opt/rust/nodejs.js:7:3709) {
code: 'ERR_INVALID_ARG_VALUE'
```


# How


By removing nested headers when combining them, the issue can be prevented. This means ensuring that there are no headers within headers when consolidating them, as this can lead to errors or crashes on the server. 

# Test Plan

Deploy the new build using the latest Vercel runtime version.

# Checklist


- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
