### PR TITLE
[docs] Merge `ImageSpotlight` and `Video` to `ContentSpotlight`

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -8,11 +8,11 @@ import Video from '~/components/plugins/Video';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BookOpen02Icon, VideoRecorderIcon } from '@expo/styleguide-icons';
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A **development build** is a debug build of your app that contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. By using development builds instead of [Expo Go](/get-started/set-up-your-environment/), you gain full control over the native runtime, so you can [install any native libraries](/workflow/using-libraries/#determining-third-party-library-compatibility), [modify any project configuration](/config-plugins/introduction/), or [write your own native code](/modules/get-started/). With Expo development builds, you are building your own native app, while with Expo Go you are running your project in a sandboxed native app environment.
 
-<ImageSpotlight
+<ContentSpotlight
   alt="expo-dev-client launcher and menu UIs on Android and iOS"
   src="/static/images/dev-client/preview.png"
   caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -8,11 +8,11 @@ import Video from '~/components/plugins/Video';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BookOpen02Icon, VideoRecorderIcon } from '@expo/styleguide-icons';
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 A **development build** is a debug build of your app that contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. By using development builds instead of [Expo Go](/get-started/set-up-your-environment/), you gain full control over the native runtime, so you can [install any native libraries](/workflow/using-libraries/#determining-third-party-library-compatibility), [modify any project configuration](/config-plugins/introduction/), or [write your own native code](/modules/get-started/). With Expo development builds, you are building your own native app, while with Expo Go you are running your project in a sandboxed native app environment.
 
-<ContentSpotlight
+<ImageSpotlight
   alt="expo-dev-client launcher and menu UIs on Android and iOS"
   src="/static/images/dev-client/preview.png"
   caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -8,7 +8,7 @@ import Highlight from '~/components/plugins/Highlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import Video from '~/components/plugins/Video';
 
 We're about to embark on a journey of building universal apps. In this tutorial, we'll create a universal app that runs on Android, iOS, and the web; all with a single codebase. Let's get started!
 
@@ -31,10 +31,7 @@ To keep it beginner friendly, we divided the tutorial into eight chapters so tha
 
 Before we get started, take a look at what we'll build. It's an app named **StickerSmash** that runs on Android, iOS, and the web:
 
-<ContentSpotlight
-  file="tutorial/final.mp4"
-  caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}
-/>
+<Video file="tutorial/final.mp4" />
 
 > **info** The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@expo-team-snacks/image-app).
 

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -6,9 +6,9 @@ description: An introduction to a tutorial on how to build a universal app that 
 
 import Highlight from '~/components/plugins/Highlight';
 import { SnackInline } from '~/ui/components/Snippet';
-import Video from '~/components/plugins/Video';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 We're about to embark on a journey of building universal apps. In this tutorial, we'll create a universal app that runs on Android, iOS, and the web; all with a single codebase. Let's get started!
 
@@ -31,7 +31,10 @@ To keep it beginner friendly, we divided the tutorial into eight chapters so tha
 
 Before we get started, take a look at what we'll build. It's an app named **StickerSmash** that runs on Android, iOS, and the web:
 
-<Video file="tutorial/final.mp4" />
+<ContentSpotlight
+  file="tutorial/final.mp4"
+  caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}
+/>
 
 > **info** The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@expo-team-snacks/image-app).
 

--- a/docs/ui/components/ContentSpotlight/LightboxImage.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxImage.tsx
@@ -1,0 +1,37 @@
+import { ImgHTMLAttributes, useState } from 'react';
+import Lightbox from 'yet-another-react-lightbox';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
+
+import 'yet-another-react-lightbox/styles.css';
+
+type Props = ImgHTMLAttributes<HTMLImageElement> & {
+  src: string;
+};
+
+export function LightboxImage({ src, alt, ...rest }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        <img src={src} alt={alt} {...rest} />
+      </button>
+      <Lightbox
+        open={open}
+        close={() => setOpen(false)}
+        slides={[{ src }]}
+        styles={{ container: { backgroundColor: 'rgba(0, 0, 0, .8)' } }}
+        controller={{
+          aria: true,
+          closeOnBackdropClick: true,
+        }}
+        carousel={{ finite: true }}
+        render={{
+          buttonPrev: () => null,
+          buttonNext: () => null,
+        }}
+        plugins={[Zoom]}
+      />
+    </>
+  );
+}

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -1,7 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
-import { type CSSProperties } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 
 import { LightboxImage } from './LightboxImage';
