### PR TITLE
[package] update Commander dependency to prepare for future changes

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Update `commander` dependency.
+- Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
 
 ## 3.5.2 - 2024-05-29
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Update `commander` dependency.
+
 ## 3.5.2 - 2024-05-29
 
 ### 🎉 New features

--- a/packages/expo-module-scripts/bin/expo-module.js
+++ b/packages/expo-module-scripts/bin/expo-module.js
@@ -1,30 +1,28 @@
 #!/usr/bin/env node
 'use strict';
 
-const commander = require('commander');
+const { program } = require('commander');
 const process = require('process');
 
-commander
-  // Common scripts
-  .command('configure', `Generate common configuration files`)
-  .command('readme', `Generate README`)
-  .command(
-    'typecheck',
-    `Type check the source TypeScript without emitting JS and watch for file changes`
-  )
-  .command('build', `Compile the source JS or TypeScript and watch for file changes`)
-  .command('lint', `Lint the files for syntax errors, style guidance, and common warnings`)
-  .command('test', `Run unit tests with an interactive watcher`)
-  .command('clean', `Removes compiled files`)
+program.command('configure', `Generate common configuration files`);
+program.command('readme', `Generate README`);
+program.command(
+  'typecheck',
+  `Type check the source TypeScript without emitting JS and watch for file changes`
+);
+program.command('build', `Compile the source JS or TypeScript and watch for file changes`);
+program.command('lint', `Lint the files for syntax errors, style guidance, and common warnings`);
+program.command('test', `Run unit tests with an interactive watcher`);
+program.command('clean', `Removes compiled files`);
 
-  // Lifecycle scripts
-  .command('prepare', `Scripts to run during the "prepare" phase`)
-  .command('prepublishOnly', `Scripts to run during the "prepublishOnly" phase`)
+// Lifecycle scripts
+program.command('prepare', `Scripts to run during the "prepare" phase`);
+program.command('prepublishOnly', `Scripts to run during the "prepublishOnly" phase`);
 
-  // Pass-through scripts
-  .command('babel', `Runs Babel CLI with the given arguments`)
-  .command('eslint', `Runs ESLint with the given arguments`)
-  .command('jest', `Runs Jest with the given arguments`)
-  .command('tsc', `Runs tsc with the given arguments`)
+// Pass-through scripts
+program.command('babel', `Runs Babel CLI with the given arguments`);
+program.command('eslint', `Runs ESLint with the given arguments`);
+program.command('jest', `Runs Jest with the given arguments`);
+program.command('tsc', `Runs tsc with the given arguments`);
 
-  .parse(process.argv);
+program.parse(process.argv);

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -36,7 +36,7 @@
     "@types/jest": "^29.2.1",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-preset-expo": "~11.0.0",
-    "commander": "^2.19.0",
+    "commander": "^12.1.0",
     "eslint-config-universe": "^13.0.0",
     "find-yarn-workspace-root": "^2.0.0",
     "glob": "^7.1.7",

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `commander` dependency.
+- Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
 
 ## 0.10.1 - 2024-05-29
 

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `commander` dependency.
+
 ## 0.10.1 - 2024-05-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -42,7 +42,7 @@
     "@types/prompts": "^2.0.6",
     "@types/semver": "^6.0.0",
     "chalk": "^4.1.2",
-    "commander": "2.20.0",
+    "commander": "^12.1.0",
     "expo-module-scripts": "^3.3.0",
     "find-up": "^5.0.0",
     "glob": "7.1.6",

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -122,7 +122,9 @@ Do you want to install the Expo CLI integration?`;
 }
 
 async function runAsync() {
-  const { projectRoot, platformAndroid, platformIos } = await normalizeProjectRootAsync(__dirname);
+  const { projectRoot, platformAndroid, platformIos } = await normalizeProjectRootAsync(
+    process.cwd()
+  );
 
   const {
     expoSdkVersion: sdkVersion,

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -25,8 +25,6 @@ import { normalizeProjectRootAsync } from './utils/projectRoot';
 
 const packageJSON = require('../package.json');
 
-let inputProjectRoot: string = '';
-
 const program = new Command(packageJSON.name)
   .version(packageJSON.version)
   .arguments('<project-directory>')
@@ -34,11 +32,10 @@ const program = new Command(packageJSON.name)
   .description('Install expo-modules into your project')
   .option('-s, --sdk-version <version>', 'Install specified expo-modules sdk version')
   .option('--non-interactive', 'Disable interactive prompts')
-  .action((_inputProjectRoot: string) => (inputProjectRoot = _inputProjectRoot))
   .parse(process.argv);
 
 function getSdkVersionInfo(projectRoot: string): VersionInfo {
-  const { sdkVersion } = program;
+  const { sdkVersion } = program.opts();
   if (sdkVersion) {
     const versionInfo = getVersionInfo(sdkVersion);
     if (!versionInfo) {
@@ -60,7 +57,7 @@ async function promptUpgradeAgpVersionAsync(projectRoot: string, agpVersion: str
   }
 
   const deploymentTargetMessage = `The minimum Android Gradle Plugin version for Expo modules is ${agpVersion}. This tool will change your AGP version to ${agpVersion}.`;
-  if (program.nonInteractive) {
+  if (program.opts().nonInteractive) {
     console.log(chalk.yellow(`⚠️  ${deploymentTargetMessage}`));
     return true;
   } else {
@@ -85,7 +82,7 @@ async function promptUpgradeIosDeployTargetAsync(projectRoot: string, iosDeploym
   }
 
   const deploymentTargetMessage = `Expo modules minimum iOS requirement is ${iosDeploymentTarget}. This tool will change your iOS deployment target to ${iosDeploymentTarget}.`;
-  if (program.nonInteractive) {
+  if (program.opts().nonInteractive) {
     console.log(chalk.yellow(`⚠️  ${deploymentTargetMessage}`));
     return true;
   } else {
@@ -112,7 +109,7 @@ Using Expo CLI has some benefits over the the default CLI in bare React Native p
 ${learnMore('https://docs.expo.dev/bare/using-expo-cli/')}
 Do you want to install the Expo CLI integration?`;
 
