### PR TITLE
feat(babel-preset-expo): Add support for `export * from` to `use client` plugin.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for `export * from` to `use client` plugin.
+- Add support for `export * from` to `use client` plugin. ([#29426](https://github.com/expo/expo/pull/29426) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for `export * from` to `use client` plugin.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -25,34 +25,96 @@ function reactClientReferencesPlugin() {
                     // This can happen in tests or systems that use Babel standalone.
                     throw new Error('[Babel] Expected a filename to be set in the state');
                 }
-                const outputKey = url_1.default.pathToFileURL(filePath).href;
                 // File starts with "use client" directive.
-                if (!isUseClient && !isUseServer) {
+                if (!isUseClient) {
                     // Do nothing for code that isn't marked as a client component.
                     return;
                 }
+                const outputKey = url_1.default.pathToFileURL(filePath).href;
+                // We need to add all of the exports to support `export * from './module'` which iterates the keys of the module.
+                const proxyModule = [
+                    `const proxy = /*@__PURE__*/ require("react-server-dom-webpack/server").createClientModuleProxy(${JSON.stringify(outputKey)});`,
+                    `module.exports = proxy;`,
+                ];
+                const getProxy = (exportName) => {
+                    return `(/*@__PURE__*/ proxy[${JSON.stringify(exportName)}])`;
+                };
+                const proxyExports = new Set();
+                const pushProxy = (exportName) => {
+                    proxyExports.add(exportName);
+                    if (exportName === 'default') {
+                        proxyModule.push(`export default ${getProxy(exportName)};`);
+                    }
+                    else {
+                        proxyModule.push(`export const ${exportName} = ${getProxy(exportName)};`);
+                    }
+                };
+                // Collect all of the exports
+                path.traverse({
+                    ExportNamedDeclaration(exportPath) {
+                        if (exportPath.node.declaration) {
+                            if (exportPath.node.declaration.type === 'VariableDeclaration') {
+                                exportPath.node.declaration.declarations.forEach((declaration) => {
+                                    if (declaration.id.type === 'Identifier') {
+                                        const exportName = declaration.id.name;
+                                        pushProxy(exportName);
+                                    }
+                                });
+                            }
+                            else if (exportPath.node.declaration.type === 'FunctionDeclaration') {
+                                const exportName = exportPath.node.declaration.id?.name;
+                                if (exportName) {
+                                    pushProxy(exportName);
+                                }
+                            }
+                            else if (exportPath.node.declaration.type === 'ClassDeclaration') {
+                                const exportName = exportPath.node.declaration.id?.name;
+                                if (exportName) {
+                                    pushProxy(exportName);
+                                }
+                            }
+                            else if (!['InterfaceDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)) {
+                                // TODO: What is this type?
+                                console.warn('[babel-preset-expo] Unsupported export specifier for "use client":', exportPath.node.declaration.type);
+                            }
+                        }
+                        else {
+                            exportPath.node.specifiers.forEach((specifier) => {
+                                if (core_1.types.isIdentifier(specifier.exported)) {
+                                    const exportName = specifier.exported.name;
+                                    pushProxy(exportName);
+                                }
+                                else {
+                                    // TODO: What is this type?
+                                    console.warn('[babel-preset-expo] Unsupported export specifier for "use client":', specifier);
+                                }
+                            });
+                        }
+                    },
+                    ExportDefaultDeclaration() {
+                        pushProxy('default');
+                    },
+                });
                 // Clear the body
-                if (isUseClient) {
-                    path.node.body = [];
-                    path.node.directives = [];
-                    path.pushContainer('body', core_1.template.ast `module.exports = require("react-server-dom-webpack/server").createClientModuleProxy(${JSON.stringify(outputKey)});`);
+                path.node.body = [];
+                path.node.directives = [];
+                path.pushContainer('body', core_1.template.ast(proxyModule.join('\n')));
+                assertExpoMetadata(state.file.metadata);
+                // Save the client reference in the metadata.
+                if (!state.file.metadata.clientReferences) {
+                    state.file.metadata.clientReferences = [];
                 }
-                else {
-                    path.pushContainer('body', core_1.template.ast `
-            ;(() => {
-              if (typeof module.exports === 'function') {
-                require('react-server-dom-webpack/server').registerServerReference(module.exports, ${JSON.stringify(outputKey)}, null);
-              } else {
-                for (const key in module.exports) {
-                  if (typeof module.exports[key] === 'function') {
-                    require('react-server-dom-webpack/server').registerServerReference(module.exports[key], ${JSON.stringify(outputKey)}, key);
-                  }
-                }
-              }
-            })()`);
-                }
+                state.file.metadata.clientReferences.push(outputKey);
+                // Store the proxy export names for testing purposes.
+                state.file.metadata.proxyExports = Array.from(proxyExports);
             },
         },
     };
 }
 exports.reactClientReferencesPlugin = reactClientReferencesPlugin;
