### PR TITLE
[docs] Update config plugin example in BuildProperties API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
@@ -24,6 +25,10 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 <ConfigPluginExample>
 
+<Tabs>
+
+<Tab label="app.json">
+
 ```json app.json|collapseHeight=450
 {
   "expo": {
@@ -32,9 +37,9 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
         "expo-build-properties",
         {
           "android": {
-            "compileSdkVersion": 31,
-            "targetSdkVersion": 31,
-            "buildToolsVersion": "31.0.0"
+            "compileSdkVersion": 34,
+            "targetSdkVersion": 34,
+            "buildToolsVersion": "34.0.0"
           },
           "ios": {
             "deploymentTarget": "13.4"
@@ -46,9 +51,9 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 }
 ```
 
-</ConfigPluginExample>
+</Tab>
 
-### Example app.config.js usage
+<Tab label="app.config.js">
 
 ```js app.config.js|collapseHeight=450
 export default {
@@ -58,9 +63,9 @@ export default {
         'expo-build-properties',
         {
           android: {
-            compileSdkVersion: 31,
-            targetSdkVersion: 31,
-            buildToolsVersion: '31.0.0',
+            compileSdkVersion: 34,
+            targetSdkVersion: 34,
+            buildToolsVersion: '34.0.0',
           },
           ios: {
             deploymentTarget: '13.4',
@@ -71,6 +76,12 @@ export default {
   },
 };
 ```
+
+</Tab>
+
+</Tabs>
+
+</ConfigPluginExample>
 
 ### All configurable properties
 

--- a/docs/pages/versions/v50.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/build-properties.mdx
@@ -9,6 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
@@ -26,6 +27,10 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 <ConfigPluginExample>
 
+<Tabs>
+
+<Tab label="app.json">
+
 ```json app.json|collapseHeight=450
 {
   "expo": {
@@ -34,9 +39,9 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
         "expo-build-properties",
         {
           "android": {
-            "compileSdkVersion": 31,
-            "targetSdkVersion": 31,
-            "buildToolsVersion": "31.0.0"
+            "compileSdkVersion": 33,
+            "targetSdkVersion": 33,
+            "buildToolsVersion": "33.0.0"
           },
           "ios": {
             "deploymentTarget": "13.0"
@@ -48,9 +53,9 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 }
 ```
 
-</ConfigPluginExample>
+</Tab>
 
-### Example app.config.js usage
+<Tab label="app.config.js">
 
 ```js app.config.js|collapseHeight=450
 export default {
@@ -60,9 +65,9 @@ export default {
         'expo-build-properties',
         {
           android: {
-            compileSdkVersion: 31,
-            targetSdkVersion: 31,
-            buildToolsVersion: '31.0.0',
+            compileSdkVersion: 33,
+            targetSdkVersion: 33,
+            buildToolsVersion: '33.0.0',
           },
           ios: {
             deploymentTarget: '13.0',
@@ -73,6 +78,12 @@ export default {
   },
 };
 ```
+
+</Tab>
+
+</Tabs>
+
+</ConfigPluginExample>
 
 ### All configurable properties
 

--- a/docs/pages/versions/v51.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/build-properties.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
 of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
@@ -24,6 +25,10 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 
 <ConfigPluginExample>
 
+<Tabs>
+
+<Tab label="app.json">
+
 ```json app.json|collapseHeight=450
 {
   "expo": {
@@ -32,12 +37,12 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
         "expo-build-properties",
         {
           "android": {
-            "compileSdkVersion": 31,
-            "targetSdkVersion": 31,
-            "buildToolsVersion": "31.0.0"
+            "compileSdkVersion": 34,
+            "targetSdkVersion": 34,
+            "buildToolsVersion": "34.0.0"
           },
           "ios": {
-            "deploymentTarget": "13.0"
+            "deploymentTarget": "13.4"
           }
         }
       ]
@@ -46,9 +51,9 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 }
 ```
 
-</ConfigPluginExample>
+</Tab>
 
-### Example app.config.js usage
+<Tab label="app.config.js">
 
 ```js app.config.js|collapseHeight=450
 export default {
@@ -58,12 +63,12 @@ export default {
         'expo-build-properties',
         {
           android: {
-            compileSdkVersion: 31,
-            targetSdkVersion: 31,
-            buildToolsVersion: '31.0.0',
+            compileSdkVersion: 34,
+            targetSdkVersion: 34,
+            buildToolsVersion: '34.0.0',
           },
           ios: {
-            deploymentTarget: '13.0',
+            deploymentTarget: '13.4',
           },
         },
       ],
@@ -71,6 +76,12 @@ export default {
   },
 };
 ```
+
+</Tab>
+
+</Tabs>
+
+</ConfigPluginExample>
 
 ### All configurable properties
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #29496

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Updates Android part of the example
- Applies the updated example changes to SDK 51 too
- Uses `Tabs` component to display `app.json` and `app.config.js` examples (not sure why we had a separate section for **app.config.js** file instead of using Tab in the first place.

All changes are now applied to the unversioned and SDK 51 doc.

For SDK 50:
- Android example updated.
-   Used `Tabs` component to display `app.json` and `app.config.js` examples

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

## Preview
![CleanShot 2024-06-07 at 17 26 45@2x](https://github.com/expo/expo/assets/10234615/51ef1315-599b-4ede-8657-5c28f77db745)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
