### PR TITLE
refactor(expo-test-runner): update `@types/node` to latest 18

### DIFF
--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@types/fs-extra": "^9.0.1",
-    "@types/node": "^16.18.11",
+    "@types/node": "^18.19.34",
     "@types/node-fetch": "^2.5.12",
     "eslint-config-universe": "^13.0.0",
     "expo-module-scripts": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4545,7 +4545,7 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^16.11.56", "@types/node@^16.18.11":
+"@types/node@^16.11.56":
   version "16.18.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.50.tgz#93003cf0251a2ecd26dad6dc757168d648519805"
   integrity sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==
@@ -4559,6 +4559,13 @@
   version "18.19.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.23.tgz#e02c759218bc9957423a3f7d585d511b17be2351"
   integrity sha512-wtE3d0OUfNKtZYAqZb8HAWGxxXsImJcPUAgZNw+dWFxO6s5tIwIjyKnY76tsTatsNCLJPkVYwUpq15D38ng9Aw==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@^18.19.34":
+  version "18.19.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.34.tgz#c3fae2bbbdb94b4a52fe2d229d0dccce02ef3d27"
+  integrity sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
# Why

Technically, we only support Node LTS (which is 20 now). But I do think lots of people in React Native are still on Node 18.

# How

- Bumped `@types/node` from 16 to 18

# Test Plan

See if CI passes (mostly type checks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
