### PR TITLE
[expo-notifications][Android] Add default channel plugin prop, restore legacy icon and color

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -366,6 +366,11 @@ To configure `expo-notifications`, use the built-in [config plugin](/config-plug
         'Tint color for the push notification image when it appears in the notification tray.',
     },
     {
+      name: 'defaultChannel',
+      platform: 'android',
+      description: 'Default channel for FCMv1 notifications.',
+    },
+    {
       name: 'sounds',
       description:
         'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.',
@@ -384,6 +389,7 @@ Here is an example of using the config plugin in the app config file:
         {
           "icon": "./local/assets/notification-icon.png",
           "color": "#ffffff",
+          "defaultChannel": "default",
           "sounds": [
             "./local/assets/notification-sound.wav",
             "./local/assets/notification-sound-other.wav"

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Add default channel plugin prop, restore legacy icon and color. ([#29491](https://github.com/expo/expo/pull/29491) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Keep using the legacy event emitter as the module is not fully migrated to Expo Modules API. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -65,6 +65,7 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
         if (extras != null) {
             if (extras.containsKey("notificationResponse")) {
                 Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
+                intent.removeExtra("notificationResponse");
                 return ReactActivityLifecycleListener.super.onNewIntent(intent);
             }
             mNotificationManager.onNotificationResponseFromExtras(extras);

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -41,6 +41,10 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
         if (intent != null) {
             Bundle extras = intent.getExtras();
             if (extras != null) {
+                if (extras.containsKey("notificationResponse")) {
+                    Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
+                    return;
+                }
                 mNotificationManager.onNotificationResponseFromExtras(extras);
             }
         }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -61,7 +61,7 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
         if (extras != null) {
             if (extras.containsKey("notificationResponse")) {
                 Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
-                return;
+                return ReactActivityLifecycleListener.super.onNewIntent(intent);
             }
             mNotificationManager.onNotificationResponseFromExtras(extras);
         }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -59,6 +59,10 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
     public boolean onNewIntent(Intent intent) {
         Bundle extras = intent.getExtras();
         if (extras != null) {
+            if (extras.containsKey("notificationResponse")) {
+                Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
+                return;
+            }
             mNotificationManager.onNotificationResponseFromExtras(extras);
         }
         return ReactActivityLifecycleListener.super.onNewIntent(intent);

--- a/packages/expo-notifications/plugin/build/withNotifications.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotifications.d.ts
@@ -14,6 +14,11 @@ export type NotificationsPluginProps = {
      */
     color?: string;
     /**
+     * Default channel for FCMv1 notifications.
+     * @platform android
+     */
+    defaultChannel?: string;
+    /**
      * Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.
      */
     sounds?: string[];

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.d.ts
@@ -10,6 +10,9 @@ export declare const ANDROID_RES_PATH = "android/app/src/main/res/";
 export declare const dpiValues: dpiMap;
 export declare const META_DATA_NOTIFICATION_ICON = "com.google.firebase.messaging.default_notification_icon";
 export declare const META_DATA_NOTIFICATION_ICON_COLOR = "com.google.firebase.messaging.default_notification_color";
+export declare const META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID = "com.google.firebase.messaging.default_notification_channel_id";
+export declare const META_DATA_LEGACY_NOTIFICATION_ICON = "expo.modules.notifications.default_notification_icon";
+export declare const META_DATA_LEGACY_NOTIFICATION_ICON_COLOR = "expo.modules.notifications.default_notification_color";
 export declare const NOTIFICATION_ICON = "notification_icon";
 export declare const NOTIFICATION_ICON_RESOURCE: string;
 export declare const NOTIFICATION_ICON_COLOR = "notification_icon_color";
@@ -23,6 +26,7 @@ export declare const withNotificationIconColor: ConfigPlugin<{
 export declare const withNotificationManifest: ConfigPlugin<{
     icon: string | null;
     color: string | null;
+    defaultChannel: string | null;
 }>;
 export declare const withNotificationSounds: ConfigPlugin<{
     sounds: string[];

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withNotificationsAndroid = exports.setNotificationSounds = exports.setNotificationIconAsync = exports.setNotificationIconColor = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationSounds = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = exports.dpiValues = exports.ANDROID_RES_PATH = void 0;
+exports.withNotificationsAndroid = exports.setNotificationSounds = exports.setNotificationIconAsync = exports.setNotificationIconColor = exports.getNotificationColor = exports.getNotificationIcon = exports.withNotificationSounds = exports.withNotificationManifest = exports.withNotificationIconColor = exports.withNotificationIcons = exports.NOTIFICATION_ICON_COLOR_RESOURCE = exports.NOTIFICATION_ICON_COLOR = exports.NOTIFICATION_ICON_RESOURCE = exports.NOTIFICATION_ICON = exports.META_DATA_LEGACY_NOTIFICATION_ICON_COLOR = exports.META_DATA_LEGACY_NOTIFICATION_ICON = exports.META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID = exports.META_DATA_NOTIFICATION_ICON_COLOR = exports.META_DATA_NOTIFICATION_ICON = exports.dpiValues = exports.ANDROID_RES_PATH = void 0;
 const image_utils_1 = require("@expo/image-utils");
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = require("fs");
@@ -19,6 +19,9 @@ const BASELINE_PIXEL_SIZE = 24;
 const ERROR_MSG_PREFIX = 'An error occurred while configuring Android notifications. ';
 exports.META_DATA_NOTIFICATION_ICON = 'com.google.firebase.messaging.default_notification_icon';
 exports.META_DATA_NOTIFICATION_ICON_COLOR = 'com.google.firebase.messaging.default_notification_color';
+exports.META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID = 'com.google.firebase.messaging.default_notification_channel_id';
+exports.META_DATA_LEGACY_NOTIFICATION_ICON = 'expo.modules.notifications.default_notification_icon';
+exports.META_DATA_LEGACY_NOTIFICATION_ICON_COLOR = 'expo.modules.notifications.default_notification_color';
 exports.NOTIFICATION_ICON = 'notification_icon';
 exports.NOTIFICATION_ICON_RESOURCE = `@drawable/${exports.NOTIFICATION_ICON}`;
 exports.NOTIFICATION_ICON_COLOR = 'notification_icon_color';
@@ -44,12 +47,13 @@ const withNotificationIconColor = (config, { color }) => {
     });
 };
 exports.withNotificationIconColor = withNotificationIconColor;
-const withNotificationManifest = (config, { icon, color }) => {
+const withNotificationManifest = (config, { icon, color, defaultChannel }) => {
     // If no icon or color provided in the config plugin props, fallback to value from app.json
     icon = icon || getNotificationIcon(config);
     color = color || getNotificationColor(config);
+    defaultChannel = defaultChannel || null;
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
-        config.modResults = setNotificationConfig({ icon, color }, config.modResults);
+        config.modResults = setNotificationConfig({ icon, color, defaultChannel }, config.modResults);
         return config;
     });
 };
@@ -95,15 +99,25 @@ function setNotificationConfig(props, manifest) {
     const mainApplication = getMainApplicationOrThrow(manifest);
     if (props.icon) {
         addMetaDataItemToMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_ICON, exports.NOTIFICATION_ICON_RESOURCE, 'resource');
+        addMetaDataItemToMainApplication(mainApplication, exports.META_DATA_LEGACY_NOTIFICATION_ICON, exports.NOTIFICATION_ICON_RESOURCE, 'resource');
     }
     else {
         removeMetaDataItemFromMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_ICON);
+        removeMetaDataItemFromMainApplication(mainApplication, exports.META_DATA_LEGACY_NOTIFICATION_ICON);
     }
     if (props.color) {
         addMetaDataItemToMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_ICON_COLOR, exports.NOTIFICATION_ICON_COLOR_RESOURCE, 'resource');
+        addMetaDataItemToMainApplication(mainApplication, exports.META_DATA_LEGACY_NOTIFICATION_ICON_COLOR, exports.NOTIFICATION_ICON_COLOR_RESOURCE, 'resource');
     }
     else {
         removeMetaDataItemFromMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_ICON_COLOR);
+        removeMetaDataItemFromMainApplication(mainApplication, exports.META_DATA_LEGACY_NOTIFICATION_ICON_COLOR);
+    }
+    if (props.defaultChannel) {
+        addMetaDataItemToMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID, props.defaultChannel, 'value');
+    }
+    else {
+        removeMetaDataItemFromMainApplication(mainApplication, exports.META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID);
     }
     return manifest;
 }
@@ -174,10 +188,10 @@ function writeNotificationSoundFile(soundFileRelativePath, projectRoot) {
         }
     }
 }
