### PR TITLE
[docs] Fix verbiage in React Compiler guide

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -6,7 +6,7 @@ description: Learn how to enable and use the React Compiler in Expo apps.
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **warning** **Warning:** React Compiler is still experimental! First available in Expo SDK 51.
+> **warning** **Warning:** React Compiler is experimental. Available from Expo SDK 51.
 
 The new [React Compiler](https://react.dev/learn/react-compiler) automatically memoizes components and hooks to enable fine-grained reactivity. This can lead to significant performance improvements in your app. The React Compiler is currently experimental and is not enabled by default. You can enable it in your app by following the instructions below.
 
@@ -121,13 +121,13 @@ function MyComponent() {
 
 > To better understand how React Compiler works, check out the [React Playground](https://playground.react.dev/).
 
-Improvements are primarily automatic. You can remove instances of `useCallback`, `useMemo`, and `React.memo` in favor of the automatic memoization. Class components will not be optimized, migrate to function components instead.
+Improvements are primarily automatic. You can remove instances of `useCallback`, `useMemo`, and `React.memo` in favor of the automatic memoization. Class components will not be optimized. Instead, migrate to function components.
 
 Expo's implementation of the React Compiler will only run on application code (no node modules), and only when bundling for the client (disabled in server rendering).
 
 ## Configuration
 
-You can pass additional settings to the React Compiler Babel plugin, by using the `react-compiler` object in your Babel configuration:
+You can pass additional settings to the React Compiler Babel plugin by using the `react-compiler` object in the Babel configuration:
 
 ```js babel.config.js
 module.exports = function (api) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #29168

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix a few verbiage issues that didn't make the code review.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
