### PR TITLE
[image][Android] Fix warning in manifest

### DIFF
--- a/packages/expo-image/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image/android/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
   <!-- Local storage (https://bumptech.github.io/glide/doc/download-setup.html#local-storage) -->
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission
+    android:name="android.permission.READ_EXTERNAL_STORAGE"
+    android:maxSdkVersion="32" />
 
   <!-- End Glide configuration -->
 </manifest>


### PR DESCRIPTION
# Why

Fixes warning in the manifest file.

# How

`READ_EXTERNAL_STORAGE` is no longer used on newer Android versions.
