### PR TITLE
[gha] Add workflow that publishes canaries

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -1,0 +1,55 @@
+name: Publish Canaries
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/publish-canaries.yml
+  schedule:
+    - cron: 0 1 * * * # Nightly at 1:00 AM UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
+      - name: 🧶 Install workspace node modules
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🧶 Install modules in tools dir
+        if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
+        run: yarn install --ignore-scripts --frozen-lockfile
+        working-directory: tools
+      - name: 📦 Publish canaries
+        run: ./bin/expotools publish-packages --canary --dry
+        env:
+          FORCE_COLOR: '2'
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+        with:
+          channel: '#expo-sdk'
+          status: ${{ job.status }}
+          fields: job,message,author,took
+          author_name: Publish Canaries

--- a/tools/src/publish-packages/tasks/packPackageToTarball.ts
+++ b/tools/src/publish-packages/tasks/packPackageToTarball.ts
@@ -31,7 +31,7 @@ export const packPackageToTarball = new Task<TaskArgs>(
           return;
         } catch (error) {
           step.fail();
-          logger.error(error);
+          logger.error(error.stderr);
           return Task.STOP;
         }
       },


### PR DESCRIPTION
# Why

It's the first version of the workflow that will be regularly publishing canaries. So far it's just running `et publish --canary --dry` every night so that we'll know if the packages can be packed (`npm pack`) without issues.

# How

Created a new workflow that can be manually dispatched and is scheduled to dispatch every night at 1:00 AM UTC time

# Test Plan

Workflow run: https://github.com/expo/expo/actions/runs/9484936952/job/26135686834