### PR TITLE
[video][android] Fix "cover" and "fill" content fit

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `isLive` property on all platforms. ([#28903](https://github.com/expo/expo/pull/28903) by [@justjoostnl](https://github.com/justjoostnl))
 
 ### 🐛 Bug fixes
+
 - [Android] Fix wrong content fit "fill" and "cover". ([#29364](https://github.com/expo/expo/pull/29364) by [@RRaideRR](https://github.com/RRaideRR))
 
 ### 💡 Others

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `isLive` property on all platforms. ([#28903](https://github.com/expo/expo/pull/28903) by [@justjoostnl](https://github.com/justjoostnl))
 
 ### 🐛 Bug fixes
+- [Android] Fix wrong content fit "fill" and "cover". ([#29364](https://github.com/expo/expo/pull/29364) by [@RRaideRR](https://github.com/RRaideRR))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/ContentFit.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/ContentFit.kt
@@ -12,8 +12,8 @@ enum class ContentFit(val value: String) : Enumerable {
   fun toResizeMode(): Int {
     return when (this) {
       CONTAIN -> AspectRatioFrameLayout.RESIZE_MODE_FIT
-      FILL -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-      COVER -> AspectRatioFrameLayout.RESIZE_MODE_FILL
+      FILL -> AspectRatioFrameLayout.RESIZE_MODE_FILL
+      COVER -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
     }
   }
 }


### PR DESCRIPTION
# Why

https://discord.com/channels/695411232856997968/1234939321316802672/1246741858399424542

The content fit properties "fill" and "cover" are interchanged in the Android implementation. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

"cover" before
<img width="287" alt="cover-before" src="https://github.com/expo/expo/assets/3411292/5d422560-f10b-4238-bb92-d39557034e19">

"cover" after
<img width="291" alt="cover-after" src="https://github.com/expo/expo/assets/3411292/aadb1a95-5b3f-43c9-8efb-67c04313c3b3">

"cover" on iOS
<img width="223" alt="cover-ios" src="https://github.com/expo/expo/assets/3411292/a96c5b8c-153b-4bfe-8f6d-8500b9c4dd03">


"fill" before
<img width="287" alt="fill-before" src="https://github.com/expo/expo/assets/3411292/a7c84fff-222b-418d-a051-6dc23c7a1ed7">

"fill" after
<img width="292" alt="fill-after" src="https://github.com/expo/expo/assets/3411292/6317d5f3-6744-465a-99f3-d3a7aec03b1f">

"fill" on iOS
<img width="228" alt="fill-ios" src="https://github.com/expo/expo/assets/3411292/f96c28b1-5a0c-47c1-a6fc-10ef162db9ad">

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
