### PR TITLE
[@expo/fingerprint] Fix: Do not overwrite default ignore paths and .fingerprintignore paths

### DIFF
--- a/packages/@expo/fingerprint/src/Options.ts
+++ b/packages/@expo/fingerprint/src/Options.ts
@@ -86,12 +86,13 @@ export async function normalizeOptionsAsync(
     platforms: ['android', 'ios'],
     concurrentIoLimit: os.cpus().length,
     hashAlgorithm: 'sha1',
-    ignorePaths: await collectIgnorePathsAsync(projectRoot, options),
     sourceSkips: SourceSkips.None,
     // Options from config
     ...config,
     // Explicit options
     ...options,
+    // Merge explicit ignorePaths with default ignore paths
+    ignorePaths: await collectIgnorePathsAsync(projectRoot, options),
   };
 }
 


### PR DESCRIPTION
# Why

Running `npx expo-updates generate:fingerprint  --workflow managed`, is currently ignoring the `.fingerprintignore`-file. This is because, in the managed workflow the ignore paths `**/android` and `**/ios` get set. This will overwrite all other `ignoredPaths` (the default ones, and the ones coming from `.fingerprintignore`).
I don't think this is intended, as it is documented otherwise.

Patching @expo/fingerprint with this change and adding a `.fingerprintignore` fixes fingerprint inconsistencies between the local fingerprint and EAS Build in two projects of mine.

I created this PR, to discuss the problem. Maybe I'm getting something wrong here. If you think, this fix is correct, I'll happily fix all remaining issues, create a changelog entry and I could try to add a test.

# Test Plan

1. Run `npx expo-update generate:fingerprint --workflow managed` in a newly created Expo Project.
1. Create a `.fingerprintignore`-file ignoring relevant fingerprint files.
2. Run `npx expo-update generate:fingerprint` again and see that the fingerprint did change and the files got ignored.
