### PR TITLE
[ios] Initial changes for iOS 18

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2407,12 +2407,12 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   Google-Maps-iOS-Utils: f77eab4c4326d7e6a277f8e23a0232402731913a
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: 7ce5de1ca9c176b95a2134cf880d7759ea2b4cea
+  hermes-engine: c8cd6a144dc677b571369ef3ccbeeb852d4e75d4
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
+- Handle new error code on `iOS` 18.
 
 ## 6.4.1 — 2024-04-23
 

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
-- Handle new error code on `iOS` 18.
+- Handle new error code on `iOS` 18. ([#29639](https://github.com/expo/expo/pull/29639) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 6.4.1 — 2024-04-23
 

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -49,6 +49,12 @@ final class RequestUnknownException: Exception {
   }
 }
 
+final class RequestMatchedExcludedCredentialException: Exception {
+  override var reason: String {
+    "This request matched an excluded credential"
+  }
+}
+
 func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception {
   switch error.code {
   case .unknown:
@@ -63,6 +69,8 @@ func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception 
     return RequestFailedException()
   case .notInteractive:
     return RequestNotInteractiveException()
+  case .matchedExcludedCredential:
+    return RequestMatchedExcludedCredentialException()
   @unknown default:
     return RequestUnknownException()
   }

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -69,8 +69,10 @@ func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception 
     return RequestFailedException()
   case .notInteractive:
     return RequestNotInteractiveException()
+  #if compiler(>=6)
   case .matchedExcludedCredential:
     return RequestMatchedExcludedCredentialException()
+  #endif
   @unknown default:
     return RequestUnknownException()
   }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 💡 Others
 
+- Handle new permission status on `iOS` 18.
+
 ## 13.0.4 - 2024-06-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Handle new permission status on `iOS` 18.
+- Handle new permission status on `iOS` 18. ([#29639](https://github.com/expo/expo/pull/29639) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 13.0.4 - 2024-06-10
 

--- a/packages/expo-contacts/ios/ContactsRequester.swift
+++ b/packages/expo-contacts/ios/ContactsRequester.swift
@@ -11,7 +11,7 @@ class ContactsPermissionRequester: NSObject, EXPermissionsRequester {
     let permissions = CNContactStore.authorizationStatus(for: .contacts)
 
     switch permissions {
-    case .authorized:
+    case .authorized, .limited:
       status = EXPermissionStatusGranted
     case .denied, .restricted:
       status = EXPermissionStatusDenied

--- a/packages/expo-contacts/ios/ContactsRequester.swift
+++ b/packages/expo-contacts/ios/ContactsRequester.swift
@@ -11,11 +11,17 @@ class ContactsPermissionRequester: NSObject, EXPermissionsRequester {
     let permissions = CNContactStore.authorizationStatus(for: .contacts)
 
     switch permissions {
-    case .authorized, .limited:
+    case .authorized:
       status = EXPermissionStatusGranted
+    #if compiler(>=6)
+    case .limited:
+      status = EXPermissionStatusGranted
+    #endif
     case .denied, .restricted:
       status = EXPermissionStatusDenied
     case .notDetermined:
+      status = EXPermissionStatusUndetermined
+    @unknown default:
       status = EXPermissionStatusUndetermined
     }
 


### PR DESCRIPTION
# Why
After running bare-expo on iOS 18, there are some minor changes to get it compiling.

# How
- Handle a new error code on `expo-apple-authentication`
- Handle a new permission status in `expo-contacts`

Note: Permissions are starting to get more granular and our permission requesters have limited types to handle this.

# Test Plan
bare-expo builds and runs and test suite is passing
~~Won't build on xcode 15~~
Added compiler directives to build on xcode 15

