### PR TITLE
[docs] APISection: add missing type parameters to method signatures

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -156,6 +156,8 @@ export type MethodSignatureData = {
   parameters: MethodParamData[];
   comment: CommentData;
   type: TypeDefinitionData;
+  kind?: TypeDocKind;
+  typeParameter?: TypeParameterData[];
 };
 
 // Properties section
@@ -209,10 +211,10 @@ export type TypeDeclarationContentData = {
   comment?: CommentData;
 };
 
-export type TypeSignaturesData = {
-  name?: string;
-  comment?: CommentData;
-  parameters?: MethodParamData[];
-  type: TypeDefinitionData;
-  kind?: TypeDocKind;
+export type TypeSignaturesData = Partial<MethodSignatureData>;
+
+export type TypeParameterData = {
+  name: string;
+  kind: TypeDocKind;
+  variant: string;
 };

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -6,9 +6,7 @@ import {
   AccessorDefinitionData,
   MethodDefinitionData,
   MethodParamData,
-  MethodSignatureData,
   PropData,
-  TypeSignaturesData,
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
@@ -72,64 +70,68 @@ export const renderMethod = (
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
   const HeaderComponent = getH3CodeWithBaseNestingLevel(baseNestingLevel);
-  return signatures.map(
-    ({ name, parameters, comment, type }: MethodSignatureData | TypeSignaturesData) => {
-      const returnComment = getTagData('returns', comment);
-      return (
-        <div
-          key={`method-signature-${method.name || name}-${parameters?.length || 0}`}
-          css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
-          <APISectionDeprecationNote comment={comment} />
-          <APISectionPlatformTags comment={comment} />
-          <HeaderComponent>
-            <MONOSPACE
-              weight="medium"
-              css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}
-              className="wrap-anywhere">
-              {getMethodName(method as MethodDefinitionData, apiName, name, parameters)}
-            </MONOSPACE>
-          </HeaderComponent>
-          {parameters && parameters.length > 0 && (
-            <>
-              {renderParams(parameters, sdkVersion)}
-              <br />
-            </>
-          )}
-          <CommentTextBlock
-            comment={comment}
-            includePlatforms={false}
-            afterContent={
-              resolveTypeName(type, sdkVersion) !== 'undefined' ? (
-                <>
-                  <div
-                    className={mergeClasses(
-                      'flex flex-row gap-2 items-start',
-                      !returnComment && getAllTagData('example', comment) && ELEMENT_SPACING
-                    )}>
-                    <div className="flex flex-row gap-2 items-center">
-                      <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
-                      <CALLOUT tag="span" theme="secondary" weight="medium">
-                        Returns:
-                      </CALLOUT>
-                    </div>
-                    <CALLOUT>
-                      <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+  return signatures.map(({ name, parameters, comment, type, typeParameter }) => {
+    const returnComment = getTagData('returns', comment);
+    return (
+      <div
+        key={`method-signature-${method.name || name}-${parameters?.length || 0}`}
+        css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
+        <APISectionDeprecationNote comment={comment} />
+        <APISectionPlatformTags comment={comment} />
+        <HeaderComponent>
+          <MONOSPACE
+            weight="medium"
+            css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}
+            className="wrap-anywhere">
+            {getMethodName(
+              method as MethodDefinitionData,
+              apiName,
+              name,
+              parameters,
+              typeParameter
+            )}
+          </MONOSPACE>
+        </HeaderComponent>
+        {parameters && parameters.length > 0 && (
+          <>
+            {renderParams(parameters, sdkVersion)}
+            <br />
+          </>
+        )}
+        <CommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={
+            type && resolveTypeName(type, sdkVersion) !== 'undefined' ? (
+              <>
+                <div
+                  className={mergeClasses(
+                    'flex flex-row gap-2 items-start',
+                    !returnComment && getAllTagData('example', comment) && ELEMENT_SPACING
+                  )}>
+                  <div className="flex flex-row gap-2 items-center">
+                    <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+                    <CALLOUT tag="span" theme="secondary" weight="medium">
+                      Returns:
                     </CALLOUT>
                   </div>
-                  {returnComment ? (
-                    <div className="flex flex-col mt-1.5 mb-1 pl-6">
-                      <CommentTextBlock comment={{ summary: returnComment.content }} />
-                    </div>
-                  ) : undefined}
-                </>
-              ) : undefined
-            }
-          />
-          {}
-        </div>
-      );
-    }
-  );
+                  <CALLOUT>
+                    <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+                  </CALLOUT>
+                </div>
+                {returnComment ? (
+                  <div className="flex flex-col mt-1.5 mb-1 pl-6">
+                    <CommentTextBlock comment={{ summary: returnComment.content }} />
+                  </div>
+                ) : undefined}
+              </>
+            ) : undefined
+          }
+        />
+        {}
+      </div>
+    );
+  });
 };
 
 const APISectionMethods = ({

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -21,6 +21,7 @@ import {
   MethodSignatureData,
   PropData,
   TypeDefinitionData,
+  TypeParameterData,
   TypePropertyDataFlags,
   TypeSignaturesData,
 } from '~/components/plugins/api/APIDataTypes';
@@ -59,6 +60,7 @@ export enum TypeDocKind {
   Property = 1024,
   Method = 2048,
   Parameter = 32768,
+  TypeParameter = 131072,
   Accessor = 262144,
   TypeAlias = 2097152,
   TypeAlias_Legacy = 4194304,
@@ -392,14 +394,14 @@ export const resolveTypeName = (
             ))}
             <span className="text-quaternary">)</span>{' '}
             <span className="text-quaternary">{'=>'}</span>{' '}
-            {resolveTypeName(baseSignature.type, sdkVersion)}
+            {baseSignature.type ? resolveTypeName(baseSignature.type, sdkVersion) : 'undefined'}
           </>
         );
       } else {
         return (
           <>
             <span className="text-quaternary">{'() =>'}</span>{' '}
-            {resolveTypeName(baseSignature.type, sdkVersion)}
+            {baseSignature.type ? resolveTypeName(baseSignature.type, sdkVersion) : 'undefined'}
           </>
         );
       }
@@ -686,14 +688,26 @@ export const getTagNamesList = (comment?: CommentData) =>
     ...(getTagData('experimental', comment) ? ['experimental'] : []),
   ];
 
+export function getTypeParametersNames(typeParameters?: TypeParameterData[]) {
+  if (typeParameters?.length) {
+    return `<${typeParameters.map(param => param.name).join(', ')}>`;
+  }
+  return '';
+}
+
 export const getMethodName = (
   method: MethodDefinitionData,
   apiName?: string,
   name?: string,
-  parameters?: MethodParamData[]
+  parameters?: MethodParamData[],
+  typeParameters?: TypeParameterData[]
 ) => {
   const isProperty = method.kind === TypeDocKind.Property && !parameters?.length;
-  const methodName = ((apiName && `${apiName}.`) ?? '') + (method.name || name);
+  const methodName =
+    ((apiName && `${apiName}.`) ?? '') +
+    (method.name || name) +
+    getTypeParametersNames(typeParameters);
+
   if (!isProperty) {
     return `${methodName}(${parameters ? listParams(parameters) : ''})`;
   }


### PR DESCRIPTION
# Why

Spotted that we are missing information about passed in type parameters in method signatures.

# How

Make sure that TypeDocs exposed this information, use already existing data to show type parameters when method supports passing them.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-06-10 at 11 31 11](https://github.com/expo/expo/assets/719641/9fd8de80-c45b-4e56-b1f1-36a8fddc35d7)
