### PR TITLE
feat(cli): skip simulator open prompt.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Deep link to simulators without prompting for permissions first.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Deep link to simulators without prompting for permissions first.
+- Deep link to simulators without prompting for permissions first. ([#29468](https://github.com/expo/expo/pull/29468) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -61,6 +61,7 @@
     "accepts": "^1.3.8",
     "arg": "^5.0.2",
     "better-opn": "~3.0.2",
+    "bplist-creator": "0.0.7",
     "bplist-parser": "^0.3.1",
     "cacache": "^18.0.2",
     "chalk": "^4.0.0",

--- a/packages/@expo/cli/src/start/platforms/DeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/DeviceManager.ts
@@ -29,9 +29,11 @@ export abstract class DeviceManager<IDevice> {
     applicationId: string
   ): Promise<boolean | string>;
 
-  abstract openUrlAsync(url: string): Promise<void>;
+  abstract openUrlAsync(url: string, options?: { appId?: string }): Promise<void>;
 
   abstract activateWindowAsync(): Promise<void>;
 
   abstract ensureExpoGoAsync(sdkVersion: string): Promise<boolean>;
+
+  abstract getExpoGoAppId(): string;
 }

--- a/packages/@expo/cli/src/start/platforms/PlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/PlatformManager.ts
@@ -119,7 +119,7 @@ export class PlatformManager<
     const installedExpo = await deviceManager.ensureExpoGoAsync(sdkVersion);
 
     deviceManager.activateWindowAsync();
-    await deviceManager.openUrlAsync(url);
+    await deviceManager.openUrlAsync(url, { appId: deviceManager.getExpoGoAppId() });
 
     await logEventAsync('Open Url on Device', {
       platform: this.props.platform,
@@ -142,6 +142,7 @@ export class PlatformManager<
     let url = this.props.getCustomRuntimeUrl({ scheme: props.scheme });
     debug(`Opening project in custom runtime: ${url} -- %O`, props);
     // TODO: It's unclear why we do application id validation when opening with a URL
+    // NOTE: But having it enables us to allow the deep link to directly open on iOS simulators without the modal.
     const applicationId = props.applicationId ?? (await this._getAppIdResolver().getAppIdAsync());
 
     const deviceManager = await this.props.resolveDeviceAsync(resolveSettings);
@@ -167,7 +168,10 @@ export class PlatformManager<
 
     deviceManager.logOpeningUrl(url);
     await deviceManager.activateWindowAsync();
-    await deviceManager.openUrlAsync(url);
+
+    await deviceManager.openUrlAsync(url, {
+      appId: applicationId,
+    });
 
     return {
       url,

--- a/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/PlatformManager-test.ts
@@ -39,6 +39,7 @@ describe('openAsync', () => {
       ensureExpoGoAsync: jest.fn(),
       activateWindowAsync: jest.fn(),
       openUrlAsync: jest.fn(),
+      getExpoGoAppId: jest.fn(() => 'host.exp.exponent'),
       isAppInstalledAndIfSoReturnContainerPathForIOSAsync: jest.fn(async () => isAppInstalled),
     } as unknown as DeviceManager<unknown>;
     const resolveDeviceAsync = jest.fn(async () => device);
@@ -96,7 +97,7 @@ describe('openAsync', () => {
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'host.exp.exponent' });
 
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
@@ -129,7 +130,7 @@ describe('openAsync', () => {
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'host.exp.exponent' });
 
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
@@ -163,7 +164,7 @@ describe('openAsync', () => {
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'host.exp.exponent' });
 
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
@@ -191,7 +192,7 @@ describe('openAsync', () => {
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenCalledTimes(1);
     expect(device.ensureExpoGoAsync).toHaveBeenNthCalledWith(1, '45.0.0');
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'host.exp.exponent' });
 
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
@@ -248,7 +249,7 @@ describe('openAsync', () => {
     );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'dev.bacon.app' });
 
     // Logging
     expect(device.logOpeningUrl).toHaveBeenNthCalledWith(1, url);
@@ -317,7 +318,7 @@ describe('openAsync', () => {
     );
 
     expect(device.activateWindowAsync).toHaveBeenCalledTimes(1);
-    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url);
+    expect(device.openUrlAsync).toHaveBeenNthCalledWith(1, url, { appId: 'dev.bacon.app' });
 
     expect(manager._resolveAlternativeLaunchUrl).toBeCalledTimes(1);
 

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -160,6 +160,10 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     await activateWindowAsync(this.device);
   }
 
+  getExpoGoAppId(): string {
+    return EXPO_GO_APPLICATION_IDENTIFIER;
+  }
+
   async ensureExpoGoAsync(sdkVersion: string): Promise<boolean> {
     const installer = new ExpoGoInstaller('android', EXPO_GO_APPLICATION_IDENTIFIER, sdkVersion);
     return installer.ensureAsync(this);

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -184,14 +184,14 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     );
   }
 
-  async openUrlAsync(url: string) {
+  async openUrlAsync(url: string, options: { appId?: string } = {}) {
     // Non-compliant URLs will be treated as application identifiers.
     if (!validateUrl(url, { requireProtocol: true })) {
       return await this.launchApplicationIdAsync(url);
     }
 
     try {
-      await SimControl.openUrlAsync(this.device, { url });
+      await SimControl.openUrlAsync(this.device, { url, appId: options.appId });
     } catch (error: any) {
       // 194 means the device does not conform to a given URL, in this case we'll assume that the desired app is not installed.
       if (error.status === 194) {
@@ -212,6 +212,10 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
     await ensureSimulatorAppRunningAsync(this.device);
     // TODO: Focus the individual window
     await osascript.execAsync(`tell application "Simulator" to activate`);
+  }
+
+  getExpoGoAppId(): string {
+    return EXPO_GO_BUNDLE_IDENTIFIER;
   }
 
   async ensureExpoGoAsync(sdkVersion: string): Promise<boolean> {

--- a/packages/@expo/cli/src/start/platforms/ios/simctl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctl.ts
@@ -122,14 +122,6 @@ export async function getInfoPlistValueAsync(
   return null;
 }
 
-const getSimulatorDataFilePath = (uniqueId: string, relativePath: string) => {
-  return path.join(
-    os.homedir(),
-    `Library/Developer/CoreSimulator/Devices/${uniqueId}/data`,
-    relativePath
-  );
-};
-
 /** Rewrite the simulator permissions to allow opening deep links without needing to prompt the user first. */
 async function updateSimulatorLinkingPermissionsAsync(
   device: Partial<DeviceContext>,
@@ -162,12 +154,12 @@ async function updateSimulatorLinkingPermissionsAsync(
     os.homedir(),
     `Library/Developer/CoreSimulator/Devices`,
     device.udid,
-    `data/Library/Preferences/com.apple.launchservices.schemeapproval.plist`,
+    `data/Library/Preferences/com.apple.launchservices.schemeapproval.plist`
   );
 
   const plistData = fs.existsSync(plistPath)
-    // If the file exists, then read it in the bplist format.
-    ? await parsePlistAsync(plistPath)
+    ? // If the file exists, then read it in the bplist format.
+      await parsePlistAsync(plistPath)
     : // The file doesn't exist when we first launch the simulator, but an empty object can be used to create it (June 2024 x Xcode 15.3).
       // Can be tested by launching a new simulator or by deleting the file and relaunching the simulator.
       {};

--- a/packages/@expo/cli/src/start/platforms/ios/simctl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctl.ts
@@ -150,26 +150,31 @@ async function updateSimulatorLinkingPermissionsAsync(
   });
   let scheme: string;
   try {
-    // Add the deeplink to the scheme approval list:
+    // Attempt to extract the scheme from the URL.
     scheme = new URL(url).protocol.slice(0, -1);
   } catch (error: any) {
     debug(`Could not parse the URL scheme: ${error.message}`);
     return;
   }
 
-  // 58BEC952-8426-4FF8-9AA8-AF2AD3240693
-  const plistPath = getSimulatorDataFilePath(
+  // Get the hard-coded path to the simulator's scheme approval plist file.
+  const plistPath = path.join(
+    os.homedir(),
+    `Library/Developer/CoreSimulator/Devices`,
     device.udid,
-    './Library/Preferences/com.apple.launchservices.schemeapproval.plist'
+    `data/Library/Preferences/com.apple.launchservices.schemeapproval.plist`,
   );
 
   const plistData = fs.existsSync(plistPath)
+    // If the file exists, then read it in the bplist format.
     ? await parsePlistAsync(plistPath)
     : // The file doesn't exist when we first launch the simulator, but an empty object can be used to create it (June 2024 x Xcode 15.3).
       // Can be tested by launching a new simulator or by deleting the file and relaunching the simulator.
       {};
+
   debug('Allowed links:', plistData);
   const key = `com.apple.CoreSimulator.CoreSimulatorBridge-->${scheme}`;
+  // Replace any existing value for the scheme with the new appId.
   plistData[key] = appId;
   debug('Allowing deep link:', { key, appId });
 

--- a/packages/@expo/cli/src/start/platforms/ios/simctl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctl.ts
@@ -1,8 +1,17 @@
 import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
+import bplistCreator from 'bplist-creator';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { xcrunAsync } from './xcrun';
 import * as Log from '../../../log';
 import { CommandError } from '../../../utils/errors';
+import { memoize } from '../../../utils/fn';
+import { parsePlistAsync } from '../../../utils/plist';
+import { profile } from '../../../utils/profile';
+
+const debug = require('debug')('expo:simctl') as typeof console.log;
 
 type DeviceState = 'Shutdown' | 'Booted';
 
@@ -113,11 +122,80 @@ export async function getInfoPlistValueAsync(
   return null;
 }
 
+const getSimulatorDataFilePath = (uniqueId: string, relativePath: string) => {
+  return path.join(
+    os.homedir(),
+    `Library/Developer/CoreSimulator/Devices/${uniqueId}/data`,
+    relativePath
+  );
+};
+
+/** Rewrite the simulator permissions to allow opening deep links without needing to prompt the user first. */
+async function updateSimulatorLinkingPermissionsAsync(
+  device: Partial<DeviceContext>,
+  { url, appId }: { url: string; appId?: string }
+) {
+  if (!device.udid || !appId) {
+    debug('Skipping deep link permissions as missing properties could not be found:', {
+      url,
+      appId,
+      udid: device.udid,
+    });
+    return;
+  }
+  debug('Rewriting simulator permissions to support deep linking:', {
+    url,
+    appId,
+    udid: device.udid,
+  });
+  let scheme: string;
+  try {
+    // Add the deeplink to the scheme approval list:
+    scheme = new URL(url).protocol.slice(0, -1);
+  } catch (error: any) {
+    debug(`Could not parse the URL scheme: ${error.message}`);
+    return;
+  }
+
+  // 58BEC952-8426-4FF8-9AA8-AF2AD3240693
+  const plistPath = getSimulatorDataFilePath(
+    device.udid,
+    './Library/Preferences/com.apple.launchservices.schemeapproval.plist'
+  );
+
+  const plistData = fs.existsSync(plistPath)
+    ? await parsePlistAsync(plistPath)
+    : // The file doesn't exist when we first launch the simulator, but an empty object can be used to create it (June 2024 x Xcode 15.3).
+      // Can be tested by launching a new simulator or by deleting the file and relaunching the simulator.
+      {};
+  debug('Allowed links:', plistData);
+  const key = `com.apple.CoreSimulator.CoreSimulatorBridge-->${scheme}`;
+  plistData[key] = appId;
+  debug('Allowing deep link:', { key, appId });
+
+  try {
+    const data = bplistCreator(plistData);
+    // Write the updated plist back to disk
+    await fs.promises.writeFile(plistPath, data);
+  } catch (error: any) {
+    Log.warn(`Could not update simulator linking permissions: ${error.message}`);
+  }
+}
+
+const updateSimulatorLinkingPermissionsAsyncMemo = memoize(updateSimulatorLinkingPermissionsAsync);
+
 /** Open a URL on a device. The url can have any protocol. */
 export async function openUrlAsync(
   device: Partial<DeviceContext>,
-  options: { url: string }
+  options: { url: string; appId?: string }
 ): Promise<void> {
+  if (options.appId) {
+    await profile(
+      updateSimulatorLinkingPermissionsAsyncMemo,
+      'updateSimulatorLinkingPermissionsAsync'
+    )({ udid: device.udid }, options);
+  }
+
   try {
     // Skip logging since this is likely to fail.
     await simctlAsync(['openurl', resolveId(device), options.url]);

--- a/packages/@expo/cli/ts-declarations/bplist-creator/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/bplist-creator/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'bplist-creator' {
+  function createPlist(target: any): Buffer;
+  export = createPlist;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,6 +6359,13 @@ boxen@1.3.0:
     term-size "^1.2.0"
     widest-line "^2.0.0"
 
+bplist-creator@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
+  integrity sha512-xp/tcaV3T5PCiaY04mXga7o/TE+t95gqeLmADeBI1CvZtdWTbgBt3uLpvh4UWtenKeBhCV6oVxGk38yZr2uYEA==
+  dependencies:
+    stream-buffers "~2.2.0"
+
 bplist-creator@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.1.0.tgz#018a2d1b587f769e379ef5519103730f8963ba1e"
@@ -18130,7 +18137,7 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-buffers@2.2.x:
+stream-buffers@2.2.x, stream-buffers@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
   integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
@@ -18231,7 +18238,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18256,6 +18263,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18326,7 +18342,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18360,6 +18376,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -20458,7 +20481,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20480,6 +20503,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

- Idea borrowed from @kmagiera. Been thinking on how [idb/detox](https://github.com/facebook/idb/blob/b7b807a8c34a1db5f824d9e9a13501a48cb19b0a/FBSimulatorControl/Commands/FBSimulatorSettingsCommands.m#L758) do this but hadn't taken the time to look before.
- Write permissions to the iOS simulator files to skip the prompt message when deep linking for the first time. This should make using dev clients nominally easier and fix the issue where opening apps with shared schemes launches the incorrect one.

# Test Plan

- `npx expo -i` in a new simulator will open directly without prompting.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
