### PR TITLE
[cli] prebuild: only alter scripts when they match default template values

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
 - Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused dependencies. ([#29177](https://github.com/expo/expo/pull/29177) by [@Simek](https://github.com/Simek))
+- Do not replace modified scripts on prebuild. ([#29490](https://github.com/expo/expo/pull/29490) by [@Simek](https://github.com/Simek))
 
 ## 0.18.15 — 2024-06-05
 

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -7,6 +7,7 @@ import {
   hashForDependencyMap,
   updatePkgDependencies,
   updatePackageJSONAsync,
+  updatePkgScripts,
 } from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
@@ -277,5 +278,35 @@ describe(updatePkgDependencies, () => {
           .join(', ')}`
       )
     );
+  });
+});
+
+describe(updatePkgScripts, () => {
+  it(`modifies the default values`, () => {
+    const pkg = {
+      scripts: {
+        android: 'expo start --android',
+        ios: 'expo start --ios',
+      },
+    };
+
+    updatePkgScripts({ pkg });
+
+    expect(pkg.scripts.android).toBe('expo run:android');
+    expect(pkg.scripts.ios).toBe('expo run:ios');
+  });
+
+  it(`skips modification if user altered the script`, () => {
+    const pkg = {
+      scripts: {
+        android: 'echo 123 && expo start --android',
+        ios: 'time expo start --ios',
+      },
+    };
+
+    updatePkgScripts({ pkg });
+
+    expect(pkg.scripts.android).toBe('echo 123 && expo start --android');
+    expect(pkg.scripts.ios).toBe('time expo start --ios');
   });
 });

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -268,7 +268,7 @@ describe(updatePkgDependencies, () => {
       'react-native': 'version-from-project', // add-only package, do not overwrite
       expo: 'version-from-project',
     });
-    expect(Log.warn).toBeCalledWith(
+    expect(Log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         `instead of recommended ${[
           `expo@version-from-template`,
@@ -282,11 +282,25 @@ describe(updatePkgDependencies, () => {
 });
 
 describe(updatePkgScripts, () => {
-  it(`modifies the default values`, () => {
+  it(`modifies the default Expo project values`, () => {
     const pkg = {
       scripts: {
         android: 'expo start --android',
         ios: 'expo start --ios',
+      },
+    };
+
+    updatePkgScripts({ pkg });
+
+    expect(pkg.scripts.android).toBe('expo run:android');
+    expect(pkg.scripts.ios).toBe('expo run:ios');
+  });
+
+  it(`modifies the default RN CLI project values`, () => {
+    const pkg = {
+      scripts: {
+        android: 'react-native run-android',
+        ios: 'react-native run-ios',
       },
     };
 

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -66,9 +66,9 @@ export async function updatePackageJSONAsync(
  * 3. Update `package.json` `main`.
  *
  * @param projectRoot The root directory of the project.
- * @param props.templatePkg Template project package.json as JSON.
- * @param props.pkg Current package.json as JSON.
- * @param props.skipDependencyUpdate Array of dependencies to skip updating.
+ * @param templatePkg Template project package.json as JSON.
+ * @param pkg Current package.json as JSON.
+ * @param skipDependencyUpdate Array of dependencies to skip updating.
  * @returns
  */
 function modifyPackageJson(
@@ -239,19 +239,19 @@ export function createDependenciesMap(dependencies: any): DependenciesMap {
 }
 
 /**
- * Update package.json scripts - `npm start` should default to `expo
- * start --dev-client` rather than `expo start` after prebuilding, for example.
+ * Updates the package.json scripts for prebuild if the scripts match
+ * the default values used in project templates.
  */
-function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
+export function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
   let hasChanged = false;
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
-  if (!pkg.scripts.android?.includes('run')) {
+  if (!pkg.scripts.android || pkg.scripts.android === 'expo start --android') {
     pkg.scripts.android = 'expo run:android';
     hasChanged = true;
   }
-  if (!pkg.scripts.ios?.includes('run')) {
+  if (!pkg.scripts.ios || pkg.scripts.ios === 'expo start --ios') {
     pkg.scripts.ios = 'expo run:ios';
     hasChanged = true;
   }

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -247,11 +247,19 @@ export function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
-  if (!pkg.scripts.android || pkg.scripts.android === 'expo start --android') {
+  if (
+    !pkg.scripts.android ||
+    pkg.scripts.android === 'expo start --android' ||
+    pkg.scripts.android === 'react-native run-android'
+  ) {
     pkg.scripts.android = 'expo run:android';
     hasChanged = true;
   }
-  if (!pkg.scripts.ios || pkg.scripts.ios === 'expo start --ios') {
+  if (
+    !pkg.scripts.ios ||
+    pkg.scripts.ios === 'expo start --ios' ||
+    pkg.scripts.ios === 'react-native run-ios'
+  ) {
     pkg.scripts.ios = 'expo run:ios';
     hasChanged = true;
   }


### PR DESCRIPTION
# Why

Fixes ENG-12448
Fixes #29446
* #29446

# How

When running `prebuild` only alter scripts when they match default template values.

# Test Plan

Add unit tests, make sure they passes.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
