### PR TITLE
fix(secure-store/ios): improve default error message

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Improve error message for unhandled errors ([#29394](https://github.com/expo/expo/pull/29394) by [@hassankhan](https://github.com/hassankhan))
+
 ### 💡 Others
 
 ## 13.0.1 — 2024-04-23

--- a/packages/expo-secure-store/ios/SecureStoreExceptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreExceptions.swift
@@ -55,6 +55,9 @@ internal class KeyChainException: GenericException<OSStatus> {
       return "Authentication failed. Provided passphrase/PIN is incorrect or there is no user authentication method configured for this device."
 
     default:
+      if let errorMessage = SecCopyErrorMessageString(param, nil) as? String {
+        return errorMessage
+      }
       return "Unknown Keychain Error."
     }
   }


### PR DESCRIPTION
# Why

I had forgotten to add Keychain entitlements to my app, and the underlying error was not being surfaced by Expo.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

The default error case now uses `SecCopyErrorMessageString` to extract an error message for the given error result code.

https://developer.apple.com/documentation/security/1394686-seccopyerrormessagestring

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Create new Expo app and add `expo-secure-store` to it
- Without adding the requisite entitlement, run the app in a simulator and try to read/write something
- See the underlying error in your logs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
