### PR TITLE
[asset][image] decouple @react-native/assets-registry

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Removed @react-native/assets-registry dependency. ([#29541](https://github.com/expo/expo/pull/29541) by [@kudo](https://github.com/kudo))
+
 ## 10.0.7 - 2024-06-05
 
 ### 💡 Others

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -37,14 +37,12 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@react-native/assets-registry": "0.74.84",
     "expo-constants": "~16.0.0",
     "invariant": "^2.2.4",
     "md5-file": "^3.2.3"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.1",
-    "@types/react-native__assets": "~1.0.0",
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Removed @react-native/assets-registry dependency. ([#29541](https://github.com/expo/expo/pull/29541) by [@kudo](https://github.com/kudo))
+
 ## 1.12.10 - 2024-06-05
 
 ### 💡 Others

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -26,9 +26,7 @@
   ],
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "dependencies": {
-    "@react-native/assets-registry": "0.74.84"
-  },
+  "dependencies": {},
   "devDependencies": {
     "expo-module-scripts": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,11 +4661,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-native__assets@~1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-native__assets/-/react-native__assets-1.0.0.tgz#5ae261d71b43560f5e4f05b7ce9212a2ff5fb02a"
-  integrity sha512-9/VzYmiUPHdRJn1WwiG5TgKlLyyFyp7MaRzh4iTCTgWOcHQ9ZMjdUbwMHaXMp6F5fnrn4Oxk7LRR4flNz6VOBw==
-
 "@types/react-redux@^7.1.16", "@types/react-redux@^7.1.20":
   version "7.1.23"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.23.tgz#3c2bb1bcc698ae69d70735f33c5a8e95f41ac528"


### PR DESCRIPTION
# Why

close ENG-12442

# How

these imports are bundled by metro. it should be safe to remove the dependencies. the idea is like all expo modules have expo-modules-core import but not have direct dependency to expo-modules-core. metro resolver will try to find ancestor node_modules and the @react-native/assets-registry will be hoisted in the ancestor node_modules.
even for pnpm isolated mode, by default all packages should be [hoisted to `node_modules/.pnpm/node_modules`](https://pnpm.io/npmrc#hoist) 

# Test Plan

- try expo-asset on bare-expo
- try expo-asset on pnpm isolated project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
