### PR TITLE
[docs] Update local build docs for EAS update channel creation

### DIFF
--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -68,7 +68,7 @@ Inside the app config, make changes to use [`runtimeVersion`](/versions/latest/c
   }
 ```
 
-> In the [introduction guide](/eas-update/getting-started), the channel name is set by EAS Build and is different for various build profiles and automatically synchronized on the server. Since this is a local build, it is necessary to set this request header explicitly in the app config and also necessary to create the channel on the server manually.
+> In the [Get started](/eas-update/getting-started) guide, the channel name is set by EAS Build and is different for various build profiles and automatically synchronized on the server. Since this is a local build, it is necessary to set the request header explicitly in the app config, as shown above, and then manually create channel on the server.
 
 <Terminal
   cmd={[
@@ -203,7 +203,7 @@ Now we're ready to publish an update that will include our changes.
 
 After optionally making additional changes to **App.js**, publish an update with the following command:
 
-<Terminal cmd={['$ eas update']} cmdCopy="eas update" />
+<Terminal cmd={['$ eas update']} />
 
 Running the command will prompt the following:
 

--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -68,7 +68,15 @@ Inside the app config, make changes to use [`runtimeVersion`](/versions/latest/c
   }
 ```
 
-> In the [introduction guide](/eas-update/getting-started), the channel name is set by EAS Build and is different for various build profiles. Since this is a local build, it is necessary to set this request header explicitly in the app config.
+> In the [introduction guide](/eas-update/getting-started), the channel name is set by EAS Build and is different for various build profiles and automatically synchronized on the server. Since this is a local build, it is necessary to set this request header explicitly in the app config and also necessary to create the channel on the server manually.
+
+<Terminal
+  cmd={[
+    '# Create the `main` channel on EAS (which points it to the main EAS Update branch by default)',
+    '$ eas channel:create main',
+  ]}
+  cmdCopy="eas channel:create main"
+/>
 
 </Step>
 
@@ -195,11 +203,11 @@ Now we're ready to publish an update that will include our changes.
 
 After optionally making additional changes to **App.js**, publish an update with the following command:
 
-<Terminal cmd={['$ eas update']} />
+<Terminal cmd={['$ eas update']} cmdCopy="eas update" />
 
 Running the command will prompt the following:
 
-- For the branch to publish on. Select the default branch: `main`.
+- For the branch to publish on. Select the default branch: `main`. This is the branch that the `main` channel was linked to by default above.
 - For entering an update message. Select the default `Initial commit` message or type in a custom message.
 
 Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/pull/2346 removed automatic channel creation from the `eas update` command since we only want to auto-create channels when a build references them.

The exception to this case is local builds: since we can't auto-create the channels they instead must be manually created.

Closes https://github.com/expo/expo/issues/29205.
Closes ENG-12409.

# How

Add docs indicating how to create the channel manually for local builds.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
