### PR TITLE
[docs] Update GitHub label in docs header

### DIFF
--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -53,7 +53,7 @@ export const Header = ({
             className="px-2 text-secondary"
             leftSlot={<Star01Icon className="icon-sm" />}
             href="https://github.com/expo/expo">
-            Star Us on GitHub
+            GitHub
           </Button>
           <Button
             openInNewTab


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, GitHub label in docs header doesn't match the label in expo.dev. We usually keep these changes in sync with each other.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the label.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2024-06-06 at 13 46 03@2x](https://github.com/expo/expo/assets/10234615/804ba1d5-64b5-463e-be0c-73f4fec19302)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