+function assertExpoMetadata(metadata) {
+    if (metadata && typeof metadata === 'object') {
+        return;
+    }
+    throw new Error('Expected Babel state.file.metadata to be an object');
+}

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -102,11 +102,11 @@ function reactClientReferencesPlugin() {
                 assertExpoMetadata(state.file.metadata);
                 // Save the client reference in the metadata.
                 if (!state.file.metadata.clientReferences) {
-                    state.file.metadata.clientReferences = [];
+                    state.file.metadata.clientReferences ??= [];
                 }
                 state.file.metadata.clientReferences.push(outputKey);
                 // Store the proxy export names for testing purposes.
-                state.file.metadata.proxyExports = Array.from(proxyExports);
+                state.file.metadata.proxyExports = [...proxyExports];
             },
         },
     };

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/client-module-proxy-plugin.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/client-module-proxy-plugin.test.ts.snap
@@ -8,25 +8,3 @@ exports[`asserts that use client and use server cannot be used together 1`] = `
   3 |     'use client';
   4 |     "
 `;
-
-exports[`use client does nothing without use client directive 1`] = `"export const foo = 'bar';"`;
-
-exports[`use client replaces client exports with React client references 1`] = `"module.exports = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");"`;
-
-exports[`use server replaces server action exports with React server references 1`] = `
-"'use server';
-
-export const greet = name => \`Hello \${name} from server!\`;
-;
-(() => {
-  if (typeof module.exports === 'function') {
-    require('react-server-dom-webpack/server').registerServerReference(module.exports, "file:///unknown", null);
-  } else {
-    for (const key in module.exports) {
-      if (typeof module.exports[key] === 'function') {
-        require('react-server-dom-webpack/server').registerServerReference(module.exports[key], "file:///unknown", key);
-      }
-    }
-  }
-})();"
-`;

--- a/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/client-module-proxy-plugin.test.ts
@@ -57,28 +57,34 @@ it(`asserts that use client and use server cannot be used together`, () => {
   expect(() => babel.transform(sourceCode, options)).toThrowErrorMatchingSnapshot();
 });
 
+function transformReactServer(sourceCode: string) {
+  const options = {
+    ...DEF_OPTIONS,
+    caller: getCaller({ ...ENABLED_CALLER, isReactServer: true, platform: 'ios' }),
+  };
+
+  const results = babel.transform(sourceCode, options);
+  if (!results) throw new Error('Failed to transform code');
+
+  return {
+    code: results.code,
+    metadata: results.metadata as unknown as { proxyExports?: string[] },
+  };
+}
+
 describe('use client', () => {
   it(`does nothing without use client directive`, () => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({ ...ENABLED_CALLER, isReactServer: true, platform: 'ios' }),
-    };
-
     const sourceCode = `
-      export const foo = 'bar';
+    export const foo = 'bar';
     `;
 
-    const contents = babel.transform(sourceCode, options)!.code;
-
-    expect(contents).toMatchSnapshot();
-    expect(contents).not.toMatch('react-server-dom-webpack');
+    const res = transformReactServer(sourceCode);
+    expect(res.metadata.proxyExports).toBeUndefined();
+    expect(res.code).not.toMatch('react-server-dom-webpack');
+    expect(res.code).toMatchInlineSnapshot(`"export const foo = 'bar';"`);
   });
-  it(`collects metadata with React client references`, () => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({ ...ENABLED_CALLER, isReactServer: true, platform: 'ios' }),
-    };
 
