### PR TITLE
[updates] fine tune e2e testing

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Message attached to the build'
     required: false
   retries:
-    description: 'Retries from eas build failures'
+    description: 'Number of times to retry the eas build command when the command fails. Note that this is not build retries.'
     required: false
     default: 3
 

--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -20,6 +20,10 @@ inputs:
   message:
     description: 'Message attached to the build'
     required: false
+  retries:
+    description: 'Retries from eas build failures'
+    required: false
+    default: 3
 
 outputs:
   build_id:
@@ -33,11 +37,30 @@ runs:
       shell: bash
       id: build_start
       run: |
-        if [[ -z "${COMMIT_MESSAGE}" ]]; then
-          COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)
-        fi
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
-        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
+        RETRIES=0
+        SUCCESS=false
+
+        while [ $RETRIES -lt $MAX_RETRIES ]; do
+          set +e
+          BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
+          BUILD_STATUS=$?
+          set -e
+          if [ $BUILD_STATUS -eq 0 ] && [ -n "$BUILD_ID" ]; then
+            echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
+            SUCCESS=true
+            break
+          else
+            echo "Build attempt $((RETRIES+1)) failed with status $BUILD_STATUS. Retrying in $RETRY_DELAY seconds..."
+            RETRIES=$((RETRIES+1))
+            sleep $RETRY_DELAY
+          fi
+        done
+
+        if [ "$SUCCESS" = false ]; then
+          echo "Build failed after $MAX_RETRIES attempts."
+          exit 1
+        fi
         echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.projectRoot }}
       env:
@@ -46,6 +69,9 @@ runs:
         PLATFORM: ${{ inputs.platform }}
         MESSAGE: ${{ inputs.message }}
         EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: host.exp.exponent
