### PR TITLE
[expo-go][android] Fixing expo-go for UIManagerModule fix for Bridgeless for 0.74

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
@@ -16,7 +16,11 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.fabric.FabricUIManager;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.common.UIManagerType;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -102,13 +106,19 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             }
 
             final Activity activity = getCurrentActivity();
-            final UIManagerModule uiManager = this.reactContext.getNativeModule(UIManagerModule.class);
 
-            uiManager.addUIBlock(new ViewShot(
+            ViewShot uiBlock = new ViewShot(
                     tag, extension, imageFormat, quality,
                     scaleWidth, scaleHeight, outputFile, resultStreamFormat,
-                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise, executor)
-            );
+                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise, executor);
+
+            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+                UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+                ((FabricUIManager)uiManager).addUIBlock(uiBlock);
+            } else {
+                final UIManagerModule uiManager = this.reactContext.getNativeModule(UIManagerModule.class);
+                uiManager.addUIBlock(uiBlock);
+            }
         } catch (final Throwable ex) {
             Log.e(RNVIEW_SHOT, "Failed to snapshot view tag " + tag, ex);
             promise.reject(ViewShot.ERROR_UNABLE_TO_SNAPSHOT, "Failed to snapshot view tag " + tag);

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/ViewShot.java
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/ViewShot.java
@@ -26,6 +26,7 @@ import android.widget.ScrollView;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.fabric.interop.UIBlockViewResolver;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 
@@ -57,7 +58,7 @@ import static android.view.View.VISIBLE;
 /**
  * Snapshot utility class allow to screenshot a view.
  */
-public class ViewShot implements UIBlock {
+public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBlock  {
     //region Constants
     /**
      * Tag fort Class logs.
@@ -183,6 +184,17 @@ public class ViewShot implements UIBlock {
     //region Overrides
     @Override
     public void execute(final NativeViewHierarchyManager nativeViewHierarchyManager) {
+        executeImpl(nativeViewHierarchyManager, null);
+    }
+
+    @Override
+    public void execute(@NonNull UIBlockViewResolver uiBlockViewResolver) {
+        executeImpl(null, uiBlockViewResolver);
+    }
+    //endregion
+
+    //region Implementation
+    private void executeImpl(final NativeViewHierarchyManager nativeViewHierarchyManager, final UIBlockViewResolver uiBlockViewResolver) {
         executor.execute(new Runnable () {
             @Override
             public void run() {
@@ -191,6 +203,8 @@ public class ViewShot implements UIBlock {
 
                     if (tag == -1) {
                         view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
+                    } else if (uiBlockViewResolver != null) {
+                        view = uiBlockViewResolver.resolveView(tag);
                     } else {
                         view = nativeViewHierarchyManager.resolveView(tag);
                     }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/blob/0cc4a2d84a0960dd938260e94b4c5b7e6f7d4c1e/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java#L105

will fail in Bridgeless mode React Native 0.74 on Android since which returns null in Bridgeless

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java#L600-L606

# How

Implemented fallback in Bridgeless to UIManagerHelper just as done in https://github.com/gre/react-native-view-shot/pull/516/

# Test Plan



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
