### PR TITLE
fix(cli): fast resolver support all mainFields in package.json

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix resolver to handle fields in package.json other than browser (e.g., react-native). ([#29549](https://github.com/expo/expo/pull/29549) by [@Nodonisko](https://github.com/Nodonisko))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -28,6 +28,8 @@ const realpathFS =
     ? fs.realpathSync.native
     : fs.realpathSync;
 
+// console.log('hello');
+
 function realpathSync(x: string) {
   try {
     return realpathFS(x);
@@ -180,15 +182,24 @@ export function createFastResolver({
           // Disable `browser` field for server environments.
           isServer
             ? undefined
-            : // Enable `browser` field support
+            : // Enable package.json `browser` and `react-native` fields support
               (pkg: any, _resolvedPath: string, relativePathIn: string): string => {
                 let relativePath = relativePathIn;
                 if (relativePath[0] !== '.') {
                   relativePath = `./${relativePath}`;
                 }
 
-                const replacements = pkg.browser;
-                if (replacements === undefined) {
+                let replacements: Record<string, string | false> | string | undefined;
+
+                for (const field of context.mainFields) {
+                  if (pkg[field]) {
+                    replacements = pkg[field];
+                    break;
+                  }
+                }
+
+                // if replacements is a string or undefined, we should ignore it for path mapping inside package because it's used for main field already
+                if (replacements === undefined || typeof replacements === 'string') {
                   return '';
                 }
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -28,8 +28,6 @@ const realpathFS =
     ? fs.realpathSync.native
     : fs.realpathSync;
 
-// console.log('hello');
-
 function realpathSync(x: string) {
   try {
     return realpathFS(x);


### PR DESCRIPTION
# Why

If there was defined overrides for inside package paths in package.json `react-native` field it was ignored by resolver. This fix should use `mainFields` config instead of hardcoded `browser` to resolve that path.

For example following `package.json` always used `browser` mapping instead of `react-native`

```json
"main": "src/index.ts",
    "browser": {
        "./src/index": "./src/index-browser.ts",
        "./src/index.ts": "./src/index-browser.ts",
    },
    "react-native": {
        "./src/index": "./src/index.ts",
        "./src/index.ts": "./src/index.ts",
    },
```

Resolves #29229 

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added unit tests
- Tested manually

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
