### PR TITLE
fix(cli): fix asset ID for static web exports

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix assetId for static web assets.
+- Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix assetId for static web assets.
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
@@ -59,7 +59,7 @@ describe(persistMetroAssetsAsync, () => {
     it(`adds files to persist without writing to disk`, async () => {
       const files = new Map();
 
-      await persistMetroAssetsAsync(assets, {
+      await persistMetroAssetsAsync('/', assets, {
         outputDirectory: '/output',
         platform: 'ios',
         files,
@@ -79,7 +79,7 @@ describe(persistMetroAssetsAsync, () => {
     });
 
     it(`writes files that match virtual output`, async () => {
-      await persistMetroAssetsAsync(assets, {
+      await persistMetroAssetsAsync('/', assets, {
         outputDirectory: '/output',
         platform: 'ios',
       });

--- a/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
@@ -71,6 +71,12 @@ describe(persistMetroAssetsAsync, () => {
         'assets/input/asset@3x.png',
       ]);
 
+      expect(files.get('assets/input/asset.png')).toEqual({
+        assetId: expect.stringContaining('input/asset.png'),
+        contents: expect.any(Buffer),
+        targetDomain: undefined,
+      });
+
       expect(Object.keys(vol.toJSON())).toEqual([
         '/input/a.png',
         '/input/a@2x.png',

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -75,7 +75,7 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
     // NOTE(EvanBacon): This may need to be adjusted in the future if want to support baseUrl on native
     // platforms when doing production embeds (unlikely).
     options.assetsDest
-      ? persistMetroAssetsAsync(assets, {
+      ? persistMetroAssetsAsync(projectRoot, assets, {
           platform: options.platform,
           outputDirectory: options.assetsDest,
           iosAssetCatalogDirectory: options.assetCatalogDest,

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -3,8 +3,8 @@ import fs from 'fs';
 import minimatch from 'minimatch';
 import path from 'path';
 
-import { persistMetroAssetsAsync } from './persistMetroAssets';
-import type { Asset, ExportAssetMap, BundleOutput } from './saveAssets';
+import { getAssetIdForLogGrouping, persistMetroAssetsAsync } from './persistMetroAssets';
+import type { Asset, BundleAssetWithFileHashes, BundleOutput, ExportAssetMap } from './saveAssets';
 import * as Log from '../log';
 import { resolveGoogleServicesFile } from '../start/server/middleware/resolveAssets';
 import { uniqBy } from '../utils/array';
@@ -145,7 +145,7 @@ export async function exportAssetsAsync(
     });
   }
 
-  const assets: Asset[] = uniqBy(
+  const assets: BundleAssetWithFileHashes[] = uniqBy(
     Object.values(bundles).flatMap((bundle) => bundle!.assets),
     (asset) => asset.hash
   );
@@ -176,11 +176,7 @@ export async function exportAssetsAsync(
 
     // Add assets to copy.
     filteredAssets.forEach((asset) => {
-      const assetId =
-        'fileSystemLocation' in asset
-          ? path.relative(projectRoot, path.join(asset.fileSystemLocation, asset.name)) +
-            (asset.type ? '.' + asset.type : '')
-          : undefined;
+      const assetId = getAssetIdForLogGrouping(projectRoot, asset);
 
       asset.files.forEach((fp: string, index: number) => {
         const hash = asset.fileHashes[index];

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -137,7 +137,7 @@ export async function exportAssetsAsync(
   if (web) {
     // Save assets like a typical bundler, preserving the file paths on web.
     // TODO: Update React Native Web to support loading files from asset hashes.
-    await persistMetroAssetsAsync(web.assets, {
+    await persistMetroAssetsAsync(projectRoot, web.assets, {
       files,
       platform: 'web',
       outputDirectory: outputDir,

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -203,7 +203,7 @@ export async function exportFromServerAsync(
   if (resources.assets) {
     // TODO: Collect files without writing to disk.
     // NOTE(kitten): Re. above, this is now using `files` except for iOS catalog output, which isn't used here
-    await persistMetroAssetsAsync(resources.assets, {
+    await persistMetroAssetsAsync(projectRoot, resources.assets, {
       files,
       platform,
       outputDirectory: outputDir,

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -88,16 +88,10 @@ export async function persistMetroAssetsAsync(
         const src = asset.files[idx];
         const dest = getAssetLocalPath(asset, { platform, scale, baseUrl });
         if (files) {
-          const assetId =
-            'fileSystemLocation' in asset
-              ? path.relative(projectRoot, path.join(asset.fileSystemLocation, asset.name)) +
-                (asset.type ? '.' + asset.type : '')
-              : undefined;
-
           const data = await fs.promises.readFile(src);
           files.set(dest, {
             contents: data,
-            assetId,
+            assetId: getAssetIdForLogGrouping(projectRoot, asset),
             targetDomain: platform === 'web' ? 'client' : undefined,
           });
         } else {
@@ -110,6 +104,16 @@ export async function persistMetroAssetsAsync(
   if (!files) {
     await copyInBatchesAsync(batches);
   }
+}
+
+export function getAssetIdForLogGrouping(
+  projectRoot: string,
+  asset: Partial<Pick<AssetData, 'fileSystemLocation' | 'name' | 'type'>>
+): string | undefined {
+  return 'fileSystemLocation' in asset && asset.fileSystemLocation != null && asset.name != null
+    ? path.relative(projectRoot, path.join(asset.fileSystemLocation, asset.name)) +
+        (asset.type ? '.' + asset.type : '')
+    : undefined;
 }
 
 function writeImageSet(imageSet: ImageSet): void {


### PR DESCRIPTION
# Why

Ensure static web assets show up in the `Exporting XXX assets:` section of the `expo export` logging.

```
assets/images/expo-icon.40f0e5c9ca5e1a6a455403ae6e0ea488.png (3 variations | 1.04 kB)
```

