### PR TITLE
[docs] Update SDK 51 Expo Notification API reference to include `defaultChannel`

### DIFF
--- a/docs/pages/versions/v51.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/notifications.mdx
@@ -366,6 +366,11 @@ To configure `expo-notifications`, use the built-in [config plugin](/config-plug
         'Tint color for the push notification image when it appears in the notification tray.',
     },
     {
+      name: 'defaultChannel',
+      platform: 'android',
+      description: 'Default channel for FCMv1 notifications.',
+    },
+    {
       name: 'sounds',
       description:
         'Array of local paths to sound files (.wav recommended) that can be used as custom notification sounds.',
@@ -384,6 +389,7 @@ Here is an example of using the config plugin in the app config file:
         {
           "icon": "./local/assets/notification-icon.png",
           "color": "#ffffff",
+          "defaultChannel": "default",
           "sounds": [
             "./local/assets/notification-sound.wav",
             "./local/assets/notification-sound-other.wav"


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #29491

# How

<!--
How did you build this feature or fix this bug and why?
-->

Apply the same changes on `defaultChannel` Expo config property to SDK 51 after @douglowder mentioned that the changes will be cherry-picked for SDK 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

## Preview of changes

![CleanShot 2024-06-08 at 00 32 18@2x](https://github.com/expo/expo/assets/10234615/dcddafb3-57cc-4854-ba8e-06759b039aa9)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
