### PR TITLE
[docs] Rewrite the main expo-updates library doc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -1,6 +1,6 @@
 ---
 title: Updates
-description: A library that allows programmatically controlling and responding to new updates made available to your app.
+description: A library that enables your app to manage remote updates to your application code.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-updates'
 packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
@@ -10,102 +10,126 @@ platforms: ['android', 'ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
-import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
+import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
-The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
+`expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates.
 
-## Installation
+## Installation and configuration
+
+The `expo-updates` library can be automatically configured using [EAS Update](/eas-update/introduction/), which is a hosted service that manages and serves updates to your app. To get started with EAS Update, follow the instructions in the [Get started](/eas-update/getting-started/) guide.
+
+Alternatively, it is also possible to configure the `expo-updates` library manually in cases where a different remote update service is required or configuration is only specified in native files.
+
+<Collapsible summary="Manual installation and configuration">
 
 <APIInstallSection hideBareInstructions={true} />
 
-If you're installing this in a [bare React Native app](/bare/overview/), you should also follow these [additional installation instructions](/bare/installing-updates/).
+If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
-<ConfigReactNative>
+If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
+- [`updates.url`](/versions/latest/config/app/#updates): a URL of a remote service implementing the [Expo Updates protocol](/technical-specs/expo-updates-1/)
+- [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](/eas-update/runtime-versions/)
 
-Learn how to configure the native projects in the [installation instructions in the `expo-updates` repository](https://github.com/expo/expo/tree/main/packages/expo-updates#installation-in-bare-react-native-projects).
-
-</ConfigReactNative>
-
-## Usage
-
-Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
-
-**To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
-
-**To test manual updates with standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
-
-### Check for updates manually
-
-The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
-
-```jsx App.js
-import { View, Button } from 'react-native';
-import * as Updates from 'expo-updates';
-
-function App() {
-  async function onFetchUpdateAsync() {
-    try {
-      const update = await Updates.checkForUpdateAsync();
-
-      if (update.isAvailable) {
-        await Updates.fetchUpdateAsync();
-        await Updates.reloadAsync();
-      }
-    } catch (error) {
-      // You can also add an alert() to see the error message in case of an error when fetching updates.
-      alert(`Error fetching latest Expo update: ${error}`);
-    }
-  }
-
-  return (
-    <View>
-      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
-    </View>
-  );
-}
-```
-
-### Use `expo-updates` with a custom server
-
-Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).
+The remote service must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/). [EAS Update](/eas-update/introduction) implements this protocol for you, and it is also possible to use this library with a custom server.
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="You can find an example implementation of a custom server and an app using that server in this GitHub repository."
+  description="Example implementation of a custom server and an app using that server"
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />
 
-### Configuration options
+</Collapsible>
 
-There are build-time configuration options that control the behavior of `expo-updates`.
+### Additional configuration options
 
-On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.overrideConfiguration()`, and the provided values will override any value specified in **AndroidManifest.xml**.
+These are build-time configuration options that control the behavior of the library. For most apps, these configuration values can be set in the [app config](/workflow/configuration/) under the [`updates` property](/versions/latest/config/app/#updates).
 
-On iOS, these properties are set as keys in the **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController overrideConfigurationWithConfiguration:]` at any point before `expo-updates` is initialized, and the values in this dictionary will override any values specified in **Expo.plist**. If you tried to use the `EXUpdatesAppController` from the **AppDelegate.mm**, you will need to add the following imports:
+You can also configure the library in your app's native project files if your project does not use Continuous Native Generation. It is also possible to override the configuration from native code.
 
-```objc From Objective-C to import Swift headers for expo-updates
+<Collapsible summary="Native configuration instructions">
+
+On Android, these options are set as `meta-data` tags in the **AndroidManifest.xml** file (adjacent to the tags added during installation if auto-setup was used). You can also set or override them at runtime using `UpdatesController.overrideConfiguration()`.
+
+On iOS, these properties are set as keys in the **Expo.plist** file. You can also set or override them at runtime by calling `AppController.overrideConfiguration`.
+
+<Collapsible summary="Importing Swift generated headers for use in Objective-C++">
+
+If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports in order to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
+
+```objc
 #import "ExpoModulesCore-Swift.h"
 #import "EXUpdatesInterface-Swift.h"
 #import "EXUpdates-Swift.h"
 ```
 
-| iOS plist/dictionary key                                      | Android Map key                                      | Android meta-data name                                                          | Default                                                          | Required?   |
-| ------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `EXUpdatesEnabled`                                            | `enabled`                                            | `expo.modules.updates.ENABLED`                                                  | `true`                                                           | <NoIcon />  |
-| `EXUpdatesURL`                                                | `updateUrl`                                          | `expo.modules.updates.EXPO_UPDATE_URL`                                          | (none)                                                           | <YesIcon /> |
-| `EXUpdatesRequestHeaders`                                     | `requestHeaders`                                     | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY`                | (none)                                                           | <NoIcon />  |
-| `EXUpdatesRuntimeVersion`                                     | `runtimeVersion`                                     | `expo.modules.updates.EXPO_RUNTIME_VERSION`                                     | (none)                                                           | <YesIcon /> |
-| `EXUpdatesCheckOnLaunch`                                      | `checkOnLaunch`                                      | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`                             | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`) | <NoIcon />  |
-| `EXUpdatesLaunchWaitMs`                                       | `launchWaitMs`                                       | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`                              | `0`                                                              | <NoIcon />  |
-| `EXUpdatesCodeSigningCertificate`                             | `codeSigningCertificate`                             | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                                 | (none)                                                           | <NoIcon />  |
-| `EXUpdatesCodeSigningMetadata`                                | `codeSigningMetadata`                                | `expo.modules.updates.CODE_SIGNING_METADATA`                                    | (none)                                                           | <NoIcon />  |
-| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false                                                            | <NoIcon />  |
-| `EXUpdatesConfigCodeSigningAllowUnsignedManifests`            | `codeSigningAllowUnsignedManifests`                  | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS`                    | false                                                            | <NoIcon />  |
+</Collapsible>
 
-For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
+</Collapsible>
+
+| [App Config property](/versions/latest/config/app/#updates)                   | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
+|----------------------------------|----------|-------------|-----------------------------------|------------------------------------------------------------------|--------------------------|
+| `updates.enabled`                | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
+| `updates.url`                    | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
+| `updates.requestHeaders`         | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
+| `runtimeVersion`                 | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
+| `updates.checkAutomatically`     | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
+| `updates.fallbackToCacheTimeout` | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
+| `updates.codeSigningCertificate` | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
+| `updates.codeSigningMetadata`    | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+
+## Usage
+
+By default, `expo-updates` checks for updates when the app launches. If an update is available, it downloads the update and applies it the next time the app is restarted. You can tune this startup behavior using the `checkAutomatically` and `fallbackToCacheTimeout` configuration options above.
+
+The library also provides a variety of constants to inspect the current update and functions to customize update behavior from your application code (after startup). For example, one common alternative usage pattern is to manually check for updates after the app has started instead of doing the default check on launch.
+
+<Collapsible summary="Example: Check for updates manually">
+
+You can configure your app to check for updates manually by doing the following steps:
+1. Set the `checkAutomatically` configuration value to `ON_ERROR_RECOVERY` or `NEVER` to disable the library's default launch behavior.
+2. Add the following code to check for available updates, download them, and reload:
+
+    ```jsx App.js
+    import { View, Button } from 'react-native';
+    import * as Updates from 'expo-updates';
+
+    function App() {
+      async function onFetchUpdateAsync() {
+        try {
+          const update = await Updates.checkForUpdateAsync();
+
+          if (update.isAvailable) {
+            await Updates.fetchUpdateAsync();
+            await Updates.reloadAsync();
+          }
+        } catch (error) {
+          // You can also add an alert() to see the error message in case of an error when fetching updates.
+          alert(`Error fetching latest Expo update: ${error}`);
+        }
+      }
+
+      return (
+        <View>
+          <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+        </View>
+      );
+    }
+    ```
+
+</Collapsible>
+
+## Testing
+
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+
+**To test the content of an update in a development build**, run [`eas update`](/eas-update/publish/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
+
+**To test updates in a release build**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test). The full [Updates API](#api) is available in a release build.
+
+**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/publish/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
 
 ## API
 
@@ -117,10 +141,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                    | Description                                                                                                                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_UPDATES_DISABLED`  | A method call was attempted when the Updates module was disabled, or the application was running in development mode                                                                                                                                          |
-| `ERR_UPDATES_RELOAD`    | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this module to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`     | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
-| `ERR_UPDATES_FETCH`     | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
-| `ERR_UPDATES_READ_LOGS` | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
+| Code                              | Description                                                                                                                                                                                                                                                   |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                          |
+| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                           |

--- a/docs/pages/versions/v51.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/updates.mdx
@@ -1,7 +1,7 @@
 ---
 title: Updates
-description: A library that allows programmatically controlling and responding to new updates made available to your app.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-updates'
+description: A library that enables your app to manage remote updates to your application code.
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-updates'
 packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
 platforms: ['android', 'ios', 'tvos']
@@ -10,102 +10,126 @@ platforms: ['android', 'ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
-import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
+import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
 
-The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
+`expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates.
 
-## Installation
+## Installation and configuration
+
+The `expo-updates` library can be automatically configured using [EAS Update](/eas-update/introduction/), which is a hosted service that manages and serves updates to your app. To get started with EAS Update, follow the instructions in the [Get started](/eas-update/getting-started/) guide.
+
+Alternatively, it is also possible to configure the `expo-updates` library manually in cases where a different remote update service is required or configuration is only specified in native files.
+
+<Collapsible summary="Manual installation and configuration">
 
 <APIInstallSection hideBareInstructions={true} />
 
-If you're installing this in a [bare React Native app](/bare/overview/), you should also follow these [additional installation instructions](/bare/installing-updates/).
+If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
-<ConfigReactNative>
+If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
+- [`updates.url`](/versions/latest/config/app/#updates): a URL of a remote service implementing the [Expo Updates protocol](/technical-specs/expo-updates-1/)
+- [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](/eas-update/runtime-versions/)
 
-Learn how to configure the native projects in the [installation instructions in the `expo-updates` repository](https://github.com/expo/expo/tree/main/packages/expo-updates#installation-in-bare-react-native-projects).
-
-</ConfigReactNative>
-
-## Usage
-
-Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
-
-**To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
-
-**To test manual updates with standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
-
-### Check for updates manually
-
-The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
-
-```jsx App.js
-import { View, Button } from 'react-native';
-import * as Updates from 'expo-updates';
-
-function App() {
-  async function onFetchUpdateAsync() {
-    try {
-      const update = await Updates.checkForUpdateAsync();
-
-      if (update.isAvailable) {
-        await Updates.fetchUpdateAsync();
-        await Updates.reloadAsync();
-      }
-    } catch (error) {
-      // You can also add an alert() to see the error message in case of an error when fetching updates.
-      alert(`Error fetching latest Expo update: ${error}`);
-    }
-  }
-
-  return (
-    <View>
-      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
-    </View>
-  );
-}
-```
-
-### Use `expo-updates` with a custom server
-
-Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).
+The remote service must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/). [EAS Update](/eas-update/introduction) implements this protocol for you, and it is also possible to use this library with a custom server.
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="You can find an example implementation of a custom server and an app using that server in this GitHub repository."
+  description="Example implementation of a custom server and an app using that server"
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />
 
-### Configuration options
+</Collapsible>
 
-There are build-time configuration options that control the behavior of `expo-updates`.
+### Additional configuration options
 
-On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.overrideConfiguration()`, and the provided values will override any value specified in **AndroidManifest.xml**.
+These are build-time configuration options that control the behavior of the library. For most apps, these configuration values can be set in the [app config](/workflow/configuration/) under the [`updates` property](/versions/latest/config/app/#updates).
 
-On iOS, these properties are set as keys in the **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController overrideConfigurationWithConfiguration:]` at any point before `expo-updates` is initialized, and the values in this dictionary will override any values specified in **Expo.plist**. If you tried to use the `EXUpdatesAppController` from the **AppDelegate.mm**, you will need to add the following imports:
+You can also configure the library in your app's native project files if your project does not use Continuous Native Generation. It is also possible to override the configuration from native code.
 
-```objc From Objective-C to import Swift headers for expo-updates
+<Collapsible summary="Native configuration instructions">
+
+On Android, these options are set as `meta-data` tags in the **AndroidManifest.xml** file (adjacent to the tags added during installation if auto-setup was used). You can also set or override them at runtime using `UpdatesController.overrideConfiguration()`.
+
+On iOS, these properties are set as keys in the **Expo.plist** file. You can also set or override them at runtime by calling `AppController.overrideConfiguration`.
+
+<Collapsible summary="Importing Swift generated headers for use in Objective-C++">
+
+If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports in order to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
+
+```objc
 #import "ExpoModulesCore-Swift.h"
 #import "EXUpdatesInterface-Swift.h"
 #import "EXUpdates-Swift.h"
 ```
 
-| iOS plist/dictionary key                                      | Android Map key                                      | Android meta-data name                                                          | Default                                                          | Required?   |
-| ------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `EXUpdatesEnabled`                                            | `enabled`                                            | `expo.modules.updates.ENABLED`                                                  | `true`                                                           | <NoIcon />  |
-| `EXUpdatesURL`                                                | `updateUrl`                                          | `expo.modules.updates.EXPO_UPDATE_URL`                                          | (none)                                                           | <YesIcon /> |
-| `EXUpdatesRequestHeaders`                                     | `requestHeaders`                                     | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY`                | (none)                                                           | <NoIcon />  |
-| `EXUpdatesRuntimeVersion`                                     | `runtimeVersion`                                     | `expo.modules.updates.EXPO_RUNTIME_VERSION`                                     | (none)                                                           | <YesIcon /> |
-| `EXUpdatesCheckOnLaunch`                                      | `checkOnLaunch`                                      | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`                             | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`) | <NoIcon />  |
-| `EXUpdatesLaunchWaitMs`                                       | `launchWaitMs`                                       | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`                              | `0`                                                              | <NoIcon />  |
-| `EXUpdatesCodeSigningCertificate`                             | `codeSigningCertificate`                             | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                                 | (none)                                                           | <NoIcon />  |
-| `EXUpdatesCodeSigningMetadata`                                | `codeSigningMetadata`                                | `expo.modules.updates.CODE_SIGNING_METADATA`                                    | (none)                                                           | <NoIcon />  |
-| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false                                                            | <NoIcon />  |
-| `EXUpdatesConfigCodeSigningAllowUnsignedManifests`            | `codeSigningAllowUnsignedManifests`                  | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS`                    | false                                                            | <NoIcon />  |
+</Collapsible>
 
