### PR TITLE
refactor(create-expo): update `@types/node` to latest 18

### DIFF
--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -40,7 +40,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.7",
     "@types/getenv": "^1.0.0",
-    "@types/node": "^16.11.56",
+    "@types/node": "^18.19.34",
     "@types/node-fetch": "^2.5.8",
     "@types/picomatch": "^2.3.3",
     "@types/prompts": "2.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4545,11 +4545,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^16.11.56":
-  version "16.18.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.50.tgz#93003cf0251a2ecd26dad6dc757168d648519805"
-  integrity sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==
-
 "@types/node@^18.0.0", "@types/node@^18.16.3", "@types/node@^18.19.34":
   version "18.19.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.34.tgz#c3fae2bbbdb94b4a52fe2d229d0dccce02ef3d27"


### PR DESCRIPTION
# Why

Technically, we only support Node LTS (which is 20 now). But I do think lots of people in React Native are still on Node 18.

# How

- Bumped `@types/node` from 16 to 18

# Test Plan

See if CI passes (mostly type checks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
