### PR TITLE
[expo-document-picker][ios] Fix video/* MIME Type

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `video/*` MIME Type not allowing to select videos with audio. ([#29673](https://github.com/expo/expo/pull/29673) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 12.0.1 — 2024-04-23

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -164,7 +164,7 @@ public class DocumentPickerModule: Module, PickingResultHandler {
     case "image/*":
       return UTType.image
     case "video/*":
-      return UTType.video
+      return UTType.movie
     case "audio/*":
       return UTType.audio
     case "text/*":


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/29403

# How

Update `toUTType(mimeType)` function to use `UTType.movie` instead of `UTType.video` given that `.video` is meant to only allow selecting pure video data with no audio.

# Test Plan

Run BareExpo locally and test `DocumentPicker.getDocumentAsync({ type: "video/*", })`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
