### PR TITLE
[docs] add last modification date to page Footer

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -32,6 +32,7 @@ export default function DocumentationPage({
   hideFromSearch,
   platforms,
   hideTOC,
+  modificationDate,
 }: DocPageProps) {
   const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
   const { version } = usePageApiVersion();
@@ -151,6 +152,7 @@ export default function DocumentationPage({
           packageName={packageName}
           previousPage={previousPage}
           nextPage={nextPage}
+          modificationDate={modificationDate}
         />
       </div>
     </DocumentationNestedScrollLayout>

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -38,6 +38,7 @@ export default function DocumentationElements(props: DocumentationElementsProps)
               hideFromSearch={props.meta.hideFromSearch}
               packageName={props.meta.packageName}
               iconUrl={props.meta.iconUrl}
+              modificationDate={props.meta.modificationDate}
               platforms={props.meta.platforms}>
               {props.children}
             </DocumentationPage>

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "dev": "yarn generate-static-resoures && next dev -p 3002",
     "build": "next build",
     "export": "yarn generate-static-resoures production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
-    "export-preview": "yarn generate-static-resoures production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
+    "export-preview": "yarn generate-static-resoures preview && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",

--- a/docs/package.json
+++ b/docs/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.6.0",
     "@emotion/jest": "^11.11.0",
+    "@expo/spawn-async": "^1.7.2",
     "@ocular-d/vale-bin": "^2.29.6",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "yarn generate-static-resoures && next dev -p 3002",
     "build": "next build",
-    "export": "yarn generate-static-resoures production && yarn run build && yarn run export-issue-404",
-    "export-preview": "yarn generate-static-resoures preview && yarn run build && yarn run export-issue-404",
+    "export": "yarn generate-static-resoures production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
+    "export-preview": "yarn generate-static-resoures production && yarn append-last-modified-dates && yarn run build && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
@@ -21,6 +21,7 @@
     "permissions-sync-android": "npx scrape-permissions-json@latest components/plugins/permissions/data --android",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
     "generate-static-resoures": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
+    "append-last-modified-dates": "node --unhandled-rejections=strict ./scripts/append-dates.js",
     "postinstall": "node --async-stack-traces --unhandled-rejections=strict ./scripts/copy-latest.js && yarn generate-static-resoures"
   },
   "resolutions": {

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,4 +1,5 @@
 ---
+modificationDate: April 8th, 2024
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -7,8 +8,6 @@ description: Learn about the current build server infrastructure when using EAS.
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BuildResourceList } from '~/ui/components/utils/infrastructure';
-
-> This document was last updated on **April 8th, 2024**.
 
 ## Builder IP addresses
 

--- a/docs/pages/technical-specs/expo-sfv-0.mdx
+++ b/docs/pages/technical-specs/expo-sfv-0.mdx
@@ -1,7 +1,8 @@
 ---
+modificationDate: May 24, 2021
 title: Expo Structured Field Values
 sidebar_title: Expo Structured Field Values
-description: Version 0 • Updated 2021-05-24
+description: Version 0
 ---
 
 Structured Field Values for HTTP, [IETF RFC 8941](https://tools.ietf.org/html/rfc8941), is a proposal to formalize header syntax and facilitate nested data.

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -1,7 +1,7 @@
 ---
+modificationDate: March 13, 2023
 title: Expo Updates v1
-sidebar_title: Expo Updates v1
-description: Version 1 • Updated 2023-03-13
+description: Version 1
 ---
 
 ## Introduction

--- a/docs/scripts/append-dates.js
+++ b/docs/scripts/append-dates.js
@@ -10,9 +10,13 @@ async function appendModificationDate(dir = './pages') {
       if (!file.isDirectory() && file.name.endsWith('.mdx')) {
         const filePath = path.join(file.path, file.name);
 
-        const { stdout } = await spawnAsync('git', ['log', '-1', '--pretty="%cs"', filePath], {
-          stdio: 'pipe',
-        });
+        const { stdout } = await spawnAsync(
+          'git',
+          ['log', '-1', '--pretty="%cd"', '--date=format:"%B %d, %Y"', filePath],
+          {
+            stdio: 'pipe',
+          }
+        );
 
         const fileContent = (await readFile(filePath, 'utf8')).split('\n');
         const modificationDateLine = `modificationDate: ${stdout.replace('\n', '')}`;

--- a/docs/scripts/append-dates.js
+++ b/docs/scripts/append-dates.js
@@ -19,12 +19,11 @@ async function appendModificationDate(dir = './pages') {
         );
 
         const fileContent = (await readFile(filePath, 'utf8')).split('\n');
-        const modificationDateLine = `modificationDate: ${stdout.replace('\n', '')}`;
+        const cleanDate = stdout.replace('\n', '').replaceAll('"', '');
+        const modificationDateLine = `modificationDate: ${cleanDate}`;
 
         if (!fileContent[1].startsWith('modificationDate')) {
           fileContent.splice(1, 0, modificationDateLine);
-        } else {
-          fileContent[1] = modificationDateLine;
         }
 
         await writeFile(filePath, fileContent.join('\n'), 'utf8');

--- a/docs/scripts/append-dates.js
+++ b/docs/scripts/append-dates.js
@@ -1,0 +1,37 @@
+import spawnAsync from '@expo/spawn-async';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+async function appendModificationDate(dir = './pages') {
+  try {
+    const files = await readdir(dir, { recursive: true, withFileTypes: true });
+
+    for (const file of files) {
+      if (!file.isDirectory() && file.name.endsWith('.mdx')) {
+        const filePath = path.join(file.path, file.name);
+
+        const { stdout } = await spawnAsync('git', ['log', '-1', '--pretty="%cs"', filePath], {
+          stdio: 'pipe',
+        });
+
+        const fileContent = (await readFile(filePath, 'utf8')).split('\n');
+        const modificationDateLine = `modificationDate: ${stdout.replace('\n', '')}`;
+
+        if (!fileContent[1].startsWith('modificationDate')) {
+          fileContent.splice(1, 0, modificationDateLine);
+        } else {
+          fileContent[1] = modificationDateLine;
+        }
+
+        await writeFile(filePath, fileContent.join('\n'), 'utf8');
+      }
+    }
+
+    process.exit();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+appendModificationDate();

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -9,6 +9,7 @@ export type PageMetadata = {
   hideFromSearch?: boolean;
   hideTOC?: boolean;
   platforms?: string[];
+  modificationDate?: string;
 };
 
 /**

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -30,7 +30,10 @@ export const Footer = ({
 }: Props) => {
   const router = useRouter();
   const isAPIPage = router?.pathname.includes('/sdk/') ?? false;
+  const isTutorial = router?.pathname.includes('/tutorial/') ?? false;
   const isExpoPackage = packageName && packageName.startsWith('expo-');
+
+  const shouldShowModifiedDate = !isExpoPackage && !isTutorial;
 
   return (
     <footer
@@ -96,12 +99,14 @@ export const Footer = ({
               <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
             )}
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
-            {!isDev && modificationDate && (
-              <LI className="!text-quaternary !text-xs !mt-4">Last modified: {modificationDate}</LI>
+            {!isDev && shouldShowModifiedDate && modificationDate && (
+              <LI className="!text-quaternary !text-2xs !mt-4">
+                Last updated on {modificationDate}
+              </LI>
             )}
-            {isDev && (
-              <LI className="!text-quaternary !text-xs !mt-4">
-                Last modified: Not available in dev mode
+            {isDev && shouldShowModifiedDate && (
+              <LI className="!text-quaternary !text-2xs !mt-4">
+                Last updated data is not available in dev mode
               </LI>
             )}
           </UL>

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
-import { ArrowLeftIcon, ArrowRightIcon, CalendarIcon } from '@expo/styleguide-icons';
+import { ArrowLeftIcon, ArrowRightIcon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { ForumsLink, EditPageLink, IssuesLink, ShareFeedbackLink } from './Links';

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -31,7 +31,7 @@ export const Footer = ({
   const router = useRouter();
   const isAPIPage = router?.pathname.includes('/sdk/') ?? false;
   const isTutorial = router?.pathname.includes('/tutorial/') ?? false;
-  const isExpoPackage = packageName && packageName.startsWith('expo-');
+  const isExpoPackage = packageName ? packageName.startsWith('expo-') : isAPIPage;
 
   const shouldShowModifiedDate = !isExpoPackage && !isTutorial;
 

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
-import { ArrowLeftIcon, ArrowRightIcon } from '@expo/styleguide-icons';
+import { ArrowLeftIcon, ArrowRightIcon, CalendarIcon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { ForumsLink, EditPageLink, IssuesLink, ShareFeedbackLink } from './Links';
@@ -7,7 +7,7 @@ import { NewsletterSignUp } from './NewsletterSignUp';
 import { PageVote } from './PageVote';
 
 import { NavigationRouteWithSection } from '~/types/common';
-import { P, FOOTNOTE, UL } from '~/ui/components/Text';
+import { P, FOOTNOTE, UL, LI } from '~/ui/components/Text';
 
 type Props = {
   title?: string;
@@ -15,9 +15,19 @@ type Props = {
   packageName?: string;
   previousPage?: NavigationRouteWithSection;
   nextPage?: NavigationRouteWithSection;
+  modificationDate?: string;
 };
 
-export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPage }: Props) => {
+const isDev = process.env.NODE_ENV === 'development';
+
+export const Footer = ({
+  title,
+  sourceCodeUrl,
+  packageName,
+  previousPage,
+  nextPage,
+  modificationDate,
+}: Props) => {
   const router = useRouter();
   const isAPIPage = router?.pathname.includes('/sdk/') ?? false;
   const isExpoPackage = packageName && packageName.startsWith('expo-');
@@ -86,6 +96,14 @@ export const Footer = ({ title, sourceCodeUrl, packageName, previousPage, nextPa
               <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
             )}
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
+            {!isDev && modificationDate && (
+              <LI className="!text-quaternary !text-xs !mt-4">Last modified: {modificationDate}</LI>
+            )}
+            {isDev && (
+              <LI className="!text-quaternary !text-xs !mt-4">
+                Last modified: Not available in dev mode
+              </LI>
+            )}
           </UL>
         </div>
         <NewsletterSignUp />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -468,6 +468,13 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@expo/spawn-async@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.7.2.tgz#fcfe66c3e387245e72154b1a7eae8cada6a47f58"
+  integrity sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==
+  dependencies:
+    cross-spawn "^7.0.3"
+
 "@expo/styleguide-base@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-1.0.1.tgz#c05b64370fc1754ed7e3c627fd2d788582445cd2"


### PR DESCRIPTION
# Why

It might be valuable in some cases for docs users to know when the page they are viewing has been updated.

# How

Add last modification date to page Footer based on the data from git about latest commit. The information is appended to the Markdown files before executing a deploy build at the cost of 30s-60s of CI run time. Locally, the data is not present, and we show a placeholder - this is the unsual pattern for docs frameworks including this functionality, i.e Docusaurus or GitBook.

# Test Plan

The changes have been reviewed locally in development and static modes.

# Preview

![Screenshot 2024-06-06 at 16 36 59](https://github.com/expo/expo/assets/719641/485aed64-aeda-4e73-b537-bad79aa7a3d1)

