### PR TITLE
[video][ios] Fix player status property always returning `undefined`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix wrong content fit "fill" and "cover". ([#29364](https://github.com/expo/expo/pull/29364) by [@RRaideRR](https://github.com/RRaideRR))
+- [iOS] Fix player status property always returning `undefined` on iOS. ([#29505](https://github.com/expo/expo/pull/29505) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -154,8 +154,8 @@ public final class VideoModule: Module {
         player.showNowPlayingNotification = showNowPlayingNotification
       }
 
-      Property("status") { player -> PlayerStatus in
-        return player.status
+      Property("status") { player in
+        return player.status.rawValue
       }
 
       Property("volume") { player -> Float in


### PR DESCRIPTION
# Why

`player.status` will always return `undefined` on iOS

# How

Made `player.status` return the raw value of the enum, as returning enums directly is not supported yet.

# Test Plan

Tested in BareExpo in iOS 17 simulator
