### PR TITLE
fix: provide more image metadata in image-picker

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -10,7 +10,7 @@
     "test:ios": "export NODE_ENV=\"test\" && ./scripts/start-simulator.sh",
     "test:android": "export NODE_ENV=\"test\" && ./scripts/start-emulator.sh",
     "edit:android": "open -a /Applications/Android\\ Studio.app ./android",
-    "edit:ios": "open -a Xcode ./ios/BareExpo.xcworkspace",
+    "edit:ios": "xed ./ios/BareExpo.xcworkspace",
     "start": "expo start --reset-cache",
     "clear-metro": "watchman watch-del-all && rm -rf /tmp/metro-bundler-cache-* && rm -rf /tmp/haste-map-react-native-packager-*",
     "clear-ios-build": "rm -rf ios/build/; kill $(lsof -t -i:8081)",

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Provide more image metadata in the result object.
+
 ### 💡 Others
 
 ## 15.0.5 — 2024-05-15

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Provide more image metadata in the result object.
+- [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -143,9 +143,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     // selection limit = 1 --> single selection, reflects the old picker behavior
     configuration.selectionLimit = options.allowsMultipleSelection ? options.selectionLimit : SINGLE_SELECTION
     configuration.filter = options.mediaTypes.toPickerFilter()
-    if #available(iOS 14, *) {
-      configuration.preferredAssetRepresentationMode = options.preferredAssetRepresentationMode.toAssetRepresentationMode()
-    }
+    configuration.preferredAssetRepresentationMode = options.preferredAssetRepresentationMode.toAssetRepresentationMode()
     if #available(iOS 15, *) {
       configuration.selection = options.orderedSelection ? .ordered : .default
     }

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -521,8 +521,8 @@ private struct ImageUtils {
 
     let metadata = mediaInfo[.mediaMetadata] as? [String: Any]
 
-    if metadata != nil {
-      let exif = ImageUtils.readExifFrom(imageMetadata: metadata!)
+    if let metadata {
+      let exif = ImageUtils.readExifFrom(imageMetadata: metadata)
       return completion(exif)
     }
 
@@ -565,18 +565,15 @@ private struct ImageUtils {
     var exif: ExifInfo = imageMetadata[kCGImagePropertyExifDictionary as String] as? ExifInfo ?? [:]
 
     // Copy ["{GPS}"]["<tag>"] to ["GPS<tag>"]
-    let gps = imageMetadata[kCGImagePropertyGPSDictionary as String] as? [String: Any]
-    if gps != nil {
-      gps!.forEach { key, value in
+    if let gps = imageMetadata[kCGImagePropertyGPSDictionary as String] as? [String: Any] {
+      gps.forEach { key, value in
         exif["GPS\(key)"] = value
       }
     }
 
-    // Inject orientation into exif
-    let orientationKey = kCGImagePropertyOrientation as String
-    let orientationValue = imageMetadata[orientationKey]
-    if orientationValue != nil {
-      exif[orientationKey] = orientationValue
+    if let tiff = imageMetadata[kCGImagePropertyTIFFDictionary as String] as? [String: Any] {
+      // Inject tiff data (make, model, resolution...)
+      exif.merge(tiff) { current, _ in current }
     }
 
     return exif


### PR DESCRIPTION
# Why

closes #29442 by adding extra metadata to the result of `ImagePicker.launchImageLibraryAsync`.

Generally speaking, with these apis, it's easy to miss this or that piece of information because the information is scattered across various places, and there are even manufacturer-specific ones, such as for [Minolta](https://developer.apple.com/documentation/imageio/kcgimagepropertymakerminoltadictionary), Canon and others.

However, I believe the TIFF information should be commonly present and also brings the result closer to Android.

# How

I'm taking metadata from [`kCGImagePropertyTIFFDictionary`](https://developer.apple.com/documentation/imageio/kcgimagepropertytiffdictionary) and merging it with the existing `exif` dictionary. In case of duplicate keys, the exif value is preserved.

I removed usage of `kCGImagePropertyOrientation` because the value, if present, is the same as the value in TIFF metadata [source](https://github.com/xybp888/iOS-SDKs/blob/d7f1be9f5b79cffcfb547bbd930f92ec0fc35038/iPhoneOS13.0.sdk/System/Library/Frameworks/ImageIO.framework/Headers/CGImageProperties.h#L75). The key is the same as well, though this is not confirmed by any docs.

# Test Plan

Tested on simulator and device

# Checklist

No need to update docs, and the rest doesn't apply imo

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
