### PR TITLE
docs(create-expo): update help output `create-expo --help`

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Use proper `create-expo(-app)` reference in `--help` and clean up bun example. ([#29504](https://github.com/expo/expo/pull/29504) by [@byCedric](https://github.com/byCedric))
+
 ## 2.3.4 — 2024-05-01
 
 ### 🐛 Bug fixes

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -59,7 +59,7 @@ async function run() {
     {bold  npm:} {cyan npm create expo-app}
     {bold yarn:} {cyan yarn create expo-app}
     {bold pnpm:} {cyan pnpm create expo-app}
-    {bold  bun:} {cyan bunx create-expo-app}
+    {bold  bun:} {cyan bun create expo-app}
     `
     );
   }

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -32,6 +32,7 @@ async function run() {
   }
 
   if (args['--help']) {
+    const nameWithoutCreate = CLI_NAME.replace('create-', '');
     printHelp(
       `Creates a new Expo project`,
       chalk`npx ${CLI_NAME} {cyan <path>} [options]`,
@@ -46,20 +47,20 @@ async function run() {
       chalk`
     {gray To choose a template pass in the {bold --template} arg:}
 
-    {gray $} npm create expo-app {cyan --template}
+    {gray $} npm create ${nameWithoutCreate} {cyan --template}
 
     {gray To choose an Expo example pass in the {bold --example} arg:}
 
-    {gray $} npm create expo-app {cyan --example}
-    {gray $} npm create expo-app {cyan --example with-router}
+    {gray $} npm create ${nameWithoutCreate} {cyan --example}
+    {gray $} npm create ${nameWithoutCreate} {cyan --example with-router}
 
     {gray The package manager used for installing}
     {gray node modules is based on how you invoke the CLI:}
 
-    {bold  npm:} {cyan npm create expo-app}
-    {bold yarn:} {cyan yarn create expo-app}
-    {bold pnpm:} {cyan pnpm create expo-app}
-    {bold  bun:} {cyan bun create expo-app}
+    {bold  npm:} {cyan npm create ${nameWithoutCreate}}
+    {bold yarn:} {cyan yarn create ${nameWithoutCreate}}
+    {bold pnpm:} {cyan pnpm create ${nameWithoutCreate}}
+    {bold  bun:} {cyan bun create ${nameWithoutCreate}}
     `
     );
   }


### PR DESCRIPTION
# Why

In this block, we use the `npm|pnpm|yarn create expo-app` notation, but for Bun we used `bunx create-expo-app`. This changes the `bun` example to the same notation.

# How

- Updated `--help` output

# Test Plan

- `npx create-expo --help` should show the same format for all package managers.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
