### PR TITLE
[video][ios] Weakify the `VideoPlayerObserver` properties

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- [iOS] Make appropriate references weak in `VideoPlayerObserver`. ([#29427](https://github.com/expo/expo/pull/29427) by [@behenate](https://github.com/behenate))
+
 ## 1.1.10 - 2024-05-29
 
 ### 💡 Others

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -58,14 +58,13 @@ final class WeakPlayerObserverDelegate: Hashable {
 }
 
 class VideoPlayerObserver {
-  let player: AVPlayer
+  weak var player: AVPlayer?
   var delegates = Set<WeakPlayerObserverDelegate>()
-  weak var delegate: VideoPlayerObserverDelegate?
   private var currentItem: VideoPlayerItem?
 
   private var isPlaying: Bool = false {
     didSet {
-      if oldValue != isPlaying {
+      if let player, oldValue != isPlaying {
         delegates.forEach { delegate in
           delegate.value?.onIsPlayingChanged(player: player, oldIsPlaying: oldValue, newIsPlaying: isPlaying)
         }
@@ -75,7 +74,7 @@ class VideoPlayerObserver {
   private var error: Exception?
   private var status: PlayerStatus = .idle {
     didSet {
-      if oldValue != status {
+      if let player, oldValue != status {
         delegates.forEach { delegate in
           delegate.value?.onStatusChanged(player: player, oldStatus: oldValue, newStatus: status, error: error)
         }
@@ -118,12 +117,27 @@ class VideoPlayerObserver {
   }
 
   private func initializePlayerObservers() {
-    playerRateObserver = player.observe(\.rate, options: [.initial, .new, .old], changeHandler: onPlayerRateChanged)
-    playerStatusObserver = player.observe(\.status, options: [.initial, .new, .old], changeHandler: onPlayerStatusChanged)
-    playerTimeControlStatusObserver = player.observe(\.timeControlStatus, options: [.new, .old], changeHandler: onTimeControlStatusChanged)
-    playerVolumeObserver = player.observe(\.volume, options: [.initial, .new, .old], changeHandler: onPlayerVolumeChanged)
-    playerIsMutedObserver = player.observe(\.isMuted, options: [.initial, .new, .old], changeHandler: onPlayerIsMutedChanged)
-    playerCurrentItemObserver = player.observe(\.currentItem, options: [.initial, .new], changeHandler: onPlayerCurrentItemChanged)
+    guard let player else {
+      return
+    }
+    playerRateObserver = player.observe(\.rate, options: [.initial, .new, .old]) { [weak self] player, change in
+      self?.onPlayerRateChanged(player, change)
+    }
+    playerStatusObserver = player.observe(\.status, options: [.initial, .new, .old]) { [weak self] player, change in
+      self?.onPlayerStatusChanged(player, change)
+    }
+    playerTimeControlStatusObserver = player.observe(\.timeControlStatus, options: [.new, .old]) { [weak self] player, change in
+      self?.onTimeControlStatusChanged(player, change)
+    }
+    playerVolumeObserver = player.observe(\.volume, options: [.initial, .new, .old]) { [weak self] player, change in
+      self?.onPlayerVolumeChanged(player, change)
+    }
+    playerIsMutedObserver = player.observe(\.isMuted, options: [.initial, .new, .old]) { [weak self] player, change in
+      self?.onPlayerIsMutedChanged(player, change)
+    }
+    playerCurrentItemObserver = player.observe(\.currentItem, options: [.initial, .new]) { [weak self] player, change in
+      self?.onPlayerCurrentItemChanged(player, change)
+    }
   }
 
   private func invalidatePlayerObservers() {
@@ -136,9 +150,17 @@ class VideoPlayerObserver {
   }
 
   private func initializeCurrentPlayerItemObservers(player: AVPlayer, playerItem: AVPlayerItem) {
-    playbackBufferEmptyObserver = playerItem.observe(\.isPlaybackBufferEmpty, changeHandler: onIsBufferEmptyChanged)
-    playbackLikelyToKeepUpObserver = playerItem.observe(\.isPlaybackLikelyToKeepUp, changeHandler: onPlayerLikelyToKeepUpChanged)
-    playerItemStatusObserver = playerItem.observe(\.status, options: [.initial, .new], changeHandler: onItemStatusChanged)
+    playbackBufferEmptyObserver = playerItem.observe(\.isPlaybackBufferEmpty) { [weak self] item, change in
+      self?.onIsBufferEmptyChanged(item, change)
+    }
+
+    playbackLikelyToKeepUpObserver = playerItem.observe(\.isPlaybackLikelyToKeepUp) { [weak self] item, change in
+      self?.onPlayerLikelyToKeepUpChanged(item, change)
+    }
+
+    playerItemStatusObserver = playerItem.observe(\.status, options: [.initial, .new]) { [weak self] item, change in
+      self?.onItemStatusChanged(item, change)
+    }
 
     playerItemObserver = NotificationCenter.default.addObserver(
       forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
@@ -191,7 +213,7 @@ class VideoPlayerObserver {
   }
 
   private func onItemStatusChanged(_ playerItem: AVPlayerItem, _ change: NSKeyValueObservedChange<AVPlayerItem.Status>) {
-    if player.status != .failed {
+    if player?.status != .failed {
       error = nil
     }
 
@@ -210,7 +232,9 @@ class VideoPlayerObserver {
     }
 
     delegates.forEach { delegate in
-      delegate.value?.onPlayerItemStatusChanged(player: player, oldStatus: change.oldValue, newStatus: playerItem.status)
+      if let player {
+        delegate.value?.onPlayerItemStatusChanged(player: player, oldStatus: change.oldValue, newStatus: playerItem.status)
+      }
     }
   }
 


### PR DESCRIPTION
# Why

The observers hold a strong reference to self, which means that the object cannot be deallocated unless all of the observers have been invalidated. 
`VideoPlayerObserver` and `VideoPlayer` hold strong references to each other, which could lead to reference cycles.

# How

Used the `weak` keyword to "weakify" the properties

# Test Plan

Tested in BareExpo in iOS 17 simulator and a physical device
