### PR TITLE
[bare-expo] Enable warnings in pods

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -16,7 +16,6 @@ install! 'cocoapods',
   :incremental_installation => true,
   :deterministic_uuids => false
 source 'https://cdn.cocoapods.org/'
-inhibit_all_warnings!
 
 prepare_react_native_project!
 


### PR DESCRIPTION
# Why
Currently, in bare-expo we are disabling warnings from pods. This is causing us to miss some useful warnings. 

# How
Remove `inhibit_all_warnings`

# Test Plan
CI