### PR TITLE
[docs] Fix verbiage and formatting issues in Build lifecycle hooks and npm hooks references

### DIFF
--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -1,12 +1,12 @@
 ---
-title: Use npm cache with Yarn Classic
+title: Use npm cache with Yarn 1 (Classic)
 hideTOC: true
-description: Learn how to use npm cache by overriding the registry in Yarn Classic.
+description: Learn how to use npm cache by overriding the registry in Yarn 1 (Classic).
 ---
 
 By default, the EAS npm cache won't work with Yarn 1 (Classic) because **yarn.lock** files contain URLs to registries for every library. Yarn 1 does not provide any way to override it and Yarn team does not plan to support it in Yarn 1. However, this issue is fixed in Yarn 2+.
 
-If you want to take advantage of the npm cache, add the [`eas-build-pre-install` npm hook](/build-reference/npm-hooks/) in **package.json** to override the registry in the **yarn.lock**:
+If you want to take advantage of the npm cache with Yarn 1, add the [`eas-build-pre-install` npm hook](/build-reference/npm-hooks/) in **package.json** to override the registry in the **yarn.lock**:
 
 ```json package.json
 {

--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -4,9 +4,9 @@ hideTOC: true
 description: Learn how to use npm cache by overriding the registry in Yarn Classic.
 ---
 
-By default, the EAS npm cache won't work with Yarn 1 (Classic), because **yarn.lock** files contain URLs to registries for every package and Yarn does not provide any way to override it. The issue is fixed in Yarn 2+ (Berry), but the Yarn team does not plan to backport it to Yarn v1.
+By default, the EAS npm cache won't work with Yarn 1 (Classic) because **yarn.lock** files contain URLs to registries for every library. Yarn 1 does not provide any way to override it and Yarn team does not plan to support it in Yarn 1. However, this issue is fixed in Yarn 2+.
 
-If you want to take advantage of the npm cache, you can add the `eas-build-pre-install` npm hook in **package.json** to override the registry in the **yarn.lock**:
+If you want to take advantage of the npm cache, add the [`eas-build-pre-install` npm hook](/build-reference/npm-hooks/) in **package.json** to override the registry in the **yarn.lock**:
 
 ```json package.json
 {

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -115,7 +115,7 @@ fi
 ```
 
 ```js pre-install.js
-// Create is a file called "pre-install.js" at the root of the project
+// Create a file called "pre-install.js" at the root of the project
 
 if (process.env.EAS_BUILD_PLATFORM === 'android') {
   console.log('Run commands for Android builds here');

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -1,22 +1,30 @@
 ---
 title: Build lifecycle hooks
 description: Learn how to use the EAS Build lifecycle hooks with npm to customize your build process.
+maxHeadingDepth: 4
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { CODE } from '~/ui/components/Text';
 
-There are five EAS Build lifecycle npm hooks that you can set in your **package.json**. See the [Android build process](android-builds.mdx) and [iOS build process](ios-builds.mdx) docs to get a better understanding about the internals of the build process.
+EAS Build lifecycle npm hooks allows you to customize your build process by running scripts before or after the build process.
 
-- `eas-build-pre-install` - executed before EAS Build runs `npm install`.
-- `eas-build-post-install` - the behavior depends on the platform and project type:
-  - Android - runs once after the following commands have all completed: `npm install` and `npx expo prebuild` (if needed)
-  - iOS - runs once after the following commands have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
-- `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
-- `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
-- `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
-- `eas-build-on-cancel` - this hook is triggered if the build is canceled.
+> For better understanding, see the [Android build process](/build-reference/android-builds/) and the [iOS build process](/build-reference/ios-builds/).
 
-Below is an example of how your **package.json** can look with lifecycle hooks:
+## EAS Build lifecycle hooks
+
+There are six EAS Build lifecycle npm hooks available. To use, them, you can set them in your **package.json**.
+
+| Build Lifecycle npm hook | Description                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eas-build-pre-install`  | Executed before EAS Build runs `npm install`.                                                                                                                                                                                                                                                                                                  |
+| `eas-build-post-install` | The behavior depends on the platform and project type. <br/> <br/> For Android, runs once after the following commands have all completed: `npm install` and `npx expo prebuild` (if needed).<br/><br/> For iOS, runs once after the following commands have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`. |
+| `eas-build-on-success`   | This hook is triggered at the end of the build process if the build was successful.                                                                                                                                                                                                                                                            |
+| `eas-build-on-error`     | This hook is triggered at the end of the build process if the build failed.                                                                                                                                                                                                                                                                    |
+| `eas-build-on-complete`  | This hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.                                                                                                                                                                |
+| `eas-build-on-cancel`    | This hook is triggered if the build is canceled.                                                                                                                                                                                                                                                                                               |
+
+An example of how a **package.json** can look when using one or more lifecycle hooks:
 
 ```json package.json
 {
@@ -31,19 +39,19 @@ Below is an example of how your **package.json** can look with lifecycle hooks:
     "test": "jest"
   },
   "dependencies": {
-    "expo": "~46.0.0"
-    // ...
+    "expo": "51.0.0"
+    /* @hide ... */ /* @end */
   }
 }
 ```
 
 ## Platform-specific hook behavior
 
-If you would like to run a script (or some part of a script) only for iOS builds or only for Android builds, you can fork the behavior depending on the platform within the script. See examples for common ways to do this through a shell script or a Node script below.
+To run a script (or some part of a script) only for Android or iOS builds, you can fork the behavior depending on the platform within the script. See the following common examples to do this through a shell script or a Node script.
 
-## Examples
+### Examples
 
-### `package.json` and shell script
+#### package.json and shell script
 
 ```json package.json
 {
@@ -51,10 +59,11 @@ If you would like to run a script (or some part of a script) only for iOS builds
   "scripts": {
     "eas-build-pre-install": "./pre-install",
     "start": "expo start"
-    // ...
+    /* @hide ... */ /* @end */
   },
   "dependencies": {
-    // ...
+    /* @hide ... */
+    /* @end */
   }
 }
 ```
@@ -71,9 +80,9 @@ elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
 fi
 ```
 
-<Collapsible summary="Example pre-install script that installs git-lfs on macOS workers">
+<Collapsible summary={<>Example: Pre-install script that installs <CODE>git-lfs</CODE> on macOS workers</>}>
 
-The following script will install [git-lfs](https://git-lfs.com/) if it is not yet installed. This is useful in some cases where git-lfs is required to install certain CocoaPods.
+The following script installs [`git-lfs`](https://git-lfs.com/) if it is not yet installed. This is useful in some cases where `git-lfs` is required to install certain CocoaPods.
 
 ```bash pre-install
 if [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
@@ -89,7 +98,7 @@ fi
 
 </Collapsible>
 
-### `package.json` and Node script
+#### package.json and Node script
 
 ```json package.json
 {
@@ -106,7 +115,7 @@ fi
 ```
 
 ```js pre-install.js
-// This is a file called "pre-install.js" in the root of the project
+// Create is a file called "pre-install.js" at the root of the project
 
 if (process.env.EAS_BUILD_PLATFORM === 'android') {
   console.log('Run commands for Android builds here');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes verbiage and formatting, updates outdated information, and fixes grammatical errors in "Build lifecycle hooks" and "Use npm cache with Yarn 1 (Classic)". Also, update the title to be consistent when it comes to referring Yarn 1 and Yarn 2.
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs lcoally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
