### PR TITLE
[docs] API Reference rendering tweaks and fixes

### DIFF
--- a/docs/common/headingManager.ts
+++ b/docs/common/headingManager.ts
@@ -93,7 +93,8 @@ export class HeadingManager {
     this._meta = meta;
     this._headings = [];
 
-    const maxHeadingDepth = meta.maxHeadingDepth ?? DEFAULT_NESTING_LIMIT;
+    const maxHeadingDepth =
+      (meta.maxHeadingDepth ?? DEFAULT_NESTING_LIMIT) + (meta.packageName ? 1 : 0);
     this._maxNestingLevel = maxHeadingDepth + BASE_HEADING_LEVEL;
   }
 

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -13,7 +13,7 @@ import { CALLOUT } from '~/ui/components/Text';
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
 const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;
 
-const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 10;
+const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 20;
 
 const isDynamicScrollAvailable = () => {
   return !window.matchMedia('(prefers-reduced-motion)').matches;
@@ -84,7 +84,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
       <nav className="pt-14 pb-12 px-6 w-[280px]" data-sidebar>
         <CALLOUT
           weight="medium"
-          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none">
+          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
           <LayoutAlt03Icon className="icon-sm" /> On this page
           <Button
             theme="quaternary"
@@ -147,7 +147,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
 
     this.props.contentRef?.current?.getScrollRef().current?.scrollTo({
       behavior: isDynamicScrollAvailable() ? 'smooth' : 'instant',
-      top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR,
+      top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR - 28,
     });
 
     if (history?.replaceState) {

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
     data-sidebar="true"
   >
     <p
-      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none css-1t1p06f-TextComponent"
+      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
       data-text="true"
     >
       <svg

--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -30,8 +30,8 @@ describe('APISection', () => {
       />
     );
 
-    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(6);
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(25);
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(5);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(24);
     expect(screen.getAllByRole('table')).toHaveLength(11);
 
     expect(screen.queryByText('Event Subscriptions'));
@@ -58,8 +58,8 @@ describe('APISection', () => {
       />
     );
 
-    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(7);
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(19);
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(6);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(18);
 
     expect(screen.queryByText('Components'));
     expect(screen.queryByText('Hooks'));

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -13,7 +13,7 @@ import APISectionProps from '~/components/plugins/api/APISectionProps';
 import APISectionTypes from '~/components/plugins/api/APISectionTypes';
 import {
   getCommentContent,
-  getComponentName,
+  getPossibleComponentPropsNames,
   TypeDocKind,
 } from '~/components/plugins/api/APISectionUtils';
 import { usePageApiVersion } from '~/providers/page-api-version';
@@ -196,9 +196,10 @@ const renderAPI = (
       [TypeDocKind.Variable, TypeDocKind.Class, TypeDocKind.Function],
       entry => isComponent(entry)
     );
-    const componentsPropNames = components.map(
-      ({ name, children }) => `${getComponentName(name, children)}Props`
-    );
+    const componentsPropNames = components
+      .map(({ name, children }) => getPossibleComponentPropsNames(name, children))
+      .flat();
+
     const componentsProps = filterDataByKind(
       props,
       [TypeDocKind.TypeAlias, TypeDocKind.TypeAlias_Legacy, TypeDocKind.Interface],

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -91,7 +91,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <span
@@ -117,7 +117,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -128,7 +128,7 @@ available via the provided properties.
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -164,7 +164,7 @@ a warning in development mode (
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       The properties of this component extend from 
@@ -218,14 +218,14 @@ button.
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
     </p>
     <blockquote
-      class="css-zknray-Callout"
+      class="!mb-3.5 css-zknray-Callout"
       data-testid="callout-container"
     >
       <div
@@ -254,7 +254,7 @@ not appear on the screen.
         class="css-1ohc0ia-Callout"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -277,51 +277,57 @@ for more details.
         </p>
       </div>
     </blockquote>
-    <h2
-      class="group css-13sdfl0-TextComponent"
-      data-heading="true"
-    >
-      <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
-        href="#props"
-        id="props"
+    <div>
+      <div
+        class="css-1mhr9hc-APISectionProps"
       >
-        <span
-          class="inline"
+        <h4
+          class="group css-1725pab-TextComponent"
+          data-heading="true"
         >
-          Props
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h2>
+          <a
+            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            href="#appleauthenticationbuttonprops"
+            id="appleauthenticationbuttonprops"
+          >
+            <span
+              class="inline"
+            >
+              AppleAuthenticationButtonProps
+            </span>
+            <svg
+              aria-label="permalink"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h4>
+      </div>
+    </div>
     <div
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -336,7 +342,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 buttonStyle
@@ -344,7 +350,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -369,7 +375,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -391,14 +397,14 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -413,7 +419,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 buttonType
@@ -421,7 +427,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -446,7 +452,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -468,14 +474,14 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -490,7 +496,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 cornerRadius
@@ -498,7 +504,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -523,7 +529,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -545,7 +551,7 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
@@ -560,7 +566,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -575,7 +581,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 onPress
@@ -583,7 +589,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -608,7 +614,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -636,7 +642,7 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -656,7 +662,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -671,7 +677,7 @@ in here.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 style
@@ -679,7 +685,7 @@ in here.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -704,7 +710,7 @@ in here.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -784,7 +790,7 @@ in here.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
@@ -805,8 +811,8 @@ in here.
 properties.
         </p>
       </div>
-      <h3
-        class="group css-nikr5x-TextComponent"
+      <h4
+        class="group css-1725pab-TextComponent"
         data-heading="true"
       >
         <a
@@ -821,7 +827,7 @@ properties.
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -844,7 +850,7 @@ properties.
             />
           </svg>
         </a>
-      </h3>
+      </h4>
       <ul
         class="css-118jp6n-TextComponent"
       >
@@ -910,7 +916,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -970,17 +976,17 @@ properties.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -1013,7 +1019,7 @@ properties.
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
@@ -1038,7 +1044,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1077,7 +1083,7 @@ This should come from the user field of an
         
 
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -1091,21 +1097,14 @@ This should come from the user field of an
 
       </div>
     </blockquote>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1124,6 +1123,17 @@ This should come from the user field of an
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -1155,31 +1165,34 @@ This should come from the user field of an
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A promise that fulfills with an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationcredentialstate"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        <code
-          class="css-qyuze8-TextComponent"
-          data-text="true"
+        A promise that fulfills with an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationcredentialstate"
         >
-          AppleAuthenticationCredentialState
-        </code>
-      </a>
-      
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            AppleAuthenticationCredentialState
+          </code>
+        </a>
+        
 value depending on the state of the credential.
-    </p>
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -1227,26 +1240,19 @@ value depending on the state of the credential.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1265,6 +1271,17 @@ value depending on the state of the credential.
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -1291,32 +1308,35 @@ value depending on the state of the credential.
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A promise that fulfills with 
-      <code
-        class="css-qyuze8-TextComponent"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
-        true
-      </code>
-       if the system supports Apple authentication, and 
-      <code
-        class="css-qyuze8-TextComponent"
-        data-text="true"
-      >
-        false
-      </code>
-       otherwise.
-    </p>
+        A promise that fulfills with 
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          true
+        </code>
+         if the system supports Apple authentication, and 
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          false
+        </code>
+         otherwise.
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -1376,17 +1396,17 @@ value depending on the state of the credential.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -1424,7 +1444,7 @@ value depending on the state of the credential.
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An 
@@ -1448,27 +1468,20 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
 Calling this method will show the sign in modal before actually refreshing the user credentials.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1487,6 +1500,17 @@ Calling this method will show the sign in modal before actually refreshing the u
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -1518,39 +1542,42 @@ Calling this method will show the sign in modal before actually refreshing the u
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A promise that fulfills with an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationcredential"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
+        A promise that fulfills with an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationcredential"
+        >
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            AppleAuthenticationCredential
+          </code>
+        </a>
+        
+object after a successful authentication, and rejects with 
         <code
           class="css-qyuze8-TextComponent"
           data-text="true"
         >
-          AppleAuthenticationCredential
+          ERR_REQUEST_CANCELED
         </code>
-      </a>
-      
-object after a successful authentication, and rejects with 
-      <code
-        class="css-qyuze8-TextComponent"
-        data-text="true"
-      >
-        ERR_REQUEST_CANCELED
-      </code>
-       if the user cancels the
+         if the user cancels the
 refresh operation.
-    </p>
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -1610,17 +1637,17 @@ refresh operation.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -1664,7 +1691,7 @@ refresh operation.
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An optional 
@@ -1688,7 +1715,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1697,7 +1724,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1707,7 +1734,7 @@ of these options at runtime.
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1735,21 +1762,14 @@ You can use
        to identify
 the user, since this remains the same for apps released by the same developer.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1768,6 +1788,17 @@ the user, since this remains the same for apps released by the same developer.
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -1799,39 +1830,42 @@ the user, since this remains the same for apps released by the same developer.
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A promise that fulfills with an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationcredential"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
+        A promise that fulfills with an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationcredential"
+        >
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            AppleAuthenticationCredential
+          </code>
+        </a>
+        
+object after a successful authentication, and rejects with 
         <code
           class="css-qyuze8-TextComponent"
           data-text="true"
         >
-          AppleAuthenticationCredential
+          ERR_REQUEST_CANCELED
         </code>
-      </a>
-      
-object after a successful authentication, and rejects with 
-      <code
-        class="css-qyuze8-TextComponent"
-        data-text="true"
-      >
-        ERR_REQUEST_CANCELED
-      </code>
-       if the user cancels the
+         if the user cancels the
 sign-in operation.
-    </p>
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -1891,17 +1925,17 @@ sign-in operation.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -1939,7 +1973,7 @@ sign-in operation.
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An 
@@ -1963,7 +1997,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -1972,7 +2006,7 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2003,21 +2037,14 @@ from using
       </a>
        methods.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -2036,6 +2063,17 @@ from using
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -2067,36 +2105,39 @@ from using
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A promise that fulfills with an 
-      <a
-        class="css-1na8e0o-A"
-        href="#appleauthenticationcredential"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
+        A promise that fulfills with an 
+        <a
+          class="css-1na8e0o-A"
+          href="#appleauthenticationcredential"
+        >
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            AppleAuthenticationCredential
+          </code>
+        </a>
+        
+object after a successful authentication, and rejects with 
         <code
           class="css-qyuze8-TextComponent"
           data-text="true"
         >
-          AppleAuthenticationCredential
+          ERR_REQUEST_CANCELED
         </code>
-      </a>
-      
-object after a successful authentication, and rejects with 
-      <code
-        class="css-qyuze8-TextComponent"
-        data-text="true"
-      >
-        ERR_REQUEST_CANCELED
-      </code>
-       if the user cancels the
+         if the user cancels the
 sign-out operation.
-    </p>
+      </p>
+    </div>
   </div>
   <h2
     class="group css-13sdfl0-TextComponent"
@@ -2139,7 +2180,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -2199,19 +2240,14 @@ sign-out operation.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
-            </th>
-            <th
-              class="css-14twqd4-HeaderCell"
-            >
-              Description
             </th>
           </tr>
         </thead>
@@ -2244,35 +2280,19 @@ sign-out operation.
                 void
               </code>
             </td>
-            <td
-              class="css-zstkv9-Cell"
-            >
-              <span
-                class="text-quaternary"
-              >
-                -
-              </span>
-            </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start mb-3.5"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -2291,15 +2311,25 @@ sign-out operation.
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           EventSubscription
         </code>
-      </li>
-    </ul>
-    <br />
+      </p>
+    </div>
   </div>
   <h2
     class="group css-13sdfl0-TextComponent"
@@ -2342,7 +2372,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -2390,7 +2420,7 @@ sign-out operation.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2434,7 +2464,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="css-zknray-Callout"
+      class="!mb-3.5 css-zknray-Callout"
       data-testid="callout-container"
     >
       <div
@@ -2463,7 +2493,7 @@ which contains all of the pertinent user and credential information.
         class="css-1ohc0ia-Callout"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -2499,17 +2529,17 @@ for more details.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -2552,7 +2582,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
@@ -2603,7 +2633,7 @@ the app's server counterpart. Unlike
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
@@ -2661,7 +2691,7 @@ an Apple domain.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The user's name. May be 
@@ -2727,7 +2757,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -2765,7 +2795,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -2808,7 +2838,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
@@ -2865,7 +2895,7 @@ will be
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -2880,7 +2910,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -2928,7 +2958,7 @@ developers.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
@@ -2954,17 +2984,17 @@ may be
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -3228,7 +3258,7 @@ may be
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -3276,7 +3306,7 @@ may be
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3295,7 +3325,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="css-zknray-Callout"
+      class="!mb-3.5 css-zknray-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3324,7 +3354,7 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="css-1ohc0ia-Callout"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -3360,17 +3390,17 @@ for more details.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -3415,7 +3445,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
@@ -3479,7 +3509,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3535,7 +3565,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -3583,7 +3613,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3602,7 +3632,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="css-zknray-Callout"
+      class="!mb-3.5 css-zknray-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3631,7 +3661,7 @@ None of these options are required.
         class="css-1ohc0ia-Callout"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -3667,17 +3697,17 @@ for more details.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -3716,7 +3746,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
@@ -3771,7 +3801,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
@@ -3835,7 +3865,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3859,7 +3889,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -3907,7 +3937,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3926,7 +3956,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="css-zknray-Callout"
+      class="!mb-3.5 css-zknray-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3955,7 +3985,7 @@ You must include the ID string of the user to sign out.
         class="css-1ohc0ia-Callout"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <strong
@@ -3991,17 +4021,17 @@ for more details.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -4040,7 +4070,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4096,7 +4126,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -4144,7 +4174,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -4162,17 +4192,17 @@ OAuth 2.0 protocol
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -4216,7 +4246,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -4269,7 +4299,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -4320,7 +4350,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4338,10 +4368,15 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationButtonStyle Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationButtonStyle Values
+        </span>
       </p>
     </div>
     <div
@@ -4399,7 +4434,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         White button with black text.
@@ -4460,7 +4495,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4521,7 +4556,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         Black button with white text.
@@ -4529,7 +4564,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -4580,7 +4615,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
@@ -4598,10 +4633,15 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationButtonType Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationButtonType Values
+        </span>
       </p>
     </div>
     <div
@@ -4659,7 +4699,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4720,7 +4760,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         "Continue with Apple"
@@ -4824,7 +4864,7 @@ After calling this function, the listener will no longer receive any events from
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         "Sign up with Apple"
@@ -4832,7 +4872,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -4883,7 +4923,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
@@ -4901,7 +4941,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="css-zknray-Callout"
+        class="!mb-3.5 css-zknray-Callout"
         data-testid="callout-container"
       >
         <div
@@ -4930,7 +4970,7 @@ After calling this function, the listener will no longer receive any events from
           class="css-1ohc0ia-Callout"
         >
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             <strong
@@ -4954,10 +4994,15 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationCredentialState Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationCredentialState Values
+        </span>
       </p>
     </div>
     <div
@@ -5182,7 +5227,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -5233,10 +5278,15 @@ for more details.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationOperation Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationOperation Values
+        </span>
       </p>
     </div>
     <div
@@ -5294,7 +5344,7 @@ for more details.
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5467,7 +5517,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -5518,7 +5568,7 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
@@ -5569,7 +5619,7 @@ for more details.
           
 
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -5580,7 +5630,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="css-zknray-Callout"
+        class="!mb-3.5 css-zknray-Callout"
         data-testid="callout-container"
       >
         <div
@@ -5609,7 +5659,7 @@ You will still need to handle null values for any fields you request.
           class="css-1ohc0ia-Callout"
         >
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             <strong
@@ -5633,10 +5683,15 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationScope Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationScope Values
+        </span>
       </p>
     </div>
     <div
@@ -5751,7 +5806,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -5802,13 +5857,13 @@ for more details.
         </a>
       </h3>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="css-zknray-Callout"
+        class="!mb-3.5 css-zknray-Callout"
         data-testid="callout-container"
       >
         <div
@@ -5837,7 +5892,7 @@ for more details.
           class="css-1ohc0ia-Callout"
         >
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             <strong
@@ -5861,10 +5916,15 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        AppleAuthenticationUserDetectionStatus Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          AppleAuthenticationUserDetectionStatus Values
+        </span>
       </p>
     </div>
     <div
@@ -5922,7 +5982,7 @@ for more details.
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -5983,7 +6043,7 @@ for more details.
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6044,7 +6104,7 @@ for more details.
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6097,7 +6157,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <div
       class="css-1avgxs7-APISectionDeprecationNote"
@@ -6132,7 +6192,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="css-1ohc0ia-Callout"
         >
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             <strong
@@ -6222,7 +6282,7 @@ for more details.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <span
@@ -6258,51 +6318,57 @@ for more details.
         </span>
       </code>
     </p>
-    <h2
-      class="group css-13sdfl0-TextComponent"
-      data-heading="true"
-    >
-      <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
-        href="#props"
-        id="props"
+    <div>
+      <div
+        class="css-1mhr9hc-APISectionProps"
       >
-        <span
-          class="inline"
+        <h4
+          class="group css-1725pab-TextComponent"
+          data-heading="true"
         >
-          Props
-        </span>
-        <svg
-          aria-label="permalink"
-          class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-          <path
-            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-            stroke="#9B9B9B"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-          />
-        </svg>
-      </a>
-    </h2>
+          <a
+            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            href="#barcodescannerprops"
+            id="barcodescannerprops"
+          >
+            <span
+              class="inline"
+            >
+              BarCodeScannerProps
+            </span>
+            <svg
+              aria-label="permalink"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </a>
+        </h4>
+      </div>
+    </div>
     <div
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -6317,7 +6383,7 @@ for more details.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 barCodeTypes
@@ -6325,7 +6391,7 @@ for more details.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6350,7 +6416,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -6372,7 +6438,7 @@ for more details.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           An array of bar code types. Usage: 
@@ -6404,7 +6470,7 @@ minimize battery usage.
         
 
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           For example: 
@@ -6418,7 +6484,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -6433,7 +6499,7 @@ minimize battery usage.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6441,7 +6507,7 @@ minimize battery usage.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6466,7 +6532,7 @@ minimize battery usage.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -6493,7 +6559,7 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
@@ -6540,7 +6606,7 @@ provided with an
             
 
             <p
-              class="mb-4 css-1kfqm4n-TextComponent"
+              class="mb-3.5 css-1kfqm4n-TextComponent"
               data-text="true"
             >
               <strong
@@ -6572,7 +6638,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-uj1dnj"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
       >
         <h3
           class="group css-nikr5x-TextComponent"
@@ -6587,7 +6653,7 @@ data has been retrieved.
               class="inline"
             >
               <code
-                class="wrap-anywhere css-s0csg4-TextComponent"
+                class="wrap-anywhere css-1odgxmq-TextComponent"
                 data-text="true"
               >
                 type
@@ -6595,7 +6661,7 @@ data has been retrieved.
             </span>
             <svg
               aria-label="permalink"
-              class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+              class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
               fill="none"
               height="24"
               viewBox="0 0 24 24"
@@ -6620,7 +6686,7 @@ data has been retrieved.
           </a>
         </h3>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <span
@@ -6674,7 +6740,7 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           Camera facing. Use one of 
@@ -6709,8 +6775,8 @@ Same as
           .
         </p>
       </div>
-      <h3
-        class="group css-nikr5x-TextComponent"
+      <h4
+        class="group css-1725pab-TextComponent"
         data-heading="true"
       >
         <a
@@ -6725,7 +6791,7 @@ Same as
           </span>
           <svg
             aria-label="permalink"
-            class="icon-md inline-flex invisible group-hover:visible group-focus-visible:visible"
+            class="inline-flex invisible group-hover:visible group-focus-visible:visible icon-sm"
             fill="none"
             height="24"
             viewBox="0 0 24 24"
@@ -6748,7 +6814,7 @@ Same as
             />
           </svg>
         </a>
-      </h3>
+      </h4>
       <ul
         class="css-118jp6n-TextComponent"
       >
@@ -6814,7 +6880,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -6874,19 +6940,14 @@ Same as
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
-            </th>
-            <th
-              class="css-14twqd4-HeaderCell"
-            >
-              Description
             </th>
           </tr>
         </thead>
@@ -6937,22 +6998,13 @@ Same as
                 </span>
               </code>
             </td>
-            <td
-              class="css-zstkv9-Cell"
-            >
-              <span
-                class="text-quaternary"
-              >
-                -
-              </span>
-            </td>
           </tr>
         </tbody>
       </table>
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Check or request permissions for the barcode scanner.
@@ -6972,93 +7024,14 @@ This uses both
       </code>
        to interact with the permissions.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start mb-3.5"
     >
-      Example
-    </p>
-    <pre
-      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
-      data-text="true"
-    >
-      <code
-        class="css-dpez7n-Code"
-      >
-        <span
-          class="token keyword"
-        >
-          const
-        </span>
-         
-        <span
-          class="token punctuation"
-        >
-          [
-        </span>
-        permissionResponse
-        <span
-          class="token punctuation"
-        >
-          ,
-        </span>
-         requestPermission
-        <span
-          class="token punctuation"
-        >
-          ]
-        </span>
-         
-        <span
-          class="token operator"
-        >
-          =
-        </span>
-         BarCodeScanner
-        <span
-          class="token punctuation"
-        >
-          .
-        </span>
-        <span
-          class="token function"
-        >
-          usePermissions
-        </span>
-        <span
-          class="token punctuation"
-        >
-          (
-        </span>
-        <span
-          class="token punctuation"
-        >
-          )
-        </span>
-        <span
-          class="token punctuation"
-        >
-          ;
-        </span>
-        
-
-      </code>
-    </pre>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
-    >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7077,6 +7050,17 @@ This uses both
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -7146,9 +7130,109 @@ This uses both
           </span>
           ]
         </code>
-      </li>
-    </ul>
-    <br />
+      </p>
+    </div>
+    <div
+      class="mb-3.5"
+    >
+      <p
+        class="!mt-1 css-1xg9efr-BoxSectionHeader"
+        data-text="true"
+      >
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          <svg
+            class="icon-sm text-icon-secondary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              id="code-square-01-outline-icon"
+            >
+              <path
+                d="M14.5 15L17.5 12L14.5 9M9.5 9L6.5 12L9.5 15M7.8 21H16.2C17.8802 21 18.7202 21 19.362 20.673C19.9265 20.3854 20.3854 19.9265 20.673 19.362C21 18.7202 21 17.8802 21 16.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V16.2C3 17.8802 3 18.7202 3.32698 19.362C3.6146 19.9265 4.07354 20.3854 4.63803 20.673C5.27976 21 6.11984 21 7.8 21Z"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+          Example
+        </span>
+      </p>
+      <pre
+        class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+        data-text="true"
+      >
+        <code
+          class="css-dpez7n-Code"
+        >
+          <span
+            class="token keyword"
+          >
+            const
+          </span>
+           
+          <span
+            class="token punctuation"
+          >
+            [
+          </span>
+          permissionResponse
+          <span
+            class="token punctuation"
+          >
+            ,
+          </span>
+           requestPermission
+          <span
+            class="token punctuation"
+          >
+            ]
+          </span>
+           
+          <span
+            class="token operator"
+          >
+            =
+          </span>
+           BarCodeScanner
+          <span
+            class="token punctuation"
+          >
+            .
+          </span>
+          <span
+            class="token function"
+          >
+            usePermissions
+          </span>
+          <span
+            class="token punctuation"
+          >
+            (
+          </span>
+          <span
+            class="token punctuation"
+          >
+            )
+          </span>
+          <span
+            class="token punctuation"
+          >
+            ;
+          </span>
+          
+
+        </code>
+      </pre>
+    </div>
   </div>
   <h2
     class="group css-13sdfl0-TextComponent"
@@ -7191,7 +7275,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -7239,26 +7323,19 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7277,6 +7354,17 @@ This uses both
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -7308,30 +7396,33 @@ This uses both
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      Return a promise that fulfills to an object of type 
-      <a
-        class="css-1na8e0o-A"
-        href="#permissionresponse"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        <code
-          class="css-qyuze8-TextComponent"
-          data-text="true"
+        Return a promise that fulfills to an object of type 
+        <a
+          class="css-1na8e0o-A"
+          href="#permissionresponse"
         >
-          PermissionResponse
-        </code>
-      </a>
-      .
-    </p>
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            PermissionResponse
+          </code>
+        </a>
+        .
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -7379,7 +7470,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
@@ -7387,7 +7478,7 @@ This uses both
     
 
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       On iOS this will require apps to specify the 
@@ -7406,21 +7497,14 @@ This uses both
       </code>
       .
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7439,6 +7523,17 @@ This uses both
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -7470,30 +7565,33 @@ This uses both
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      Return a promise that fulfills to an object of type 
-      <a
-        class="css-1na8e0o-A"
-        href="#permissionresponse"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        <code
-          class="css-qyuze8-TextComponent"
-          data-text="true"
+        Return a promise that fulfills to an object of type 
+        <a
+          class="css-1na8e0o-A"
+          href="#permissionresponse"
         >
-          PermissionResponse
-        </code>
-      </a>
-      .
-    </p>
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
+          >
+            PermissionResponse
+          </code>
+        </a>
+        .
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -7553,17 +7651,17 @@ This uses both
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -7596,7 +7694,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 URL to get the image from.
@@ -7635,7 +7733,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 An array of bar code types. Defaults to all supported bar code types on
@@ -7675,7 +7773,7 @@ the platform.
                   
 
                   <p
-                    class="mb-4 css-1kfqm4n-TextComponent"
+                    class="mb-3.5 css-1kfqm4n-TextComponent"
                     data-text="true"
                   >
                     <strong
@@ -7696,26 +7794,19 @@ the platform.
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7734,6 +7825,17 @@ the platform.
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -7766,24 +7868,27 @@ the platform.
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      A possibly empty array of objects of the 
-      <code
-        class="css-qyuze8-TextComponent"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
-        BarCodeScannerResult
-      </code>
-       shape, where the type
+        A possibly empty array of objects of the 
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          BarCodeScannerResult
+        </code>
+         shape, where the type
 refers to the bar code type that was scanned and the data is the information encoded in the bar
 code.
-    </p>
+      </p>
+    </div>
   </div>
   <h2
     class="group css-13sdfl0-TextComponent"
@@ -7826,7 +7931,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -7874,16 +7979,21 @@ code.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-wrgtfc-BoxSectionHeader"
+      class="css-1xg9efr-BoxSectionHeader"
       data-text="true"
     >
-      PermissionResponse Properties
+      <span
+        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        data-text="true"
+      >
+        PermissionResponse Properties
+      </span>
     </p>
     <div
       class="css-1uyflf8-Table"
@@ -7898,17 +8008,17 @@ code.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -7941,7 +8051,7 @@ code.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -7981,7 +8091,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -8014,7 +8124,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -8052,7 +8162,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -8105,7 +8215,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8165,17 +8275,17 @@ in order to enable/disable the permission.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -8213,7 +8323,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The origin point of the bounding box.
@@ -8251,7 +8361,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The size of the bounding box.
@@ -8263,7 +8373,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8311,11 +8421,11 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-1kfqm4n-TextComponent"
+      class="css-1ac5bb0-TextComponent"
       data-text="true"
     >
       <code
-        class="css-ite7ne-TextComponent"
+        class="text-default css-ite7ne-TextComponent"
         data-text="true"
       >
         <a
@@ -8343,17 +8453,17 @@ in order to enable/disable the permission.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -8403,7 +8513,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8463,17 +8573,17 @@ in order to enable/disable the permission.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -8522,7 +8632,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8570,7 +8680,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -8589,17 +8699,17 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -8632,7 +8742,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The 
@@ -8672,7 +8782,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The 
@@ -8691,7 +8801,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8753,19 +8863,14 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-190f936-Row"
             >
               <th
-                class="css-14twqd4-HeaderCell"
+                class="css-17s7rsv-HeaderCell"
               >
                 Name
               </th>
               <th
-                class="css-14twqd4-HeaderCell"
+                class="css-17s7rsv-HeaderCell"
               >
                 Type
-              </th>
-              <th
-                class="css-14twqd4-HeaderCell"
-              >
-                Description
               </th>
             </tr>
           </thead>
@@ -8797,15 +8902,6 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                   </a>
                 </code>
               </td>
-              <td
-                class="css-zstkv9-Cell"
-              >
-                <span
-                  class="text-quaternary"
-                >
-                  -
-                </span>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -8813,7 +8909,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -8873,17 +8969,17 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -8921,7 +9017,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The 
@@ -8984,7 +9080,7 @@ For some types, they will represent the area used by the scanner.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Corner points of the bounding box.
@@ -9040,7 +9136,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The parsed information encoded in the bar code.
@@ -9073,7 +9169,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The barcode type.
@@ -9085,7 +9181,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -9145,17 +9241,17 @@ you don't get this value.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -9188,7 +9284,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The height value.
@@ -9221,7 +9317,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 The width value.
@@ -9233,7 +9329,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -9285,7 +9381,7 @@ you don't get this value.
       data-text="true"
     >
       <span
-        class="css-oecriz-TextComponent"
+        class="css-1mm9j88-TextComponent"
         data-text="true"
       >
         Literal Type:
@@ -9297,8 +9393,13 @@ you don't get this value.
       class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
-      Acceptable values are:
-       
+      <span
+        class="css-1mm9j88-TextComponent"
+        data-text="true"
+      >
+        Acceptable values are:
+         
+      </span>
       <span>
         <code
           class="css-ite7ne-TextComponent"
@@ -9364,7 +9465,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -9415,10 +9516,15 @@ you don't get this value.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        PermissionStatus Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          PermissionStatus Values
+        </span>
       </p>
     </div>
     <div
@@ -9476,7 +9582,7 @@ you don't get this value.
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User has denied the permission.
@@ -9537,7 +9643,7 @@ you don't get this value.
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User has granted the permission.
@@ -9598,7 +9704,7 @@ you don't get this value.
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -9651,7 +9757,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -9699,26 +9805,19 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start mb-3.5"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -9737,6 +9836,17 @@ exports[`APISection expo-pedometer 1`] = `
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -9768,12 +9878,11 @@ exports[`APISection expo-pedometer 1`] = `
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -9876,17 +9985,17 @@ exports[`APISection expo-pedometer 1`] = `
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -9926,7 +10035,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -9966,7 +10075,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -9978,26 +10087,19 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Get the step count between two dates.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -10016,6 +10118,17 @@ exports[`APISection expo-pedometer 1`] = `
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -10047,91 +10160,94 @@ exports[`APISection expo-pedometer 1`] = `
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      Returns a promise that fulfills with a 
-      <a
-        class="css-1na8e0o-A"
-        href="#pedometerresult"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        <code
-          class="css-qyuze8-TextComponent"
-          data-text="true"
+        Returns a promise that fulfills with a 
+        <a
+          class="css-1na8e0o-A"
+          href="#pedometerresult"
         >
-          PedometerResult
-        </code>
-      </a>
-      .
-    </p>
-    
-
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
-    >
-      As 
-      <a
-        class="css-1na8e0o-A"
-        href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Apple documentation states
-      </a>
-      :
-    </p>
-    
-
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            id="info-circle-solid-icon"
+          <code
+            class="css-qyuze8-TextComponent"
+            data-text="true"
           >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1ohc0ia-Callout"
+            PedometerResult
+          </code>
+        </a>
+        .
+      </p>
+      
+
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
+        data-text="true"
       >
-        
-
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
+        As 
+        <a
+          class="css-1na8e0o-A"
+          href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          Only the past seven days worth of data is stored and available for you to retrieve. Specifying
-a start date that is more than seven days in the past returns only the available data.
-        </p>
-        
+          Apple documentation states
+        </a>
+        :
+      </p>
+      
 
-      </div>
-    </blockquote>
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
+        >
+          <svg
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="css-1ohc0ia-Callout"
+        >
+          
+
+          <p
+            class="mb-3.5 css-1kfqm4n-TextComponent"
+            data-text="true"
+          >
+            Only the past seven days worth of data is stored and available for you to retrieve. Specifying
+a start date that is more than seven days in the past returns only the available data.
+          </p>
+          
+
+        </div>
+      </blockquote>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -10179,26 +10295,19 @@ a start date that is more than seven days in the past returns only the available
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -10217,6 +10326,17 @@ a start date that is more than seven days in the past returns only the available
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -10243,26 +10363,29 @@ a start date that is more than seven days in the past returns only the available
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      Returns a promise that fulfills with a 
-      <code
-        class="css-qyuze8-TextComponent"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
-        boolean
-      </code>
-      , indicating whether the pedometer is
+        Returns a promise that fulfills with a 
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          boolean
+        </code>
+        , indicating whether the pedometer is
 available on this device.
-    </p>
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -10310,26 +10433,19 @@ available on this device.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start mb-3.5"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -10348,6 +10464,17 @@ available on this device.
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
@@ -10379,12 +10506,11 @@ available on this device.
             &gt;
           </span>
         </code>
-      </li>
-    </ul>
-    <br />
+      </p>
+    </div>
   </div>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -10444,17 +10570,17 @@ available on this device.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -10492,7 +10618,7 @@ available on this device.
               class="css-zstkv9-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
@@ -10517,26 +10643,19 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Subscribe to pedometer updates.
     </p>
-    <p
-      class="css-wrgtfc-BoxSectionHeader"
-      data-text="true"
+    <div
+      class="flex flex-row gap-2 items-start"
     >
-      Returns
-    </p>
-    <ul
-      class="!list-none !ml-0 css-118jp6n-TextComponent"
-    >
-      <li
-        class="css-1hxzfrf-TextComponent"
-        data-text="true"
+      <div
+        class="flex flex-row gap-2 items-center"
       >
         <svg
-          class="inline-block icon-sm text-icon-secondary align-middle mr-2"
+          class="inline-block icon-sm text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -10555,107 +10674,121 @@ provided with a single argument that is
             />
           </g>
         </svg>
+        <span
+          class="css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          Returns:
+        </span>
+      </div>
+      <p
+        class="css-1yjys1n-TextComponent"
+        data-text="true"
+      >
         <code
           class="[&>span]:!text-inherit css-ite7ne-TextComponent"
           data-text="true"
         >
           EventSubscription
         </code>
-      </li>
-    </ul>
-    <br />
-    <p
-      class="mb-4 css-1kfqm4n-TextComponent"
-      data-text="true"
+      </p>
+    </div>
+    <div
+      class="flex flex-col mt-1.5 mb-1 pl-6"
     >
-      Returns a 
-      <a
-        class="css-1na8e0o-A"
-        href="#subscription"
-      >
-        <code
-          class="css-qyuze8-TextComponent"
-          data-text="true"
-        >
-          Subscription
-        </code>
-      </a>
-       that enables you to call
-
-      <code
-        class="css-qyuze8-TextComponent"
+      <p
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
-        remove()
-      </code>
-       when you would like to unsubscribe the listener.
-    </p>
-    
-
-    <blockquote
-      class="css-zknray-Callout"
-      data-testid="callout-container"
-    >
-      <div
-        class="css-7jywx8-Callout"
-      >
-        <svg
-          class="icon-sm text-icon-default"
-          fill="currentColor"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        Returns a 
+        <a
+          class="css-1na8e0o-A"
+          href="#subscription"
         >
-          <g
-            id="info-circle-solid-icon"
-          >
-            <path
-              clip-rule="evenodd"
-              d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-              fill-rule="evenodd"
-              id="Solid"
-            />
-          </g>
-        </svg>
-      </div>
-      <div
-        class="css-1ohc0ia-Callout"
-      >
-        
-
-        <p
-          class="mb-4 css-1kfqm4n-TextComponent"
-          data-text="true"
-        >
-          Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
-
-          <a
-            class="css-1na8e0o-A"
-            href="https://developer.android.com/health-and-fitness/guides/health-connect"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <code
-              class="css-qyuze8-TextComponent"
-              data-text="true"
-            >
-              Health Connect API
-            </code>
-          </a>
-          .
-On iOS, the 
           <code
             class="css-qyuze8-TextComponent"
             data-text="true"
           >
-            getStepCountAsync
+            Subscription
           </code>
-           method can be used to get the step count between two dates.
-        </p>
-        
+        </a>
+         that enables you to call
 
-      </div>
-    </blockquote>
+        <code
+          class="css-qyuze8-TextComponent"
+          data-text="true"
+        >
+          remove()
+        </code>
+         when you would like to unsubscribe the listener.
+      </p>
+      
+
+      <blockquote
+        class="css-zknray-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-7jywx8-Callout"
+        >
+          <svg
+            class="icon-sm text-icon-default"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              id="info-circle-solid-icon"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
+                fill-rule="evenodd"
+                id="Solid"
+              />
+            </g>
+          </svg>
+        </div>
+        <div
+          class="css-1ohc0ia-Callout"
+        >
+          
+
+          <p
+            class="mb-3.5 css-1kfqm4n-TextComponent"
+            data-text="true"
+          >
+            Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
+
+            <a
+              class="css-1na8e0o-A"
+              href="https://developer.android.com/health-and-fitness/guides/health-connect"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <code
+                class="css-qyuze8-TextComponent"
+                data-text="true"
+              >
+                Health Connect API
+              </code>
+            </a>
+            .
+On iOS, the 
+            <code
+              class="css-qyuze8-TextComponent"
+              data-text="true"
+            >
+              getStepCountAsync
+            </code>
+             method can be used to get the step count between two dates.
+          </p>
+          
+
+        </div>
+      </blockquote>
+    </div>
   </div>
   <h2
     class="group css-13sdfl0-TextComponent"
@@ -10698,7 +10831,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-uj1dnj"
+    class="css-1vwg38e"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -10746,16 +10879,21 @@ On iOS, the
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-wrgtfc-BoxSectionHeader"
+      class="css-1xg9efr-BoxSectionHeader"
       data-text="true"
     >
-      PermissionResponse Properties
+      <span
+        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        data-text="true"
+      >
+        PermissionResponse Properties
+      </span>
     </p>
     <div
       class="css-1uyflf8-Table"
@@ -10770,17 +10908,17 @@ On iOS, the
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -10813,7 +10951,7 @@ On iOS, the
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -10853,7 +10991,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -10886,7 +11024,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -10924,7 +11062,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -10977,7 +11115,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -11037,17 +11175,17 @@ in order to enable/disable the permission.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -11080,7 +11218,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -11092,7 +11230,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -11141,7 +11279,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Callback function providing event result as an argument.
@@ -11160,19 +11298,14 @@ in order to enable/disable the permission.
               class="css-190f936-Row"
             >
               <th
-                class="css-14twqd4-HeaderCell"
+                class="css-17s7rsv-HeaderCell"
               >
                 Name
               </th>
               <th
-                class="css-14twqd4-HeaderCell"
+                class="css-17s7rsv-HeaderCell"
               >
                 Type
-              </th>
-              <th
-                class="css-14twqd4-HeaderCell"
-              >
-                Description
               </th>
             </tr>
           </thead>
@@ -11204,15 +11337,6 @@ in order to enable/disable the permission.
                   </a>
                 </code>
               </td>
-              <td
-                class="css-zstkv9-Cell"
-              >
-                <span
-                  class="text-quaternary"
-                >
-                  -
-                </span>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -11220,7 +11344,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -11272,7 +11396,7 @@ in order to enable/disable the permission.
       data-text="true"
     >
       <span
-        class="css-oecriz-TextComponent"
+        class="css-1mm9j88-TextComponent"
         data-text="true"
       >
         Literal Type:
@@ -11281,7 +11405,7 @@ in order to enable/disable the permission.
       multiple types
     </p>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
@@ -11290,8 +11414,13 @@ in order to enable/disable the permission.
       class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
-      Acceptable values are:
-       
+      <span
+        class="css-1mm9j88-TextComponent"
+        data-text="true"
+      >
+        Acceptable values are:
+         
+      </span>
       <span>
         <code
           class="css-ite7ne-TextComponent"
@@ -11317,7 +11446,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-1fultt1"
+    class="css-15gi84a"
   >
     <h3
       class="group css-nikr5x-TextComponent"
@@ -11365,7 +11494,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       A subscription object that allows to conveniently remove an event listener from the emitter.
@@ -11383,17 +11512,17 @@ in order to enable/disable the permission.
             class="css-190f936-Row"
           >
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Name
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Type
             </th>
             <th
-              class="css-14twqd4-HeaderCell"
+              class="css-17s7rsv-HeaderCell"
             >
               Description
             </th>
@@ -11437,7 +11566,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="mb-4 css-1kfqm4n-TextComponent"
+                class="mb-3.5 css-1kfqm4n-TextComponent"
                 data-text="true"
               >
                 Removes an event listener for which the subscription has been created.
@@ -11490,7 +11619,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1fultt1"
+    class="!p-0 css-15gi84a"
   >
     <div
       class="px-5 pt-4"
@@ -11541,10 +11670,15 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-wrgtfc-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
         data-text="true"
       >
-        PermissionStatus Values
+        <span
+          class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+          data-text="true"
+        >
+          PermissionStatus Values
+        </span>
       </p>
     </div>
     <div
@@ -11602,7 +11736,7 @@ After calling this function, the listener will no longer receive any events from
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User has denied the permission.
@@ -11663,7 +11797,7 @@ After calling this function, the listener will no longer receive any events from
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User has granted the permission.
@@ -11724,7 +11858,7 @@ After calling this function, the listener will no longer receive any events from
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -63,7 +63,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </code>
     </p>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Name of your app.
@@ -139,7 +139,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           Edit the 'Display Name' field in Xcode
@@ -148,7 +148,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -208,7 +208,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </code>
     </p>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Configuration for the bottom navigation bar on Android.
@@ -284,7 +284,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           Set this property using AppConstants.java.
@@ -362,7 +362,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           Set this property using just Xcode
@@ -370,7 +370,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </details>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -439,7 +439,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         Determines how and when the navigation bar is shown.
@@ -515,7 +515,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="last:[&>*]:!mb-1 css-qbaxbl"
         >
           <p
-            class="mb-4 css-1kfqm4n-TextComponent"
+            class="mb-3.5 css-1kfqm4n-TextComponent"
             data-text="true"
           >
             Set this property using Xcode.
@@ -523,7 +523,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -592,7 +592,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           Test sub-sub-property
@@ -600,7 +600,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -669,7 +669,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         Specifies the background color of the navigation bar.
@@ -677,7 +677,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       
 
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         6 character long hex color string, eg: 
@@ -691,7 +691,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -751,7 +751,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </code>
     </p>
     <p
-      class="mb-4 css-1kfqm4n-TextComponent"
+      class="mb-3.5 css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Configuration for setting an array of custom intent filters in Android manifest.
@@ -827,7 +827,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="last:[&>*]:!mb-1 css-qbaxbl"
       >
         <p
-          class="mb-4 css-1kfqm4n-TextComponent"
+          class="mb-3.5 css-1kfqm4n-TextComponent"
           data-text="true"
         >
           This is set in AndroidManifest.xml directly.
@@ -862,7 +862,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </span>
     </span>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -931,14 +931,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <p
-        class="mb-4 css-1kfqm4n-TextComponent"
+        class="mb-3.5 css-1kfqm4n-TextComponent"
         data-text="true"
       >
         You may also use an intent filter to set your app as the default handler for links
       </p>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -1007,7 +1007,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-c2t1qw-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -15,6 +15,7 @@ import {
   STYLES_APIBOX,
   getTagNamesList,
   H3Code,
+  getPossibleComponentPropsNames,
 } from '~/components/plugins/api/APISectionUtils';
 import { H2, DEMI, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
@@ -83,7 +84,7 @@ const renderComponent = (
         <APISectionProps
           sdkVersion={sdkVersion}
           data={componentsProps}
-          header={componentsProps.length === 1 ? 'Props' : `${resolvedName}Props`}
+          header={`${resolvedName}Props`}
         />
       ) : null}
     </div>
@@ -99,7 +100,7 @@ const APISectionComponents = ({ data, sdkVersion, componentsProps }: APISectionC
           component,
           sdkVersion,
           componentsProps.filter(cp =>
-            cp.name.includes(getComponentName(component.name, component.children))
+            getPossibleComponentPropsNames(component.name, component.children).includes(cp.name)
           )
         )
       )}

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -45,7 +45,7 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
       <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
         <APISectionDeprecationNote comment={enumValue.comment} />
         <APISectionPlatformTags comment={enumValue.comment} />
-        <H4 className="!mt-0">
+        <H4 className="!mt-0" hideInSidebar>
           <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
         </H4>
         <CODE theme="secondary" className="mb-3">

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -125,7 +125,7 @@ const renderInterface = (
       </H3Code>
       {extendedTypes?.length ? (
         <CALLOUT className={ELEMENT_SPACING}>
-          <CALLOUT tag="span" theme="secondary" weight="semiBold">
+          <CALLOUT tag="span" theme="secondary" weight="medium">
             Extends:{' '}
           </CALLOUT>
           {extendedTypes.map(extendedType => (

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons';
 
 import { APIDataType } from '~/components/plugins/api/APIDataType';
@@ -22,9 +23,10 @@ import {
   TypeDocKind,
   getH3CodeWithBaseNestingLevel,
   getTagData,
-  BoxSectionHeader,
+  getAllTagData,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, LI, UL, MONOSPACE } from '~/ui/components/Text';
+import { ELEMENT_SPACING } from '~/components/plugins/api/styles';
+import { CALLOUT, H2, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionMethodsProps = {
   data: (MethodDefinitionData | PropData)[];
@@ -93,22 +95,37 @@ export const renderMethod = (
               <br />
             </>
           )}
-          <CommentTextBlock comment={comment} includePlatforms={false} />
-          {resolveTypeName(type, sdkVersion) !== 'undefined' && (
-            <>
-              <BoxSectionHeader text="Returns" />
-              <UL className="!list-none !ml-0">
-                <LI>
-                  <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" />
-                  <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
-                </LI>
-              </UL>
-              <>
-                <br />
-                {returnComment && <CommentTextBlock comment={{ summary: returnComment.content }} />}
-              </>
-            </>
-          )}
+          <CommentTextBlock
+            comment={comment}
+            includePlatforms={false}
+            afterContent={
+              resolveTypeName(type, sdkVersion) !== 'undefined' ? (
+                <>
+                  <div
+                    className={mergeClasses(
+                      'flex flex-row gap-2 items-start',
+                      !returnComment && getAllTagData('example', comment) && ELEMENT_SPACING
+                    )}>
+                    <div className="flex flex-row gap-2 items-center">
+                      <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+                      <CALLOUT tag="span" theme="secondary" weight="medium">
+                        Returns:
+                      </CALLOUT>
+                    </div>
+                    <CALLOUT>
+                      <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+                    </CALLOUT>
+                  </div>
+                  {returnComment ? (
+                    <div className="flex flex-col mt-1.5 mb-1 pl-6">
+                      <CommentTextBlock comment={{ summary: returnComment.content }} />
+                    </div>
+                  ) : undefined}
+                </>
+              ) : undefined
+            }
+          />
+          {}
         </div>
       );
     }

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -168,24 +168,21 @@ const APISectionProps = ({
   const baseProp = data.find(prop => prop.name === header);
   return data?.length > 0 ? (
     <>
-      {data?.length === 1 || header === 'Props' ? (
+      {header === 'Props' ? (
         <H2 key="props-header">{header}</H2>
       ) : (
         <div>
           {baseProp && <APISectionDeprecationNote comment={baseProp.comment} />}
           <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4 key={`${header}-props-header`}>{header}</H4>
+            <H4 key={`${header}-props-header`} hideInSidebar>
+              {header}
+            </H4>
           </div>
           {baseProp && baseProp.comment ? <CommentTextBlock comment={baseProp.comment} /> : null}
         </div>
       )}
       {data.map((propsDefinition: PropsDefinitionData) =>
-        renderProps(
-          propsDefinition,
-          sdkVersion,
-          defaultProps,
-          data?.length === 1 || header === 'Props'
-        )
+        renderProps(propsDefinition, sdkVersion, defaultProps, header === 'Props')
       )}
     </>
   ) : null;

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -143,19 +143,19 @@ const renderType = (
           <CommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
-              <P>
+              <CALLOUT theme="secondary">
                 {type.types
                   .filter(type =>
                     ['reference', 'union', 'intersection', 'intrinsic'].includes(type.type)
                   )
                   .map(validType => (
                     <Fragment key={`nested-reference-type-${validType.name}`}>
-                      <CODE>{resolveTypeName(validType, sdkVersion)}</CODE>
+                      <CODE className="text-default">{resolveTypeName(validType, sdkVersion)}</CODE>
                       {type.type === 'union' ? ' or ' : ' '}
                     </Fragment>
                   ))}
                 {type.type === 'union' ? 'object shaped as below' : 'extended by'}:
-              </P>
+              </CALLOUT>
               <br />
             </>
           ) : null}
@@ -178,14 +178,16 @@ const renderType = (
             </MONOSPACE>
           </H3Code>
           <CALLOUT className="mb-3">
-            <CALLOUT tag="span" theme="secondary" weight="semiBold">
+            <CALLOUT tag="span" theme="secondary" weight="medium">
               Literal Type:{' '}
             </CALLOUT>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
           <CommentTextBlock comment={comment} includePlatforms={false} />
           <P>
-            Acceptable values are:{' '}
+            <CALLOUT tag="span" theme="secondary" weight="medium">
+              Acceptable values are:{' '}
+            </CALLOUT>
             {literalTypes.map((lt, index) => (
               <span key={`${name}-literal-type-${index}`}>
                 <CODE>{resolveTypeName(lt, sdkVersion)}</CODE>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="mb-4 css-1kfqm4n-TextComponent"
+    class="mb-3.5 css-1kfqm4n-TextComponent"
     data-text="true"
   >
     This is the basic comment.
@@ -57,7 +57,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     </span>
   </div>
   <p
-    class="mb-4 css-1kfqm4n-TextComponent"
+    class="mb-3.5 css-1kfqm4n-TextComponent"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
@@ -77,61 +77,90 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
-  <p
-    class="css-wrgtfc-BoxSectionHeader"
-    data-text="true"
+  <div
+    class="mb-3.5"
   >
-    Example
-  </p>
-  <pre
-    class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
-    data-text="true"
-  >
-    <code
-      class="css-dpez7n-Code"
+    <p
+      class="!mt-1 css-1xg9efr-BoxSectionHeader"
+      data-text="true"
     >
       <span
-        class="token keyword"
+        class="text-inherit flex flex-row gap-2 items-center css-1mm9j88-TextComponent"
+        data-text="true"
       >
-        await
+        <svg
+          class="icon-sm text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g
+            id="code-square-01-outline-icon"
+          >
+            <path
+              d="M14.5 15L17.5 12L14.5 9M9.5 9L6.5 12L9.5 15M7.8 21H16.2C17.8802 21 18.7202 21 19.362 20.673C19.9265 20.3854 20.3854 19.9265 20.673 19.362C21 18.7202 21 17.8802 21 16.2V7.8C21 6.11984 21 5.27976 20.673 4.63803C20.3854 4.07354 19.9265 3.6146 19.362 3.32698C18.7202 3 17.8802 3 16.2 3H7.8C6.11984 3 5.27976 3 4.63803 3.32698C4.07354 3.6146 3.6146 4.07354 3.32698 4.63803C3 5.27976 3 6.11984 3 7.8V16.2C3 17.8802 3 18.7202 3.32698 19.362C3.6146 19.9265 4.07354 20.3854 4.63803 20.673C5.27976 21 6.11984 21 7.8 21Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+        Example
       </span>
-       Application
-      <span
-        class="token punctuation"
+    </p>
+    <pre
+      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+      data-text="true"
+    >
+      <code
+        class="css-dpez7n-Code"
       >
-        .
-      </span>
-      <span
-        class="token function"
-      >
-        getInstallReferrerAsync
-      </span>
-      <span
-        class="token punctuation"
-      >
-        (
-      </span>
-      <span
-        class="token punctuation"
-      >
-        )
-      </span>
-      <span
-        class="token punctuation"
-      >
-        ;
-      </span>
-      
+        <span
+          class="token keyword"
+        >
+          await
+        </span>
+         Application
+        <span
+          class="token punctuation"
+        >
+          .
+        </span>
+        <span
+          class="token function"
+        >
+          getInstallReferrerAsync
+        </span>
+        <span
+          class="token punctuation"
+        >
+          (
+        </span>
+        <span
+          class="token punctuation"
+        >
+          )
+        </span>
+        <span
+          class="token punctuation"
+        >
+          ;
+        </span>
+        
 
-      <span
-        class="token comment"
-      >
-        // "utm_source=google-play&utm_medium=organic"
-      </span>
-      
+        <span
+          class="token comment"
+        >
+          // "utm_source=google-play&utm_medium=organic"
+        </span>
+        
 
-    </code>
-  </pre>
+      </code>
+    </pre>
+  </div>
 </div>
 `;
 

--- a/docs/components/plugins/api/styles.ts
+++ b/docs/components/plugins/api/styles.ts
@@ -1,6 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
 
-export const ELEMENT_SPACING = mergeClasses('mb-4');
+export const ELEMENT_SPACING = mergeClasses('mb-3.5');
 
 export const STYLES_SECONDARY = mergeClasses('text-secondary font-medium text-[90%]');
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -3,7 +3,7 @@ title: SQLite
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sqlite'
 packageName: 'expo-sqlite'
-maxHeadingDepth: 3
+maxHeadingDepth: 5
 iconUrl: '/static/images/packages/expo-sqlite.png'
 platforms: ['android', 'ios']
 ---

--- a/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sqlite-next.mdx
@@ -3,7 +3,7 @@ title: SQLite (Next)
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-50/packages/expo-sqlite'
 packageName: 'expo-sqlite'
-maxHeadingDepth: 3
+maxHeadingDepth: 5
 iconUrl: '/static/images/packages/expo-sqlite.png'
 ---
 

--- a/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sqlite.mdx
@@ -3,7 +3,7 @@ title: SQLite
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-sqlite'
 packageName: 'expo-sqlite'
-maxHeadingDepth: 3
+maxHeadingDepth: 5
 iconUrl: '/static/images/packages/expo-sqlite.png'
 platforms: ['android', 'ios']
 ---

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -13,6 +13,7 @@ type CalloutType = 'default' | 'warning' | 'error' | 'info';
 
 type CalloutProps = PropsWithChildren<{
   type?: CalloutType;
+  className?: string;
   icon?: ComponentType<any> | string;
 }>;
 
@@ -31,7 +32,7 @@ const extractType = (childrenArray: ReactNode[]) => {
   return false;
 };
 
-export const Callout = ({ type = 'default', icon, children }: CalloutProps) => {
+export const Callout = ({ type = 'default', icon, children, className }: CalloutProps) => {
   const content = Children.toArray(children).filter(child => isValidElement(child))[0];
   const contentChildren = Children.toArray(isValidElement(content) && content?.props?.children);
 
@@ -40,7 +41,10 @@ export const Callout = ({ type = 'default', icon, children }: CalloutProps) => {
   const Icon = icon || getCalloutIcon(finalType);
 
   return (
-    <blockquote css={[containerStyle, getCalloutColor(finalType)]} data-testid="callout-container">
+    <blockquote
+      css={[containerStyle, getCalloutColor(finalType)]}
+      className={className}
+      data-testid="callout-container">
       <div css={iconStyle}>
         {typeof icon === 'string' ? (
           icon

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -8,15 +8,21 @@ import { convertAlign } from './utils';
 
 type HeaderCellProps = PropsWithChildren<{
   align?: TextAlign | 'char';
+  size?: 'md' | 'sm';
 }>;
 
-export const HeaderCell = ({ children, align = 'left' }: HeaderCellProps) => (
-  <th css={[tableHeadersCellStyle, { textAlign: convertAlign(align) }]}>{children}</th>
+export const HeaderCell = ({ children, align = 'left', size = 'md' }: HeaderCellProps) => (
+  <th
+    css={[
+      tableHeadersCellStyle,
+      { textAlign: convertAlign(align), fontSize: size === 'sm' ? '0.75rem' : '0.875rem' },
+    ]}>
+    {children}
+  </th>
 );
 
 const tableHeadersCellStyle = css({
   padding: spacing[4],
-  fontSize: '0.875rem',
   fontWeight: 500,
   color: theme.text.secondary,
   verticalAlign: 'middle',

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -225,6 +225,8 @@ export const CAPTION = createTextComponent(TextElement.P, css(typography.body.ca
 export const CALLOUT = createTextComponent(TextElement.P, css(typography.body.callout));
 export const BOLD = createTextComponent(TextElement.STRONG, css({ fontWeight: 600 }));
 export const DEMI = createTextComponent(TextElement.SPAN, css({ fontWeight: 500 }));
+export const SPAN = createTextComponent(TextElement.SPAN, css(typography.body.callout));
+
 export const UL = createTextComponent(
   TextElement.UL,
   css([typography.body.ul, { listStyle: 'disc' }])

--- a/yarn.lock
+++ b/yarn.lock
@@ -7356,7 +7356,7 @@ commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1, commander@^4.1.1:
+commander@^4.0.0, commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -15358,7 +15358,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.4, pirates@^4.0.5:
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
@@ -18243,7 +18243,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18268,15 +18268,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18347,7 +18338,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18381,13 +18372,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -20486,7 +20470,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20508,15 +20492,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

Tweaks and fixes for the API Reference pages based on the feedback gathered lately.

# How

The following changes have been made:
* components will always render in nested form for the readability, since now we have a bit more place in the right sidebar (previously it was a default behaviour when there was more than one component
* the default max heading nesting level has been rise by default for API pages by 1 (from 3 to 4)
* entity return data section has been streamlined and moved above example block
* improve the table of content active element highlight and links and headers scroll offsets
* fix issue when exported component props miss-match the usual pattern, handle skip `View` case (`CameraView` -> `CameraProps`)
* fix unwanted overlay of deprecated entries in right sidebar
* fix issue with missing `<COMPONENT_NAME>Props` internal links
* minor appearance and spacing tweaks

In the near future I plan the few follow up with PRs including the component methods move inside of the component section (like props) and similar drop off single entry display alteration for classes, but those cases will require a bit more testing.

# Test Plan

The changes have been reviewed locally. All lint checks and test are passing.

# Preview

![Screenshot 2024-06-02 at 18 28 33](https://github.com/expo/expo/assets/719641/6f460422-b403-45d7-a1df-1c82173af808)
![Screenshot 2024-06-02 at 18 21 15](https://github.com/expo/expo/assets/719641/0d9892b3-5d75-4e12-8cff-6960a68acf51)
![Screenshot 2024-06-02 at 18 21 49](https://github.com/expo/expo/assets/719641/e9811691-6393-4c9b-9efa-3990b26e9a27)
![Screenshot 2024-06-02 at 18 24 48](https://github.com/expo/expo/assets/719641/4962a894-e175-47cc-93b1-08a9c5010e6f)

