### PR TITLE
[docs] Remove public links of examples in AV API references

### DIFF
--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -323,7 +323,7 @@ An emulator for iOS devices that you can run on macOS (or in [Snack](#snack)) to
 
 ### Slug
 
-We use the word "slug" in [**app.json**](#appjson) to refer to the name to use for your app in its URL.
+`slug` in the [app config]((#appjson) is a URL-friendly name for your project. It is unique across your Expo account.
 
 ### Snack
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -323,7 +323,7 @@ An emulator for iOS devices that you can run on macOS (or in [Snack](#snack)) to
 
 ### Slug
 
-We use the word "slug" in [**app.json**](#appjson) to refer to the name to use for your app in its URL. For example, the [Native Component List](https://expo.dev/@community/native-component-list) app lives at https://expo.dev/@community/native-component-list and the slug is native-component-list.
+We use the word "slug" in [**app.json**](#appjson) to refer to the name to use for your app in its URL.
 
 ### Snack
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -18,7 +18,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
-Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the media playback API, and the [recording example app](https://github.com/expo/audio-recording-example) for an example of the recording API.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -20,7 +20,7 @@ The [`Audio.Sound`](audio.mdx) objects and [`Video`](video-av.mdx) components sh
 
 Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
-Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the playback API for both `Audio.Sound` and `Video`.
 
 > **Info** Audio recording APIs are not available on tvOS (Apple TV).
 

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -16,7 +16,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
-Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the media playback API, and the [recording example app](https://github.com/expo/audio-recording-example) for an example of the recording API.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/av.mdx
@@ -20,7 +20,7 @@ The [`Audio.Sound`](audio.mdx) objects and [`Video`](video.mdx) components share
 
 Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
-Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the playback API for both `Audio.Sound` and `Video`.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/audio.mdx
@@ -16,7 +16,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
-Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the media playback API, and the [recording example app](https://github.com/expo/audio-recording-example) for an example of the recording API.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -20,7 +20,7 @@ The [`Audio.Sound`](audio.mdx) objects and [`Video`](video.mdx) components share
 
 Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
-Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the playback API for both `Audio.Sound` and `Video`.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v51.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/audio.mdx
@@ -18,7 +18,7 @@ import { PlatformTags } from '~/ui/components/Tag';
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
-Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the media playback API, and the [recording example app](https://github.com/expo/audio-recording-example) for an example of the recording API.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/av.mdx
@@ -20,7 +20,7 @@ The [`Audio.Sound`](audio.mdx) objects and [`Video`](video-av.mdx) components sh
 
 Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
-Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
+See the [playlist example app](https://github.com/expo/playlist-example) for an example on the playback API for both `Audio.Sound` and `Video`.
 
 > **Info** Audio recording APIs are not available on tvOS (Apple TV).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

See [Slack context](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1718140344288949)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove public links of examples in AV API references and use GitHub repo links instead.
- Also, remove example for "slug" property in Glossary.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
