### PR TITLE
[core][Android] Fix no implementation found for `JavaScriptModuleObject.initHybrid`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' ([#29075](https://github.com/expo/expo/pull/29075) by [@rafi16jan](https://github.com/rafi16jan))
 - [Android] Fix `getContext().getNativeModule(UIManagerModule.class)` in Bridgeless. ([#29203](https://github.com/expo/expo/pull/29203) by [@arushikesarwani94](https://github.com/arushikesarwani94))
 - [Android] Fixed converting from `null` to `Record` sometimes didn't work as expected. ([#29508](https://github.com/expo/expo/pull/29508) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed `No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [Android] Fix error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr' ([#29075](https://github.com/expo/expo/pull/29075) by [@rafi16jan](https://github.com/rafi16jan))
 - [Android] Fix `getContext().getNativeModule(UIManagerModule.class)` in Bridgeless. ([#29203](https://github.com/expo/expo/pull/29203) by [@arushikesarwani94](https://github.com/arushikesarwani94))
 - [Android] Fixed converting from `null` to `Record` sometimes didn't work as expected. ([#29508](https://github.com/expo/expo/pull/29508) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed `No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid`.
+- [Android] Fixed `No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid`. ([#29513](https://github.com/expo/expo/pull/29513) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
@@ -90,8 +90,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
     mModuleRegistry.ensureIsInitialized();
 
     KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
-    kotlinModuleRegistry.emitOnCreate();
     kotlinModuleRegistry.installJSIInterop();
+    kotlinModuleRegistry.emitOnCreate();
 
     Map<String, Object> constants = new HashMap<>(3);
     constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());


### PR DESCRIPTION
# Why

Fixes:

```
2024-06-06 08:52:12.678 21901-21992 .blueskyweb.app         xyz.blueskyweb.app                   E  No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid() (tried Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid and Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid__) - is the library loaded, e.g. System.loadLibrary?
2024-06-06 08:52:12.681 21901-21992 ReactNativeJS           xyz.blueskyweb.app                   E  Error: Exception in HostObject::get for prop 'NativeUnimoduleProxy': java.lang.UnsatisfiedLinkError: No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid() (tried Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid and Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid__) - is the library loaded, e.g. System.loadLibrary?, js engine: hermes
2024-06-06 08:52:12.683 21901-21992 ReactNativeJS           xyz.blueskyweb.app                   E  Invariant Violation: "main" has not been registered. This can happen if:
                                                                                                    * Metro (the local dev server) is run from the wrong folder. Check if Metro is running, stop it and restart it in the current project.
                                                                                                    * A module failed to load due to an error and `AppRegistry.registerComponent` wasn't called., js engine: hermes
2024-06-06 08:52:12.685 21901-21994 AndroidRuntime          xyz.blueskyweb.app                   E  FATAL EXCEPTION: mqt_native_modules
                                                                                                    Process: xyz.blueskyweb.app, PID: 21901
                                                                                                    com.facebook.react.common.JavascriptException: Error: Exception in HostObject::get for prop 'NativeUnimoduleProxy': java.lang.UnsatisfiedLinkError: No implementation found for com.facebook.jni.HybridData expo.modules.kotlin.jni.JavaScriptModuleObject.initHybrid() (tried Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid and Java_expo_modules_kotlin_jni_JavaScriptModuleObject_initHybrid__) - is the library loaded, e.g. System.loadLibrary?, js engine: hermes, stack:
                                                                                                    anonymous@1:1623065
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    metroImportDefault@1:111772
                                                                                                    anonymous@1:1621805
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:1620979
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:1620729
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:1620596
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:1563714
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:1563525
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112084
                                                                                                    metroRequire@1:111706
                                                                                                    anonymous@1:118637
                                                                                                    loadModuleImplementation@1:112536
                                                                                                    guardedLoadModule@1:112041
                                                                                                    metroRequire@1:111706
                                                                                                    global@1:111258
                                                                                                    
                                                                                                    	at com.facebook.react.modules.core.ExceptionsManagerModule.reportException(ExceptionsManagerModule.java:65)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
                                                                                                    	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:146)
                                                                                                    	at com.facebook.jni.NativeRunnable.run(Native Method)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:958)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:230)
                                                                                                    	at android.os.Looper.loop(Looper.java:319)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:233)
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)
```

# How

Made sure that the order of initialization is correct. I have no clue, why it's working when launching the app from main intent, but it starts to break when opening from a share activity.

# Test Plan

- bluesky ✅ 