-  if (program.nonInteractive) {
+  if (program.opts().nonInteractive) {
     return true;
   }
   const { value } = await prompts({
@@ -124,9 +121,8 @@ Do you want to install the Expo CLI integration?`;
   return !!value;
 }
 
-async function runAsync(programName: string) {
-  const { projectRoot, platformAndroid, platformIos } =
-    await normalizeProjectRootAsync(inputProjectRoot);
+async function runAsync() {
+  const { projectRoot, platformAndroid, platformIos } = await normalizeProjectRootAsync(__dirname);
 
   const {
     expoSdkVersion: sdkVersion,
@@ -200,7 +196,7 @@ async function runAsync(programName: string) {
 (async () => {
   program.parse(process.argv);
   try {
-    await runAsync(packageJSON.name);
+    await runAsync();
   } catch (e) {
     console.error('Uncaught Error', e);
     process.exit(1);

--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `commander` dependency.
+- Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
 
 ## 0.2.2 — 2024-04-24
 

--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `commander` dependency.
+
 ## 0.2.2 — 2024-04-24
 
 _This version does not introduce any user-facing changes._

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -36,9 +36,9 @@
   "devDependencies": {
     "@expo/package-manager": "^1.5.0",
     "chalk": "^4.0.0",
-    "commander": "2.20.0",
+    "commander": "^12.1.0",
     "expo-module-scripts": "^3.3.0",
     "terminal-link": "^2.1.1",
-    "update-check": "1.5.4"
+    "update-check": "^1.5.4"
   }
 }

--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `commander` dependency.
+- Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
 
 ## 1.2.2 - 2024-05-29
 

--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `commander` dependency.
+
 ## 1.2.2 - 2024-05-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/uri-scheme/package.json
+++ b/packages/uri-scheme/package.json
@@ -42,9 +42,9 @@
     "@expo/spawn-async": "^1.7.2",
     "@types/prompts": "^2.0.6",
     "chalk": "^4.0.0",
-    "commander": "2.20.0",
+    "commander": "^12.1.0",
     "expo-module-scripts": "^3.3.0",
-    "glob": "7.1.6",
+    "glob": "^7.1.6",
     "prompts": "^2.3.2",
     "update-check": "^1.5.4"
   }

--- a/packages/uri-scheme/src/CLI.ts
+++ b/packages/uri-scheme/src/CLI.ts
@@ -44,9 +44,9 @@ buildCommand('add', ['com.app', 'myapp'])
     try {
       const options = await parseArgsAsync(uri, args);
       await URIScheme.addAsync(options);
-      shouldUpdate();
+      await shouldUpdate();
     } catch (error) {
-      commandDidThrowAsync(error);
+      await commandDidThrowAsync(error);
     }
   });
 
@@ -62,9 +62,9 @@ buildCommand('remove', ['com.app', 'myapp'])
     try {
       const options = await parseArgsAsync(uri, args);
       await URIScheme.removeAsync(options);
-      shouldUpdate();
+      await shouldUpdate();
     } catch (error) {
-      commandDidThrowAsync(error);
+      await commandDidThrowAsync(error);
     }
   });
 
@@ -82,9 +82,9 @@ buildCommand('open', ['com.app://oauth', 'http://expo.dev'])
         androidPackage: args['package'],
         uri,
       });
-      shouldUpdate();
+      await shouldUpdate();
     } catch (error) {
-      commandDidThrowAsync(error);
+      await commandDidThrowAsync(error);
     }
   });
 
@@ -99,9 +99,9 @@ buildCommand('list')
     try {
       const options = await parseArgsAsync(uri, args);
       await URIScheme.listAsync(options);
-      shouldUpdate();
+      await shouldUpdate();
     } catch (error) {
-      commandDidThrowAsync(error);
+      await commandDidThrowAsync(error);
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7375,7 +7375,12 @@ commander@^11.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
-commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
+commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -18267,7 +18272,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18292,15 +18297,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18371,7 +18367,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18405,13 +18401,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -20515,7 +20504,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20537,15 +20526,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19538,7 +19538,7 @@ update-check@1.5.3:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
 
-update-check@1.5.4, update-check@^1.5.4:
+update-check@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/update-check/-/update-check-1.5.4.tgz#5b508e259558f1ad7dbc8b4b0457d4c9d28c8743"
   integrity sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==


### PR DESCRIPTION
# Why

We are using and pinning in few cases quite an old version of Commander package. This bump also will help with some planned changes in the future.

# How

This PR updates the Commander and performs related code changes in `expo-module-scripts`, `install-expo-modules`, `pod-install` and `uri-scheme` packages.

# Test Plan

The changes have been reviewed locally by manually forcing packages to use local version of the package `expo-module-scripts`. Run all checks and tests in both packages.
