### PR TITLE
[ios][location] Fix issue with "Allow Once" permission

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fix an issue where if the user selects "Allow Once" for location permissions, we needed to request background permissions twice because the first time had effect.
+- On `iOS`, fix an issue where if the user selects "Allow Once" for location permissions, we needed to request background permissions twice because the first time had effect. ([#29272](https://github.com/expo/expo/pull/29272) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fix an issue where if the user selects "Allow Once" for location permissions, we needed to request background permissions twice because the first time had effect.
+
 ### 💡 Others
 
 - Keep using the legacy event emitter as the module is not fully migrated to Expo Modules API. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-location/ios/EXLocation/Requesters/EXBaseLocationRequester.m
+++ b/packages/expo-location/ios/EXLocation/Requesters/EXBaseLocationRequester.m
@@ -137,7 +137,9 @@
       // to the "Don't Allow" / "Allow" dialog box. This isn't the event we care about so we skip it. See:
       // http://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called/30107511#30107511
       _locationManagerWasCalled = true;
-      return;
+      if (status != kCLAuthorizationStatusAuthorizedWhenInUse) {
+        return;
+      }
     }
 
     if (_resolve) {


### PR DESCRIPTION
# Why
Closes ENG-10918
Closes #25873

# How
There is an issue on iOS where the delegate method for permission changes is called immediately after it is set with `kCLAuthorizationStatusNotDetermined`. We have code in place to ignore this and it's this code that is causing the problem. What is happening is we are ignoring the next permission request to set `_locationManagerWasCalled ` to true but then not resolving the promise. Then on the second attempt, it works as expected. I think we could probably remove this check but there may be edge cases I'm not aware of so I just check for `kCLAuthorizationStatusAuthorizedWhenInUse` and resolve the permissions.

# Test Plan
Used the provided repro 