+  it(`collects metadata with React client references`, () => {
     const sourceCode = `
     "use client";
     import { Text } from 'react-native';
@@ -90,11 +96,116 @@ describe('use client', () => {
     }
     `;
 
-    const contents = babel.transform(sourceCode, options);
-    expect(contents?.code).toMatch('react-server-dom-webpack');
+    const res = transformReactServer(sourceCode);
+    expect(res.metadata.proxyExports).toEqual(['foo', 'default']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export const foo = proxy["foo"];
+      export default proxy["default"];"
+    `);
   });
 
-  it(`does not collect metadata when bundling for the client`, () => {
+  it(`exports default from module`, () => {
+    const res = transformReactServer(`
+    "use client";    
+    export { default } from "client-only"
+    `);
+    expect(res.metadata.proxyExports).toEqual(['default']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export default proxy["default"];"
+    `);
+  });
+
+  it(`exports class`, () => {
+    const res = transformReactServer(`
+    "use client";    
+    export class Pattern {}
+    `);
+    expect(res.metadata.proxyExports).toEqual(['Pattern']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export const Pattern = proxy["Pattern"];"
+    `);
+  });
+
+  it(`skips typescript exports`, () => {
+    const res = transformReactServer(`
+    "use client";    
+export type EdgeInsetsProp = object;
+
+export interface BaseProps {
+  accessible?: boolean;
+}
+    `);
+    expect(res.metadata.proxyExports).toEqual([]);
+  });
+
+  it(`handles mixed exports from react-native-svg`, () => {
+    const res = transformReactServer(`
+    "use client";    
+export * from './elements/Circle';
+
+export type EdgeInsetsProp = object;
+
+export interface BaseProps {
+  accessible?: boolean;
+}
+
+export class Pattern extends WebShape<BaseProps & PatternProps> {
+  tag = 'pattern';
+}
+
+const Svg = {};
+
+export default Svg;
+
+    `);
+    expect(res.metadata.proxyExports).toEqual(['Pattern', 'default']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export const Pattern = proxy["Pattern"];
+      export default proxy["default"];"
+    `);
+  });
+
+  it(`(TODO) does not support export * from correctly`, () => {
+    const res = transformReactServer(`
+    "use client";  
+    export * from './other';
+    `);
+    expect(res.metadata.proxyExports).toEqual([]);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;"
+    `);
+  });
+
+  it(`replaces client exports with React client references (cjs)`, () => {
+    const res = transformReactServer(`
+    "use client";
+    import { Text } from 'react-native';
+    
+    export const foo = 'bar';
+    
+    module.exports = function App() {
+      return <Text>Hello World</Text>
+    }
+    `);
+    expect(res.metadata.proxyExports).toEqual(['foo']);
+    expect(res.code).toMatchInlineSnapshot(`
+      "const proxy = require("react-server-dom-webpack/server").createClientModuleProxy("file:///unknown");
+      module.exports = proxy;
+      export const foo = proxy["foo"];"
+    `);
+  });
+
+  // Caller is marked for client.
+  it(`does NOT collect metadata when bundling for the client`, () => {
     const options = {
       ...DEF_OPTIONS,
       caller: getCaller({ ...ENABLED_CALLER, isReactServer: false, platform: 'ios' }),
@@ -115,46 +226,5 @@ describe('use client', () => {
     expect(contents?.metadata).toEqual({});
 
     expect(contents?.code).not.toMatch('react-server-dom-webpack');
-  });
-
-  it(`replaces client exports with React client references`, () => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({ ...ENABLED_CALLER, isReactServer: true, platform: 'ios' }),
-    };
-
-    const sourceCode = `
-  "use client";
-  import { Text } from 'react-native';
-  
-  export const foo = 'bar';
-  
-  export default function App() {
-    return <Text>Hello World</Text>
-  }
-  `;
-
-    const contents = babel.transform(sourceCode, options)!.code;
-    expect(contents).toMatchSnapshot();
-
-    expect(contents).toMatch('react-server-dom-webpack');
-  });
-});
-
-describe('use server', () => {
-  it(`replaces server action exports with React server references`, () => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({ ...ENABLED_CALLER, isReactServer: true, platform: 'ios' }),
-    };
-
-    const sourceCode = `
-        'use server';
-      
-        export const greet = (name: string) => \`Hello $\{name} from server!\`;
-      `;
-
-    const contents = babel.transform(sourceCode, options)!.code;
-    expect(contents).toMatchSnapshot();
   });
 });

