### PR TITLE
[docs] fix nested code block in an additional `pre` element

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -4,7 +4,15 @@ import { borderRadius, spacing } from '@expo/styleguide-base';
 import { FileCode01Icon, LayoutAlt01Icon, Server03Icon } from '@expo/styleguide-icons';
 import partition from 'lodash/partition';
 import { Language, Prism } from 'prism-react-renderer';
-import { useEffect, useRef, useState, type PropsWithChildren, Children } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  Children,
+  ReactNode,
+  isValidElement,
+} from 'react';
 import tippy, { roundArrow } from 'tippy.js';
 
 import { useCodeBlockSettingsContext } from '~/providers/CodeBlockSettingsProvider';
@@ -157,17 +165,31 @@ function parseValue(value: string) {
   };
 }
 
+function getRootCodeBlockProps(children: ReactNode, className?: string) {
+  if (className && className.startsWith('language')) {
+    return { className, children };
+  }
+
+  const firstChild = Children.toArray(children)[0];
+  if (isValidElement(firstChild)) {
+    if (firstChild.props.className.startsWith('language')) {
+      return {
+        className: firstChild.props.className,
+        children: firstChild.props.children,
+        isNested: true,
+      };
+    }
+  }
+
+  return {};
+}
+
 export function Code({ className, children }: PropsWithChildren<Props>) {
   const contentRef = useRef<HTMLPreElement>(null);
   const { preferredTheme, wordWrap } = useCodeBlockSettingsContext();
   const [isExpanded, setExpanded] = useState(true);
 
-  // note(simek): MDX dropped `inlineCode` pseudo-tag, and we need to relay on `pre` and `code` now,
-  // which results in this nesting mess, we should fix it in the future
-  const rootProps =
-    className && className.startsWith('language')
-      ? { className, children }
-      : (Children.toArray(children)[0] as JSX.Element)?.props;
+  const rootProps = getRootCodeBlockProps(children, className);
 
   const codeBlockData = parseValue(rootProps?.children?.toString() || '');
   const collapseHeight = codeBlockData?.params?.collapseHeight

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -171,7 +171,7 @@ function getRootCodeBlockProps(children: ReactNode, className?: string) {
   }
 
   const firstChild = Children.toArray(children)[0];
-  if (isValidElement(firstChild)) {
+  if (isValidElement(firstChild) && firstChild.props.className) {
     if (firstChild.props.className.startsWith('language')) {
       return {
         className: firstChild.props.className,

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6974,73 +6974,71 @@ This uses both
     >
       Example
     </p>
-    <pre>
-      <pre
-        class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
-        data-text="true"
+    <pre
+      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+      data-text="true"
+    >
+      <code
+        class="css-dpez7n-Code"
       >
-        <code
-          class="css-dpez7n-Code"
+        <span
+          class="token keyword"
         >
-          <span
-            class="token keyword"
-          >
-            const
-          </span>
-           
-          <span
-            class="token punctuation"
-          >
-            [
-          </span>
-          permissionResponse
-          <span
-            class="token punctuation"
-          >
-            ,
-          </span>
-           requestPermission
-          <span
-            class="token punctuation"
-          >
-            ]
-          </span>
-           
-          <span
-            class="token operator"
-          >
-            =
-          </span>
-           BarCodeScanner
-          <span
-            class="token punctuation"
-          >
-            .
-          </span>
-          <span
-            class="token function"
-          >
-            usePermissions
-          </span>
-          <span
-            class="token punctuation"
-          >
-            (
-          </span>
-          <span
-            class="token punctuation"
-          >
-            )
-          </span>
-          <span
-            class="token punctuation"
-          >
-            ;
-          </span>
-          
+          const
+        </span>
+         
+        <span
+          class="token punctuation"
+        >
+          [
+        </span>
+        permissionResponse
+        <span
+          class="token punctuation"
+        >
+          ,
+        </span>
+         requestPermission
+        <span
+          class="token punctuation"
+        >
+          ]
+        </span>
+         
+        <span
+          class="token operator"
+        >
+          =
+        </span>
+         BarCodeScanner
+        <span
+          class="token punctuation"
+        >
+          .
+        </span>
+        <span
+          class="token function"
+        >
+          usePermissions
+        </span>
+        <span
+          class="token punctuation"
+        >
+          (
+        </span>
+        <span
+          class="token punctuation"
+        >
+          )
+        </span>
+        <span
+          class="token punctuation"
+        >
+          ;
+        </span>
+        
 
-        </code>
-      </pre>
+      </code>
     </pre>
     <p
       class="css-wrgtfc-BoxSectionHeader"

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -71,6 +71,7 @@ const renderInterfaceComment = (
       <>
         <APISectionDeprecationNote comment={comment} />
         <CommentTextBlock
+          inlineHeaders
           comment={comment}
           afterContent={renderDefaultValue(initValue)}
           emptyCommentFallback="-"

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -78,6 +78,7 @@ export const mdComponents: MDComponents = {
     ) : (
       <CODE css={css({ display: 'inline' })}>{children}</CODE>
     ),
+  pre: ({ children }) => <>{children}</>,
   h1: ({ children }) => <H4>{children}</H4>,
   ul: ({ children }) => <UL className={ELEMENT_SPACING}>{children}</UL>,
   ol: ({ children }) => <OL className={ELEMENT_SPACING}>{children}</OL>,
@@ -722,7 +723,7 @@ export const CommentTextBlock = ({
   const exampleText = examples?.map((example, index) => (
     <Fragment key={'example-' + index}>
       {inlineHeaders ? (
-        <DEMI theme="secondary" className="my-2">
+        <DEMI theme="secondary" className="flex mb-1">
           Example
         </DEMI>
       ) : (

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -79,56 +79,54 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   >
     Example
   </p>
-  <pre>
-    <pre
-      class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
-      data-text="true"
+  <pre
+    class="relative max-h-[unset] last:mb-0 css-1r21cuo-Code"
+    data-text="true"
+  >
+    <code
+      class="css-dpez7n-Code"
     >
-      <code
-        class="css-dpez7n-Code"
+      <span
+        class="token keyword"
       >
-        <span
-          class="token keyword"
-        >
-          await
-        </span>
-         Application
-        <span
-          class="token punctuation"
-        >
-          .
-        </span>
-        <span
-          class="token function"
-        >
-          getInstallReferrerAsync
-        </span>
-        <span
-          class="token punctuation"
-        >
-          (
-        </span>
-        <span
-          class="token punctuation"
-        >
-          )
-        </span>
-        <span
-          class="token punctuation"
-        >
-          ;
-        </span>
-        
+        await
+      </span>
+       Application
+      <span
+        class="token punctuation"
+      >
+        .
+      </span>
+      <span
+        class="token function"
+      >
+        getInstallReferrerAsync
+      </span>
+      <span
+        class="token punctuation"
+      >
+        (
+      </span>
+      <span
+        class="token punctuation"
+      >
+        )
+      </span>
+      <span
+        class="token punctuation"
+      >
+        ;
+      </span>
+      
 
-        <span
-          class="token comment"
-        >
-          // "utm_source=google-play&utm_medium=organic"
-        </span>
-        
+      <span
+        class="token comment"
+      >
+        // "utm_source=google-play&utm_medium=organic"
+      </span>
+      
 
-      </code>
-    </pre>
+    </code>
   </pre>
 </div>
 `;


### PR DESCRIPTION
# Why

Nesting `pre` tag was unintentional side-effect of latest TypeDocs upgrade, and it's semantically incorrect.

# How

Get to the root cause of `pre` elements nesting (this also fixes spacing issues), rewrite root props helper, use inline header when rendering examples in interfaces.

# Test Plan

The changes have been reviewed locally. All lint checks are passing, test snapshots have been updated.

# Preview

![Screenshot 2024-06-03 at 16 11 46](https://github.com/expo/expo/assets/719641/618f4f7e-06e2-4e0c-a024-3af9bfb215ee)
