### PR TITLE
fix(babel-preset-expo): path to the expo config

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- fix path to the expo config file ([#29397](https://github.com/expo/expo/pull/29397))
+
 ## 11.0.6 — 2024-05-13
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoInlineManifestPlugin = void 0;
-const config_1 = require("expo/config");
+const config_1 = require("@expo/config");
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:inline-manifest');
 // Convert expo value to PWA value

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -1,5 +1,5 @@
 import { ConfigAPI } from '@babel/core';
-import { ExpoConfig, getConfig, getNameFromConfig, ProjectConfig } from 'expo/config';
+import { ExpoConfig, getConfig, getNameFromConfig, ProjectConfig } from '@expo/config';
 
 import { getPlatform, getPossibleProjectRoot } from './common';
 


### PR DESCRIPTION
# Why

You can not use `babel-preset-expo` in your project without installing `expo` because `babel-preset-expo` has a relation to the `expo` in the `expo-inline-manifest-plugin.ts` file line:2 `import { ExpoConfig, getConfig, getNameFromConfig, ProjectConfig } from 'expo/config';`. 
However, in the `expo/config.js` file, there is only the export of the `@expo/config` - file content: `module.exports = require('@expo/config');`.

Please follow the [link](https://github.com/expo/expo/discussions/27256)


# How
By changing the path to the config, you will be able to install only `babel-preset-expo` and `@expo/config` to your project and don't install the `expo` to be able to build an app.


# Checklist
- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
