### PR TITLE
fix: blur radius not working in expo-image

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageAnimatedStyles.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAnimatedStyles.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { Animated, StyleSheet, Switch, Text, View } from 'react-native';
+
+import { ImageComparisonBody } from './ImageComparisonScreen';
+import imageTests from './tests';
+import { anyAnimationDriver, jsOnlyAnimationDriver } from './tests/constants';
+import Button from '../../components/Button';
+import Colors from '../../constants/Colors';
+
+export default function ImageAnimatedStyles() {
+  const targetValue = React.useRef(1);
+  const animValue = React.useRef(new Animated.Value(0)).current;
+  const [useNativeDriver, setUseNativeDriver] = React.useState(false);
+
+  const sections = imageTests.tests.map((test) => ({
+    title: test.name,
+    data: test.tests.filter((it) => {
+      return (
+        it.animationDriver === anyAnimationDriver ||
+        (it.animationDriver === jsOnlyAnimationDriver && !useNativeDriver)
+      );
+    }),
+  }));
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.topContent}>
+        <Text style={styles.text}>
+          use native animation driver (set this before running animations)
+        </Text>
+        <Switch value={useNativeDriver} onValueChange={setUseNativeDriver} />
+      </View>
+      <Button
+        title="start animation"
+        onPress={() => {
+          Animated.timing(animValue, {
+            toValue: targetValue.current,
+            duration: 2000,
+            useNativeDriver,
+          }).start(({ finished }) => {
+            if (finished) {
+              targetValue.current = targetValue.current === 1 ? 0 : 1;
+            }
+          });
+        }}
+      />
+
+      <ImageComparisonBody sections={sections} useAnimatedComponent animValue={animValue} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.greyBackground,
+  },
+  text: {
+    flexShrink: 1,
+  },
+  topContent: {
+    flexDirection: 'row',
+    gap: 10,
+    alignItems: 'center',
+    paddingHorizontal: 10,
+  },
+  header: {
+    backgroundColor: 'white',
+    paddingHorizontal: 10,
+    paddingTop: 10,
+    paddingBottom: 4,
+    borderBottomColor: Colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageComparisonScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageComparisonScreen.tsx
@@ -1,15 +1,28 @@
 import * as React from 'react';
-import { SectionList, StyleSheet, Text, View } from 'react-native';
+import { Animated, SectionList, StyleSheet, Text, View } from 'react-native';
 
-import ImageTestListItem from './ImageTestListItem';
+import { ImageTestListItem } from './ImageTestListItem';
 import imageTests from './tests';
 import { ImageTest } from './types';
 import Colors from '../../constants/Colors';
 
-export default function ImageComparisonScreen() {
-  const renderItem = ({ item }: any) => {
-    const test: ImageTest = item;
-    return <ImageTestListItem test={test} />;
+export function ImageComparisonBody({
+  useAnimatedComponent,
+  animValue,
+  sections,
+}: {
+  useAnimatedComponent?: boolean;
+  animValue?: Animated.Value;
+  sections: { title: string; data: ImageTest[] }[];
+}) {
+  const renderItem = ({ item }: { item: ImageTest }) => {
+    return (
+      <ImageTestListItem
+        test={item}
+        animValue={animValue}
+        useAnimatedComponent={!!useAnimatedComponent}
+      />
+    );
   };
 
   const renderSectionHeader = ({ section }: any) => {
@@ -24,12 +37,6 @@ export default function ImageComparisonScreen() {
     return item + index;
   };
 
-  const sections = imageTests.tests.map((test) => ({
-    title: test.name,
-    // @ts-ignore
-    data: test.tests,
-  }));
-
   return (
     <View style={styles.container}>
       <SectionList
@@ -41,6 +48,14 @@ export default function ImageComparisonScreen() {
       />
     </View>
   );
+}
+
+export default function ImageComparisonScreen() {
+  const sections = imageTests.tests.map((test) => ({
+    title: test.name,
+    data: test.tests,
+  }));
+  return <ImageComparisonBody sections={sections} />;
 }
 
 const styles = StyleSheet.create({

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -13,6 +13,14 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Animated styles',
+    route: 'image/animated-styles',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./ImageAnimatedStyles'));
+    },
+  },
+  {
     name: 'List with thousands images',
     route: 'image/flashlist',
     options: {},

--- a/apps/native-component-list/src/screens/Image/ImageTestListItem.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTestListItem.tsx
@@ -24,9 +24,11 @@ type ImageTest = {
 type PropsType = {
   test: ImageTest;
   animValue?: Animated.Value;
+  useAnimatedComponent: boolean;
 };
+const AnimatedExpoImage = Animated.createAnimatedComponent(Image);
 
-export default function ImageTestListItem({ test, animValue }: PropsType) {
+export function ImageTestListItem({ test, animValue, useAnimatedComponent }: PropsType) {
   const imageProps = resolveProps(test.props, animValue);
 
   return (
@@ -38,14 +40,13 @@ export default function ImageTestListItem({ test, animValue }: PropsType) {
         <ImageTestView
           style={styles.image}
           imageProps={imageProps}
-          ImageComponent={Image}
+          ImageComponent={useAnimatedComponent ? AnimatedExpoImage : Image}
           loadOnDemand={test.loadOnDemand}
         />
-        <View style={styles.spacer} />
         <ImageTestView
           style={styles.image}
           imageProps={imageProps}
-          ImageComponent={RNImage}
+          ImageComponent={useAnimatedComponent ? Animated.Image : RNImage}
           loadOnDemand={test.loadOnDemand}
         />
       </View>
@@ -76,9 +77,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     alignItems: 'center',
-  },
-  spacer: {
-    width: 10,
+    columnGap: 10,
   },
   image: {
     width: (Dimensions.get('window').width - 30) / 2,

--- a/apps/native-component-list/src/screens/Image/tests/appearance.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/appearance.tsx
@@ -1,4 +1,4 @@
-import { tintColor, tintColor2 } from './constants';
+import { anyAnimationDriver, tintColor, tintColor2 } from './constants';
 import { ImageTestGroup, ImageTestPropsFnInput } from '../types';
 
 const imageTests: ImageTestGroup = {
@@ -57,12 +57,14 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Blur radius',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         blurRadius: range(0, 60),
       }),
     },
     {
       name: 'Opacity',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           opacity: range(0, 1),

--- a/apps/native-component-list/src/screens/Image/tests/borders.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/borders.tsx
@@ -1,4 +1,4 @@
-import { tintColor, tintColor2 } from './constants';
+import { anyAnimationDriver, jsOnlyAnimationDriver, tintColor, tintColor2 } from './constants';
 import { images } from '../images';
 import { ImageTestGroup, ImageTestPropsFnInput } from '../types';
 
@@ -16,6 +16,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Border width',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           borderWidth: range(0, 20),
@@ -25,6 +26,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Border radius',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           borderWidth: 5,
@@ -35,6 +37,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Dotted border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           borderWidth: range(0, 50),
@@ -45,6 +48,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Dashed border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           borderWidth: range(0, 50),
@@ -55,6 +59,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Separate border radius',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -69,6 +74,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Separate border radius dotted',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -99,6 +105,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Top border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -111,6 +118,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Right border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -123,6 +131,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Bottom border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -135,6 +144,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Left border',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -147,7 +157,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Exclude border',
-      props: ({ range }: ImageTestPropsFnInput) => ({
+      props: {
         source: images.require_jpg1,
         style: {
           borderWidth: 12,
@@ -156,10 +166,11 @@ const imageTests: ImageTestGroup = {
           borderBottomWidth: 0,
           borderBottomLeftRadius: 0,
         },
-      }),
+      },
     },
     {
       name: 'Different colors',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -185,6 +196,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'All different borders',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {
@@ -205,6 +217,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Start border (left on non RTL)',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         source: images.require_jpg1,
         style: {

--- a/apps/native-component-list/src/screens/Image/tests/constants.ts
+++ b/apps/native-component-list/src/screens/Image/tests/constants.ts
@@ -1,2 +1,5 @@
 export const tintColor = 'pink';
 export const tintColor2 = 'purple';
+
+export const jsOnlyAnimationDriver = 'js-only';
+export const anyAnimationDriver = 'any';

--- a/apps/native-component-list/src/screens/Image/tests/index.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/index.tsx
@@ -2,9 +2,8 @@ import AppearanceTests from './appearance';
 import BorderTests from './borders';
 import ShadowsTests from './shadows';
 import SourcesTests from './sources';
-import { ImageTestGroup } from '../types';
 
-const tests: ImageTestGroup = {
+const tests = {
   name: 'Image',
   tests: [AppearanceTests, BorderTests, ShadowsTests, SourcesTests],
 };

--- a/apps/native-component-list/src/screens/Image/tests/shadows.tsx
+++ b/apps/native-component-list/src/screens/Image/tests/shadows.tsx
@@ -1,4 +1,4 @@
-import { tintColor } from './constants';
+import { anyAnimationDriver, jsOnlyAnimationDriver, tintColor } from './constants';
 import { ImageTestGroup, ImageTestPropsFnInput } from '../types';
 
 const backgroundColor = '#fff';
@@ -8,6 +8,7 @@ const imageTests: ImageTestGroup = {
   tests: [
     {
       name: 'Shadow',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           backgroundColor,
@@ -24,6 +25,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Shadow: and border-radius',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           backgroundColor,
@@ -41,6 +43,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Shadow: and separate border-radius',
+      animationDriver: anyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           backgroundColor,
@@ -61,7 +64,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Shadow: Color (iOS only)',
-      props: ({ range }: ImageTestPropsFnInput) => ({
+      props: {
         style: {
           backgroundColor,
           shadowColor: tintColor,
@@ -73,10 +76,11 @@ const imageTests: ImageTestGroup = {
           shadowRadius: 10,
           elevation: 10,
         },
-      }),
+      },
     },
     {
       name: 'Shadow: and no background (gives warning)',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           shadowColor: '#000',
@@ -92,6 +96,7 @@ const imageTests: ImageTestGroup = {
     },
     {
       name: 'Shadow: and transparent background (gives warning)',
+      animationDriver: jsOnlyAnimationDriver,
       props: ({ range }: ImageTestPropsFnInput) => ({
         style: {
           backgroundColor: '#00000088',

--- a/apps/native-component-list/src/screens/Image/types.ts
+++ b/apps/native-component-list/src/screens/Image/types.ts
@@ -1,6 +1,8 @@
-import { ImageProps } from 'expo-image';
+import { Image, ImageProps } from 'expo-image';
 import React from 'react';
-import { Animated, ImageProps as RNImageProps } from 'react-native';
+import { Animated, ImageProps as RNImageProps, Image as RNImage } from 'react-native';
+
+import { anyAnimationDriver, jsOnlyAnimationDriver } from './tests/constants';
 
 export type ImageTestEventHandler = (...args: any) => void;
 
@@ -15,17 +17,20 @@ export type ImageTestPropsFn = (input: ImageTestPropsFnInput) => ImageTestProps;
 
 export type ImageTestComponent =
   | React.ComponentType<ImageProps>
-  | React.ComponentType<RNImageProps>;
+  | React.ComponentType<RNImageProps>
+  | Animated.AnimatedComponent<typeof Image>
+  | Animated.AnimatedComponent<typeof RNImage>;
 
 export interface ImageTest {
   name: string;
   props: ImageTestProps | ImageTestPropsFn;
   loadOnDemand?: boolean;
   testInformation?: string;
+  animationDriver?: typeof jsOnlyAnimationDriver | typeof anyAnimationDriver;
 }
 
 export interface ImageTestGroup {
   name: string;
-  tests: (ImageTest | ImageTestGroup)[];
+  tests: ImageTest[];
   description?: string;
 }

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed blur radius not working. Additionally, appearance of the effect is now more consistent across platforms. For iOS, you may need to increase the `blurRadius` prop value to get the same effect as previously. ([#29678](https://github.com/expo/expo/pull/29678) by [@vonovak](https://github.com/vonovak))
 - Fixed `tintColor` not working on Safari browsers. ([#29169](https://github.com/expo/expo/pull/29169) by [@bradleyayers](https://github.com/bradleyayers))
 
 ### 💡 Others

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed blur radius not working. Additionally, appearance of the effect is now more consistent across platforms. For iOS, you may need to increase the `blurRadius` prop value to get the same effect as previously. ([#29678](https://github.com/expo/expo/pull/29678) by [@vonovak](https://github.com/vonovak))
+- [iOS] Fixed `blurRadius` not working. Also made the effect render more consistently across platforms. ([#29678](https://github.com/expo/expo/pull/29678) by [@vonovak](https://github.com/vonovak))
 - Fixed `tintColor` not working on Safari browsers. ([#29169](https://github.com/expo/expo/pull/29169) by [@bradleyayers](https://github.com/bradleyayers))
 
 ### 💡 Others

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -50,7 +50,8 @@ public final class ImageModule: Module {
       }
 
       Prop("blurRadius") { (view, blurRadius: Double?) in
-        view.blurRadius = blurRadius ?? .zero
+        let radius = blurRadius ?? .zero
+        view.blurRadius = radius / 2.0
       }
 
       Prop("tintColor") { (view, tintColor: UIColor?) in

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -51,6 +51,9 @@ public final class ImageModule: Module {
 
       Prop("blurRadius") { (view, blurRadius: Double?) in
         let radius = blurRadius ?? .zero
+        // the implementation uses Apple's CIGaussianBlur internally
+        // we divide the radius to achieve more consistent cross-platform appearance
+        // the value was found experimentally
         view.blurRadius = radius / 2.0
       }
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -27,7 +27,7 @@ public final class ImageView: ExpoView {
     .handleCookies, // Handle cookies stored in the shared `HTTPCookieStore`
     // Images from cache are `AnimatedImage`s. BlurRadius is done via a SDImageBlurTransformer
     // so this flag needs to be enabled. Beware most transformers cannot manage animated images.
-    .transformAnimatedImage,
+    .transformAnimatedImage
   ]
 
   var sources: [ImageSource]?

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -24,7 +24,10 @@ public final class ImageView: ExpoView {
 
   var loadingOptions: SDWebImageOptions = [
     .retryFailed, // Don't blacklist URLs that failed downloading
-    .handleCookies // Handle cookies stored in the shared `HTTPCookieStore`
+    .handleCookies, // Handle cookies stored in the shared `HTTPCookieStore`
+    // Images from cache are `AnimatedImage`s. BlurRadius is done via a SDImageBlurTransformer
+    // so this flag needs to be enabled. Beware most transformers cannot manage animated images.
+    .transformAnimatedImage,
   ]
 
   var sources: [ImageSource]?


### PR DESCRIPTION
# Why

closes #29536

NOTE: For iOS, after installing this fix, you may need to increase the `blurRadius` prop value to get the same effect as previously.

# How

Reason why blurRadius does not work now:

[This variable](https://github.com/SDWebImage/SDWebImage/blob/b8523c1642f3c142b06dd98443ea7c48343a4dfd/SDWebImage/Core/SDImageCacheDefine.m#L95) evaluates to false currently, causing [this branch](https://github.com/SDWebImage/SDWebImage/blob/b8523c1642f3c142b06dd98443ea7c48343a4dfd/SDWebImage/Core/SDImageCacheDefine.m#L108) to run.

blurRadius is done via transform [in Expo-image](https://github.com/expo/expo/blob/d9bdec0a2596437f38584df91133b9c8a37cdf1a/packages/expo-image/ios/ImageView.swift#L362)

but here [shouldTransformImage](https://github.com/SDWebImage/SDWebImage/blob/b8523c1642f3c142b06dd98443ea7c48343a4dfd/SDWebImage/Core/SDWebImageManager.m#L495) evaluates to false

```
(!originalImage.sd_isAnimated || (options & SDWebImageTransformAnimatedImage))
```
because `originalImage.sd_isAnimated` is true but `SDWebImageTransformAnimatedImage` flag is not present.

Because `shouldTransformImage` is false, the `SDImageBlurTransformer` transform is not applied.

There are (at least) 2 ways to fix this, but I'm not sure about their side-effects. I might be fixing this but breaking something else.

Option 1 (now in this PR): 

Enable `SDWebImageTransformAnimatedImage`. `SDImageBlurTransformer` is the only transform we use now, and it works for blurRadius, afaict. 

The SDWebImage sources give a bit of a warning - if we, in the future, need more transforms, they may not work because "transformers could not manage animated images".

```
    /**
     * We usually don't apply transform on animated images as most transformers could not manage animated images.
     * Use this flag to transform them anyway.
     */
    SDWebImageTransformAnimatedImage = 1 << 9,
```

Option 2:
forcing [the variable](https://github.com/SDWebImage/SDWebImage/blob/b8523c1642f3c142b06dd98443ea7c48343a4dfd/SDWebImage/Core/SDImageCacheDefine.m#L95) to evaluate to true by using [SDWebImageDecodeFirstFrameOnly](https://github.com/SDWebImage/SDWebImage/blob/b8523c1642f3c142b06dd98443ea7c48343a4dfd/SDWebImage/Core/SDWebImageDefine.h#L185). Then the output image will not be AnimatedImage and the transforms will be applied. 

However, as I was testing it, I can already tell that this breaks animations, so not a good approach.

# Test Plan

I'm adding more examples, with animations, to the bare-expo app. I'll push them later.

# Checklist

doesn't apply
<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
