### PR TITLE
[gha] run only one workflow for most of docs changes

### DIFF
--- a/.github/workflows/docs-pr-destroy.yml
+++ b/.github/workflows/docs-pr-destroy.yml
@@ -1,5 +1,4 @@
-
-name: docs-pr-destroy
+name: Docs Website PR Destroy Preview
 
 on:
   pull_request:

--- a/.github/workflows/docs-pr-destroy.yml
+++ b/.github/workflows/docs-pr-destroy.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - 'docs/**'
-      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr.yml'
       - '.github/workflows/docs-pr-destroy.yml'
     types: [closed, unlabeled]
 

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,4 +1,4 @@
-name: docs-pr-deploy
+name: Docs Website PR
 
 defaults:
   run:
@@ -9,16 +9,15 @@ on:
   workflow_dispatch: {}
   push:
     paths:
-      - 'docs/**'
       - '.github/workflows/docs-pr-deploy.yml'
       - '.github/workflows/docs-pr-destroy.yml'
   pull_request:
     paths:
       - 'docs/**'
-      - '.github/workflows/docs.yml'
       - '.github/workflows/docs-pr-deploy.yml'
       - '.github/workflows/docs-pr-destroy.yml'
     types:
+      - opened
       - labeled
       - synchronize
 
@@ -28,7 +27,6 @@ concurrency:
 
 jobs:
   docs-pr-deploy:
-    if: contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: ubuntu-22.04
     steps:
       - name: 👀 Checkout
@@ -44,7 +42,21 @@ jobs:
           yarn-docs: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-docs-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🧪 Run Docs tests
+        run: yarn test
+      - name: 🚨 Lint Docs website code
+        run: yarn lint --max-warnings 0
+      - name: 💬 Lint Docs website content
+        run: yarn lint-prose
+      - name: ⚠️ Danger check
+        run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🪣 Set up docs preview bucket
+        if: contains(github.event.pull_request.labels.*.name, 'preview')
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -61,18 +73,25 @@ jobs:
 
           # Set up static website hosting
           aws s3 website s3://docs.expo.dev-pr-${{ github.event.pull_request.number }}/ --index-document index.html
-      - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-docs-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - run: yarn danger ci
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗️ Build Docs website for deploy
         run: yarn export-preview
         timeout-minutes: 20
         env:
           AWS_BUCKET: 'docs.expo.dev-pr-${{ github.event.pull_request.number }}'
+      - name: 🔗 Lint pages links
+        working-directory: docs
+        run: yarn lint-links --quiet
+      - name: ✅ Test links (legacy)
+        working-directory: docs
+        run: |
+          yarn export-server &
+          while ! nc -z localhost 8000; do
+            sleep 1
+          done
+          yarn test-links http://127.0.0.1:8000
+        timeout-minutes: 3
       - name: 🚀 Deploy Docs website
+        if: contains(github.event.pull_request.labels.*.name, 'preview')
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -80,6 +99,7 @@ jobs:
           AWS_BUCKET: docs.expo.dev-pr-${{ github.event.pull_request.number }}
         run: ./deploy.sh
       - name: 🔍 Find old comment if it exists
+        if: contains(github.event.pull_request.labels.*.name, 'preview')
         uses: peter-evans/find-comment@v2
         id: old_comment
         with:
@@ -87,7 +107,7 @@ jobs:
           comment-author: 'expo-bot'
           body-includes: 📘 Your docs
       - name: 💬 Add comment with preview URL
-        if: steps.old_comment.outputs.comment-id == ''
+        if: contains(github.event.pull_request.labels.*.name, 'preview') && steps.old_comment.outputs.comment-id == ''
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
@@ -99,7 +119,7 @@ jobs:
               body: '📘 Your docs [preview website](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/) is ready!'
             });
       - name: 💬 Update comment with preview URL
-        if: steps.old_comment.outputs.comment-id != ''
+        if: contains(github.event.pull_request.labels.*.name, 'preview') && steps.old_comment.outputs.comment-id != ''
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -9,12 +9,12 @@ on:
   workflow_dispatch: {}
   push:
     paths:
-      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr.yml'
       - '.github/workflows/docs-pr-destroy.yml'
   pull_request:
     paths:
       - 'docs/**'
-      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr.yml'
       - '.github/workflows/docs-pr-destroy.yml'
     types:
       - opened
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-pr-deploy:
+  docs-pr:
     runs-on: ubuntu-22.04
     steps:
       - name: 👀 Checkout
@@ -55,6 +55,23 @@ jobs:
         run: yarn danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏗️ Build Docs website
+        run: yarn export-preview
+        timeout-minutes: 20
+        env:
+          AWS_BUCKET: 'docs.expo.dev-pr-${{ github.event.pull_request.number }}'
+      - name: 🔗 Lint pages links
+        working-directory: docs
+        run: yarn lint-links --quiet
+      - name: ✅ Test links (legacy)
+        working-directory: docs
+        run: |
+          yarn export-server &
+          while ! nc -z localhost 8000; do
+            sleep 1
+          done
+          yarn test-links http://127.0.0.1:8000
+        timeout-minutes: 3
       - name: 🪣 Set up docs preview bucket
         if: contains(github.event.pull_request.labels.*.name, 'preview')
         env:
@@ -73,23 +90,6 @@ jobs:
 
           # Set up static website hosting
           aws s3 website s3://docs.expo.dev-pr-${{ github.event.pull_request.number }}/ --index-document index.html
-      - name: 🏗️ Build Docs website for deploy
-        run: yarn export-preview
-        timeout-minutes: 20
-        env:
-          AWS_BUCKET: 'docs.expo.dev-pr-${{ github.event.pull_request.number }}'
-      - name: 🔗 Lint pages links
-        working-directory: docs
-        run: yarn lint-links --quiet
-      - name: ✅ Test links (legacy)
-        working-directory: docs
-        run: |
-          yarn export-server &
-          while ! nc -z localhost 8000; do
-            sleep 1
-          done
-          yarn test-links http://127.0.0.1:8000
-        timeout-minutes: 3
       - name: 🚀 Deploy Docs website
         if: contains(github.event.pull_request.labels.*.name, 'preview')
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
-      - 'docs/**'
       - '.github/workflows/docs.yml'
 
 concurrency:


### PR DESCRIPTION
# Why

Currently, we were running two very similar workflows on each docs changes (in PRs and on push), which lead to building docs app twice on CI for every commit on changeset which used "Preview" label.

> In this PR the multiple workflows were run since I have touched the YAML workflow definition file, which is an expected behaviour.

# How

Move the missing checks from base Docs workflow to the one for PRs, add inline ifs for the `preview` flag on certain steps, adjust the run rules, so in most cases we will run only one workflow.

# Test Plan

Run the CI!