--- a/packages/babel-preset-expo/src/__tests__/environment-restricted-imports.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/environment-restricted-imports.test.ts
@@ -105,7 +105,6 @@ describe('forbidden server imports', () => {
       return babel.transform(
         src,
         getOpts({
-          // @ts-expect-error
           isReactServer: undefined,
         })
       );

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -120,12 +120,12 @@ export function reactClientReferencesPlugin(): babel.PluginObj {
 
         // Save the client reference in the metadata.
         if (!state.file.metadata.clientReferences) {
-          state.file.metadata.clientReferences = [];
+          state.file.metadata.clientReferences ??= [];
         }
         state.file.metadata.clientReferences.push(outputKey);
 
         // Store the proxy export names for testing purposes.
-        state.file.metadata.proxyExports = Array.from(proxyExports);
+        state.file.metadata.proxyExports = [...proxyExports];
       },
     },
   };

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { template } from '@babel/core';
+import { template, types } from '@babel/core';
 import url from 'url';
 
 export function reactClientReferencesPlugin(): babel.PluginObj {
@@ -24,50 +24,118 @@ export function reactClientReferencesPlugin(): babel.PluginObj {
         }
 
         const filePath = state.file.opts.filename;
+
         if (!filePath) {
           // This can happen in tests or systems that use Babel standalone.
           throw new Error('[Babel] Expected a filename to be set in the state');
         }
-        const outputKey = url.pathToFileURL(filePath).href;
 
         // File starts with "use client" directive.
-        if (!isUseClient && !isUseServer) {
+        if (!isUseClient) {
           // Do nothing for code that isn't marked as a client component.
           return;
         }
 
-        // Clear the body
-        if (isUseClient) {
-          path.node.body = [];
-          path.node.directives = [];
-          path.pushContainer(
-            'body',
-            template.ast`module.exports = require("react-server-dom-webpack/server").createClientModuleProxy(${JSON.stringify(
-              outputKey
-            )});`
-          );
-        } else {
-          path.pushContainer(
-            'body',
-            template.ast`
-            ;(() => {
-              if (typeof module.exports === 'function') {
-                require('react-server-dom-webpack/server').registerServerReference(module.exports, ${JSON.stringify(
-                  outputKey
-                )}, null);
-              } else {
-                for (const key in module.exports) {
-                  if (typeof module.exports[key] === 'function') {
-                    require('react-server-dom-webpack/server').registerServerReference(module.exports[key], ${JSON.stringify(
-                      outputKey
-                    )}, key);
+        const outputKey = url.pathToFileURL(filePath).href;
+
+        // We need to add all of the exports to support `export * from './module'` which iterates the keys of the module.
+        const proxyModule = [
+          `const proxy = /*@__PURE__*/ require("react-server-dom-webpack/server").createClientModuleProxy(${JSON.stringify(
+            outputKey
+          )});`,
+          `module.exports = proxy;`,
+        ];
+
+        const getProxy = (exportName: string) => {
+          return `(/*@__PURE__*/ proxy[${JSON.stringify(exportName)}])`;
+        };
+
+        const proxyExports = new Set<string>();
+        const pushProxy = (exportName: string) => {
+          proxyExports.add(exportName);
+          if (exportName === 'default') {
+            proxyModule.push(`export default ${getProxy(exportName)};`);
+          } else {
+            proxyModule.push(`export const ${exportName} = ${getProxy(exportName)};`);
+          }
+        };
+
+        // Collect all of the exports
+        path.traverse({
+          ExportNamedDeclaration(exportPath) {
+            if (exportPath.node.declaration) {
+              if (exportPath.node.declaration.type === 'VariableDeclaration') {
+                exportPath.node.declaration.declarations.forEach((declaration) => {
+                  if (declaration.id.type === 'Identifier') {
+                    const exportName = declaration.id.name;
+                    pushProxy(exportName);
                   }
+                });
+              } else if (exportPath.node.declaration.type === 'FunctionDeclaration') {
+                const exportName = exportPath.node.declaration.id?.name;
+                if (exportName) {
+                  pushProxy(exportName);
                 }
+              } else if (exportPath.node.declaration.type === 'ClassDeclaration') {
+                const exportName = exportPath.node.declaration.id?.name;
+                if (exportName) {
+                  pushProxy(exportName);
+                }
+              } else if (
+                !['InterfaceDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)
+              ) {
+                // TODO: What is this type?
+                console.warn(
+                  '[babel-preset-expo] Unsupported export specifier for "use client":',
+                  exportPath.node.declaration.type
+                );
               }
-            })()`
-          );
+            } else {
+              exportPath.node.specifiers.forEach((specifier) => {
+                if (types.isIdentifier(specifier.exported)) {
+                  const exportName = specifier.exported.name;
+                  pushProxy(exportName);
+                } else {
+                  // TODO: What is this type?
+                  console.warn(
+                    '[babel-preset-expo] Unsupported export specifier for "use client":',
+                    specifier
+                  );
+                }
+              });
+            }
+          },
+          ExportDefaultDeclaration() {
+            pushProxy('default');
+          },
+        });
+
+        // Clear the body
+        path.node.body = [];
+        path.node.directives = [];
+
+        path.pushContainer('body', template.ast(proxyModule.join('\n')));
+
+        assertExpoMetadata(state.file.metadata);
+
+        // Save the client reference in the metadata.
+        if (!state.file.metadata.clientReferences) {
+          state.file.metadata.clientReferences = [];
         }
+        state.file.metadata.clientReferences.push(outputKey);
+
+        // Store the proxy export names for testing purposes.
+        state.file.metadata.proxyExports = Array.from(proxyExports);
       },
     },
   };
+}
+
+function assertExpoMetadata(
+  metadata: any
+): asserts metadata is { clientReferences?: string[]; proxyExports?: string[] } {
+  if (metadata && typeof metadata === 'object') {
+    return;
+  }
+  throw new Error('Expected Babel state.file.metadata to be an object');
 }


### PR DESCRIPTION
# Why

- needed for react-native-svg support.
- this PR also drops the basic support for server actions which I stopped using in the prototype.
