### PR TITLE
[jest-expo] Fix error thrown by ref stubbing.

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixes jest spitting console error caused by ref stubbing.
+
 ### 💡 Others
 
 ## 51.0.2 — 2024-05-16

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixes jest spitting console error caused by ref stubbing.
+- Fixes jest spitting console error caused by ref stubbing. ([#29420](https://github.com/expo/expo/pull/29420) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -185,9 +185,8 @@ jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
 // Mock the `createSnapshotFriendlyRef` to return an ref that can be serialized in snapshots.
 jest.doMock('expo-modules-core/build/Refs', () => ({
   createSnapshotFriendlyRef: () => {
-    const { createSnapshotFriendlyRef } = jest.requireActual('expo-modules-core/build/Refs');
-    // Fixes: `cannot define property "toJSON", object is not extensible
-    const ref = Object.create(createSnapshotFriendlyRef());
+    // We cannot use `createRef` since it is not extensible.
+    const ref = { current: null };
     Object.defineProperty(ref, 'toJSON', {
       value: () => '[React.ref]',
     });


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/28831

# How

Calling `Object.create` clashed with jest for some reason causing this error:
`Warning: Unexpected ref object provided for ExpoImage. Use either a ref-setter function or React.createRef().`

Instead of importing actual and copying we can just return an empty object with `current: null` - it's the same thing that react does, without the seal:

<img width="406" alt="image" src="https://github.com/expo/expo/assets/5597580/adf138ca-f9df-47fb-aca9-ccd4177fc16d">


# Test Plan

Tested that this fixes the issue in the original repro.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
