### PR TITLE
[cli] Fix resolving mainModule for Expo Router static exports on Windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix resolving the main entry file Expo Router static export on Windows
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 🐛 Bug fixes
 
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix resolving the main entry file Expo Router static export on Windows
+- Fix resolving the main entry file Expo Router static export on Windows ([#29670](https://github.com/expo/expo/pull/29670) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -261,7 +261,9 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const platform = 'web';
 
     const resolvedMainModuleName =
-      mainModuleName ?? '.' + path.sep + resolveMainModuleName(this.projectRoot, { platform });
+      // The `./` appears in incorrect (as path.sep is standard) but this is actually needed for Metro on Windows.
+      mainModuleName ?? './' + resolveMainModuleName(this.projectRoot, { platform });
+
     return await this.metroImportAsArtifactsAsync(resolvedMainModuleName, {
       splitChunks: isExporting && !env.EXPO_NO_BUNDLE_SPLITTING,
       platform,


### PR DESCRIPTION
# Why

Fix: https://github.com/expo/expo/issues/29631

# How

@EvanBacon @byCedric I'm opening this PR more for a discussion, as I don't believe this is the best fix. I don't understand this fix and I'd like to improve the comment with more clarification. To me, `path.sep` should be correct and this might be a sign of a downstream issue?

I'm also suspicious of https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/start/server/metro/MetroBundlerDevServer.ts#L547-L552 which was changed in the same PR

# Test Plan

Reproduction repo: https://github.com/liambogenholm/Expo-web-bug

Need to test on Window

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
