### PR TITLE
[video][ios] Fix crashes when creating new players

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,8 +15,8 @@
 - [Android] Fix wrong content fit "fill" and "cover". ([#29364](https://github.com/expo/expo/pull/29364) by [@RRaideRR](https://github.com/RRaideRR))
 - [iOS] Fix player status property always returning `undefined` on iOS. ([#29505](https://github.com/expo/expo/pull/29505) by [@behenate](https://github.com/behenate))
 - [Android] Fix `VideoPlayer.replace` not working when the previous source caused an error. ([#29598](https://github.com/expo/expo/pull/29598) by [@lukmccall](https://github.com/lukmccall))
-
 - [Web] Fix default behavior for `nativeControls` to match documentation. ([#29667](https://github.com/expo/expo/pull/29667) by [@nahn20](https://github.com/nahn20))
+- [iOS] Fix crashes when creating new players. ([#29428](https://github.com/expo/expo/pull/29428) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -13,6 +13,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   static var shared = NowPlayingManager()
 
   private let skipTimeInterval = 10.0
+  private let fetchMetadataQueue = DispatchQueue(label: "com.expo.fetchMetadataQueue")
   private var timeObserver: Any?
   private weak var mostRecentInteractionPlayer: AVPlayer?
   private var players = NSHashTable<VideoPlayer>.weakObjects()
@@ -138,40 +139,53 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   }
 
   private func updateNowPlayingInfo() {
-    guard let player = mostRecentInteractionPlayer, let currentItem = mostRecentInteractionPlayer?.currentItem else {
+    guard let player = mostRecentInteractionPlayer, let currentItem = player.currentItem else {
       return
     }
     let videoPlayerItem = currentItem as? VideoPlayerItem
 
-    // Metadata explicily specified by the user
+    // Metadata explicitly specified by the user
     let userMetadata = videoPlayerItem?.videoSource.metadata
 
-    // Metadata fetched with the video
-    let assetMetadata = currentItem.asset.commonMetadata
+    Task {
+      let assetMetadata = await try loadMetadata(for: currentItem)
 
-    let title = assetMetadata.first(where: {
-      $0.commonKey == .commonKeyTitle
-    })
+      let title = assetMetadata.first(where: {
+        $0.commonKey == .commonKeyTitle
+      })
 
-    let artist = assetMetadata.first(where: {
-      $0.commonKey == .commonKeyArtist
-    })
+      let artist = assetMetadata.first(where: {
+        $0.commonKey == .commonKeyArtist
+      })
 
-    let artwork = assetMetadata.first(where: {
-      $0.commonKey == .commonKeyArtwork
-    })
+      let artwork = assetMetadata.first(where: {
+        $0.commonKey == .commonKeyArtwork
+      })
 
-    var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+      var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
 
-    nowPlayingInfo[MPMediaItemPropertyTitle] = userMetadata?.title ?? title
-    nowPlayingInfo[MPMediaItemPropertyArtist] = userMetadata?.artist ?? artist
-    nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
-    nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
-    nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = player.rate
-    nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue // Using MPNowPlayingInfoMediaType.video causes a crash
-    nowPlayingInfo[MPMediaItemPropertyArtwork] = artwork
+      nowPlayingInfo[MPMediaItemPropertyTitle] = userMetadata?.title ?? title
+      nowPlayingInfo[MPMediaItemPropertyArtist] = userMetadata?.artist ?? artist
+      nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
+      nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
+      nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = await player.rate
+      nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue // Using MPNowPlayingInfoMediaType.video causes a crash
+      nowPlayingInfo[MPMediaItemPropertyArtwork] = artwork
 
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+      MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+  }
+
+  private func loadMetadata(for mediaItem: AVPlayerItem) async throws -> [AVMetadataItem] {
+    if #available(iOS 15.0, *) {
+      return try await mediaItem.asset.loadMetadata(for: .iTunesMetadata)
+    }
+
+    return await withCheckedContinuation { continuation in
+      fetchMetadataQueue.async {
+        continuation.resume(returning: mediaItem.asset.metadata)
+      }
+    }
   }
 
   // Updates nowPlaying information that changes dynamically during playback e.g. progress

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -83,9 +83,9 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   deinit {
+    observer.cleanup()
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
-    observer.unregisterDelegate(delegate: self)
     pointer.replaceCurrentItem(with: nil)
   }
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -104,8 +104,7 @@ class VideoPlayerObserver {
   }
 
   deinit {
-    invalidatePlayerObservers()
-    invalidateCurrentPlayerItemObservers()
+    cleanup()
   }
 
   func registerDelegate(delegate: VideoPlayerObserverDelegate) {
@@ -115,6 +114,12 @@ class VideoPlayerObserver {
 
   func unregisterDelegate(delegate: VideoPlayerObserverDelegate) {
     delegates.remove(WeakPlayerObserverDelegate(value: delegate))
+  }
+
+  func cleanup() {
+    delegates.removeAll()
+    invalidatePlayerObservers()
+    invalidateCurrentPlayerItemObservers()
   }
 
   private func initializePlayerObservers() {


### PR DESCRIPTION
# Why

When switching the video by creating a new player (passing a source state as an input into useVideoPlayer) the app would sometimes hard-crash with `EXC_BAD_ACCESS`

# How

Turns out the `currentItem.asset.commonMetadata` takes a long time to resolve. Since iOS 15+ `mediaItem.asset.loadMetadata(for:` should be used, on lower versions, I created a separate queue on which the request will be executed.

# Test Plan

Tested in BareExpo on a physical device and an iOS simulator

