### PR TITLE
[video][Android] Bump androidx-media3 to `1.3.1`

### DIFF
--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
   implementation 'com.facebook.react:react-android'
 
-  def androidxMedia3Version = "1.2.1"
+  def androidxMedia3Version = "1.3.1"
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${androidxMedia3Version}"

--- a/packages/expo-video/android/src/main/AndroidManifest.xml
+++ b/packages/expo-video/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 


### PR DESCRIPTION
# Why

Bumps androidx-media3 to `1.3.1`
Also, I've added the network permission to the manifest. 

# Test Plan

- bare-expo ✅ 