### PR TITLE
docs: update analyzing-bundles with Expo Atlas

### DIFF
--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -8,7 +8,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 Bundle performance varies for different platforms. For example, web browsers don't support precompiled bytecode, so the JavaScript bundle size is important for improving startup time and performance. The smaller the bundle, the faster it can be downloaded and parsed.
 
-## Analyzing bundle size
+## Analyzing bundle size with Atlas
 
 > Available only for **SDK 51 and above**.
 
@@ -47,6 +47,82 @@ You can also use Expo Atlas when generating a production bundle for your app or 
 ]} />
 
 You can also specify the platforms you want to analyze using the `--platform` option. Atlas will gather the data for the exported platforms only.
+
+## Analyzing bundle size with source-map-explorer
+
+> Alternative method for **SDK 50 and below**.
+
+If you are using SDK 50 or below, you can use the [source-map-explorer](https://www.npmjs.com/package/source-map-explorer) package to visualize and analyze the production JavaScript bundle.
+
+<Step label="1">
+
+To use source map explorer, run the following command to install it:
+
+<Terminal cmd={['$ npm i --save-dev source-map-explorer']} />
+
+</Step>
+
+<Step label="2">
+
+Add a script to **package.json** to run it. You might have to adjust the input path depending on the platform or SDK you are using. For brevity, the following example assumes the project is Expo SDK 50 and does not use Expo Router `server` output.
+
+```json package.json
+{
+  "scripts": {
+    "analyze:web": "source-map-explorer 'dist/_expo/static/js/web/*.js' 'dist/_expo/static/js/web/*.js.map'",
+    "analyze:ios": "source-map-explorer 'dist/_expo/static/js/ios/*.js' 'dist/_expo/static/js/ios/*.js.map'",
+    "analyze:android": "source-map-explorer 'dist/_expo/static/js/android/*.js' 'dist/_expo/static/js/android/*.js.map'"
+  }
+}
+```
+
+If you are using the SDK 50 `server` output for web, then use the following to map web bundles:
+
+<Terminal
+  cmd={[
+    "$ npx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
+  ]}
+/>
+
+Web bundles are output to the **dist/client** subdirectory to prevent exposing server code to the client.
+
+</Step>
+
+<Step label="3">
+
+Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps:
+
+<Terminal
+  cmd={[
+    '$ npx expo export --source-maps --platform web',
+    '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
+    '$ npx expo export --source-maps --platform ios --no-bytecode',
+  ]}
+/>
+
+This command shows the JavaScript bundle and source map paths in the output. In the next step, you will pass these paths to the source map explorer.
+
+> Avoid publishing source maps to production as they can cause both security issues and performance issues (a browser will download the large maps).
+
+</Step>
+
+<Step label="4">
+
+Run the script to analyze your bundle:
+
+<Terminal cmd={['$ npm run analyze:web']} />
+
+On running this command, you might see the following error:
+
+```text
+You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
+```
+
+This is probably due to a [known issue](https://github.com/danvk/source-map-explorer/issues/247) in `source-map-explorer` in Node.js 18 and above. To resolve this, set the environment variable `NODE_OPTIONS=--no-experimental-fetch` before running the analyze script.
+
+</Step>
+
+You might encounter a warning such as `Unable to map 809/13787 bytes (5.87%)`. This occurs because source maps often exclude bundler runtime definitions (for example, `__d(() => {}, [])`). This value is consistent and not a reason for concern.
 
 ## Lighthouse
 

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -10,77 +10,39 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 ## Analyzing bundle size
 
-The libraries used in a project influence the size of the production JavaScript bundle. You can use [source map explorer](https://www.npmjs.com/package/source-map-explorer) to visualize the production bundle and identify which libraries are contributing to the bundle size.
+The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
-<Step label="1">
+### Using Atlas with `expo start`
 
-To use source map explorer, run the following command to install it:
+You can use Expo Atlas with the local development server. This method allows Atlas to update whenever you change any code within your project. 
 
-<Terminal cmd={['$ npm i --save-dev source-map-explorer']} />
+Once your app is up and running on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>shift</kbd> + <kbd>m</kbd>.
 
-</Step>
+<Terminal cmd={[
+  '# Start the local development server with Atlas',
+  '$ EXPO_UNSTABLE_ATLAS=true npx expo start',
+  '',
+  '# Optionally, run the local development server in production mode',
+  '$ EXPO_UNSTABLE_ATLAS=true npx expo start --no-dev', 
+]} />
 
-<Step label="2">
+> **Changing development mode to production**
+>
+> Expo starts in development mode by default. Development mode may turn off optimizations that are enabled in production mode. You can also start the local development server in production mode, which provides a more accurate representation of the production bundle size.
 
-Add a script to **package.json** to run it. You might have to adjust the input path depending on the platform or SDK you are using. For brevity, the following example assumes the project is Expo SDK 50 and does not use Expo Router `server` output.
+### Using Atlas with `expo export`
 
-```json package.json
-{
-  "scripts": {
-    "analyze:web": "source-map-explorer 'dist/_expo/static/js/web/*.js' 'dist/_expo/static/js/web/*.js.map'",
-    "analyze:ios": "source-map-explorer 'dist/_expo/static/js/ios/*.js' 'dist/_expo/static/js/ios/*.js.map'",
-    "analyze:android": "source-map-explorer 'dist/_expo/static/js/android/*.js' 'dist/_expo/static/js/android/*.js.map'"
-  }
-}
-```
+You can also use Expo Atlas when generating a production bundle for your app or EAS Update. Atlas generates a **.expo/atlas.jsonl** file during export, which you can share and open without having access to the project.
 
-If you are using the SDK 50 `server` output for web, then use the following to map web bundles:
+<Terminal cmd={[
+  '# Export your app for all platforms',
+  '$ EXPO_UNSTABLE_ATLAS=true npx expo export',
+  '',
+  '# Open the generated Atlas file',
+  '$ npx expo-atlas .expo/atlas.jsonl',
+]} />
 
-<Terminal
-  cmd={[
-    "$ npx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
-  ]}
-/>
-
-Web bundles are output to the **dist/client** subdirectory to prevent exposing server code to the client.
-
-</Step>
-
-<Step label="3">
-
-Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps:
-
-<Terminal
-  cmd={[
-    '$ npx expo export --source-maps --platform web',
-    '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
-    '$ npx expo export --source-maps --platform ios --no-bytecode',
-  ]}
-/>
-
-This command shows the JavaScript bundle and source map paths in the output. In the next step, you will pass these paths to the source map explorer.
-
-> Avoid publishing source maps to production as they can cause both security issues and performance issues (a browser will download the large maps).
-
-</Step>
-
-<Step label="4">
-
-Run the script to analyze your bundle:
-
-<Terminal cmd={['$ npm run analyze:web']} />
-
-On running this command, you might see the following error:
-
-```text
-You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
-```
-
-This is probably due to a [known issue](https://github.com/danvk/source-map-explorer/issues/247) in `source-map-explorer` in Node.js 18 and above. To resolve this, set the environment variable `NODE_OPTIONS=--no-experimental-fetch` before running the analyze script.
-
-</Step>
-
-You might encounter a warning such as `Unable to map 809/13787 bytes (5.87%)`. This occurs because source maps often exclude bundler runtime definitions (for example, `__d(() => {}, [])`). This value is consistent and not a reason for concern.
+You can also specify the platforms you want to analyze, using the `--platform` flag. Atlas will gather the data for the exported platforms only.
 
 ## Lighthouse
 
@@ -92,6 +54,7 @@ After creating a production build with `npx expo export -p web` and serving it (
   cmd={[
     '# Install the lighthouse CLI',
     '$ npm install -g lighthouse',
+    '',
     '# Run the lighthouse CLI for your site',
     '$ npx lighthouse <url> --view',
   ]}

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -12,8 +12,6 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 > Available only for **SDK 51 and above**.
 
-> Available only for **SDK 51 and above**.
-
 The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
 ### Using Atlas with `npx expo start`

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -10,25 +10,29 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 ## Analyzing bundle size
 
+> Available only for **SDK 51 and above**.
+
 The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
 ### Using Atlas with `expo start`
 
-You can use Expo Atlas with the local development server. This method allows Atlas to update whenever you change any code within your project. 
+You can use Expo Atlas with the local development server. This method allows Atlas to update whenever you change any code in your project. 
 
-Once your app is up and running on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>shift</kbd> + <kbd>m</kbd>.
+Once your app is running using the local development server on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>shift</kbd> + <kbd>m</kbd>.
 
 <Terminal cmd={[
   '# Start the local development server with Atlas',
   '$ EXPO_UNSTABLE_ATLAS=true npx expo start',
-  '',
-  '# Optionally, run the local development server in production mode',
-  '$ EXPO_UNSTABLE_ATLAS=true npx expo start --no-dev', 
 ]} />
 
-> **Changing development mode to production**
->
-> Expo starts in development mode by default. Development mode may turn off optimizations that are enabled in production mode. You can also start the local development server in production mode, which provides a more accurate representation of the production bundle size.
+#### Changing development mode to production
+
+By default, Expo starts the local development server in [development mode](/workflow/development-mode/#development-mode). Development mode disables some optimizations that are enabled in [production mode](/workflow/development-mode/#production-mode). You can also start the local development server in production mode to get a more accurate representation of the production bundle size:
+
+<Terminal cmd={[
+  '# Run the local development server in production mode',
+  '$ EXPO_UNSTABLE_ATLAS=true npx expo start --no-dev', 
+]} />
 
 ### Using Atlas with `expo export`
 
@@ -42,7 +46,7 @@ You can also use Expo Atlas when generating a production bundle for your app or 
   '$ npx expo-atlas .expo/atlas.jsonl',
 ]} />
 
-You can also specify the platforms you want to analyze, using the `--platform` flag. Atlas will gather the data for the exported platforms only.
+You can also specify the platforms you want to analyze using the `--platform` option. Atlas will gather the data for the exported platforms only.
 
 ## Lighthouse
 

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -12,6 +12,8 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 > Available only for **SDK 51 and above**.
 
+> Available only for **SDK 51 and above**.
+
 The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
 ### Using Atlas with `npx expo start`

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -14,7 +14,7 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
-### Using Atlas with `expo start`
+### Using Atlas with `npx expo start`
 
 You can use Expo Atlas with the local development server. This method allows Atlas to update whenever you change any code in your project. 
 
@@ -34,7 +34,7 @@ By default, Expo starts the local development server in [development mode](/work
   '$ EXPO_UNSTABLE_ATLAS=true npx expo start --no-dev', 
 ]} />
 
-### Using Atlas with `expo export`
+### Using Atlas with `npx expo export`
 
 You can also use Expo Atlas when generating a production bundle for your app or EAS Update. Atlas generates a **.expo/atlas.jsonl** file during export, which you can share and open without having access to the project.
 


### PR DESCRIPTION
# Why

This replaces the outdated source map analyzer with Expo Atlas instructions for https://docs.expo.dev/guides/analyzing-bundles/

# How

- Updated documentation

# Test Plan

- Docs change only 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
