### PR TITLE
fix: [docs] Expo-Location Usage Example containes a falsy import when copied (by using the default tsconfig)

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -126,7 +126,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 import React, { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
-import Device from 'expo-device';
+import * as Device from 'expo-device';
 /* @end */
 import * as Location from 'expo-location';
 

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -120,7 +120,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 import React, { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
-import Device from 'expo-device';
+import * as Device from 'expo-device';
 /* @end */
 import * as Location from 'expo-location';
 

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -128,7 +128,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 import React, { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
-import Device from 'expo-device';
+import * as Device from 'expo-device';
 /* @end */
 import * as Location from 'expo-location';
 

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -126,7 +126,7 @@ If you're using the Android Emulator or iOS Simulator, ensure that [Location is 
 import React, { useState, useEffect } from 'react';
 import { Platform, Text, View, StyleSheet } from 'react-native';
 /* @hide */
-import Device from 'expo-device';
+import * as Device from 'expo-device';
 /* @end */
 import * as Location from 'expo-location';
 


### PR DESCRIPTION
# Why

The code being provided as an example under [#usage](https://docs.expo.dev/versions/latest/sdk/location/#usage) imports `expo-device` with an default export although this package (expo-device) does not have one. 
Issue: #29458 

# How

I changed the import to import `expo-device` to not be a default-import (because npx create-expo-app@latest creates a tsconfig without setting `allowSyntheticDefaultImports` to true). 
Instead expo-device gets imported via `* as`-syntax which should have the same effect.

# Test Plan

I ran `npx expo prebuild` and `expo run:android` (lastly on my Galaxy A52s) and both ran/build with no errors.
Output of  `npx expo prebuild`.
```bash
PS D:\dev\react-native\test-project> npx expo prebuild

📝  Android package Learn more: https://expo.fyi/android-package

√ What would you like your Android package name to be? ... com.chfuchte.testproject

√ Created native directory
√ Updated package.json
√ Finished prebuild
PS D:\dev\react-native\test-project> 
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md). 
In addition: please not that the import of `expo-device` is not visible without copying the snippet via the "copy"-button.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
