### PR TITLE
[docs] Fix Vale warnings in Updates API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -29,6 +29,7 @@ Alternatively, it is also possible to configure the `expo-updates` library manua
 If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
 If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
+
 - [`updates.url`](/versions/latest/config/app/#updates): a URL of a remote service implementing the [Expo Updates protocol](/technical-specs/expo-updates-1/)
 - [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](/eas-update/runtime-versions/)
 
@@ -57,7 +58,7 @@ On iOS, these properties are set as keys in the **Expo.plist** file. You can als
 
 <Collapsible summary="Importing Swift generated headers for use in Objective-C++">
 
-If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports in order to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
+If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
 
 ```objc
 #import "ExpoModulesCore-Swift.h"
@@ -69,16 +70,16 @@ If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you wil
 
 </Collapsible>
 
-| [App Config property](/versions/latest/config/app/#updates)                   | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
-|----------------------------------|----------|-------------|-----------------------------------|------------------------------------------------------------------|--------------------------|
-| `updates.enabled`                | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
-| `updates.url`                    | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
-| `updates.requestHeaders`         | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
-| `runtimeVersion`                 | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
-| `updates.checkAutomatically`     | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
-| `updates.fallbackToCacheTimeout` | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
-| `updates.codeSigningCertificate` | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
-| `updates.codeSigningMetadata`    | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+| [App Config property](/versions/latest/config/app/#updates) | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
+| ----------------------------------------------------------- | -------- | ----------- | --------------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| `updates.enabled`                                           | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
+| `updates.url`                                               | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
+| `updates.requestHeaders`                                    | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
+| `runtimeVersion`                                            | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
+| `updates.checkAutomatically`                                | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
+| `updates.fallbackToCacheTimeout`                            | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
+| `updates.codeSigningCertificate`                            | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
+| `updates.codeSigningMetadata`                               | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
 
 ## Usage
 
@@ -89,35 +90,36 @@ The library also provides a variety of constants to inspect the current update a
 <Collapsible summary="Example: Check for updates manually">
 
 You can configure your app to check for updates manually by doing the following steps:
+
 1. Set the `checkAutomatically` configuration value to `ON_ERROR_RECOVERY` or `NEVER` to disable the library's default launch behavior.
 2. Add the following code to check for available updates, download them, and reload:
 
-    ```jsx App.js
-    import { View, Button } from 'react-native';
-    import * as Updates from 'expo-updates';
+   ```jsx App.js
+   import { View, Button } from 'react-native';
+   import * as Updates from 'expo-updates';
 
-    function App() {
-      async function onFetchUpdateAsync() {
-        try {
-          const update = await Updates.checkForUpdateAsync();
+   function App() {
+     async function onFetchUpdateAsync() {
+       try {
+         const update = await Updates.checkForUpdateAsync();
 
-          if (update.isAvailable) {
-            await Updates.fetchUpdateAsync();
-            await Updates.reloadAsync();
-          }
-        } catch (error) {
-          // You can also add an alert() to see the error message in case of an error when fetching updates.
-          alert(`Error fetching latest Expo update: ${error}`);
-        }
-      }
+         if (update.isAvailable) {
+           await Updates.fetchUpdateAsync();
+           await Updates.reloadAsync();
+         }
+       } catch (error) {
+         // You can also add an alert() to see the error message in case of an error when fetching updates.
+         alert(`Error fetching latest Expo update: ${error}`);
+       }
+     }
 
-      return (
-        <View>
-          <Button title="Fetch update" onPress={onFetchUpdateAsync} />
-        </View>
-      );
-    }
-    ```
+     return (
+       <View>
+         <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+       </View>
+     );
+   }
+   ```
 
 </Collapsible>
 
@@ -141,11 +143,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                              | Description                                                                                                                                                                                                                                                   |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Code                              | Description                                                                                                                                                                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                          |
 | `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
-| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
-| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
-| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                           |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                               |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                  |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                    |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                             |

--- a/docs/pages/versions/v51.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/updates.mdx
@@ -29,6 +29,7 @@ Alternatively, it is also possible to configure the `expo-updates` library manua
 If you're installing this library in a [bare React Native app](/bare/overview/) or a generic app with manually configured native code, follow these [installation instructions](/bare/installing-updates/).
 
 If using [app config](/workflow/configuration/) for configuration, this library can be configured by setting at least the following app config properties:
