### PR TITLE
fix(expo-contacts): do not reject `requestPermissionsAsync` promise on iOS

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unpublished
 
+- Fixed an issue where the `requestPermissionsAsync` promise throws when denying access to contacts on iOS. ([#29528](https://github.com/expo/expo/issues/29528) by [@jp1987](https://github.com/jp1987))
 - Fixed an issue where the `presentFormAsync` promise doesn't resolve when the form is closed on Android. ([#29201](https://github.com/expo/expo/pull/29201) by [@jp1987](https://github.com/jp1987))
 - Fixed an issue where the `presentContactPickerAsync` promise doesn't resolve when using the Android back button. ([#29202](https://github.com/expo/expo/pull/29202) by [@jp1987](https://github.com/jp1987))
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- Fixed an issue where the `requestPermissionsAsync` promise throws when denying access to contacts on iOS. ([#29528](https://github.com/expo/expo/issues/29528) by [@jp1987](https://github.com/jp1987))
+- Fixed an issue where the `requestPermissionsAsync` promise throws when denying access to contacts on iOS. ([#29529](https://github.com/expo/expo/pull/29529) by [@jp1987](https://github.com/jp1987))
 - Fixed an issue where the `presentFormAsync` promise doesn't resolve when the form is closed on Android. ([#29201](https://github.com/expo/expo/pull/29201) by [@jp1987](https://github.com/jp1987))
 - Fixed an issue where the `presentContactPickerAsync` promise doesn't resolve when using the Android back button. ([#29202](https://github.com/expo/expo/pull/29202) by [@jp1987](https://github.com/jp1987))
 

--- a/packages/expo-contacts/ios/ContactsRequester.swift
+++ b/packages/expo-contacts/ios/ContactsRequester.swift
@@ -26,7 +26,7 @@ class ContactsPermissionRequester: NSObject, EXPermissionsRequester {
 
   func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
     let store = CNContactStore()
-    store.requestAccess(for: .contacts) { [weak self] _, error in
+    store.requestAccess(for: .contacts) { [weak self] _, _ in
       guard let self else {
         return
       }

--- a/packages/expo-contacts/ios/ContactsRequester.swift
+++ b/packages/expo-contacts/ios/ContactsRequester.swift
@@ -30,10 +30,6 @@ class ContactsPermissionRequester: NSObject, EXPermissionsRequester {
       guard let self else {
         return
       }
-      if let error {
-        reject("E_CONTACTS_ERROR_UNKNOWN", error.localizedDescription, error)
-        return
-      }
 
       resolve(self.getPermissions())
     }


### PR DESCRIPTION
# Why

Closes [#29528](https://github.com/expo/expo/issues/29528)

# How

`CNContactStore.requestAccess` may return a boolean and error, but the [documentation](https://developer.apple.com/documentation/contacts/cncontactstore/requestaccess(for:completionhandler:)) is pretty vague as to when `error` is set. As demonstrated in the video of [#29528](https://github.com/expo/expo/issues/29528), `error` is set when denying access. This change makes sure the promise always resolves, which I believe is fine in this case.

# Test Plan

Manually tested in `bare-expo`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
