### PR TITLE
[docs] APISection: unify classes render, tweak types appearance

### DIFF
--- a/docs/common/headingManager.ts
+++ b/docs/common/headingManager.ts
@@ -94,7 +94,7 @@ export class HeadingManager {
     this._headings = [];
 
     const maxHeadingDepth =
-      (meta.maxHeadingDepth ?? DEFAULT_NESTING_LIMIT) + (meta.packageName ? 1 : 0);
+      (meta.maxHeadingDepth ?? DEFAULT_NESTING_LIMIT) + (meta.packageName ? 2 : 0);
     this._maxNestingLevel = maxHeadingDepth + BASE_HEADING_LEVEL;
   }
 

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -278,15 +278,16 @@ for more details.
       </div>
     </blockquote>
     <div>
-      <div
-        class="css-1mhr9hc-APISectionProps"
+      <p
+        class="!text-secondary !font-medium css-1xg9efr-BoxSectionHeader"
+        data-text="true"
       >
-        <h4
-          class="group css-1725pab-TextComponent"
-          data-heading="true"
+        <span
+          class="group css-11zd19b-TextComponent"
+          data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="scroll-m-5 relative decoration-0 text-inherit flex flex-row gap-2 items-center"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -320,8 +321,8 @@ for more details.
               />
             </svg>
           </a>
-        </h4>
-      </div>
+        </span>
+      </p>
     </div>
     <div
       class="[&>*:last-child]:!mb-0"
@@ -6319,15 +6320,16 @@ for more details.
       </code>
     </p>
     <div>
-      <div
-        class="css-1mhr9hc-APISectionProps"
+      <p
+        class="!text-secondary !font-medium css-1xg9efr-BoxSectionHeader"
+        data-text="true"
       >
-        <h4
-          class="group css-1725pab-TextComponent"
-          data-heading="true"
+        <span
+          class="group css-11zd19b-TextComponent"
+          data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="scroll-m-5 relative decoration-0 text-inherit flex flex-row gap-2 items-center"
             href="#barcodescannerprops"
             id="barcodescannerprops"
           >
@@ -6361,8 +6363,8 @@ for more details.
               />
             </svg>
           </a>
-        </h4>
-      </div>
+        </span>
+      </p>
     </div>
     <div
       class="[&>*:last-child]:!mb-0"
@@ -8421,9 +8423,16 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-1ac5bb0-TextComponent"
+      class="css-1yjys1n-TextComponent"
       data-text="true"
     >
+      <span
+        class="css-1mm9j88-TextComponent"
+        data-text="true"
+      >
+        Type:
+         
+      </span>
       <code
         class="text-default css-ite7ne-TextComponent"
         data-text="true"
@@ -8436,8 +8445,13 @@ in order to enable/disable the permission.
         </a>
       </code>
        
-      extended by
-      :
+      <span
+        class="css-1ac5bb0-TextComponent"
+        data-text="true"
+      >
+        extended by
+        :
+      </span>
     </p>
     <br />
     <div
@@ -9390,7 +9404,7 @@ you don't get this value.
       multiple types
     </p>
     <p
-      class="css-1kfqm4n-TextComponent"
+      class="css-1yjys1n-TextComponent"
       data-text="true"
     >
       <span
