### PR TITLE
[docs] Update "Use Sentry" tab from "SDK 50" to "SDK 50 and higher"

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -24,7 +24,7 @@ It notifies you of exceptions or errors that your users run into while using you
 
 <Tabs>
 
-<Tab label="SDK 50">
+<Tab label="SDK 50 and above">
 
 <Step label="1">
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Close ENG-12462

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the tab label.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

## Changes preview

![CleanShot 2024-06-07 at 23 41 43@2x](https://github.com/expo/expo/assets/10234615/7f6b70da-ed1f-42bd-9e27-21c2f04cb8a1)

_Also checked for other places but didn't find any outdated labels_.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
