### PR TITLE
Fix cancel button on expo-contacts presentFormAsync for unknown contacts

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed an issue where only paths of urls were stored in contacts and social profiles were only stored when all fields were filled. ([#29199](https://github.com/expo/expo/pull/29199) by [@mlecoq](https://github.com/mlecoq))
+- Fixed an iOS issue where the Cancel button is not visible on the unknown contact form. ([#29555](https://github.com/expo/expo/pull/29555) by [@Tug](https://github.com/Tug))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -103,7 +103,8 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
         return
       }
 
-      let cancelButtonTitle = options.cancelButtonTitle != nil ? options.cancelButtonTitle : "Cancel"
+      let cancelButtonTitle = options.cancelButtonTitle ?? "Cancel"
+      controller.setCloseButton(title: cancelButtonTitle)
       controller.contactStore = contactStore
       controller.delegate = delegate
 


### PR DESCRIPTION
# Why

Currently the `cancelButtonTitle` option from [FormOptions](https://docs.expo.dev/versions/latest/sdk/contacts/#formoptions) isn't passed down to the controller when calling `presentFormAsync` with `isNew: false`.
This makes the contact form popup difficult to close as the cancel button is not visible in that case.
This is not an issue for the new contact form as the default Cancel and Done button will be visible anyway.

# How

This addresses the problem by calling the `controller.setCloseButton` method as expected

| Before | After |
| ------| ----- |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-08 at 10 44 10](https://github.com/expo/expo/assets/230230/c114fea4-10af-4780-8e26-6ccc710e46f8) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-08 at 10 42 56](https://github.com/expo/expo/assets/230230/63398a79-cf56-4f0e-8c14-740eb5d47a87) |

# Test Plan

Try calling this function
```
Contacts.presentFormAsync(
    null,
    {"addresses": [], "company": "Company Name LTD", "contactType": "person", "department": "", "emails": [{"email": "email2@acme.vkard.io", "label": "E-mail"}], "firstName": "Johana", "id": "9450d242-757a-4057-8c20-a78edac03b26", "jobTitle": "CEO", "lastName": "Branda", "name": "Johana Branda", "phoneNumbers": [{"label": "Cell", "number": "+33601020304"}]},
    {
        isNew: false,
        allowsActions: true,
        cancelButtonTitle: 'Done',
    },
);
```

It should display the Done button in the top left of the popup

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
