### PR TITLE
refactor(expo-updates): update `@types/node` to latest 18

### DIFF
--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.2.1",
-    "@types/node": "^17.0.15",
+    "@types/node": "^18.19.34",
     "@types/node-forge": "^1.0.0",
     "expo-module-scripts": "^3.0.0",
     "express": "^4.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4550,15 +4550,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.50.tgz#93003cf0251a2ecd26dad6dc757168d648519805"
   integrity sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==
 
-"@types/node@^17.0.15":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
-  integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
-
 "@types/node@^18.0.0", "@types/node@^18.16.3":
   version "18.19.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.23.tgz#e02c759218bc9957423a3f7d585d511b17be2351"
   integrity sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.19.34":
+  version "18.19.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.34.tgz#c3fae2bbbdb94b4a52fe2d229d0dccce02ef3d27"
+  integrity sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
# Why

Technically, we only support Node LTS (which is 20 now). But I do think lots of people in React Native are still on Node 18.

# How

- Bumped `@types/node` from 17 to 18

# Test Plan

See if CI passes (mostly type checks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