@@ -19,9 +18,8 @@ type ContentSpotlightProps = {
   file?: string;
   caption?: string;
   controls?: any;
-  spaceAfter?: boolean | number;
   loop?: boolean;
-  style?: CSSProperties;
+  maxWidth?: number;
   containerClassName?: string;
 };
 
@@ -32,34 +30,22 @@ export function ContentSpotlight({
   file,
   caption,
   controls,
-  spaceAfter,
   loop = true,
-  style,
+  maxWidth,
   containerClassName,
 }: ContentSpotlightProps) {
   const isYouTubeDomain = (url?: string) => {
     return url ? YOUTUBE_DOMAINS.some(domain => url.includes(domain)) : false;
   };
 
-  const getInitialMarginBottom = (spaceAfter: ContentSpotlightProps['spaceAfter']) => {
-    if (typeof spaceAfter === 'undefined') {
-      return 'mb-2';
-    } else if (typeof spaceAfter === 'number') {
-      return `mb-${spaceAfter}`;
-    } else if (spaceAfter) {
-      return 'mb-12';
-    }
-    return 'mb-0';
-  };
-
-  const [hover, setHover] = useState(false);
   const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
   const isVideo = !!(url || file);
+  const maxWidthClass = maxWidth && `max-w-[${maxWidth}px]`;
 
   return (
     <figure
       className={mergeClasses(
-        'text-center py-2.5 my-5 rounded-lg',
+        'text-center py-2.5 my-5 rounded-lg cursor-pointer',
         containerClassName,
         !isVideo && 'bg-subtle'
       )}
@@ -67,58 +53,50 @@ export function ContentSpotlight({
         if (typeof controls === 'undefined' && !forceShowControls) {
           setForceShowControls(true);
         }
-      }}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={hover ? { cursor: 'pointer' } : undefined}>
+      }}>
       {src ? (
         <LightboxImage
           src={src}
           alt={alt}
-          style={style}
-          className="inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80"
+          className={mergeClasses(
+            'inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80',
+            maxWidthClass
+          )}
         />
       ) : isVideo ? (
         <VisibilitySensor partialVisibility>
           {({ isVisible }: { isVisible: boolean }) => (
-            <div className={getInitialMarginBottom(spaceAfter)}>
-              <div className="relative w-full h-[400px] bg-palette-black rounded-lg overflow-hidden">
-                <ReactPlayer
-                  url={isVisible ? url || `/static/videos/${file}` : undefined}
-                  className="react-player"
-                  width={PLAYER_WIDTH}
-                  height={PLAYER_HEIGHT}
-                  style={{
-                    outline: 'none',
-                    backgroundColor: '#000',
-                  }}
-                  muted
-                  playing={isVisible && !!file}
-                  controls={typeof controls === 'undefined' ? forceShowControls : controls}
-                  playsinline
-                  loop={loop}
-                />
-                <div
-                  className={`pointer-events-none absolute inset-0 transition-opacity duration-500 ${
-                    isVisible ? 'opacity-0' : 'opacity-70'
-                  } md:hidden`}
-                />
-              </div>
+            <div className="relative w-full h-[400px] bg-palette-black rounded-lg overflow-hidden">
+              <ReactPlayer
+                url={isVisible ? url || `/static/videos/${file}` : undefined}
+                className="react-player"
+                width={PLAYER_WIDTH}
+                height={PLAYER_HEIGHT}
+                muted
+                playing={isVisible && !!file}
+                controls={typeof controls === 'undefined' ? forceShowControls : controls}
+                playsinline
+                loop={loop}
+              />
+              <div
+                className={mergeClasses(
+                  'pointer-events-none absolute inset-0 transition-opacity duration-500 md:hidden',
+                  isVisible ? 'opacity-0' : 'opacity-70'
+                )}
+              />
             </div>
           )}
         </VisibilitySensor>
       ) : null}
       {caption && (
         <figcaption
-          className={`mt-[14px] text-secondary text-center text-xs px-8 py-2 ${
-            isVideo ? 'bg-transparent' : ''
-          }`}
-          style={hover ? { cursor: 'auto' } : undefined}>
+          className={mergeClasses(
+            'mt-3.5 text-secondary text-center text-xs px-8 py-2 cursor-text',
+            isVideo && 'bg-transparent'
+          )}>
           {caption}
         </figcaption>
       )}
     </figure>
   );
 }
