### PR TITLE
[camera] Make barcode type consistent

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
+- Make the returned `type` in `BarCodeScanningResult` consistent. ([#29421](https://github.com/expo/expo/pull/29421)) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 15.0.9 — 2024-05-16
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -533,7 +533,7 @@ class ExpoCameraView(
           target = id,
           data = barcode.value,
           raw = barcode.raw,
-          type = barcode.type,
+          type = BarcodeType.mapFormatToString(barcode.type),
           cornerPoints = cornerPoints,
           boundingBox = boundingBox
         )

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
@@ -8,7 +8,7 @@ class BarcodeScannedEvent(
   @Field val target: Int,
   @Field val data: String,
   @Field val raw: String,
-  @Field val type: Int,
+  @Field val type: String,
   @Field val cornerPoints: ArrayList<Bundle>,
   @Field val boundingBox: Bundle
 ) : Record

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/ExpoCameraView.kt
@@ -44,6 +44,7 @@ import android.view.WindowManager
 import expo.modules.camera.common.BarcodeScannedEvent
 import expo.modules.camera.common.CameraMountErrorEvent
 import expo.modules.camera.common.PictureSavedEvent
+import expo.modules.camera.records.BarcodeType
 import expo.modules.interfaces.barcodescanner.BarCodeScannerResult.BoundingBox
 import expo.modules.kotlin.viewevent.EventDispatcher
 
@@ -282,7 +283,7 @@ class ExpoCameraView(
           target = id,
           data = barCode.value,
           raw = barCode.raw,
-          type = barCode.type,
+          type = BarcodeType.mapFormatToString(barCode.type),
           cornerPoints = cornerPoints,
           boundingBox = boundingBox
         )

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
@@ -66,7 +66,7 @@ data class BarcodeSettings(
   @Field val barcodeTypes: List<BarcodeType>
 ) : Record
 
-enum class BarcodeType(val value: String) : Enumerable {
+enum class BarcodeType(private val value: String) : Enumerable {
   AZTEC("aztec"),
   EAN13("ean13"),
   EAN8("ean8"),
@@ -79,7 +79,8 @@ enum class BarcodeType(val value: String) : Enumerable {
   ITF14("itf14"),
   CODABAR("codabar"),
   CODE128("code128"),
-  UPCA("upc_a");
+  UPCA("upc_a"),
+  UNKNOWN("unknown");
 
   fun mapToBarcode() = when (this) {
     AZTEC -> Barcode.FORMAT_AZTEC
@@ -95,5 +96,29 @@ enum class BarcodeType(val value: String) : Enumerable {
     CODABAR -> Barcode.FORMAT_CODABAR
     CODE128 -> Barcode.FORMAT_CODE_128
     UPCA -> Barcode.FORMAT_UPC_A
+    UNKNOWN -> Barcode.FORMAT_UNKNOWN
+  }
+
+  companion object {
+    fun mapFormatToString(format: Int): String {
+      val result = when (format) {
+        Barcode.FORMAT_AZTEC -> AZTEC
+        Barcode.FORMAT_EAN_13 -> EAN13
+        Barcode.FORMAT_EAN_8 -> EAN8
+        Barcode.FORMAT_QR_CODE -> QR
+        Barcode.FORMAT_PDF417 -> PDF417
+        Barcode.FORMAT_UPC_E -> UPCE
+        Barcode.FORMAT_DATA_MATRIX -> DATAMATRIX
+        Barcode.FORMAT_CODE_39 -> CODE39
+        Barcode.FORMAT_CODE_93 -> CODE93
+        Barcode.FORMAT_ITF -> ITF14
+        Barcode.FORMAT_CODABAR -> CODABAR
+        Barcode.FORMAT_CODE_128 -> CODE128
+        Barcode.FORMAT_UPC_A -> UPCA
+        else -> UNKNOWN
+      }
+
+      return result.value
+    }
   }
 }

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -81,8 +81,6 @@ enum BarcodeType: String, Enumerable {
       return .pdf417
     case .itf14:
       return .itf14
-    case .ean13:
-      return .ean13
     case .upce:
       return .upc_e
     case .code39:

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -61,7 +61,7 @@ enum BarcodeType: String, Enumerable {
       return .aztec
     }
   }
-  
+
   static func toBarcodeType(type: AVMetadataObject.ObjectType) -> BarcodeType {
     if #available(iOS 15.4, *) {
       if type == .codabar {

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -61,6 +61,42 @@ enum BarcodeType: String, Enumerable {
       return .aztec
     }
   }
+  
+  static func toBarcodeType(type: AVMetadataObject.ObjectType) -> BarcodeType {
+    if #available(iOS 15.4, *) {
+      if type == .codabar {
+        return .codabar
+      }
+    }
+    switch type {
+    case .aztec:
+      return .aztec
+    case .qr:
+      return .qr
+    case .ean13:
+      return .ean13
+    case .ean8:
+      return .ean8
+    case .pdf417:
+      return .pdf417
+    case .itf14:
+      return .itf14
+    case .ean13:
+      return .ean13
+    case .upce:
+      return .upc_e
+    case .code39:
+      return .code39
+    case .code93:
+      return .code93
+    case .dataMatrix:
+      return .datamatrix
+    case .code128:
+      return .code128
+    default:
+      return .aztec
+    }
+  }
 }
 
 enum VNBarcodeType: String, Enumerable {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -31,7 +31,7 @@ class BarcodeScannerUtils {
 
   static func avMetadataCodeObjectToDictionary(_ barcodeScannerResult: AVMetadataMachineReadableCodeObject) -> [String: Any] {
     var result = [String: Any]()
-    result["type"] = barcodeScannerResult.type
+    result["type"] = BarcodeType.toBarcodeType(type: barcodeScannerResult.type).rawValue
     result["data"] = barcodeScannerResult.stringValue
 
     // iOS converts upc_a to ean13 and appends a leading 0


### PR DESCRIPTION
# Why
Currently in both the legacy and new package, the barcode type on `BarcodeScanningResult` is inconsistent between platforms. On `iOS` you will receive a string, something like this `org.gs1.EAN-13`, and on android an int. 

# How
Make this consistent by parsing the value and returning the same string we use  in typescript to identify barcodes. Scanning a code will now result in something like this on both platforms.
```json
{
  "type": "qr"
},
{
  "type": "ean13"
}
```

# Test Plan
Bare-expo ✅

