### PR TITLE
[cli] decouple @react-native/dev-middleware

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Drop outdated React Native resolver patch. ([#29214](https://github.com/expo/expo/pull/29214) by [@EvanBacon](https://github.com/EvanBacon))
 - Use Metro instance directly for server rendering. ([#28552](https://github.com/expo/expo/pull/28552) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove unused dependencies. ([#29177](https://github.com/expo/expo/pull/29177) by [@Simek](https://github.com/Simek))
+- Removed @react-native/dev-middleware dependency. ([#29542](https://github.com/expo/expo/pull/29542) by [@kudo](https://github.com/kudo))
 
 ## 0.18.15 — 2024-06-05
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -55,7 +55,6 @@
     "@expo/rudder-sdk-node": "^1.1.1",
     "@expo/spawn-async": "^1.7.2",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.74.84",
     "@urql/core": "^2.3.6",
     "@urql/exchange-retry": "0.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,13 +2,23 @@ import chalk from 'chalk';
 
 import { createHandlersFactory } from './createHandlersFactory';
 import { Log } from '../../../../log';
+import { resolveProjectTransitiveDependency } from '../../../../utils/resolvePackage';
 import { type MetroBundlerDevServer } from '../MetroBundlerDevServer';
 
 export function createDebugMiddleware(metroBundler: MetroBundlerDevServer) {
   // Load the React Native debugging tools from project
-  // TODO: check if this works with isolated modules
-  const { createDevMiddleware } =
-    require('@react-native/dev-middleware') as typeof import('@react-native/dev-middleware');
+  const devMiddlewarePath = resolveProjectTransitiveDependency(
+    metroBundler.projectRoot,
+    'react-native',
+    '@react-native/community-cli-plugin',
+    '@react-native/dev-middleware'
+  );
+  if (!devMiddlewarePath) {
+    throw new Error('Unable to resolve the @react-native/dev-middleware package.');
+  }
+  const { createDevMiddleware } = require(
+    devMiddlewarePath
+  ) as typeof import('@react-native/dev-middleware');
 
   const { middleware, websocketEndpoints } = createDevMiddleware({
     projectRoot: metroBundler.projectRoot,

--- a/packages/@expo/cli/src/utils/__tests__/resolvePackage-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolvePackage-test.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+
+import { resolveProjectTransitiveDependency } from '../resolvePackage';
+
+jest.unmock('resolve-from');
+
+describe(resolveProjectTransitiveDependency, () => {
+  const expoRoot = path.resolve(__dirname, '../../../../../..');
+
+  it('should return null if dependency is not found', () => {
+    const depPath = resolveProjectTransitiveDependency(expoRoot, 'not-found');
+    expect(depPath).toBe(null);
+  });
+
+  it('should support direct dependency', () => {
+    const depPath = resolveProjectTransitiveDependency(expoRoot, 'react-native');
+    expect(depPath).toBe(path.join(expoRoot, 'node_modules/react-native/index.js'));
+  });
+
+  it('should support transitive dependency', () => {
+    const depPath = resolveProjectTransitiveDependency(
+      expoRoot,
+      'react-native',
+      '@react-native/community-cli-plugin',
+      '@react-native/dev-middleware'
+    );
+    expect(depPath).toBe(
+      path.join(expoRoot, 'node_modules/@react-native/dev-middleware/dist/index.js')
+    );
+  });
+});

--- a/packages/@expo/cli/src/utils/resolvePackage.ts
+++ b/packages/@expo/cli/src/utils/resolvePackage.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+/**
+ * Resolve the path to a transitive dependency from the project.
+ */
+export function resolveProjectTransitiveDependency(
+  projectRoot: string,
+  ...deps: string[]
+): string | null {
+  let currentDir: string | null = projectRoot;
+  for (let i = 0; i < deps.length; ++i) {
+    const dep = deps[i];
+    const target = i === deps.length - 1 ? dep : `${dep}/package.json`;
+    const resolved = resolveFrom.silent(currentDir, target);
+    if (!resolved) {
+      currentDir = null;
+      break;
+    }
+    if (i === deps.length - 1) {
+      return resolved;
+    }
+    currentDir = path.dirname(resolved);
+  }
+  return null;
+}


### PR DESCRIPTION
# Why

close ENG-12442

# How

remove `@react-native/dev-middleware` dependency and resolve from `react-native` -> `@react-native/community-cli-plugin` -> `@react-native/dev-middleware`.

# Test Plan

- add unit test for `resolveProjectTransitiveDependency`
- expo start on pnpm isolated project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
