### PR TITLE
fix(expo-server): Use nativeFetch for remix globals

### DIFF
--- a/packages/@expo/server/install.js
+++ b/packages/@expo/server/install.js
@@ -2,4 +2,4 @@ const { installGlobals } = require('@expo/server/build/environment');
 
 require('source-map-support/register');
 
-installGlobals();
+installGlobals({ nativeFetch: true });


### PR DESCRIPTION
# Why

Hi
 [@expo/server](https://github.com/expo/expo/blob/main/packages/%40expo/server/package.json#L33) use `@remix-run/node@2.7.2` as part of the server api handling, the issue is with `@remix-run/web-stream` which I understand doesn't use native fetch and cause incompatibility other library with `ReadableStream`. like :  

https://github.com/vercel/ai/blob/4d458dfd1806e793b7b14acddb56ff48517b3b41/packages/provider-utils/src/response-handler.ts#L98

The error being raised is: 

```
TypeError: First parameter has member 'readable' that is not a ReadableStream.
    at assertReadableStream (/Users/x/test-ai/node_modules/web-streams-polyfill/src/lib/validators/readable-stream.ts:5:11)
    at convertReadableWritablePair (/Users/x/test-ai/node_modules/web-streams-polyfill/src/lib/validators/readable-writable-pair.ts:15:3)
    at ReadableStream.pipeThrough (/Users/x/test-ai/node_modules/web-streams-polyfill/src/lib/readable-stream.ts:223:23)
```
    
Is there a way for solve the issue ?


# How

Solution, in vite.config.ts:

`installGlobals({ nativeFetch: true })`


# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
