### PR TITLE
[expo-video][iOS] Support Apple TV

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -51,6 +51,7 @@ function getExpoDependencyChunks({
             'expo-localization',
             'expo-crypto',
             'expo-network',
+            'expo-video',
           ],
         ]
       : []),
@@ -341,8 +342,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.74.1-0',
-        '@react-native-tvos/config-tv': '^0.0.9',
+        'react-native': 'npm:react-native-tvos@~0.74.2-0',
+        '@react-native-tvos/config-tv': '^0.0.10',
       },
       expo: {
         install: {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add `isLive` property on all platforms. ([#28903](https://github.com/expo/expo/pull/28903) by [@justjoostnl](https://github.com/justjoostnl))
 - [iOS] Add base64 certificate support for FairPlay DRM. ([#28990](https://github.com/expo/expo/pull/28990) by [@behenate](https://github.com/behenate))
+- [iOS] Support Apple TV. ([#29560](https://github.com/expo/expo/pull/29560) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/expo-module.config.json
+++ b/packages/expo-video/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "android"],
+  "platforms": ["ios", "tvos", "android"],
   "ios": {
     "modules": ["VideoModule"]
   },

--- a/packages/expo-video/expo-module.config.json
+++ b/packages/expo-video/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["ios", "tvos", "android"],
+  "platforms": ["apple", "android"],
   "ios": {
     "modules": ["VideoModule"]
   },

--- a/packages/expo-video/ios/ExpoVideo.podspec
+++ b/packages/expo-video/ios/ExpoVideo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -6,8 +6,11 @@ public final class VideoModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoVideo")
 
-    Function("isPictureInPictureSupported") {
-      return AVPictureInPictureController.isPictureInPictureSupported()
+    Function("isPictureInPictureSupported") { () -> Bool in
+      if #available(iOS 13.4, tvOS 14.0, *) {
+        return AVPictureInPictureController.isPictureInPictureSupported()
+      }
+      return false
     }
 
     View(VideoView.self) {
@@ -22,6 +25,10 @@ public final class VideoModule: Module {
 
       Prop("nativeControls") { (view, nativeControls: Bool?) in
         view.playerViewController.showsPlaybackControls = nativeControls ?? true
+        #if os(tvOS)
+        view.playerViewController.isSkipForwardEnabled = nativeControls ?? true
+        view.playerViewController.isSkipBackwardEnabled = nativeControls ?? true
+        #endif
       }
 
       Prop("contentFit") { (view, contentFit: VideoContentFit?) in
@@ -40,11 +47,15 @@ public final class VideoModule: Module {
       }
 
       Prop("allowsFullscreen") { (view, allowsFullscreen: Bool?) in
+        #if !os(tvOS)
         view.playerViewController.setValue(allowsFullscreen ?? true, forKey: "allowsEnteringFullScreen")
+        #endif
       }
 
       Prop("showsTimecodes") { (view, showsTimecodes: Bool?) in
+        #if !os(tvOS)
         view.playerViewController.showsTimecodes = showsTimecodes ?? true
+        #endif
       }
 
       Prop("requiresLinearPlayback") { (view, requiresLinearPlayback: Bool?) in
@@ -56,7 +67,9 @@ public final class VideoModule: Module {
       }
 
       Prop("startsPictureInPictureAutomatically") { (view, startsPictureInPictureAutomatically: Bool?) in
+        #if !os(tvOS)
         view.startPictureInPictureAutomatically = startsPictureInPictureAutomatically ?? false
+        #endif
       }
 
       AsyncFunction("enterFullscreen") { view in

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -16,7 +16,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       if oldValue != playbackRate {
         safeEmit(event: "playbackRateChange", arguments: playbackRate, oldValue)
       }
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, *) {
         pointer.defaultRate = playbackRate
       }
       pointer.rate = playbackRate
@@ -143,7 +143,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onRateChanged(player: AVPlayer, oldRate: Float?, newRate: Float) {
-    if #available(iOS 16.0, *) {
+    if #available(iOS 16.0, tvOS 16.0, *) {
       if player.defaultRate != playbackRate {
         // User changed the playback speed in the native controls. Update the desiredRate variable
         playbackRate = player.defaultRate

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -12,7 +12,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     }
   }
 
+  #if os(tvOS)
   var wasPlaying: Bool = false
+  #endif
   var isFullscreen: Bool = false
   var isInPictureInPicture = false
   #if os(tvOS)

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -144,7 +144,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     #endif
     return true
   }
-  
+ 
   #if !os(tvOS)
   public func playerViewController(
     _ playerViewController: AVPlayerViewController,

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -14,6 +14,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   var isFullscreen: Bool = false
   var isInPictureInPicture = false
+  #if os(tvOS)
+  let startPictureInPictureAutomatically = false
+  #else
   var startPictureInPictureAutomatically = false {
     didSet {
       if #available(iOS 14.2, *) {
@@ -21,12 +24,15 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       }
     }
   }
+  #endif
 
   var allowPictureInPicture: Bool = false {
     didSet {
       // PiP requires `.playback` audio session category in `.moviePlayback` mode
-      VideoManager.shared.setAppropriateAudioSessionOrWarn()
-      playerViewController.allowsPictureInPicturePlayback = allowPictureInPicture
+      if #available(iOS 13.4, tvOS 14.0, *) {
+        VideoManager.shared.setAppropriateAudioSessionOrWarn()
+          playerViewController.allowsPictureInPicturePlayback = allowPictureInPicture
+      }
     }
   }
 
@@ -40,7 +46,10 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   }
 
   lazy var supportsPictureInPicture: Bool = {
-    return AVPictureInPictureController.isPictureInPictureSupported()
+    if #available(iOS 13.4, tvOS 14.0, *) {
+      return AVPictureInPictureController.isPictureInPictureSupported()
+    }
+    return false
   }()
 
   public required init(appContext: AppContext? = nil) {
@@ -53,7 +62,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     playerViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     playerViewController.view.backgroundColor = .clear
     // Now playing is managed by the `NowPlayingManager`
+    #if !os(tvOS)
     playerViewController.updatesNowPlayingInfoCenter = false
+    #endif
 
     addSubview(playerViewController.view)
   }
@@ -71,6 +82,13 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
     if playerViewController.responds(to: selectorToForceFullScreenMode) {
       playerViewController.perform(selectorToForceFullScreenMode, with: true, with: nil)
+    } else {
+      #if os(tvOS)
+      // For TV, present the view controller normally
+      DispatchQueue.main.async {
+        self.reactViewController().present(self.playerViewController, animated: true)
+      }
+      #endif
     }
   }
 
@@ -110,6 +128,24 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   // MARK: - AVPlayerViewControllerDelegate
 
+  public func playerViewControllerShouldDismiss(_ playerViewController: AVPlayerViewController) -> Bool {
+    // TV presents the player view controller on enterFullscreen(),
+    // so set the fullscreen value back to false on dismiss
+    #if os(tvOS)
+    self.isFullscreen = false
+    let layer = self.playerViewController.view.layer
+
+    layer.frame = CGRect(
+      x: 0,
+      y: 0,
+      width: layer.frame.width,
+      height: layer.frame.height
+    )
+    #endif
+    return true
+  }
+  
+  #if !os(tvOS)
   public func playerViewController(
     _ playerViewController: AVPlayerViewController,
     willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator
@@ -134,6 +170,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       }
     }
   }
+  #endif
 
   public func playerViewControllerDidStartPictureInPicture(_ playerViewController: AVPlayerViewController) {
     isInPictureInPicture = true
@@ -146,6 +183,10 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   }
 
   public override func didMoveToWindow() {
+    // TV is doing a normal view controller present, so we should not execute
+    // this code
+    #if !os(tvOS)
     playerViewController.beginAppearanceTransition(self.window != nil, animated: true)
+    #endif
   }
 }


### PR DESCRIPTION
# Why

`expo-video` package should support TV, similarly to `expo-av`.

# How

- Make changes in iOS implementation to allow tvOS to work

# Test Plan

- CI should pass, including adding expo-video to TV compile test
- Testing these changes in a sample app: https://github.com/douglowder/VideoTest/tree/canary-expo-video
  - Testing full screen and picture-in-picture, and other features

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