-
-export default ContentSpotlight;

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -43,7 +43,7 @@ export function ContentSpotlight({
 
   const getInitialMarginBottom = (spaceAfter: ContentSpotlightProps['spaceAfter']) => {
     if (typeof spaceAfter === 'undefined') {
-      return 'mb-4';
+      return 'mb-2';
     } else if (typeof spaceAfter === 'number') {
       return `mb-${spaceAfter}`;
     } else if (spaceAfter) {

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -37,7 +37,6 @@ export function ContentSpotlight({
   const isYouTubeDomain = (url?: string) => {
     return url ? YOUTUBE_DOMAINS.some(domain => url.includes(domain)) : false;
   };
-
   const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
   const isVideo = !!(url || file);
   const maxWidthClass = maxWidth && `max-w-[${maxWidth}px]`;

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -1,0 +1,124 @@
+import { mergeClasses } from '@expo/styleguide';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { type CSSProperties } from 'react';
+import VisibilitySensor from 'react-visibility-sensor';
+
+import { LightboxImage } from './LightboxImage';
+
+const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
+
+const PLAYER_WIDTH = '100%' as const;
+const PLAYER_HEIGHT = 400 as const;
+const YOUTUBE_DOMAINS = ['youtube.com', 'youtu.be'] as const;
+
+type ContentSpotlightProps = {
+  alt?: string;
+  src?: string;
+  url?: string;
+  file?: string;
+  caption?: string;
+  controls?: any;
+  spaceAfter?: boolean | number;
+  loop?: boolean;
+  style?: CSSProperties;
+  containerClassName?: string;
+};
+
+export function ContentSpotlight({
+  alt,
+  src,
+  url,
+  file,
+  caption,
+  controls,
+  spaceAfter,
+  loop = true,
+  style,
+  containerClassName,
+}: ContentSpotlightProps) {
+  const isYouTubeDomain = (url?: string) => {
+    return url ? YOUTUBE_DOMAINS.some(domain => url.includes(domain)) : false;
+  };
+
+  const getInitialMarginBottom = (spaceAfter: ContentSpotlightProps['spaceAfter']) => {
+    if (typeof spaceAfter === 'undefined') {
+      return 'mb-4';
+    } else if (typeof spaceAfter === 'number') {
+      return `mb-${spaceAfter}`;
+    } else if (spaceAfter) {
+      return 'mb-12';
+    }
+    return 'mb-0';
+  };
+
+  const [hover, setHover] = useState(false);
+  const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
+  const isVideo = !!(url || file);
+
+  return (
+    <figure
+      className={mergeClasses(
+        'text-center py-2.5 my-5 rounded-lg',
+        containerClassName,
+        !isVideo && 'bg-subtle'
+      )}
+      onClick={() => {
+        if (typeof controls === 'undefined' && !forceShowControls) {
+          setForceShowControls(true);
+        }
+      }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={hover ? { cursor: 'pointer' } : undefined}>
+      {src ? (
+        <LightboxImage
+          src={src}
+          alt={alt}
+          style={style}
+          className="inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80"
+        />
+      ) : isVideo ? (
+        <VisibilitySensor partialVisibility>
+          {({ isVisible }: { isVisible: boolean }) => (
+            <div className={getInitialMarginBottom(spaceAfter)}>
+              <div className="relative w-full h-[400px] bg-palette-black rounded-lg overflow-hidden">
+                <ReactPlayer
+                  url={isVisible ? url || `/static/videos/${file}` : undefined}
+                  className="react-player"
+                  width={PLAYER_WIDTH}
+                  height={PLAYER_HEIGHT}
+                  style={{
+                    outline: 'none',
+                    backgroundColor: '#000',
+                  }}
+                  muted
+                  playing={isVisible && !!file}
+                  controls={typeof controls === 'undefined' ? forceShowControls : controls}
+                  playsinline
+                  loop={loop}
+                />
+                <div
+                  className={`pointer-events-none absolute inset-0 transition-opacity duration-500 ${
+                    isVisible ? 'opacity-0' : 'opacity-70'
+                  } md:hidden`}
+                />
+              </div>
+            </div>
+          )}
+        </VisibilitySensor>
+      ) : null}
+      {caption && (
+        <figcaption
+          className={`mt-[14px] text-secondary text-center text-xs px-8 py-2 ${
+            isVideo ? 'bg-transparent' : ''
+          }`}
+          style={hover ? { cursor: 'auto' } : undefined}>
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+export default ContentSpotlight;

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -19,7 +19,7 @@ type ContentSpotlightProps = {
   caption?: string;
   controls?: any;
   loop?: boolean;
-  maxWidthClass?: string;
+  className?: string;
   containerClassName?: string;
 };
 
@@ -31,7 +31,7 @@ export function ContentSpotlight({
   caption,
   controls,
   loop = true,
-  maxWidthClass,
+  className,
   containerClassName,
 }: ContentSpotlightProps) {
   const isYouTubeDomain = (url?: string) => {
@@ -39,7 +39,6 @@ export function ContentSpotlight({
   };
   const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
   const isVideo = !!(url || file);
-  // const maxWidthClass = maxWidth && `max-w-[${maxWidth}px]`;
 
   return (
     <figure
@@ -59,7 +58,7 @@ export function ContentSpotlight({
           alt={alt}
           className={mergeClasses(
             'inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80',
-            maxWidthClass
+            className
           )}
         />
       ) : isVideo ? (

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -19,7 +19,7 @@ type ContentSpotlightProps = {
   caption?: string;
   controls?: any;
   loop?: boolean;
-  maxWidth?: number;
+  maxWidthClass?: string;
   containerClassName?: string;
 };
 
@@ -31,7 +31,7 @@ export function ContentSpotlight({
   caption,
   controls,
   loop = true,
-  maxWidth,
+  maxWidthClass,
   containerClassName,
 }: ContentSpotlightProps) {
   const isYouTubeDomain = (url?: string) => {
@@ -39,7 +39,7 @@ export function ContentSpotlight({
   };
   const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
   const isVideo = !!(url || file);
-  const maxWidthClass = maxWidth && `max-w-[${maxWidth}px]`;
+  // const maxWidthClass = maxWidth && `max-w-[${maxWidth}px]`;
 
   return (
     <figure
@@ -79,7 +79,7 @@ export function ContentSpotlight({
               />
               <div
                 className={mergeClasses(
-                  'pointer-events-none absolute inset-0 transition-opacity duration-500 md:hidden',
+                  'pointer-events-none absolute inset-0 transition-opacity duration-500 max-md-gutters:hidden',
                   isVisible ? 'opacity-0' : 'opacity-70'
                 )}
               />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-11611

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Use a single React component (`ContentSpotlight`) to share props for displaying an image or a video in the Expo docs.
- All functionality and props are the same from `ImageSpotlight` and `Video`.
- Convert and remove emotion/css to Tailwind for displaying a Video in this new component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally, replacing `ImageSpotlight` and `Video` references with `ContentSpotlight`.

## Preview of tested changes

![CleanShot 2024-06-11 at 16 23 44@2x](https://github.com/expo/expo/assets/10234615/a738f5f0-6199-4582-93c4-883377ab5b97)

![CleanShot 2024-06-11 at 16 23 38@2x](https://github.com/expo/expo/assets/10234615/062a0212-305b-485e-b936-07070c2bb60a)

![CleanShot 2024-06-11 at 16 23 32@2x](https://github.com/expo/expo/assets/10234615/466c00ff-e084-465e-8cba-ebf93c6a6c26)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
