### PR TITLE
[docs] Remove platform compatibility table from third party library references for latest versioned docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -7,13 +7,10 @@ platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
-
-<PlatformsSection android emulator ios simulator web />
+`@shopify/flash-list` is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -7,42 +7,15 @@ platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-An API for handling complex gestures. From the project's README:
+`react-native-gesture-handler` is a library for handling complex gestures. From it's README:
 
 > This library provides an API that exposes mobile platform-specific native capabilities of touch and gesture handling and recognition. It allows for defining complex gesture handling and recognition logic that runs 100% in the native thread and is therefore deterministic.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
 
-## API
-
-Add this import to the top of your app entry file, such as **App.js**:
-
-```js
-import 'react-native-gesture-handler';
-```
-
-This will ensure that appropriate event handlers are registered with React Native. Now, you can import gesture handlers wherever you need them:
-
-```js
-import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
-
-class ComponentName extends Component {
-  render() {
-    return (
-      <TapGestureHandler>
-        <RotationGestureHandler>...</RotationGestureHandler>
-      </TapGestureHandler>
-    );
-  }
-}
-```
-
 ## Usage
 
-Read the [react-native-gesture-handler docs](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.
+Read the [`react-native-gesture-handler` documentation](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -7,15 +7,12 @@ platforms: ['android', 'ios', 'tvos']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `@react-native-masked-view/masked-view` provides a masked view that only displays the pixels that overlap with the view rendered in its mask element.
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
 > **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -7,15 +7,12 @@ platforms: ['android', 'ios', 'macos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
@@ -8,7 +8,7 @@ packageName: 'react-native-gesture-handler'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-An API for handling complex gestures. From the project's README:
+`react-native-gesture-handler` is a library for handling complex gestures. From it's README:
 
 > This library provides an API that exposes mobile platform-specific native capabilities of touch and gesture handling and recognition. It allows for defining complex gesture handling and recognition logic that runs 100% in the native thread and is therefore deterministic.
 
@@ -18,30 +18,6 @@ An API for handling complex gestures. From the project's README:
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
 
-## API
-
-Add this import to the top of your app entry file, such as **App.js**:
-
-```js
-import 'react-native-gesture-handler';
-```
-
-This will ensure that appropriate event handlers are registered with React Native. Now, you can import gesture handlers wherever you need them:
-
-```js
-import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
-
-class ComponentName extends Component {
-  render() {
-    return (
-      <TapGestureHandler>
-        <RotationGestureHandler>...</RotationGestureHandler>
-      </TapGestureHandler>
-    );
-  }
-}
-```
-
 ## Usage
 
-Read the [react-native-gesture-handler docs](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.
+Read the [`react-native-gesture-handler` documentation](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.

--- a/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
@@ -8,7 +8,7 @@ packageName: 'react-native-gesture-handler'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-An API for handling complex gestures. From the project's README:
+`react-native-gesture-handler` is a library for handling complex gestures. From it's README:
 
 > This library provides an API that exposes mobile platform-specific native capabilities of touch and gesture handling and recognition. It allows for defining complex gesture handling and recognition logic that runs 100% in the native thread and is therefore deterministic.
 
@@ -18,30 +18,6 @@ An API for handling complex gestures. From the project's README:
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
 
-## API
-
-Add this import to the top of your app entry file, such as **App.js**:
-
-```js
-import 'react-native-gesture-handler';
-```
-
-This will ensure that appropriate event handlers are registered with React Native. Now, you can import gesture handlers wherever you need them:
-
-```js
-import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
-
-class ComponentName extends Component {
-  render() {
-    return (
-      <TapGestureHandler>
-        <RotationGestureHandler>...</RotationGestureHandler>
-      </TapGestureHandler>
-    );
-  }
-}
-```
-
 ## Usage
 
-Read the [react-native-gesture-handler docs](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.
+Read the [`react-native-gesture-handler` documentation](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.

--- a/docs/pages/versions/v51.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/flash-list.mdx
@@ -7,13 +7,10 @@ platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
-
-<PlatformsSection android emulator ios simulator web />
+`@shopify/flash-list` is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
@@ -7,42 +7,15 @@ platforms: ['android', 'ios', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-An API for handling complex gestures. From the project's README:
+`react-native-gesture-handler` is a library for handling complex gestures. From it's README:
 
 > This library provides an API that exposes mobile platform-specific native capabilities of touch and gesture handling and recognition. It allows for defining complex gesture handling and recognition logic that runs 100% in the native thread and is therefore deterministic.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
 
-## API
-
-Add this import to the top of your app entry file, such as **App.js**:
-
-```js
-import 'react-native-gesture-handler';
-```
-
-This will ensure that appropriate event handlers are registered with React Native. Now, you can import gesture handlers wherever you need them:
-
-```js
-import { TapGestureHandler, RotationGestureHandler } from 'react-native-gesture-handler';
-
-class ComponentName extends Component {
-  render() {
-    return (
-      <TapGestureHandler>
-        <RotationGestureHandler>...</RotationGestureHandler>
-      </TapGestureHandler>
-    );
-  }
-}
-```
-
 ## Usage
 
-Read the [react-native-gesture-handler docs](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.
+Read the [`react-native-gesture-handler` documentation](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.

--- a/docs/pages/versions/v51.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/masked-view.mdx
@@ -7,15 +7,12 @@ platforms: ['android', 'ios', 'tvos']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `@react-native-masked-view/masked-view` provides a masked view that only displays the pixels that overlap with the view rendered in its mask element.
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and above requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.
 
 > **warning** Android support for this library is experimental and you may encounter inconsistencies in behavior across platforms. Please report issues you encounter to [react-native-masked-view/masked-view/issues](https://github.com/react-native-masked-view/masked-view).
-
-<PlatformsSection android emulator ios simulator />
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/picker.mdx
@@ -7,15 +7,12 @@ platforms: ['android', 'ios', 'macos', 'web']
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 {/* todo: add video */}
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component that provides access to the system UI for picking between several options.
-
-<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, some third-party library references have Platform tags and Platform compatibility tables.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Removes platform compatibility tables from third party library references (changes applied to unversioned and SDK 51)
- Updates RNGH API reference to remove outdated API section, fixes intro, and fixes Usage section (changes applied to all SDK versions) 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

![CleanShot 2024-06-04 at 17 33 10](https://github.com/expo/expo/assets/10234615/b934dc2a-c342-4e88-a83a-840d4cc49359)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
