### PR TITLE
[expo-contacts] Fix urlAddresses and socialProfiles on contacts

### DIFF
--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -80,6 +80,8 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
         throw ContactManipulationInProgressException()
       }
 
+      presentingViewController?.dismiss(animated: false, completion: nil)
+
       var controller: ContactsViewController?
 
       if let identifier {

--- a/packages/expo-contacts/ios/ContactsRecords.swift
+++ b/packages/expo-contacts/ios/ContactsRecords.swift
@@ -60,7 +60,7 @@ struct Contact: Record {
 struct SocialProfile: Record {
   @Field var service: String?
   @Field var localizedProfile: String?
-  @Field var url: URL?
+  @Field var url: String?
   @Field var username: String?
   @Field var userId: String?
   @Field var label: String
@@ -77,7 +77,7 @@ struct InstantMessageAddress: Record {
 
 struct UrlAddress: Record {
   @Field var label: String
-  @Field var url: URL?
+  @Field var url: String?
   @Field var id: String?
 }
 

--- a/packages/expo-contacts/ios/Decoding.swift
+++ b/packages/expo-contacts/ios/Decoding.swift
@@ -68,7 +68,7 @@ func decodeUrlAddresses(_ input: [UrlAddress]?) -> [CNLabeledValue<NSString>]? {
   var output = [CNLabeledValue<NSString>]()
   for item in input {
     let label = decodeUrlAddressLabel(item.label)
-    if let urlString = item.url?.absoluteString {
+    if let urlString = item.url {
       output.append(CNLabeledValue(label: label, value: urlString as NSString))
     }
   }


### PR DESCRIPTION
# Why

TypeScript types `UrlAddress` and `SocialProfile` expects a String for the url properties. However the iOS module expects a URL for the equivalent types. This causes the urls to fail

# How

This PR fixes it by reverting Swift structs to use `String` instead of `URL`.

It also introduce a change that fixes calling `presentFormAsync` twice with different FormOptions and not picking up the changes. Calling `presentingViewController?.dismiss(animated: false, completion: nil)` fixes it and allows easier testing.

# Test Plan

Call this function to test presenting a form for an unknown contact with urls and socials:

```
Contacts.presentFormAsync(
    null,
    {
        "addresses": [], "company": "Company Name LTD", "contactType": "person", "department": "", "emails": [{"email": "email@acme.com", "label": "E-mail"}], "firstName": "Johana", "id": "9450d242-757a-4057-8c20-a78edac03b26", "jobTitle": "CEO", "lastName": "Branda", "name": "Johana Branda", "phoneNumbers": [{"label": "Cell", "number": "+33601020304"}],
        urlAddresses: [
            {
                label: 'Website',
                url: 'https://mysite.com',
            },
        ],
        socialProfiles: [
            {
                label: 'LinkedIn',
                service: 'LinkedIn',
                username: 'johana-branda',
                url: 'https://www.linkedin.com/in/johana-branda-68a81b235/',
            },
            {
                label: 'Facebook',
                service: 'Facebook',
                username: 'johana.branda',
                url: 'https://facebook.com/johana.branda',
            },
            {
                label: 'YouTube',
                service: 'YouTube',
                username: 'Johana Branda',
                url: 'https://www.youtube.com/@johanabranda',
            },
            {
                label: 'Telegram',
                service: 'Telegram',
                username: '@johanabranda',
                url: 'https://t.me/@johanabranda',
            },
        ],
    },
    {
        isNew: false,
        allowsActions: true,
        cancelButtonTitle: 'Done',
    },
);
```

# Checklist

- [ ] Check that `mutateContact` still works as expected from other functions of this module
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