-For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
+</Collapsible>
+
+| [App Config property](/versions/latest/config/app/#updates)                   | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
+|----------------------------------|----------|-------------|-----------------------------------|------------------------------------------------------------------|--------------------------|
+| `updates.enabled`                | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
+| `updates.url`                    | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
+| `updates.requestHeaders`         | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
+| `runtimeVersion`                 | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
+| `updates.checkAutomatically`     | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
+| `updates.fallbackToCacheTimeout` | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
+| `updates.codeSigningCertificate` | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
+| `updates.codeSigningMetadata`    | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+
+## Usage
+
+By default, `expo-updates` checks for updates when the app launches. If an update is available, it downloads the update and applies it the next time the app is restarted. You can tune this startup behavior using the `checkAutomatically` and `fallbackToCacheTimeout` configuration options above.
+
+The library also provides a variety of constants to inspect the current update and functions to customize update behavior from your application code (after startup). For example, one common alternative usage pattern is to manually check for updates after the app has started instead of doing the default check on launch.
+
+<Collapsible summary="Example: Check for updates manually">
+
+You can configure your app to check for updates manually by doing the following steps:
+1. Set the `checkAutomatically` configuration value to `ON_ERROR_RECOVERY` or `NEVER` to disable the library's default launch behavior.
+2. Add the following code to check for available updates, download them, and reload:
+
+    ```jsx App.js
+    import { View, Button } from 'react-native';
+    import * as Updates from 'expo-updates';
+
+    function App() {
+      async function onFetchUpdateAsync() {
+        try {
+          const update = await Updates.checkForUpdateAsync();
+
+          if (update.isAvailable) {
+            await Updates.fetchUpdateAsync();
+            await Updates.reloadAsync();
+          }
+        } catch (error) {
+          // You can also add an alert() to see the error message in case of an error when fetching updates.
+          alert(`Error fetching latest Expo update: ${error}`);
+        }
+      }
+
+      return (
+        <View>
+          <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+        </View>
+      );
+    }
+    ```
+
+</Collapsible>
+
+## Testing
+
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+
+**To test the content of an update in a development build**, run [`eas update`](/eas-update/publish/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
+
+**To test updates in a release build**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test). The full [Updates API](#api) is available in a release build.
+
+**To test the content of an update in Expo Go**, run [`eas update`](/eas-update/publish/) and then browse to the update in Expo Go. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in Expo Go. Also note that only updates using [Expo Go-compatible libraries](/workflow/using-libraries/#determining-third-party-library-compatibility) are supported.
 
 ## API
 
@@ -117,10 +141,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                    | Description                                                                                                                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_UPDATES_DISABLED`  | A method call was attempted when the Updates module was disabled, or the application was running in development mode                                                                                                                                          |
-| `ERR_UPDATES_RELOAD`    | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this module to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`     | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
-| `ERR_UPDATES_FETCH`     | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
-| `ERR_UPDATES_READ_LOGS` | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
+| Code                              | Description                                                                                                                                                                                                                                                   |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                          |
+| `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                           |

--- a/packages/expo-updates/DEVELOPMENT.md
+++ b/packages/expo-updates/DEVELOPMENT.md
@@ -27,10 +27,6 @@ If you are using expo-updates to test a server you're developing, you may want t
 
 You can do tell expo-updates to ignore the embedded bundle and force a remote update by setting `EXUpdatesHasEmbeddedUpdate` and `expo.modules.updates.HAS_EMBEDDED_UPDATE` to false.
 
-### New Manifest Format
-
-To test the new EAS update manifest format, set `EXUpdatesUsesLegacyManifest` and `expo.modules.updates.EXPO_LEGACY_MANIFEST` to false.
-
 ### Additional Headers
 
 If you want any additional headers to be sent in manifest requests, you can add these to a map under the key `EXUpdatesRequestHeaders` on iOS, or `requestHeaders` on Android (currently, this can't be configured in AndroidManifest.xml and you need to use the `UpdatesController.overrideConfiguration(Context context, Map<String, Object> configuration)` method in MainApplication.java).

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-The `expo-updates` module allows your app to download and manage remote updates to your application code.
+The `expo-updates` module enables your app to manage remote updates to your application code.
 
 This module works with a server that implements the [Expo Update protocol](https://docs.expo.dev/technical-specs/expo-updates-1/).
 


### PR DESCRIPTION
# Why

This roughly addresses https://exponent-internal.slack.com/archives/C013ZK4SA12/p1717105354880419?thread_ts=1717104096.294779&cid=C013ZK4SA12 and is a start to https://exponent-internal.slack.com/archives/C013ZK4SA12/p1717105539737579?thread_ts=1717104096.294779&cid=C013ZK4SA12.

It mainly addresses a few things:
- mentions EAS Update
- condenses the docs by putting optional things in `Collapsible`
- clarifies configuration (mainly that it can/should happen in app config most of the time)

This is in an effort to simplify the entry into using the library.

Plan to backport to 51 before merge.

# Test Plan

Read it over. Lots of proofreading is needed as this is a pretty significant overhaul.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
