### PR TITLE
[docs] Fix ToC UI

### DIFF
--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -81,10 +81,10 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     );
 
     return (
-      <nav className="pb-6 px-6 w-[280px]" data-sidebar>
+      <nav className="pt-14 pb-12 px-6 w-[280px]" data-sidebar>
         <CALLOUT
           weight="medium"
-          className="absolute bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
+          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10">
           <LayoutAlt03Icon className="icon-sm" /> On this page
           <Button
             theme="quaternary"

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="pb-6 px-6 w-[280px]"
+    class="pt-14 pb-12 px-6 w-[280px]"
     data-sidebar="true"
   >
     <p
-      class="absolute bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
+      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none z-10 css-1t1p06f-TextComponent"
       data-text="true"
     >
       <svg


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In the [#29487](https://github.com/expo/expo/issues/29487), changes introduced to ToC started truncating top level items.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Revert style changes back to fix ToC truncation issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, run `yarn run test`, and run `yarn test- u` to make sure all tests are passing

## Preview

![CleanShot 2024-06-07 at 15 48 24@2x](https://github.com/expo/expo/assets/10234615/faccc0b6-7c99-4c10-b941-84531961c965)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