@@ -11411,7 +11425,7 @@ in order to enable/disable the permission.
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="css-1kfqm4n-TextComponent"
+      class="css-1yjys1n-TextComponent"
       data-text="true"
     >
       <span

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -1,3 +1,4 @@
+import { CornerDownRightIcon } from '@expo/styleguide-icons';
 import ReactMarkdown from 'react-markdown';
 
 import {
@@ -23,7 +24,7 @@ import {
   BoxSectionHeader,
   DEFAULT_BASE_NESTING_LEVEL,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, P, CODE, MONOSPACE, DEMI } from '~/ui/components/Text';
+import { H2, CODE, MONOSPACE, CALLOUT, SPAN } from '~/ui/components/Text';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
@@ -75,7 +76,7 @@ const remapClass = (clx: ClassDefinitionData) => {
 
 const renderClass = (
   clx: ClassDefinitionData,
-  options: { exposeAllClassPropsInSidebar: boolean; baseNestingLevelForClassProps: number },
+  options: { hasOnlyOneClass: boolean },
   sdkVersion: string
 ): JSX.Element => {
   const { name, comment, type, extendedTypes, children, implementedTypes, isSensor } = clx;
@@ -85,6 +86,8 @@ const renderClass = (
     ?.filter(child => isMethod(child, isSensor))
     .sort((a: PropData, b: PropData) => a.name.localeCompare(b.name));
   const returnComment = getTagData('returns', comment);
+
+  const linksNestingLevel = DEFAULT_BASE_NESTING_LEVEL + 2 + (options.hasOnlyOneClass ? 1 : 0);
 
   return (
     <div key={`class-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
@@ -96,12 +99,18 @@ const renderClass = (
         </MONOSPACE>
       </H3Code>
       {(extendedTypes?.length || implementedTypes?.length) && (
-        <P className="mb-3">
-          <DEMI theme="secondary">Type: </DEMI>
-          {type ? <CODE>{resolveTypeName(type, sdkVersion)}</CODE> : 'Class'}
+        <CALLOUT className="mb-3">
+          <SPAN theme="secondary" weight="medium">
+            Type:{' '}
+          </SPAN>
+          {type ? (
+            <CODE>{resolveTypeName(type, sdkVersion)}</CODE>
+          ) : (
+            <SPAN theme="secondary">Class</SPAN>
+          )}
           {extendedTypes?.length && (
             <>
-              <span> extends </span>
+              <SPAN theme="secondary"> extends </SPAN>
               {extendedTypes.map(extendedType => (
                 <CODE key={`extends-${extendedType.name}`}>
                   {resolveTypeName(extendedType, sdkVersion)}
@@ -111,7 +120,7 @@ const renderClass = (
           )}
           {implementedTypes?.length && (
             <>
-              <span> implements </span>
+              <SPAN theme="secondary"> implements </SPAN>
               {implementedTypes.map(implementedType => (
                 <CODE key={`implements-${implementedType.name}`}>
                   {resolveTypeName(implementedType, sdkVersion)}
@@ -119,29 +128,40 @@ const renderClass = (
               ))}
             </>
           )}
-        </P>
+        </CALLOUT>
       )}
-      <CommentTextBlock comment={comment} includePlatforms={false} />
-      {returnComment && (
-        <>
-          <BoxSectionHeader text="Returns" />
-          <ReactMarkdown components={mdComponents}>
-            {getCommentContent(returnComment.content)}
-          </ReactMarkdown>
-        </>
-      )}
+      <CommentTextBlock
+        comment={comment}
+        includePlatforms={false}
+        afterContent={
+          returnComment && (
+            <div className="flex flex-col gap-2 items-start">
+              <div className="flex flex-row gap-2 items-center">
+                <CornerDownRightIcon className="inline-block icon-sm text-icon-secondary" />
+                <CALLOUT tag="span" theme="secondary" weight="medium">
+                  Returns
+                </CALLOUT>
+              </div>
+              <ReactMarkdown components={mdComponents}>
+                {getCommentContent(returnComment.content)}
+              </ReactMarkdown>
+            </div>
+          )
+        }
+      />
       {properties?.length ? (
         <>
           <BoxSectionHeader
             text={`${name} Properties`}
-            exposeInSidebar={options.exposeAllClassPropsInSidebar}
-            baseNestingLevel={options.baseNestingLevelForClassProps}
+            className="!text-secondary !font-medium"
+            exposeInSidebar={options.hasOnlyOneClass}
+            baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
           <div>
             {properties.map(property =>
               renderProp(property, sdkVersion, property?.defaultValue, {
-                exposeInSidebar: options.exposeAllClassPropsInSidebar,
-                baseNestingLevel: options.baseNestingLevelForClassProps + 1,
+                exposeInSidebar: true,
+                baseNestingLevel: linksNestingLevel,
               })
             )}
           </div>
@@ -151,13 +171,14 @@ const renderClass = (
         <>
           <BoxSectionHeader
             text={`${name} Methods`}
-            exposeInSidebar={options.exposeAllClassPropsInSidebar}
-            baseNestingLevel={options.baseNestingLevelForClassProps}
+            className="!text-secondary !font-medium !text-sm"
+            exposeInSidebar={options.hasOnlyOneClass}
+            baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
           {methods.map(method =>
             renderMethod(method, {
-              exposeInSidebar: options.exposeAllClassPropsInSidebar,
-              baseNestingLevel: options.baseNestingLevelForClassProps + 1,
+              exposeInSidebar: true,
+              baseNestingLevel: linksNestingLevel,
               sdkVersion,
             })
           )}
@@ -167,13 +188,9 @@ const renderClass = (
   );
 };
 
-const APISectionClasses = ({ data, sdkVersion, ...props }: APISectionClassesProps) => {
+const APISectionClasses = ({ data, sdkVersion }: APISectionClassesProps) => {
   if (data?.length) {
-    const hasMultipleClasses = data.length > 1;
-    const exposeAllClassPropsInSidebar = props.exposeAllClassPropsInSidebar ?? !hasMultipleClasses;
-    const baseNestingLevelForClassProps = hasMultipleClasses
-      ? DEFAULT_BASE_NESTING_LEVEL + 2
-      : DEFAULT_BASE_NESTING_LEVEL;
+    const hasOnlyOneClass = data.length === 1;
     return (
       <>
         <H2>Classes</H2>
@@ -181,8 +198,7 @@ const APISectionClasses = ({ data, sdkVersion, ...props }: APISectionClassesProp
           renderClass(
             remapClass(clx),
             {
-              exposeAllClassPropsInSidebar,
-              baseNestingLevelForClassProps,
+              hasOnlyOneClass,
             },
             sdkVersion
           )

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -11,6 +11,7 @@ import {
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
+  BoxSectionHeader,
   CommentTextBlock,
   getCommentContent,
   getCommentOrSignatureComment,
@@ -21,7 +22,6 @@ import {
   resolveTypeName,
   STYLES_APIBOX,
   STYLES_APIBOX_NESTED,
-  STYLES_NESTED_SECTION_HEADER,
   STYLES_NOT_EXPOSED_HEADER,
   TypeDocKind,
 } from '~/components/plugins/api/APISectionUtils';
@@ -173,11 +173,12 @@ const APISectionProps = ({
       ) : (
         <div>
           {baseProp && <APISectionDeprecationNote comment={baseProp.comment} />}
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4 key={`${header}-props-header`} hideInSidebar>
-              {header}
-            </H4>
-          </div>
+          <BoxSectionHeader
+            text={header}
+            className="!text-secondary !font-medium"
+            exposeInSidebar
+            baseNestingLevel={99}
+          />
           {baseProp && baseProp.comment ? <CommentTextBlock comment={baseProp.comment} /> : null}
         </div>
       )}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -28,7 +28,7 @@ import {
   getCommentContent,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, DEMI, P, CODE, MONOSPACE, CALLOUT } from '~/ui/components/Text';
+import { H2, BOLD, CODE, MONOSPACE, CALLOUT, SPAN } from '~/ui/components/Text';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
@@ -143,7 +143,10 @@ const renderType = (
           <CommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' || type.type === 'union' ? (
             <>
-              <CALLOUT theme="secondary">
+              <CALLOUT>
+                <SPAN theme="secondary" weight="medium">
+                  Type:{' '}
+                </SPAN>
                 {type.types
                   .filter(type =>
                     ['reference', 'union', 'intersection', 'intrinsic'].includes(type.type)
@@ -154,7 +157,9 @@ const renderType = (
                       {type.type === 'union' ? ' or ' : ' '}
                     </Fragment>
                   ))}
-                {type.type === 'union' ? 'object shaped as below' : 'extended by'}:
+                <SPAN theme="secondary">
+                  {type.type === 'union' ? 'object shaped as below' : 'extended by'}:
+                </SPAN>
               </CALLOUT>
               <br />
             </>
@@ -178,16 +183,16 @@ const renderType = (
             </MONOSPACE>
           </H3Code>
           <CALLOUT className="mb-3">
-            <CALLOUT tag="span" theme="secondary" weight="medium">
+            <SPAN theme="secondary" weight="medium">
               Literal Type:{' '}
-            </CALLOUT>
+            </SPAN>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
           <CommentTextBlock comment={comment} includePlatforms={false} />
-          <P>
-            <CALLOUT tag="span" theme="secondary" weight="medium">
+          <CALLOUT>
+            <SPAN theme="secondary" weight="medium">
               Acceptable values are:{' '}
-            </CALLOUT>
+            </SPAN>
             {literalTypes.map((lt, index) => (
               <span key={`${name}-literal-type-${index}`}>
                 <CODE>{resolveTypeName(lt, sdkVersion)}</CODE>
@@ -200,7 +205,7 @@ const renderType = (
                 )}
               </span>
             ))}
-          </P>
+          </CALLOUT>
         </div>
       );
     }
@@ -217,10 +222,12 @@ const renderType = (
             {name}
           </MONOSPACE>
         </H3Code>
-        <P className="mb-3">
-          <DEMI theme="secondary">Type: </DEMI>
+        <CALLOUT className="mb-3">
+          <SPAN theme="secondary" weight="medium">
+            Type:{' '}
+          </SPAN>
           <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
-        </P>
+        </CALLOUT>
         <CommentTextBlock comment={comment} includePlatforms={false} />
       </div>
     );
@@ -235,10 +242,12 @@ const renderType = (
           </MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
-        <P>
-          <DEMI theme="secondary">Type: </DEMI>
+        <CALLOUT>
+          <SPAN theme="secondary" weight="medium">
+            Type:{' '}
+          </SPAN>
           <CODE>{type.name}</CODE>
-        </P>
+        </CALLOUT>
       </div>
     );
   } else if (type.type === 'conditional' && type.checkType) {
@@ -252,15 +261,19 @@ const renderType = (
           </MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
-        <P>
-          <DEMI theme="secondary">Generic: </DEMI>
+        <CALLOUT>
+          <SPAN theme="secondary" weight="medium">
+            Generic:{' '}
+          </SPAN>
           <CODE>
             {type.checkType.name}
             {typeParameter && <> extends {resolveTypeName(typeParameter[0].type, sdkVersion)}</>}
           </CODE>
-        </P>
-        <P>
-          <DEMI theme="secondary">Type: </DEMI>
+        </CALLOUT>
+        <CALLOUT>
+          <SPAN theme="secondary" weight="medium">
+            Type:{' '}
+          </SPAN>
           <CODE>
             {type.checkType.name}
             {typeParameter && (
@@ -271,7 +284,7 @@ const renderType = (
             {' : '}
             {type.falseType && resolveTypeName(type.falseType, sdkVersion)}
           </CODE>
-        </P>
+        </CALLOUT>
       </div>
     );
   } else if (type.type === 'templateLiteral' && type.tail) {
@@ -293,9 +306,9 @@ const renderType = (
           </MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
-        <P>
+        <CALLOUT>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.
-        </P>
+        </CALLOUT>
       </div>
     );
   }

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -749,7 +749,8 @@ export const CommentTextBlock = ({
   const exampleText = examples?.map((example, index) => (
     <div key={'example-' + index} className={ELEMENT_SPACING}>
       {inlineHeaders ? (
-        <DEMI theme="secondary" className="flex mb-1">
+        <DEMI theme="secondary" className="flex flex-row gap-1.5 items-center mb-1.5">
+          <CodeSquare01Icon className="icon-sm" />
           Example
         </DEMI>
       ) : (


### PR DESCRIPTION
# Why

Lately, we have changed how the export Components are render in API Reference, now it's time to update Classes to match the new pattern.

# How

The following changes have been made:
* adjust Classes render pattern, improve the section ToC structure
  * this also required the change of the base nested headers depth value for API pages, to avoid several changes in frontmatter params for API docs 
* unify the styling of type related metadata in API entries
* add icon to the inline Example header

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-06-10 at 12 26 42](https://github.com/expo/expo/assets/719641/f08876b0-6ab6-4e18-b815-61004bac6950)
![Screenshot 2024-06-10 at 12 27 42](https://github.com/expo/expo/assets/719641/de1f9c5a-6e65-45b5-8b52-639d3ff29eab)
![Screenshot 2024-06-10 at 12 28 31](https://github.com/expo/expo/assets/719641/8314b066-1ef6-422b-af70-9c55dfb4ed72)

