### PR TITLE
[docs] duplicate "Edit this page" button in `PageHeader`

### DIFF
--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -1,12 +1,14 @@
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { render, RenderOptions } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
-import { PropsWithChildren, ReactElement } from 'react';
+import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { type NextRouter } from 'next/router';
+import { type PropsWithChildren, type ReactElement } from 'react';
 
 import { HeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
-const Wrapper = ({ children }: PropsWithChildren<object>) => (
+const Wrapper = ({ children }: PropsWithChildren) => (
   <TooltipProvider>
     <HeadingsContext.Provider value={new HeadingManager(new GithubSlugger(), { headings: [] })}>
       {children}
@@ -18,3 +20,7 @@ export const renderWithHeadings = (
   element: ReactElement,
   options?: Omit<RenderOptions, 'wrapper'>
 ) => render(element, { wrapper: Wrapper, ...options });
+
+export const renderWithTestRouter = (element: ReactElement, router: Partial<NextRouter> = {}) => (
+  render(<RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>)
+);

--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -16,11 +16,15 @@ const Wrapper = ({ children }: PropsWithChildren) => (
   </TooltipProvider>
 );
 
-export const renderWithHeadings = (
+export function renderWithHeadings(
   element: ReactElement,
   options?: Omit<RenderOptions, 'wrapper'>
-) => render(element, { wrapper: Wrapper, ...options });
+) {
+  return render(element, { wrapper: Wrapper, ...options });
+}
 
-export const renderWithTestRouter = (element: ReactElement, router: Partial<NextRouter> = {}) => (
-  render(<RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>)
-);
+export function renderWithTestRouter(element: ReactElement, router: Partial<NextRouter> = {}) {
+  return render(
+    <RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>
+  );
+}

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -19,7 +19,6 @@ import { PagePlatformTags } from '~/ui/components/PagePlatformTags';
 import { PageTitle } from '~/ui/components/PageTitle';
 import { Separator } from '~/ui/components/Separator';
 import { Sidebar } from '~/ui/components/Sidebar';
-import { P } from '~/ui/components/Text';
 
 export type DocPageProps = PropsWithChildren<PageMetadata>;
 
@@ -137,15 +136,11 @@ export default function DocumentationPage({
         {title && (
           <PageTitle
             title={title}
+            description={description}
             sourceCodeUrl={sourceCodeUrl}
             packageName={packageName}
             iconUrl={iconUrl}
           />
-        )}
-        {description && (
-          <P theme="secondary" data-description="true">
-            {description}
-          </P>
         )}
         {platforms && <PagePlatformTags platforms={platforms} />}
         {title && <Separator />}

--- a/docs/ui/components/Footer/Footer.test.tsx
+++ b/docs/ui/components/Footer/Footer.test.tsx
@@ -1,19 +1,14 @@
-import { render, screen } from '@testing-library/react';
-import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
-import { NextRouter } from 'next/router';
-import { ReactElement } from 'react';
+import { screen } from '@testing-library/react';
 
 import { Footer } from './Footer';
 import { githubUrl } from './utils';
 
-const withTestRouter = (tree: ReactElement, router: Partial<NextRouter> = {}) => (
-  <RouterContext.Provider value={router as NextRouter}>{tree}</RouterContext.Provider>
-);
+import { renderWithTestRouter } from '~/common/test-utilities';
 
 describe('Footer', () => {
   test('displays default links', () => {
     const router = { pathname: '/example/' };
-    render(withTestRouter(<Footer title="test-title" />, router));
+    renderWithTestRouter(<Footer title="test-title" />, router);
 
     screen.getByText('Ask a question on the forums');
     screen.getByText('Edit this page');
@@ -21,29 +16,27 @@ describe('Footer', () => {
 
   test('displays forums link with tag', () => {
     const router = { pathname: '/sdk/' };
-    render(withTestRouter(<Footer title="test-title" />, router));
+    renderWithTestRouter(<Footer title="test-title" />, router);
 
     screen.getByText('Ask a question on the forums about test-title');
   });
 
   test('displays issues link', () => {
     const router = { pathname: '/sdk/' };
-    render(withTestRouter(<Footer title="test-title" />, router));
+    renderWithTestRouter(<Footer title="test-title" />, router);
 
     screen.getByText('View open bug reports for test-title');
   });
 
   test('displays correct issues link for 3rd-party package', () => {
     const router = { pathname: '/sdk/' };
-    render(
-      withTestRouter(
-        <Footer
-          title="GestureHandler"
-          sourceCodeUrl="https://github.com/software-mansion/react-native-gesture-handler"
-          packageName="react-native-gesture-handler"
-        />,
-        router
-      )
+    renderWithTestRouter(
+      <Footer
+        title="GestureHandler"
+        sourceCodeUrl="https://github.com/software-mansion/react-native-gesture-handler"
+        packageName="react-native-gesture-handler"
+      />,
+      router
     );
 
     const link = screen.getByRole('link', {

--- a/docs/ui/components/PageTitle/PageTitle.test.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.test.tsx
@@ -2,13 +2,14 @@ import { render, screen } from '@testing-library/react';
 
 import { PageTitle } from './PageTitle';
 
+import { renderWithTestRouter } from '~/common/test-utilities';
+
 describe('PageTitle', () => {
   test('displays npm registry link', () => {
     render(<PageTitle title="test-title" packageName="expo-av" />);
-    expect(screen.getByRole('link').getAttribute('href')).toEqual(
-      'https://www.npmjs.com/package/expo-av'
-    );
-    screen.getByTitle('View package in npm Registry');
+    const linkElement = screen.getAllByRole('link', { hidden: false })[0];
+    expect(linkElement.getAttribute('href')).toEqual('https://www.npmjs.com/package/expo-av');
+    expect(linkElement.getAttribute('title')).toEqual('View package in npm Registry');
   });
 
   test('displays GitHub source code link', () => {
@@ -19,6 +20,22 @@ describe('PageTitle', () => {
         sourceCodeUrl="https://github.com/expo/expo/tree/main/packages/expo-av"
       />
     );
-    screen.getByTitle('View source code of expo-av on GitHub');
+    const linkElement = screen.getAllByRole('link', { hidden: false })[0];
+    expect(linkElement.getAttribute('href')).toEqual(
+      'https://github.com/expo/expo/tree/main/packages/expo-av'
+    );
+    expect(linkElement.getAttribute('title')).toEqual('View source code of expo-av on GitHub');
+  });
+
+  test('displays edit page link for non-API docs', () => {
+    const router = { pathname: '/router/reference/hooks/' };
+
+    renderWithTestRouter(<PageTitle title="test-title" />, router);
+    const linkElement = screen.getAllByRole('link', { hidden: false })[0];
+
+    expect(linkElement.getAttribute('href')).toEqual(
+      'https://github.com/expo/expo/edit/main/docs/pages/router/reference/hooks.mdx'
+    );
+    expect(linkElement.getAttribute('title')).toEqual('Edit content of this page on GitHub');
   });
 });

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -1,71 +1,48 @@
-import { Button, mergeClasses } from '@expo/styleguide';
-import { BuildIcon, GithubIcon } from '@expo/styleguide-icons';
+import { mergeClasses } from '@expo/styleguide';
 
-import { CALLOUT, H1 } from '~/ui/components/Text';
+import { PageTitleButtons } from './PageTitleButtons';
+
+import { H1, P } from '~/ui/components/Text';
 
 type Props = {
   title?: string;
+  description?: string;
   packageName?: string;
   sourceCodeUrl?: string;
   iconUrl?: string;
 };
 
-export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => (
-  <div
-    className={mergeClasses(
-      'flex my-2 items-center justify-between',
-      'max-xl-gutters:flex-col max-xl-gutters:items-start'
-    )}>
-    <H1 className="!my-0 !font-bold">
-      {iconUrl && (
-        <img
-          src={iconUrl}
-          className="float-left mr-3.5 relative -top-0.5 size-[42px]"
-          alt={`Expo ${title} icon`}
-        />
+export const PageTitle = ({ title, description, packageName, iconUrl, sourceCodeUrl }: Props) => {
+  return (
+    <>
+      <div
+        className={mergeClasses(
+          'flex my-2 items-start justify-between gap-4',
+          'max-xl-gutters:flex-col max-xl-gutters:items-start'
+        )}>
+        <H1 className="!my-0 !font-bold">
+          {iconUrl && (
+            <img
+              src={iconUrl}
+              className="float-left mr-3.5 relative -top-0.5 size-[42px]"
+              alt={`Expo ${title} icon`}
+            />
+          )}
+          {packageName && packageName.startsWith('expo-') && 'Expo '}
+          {title}
+        </H1>
+        <span className="flex gap-1 max-xl-gutters:hidden">
+          <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+        </span>
+      </div>
+      {description && (
+        <P theme="secondary" data-description="true">
+          {description}
+        </P>
       )}
-      {packageName && packageName.startsWith('expo-') && 'Expo '}
-      {title}
-    </H1>
-    {packageName && (
-      <span className="flex gap-1 max-xl-gutters:mt-3 max-xl-gutters:mb-1">
-        {sourceCodeUrl && (
-          <Button
-            theme="quaternary"
-            className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
-            openInNewTab
-            href={sourceCodeUrl}
-            title={`View source code of ${packageName} on GitHub`}>
-            <div
-              className={mergeClasses(
-                'flex flex-col items-center',
-                'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-              )}>
-              <GithubIcon className="mt-0.5 text-icon-secondary" />
-              <CALLOUT crawlable={false} theme="secondary">
-                GitHub
-              </CALLOUT>
-            </div>
-          </Button>
-        )}
-        <Button
-          theme="quaternary"
-          openInNewTab
-          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
-          href={`https://www.npmjs.com/package/${packageName}`}
-          title="View package in npm Registry">
-          <div
-            className={mergeClasses(
-              'flex flex-col items-center',
-              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-            )}>
-            <BuildIcon className="mt-0.5 text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
-              npm
-            </CALLOUT>
-          </div>
-        </Button>
+      <span className="hidden gap-1 mt-3 mb-1 max-xl-gutters:flex">
+        <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
       </span>
-    )}
-  </div>
-);
+    </>
+  );
+};

--- a/docs/ui/components/PageTitle/PageTitleButtons.tsx
+++ b/docs/ui/components/PageTitle/PageTitleButtons.tsx
@@ -1,0 +1,72 @@
+import { Button, mergeClasses } from '@expo/styleguide';
+import { BuildIcon, Edit05Icon, GithubIcon } from '@expo/styleguide-icons';
+import { useRouter } from 'next/compat/router';
+
+import { githubUrl } from '~/ui/components/Footer/utils';
+import { CALLOUT } from '~/ui/components/Text';
+
+type Props = {
+  packageName?: string;
+  sourceCodeUrl?: string;
+};
+
+export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
+  const router = useRouter();
+  return (
+    <>
+      {!sourceCodeUrl && !packageName && router?.pathname && (
+        <Button
+          theme="quaternary"
+          className="px-2 justify-center"
+          openInNewTab
+          href={githubUrl(router.pathname)}
+          title="Edit content of this page on GitHub">
+          <div className="flex flex-row items-center gap-2">
+            <Edit05Icon className="text-icon-secondary icon-sm" />
+            <CALLOUT crawlable={false} theme="secondary">
+              Edit this page
+            </CALLOUT>
+          </div>
+        </Button>
+      )}
+      {sourceCodeUrl && (
+        <Button
+          theme="quaternary"
+          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
+          openInNewTab
+          href={sourceCodeUrl}
+          title={`View source code of ${packageName} on GitHub`}>
+          <div
+            className={mergeClasses(
+              'flex flex-col items-center',
+              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+            )}>
+            <GithubIcon className="mt-0.5 text-icon-secondary" />
+            <CALLOUT crawlable={false} theme="secondary">
+              GitHub
+            </CALLOUT>
+          </div>
+        </Button>
+      )}
+      {packageName && (
+        <Button
+          theme="quaternary"
+          openInNewTab
+          className="min-h-[48px] min-w-[60px] px-2 justify-center max-xl-gutters:min-h-[unset]"
+          href={`https://www.npmjs.com/package/${packageName}`}
+          title="View package in npm Registry">
+          <div
+            className={mergeClasses(
+              'flex flex-col items-center',
+              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+            )}>
+            <BuildIcon className="mt-0.5 text-icon-secondary" />
+            <CALLOUT crawlable={false} theme="secondary">
+              npm
+            </CALLOUT>
+          </div>
+        </Button>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
# Why

To make the page edit button more prominent and easier to found.

# How

Add "Edit this page" button to the `PageHeader` on non-API doc pages. Adjust the position and layout for smaller viewports.

Add unit tests, extract and refactor `withTestRouter` test helper.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-06-06 at 11 14 21](https://github.com/expo/expo/assets/719641/9ca3785e-caf4-4a51-8b22-4e836d7a70ff)
![Screenshot 2024-06-06 at 11 14 49](https://github.com/expo/expo/assets/719641/e26d241d-1c8d-4fe5-b82f-f34d801349f8)
