### PR TITLE
[expo-notifications][Android] Remove unneeded logging

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Correctly map response in useLastNotificationResponse hook. ([#28938](https://github.com/expo/expo/pull/28938) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix FCMv1 icons and NPE. ([#29204](https://github.com/expo/expo/pull/29204) by [@douglowder](https://github.com/douglowder))
+- [Android] Remove unneeded logging. ([#29370](https://github.com/expo/expo/pull/29370) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -38,11 +38,9 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
     @Override
     public void onCreate(Activity activity, Bundle savedInstanceState) {
         Intent intent = activity.getIntent();
-        String actionIdentifier = intent.getAction();
         if (intent != null) {
             Bundle extras = intent.getExtras();
             if (extras != null) {
-                logExtra("onCreate", extras);
                 mNotificationManager.onNotificationResponseFromExtras(extras);
             }
         }
@@ -60,22 +58,9 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
     @Override
     public boolean onNewIntent(Intent intent) {
         Bundle extras = intent.getExtras();
-        String actionIdentifier = intent.getAction();
         if (extras != null) {
-            logExtra("onNewIntent", extras);
             mNotificationManager.onNotificationResponseFromExtras(extras);
         }
         return ReactActivityLifecycleListener.super.onNewIntent(intent);
-    }
-
-    private void logExtra(String method, Bundle extra) {
-        Log.d("ExpoNotificationLifecycleListener", method + " : keys count = " + extra.keySet().size());
-
-        for (String key : extra.keySet()) {
-            Log.d(
-                    "ExpoNotificationLifecycleListener",
-                    method + " : key = " + key + " = " + Objects.requireNonNull(extra.get(key)).toString()
-            );
-        }
     }
 }


### PR DESCRIPTION
# Why

After the fixes in #29204 , there are still reports of NPEs happening in the notification lifecycle listener methods. These NPEs are coming from code that causes Android to log events.

# How

Remove the logging code that was causing the issue.

# Test Plan

- CI should pass
- Test app should work, show correct icons in notifications, and responses should show up even if app is killed

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
