### PR TITLE
[docs] rewrite error page styling

### DIFF
--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -1,7 +1,5 @@
-import { css } from '@emotion/react';
-import { Button, theme, typography } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
-import * as Sentry from '@sentry/browser';
+import { Button } from '@expo/styleguide';
+import { captureMessage } from '@sentry/browser';
 import { useEffect, useState } from 'react';
 
 import { getRedirectPath } from '~/common/error-utilities';
@@ -11,48 +9,6 @@ import { Layout } from '~/ui/components/Layout';
 import { H1, P } from '~/ui/components/Text';
 
 const REDIRECT_SUFFIX = '?redirected';
-
-const renderRedirect = () => (
-  // note(simek): "redirect-link" ID is needed for test-links script
-  <>
-    <Head title="Redirecting" />
-    <RedirectImage />
-    <H1 css={styles.header}>Redirecting</H1>
-    <P css={styles.description} id="redirect-link">
-      Just a moment…
-    </P>
-  </>
-);
-
-const renderNotFoundAfterRedirect = () => (
-  <>
-    <Head title="Not Found" />
-    <ServerErrorImage />
-    <H1 css={styles.header}>404: Not Found</H1>
-    <P css={styles.description} id="__redirect_failed">
-      We took an educated guess and tried to direct you to the right page, but it seems that did not
-      work out! Maybe it doesn't exist anymore! 😔
-    </P>
-    <Button theme="secondary" href="/">
-      Return Home
-    </Button>
-  </>
-);
-
-const renderNotFound = () => (
-  <>
-    <Head title="Not Found" />
-    <NotFoundImage />
-    <H1 css={styles.header}>404: Not Found</H1>
-    <P css={styles.description} id="__not_found">
-      We couldn't find the page you were looking for. Check the URL to make sure it's correct and
-      try again.
-    </P>
-    <Button theme="secondary" href="/">
-      Return Home
-    </Button>
-  </>
-);
 
 const Error = () => {
   const [notFound, setNotFound] = useState<boolean>(false);
@@ -67,7 +23,7 @@ const Error = () => {
     const { pathname, search } = window.location;
 
     if (search === REDIRECT_SUFFIX) {
-      Sentry.captureMessage(`Redirect failed`);
+      captureMessage(`Redirect failed`);
       setRedirectFailed(true);
       return;
     }
@@ -81,7 +37,7 @@ const Error = () => {
 
     // We are confident now that we can render a not found error
     setNotFound(true);
-    Sentry.captureMessage(`Page not found (404)`, {
+    captureMessage(`Page not found (404)`, {
       extra: {
         '404': pathname,
       },
@@ -94,45 +50,42 @@ const Error = () => {
     }
   }, [redirectPath]);
 
-  const getContent = () => {
-    if (redirectPath) {
-      return renderRedirect();
-    } else if (redirectFailed) {
-      return renderNotFoundAfterRedirect();
-    } else if (notFound) {
-      return renderNotFound();
-    }
-    return undefined;
-  };
-
   return (
-    <Layout cssLayout={styles.layout} cssContent={styles.container}>
-      {getContent()}
+    <Layout className="flex items-center justify-center flex-col !pb-20">
+      {redirectPath && (
+        <>
+          <Head title="Redirecting" />
+          <RedirectImage />
+          <H1 className="!mt-8">Redirecting</H1>
+          {/* note(simek): "redirect-link" ID is needed for test-links script */}
+          <P theme="secondary" className="text-center max-w-[450px] mb-8" id="redirect-link">
+            Just a moment…
+          </P>
+        </>
+      )}
+      {(redirectFailed || notFound) && (
+        <>
+          <Head title="Not Found" />
+          {redirectFailed ? <ServerErrorImage /> : <NotFoundImage />}
+          <H1 className="!mt-8">404: Not Found</H1>
+          {redirectFailed ? (
+            <P theme="secondary" className="text-center max-w-[450px] mb-8" id="__redirect_failed">
+              We took an educated guess and tried to direct you to the right page, but it seems that
+              did not work out! Maybe it doesn't exist anymore! 😔
+            </P>
+          ) : (
+            <P theme="secondary" className="text-center max-w-[450px] mb-8" id="__not_found">
+              We couldn't find the page you were looking for. Check the URL to make sure it's
+              correct and try again.
+            </P>
+          )}
+          <Button theme="secondary" href="/">
+            Return Home
+          </Button>
+        </>
+      )}
     </Layout>
   );
 };
 
 export default Error;
-
-const styles = {
-  layout: css({
-    backgroundColor: theme.background.subtle,
-  }),
-  container: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'column',
-  }),
-  header: css({
-    ...typography.fontSizes[31],
-    marginTop: spacing[8],
-  }),
-  description: css({
-    textAlign: 'center',
-    maxWidth: 450,
-    marginTop: spacing[6],
-    marginBottom: spacing[8],
-    color: theme.text.secondary,
-  }),
-};

--- a/docs/ui/components/ErrorPage/NotFoundImage.tsx
+++ b/docs/ui/components/ErrorPage/NotFoundImage.tsx
@@ -1,11 +1,11 @@
 import { theme } from '@expo/styleguide';
-import React from 'react';
 
 export const NotFoundImage = () => (
   <svg width="218" height="133" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="m25.977 131.315 63.762-8.961c5.47-.769 9.28-5.826 8.511-11.295l-9.14-65.046a10 10 0 0 0-3.885-6.594L56.807 18.005a10 10 0 0 0-7.41-1.917l-38.846 5.46c-5.47.769-9.28 5.825-8.511 11.294l12.643 89.962c.769 5.469 5.825 9.279 11.294 8.511z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path
@@ -15,6 +15,7 @@ export const NotFoundImage = () => (
     <path
       d="m128.261 122.354 63.762 8.961c5.469.768 10.525-3.042 11.294-8.511l9.142-65.046a10.001 10.001 0 0 0-1.917-7.41l-21.414-28.417a9.999 9.999 0 0 0-6.595-3.885l-38.846-5.46c-5.469-.768-10.525 3.043-11.294 8.512l-12.643 89.961c-.769 5.469 3.041 10.526 8.511 11.295z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path

--- a/docs/ui/components/ErrorPage/RedirectImage.tsx
+++ b/docs/ui/components/ErrorPage/RedirectImage.tsx
@@ -1,11 +1,11 @@
 import { theme } from '@expo/styleguide';
-import React from 'react';
 
 export const RedirectImage = () => (
   <svg width="218" height="133" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="m25.977 131.315 63.762-8.961c5.47-.769 9.28-5.826 8.511-11.295l-9.14-65.046a10 10 0 0 0-3.885-6.594L56.807 18.005a10 10 0 0 0-7.41-1.917l-38.846 5.46c-5.47.769-9.28 5.825-8.51 11.294l12.642 89.962c.77 5.469 5.825 9.279 11.294 8.511Z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path
@@ -15,6 +15,7 @@ export const RedirectImage = () => (
     <path
       d="m128.261 122.354 63.762 8.961c5.469.768 10.525-3.042 11.294-8.511l9.142-65.046a10.002 10.002 0 0 0-1.917-7.41l-21.414-28.417a9.99 9.99 0 0 0-6.595-3.885l-38.846-5.46c-5.469-.768-10.525 3.043-11.294 8.512L119.75 111.06c-.769 5.469 3.041 10.526 8.511 11.295Z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path

--- a/docs/ui/components/ErrorPage/ServerErrorImage.tsx
+++ b/docs/ui/components/ErrorPage/ServerErrorImage.tsx
@@ -1,11 +1,11 @@
 import { theme } from '@expo/styleguide';
-import React from 'react';
 
 export const ServerErrorImage = () => (
   <svg width="218" height="133" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="m25.977 131.315 63.762-8.961c5.47-.769 9.28-5.826 8.511-11.295l-9.14-65.046a10 10 0 0 0-3.885-6.594L56.807 18.005a10 10 0 0 0-7.41-1.917l-38.846 5.46c-5.47.769-9.28 5.825-8.511 11.294l12.643 89.962c.769 5.469 5.825 9.279 11.294 8.511z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path
@@ -15,6 +15,7 @@ export const ServerErrorImage = () => (
     <path
       d="m128.26 122.354 63.762 8.961c5.469.768 10.526-3.042 11.295-8.511l9.141-65.046a10 10 0 0 0-1.916-7.41l-21.414-28.417a9.999 9.999 0 0 0-6.595-3.885l-38.846-5.46c-5.469-.768-10.526 3.043-11.294 8.512l-12.644 89.961c-.768 5.469 3.042 10.526 8.511 11.295z"
       stroke={theme.border.default}
+      fill={theme.background.subtle}
       strokeWidth="2"
     />
     <path

--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -1,8 +1,5 @@
-import { css, Global } from '@emotion/react';
-import { SerializedStyles } from '@emotion/serialize';
-import { theme } from '@expo/styleguide';
-import { breakpoints, spacing } from '@expo/styleguide-base';
-import { PropsWithChildren, ReactNode } from 'react';
+import { mergeClasses } from '@expo/styleguide';
+import { type PropsWithChildren, type ReactNode } from 'react';
 
 import { Sidebar } from '../Sidebar';
 
@@ -23,16 +20,12 @@ type LayoutProps = PropsWithChildren<{
    */
   sidebar?: ReactNode;
   /**
-   * Custom CSS for the whole layout.
+   * Custom className for the main content wrapper.
    */
-  cssLayout?: SerializedStyles;
-  /**
-   * Custom CSS for the main content wrapper.
-   */
-  cssContent?: SerializedStyles;
+  className?: string;
 }>;
 
-export const Layout = ({
+export function Layout({
   // note(simek): stub props for now, until we don't use new Layout
   header = (
     <Header
@@ -45,71 +38,25 @@ export const Layout = ({
   navigation,
   sidebar,
   children,
-  cssLayout = undefined,
-  cssContent = undefined,
-}: LayoutProps) => (
-  <>
-    <Global
-      styles={css({
-        // Ensure correct background for Overscroll
-        'body.dark-theme': {
-          backgroundColor: theme.background.screen,
-        },
-      })}
-    />
-    <header css={headerStyle}>{header}</header>
-    <main css={[layoutStyle, cssLayout]}>
-      {navigation && <nav css={navigationStyle}>{navigation}</nav>}
-      <LayoutScroll>
-        <article css={[innerContentStyle, cssContent]}>{children}</article>
-      </LayoutScroll>
-      {sidebar && <aside css={asideStyle}>{sidebar}</aside>}
-    </main>
-  </>
-);
-
-const HEADER_HEIGHT = 60;
-
-const layoutStyle = css({
-  display: 'flex',
-  alignItems: 'stretch',
-  maxHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
-  marginTop: HEADER_HEIGHT,
-  backgroundColor: theme.background.default,
-  '.dark-theme &': {
-    backgroundColor: theme.background.screen,
-  },
-  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
-    // Ditch inner scroll on mobile, which results in weird bugs
-    maxHeight: 'none',
-  },
-});
-
-const headerStyle = css({
-  position: 'fixed',
-  top: 0,
-  width: '100%',
-  height: HEADER_HEIGHT,
-  zIndex: 100,
-});
-
-const navigationStyle = css({
-  flexBasis: 256,
-  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
-    display: 'none',
-  },
-});
-
-const innerContentStyle = css({
-  margin: '0 auto',
-  minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`,
-  maxWidth: breakpoints.large,
-  padding: `${spacing[8]}px ${spacing[4]}px`,
-});
-
-const asideStyle = css({
-  flexBasis: 288,
-  [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
-    display: 'none',
-  },
-});
+  className,
+}: LayoutProps) {
+  return (
+    <>
+      <header className="fixed top-0 w-full h-[60px] z-[100]">{header}</header>
+      <main
+        className={mergeClasses('flex items-stretch mt-[60px]', 'max-md-gutters:max-h-[unset]')}>
+        {navigation && <nav className="basis-[256px] max-md-gutters:hidden">{navigation}</nav>}
+        <LayoutScroll>
+          <article
+            className={mergeClasses(
+              'mx-auto min-h-[calc(100vh-60px)] max-w-screen-lg py-8 px-4',
+              className
+            )}>
+            {children}
+          </article>
+        </LayoutScroll>
+        {sidebar && <aside className="basis-[288px] max-md-gutters:hidden">{sidebar}</aside>}
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
# Why

Another batch of Emotion styling rewrite.

# How

Rewrite the error page and it's layout using Tailwind, small appearance tweaks.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-06-12 at 13 30 07](https://github.com/expo/expo/assets/719641/224c250b-a1ea-44e5-8edf-68661d89acc5)

