### PR TITLE
[babel-preset-expo] decouple @react-native/babel-preset

### DIFF
--- a/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
@@ -17,6 +17,8 @@ import { fromRawMappings } from 'metro-source-map';
 import type { JsTransformerConfig, JsTransformOptions, JsOutput } from 'metro-transform-worker';
 import * as path from 'path';
 
+jest.unmock('resolve-from');
+
 /** Converts source mappings from Metro to a “TraceMap”, which is similar to source-map’s SourceMapConsumer */
 const toTraceMap = (output: JsOutput, contents: string) => {
   const map = fromRawMappings([output.data]).toMap();

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Removed `@react-native/babel-preset` dependency. ([#29544](https://github.com/expo/expo/pull/29544) by [@kudo](https://github.com/kudo))
+
 ## 11.0.7 - 2024-06-05
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -7,6 +7,7 @@ const expo_inline_manifest_plugin_1 = require("./expo-inline-manifest-plugin");
 const expo_router_plugin_1 = require("./expo-router-plugin");
 const inline_env_vars_1 = require("./inline-env-vars");
 const lazyImports_1 = require("./lazyImports");
+const resolve_package_1 = require("./resolve-package");
 const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 function getOptions(options, platform) {
     const tag = platform === 'web' ? 'web' : 'native';
@@ -167,11 +168,7 @@ function babelPresetExpo(api, options = {}) {
     return {
         presets: [
             [
-                // We use `require` here instead of directly using the package name because we want to
-                // specifically use the `@react-native/babel-preset` installed by this package (ex:
-                // `babel-preset-expo/node_modules/`). This way the preset will not change unintentionally.
-                // Reference: https://github.com/expo/expo/pull/4685#discussion_r307143920
-                isModernEngine ? require('./web-preset') : require('@react-native/babel-preset'),
+                isModernEngine ? require('./web-preset') : (0, resolve_package_1.requireUpstreamBabelPreset)(),
                 {
                     // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
                     disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,

--- a/packages/babel-preset-expo/build/resolve-package.d.ts
+++ b/packages/babel-preset-expo/build/resolve-package.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Resolve and import the @react-native/babel-preset package.
+ */
+export declare function requireUpstreamBabelPreset(): any;
+/**
+ * Resolve the path to a transitive dependency from the project.
+ */
+export declare function resolveProjectTransitiveDependency(projectRoot: string, ...deps: string[]): string | null;

--- a/packages/babel-preset-expo/build/resolve-package.js
+++ b/packages/babel-preset-expo/build/resolve-package.js
@@ -1,0 +1,42 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveProjectTransitiveDependency = exports.requireUpstreamBabelPreset = void 0;
+const path_1 = __importDefault(require("path"));
+const resolve_from_1 = __importDefault(require("resolve-from"));
+/**
+ * Resolve and import the @react-native/babel-preset package.
+ */
+function requireUpstreamBabelPreset() {
+    const reactNativePackageJsonPath = require.resolve('react-native/package.json');
+    const reactNativePath = path_1.default.dirname(reactNativePackageJsonPath);
+    const babelPresetPath = resolveProjectTransitiveDependency(reactNativePath, '@react-native/community-cli-plugin', '@react-native/metro-babel-transformer', '@react-native/babel-preset');
+    if (!babelPresetPath) {
+        throw new Error('Unable to resolve the @react-native/babel-preset package.');
+    }
+    return require(babelPresetPath);
+}
+exports.requireUpstreamBabelPreset = requireUpstreamBabelPreset;
+/**
+ * Resolve the path to a transitive dependency from the project.
+ */
+function resolveProjectTransitiveDependency(projectRoot, ...deps) {
+    let currentDir = projectRoot;
+    for (let i = 0; i < deps.length; ++i) {
+        const dep = deps[i];
+        const target = i === deps.length - 1 ? dep : `${dep}/package.json`;
+        const resolved = resolve_from_1.default.silent(currentDir, target);
+        if (!resolved) {
+            currentDir = null;
+            break;
+        }
+        if (i === deps.length - 1) {
+            return resolved;
+        }
+        currentDir = path_1.default.dirname(resolved);
+    }
+    return null;
+}
+exports.resolveProjectTransitiveDependency = resolveProjectTransitiveDependency;

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -48,10 +48,10 @@
     "@babel/plugin-transform-parameters": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
     "@babel/preset-react": "^7.22.15",
-    "@react-native/babel-preset": "0.74.84",
     "babel-plugin-react-compiler": "^0.0.0-experimental-592953e-20240517",
     "babel-plugin-react-native-web": "~0.19.10",
-    "react-refresh": "^0.14.2"
+    "react-refresh": "^0.14.2",
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/babel-preset-expo/src/__tests__/resolve-package.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/resolve-package.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+
+import { resolveProjectTransitiveDependency } from '../resolve-package';
+
+describe(resolveProjectTransitiveDependency, () => {
+  const expoRoot = path.resolve(__dirname, '../../../..');
+
+  it('should return null if dependency is not found', () => {
+    const depPath = resolveProjectTransitiveDependency(expoRoot, 'not-found');
+    expect(depPath).toBe(null);
+  });
+
+  it('should support direct dependency', () => {
+    const depPath = resolveProjectTransitiveDependency(expoRoot, 'react-native');
+    expect(depPath).toBe(path.join(expoRoot, 'node_modules/react-native/index.js'));
+  });
+
+  it('should support transitive dependency', () => {
+    const depPath = resolveProjectTransitiveDependency(
+      expoRoot,
+      'react-native',
+      '@react-native/community-cli-plugin',
+      '@react-native/metro-babel-transformer',
+      '@react-native/babel-preset'
+    );
+    expect(depPath).toBe(
+      path.join(expoRoot, 'node_modules/@react-native/babel-preset/src/index.js')
+    );
+  });
+});

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -19,6 +19,7 @@ import { expoInlineManifestPlugin } from './expo-inline-manifest-plugin';
 import { expoRouterBabelPlugin } from './expo-router-plugin';
 import { expoInlineEnvVars } from './inline-env-vars';
 import { lazyImports } from './lazyImports';
+import { requireUpstreamBabelPreset } from './resolve-package';
 import { environmentRestrictedReactAPIsPlugin } from './restricted-react-api-plugin';
 
 type BabelPresetExpoPlatformOptions = {
@@ -303,11 +304,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   return {
     presets: [
       [
-        // We use `require` here instead of directly using the package name because we want to
-        // specifically use the `@react-native/babel-preset` installed by this package (ex:
-        // `babel-preset-expo/node_modules/`). This way the preset will not change unintentionally.
-        // Reference: https://github.com/expo/expo/pull/4685#discussion_r307143920
-        isModernEngine ? require('./web-preset') : require('@react-native/babel-preset'),
+        isModernEngine ? require('./web-preset') : requireUpstreamBabelPreset(),
         {
           // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
           disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,

--- a/packages/babel-preset-expo/src/resolve-package.ts
+++ b/packages/babel-preset-expo/src/resolve-package.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+/**
+ * Resolve and import the @react-native/babel-preset package.
+ */
+export function requireUpstreamBabelPreset() {
+  const reactNativePackageJsonPath = require.resolve('react-native/package.json');
+  const reactNativePath = path.dirname(reactNativePackageJsonPath);
+  const babelPresetPath = resolveProjectTransitiveDependency(
+    reactNativePath,
+    '@react-native/community-cli-plugin',
+    '@react-native/metro-babel-transformer',
+    '@react-native/babel-preset'
+  );
+  if (!babelPresetPath) {
+    throw new Error('Unable to resolve the @react-native/babel-preset package.');
+  }
+  return require(babelPresetPath);
+}
+
+/**
+ * Resolve the path to a transitive dependency from the project.
+ */
+export function resolveProjectTransitiveDependency(
+  projectRoot: string,
+  ...deps: string[]
+): string | null {
+  let currentDir: string | null = projectRoot;
+  for (let i = 0; i < deps.length; ++i) {
+    const dep = deps[i];
+    const target = i === deps.length - 1 ? dep : `${dep}/package.json`;
+    const resolved = resolveFrom.silent(currentDir, target);
+    if (!resolved) {
+      currentDir = null;
+      break;
+    }
+    if (i === deps.length - 1) {
+      return resolved;
+    }
+    currentDir = path.dirname(resolved);
+  }
+  return null;
+}


### PR DESCRIPTION
# Why

close ENG-12442

# How

remove `@react-native/babel-preset` and try to resolve from `react-native` -> `@react-native/community-cli-plugin` -> `@react-native/metro-babel-transformer` -> `@react-native/babel-preset`

# Test Plan

- add unit test for `resolveProjectTransitiveDependency()`
- try expo start from pnpm isolated project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