+
 - [`updates.url`](/versions/latest/config/app/#updates): a URL of a remote service implementing the [Expo Updates protocol](/technical-specs/expo-updates-1/)
 - [`runtimeVersion`](/versions/latest/config/app/#runtimeversion): a [runtime version](/eas-update/runtime-versions/)
 
@@ -57,7 +58,7 @@ On iOS, these properties are set as keys in the **Expo.plist** file. You can als
 
 <Collapsible summary="Importing Swift generated headers for use in Objective-C++">
 
-If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports in order to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
+If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you will need to add the following imports to reference methods on `EXUpdatesAppController`. This is only necessary for overriding configuration at runtime.
 
 ```objc
 #import "ExpoModulesCore-Swift.h"
@@ -69,16 +70,16 @@ If your iOS native code or `AppDelegate.mm` is written in Objective-C++, you wil
 
 </Collapsible>
 
-| [App Config property](/versions/latest/config/app/#updates)                   | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
-|----------------------------------|----------|-------------|-----------------------------------|------------------------------------------------------------------|--------------------------|
-| `updates.enabled`                | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
-| `updates.url`                    | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
-| `updates.requestHeaders`         | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
-| `runtimeVersion`                 | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
-| `updates.checkAutomatically`     | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
-| `updates.fallbackToCacheTimeout` | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
-| `updates.codeSigningCertificate` | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
-| `updates.codeSigningMetadata`    | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
+| [App Config property](/versions/latest/config/app/#updates) | Default  | Required?   | iOS plist/dictionary key          | Android meta-data name                                           | Android Map key          |
+| ----------------------------------------------------------- | -------- | ----------- | --------------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| `updates.enabled`                                           | `true`   | <NoIcon />  | `EXUpdatesEnabled`                | `expo.modules.updates.ENABLED`                                   | `enabled`                |
+| `updates.url`                                               | (none)   | <YesIcon /> | `EXUpdatesURL`                    | `expo.modules.updates.EXPO_UPDATE_URL`                           | `updateUrl`              |
+| `updates.requestHeaders`                                    | (none)   | <NoIcon />  | `EXUpdatesRequestHeaders`         | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | `requestHeaders`         |
+| `runtimeVersion`                                            | (none)   | <YesIcon /> | `EXUpdatesRuntimeVersion`         | `expo.modules.updates.EXPO_RUNTIME_VERSION`                      | `runtimeVersion`         |
+| `updates.checkAutomatically`                                | `ALWAYS` | <NoIcon />  | `EXUpdatesCheckOnLaunch`          | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`              | `checkOnLaunch`          |
+| `updates.fallbackToCacheTimeout`                            | `0`      | <NoIcon />  | `EXUpdatesLaunchWaitMs`           | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`               | `launchWaitMs`           |
+| `updates.codeSigningCertificate`                            | (none)   | <NoIcon />  | `EXUpdatesCodeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                  | `codeSigningCertificate` |
+| `updates.codeSigningMetadata`                               | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`    |
 
 ## Usage
 
@@ -89,35 +90,36 @@ The library also provides a variety of constants to inspect the current update a
 <Collapsible summary="Example: Check for updates manually">
 
 You can configure your app to check for updates manually by doing the following steps:
+
 1. Set the `checkAutomatically` configuration value to `ON_ERROR_RECOVERY` or `NEVER` to disable the library's default launch behavior.
 2. Add the following code to check for available updates, download them, and reload:
 
-    ```jsx App.js
-    import { View, Button } from 'react-native';
-    import * as Updates from 'expo-updates';
+   ```jsx App.js
+   import { View, Button } from 'react-native';
+   import * as Updates from 'expo-updates';
 
-    function App() {
-      async function onFetchUpdateAsync() {
-        try {
-          const update = await Updates.checkForUpdateAsync();
+   function App() {
+     async function onFetchUpdateAsync() {
+       try {
+         const update = await Updates.checkForUpdateAsync();
 
-          if (update.isAvailable) {
-            await Updates.fetchUpdateAsync();
-            await Updates.reloadAsync();
-          }
-        } catch (error) {
-          // You can also add an alert() to see the error message in case of an error when fetching updates.
-          alert(`Error fetching latest Expo update: ${error}`);
-        }
-      }
+         if (update.isAvailable) {
+           await Updates.fetchUpdateAsync();
+           await Updates.reloadAsync();
+         }
+       } catch (error) {
+         // You can also add an alert() to see the error message in case of an error when fetching updates.
+         alert(`Error fetching latest Expo update: ${error}`);
+       }
+     }
 
-      return (
-        <View>
-          <Button title="Fetch update" onPress={onFetchUpdateAsync} />
-        </View>
-      );
-    }
-    ```
+     return (
+       <View>
+         <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+       </View>
+     );
+   }
+   ```
 
 </Collapsible>
 
@@ -141,11 +143,11 @@ import * as Updates from 'expo-updates';
 
 ## Error codes
 
-| Code                              | Description                                                                                                                                                                                                                                                   |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Code                              | Description                                                                                                                                                                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ERR_UPDATES_DISABLED`            | A method call was attempted when the Updates library was disabled, or the application was running in development mode                                                                                                                                          |
 | `ERR_UPDATES_RELOAD`              | An error occurred when trying to reload the application and it could not be reloaded. For bare workflow apps, double check the setup steps for this library to ensure it has been installed correctly and the proper native initialization methods are called. |
-| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                              |
-| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                 |
-| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                   |
-| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                           |
+| `ERR_UPDATES_CHECK`               | An unexpected error occurred when trying to check for new updates. Check the error message for more information.                                                                                                                                               |
+| `ERR_UPDATES_FETCH`               | An unexpected error occurred when trying to fetch a new update. Check the error message for more information.                                                                                                                                                  |
+| `ERR_UPDATES_READ_LOGS`           | An unexpected error occurred when trying to read log entries. Check the error message for more information.                                                                                                                                                    |
+| `ERR_NOT_AVAILABLE_IN_DEV_CLIENT` | A method is not available when running in a development build. A release build should be used to test this method.                                                                                                                                             |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After recent updates to Updates API reference some Vale warnings weren't addressed.

![CleanShot 2024-06-05 at 16 27 32@2x](https://github.com/expo/expo/assets/10234615/4cef9f3a-c4dc-482d-b20b-1f1625b23c03)


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes Vale warnings as per our writing style guide and incorporated Vale rules. It also applies docs prettier configuration to these files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs lcoally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
