### PR TITLE
refactor(cli): replace `node-fetch` with built-in `fetch` for Node 22

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -47,6 +47,7 @@ jobs:
     strategy:
       matrix:
         shard: [1, 2, 3]
+        node: [18, 20, 22]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -54,7 +55,7 @@ jobs:
           fetch-depth: 100
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node }}
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        shard: [1, 2, 3]
+        # shard: [1, 2, 3]
         node: [18, 20, 22]
     steps:
       - name: 👀 Checkout
@@ -85,7 +85,7 @@ jobs:
         run: yarn typecheck
         working-directory: packages/@expo/cli
       - name: E2E Test CLI
-        run: yarn test:e2e --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:e2e #--shard ${{ matrix.shard }}/${{ strategy.job-total }}
         working-directory: packages/@expo/cli
 
   web:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -30,6 +30,9 @@ concurrency:
 jobs:
   check-packages:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node: [18, 20, 22]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -40,7 +43,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -5,7 +5,6 @@ import {
 } from '@expo/multipart-body-parser';
 import execa from 'execa';
 import fs from 'fs-extra';
-import fetch from 'node-fetch';
 import nullthrows from 'nullthrows';
 import path from 'path';
 
@@ -147,7 +146,7 @@ describe('server', () => {
 
       const multipartParts = await parseMultipartMixedResponseAsync(
         response.headers.get('content-type') as string,
-        await response.buffer()
+        Buffer.from(await response.arrayBuffer())
       );
       const manifestPart = nullthrows(
         multipartParts.find((part) => isMultipartPartWithName(part, 'manifest'))

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -157,7 +157,7 @@
     "jest-runner-tsd": "^6.0.0",
     "klaw-sync": "^6.0.0",
     "memfs": "^3.2.0",
-    "nock": "~13.2.2",
+    "nock": "14.0.0-beta.7",
     "node-html-parser": "^6.1.5",
     "nullthrows": "^1.1.1",
     "playwright": "^1.40.1",

--- a/packages/@expo/cli/src/api/graphql/client.ts
+++ b/packages/@expo/cli/src/api/graphql/client.ts
@@ -12,7 +12,6 @@ import {
 } from '@urql/core';
 import { retryExchange } from '@urql/exchange-retry';
 import { DocumentNode } from 'graphql';
-import fetch from 'node-fetch';
 
 import * as Log from '../../log';
 import { getExpoApiBaseUrl } from '../endpoint';

--- a/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/wrapFetchWithProgress-test.ts
@@ -1,14 +1,10 @@
 import nock from 'nock';
-import fetch from 'node-fetch';
 import path from 'path';
-import { Stream } from 'stream';
-import { promisify } from 'util';
 
 import * as Log from '../../../log';
 import { wrapFetchWithProgress } from '../wrapFetchWithProgress';
 
 const fs = jest.requireActual('fs') as typeof import('fs');
-const pipeline = promisify(Stream.pipeline);
 
 jest.mock(`../../../log`);
 
@@ -16,68 +12,81 @@ describe(wrapFetchWithProgress, () => {
   beforeEach(() => {
     jest.mocked(Log.warn).mockClear();
   });
+
   it('should call the progress callback', async () => {
     const url = 'https://example.com';
+    const fixturePath = path.join(__dirname, './fixtures/panda.png');
+    const fixtureSize = fs.statSync(fixturePath).size;
 
     const scope = nock(url)
       .get('/asset')
       .reply(() => {
-        const fixturePath = path.join(__dirname, './fixtures/panda.png');
         return [
-          // Status
-          200,
-          // Data
-          fs.createReadStream(fixturePath),
-          {
-            // Headers for progress
-            'Content-Length': fs.statSync(fixturePath).size,
-          },
+          200, // Status
+          fs.createReadStream(fixturePath), // Data
+          { 'Content-Length': fixtureSize }, // Headers for progress
         ];
       });
 
     const onProgress = jest.fn();
+    const response = await wrapFetchWithProgress(fetch)(url + '/asset', { onProgress });
+    // Load the response body to trigger the progression events
+    await response.blob();
 
-    await pipeline(
-      (
-        await wrapFetchWithProgress(fetch)(url + '/asset', {
-          onProgress,
-        })
-      ).body,
-      require('fs').createWriteStream('/foobar')
-    );
-    // Ensure this example is called more than once.
-    expect(onProgress).toHaveBeenCalledTimes(4);
+    // Ensure the progress callback was called more than start and end
+    expect(onProgress.mock.calls.length).toBeGreaterThan(2);
+    // Ensure progress starts at 0%
     expect(onProgress).toHaveBeenNthCalledWith(1, {
-      loaded: 65536,
-      progress: 0.43515444476906323,
-      total: 150604,
+      loaded: 0,
+      progress: 0,
+      total: fixtureSize,
+    });
+    // Ensure progress ends at 100%
+    expect(onProgress).toHaveBeenLastCalledWith({
+      loaded: fixtureSize,
+      progress: 1,
+      total: fixtureSize,
     });
 
-    // Ensure progress ends on 1.0
-    expect(onProgress).toHaveBeenLastCalledWith({
-      loaded: 150604,
-      progress: 1,
-      total: 150604,
-    });
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should not call progress when response is not ok', async () => {
+    const url = 'https://example.com';
+    const scope = nock(url).get('/asset').reply(404, { error: 'Not Found' });
+
+    const onProgress = jest.fn();
+    const response = await wrapFetchWithProgress(fetch)(url + '/asset', { onProgress });
+    // Load the response body to trigger the progression events
+    await response.json();
+
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('should not call progress when response is empty', async () => {
+    const url = 'https://example.com';
+    const scope = nock(url).get('/asset').reply(204);
+
+    const onProgress = jest.fn();
+    const response = await wrapFetchWithProgress(fetch)(url + '/asset', { onProgress });
+    // Load the response body to trigger the progression events
+    await response.text();
+
+    expect(onProgress).not.toHaveBeenCalled();
     expect(scope.isDone()).toBe(true);
   });
 
   it('should warn that a request is missing the content length header', async () => {
     const url = 'https://example.com';
+    const scope = nock(url).get('/asset').reply(200, ''); // Return no Content-Length header
 
-    // Return no Content-Length header.
-    const scope = nock(url).get('/asset').reply(200, '');
+    await wrapFetchWithProgress(fetch)(url + '/asset', { onProgress: jest.fn() });
 
-    const onProgress = jest.fn();
-
-    await wrapFetchWithProgress(fetch)(url + '/asset', {
-      onProgress,
-    });
     expect(Log.warn).toHaveBeenCalledWith(
       'Progress callback not supported for network request because "Content-Length" header missing or invalid in response from URL:',
       'https://example.com/asset'
     );
-
     expect(scope.isDone()).toBe(true);
   });
 });

--- a/packages/@expo/cli/src/api/rest/cache/response.ts
+++ b/packages/@expo/cli/src/api/rest/cache/response.ts
@@ -1,5 +1,4 @@
 import type { CacheObject } from 'cacache';
-import { BodyInit, Response, ResponseInit } from 'node-fetch';
 
 const responseInternalSymbol = Object.getOwnPropertySymbols(new Response())[1];
 
@@ -22,10 +21,10 @@ export class NFCResponse extends Response {
       url: res.url,
       status: res.status,
       statusText: res.statusText,
-      headers: res.headers.raw(),
-      size: res.size,
-      timeout: res.timeout,
-      // @ts-ignore
+      headers: Object.fromEntries(res.headers.entries()),
+      size: res.headers.get('content-length'),
+      // timeout: res.timeout, // Non-standard node-fetch property
+      // @ts-expect-error
       counter: res[responseInternalSymbol].counter,
     };
 

--- a/packages/@expo/cli/src/api/rest/client.types.ts
+++ b/packages/@expo/cli/src/api/rest/client.types.ts
@@ -1,5 +1,4 @@
-import { RequestInfo, RequestInit, Response } from 'node-fetch';
-import { URLSearchParams } from 'url';
+import { type URLSearchParams } from 'url';
 
 export type ProgressCallback = (props: {
   /** Number ranging from 0 to 1 representing the download percentage. */

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithOffline.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithOffline.ts
@@ -9,8 +9,20 @@ export function wrapFetchWithOffline(fetchFunction: FetchLike): FetchLike {
   return function fetchWithOffline(url, options = {}) {
     if (env.EXPO_OFFLINE) {
       debug('Skipping network request: ' + url);
-      options.timeout = 1;
+      options.signal = getAbortController().signal;
     }
     return fetchFunction(url, options);
   };
+}
+
+/** The default abort controller when running in offline mode */
+let abortController: AbortController | undefined;
+/** Get the default abort controller that disables all requests when running in offline mode */
+function getAbortController() {
+  if (!abortController) {
+    abortController = new AbortController();
+    abortController.abort();
+  }
+
+  return abortController;
 }

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithProgress.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithProgress.ts
@@ -3,44 +3,69 @@ import * as Log from '../../log';
 const debug = require('debug')('expo:api:fetch:progress') as typeof console.log;
 
 export function wrapFetchWithProgress(fetch: FetchLike): FetchLike {
-  return (url, init) => {
-    return fetch(url, init).then((res) => {
-      if (res.ok && init?.onProgress) {
-        const totalDownloadSize = res.headers.get('Content-Length');
-        const total = Number(totalDownloadSize);
+  return function fetchWithProgress(url, init) {
+    return fetch(url, init).then((response) => {
+      const onProgress = init?.onProgress;
 
-        debug(`Download size: ${totalDownloadSize}`);
-        if (!totalDownloadSize || isNaN(total) || total < 0) {
-          Log.warn(
-            'Progress callback not supported for network request because "Content-Length" header missing or invalid in response from URL:',
-            url.toString()
-          );
-          return res;
-        }
-
-        let length = 0;
-
-        debug(`Starting progress animation for ${url}`);
-        res.body.on('data', (chunk) => {
-          length += Buffer.byteLength(chunk);
-          onProgress();
-        });
-
-        res.body.on('end', () => {
-          debug(`Finished progress animation for ${url}`);
-          onProgress();
-        });
-
-        const onProgress = () => {
-          const progress = length / total || 0;
-          init.onProgress?.({
-            progress,
-            total,
-            loaded: length,
-          });
-        };
+      // Abort if no `onProgress` is provided, the request failed, or there is no response body
+      if (!onProgress || !response.ok || !response.body) {
+        return response;
       }
-      return res;
+
+      // Calculate total progress size
+      const contentLength = response.headers.get('Content-Length');
+      const progressTotal = Number(contentLength);
+
+      debug(`Download size: %d`, progressTotal);
+
+      // Abort if the `Content-Length` header is missing or invalid
+      if (!progressTotal || isNaN(progressTotal) || progressTotal < 0) {
+        Log.warn(
+          'Progress callback not supported for network request because "Content-Length" header missing or invalid in response from URL:',
+          url.toString()
+        );
+        return response;
+      }
+
+      debug(`Starting progress animation for: %s`, url);
+
+      // Initialize the progression variables
+      let progressCurrent = 0;
+      const progressUpdate = () => {
+        const progress = progressCurrent / progressTotal || 0;
+        onProgress({
+          progress,
+          total: progressTotal,
+          loaded: progressCurrent,
+        });
+      };
+
+      // Create a new body-wrapping stream that handles the progression methods
+      const bodyReader = response.body.getReader();
+      const bodyWithProgress = new ReadableStream({
+        start(controller) {
+          function next() {
+            bodyReader.read().then(({ done, value }) => {
+              // Close the controller once stream is done
+              if (done) return controller.close();
+
+              // Update the progression
+              progressCurrent += Buffer.byteLength(value);
+              progressUpdate();
+
+              // Continue the stream, and read the next chunk
+              controller.enqueue(value);
+              next();
+            });
+          }
+
+          progressUpdate();
+          next();
+        },
+      });
+
+      // Return the new response with the wrapped body stream
+      return new Response(bodyWithProgress, response);
     });
   };
 }

--- a/packages/@expo/cli/src/api/rest/wrapFetchWithProxy.ts
+++ b/packages/@expo/cli/src/api/rest/wrapFetchWithProxy.ts
@@ -1,4 +1,4 @@
-import createHttpsProxyAgent from 'https-proxy-agent';
+// import createHttpsProxyAgent from 'https-proxy-agent';
 
 import { FetchLike } from './client.types';
 import { env } from '../../utils/env';
@@ -10,9 +10,14 @@ export function wrapFetchWithProxy(fetchFunction: FetchLike): FetchLike {
   // NOTE(EvanBacon): DO NOT RETURN AN ASYNC WRAPPER. THIS BREAKS LOADING INDICATORS.
   return function fetchWithProxy(url, options = {}) {
     const proxy = env.HTTP_PROXY;
-    if (!options.agent && proxy) {
+    if (!(options as any).agent && proxy) {
       debug('Using proxy:', proxy);
-      options.agent = createHttpsProxyAgent(proxy);
+      // NOTE(cedric): This isn't possible with the built-in fetch API.
+      // For this specific feature we could swap to undici instead as it supports `Agent`.
+      // See: https://github.com/TooTallNate/proxy-agents/issues/239
+      throw new Error('Proxy support is not implemented for the built-in fetch API');
+
+      // options.agent = createHttpsProxyAgent(proxy);
     }
     return fetchFunction(url, options);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7354,7 +7354,7 @@ commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1, commander@^4.1.1:
+commander@^4.0.0, commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -13235,11 +13235,6 @@ lodash.merge@4.6.2, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
@@ -14364,14 +14359,12 @@ nocache@^3.0.1:
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-3.0.4.tgz#5b37a56ec6e09fc7d401dceaed2eab40c8bfdf79"
   integrity sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==
 
-nock@~13.2.2:
-  version "13.2.4"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.4.tgz#43a309d93143ee5cdcca91358614e7bde56d20e1"
-  integrity sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==
+nock@14.0.0-beta.7:
+  version "14.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.0-beta.7.tgz#bdb3f3cfa2276659c87412f6dff2aea9ee69a7fc"
+  integrity sha512-+EQMm5W9K8YnBE2Ceg4hnJynaCZmvK8ZlFXQ2fxGwtkOkBUq8GpQLTks2m1jpvse9XDxMDDOHgOWpiznFuh0bA==
   dependencies:
-    debug "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash.set "^4.3.2"
     propagate "^2.0.0"
 
 node-abi@^3.3.0:
@@ -15356,7 +15349,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.4, pirates@^4.0.5:
+pirates@^4.0.1, pirates@^4.0.4, pirates@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==


### PR DESCRIPTION
# Why

This PR is a experiment to see if we can move away from `node-fetch` to the built-in `fetch` API.

Starting from Node 22, we now get "using deprecated API" warnings for `node-fetch@2`. We also don't want to upgrade to `node-fetch@3` as it's rather bloated, while we don't need all of the spec.

# How

- Added Node 18, 20, 22 to both `cli` and `sdk` workflows 
  → to ensure tests run on all supported major versions
- Create separate PRs based on Node 22 CI failures
  → _will be cherry-picked into this PR to continue testing_
  → PR #29392

# TODO

- Search & replace all `node-fetch` usage in `@expo/cli`

# Test Plan

See if tests passes for both Node 18, 20, and 22.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
