### PR TITLE
[dev-launcher] fix android reload error

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed empty screen after reloading on Android. ([#29400](https://github.com/expo/expo/pull/29400) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/runtime/NonFinalBridgelessDevSupportManager.java
+++ b/packages/expo-dev-launcher/android/src/main/java/com/facebook/react/runtime/NonFinalBridgelessDevSupportManager.java
@@ -116,11 +116,13 @@ public class NonFinalBridgelessDevSupportManager extends DevSupportManagerBase {
         hideRedboxDialog();
         mReactHost.reload("BridgelessDevSupportManager.handleReloadJS()");
 
-        PrinterHolder.getPrinter()
-                .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server");
-        String bundleURL =
-                getDevServerHelper().getDevServerBundleURL(Assertions.assertNotNull(getJSAppBundleName()));
-        reloadJSFromServer(bundleURL);
+        // 0.74 workaround for https://github.com/facebook/react-native/commit/524e3eec3e73f56746ace8bef569f36802a7a62e
+        isPackagerRunning(isMetroRunning -> {
+          if (!isMetroRunning) {
+            String bundleURL = getDevServerHelper().getDevServerBundleURL(Assertions.assertNotNull(getJSAppBundleName()));
+            reloadJSFromServer(bundleURL);
+          }
+        });
     }
 
     private static ReactInstanceDevHelper createInstanceDevHelper(final ReactHostImpl reactHost) {


### PR DESCRIPTION
# Why

fix the empty screen after reloading on bridgeless android with dev-client.

# How

the relevant issue is https://github.com/facebook/react-native/issues/44241 but https://github.com/facebook/react-native/commit/524e3eec3e73f56746ace8bef569f36802a7a62e comes with breaking changes and would better to fix on 0.75. i would just address https://github.com/facebook/react-native/pull/42917 on this pr for 0.74

# Test Plan

- try reload on android fabric-tester
- stop metro server and reload again

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
