### PR TITLE
[docs] update build-properties `ios.deploymentTarget` example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -37,7 +37,7 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
             "buildToolsVersion": "31.0.0"
           },
           "ios": {
-            "deploymentTarget": "13.0"
+            "deploymentTarget": "13.4"
           }
         }
       ]
@@ -63,7 +63,7 @@ export default {
             buildToolsVersion: '31.0.0',
           },
           ios: {
-            deploymentTarget: '13.0',
+            deploymentTarget: '13.4',
           },
         },
       ],


### PR DESCRIPTION
# Why

because VSCode said it 😅 

![image](https://github.com/expo/expo/assets/360936/e62d74a6-4278-4747-9750-82194dfa2778)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- [x] tested a expo SDK 51 build on iOS
- [ ] tested a expo SDK 51 build on Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
