### PR TITLE
[expo-notifications][Android] Fix setBadgeCount() when badge count is 0

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt
@@ -12,7 +12,12 @@ object BadgeHelper {
 
   fun setBadgeCount(context: Context, badgeCount: Int): Boolean {
     return try {
-      ShortcutBadger.applyCountOrThrow(context.applicationContext, badgeCount)
+      if (badgeCount == 0) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+        notificationManager.cancelAll()
+      } else {
+        ShortcutBadger.applyCountOrThrow(context.applicationContext, badgeCount)
+      }
       BadgeHelper.badgeCount = badgeCount
       true
     } catch (e: ShortcutBadgeException) {


### PR DESCRIPTION
# Why

The `ShortcutBadger` package does not correctly set the badge count on Android if the value to be set is 0. This fixes the issue, using a fix provided by @haileyok in #29634 .

Fixes #29634.

# How

In the case where badge count is 0, use Android built in notification manager to cancel all notifications.

# Test Plan

- CI should pass
- API should behave correctly in our test app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