-const withNotificationsAndroid = (config, { icon = null, color = null, sounds = [] }) => {
+const withNotificationsAndroid = (config, { icon = null, color = null, sounds = [], defaultChannel = null }) => {
     config = (0, exports.withNotificationIconColor)(config, { color });
     config = (0, exports.withNotificationIcons)(config, { icon });
-    config = (0, exports.withNotificationManifest)(config, { icon, color });
+    config = (0, exports.withNotificationManifest)(config, { icon, color, defaultChannel });
     config = (0, exports.withNotificationSounds)(config, { sounds });
     return config;
 };

--- a/packages/expo-notifications/plugin/src/withNotifications.ts
+++ b/packages/expo-notifications/plugin/src/withNotifications.ts
@@ -20,6 +20,11 @@ export type NotificationsPluginProps = {
    */
   color?: string;
   /**
+   * Default channel for FCMv1 notifications.
+   * @platform android
+   */
+  defaultChannel?: string;
+  /**
    * Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.
    */
   sounds?: string[];

--- a/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
@@ -32,10 +32,19 @@ const {
 } = AndroidConfig.Manifest;
 const BASELINE_PIXEL_SIZE = 24;
 const ERROR_MSG_PREFIX = 'An error occurred while configuring Android notifications. ';
+
 export const META_DATA_NOTIFICATION_ICON =
   'com.google.firebase.messaging.default_notification_icon';
 export const META_DATA_NOTIFICATION_ICON_COLOR =
   'com.google.firebase.messaging.default_notification_color';
+export const META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID =
+  'com.google.firebase.messaging.default_notification_channel_id';
+
+export const META_DATA_LEGACY_NOTIFICATION_ICON =
+  'expo.modules.notifications.default_notification_icon';
+export const META_DATA_LEGACY_NOTIFICATION_ICON_COLOR =
+  'expo.modules.notifications.default_notification_color';
+
 export const NOTIFICATION_ICON = 'notification_icon';
 export const NOTIFICATION_ICON_RESOURCE = `@drawable/${NOTIFICATION_ICON}`;
 export const NOTIFICATION_ICON_COLOR = 'notification_icon_color';
@@ -68,12 +77,14 @@ export const withNotificationIconColor: ConfigPlugin<{ color: string | null }> =
 export const withNotificationManifest: ConfigPlugin<{
   icon: string | null;
   color: string | null;
-}> = (config, { icon, color }) => {
+  defaultChannel: string | null;
+}> = (config, { icon, color, defaultChannel }) => {
   // If no icon or color provided in the config plugin props, fallback to value from app.json
   icon = icon || getNotificationIcon(config);
   color = color || getNotificationColor(config);
+  defaultChannel = defaultChannel || null;
   return withAndroidManifest(config, (config) => {
-    config.modResults = setNotificationConfig({ icon, color }, config.modResults);
+    config.modResults = setNotificationConfig({ icon, color, defaultChannel }, config.modResults);
     return config;
   });
 };
@@ -118,7 +129,7 @@ export async function setNotificationIconAsync(projectRoot: string, icon: string
 }
 
 function setNotificationConfig(
-  props: { icon: string | null; color: string | null },
+  props: { icon: string | null; color: string | null; defaultChannel?: string | null },
   manifest: AndroidConfig.Manifest.AndroidManifest
 ) {
   const mainApplication = getMainApplicationOrThrow(manifest);
@@ -129,8 +140,15 @@ function setNotificationConfig(
       NOTIFICATION_ICON_RESOURCE,
       'resource'
     );
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      META_DATA_LEGACY_NOTIFICATION_ICON,
+      NOTIFICATION_ICON_RESOURCE,
+      'resource'
+    );
   } else {
     removeMetaDataItemFromMainApplication(mainApplication, META_DATA_NOTIFICATION_ICON);
+    removeMetaDataItemFromMainApplication(mainApplication, META_DATA_LEGACY_NOTIFICATION_ICON);
   }
   if (props.color) {
     addMetaDataItemToMainApplication(
@@ -139,8 +157,32 @@ function setNotificationConfig(
       NOTIFICATION_ICON_COLOR_RESOURCE,
       'resource'
     );
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      META_DATA_LEGACY_NOTIFICATION_ICON_COLOR,
+      NOTIFICATION_ICON_COLOR_RESOURCE,
+      'resource'
+    );
   } else {
     removeMetaDataItemFromMainApplication(mainApplication, META_DATA_NOTIFICATION_ICON_COLOR);
+    removeMetaDataItemFromMainApplication(
+      mainApplication,
+      META_DATA_LEGACY_NOTIFICATION_ICON_COLOR
+    );
+  }
+
+  if (props.defaultChannel) {
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID,
+      props.defaultChannel,
+      'value'
+    );
+  } else {
+    removeMetaDataItemFromMainApplication(
+      mainApplication,
+      META_DATA_NOTIFICATION_DEFAULT_CHANNEL_ID
+    );
   }
   return manifest;
 }
