### PR TITLE
Fix @expo/vector-icons version in bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/metro-runtime": "~3.2.1",
-  "@expo/vector-icons": "^14.0.0",
+  "@expo/vector-icons": "^14.0.2",
   "@react-native-async-storage/async-storage": "1.23.1",
   "@react-native-community/datetimepicker": "8.0.1",
   "@react-native-masked-view/masked-view": "0.3.1",


### PR DESCRIPTION
# Why

`@expo/vector-icons@14.0.1` shipped the prop-types fix. If you upgrade from 50->51 and your lockfile already had `14.0.0`, `@expo/vector-icons` will not get updated to the latest and you'll get:

```
Unable to resolve "prop-types" from "node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/lib/icon-button.js"
```

No idea how common this is, but it's happened to me twice now, and I'm a little confused each time :-D.

# How

Updated to `^14.0.2` as that's the latest and there's no reason not to have it on SDK 51.
