### PR TITLE
[docs] Update file-based-routing.mdx

### DIFF
--- a/docs/pages/develop/file-based-routing.mdx
+++ b/docs/pages/develop/file-based-routing.mdx
@@ -240,7 +240,7 @@ export default function RootLayout() {
 }
 ```
 
-> **Note:** In the above example, the screen options are moved to **(home)/layout.tsx** file. This means if you add any route to the Stack navigator inside the Root layout, it will not use the same screen options as the routes inside the Home layout.
+> **Note:** In the above example, the screen options are moved to **(home)/\_layout.tsx** file. This means if you add any route to the Stack navigator inside the Root layout, it will not use the same screen options as the routes inside the Home layout.
 
 ## Tab navigator
 


### PR DESCRIPTION
Fix type in Groups section

# Why

- Readers of the document may be confused about the difference between `(home)/_layout.tsx` and `(home)/layout.tsx`
- `(home)/layout.tsx` will be compiled as a page instead of a _layout_

# How

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