+        MAX_RETRIES: ${{ inputs.retries }}
+        RETRY_DELAY: 30
+
     - name: Wait for build to finish
       shell: bash
       if: ${{ !inputs.noWait }}

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
 - [Android] Upgrade dependencies and remove unused ones. Change multipart parser to okhttp. ([#29060](https://github.com/expo/expo/pull/29060) by [@wschurman](https://github.com/wschurman))
 - [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
+- Improved stability of E2E testing. ([#29402](https://github.com/expo/expo/pull/29402) by [@kudo](https://github.com/kudo))
 
 ## 0.25.14 — 2024-05-16
 

--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -76,9 +76,8 @@ eas build --profile=updates_testing_debug --platform=<android|ios>
 @@ -15,7 +15,8 @@
      "updates_testing_debug": {
        "env": {
-         "EX_UPDATES_NATIVE_DEBUG": "1",
--        "NO_FLIPPER": "1"
-+        "NO_FLIPPER": "1",
+-        "EX_UPDATES_NATIVE_DEBUG": "1"
++        "EX_UPDATES_NATIVE_DEBUG": "1",
 +        "LOCAL_TESTING": "1"
        },
        "android": {

--- a/packages/expo-updates/e2e/fixtures/App-updates-disabled.tsx
+++ b/packages/expo-updates/e2e/fixtures/App-updates-disabled.tsx
@@ -15,7 +15,7 @@ function TestValue(props: { testID: string; value: string }) {
         <Text style={styles.labelText}>{props.testID}</Text>
         <Text style={styles.labelText}>&nbsp;</Text>
         <Text style={styles.labelText} testID={props.testID}>
-          {props.value}
+          {props.value || 'null'}
         </Text>
       </View>
     </View>

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -24,7 +24,7 @@ function TestValue(props: { testID: string; value: string }) {
         <Text style={styles.labelText}>{props.testID}</Text>
         <Text style={styles.labelText}>&nbsp;</Text>
         <Text style={styles.labelText} testID={props.testID}>
-          {props.value}
+          {props.value || 'null'}
         </Text>
       </View>
     </View>

--- a/packages/expo-updates/e2e/fixtures/Updates-dev-client.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-dev-client.e2e.ts
@@ -34,7 +34,7 @@ describe('Basic tests', () => {
 
     jestExpect(await testElementValueAsync('updateString')).toBe('test');
     jestExpect(await testElementValueAsync('updateID')).toBeTruthy();
-    jestExpect(await testElementValueAsync('runtimeVersion')).toBe('');
+    jestExpect(await testElementValueAsync('runtimeVersion')).toBe('null');
     jestExpect(await testElementValueAsync('checkAutomatically')).toBe('NEVER');
     jestExpect(await testElementValueAsync('isEmbeddedLaunch')).toBe('false');
     jestExpect(await testElementValueAsync('availableUpdateID')).toBe('undefined');

--- a/packages/expo-updates/e2e/fixtures/Updates-disabled.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-disabled.e2e.ts
@@ -32,7 +32,7 @@ describe('Basic tests', () => {
 
     jestExpect(await testElementValueAsync('updateString')).toBe('test');
     jestExpect(await testElementValueAsync('updateID')).toBeTruthy();
-    jestExpect(await testElementValueAsync('runtimeVersion')).toBe('');
+    jestExpect(await testElementValueAsync('runtimeVersion')).toBe('null');
     jestExpect(await testElementValueAsync('checkAutomatically')).toBe('NEVER');
     jestExpect(await testElementValueAsync('isEmbeddedLaunch')).toBe('false');
     jestExpect(await testElementValueAsync('availableUpdateID')).toBe('undefined');

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -775,14 +775,14 @@ describe('JS API tests', () => {
     jestExpect(isUpdateAvailable).toEqual('false');
     jestExpect(isUpdatePending).toEqual('false');
     jestExpect(isRollback).toEqual('false');
-    jestExpect(latestManifestId).toEqual('');
-    jestExpect(downloadedManifestId).toEqual('');
+    jestExpect(latestManifestId).toEqual('null');
+    jestExpect(downloadedManifestId).toEqual('null');
     // After check for update and getting a manifest
     jestExpect(isUpdateAvailable2).toEqual('true');
     jestExpect(isUpdatePending2).toEqual('false');
     jestExpect(isRollback2).toEqual('false');
     jestExpect(latestManifestId2).toEqual(manifest.id);
-    jestExpect(downloadedManifestId2).toEqual('');
+    jestExpect(downloadedManifestId2).toEqual('null');
     // After downloading the update
     jestExpect(isUpdateAvailable3).toEqual('true');
     jestExpect(isUpdatePending3).toEqual('true');
@@ -797,16 +797,16 @@ describe('JS API tests', () => {
     jestExpect(isUpdateAvailable4).toEqual('false');
     jestExpect(isUpdatePending4).toEqual('false');
     jestExpect(isRollback4).toEqual('false');
-    jestExpect(latestManifestId4).toEqual('');
-    jestExpect(downloadedManifestId4).toEqual('');
-    jestExpect(rollbackCommitTime4).toEqual('');
+    jestExpect(latestManifestId4).toEqual('null');
+    jestExpect(downloadedManifestId4).toEqual('null');
+    jestExpect(rollbackCommitTime4).toEqual('null');
     // After check for update and getting a rollback
     jestExpect(isUpdateAvailable5).toEqual('true');
     jestExpect(isUpdatePending5).toEqual('false');
     jestExpect(isRollback5).toEqual('true');
-    jestExpect(latestManifestId5).toEqual('');
-    jestExpect(downloadedManifestId5).toEqual('');
-    jestExpect(rollbackCommitTime5).not.toEqual('');
+    jestExpect(latestManifestId5).toEqual('null');
+    jestExpect(downloadedManifestId5).toEqual('null');
+    jestExpect(rollbackCommitTime5).not.toEqual('null');
 
     // Check for update, and expect isRollback to be true
     await pressTestButtonAsync('triggerParallelFetchAndDownload');

--- a/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
@@ -36,7 +36,7 @@
       "type": "ios.simulator",
       "headless": true,
       "device": {
-        "type": "iPhone 14"
+        "type": "iPhone 15"
       }
     },
     "emulator": {

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -32,7 +32,6 @@ export UPDATES_PORT=4747
 export PROJECT_ROOT=$PWD
 
 export EX_UPDATES_NATIVE_DEBUG=1
-export NO_FLIPPER=1
 
 mkdir ./logs
 

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -4,7 +4,13 @@
   },
   "build": {
     "base": {
-      "node": "18.18.0"
+      "node": "20.14.0",
+      "android": {
+        "image": "latest"
+      },
+      "ios": {
+        "image": "latest"
+      }
     },
     "development": {
       "extends": "base",
@@ -19,19 +25,18 @@
     "updates_testing_debug": {
       "extends": "base",
       "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1",
-        "NO_FLIPPER": "1"
+        "EX_UPDATES_NATIVE_DEBUG": "1"
       },
       "android": {
-        "image": "ubuntu-22.04-jdk-17-ndk-r21e",
+        // Not necessarily to upload the archive for updates_testing_debug, upload eas.json instead.
+        "applicationArchivePath": "eas.json",
         "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
-        "withoutCredentials": true,
-        "resourceClass": "large"
+        "withoutCredentials": true
       },
       "ios": {
+        // Not necessarily to upload the archive for updates_testing_debug, upload eas.json instead.
+        "applicationArchivePath": "eas.json",
         "simulator": true,
-        "resourceClass": "m-medium",
-        "image": "macos-ventura-13.3-xcode-14.3",
         "buildConfiguration": "Debug",
         "cache": {
           "cacheDefaultPaths": false
@@ -43,19 +48,14 @@
     "updates_testing_release": {
       "extends": "base",
       "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1",
-        "NO_FLIPPER": "1"
+        "EX_UPDATES_NATIVE_DEBUG": "1"
       },
       "android": {
-        "image": "ubuntu-22.04-jdk-17-ndk-r21e",
         "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
-        "withoutCredentials": true,
-        "resourceClass": "large"
+        "withoutCredentials": true
       },
       "ios": {
         "simulator": true,
-        "resourceClass": "m-medium",
-        "image": "macos-ventura-13.3-xcode-14.3",
         "buildConfiguration": "Release",
         "cache": {
           "cacheDefaultPaths": false
@@ -64,6 +64,7 @@
       "distribution": "internal",
       "buildArtifactPaths": ["logs/*.log"]
     },
+
     "production": {
       "extends": "base"
     }

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -37,10 +37,7 @@
         // Not necessarily to upload the archive for updates_testing_debug, upload eas.json instead.
         "applicationArchivePath": "eas.json",
         "simulator": true,
-        "buildConfiguration": "Debug",
-        "cache": {
-          "cacheDefaultPaths": false
-        }
+        "buildConfiguration": "Debug"
       },
       "distribution": "internal",
       "buildArtifactPaths": ["logs/*.log"]
@@ -56,10 +53,7 @@
       },
       "ios": {
         "simulator": true,
-        "buildConfiguration": "Release",
-        "cache": {
-          "cacheDefaultPaths": false
-        }
+        "buildConfiguration": "Release"
       },
       "distribution": "internal",
       "buildArtifactPaths": ["logs/*.log"]


### PR DESCRIPTION
# Why

try to improve the stability of e2e testing

# How

- one issue i've seen often is timeout from upload app archive on eas build. it's basically a waste to upload app archives for updates e2e since we don't download the app. this pr tries to use `applicationArchivePath` to upload eas.json instead. (only for updates_testing_debug variant)
- the other issue i've seen often is detox failures. i suspect at some point android `adb shell uiautomator dump` will not dump `<Text></Text>` with empty string (zero width view). even though android studio layout inspector has the text view, uiautomator doesn't dump that view at all. i don't exactly know what caused the problem but it breaks from my attempt of maestro migration at #29369. it should be the reason to break detox testing `await element(by.id(testID)).getAttributes();`. this pr tries to fallback empty string text to `null`.
- `eas build` sometimes fails with `Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue. Error: build command failed.`. i suspect it's because we now have 8 simultaneous build requests. this pr tries to add retries to the `eas build` requests.
- remove deprecated `NO_FLIPPER`
- remove deprecated `cacheDefaultPaths`
- always to latest eas image
- bump eas build node version
- it's not necessary to use large workers for testing. just use the default workers.

# Test Plan

update e2e ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