@@ -230,11 +272,11 @@ function writeNotificationSoundFile(soundFileRelativePath: string, projectRoot: 
 
 export const withNotificationsAndroid: ConfigPlugin<NotificationsPluginProps> = (
   config,
-  { icon = null, color = null, sounds = [] }
+  { icon = null, color = null, sounds = [], defaultChannel = null }
 ) => {
   config = withNotificationIconColor(config, { color });
   config = withNotificationIcons(config, { icon });
-  config = withNotificationManifest(config, { icon, color });
+  config = withNotificationManifest(config, { icon, color, defaultChannel });
   config = withNotificationSounds(config, { sounds });
   return config;
 };


### PR DESCRIPTION
# Why

Based on customer feedback from `expo-notifications@0.28.7`, three adjustments are still needed:

- Set both FCM legacy and FCMv1 metadata items in the Android manifest, so that icon and color work in both cases
- Add a config plugin property, `defaultChannel`, to allow a developer to set the FCMv1 default channel in the manifest.
- The Android lifecycle listeners should check to see if the intent extras have a `notificationResponse` object, and not map the intent bundle to create a duplicate response in JS.

See [this comment](https://github.com/expo/expo/issues/28656#issuecomment-2151176680) by @mgscreativa and other comments in that issue.

# How

- Make the appropriate code changes in the plugin and in `ExpoNotificationLifecycleListener.java`

# Test Plan

- CI should pass
- Test app patched with these changes should behave as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
