### PR TITLE
[docs] rewrite header and ToC styling, breakpoints tweaks

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -82,8 +82,8 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
           {!hideTOC && (
             <div
               className={mergeClasses(
-                'flex flex-col shrink-0 max-w-[280px] h-full overflow-hidden border-l border-l-default',
-                'max-lg-gutters:hidden'
+                'flex flex-col shrink-0 max-w-[280px] h-[calc(100dvh-60px)] overflow-hidden border-l border-l-default',
+                'max-xl-gutters:hidden'
               )}>
               <ScrollContainer ref={this.sidebarRightRef}>
                 {cloneElement(sidebarRight, {

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -81,10 +81,10 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     );
 
     return (
-      <nav className="pt-14 pb-12 px-6 w-[280px]" data-sidebar>
+      <nav className="pb-6 px-6 w-[280px]" data-sidebar>
         <CALLOUT
           weight="medium"
-          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
+          className="absolute bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
           <LayoutAlt03Icon className="icon-sm" /> On this page
           <Button
             theme="quaternary"

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="pt-14 pb-12 px-6 w-[280px]"
+    class="pb-6 px-6 w-[280px]"
     data-sidebar="true"
   >
     <p
-      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
+      class="absolute bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
       data-text="true"
     >
       <svg

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -1,8 +1,6 @@
-import { css } from '@emotion/react';
-import { theme, Button } from '@expo/styleguide';
-import { breakpoints, spacing } from '@expo/styleguide-base';
+import { Button, mergeClasses } from '@expo/styleguide';
 import { GithubIcon, Menu01Icon, Star01Icon } from '@expo/styleguide-icons';
-import type { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 import { Logo } from './Logo';
 import { ThemeSelector } from './ThemeSelector';
@@ -26,31 +24,29 @@ export const Header = ({
   const isArchive = sidebarActiveGroup === 'archive';
   return (
     <>
-      <nav css={[containerStyle, isMobileMenuVisible]}>
-        <div css={[columnStyle, leftColumnStyle]}>
+      <nav className="flex items-center justify-between relative bg-default z-10 mx-auto p-0 px-4 h-[60px] border-b border-default gap-2">
+        <div className="flex items-center gap-8">
           <Logo subgroup={isArchive ? 'Archive' : undefined} />
         </div>
-        <div css={[columnStyle, rightColumnStyle]}>
+        <div className="flex items-center gap-3">
           <Button
             openInNewTab
             theme="quaternary"
-            className="px-2 text-secondary"
+            className={mergeClasses('px-2 text-secondary', 'max-sm-gutters:hidden')}
             href="https://expo.dev/blog">
             Blog
           </Button>
           <Button
             openInNewTab
             theme="quaternary"
-            css={hideOnMobileStyle}
-            className="px-2 text-secondary"
+            className={mergeClasses('px-2 text-secondary', 'max-sm-gutters:hidden')}
             href="https://expo.dev/changelog">
             Changelog
           </Button>
           <Button
             openInNewTab
             theme="quaternary"
-            css={hideOnMobileStyle}
-            className="px-2 text-secondary"
+            className={mergeClasses('px-2 text-secondary', 'max-lg-gutters:hidden')}
             leftSlot={<Star01Icon className="icon-sm" />}
             href="https://github.com/expo/expo">
             Star Us on GitHub
@@ -59,18 +55,21 @@ export const Header = ({
             openInNewTab
             theme="quaternary"
             href="https://github.com/expo/expo"
-            css={showOnMobileStyle}
             aria-label="GitHub"
-            className="px-2">
+            className={mergeClasses('px-2 hidden', 'max-lg-gutters:flex')}>
             <GithubIcon className="icon-lg" />
           </Button>
-          <div css={hideOnMobileStyle}>
+          <div className="max-lg-gutters:hidden">
             <ThemeSelector />
           </div>
-          <div css={showOnMobileStyle}>
+          <div className={mergeClasses('hidden', 'max-lg-gutters:flex')}>
             <Button
               theme="quaternary"
-              css={[mobileButtonStyle, isMobileMenuVisible && mobileButtonActiveStyle]}
+              className={mergeClasses(
+                'px-3',
+                'hocus:bg-element hocus:shadow-[none]',
+                isMobileMenuVisible && 'bg-hover'
+              )}
               onClick={() => {
                 setMobileMenuVisible(!isMobileMenuVisible);
               }}>
@@ -80,17 +79,21 @@ export const Header = ({
         </div>
       </nav>
       {isMobileMenuVisible && (
-        <nav css={[containerStyle, showOnMobileStyle]}>
-          <div css={[columnStyle, leftColumnStyle]}>
+        <nav
+          className={mergeClasses(
+            'items-center justify-between relative bg-default z-10 mx-auto p-0 px-4 h-[60px] border-b border-default hidden',
+            'max-lg-gutters:flex'
+          )}>
+          <div className="flex items-center">
             <DEMI>Theme</DEMI>
           </div>
-          <div css={[columnStyle, rightColumnStyle]}>
+          <div className="flex items-center">
             <ThemeSelector />
           </div>
         </nav>
       )}
       {isMobileMenuVisible && (
-        <div css={mobileSidebarStyle}>
+        <div className="bg-subtle h-[calc(100dvh-(60px*2))] overflow-x-hidden overflow-y-auto">
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
           <SidebarFooter isMobileMenuVisible={isMobileMenuVisible} />
@@ -99,84 +102,3 @@ export const Header = ({
     </>
   );
 };
-
-const containerStyle = css`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  position: relative;
-  background-color: ${theme.background.default};
-  z-index: 2;
-  margin: 0 auto;
-  padding: 0 ${spacing[4]}px;
-  height: 60px;
-  box-sizing: border-box;
-  border-bottom: 1px solid ${theme.border.default};
-  gap: ${spacing[2.5]}px;
-`;
-
-const columnStyle = css`
-  flex-shrink: 0;
-  display: flex;
-  gap: ${spacing[8]}px;
-  align-items: center;
-  background-color: transparent;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    gap: ${spacing[4]}px;
-  }
-`;
-
-const leftColumnStyle = css`
-  flex-grow: 1;
-  align-items: center;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    flex-basis: auto;
-    width: auto;
-  }
-`;
-
-const rightColumnStyle = css`
-  justify-content: flex-end;
-  gap: ${spacing[4]}px;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    flex-basis: auto;
-    width: auto;
-  }
-`;
-
-const showOnMobileStyle = css`
-  display: none;
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    display: flex;
-  }
-`;
-
-const hideOnMobileStyle = css`
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    display: none;
-  }
-`;
-
-const mobileButtonStyle = css`
-  padding: 0 ${spacing[3]}px;
-
-  &:hover {
-    background-color: ${theme.background.element};
-    box-shadow: none;
-  }
-`;
-
-const mobileButtonActiveStyle = css`
-  background-color: ${theme.background.subtle};
-`;
-
-const mobileSidebarStyle = css`
-  background-color: ${theme.background.subtle};
-  height: calc(100vh - (60px * 2));
-  overflow-y: auto;
-  overflow-x: hidden;
-`;

--- a/docs/ui/components/Header/Logo.tsx
+++ b/docs/ui/components/Header/Logo.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
-import { theme, typography, Logo as LogoIcon, WordMarkLogo, LinkBase } from '@expo/styleguide';
-import { breakpoints, spacing, borderRadius } from '@expo/styleguide-base';
+import { Logo as LogoIcon, WordMarkLogo, LinkBase, mergeClasses } from '@expo/styleguide';
 import { ChevronRightIcon } from '@expo/styleguide-icons';
 
 import { DocumentationIcon } from '~/ui/components/Sidebar/icons/Documentation';
@@ -11,76 +9,39 @@ type Props = {
 
 export const Logo = ({ subgroup }: Props) => (
   <div className="flex items-center gap-4">
-    <LinkBase css={linkStyle} href="https://expo.dev">
+    <LinkBase
+      className="flex flex-row items-center decoration-0 select-none gap-2 outline-offset-1"
+      href="https://expo.dev">
       <WordMarkLogo
-        className="w-[72px] mt-px h-5 text-default my-1"
-        css={hideOnMobile}
+        className={mergeClasses('w-[72px] mt-px h-5 text-default my-1', 'max-md-gutters:hidden')}
         title="Expo"
       />
-      <LogoIcon className="icon-lg mt-px text-default" css={showOnMobile} title="Expo" />
+      <LogoIcon
+        className={mergeClasses('icon-lg mr-1.5 text-default hidden', 'max-md-gutters:flex')}
+        title="Expo"
+      />
     </LinkBase>
-    <LinkBase css={linkStyle} href="/">
-      <div css={iconContainer}>
+    <LinkBase
+      className="flex flex-row items-center decoration-0 select-none gap-2 outline-offset-1"
+      href="/">
+      <div className="flex items-center justify-center bg-palette-blue4 rounded-sm size-6">
         <DocumentationIcon className="icon-sm" />
       </div>
-      <span css={subtitleStyle}>Docs</span>
+      <span
+        className={mergeClasses(
+          'text-default font-medium text-lg select-none',
+          subgroup && 'max-md-gutters:hidden'
+        )}>
+        Docs
+      </span>
     </LinkBase>
     {subgroup && (
       <>
-        <ChevronRightIcon className="text-icon-secondary" css={[chevronStyle, hideOnMobile]} />
-        <span css={[subtitleStyle, hideOnMobile]}>{subgroup}</span>
+        <ChevronRightIcon
+          className={mergeClasses('text-icon-secondary -mx-2', 'max-md-gutters:hidden')}
+        />
+        <span className="text-default font-medium text-lg select-none">{subgroup}</span>
       </>
     )}
   </div>
 );
-
-const linkStyle = css`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  text-decoration: none;
-  user-select: none;
-  gap: ${spacing[2]}px;
-  outline-offset: 4px;
-`;
-
-const chevronStyle = css`
-  margin: 0 ${-spacing[2]}px;
-
-  @media screen and (max-width: ${breakpoints.medium}px) {
-    margin-left: ${spacing[0.5]}px;
-  }
-`;
-
-const hideOnMobile = css`
-  @media screen and (max-width: ${breakpoints.medium}px) {
-    display: none;
-  }
-`;
-
-const showOnMobile = css`
-  display: none;
-
-  @media screen and (max-width: ${breakpoints.medium}px) {
-    display: block;
-    margin-top: 0;
-    margin-right: ${spacing[1.5]}px;
-  }
-`;
-
-const subtitleStyle = css`
-  color: ${theme.text.default};
-  font-weight: 500;
-  user-select: none;
-  ${typography.fontSizes[18]}
-`;
-
-const iconContainer = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  backgroundColor: theme.palette.blue4,
-  borderRadius: borderRadius.sm,
-  height: 24,
-  width: 24,
-});

--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
-import { useTheme, theme, shadows, typography } from '@expo/styleguide';
-import { borderRadius, breakpoints, spacing } from '@expo/styleguide-base';
+import { useTheme, mergeClasses } from '@expo/styleguide';
 import {
   ChevronDownIcon,
   Moon01SolidIcon,
@@ -22,7 +20,11 @@ export const ThemeSelector = () => {
       <select
         aria-label="Theme selector"
         title="Select theme"
-        css={selectStyle}
+        className={mergeClasses(
+          'flex items-center justify-center h-9 text-default leading-[1.3] p-0 m-0 w-[50px] border border-default shadow-xs rounded-md indent-[-9999px] appearance-none bg-default text-sm',
+          'hocus:bg-element',
+          'max-lg-gutters:w-auto max-lg-gutters:min-w-[100px] max-lg-gutters:px-2 max-lg-gutters:text-secondary max-lg-gutters:indent-0 max-lg-gutters:pl-8'
+        )}
         value={themeName}
         onChange={e => {
           const option = e.target.value;
@@ -47,42 +49,3 @@ export const ThemeSelector = () => {
 };
 
 const ICON_CLASSES = 'icon-sm absolute left-2.5 top-2.5 text-icon-secondary pointer-events-none';
-
-const selectStyle = css`
-  ${typography.fontSizes[14]}
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 36px;
-  color: ${theme.text.default};
-  line-height: 1.3;
-  padding: 0;
-  width: 50px;
-  margin: 0;
-  border: 1px solid ${theme.border.default};
-  box-shadow: ${shadows.xs};
-  border-radius: ${borderRadius.md}px;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-  background-color: ${theme.background.default};
-  cursor: pointer;
-  text-indent: -9999px;
-
-  :hover {
-    background-color: ${theme.background.element};
-  }
-
-  :focus-visible {
-    background-color: ${theme.background.element};
-  }
-
-  @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
-    width: auto;
-    min-width: 100px;
-    padding: 0 ${spacing[2]}px;
-    padding-left: ${spacing[8]}px;
-    color: ${theme.text.secondary};
-    text-indent: 0;
-  }
-`;


### PR DESCRIPTION
# Why

Address issues spotted when tried to repro recently reported scroll issue in certain situations/on certain devices.

# How

This PR performs the following changes:
* hide Table of Content earlier, to avoid having very narrow content column on certain devices
* rewrite and simplify Header and Table of Content components styling
* adjust the breakpoints and the hiding rules for certain Header elements
* rewrite Logo styling to make sure that everything in Header relies on the same breakpoints set
* correct height used by Table of Content component

# Test Plan

The changes have been reviewed locally. Test snapshots are regenerated, unit tests are passing.

# Preview

https://github.com/expo/expo/assets/719641/6260adfd-603b-42fa-acfb-7a5f3fa67256

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-06-05 at 21 47 42](https://github.com/expo/expo/assets/719641/685c7e94-33ea-424d-a25b-55282e4afdba)

