### PR TITLE
[ios] Reduce warnings

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2394,7 +2394,7 @@ SPEC CHECKSUMS:
   ExpoSymbols: 5adb1166f2929fc8d2497b98d5c48c4b94effe33
   ExpoSystemUI: b5ecc4b6781b6369fb8b3a0903bea36fae3dd090
   ExpoTrackingTransparency: 005340638bbd48449066a6c1a54ee44ae65ed7b4
-  ExpoVideo: 9a2fab6c628895324232b99483cf1c130d482c38
+  ExpoVideo: 73a2ca98c0c432fe81ede97816656d4246c0b450
   ExpoVideoThumbnails: 40c737b2507a7470b14e9452e286513beb9a7d77
   ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
   EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
@@ -2407,7 +2407,7 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   Google-Maps-iOS-Utils: f77eab4c4326d7e6a277f8e23a0232402731913a
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -63,5 +63,7 @@ func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception 
     return RequestFailedException()
   case .notInteractive:
     return RequestNotInteractiveException()
+  @unknown default:
+    return RequestUnknownException()
   }
 }

--- a/packages/expo-asset/ios/AssetModule.swift
+++ b/packages/expo-asset/ios/AssetModule.swift
@@ -62,12 +62,11 @@ public class AssetModule: Module {
       promise.reject(UnableToSaveAssetToDirectoryException(url))
       return
     }
-    do {
-      try fileSystem.ensureDirExists(withPath: localUrl.path)
-    } catch {
+    if !fileSystem.ensureDirExists(withPath: localUrl.path) {
       promise.reject(UnableToSaveAssetToDirectoryException(localUrl))
       return
     }
+  
     guard fileSystem.permissions(forURI: localUrl).contains(EXFileSystemPermissionFlags.write) else {
       promise.reject(UnableToSaveAssetToDirectoryException(localUrl))
       return

--- a/packages/expo-asset/ios/AssetModule.swift
+++ b/packages/expo-asset/ios/AssetModule.swift
@@ -66,7 +66,7 @@ public class AssetModule: Module {
       promise.reject(UnableToSaveAssetToDirectoryException(localUrl))
       return
     }
-  
+
     guard fileSystem.permissions(forURI: localUrl).contains(EXFileSystemPermissionFlags.write) else {
       promise.reject(UnableToSaveAssetToDirectoryException(localUrl))
       return

--- a/packages/expo-calendar/ios/CalendarExceptions.swift
+++ b/packages/expo-calendar/ios/CalendarExceptions.swift
@@ -20,7 +20,7 @@ internal class CalendarNotSavedException: GenericException<String> {
 
 internal class EntityNotSupportedException: GenericException<String?> {
   override var reason: String {
-    "Calendar entityType \(param) is not supported"
+    "Calendar entityType \(String(describing: param)) is not supported"
   }
 }
 
@@ -56,7 +56,7 @@ internal class ReminderNotFoundException: GenericException<String> {
 
 internal class InvalidCalendarEntityException: GenericException<String?> {
   override var reason: String {
-    "Calendar entityType \(param) is not supported"
+    "Calendar entityType \(String(describing: param)) is not supported"
   }
 }
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -45,7 +45,7 @@ public class CalendarModule: Module {
       guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
         throw DefaultCalendarNotFoundException()
       }
-      return serializeCalendar(calendar: defaultCalendar) as [String : Any]
+      return serializeCalendar(calendar: defaultCalendar) as [String: Any]
     }
 
     AsyncFunction("saveCalendarAsync") { (details: CalendarRecord) -> String in

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -45,7 +45,7 @@ public class CalendarModule: Module {
       guard let defaultCalendar = eventStore.defaultCalendarForNewEvents else {
         throw DefaultCalendarNotFoundException()
       }
-      return serializeCalendar(calendar: defaultCalendar)
+      return serializeCalendar(calendar: defaultCalendar) as [String : Any]
     }
 
     AsyncFunction("saveCalendarAsync") { (details: CalendarRecord) -> String in

--- a/packages/expo-calendar/ios/CalendarUtils.swift
+++ b/packages/expo-calendar/ios/CalendarUtils.swift
@@ -28,7 +28,7 @@ func createRecurrenceRule(rule: RecurrenceRule) -> EKRecurrenceRule? {
   guard ["daily", "weekly", "monthly", "yearly"].contains(rule.frequency) else {
     return nil
   }
-  var endDate = parse(date: rule.endDate)
+  let endDate = parse(date: rule.endDate)
 
   let daysOfTheWeek = rule.daysOfTheWeek?.map { day in
     EKRecurrenceDayOfWeek(day.dayOfTheWeek.toEKType(), weekNumber: day.weekNumber)

--- a/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
@@ -23,7 +23,7 @@ public class CalendarPermissionsRequester: NSObject, EXPermissionsRequester {
       return "NSCalendarsUsageDescription"
     }()
 
-    if let calendarUsageDescription = Bundle.main.object(forInfoDictionaryKey: description) {
+    if Bundle.main.object(forInfoDictionaryKey: description) != nil {
       permissions = EKEventStore.authorizationStatus(for: .event)
     } else {
       EXFatal(MissingCalendarPListValueException(description))

--- a/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
@@ -23,7 +23,7 @@ public class RemindersPermissionRequester: NSObject, EXPermissionsRequester {
       return "NSRemindersUsageDescription"
     }()
 
-    if let remindersUsageDescription = Bundle.main.object(forInfoDictionaryKey: description) {
+    if Bundle.main.object(forInfoDictionaryKey: description) != nil {
       permissions = EKEventStore.authorizationStatus(for: .reminder)
     } else {
       EXFatal(MissingCalendarPListValueException(description))

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -32,7 +32,7 @@ internal class CameraSavingImageException: Exception {
 
 internal class CameraRecordingException: GenericException<String?> {
   override var reason: String {
-    "Video Codec '\(param)' is not supported on this device"
+    "Video Codec '\(String(describing: param))' is not supported on this device"
   }
 }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -361,7 +361,7 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
         photoSettings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
       }
 
-      var requestedFlashMode = self.flashMode.toDeviceFlashMode()
+      let requestedFlashMode = self.flashMode.toDeviceFlashMode()
       if photoOutput.supportedFlashModes.contains(requestedFlashMode) {
         photoSettings.flashMode = requestedFlashMode
       }

--- a/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
+++ b/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
@@ -544,7 +544,7 @@ public class CameraViewLegacy: ExpoView, EXCameraInterface, EXAppLifecycleListen
       guard let exifDict = metadata[kCGImagePropertyExifDictionary as String] as? NSDictionary else {
         return
       }
-      var updatedExif = ExpoCameraUtils.updateExif(
+      let updatedExif = ExpoCameraUtils.updateExif(
         metadata: exifDict,
         with: ["Orientation": ExpoCameraUtils.toExifOrientation(orientation: takenImage.imageOrientation)]
       )
@@ -581,7 +581,7 @@ public class CameraViewLegacy: ExpoView, EXCameraInterface, EXAppLifecycleListen
         if updatedMetadata[kCGImagePropertyGPSDictionary as String] == nil {
           updatedMetadata[kCGImagePropertyGPSDictionary as String] = gpsDict
         } else {
-          if var metadataGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? NSMutableDictionary {
+          if let metadataGpsDict = updatedMetadata[kCGImagePropertyGPSDictionary as String] as? NSMutableDictionary {
             metadataGpsDict.addEntries(from: gpsDict)
           }
         }

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -109,6 +109,6 @@ public class CellularModule: Module {
       }
       return providers.values.first
     }
-    return netinfo.subscriberCellularProvider
+    return netinfo.serviceSubscriberCellularProviders?.first?.value
   }
 }

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -103,12 +103,12 @@ public class CellularModule: Module {
   static func currentCarrier() -> CTCarrier? {
     let netinfo = CTTelephonyNetworkInfo()
 
-    if #available(iOS 12.0, *), let providers = netinfo.serviceSubscriberCellularProviders {
+    if let providers = netinfo.serviceSubscriberCellularProviders {
       for carrier in providers.values where carrier.carrierName != nil {
         return carrier
       }
       return providers.values.first
     }
-    return netinfo.serviceSubscriberCellularProviders?.first?.value
+    return nil
   }
 }

--- a/packages/expo-cellular/ios/CellularModule.swift
+++ b/packages/expo-cellular/ios/CellularModule.swift
@@ -92,12 +92,7 @@ public class CellularModule: Module {
 
   static func currentRadioAccessTechnology() -> String? {
     let netinfo = CTTelephonyNetworkInfo()
-
-    if #available(iOS 12.0, *) {
-      return netinfo.serviceCurrentRadioAccessTechnology?.values.first
-    } else {
-      return netinfo.currentRadioAccessTechnology
-    }
+    return netinfo.serviceCurrentRadioAccessTechnology?.values.first
   }
 
   static func currentCarrier() -> CTCarrier? {

--- a/packages/expo-clipboard/ios/ClipboardExceptions.swift
+++ b/packages/expo-clipboard/ios/ClipboardExceptions.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 
 internal class InvalidImageException: GenericException<String> {
   override var reason: String {
-    "Invalid base64 image: \(param.prefix(32))\(param.count ?? 0 > 32 ? "..." : "")"
+    "Invalid base64 image: \(param.prefix(32))\(param.count > 32 ? "..." : "")"
   }
 }
 

--- a/packages/expo-clipboard/ios/ClipboardOptions.swift
+++ b/packages/expo-clipboard/ios/ClipboardOptions.swift
@@ -10,7 +10,7 @@ internal struct GetImageOptions: Record {
   var jpegQuality: Double = 1.0
 }
 
-internal enum ImageFormat: String, EnumArgument {
+internal enum ImageFormat: String, Enumerable {
   case jpeg
   case png
 
@@ -34,7 +34,7 @@ internal struct SetStringOptions: Record {
   var inputFormat: StringFormat = .plainText
 }
 
-internal enum StringFormat: String, EnumArgument {
+internal enum StringFormat: String, Enumerable {
   case plainText
   case html
 }

--- a/packages/expo-clipboard/ios/ClipboardPasteButton.swift
+++ b/packages/expo-clipboard/ios/ClipboardPasteButton.swift
@@ -69,7 +69,7 @@ class ClipboardPasteButton: ExpoView {
 
           self.onPastePressed([
             "type": "text",
-            "text": data?.absoluteString
+            "text": data?.absoluteString as Any
           ])
         }
       } else if provider.hasItemConformingToTypeIdentifier(UTType.html.identifier) && acceptedContentTypes.contains(.html) {
@@ -87,7 +87,7 @@ class ClipboardPasteButton: ExpoView {
             return
           }
 
-          guard let data = data as? String else {
+          guard let data else {
             log.error("Failed to read text data")
             return
           }
@@ -126,11 +126,6 @@ class ClipboardPasteButton: ExpoView {
       return
     }
 
-    guard let fileSystem = appContext?.fileSystem else {
-      log.error("Failed to access FileSystem")
-      return
-    }
-
     let imageData = "data:\(imageOptions.imageFormat.getMimeType());base64,\(data.base64EncodedString())"
     self.onPastePressed([
       "type": "image",
@@ -143,7 +138,7 @@ class ClipboardPasteButton: ExpoView {
   }
 
   private func processHtml(data: String?) {
-    guard let htmlString = data as? String else {
+    guard let htmlString = data else {
       log.error("Failed to read html data")
       return
     }

--- a/packages/expo-clipboard/ios/UIPasteboard+html.swift
+++ b/packages/expo-clipboard/ios/UIPasteboard+html.swift
@@ -10,7 +10,7 @@ extension UIPasteboard {
         return htmlString
       }
 
-      if let rtfData = self.data(forPasteboardType: kUTTypeRTF as String) as? Data {
+      if let rtfData = self.data(forPasteboardType: kUTTypeRTF as String) {
         let attributedString = try? NSAttributedString(data: rtfData,
                                                        options: [
                                                          .documentType: NSAttributedString.DocumentType.rtf
@@ -32,8 +32,8 @@ extension UIPasteboard {
         return
       }
       let item: [String: Any] = [
-        kUTTypeRTF as String: attributedString.rtfData,
-        kUTTypeHTML as String: attributedString.htmlString,
+        kUTTypeRTF as String: attributedString.rtfData as Any,
+        kUTTypeHTML as String: attributedString.htmlString as Any,
         kUTTypeUTF8PlainText as String: attributedString.string
       ]
 

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -32,7 +32,7 @@ internal class FailedToSaveException: Exception {
 
 internal class FilePermissionException: GenericException<String?> {
   override var reason: String {
-    "File '\(param)' isn't readable."
+    "File '\(String(describing: param))' isn't readable."
   }
 }
 

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -27,7 +27,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       let keys = contactKeysToFetch(from: options.fields)
       let payload = fetchContactsData(options: options, keys: keys, isWriting: true)
 
-      if let error = payload["error"] {
+      if payload["error"] != nil {
         throw FailedToFetchContactsException()
       }
 
@@ -167,7 +167,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       let saveRequest = CNSaveRequest()
       let keysToFetch = contactKeysToFetch(from: nil)
 
-      if var contact = try getContact(with: identifier, keysToFetch: keysToFetch) {
+      if let contact = try getContact(with: identifier, keysToFetch: keysToFetch) {
         let group = try group(with: groupId)
         saveRequest.addMember(contact, to: group)
         try executeSaveRequest(saveRequest)
@@ -210,7 +210,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     AsyncFunction("updateGroupNameAsync") { (groupName: String, groupId: String) in
       let saveRequest = CNSaveRequest()
       let group = try group(with: groupId)
-      guard var mutatbleGroup = group as? CNMutableGroup else {
+      guard let mutatbleGroup = group as? CNMutableGroup else {
         return
       }
       mutatbleGroup.name = groupName
@@ -230,7 +230,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
 
     AsyncFunction("createGroupAsync") { (name: String, containerId: String) -> String in
       let saveRequest = CNSaveRequest()
-      var group = CNMutableGroup()
+      let group = CNMutableGroup()
       group.name = name
       saveRequest.add(group, toContainerWithIdentifier: containerId)
       try executeSaveRequest(saveRequest)
@@ -382,7 +382,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
   }
 
   private func serializeContactPayload(payload: [String: Any], keys: [String], options: ContactsQuery) throws -> [String: Any]? {
-    if let error = payload["error"] {
+    if payload["error"] != nil {
       return nil
     }
     var mutablePayload = payload
@@ -411,7 +411,6 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
 
   private func group(with identifier: String) throws -> CNGroup {
     let predicate = CNGroup.predicateForGroups(withIdentifiers: [identifier])
-    var error: NSError?
 
     do {
       let groups = try contactStore.groups(matching: predicate)
@@ -562,13 +561,13 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       predicate = CNContact.predicateForContacts(withIdentifiers: [containerId])
     }
 
-    var descriptors = getDescriptors(for: keys, isWriting: isWriting)
+    let descriptors = getDescriptors(for: keys, isWriting: isWriting)
     return queryContacts(with: predicate, keys: descriptors, options: options)
   }
 
   private func queryContacts(with predicate: NSPredicate?, keys: [CNKeyDescriptor], options: ContactsQuery) -> [String: Any] {
-    var pageOffset = options.pageOffset ?? 0
-    var pageSize = options.pageSize ?? 0
+    let pageOffset = options.pageOffset ?? 0
+    let pageSize = options.pageSize ?? 0
 
     let fetchRequest = buildFetchRequest(sort: options.sort, keys: keys)
     fetchRequest.predicate = predicate
@@ -579,9 +578,8 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     }
 
     var currentIndex = 0
-    var error: NSError
     var response = [CNContact]()
-    var endIndex = pageOffset + pageSize
+    let endIndex = pageOffset + pageSize
 
     do {
       try contactStore.enumerateContacts(with: fetchRequest) { contact, _ in

--- a/packages/expo-contacts/ios/Decoding.swift
+++ b/packages/expo-contacts/ios/Decoding.swift
@@ -98,7 +98,7 @@ func decodeDates(_ input: [ContactDate]?) -> [CNLabeledValue<NSDateComponents>]?
       continue
     }
 
-    var val = NSDateComponents()
+    let val = NSDateComponents()
     if let day = item.day {
       val.day = day
     }

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -49,7 +49,7 @@ func decodePhoneLabel(_ label: String?) -> String? {
     return nil
   }
 
-  var decodedLabel = decodeLabel(label: label)
+  let decodedLabel = decodeLabel(label: label)
   switch decodedLabel {
   case CNLabeledValue<NSString>.localizedString(forLabel: CNLabelPhoneNumberMain):
     return CNLabelPhoneNumberMain
@@ -200,7 +200,7 @@ func getDescriptors(for fields: [String]?, isWriting: Bool = false) -> [CNKeyDes
 }
 
 func serializeContact(person: CNContact, keys: [String]?, directory: URL?) throws -> [String: Any] {
-  var keysToFetch = keys ?? contactKeysToFetch(from: nil)
+  let keysToFetch = keys ?? contactKeysToFetch(from: nil)
   var contact = [String: Any]()
 
   contact[ContactsKey.id] = person.identifier
@@ -409,7 +409,7 @@ private func socialProfilesFor(contact person: CNContact) -> [[String: Any]]? {
     profile["userId"] = val.userIdentifier
     profile["id"] = container.identifier
     if let label = container.label {
-      profile["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label) ?? label
+      profile["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
     }
     results.append(profile)
   }
@@ -566,7 +566,7 @@ private func calendarFormatToString(_ identifier: Calendar.Identifier) -> String
 
 func encodeContainer(_ container: CNContainer) -> [String: Any] {
   return [
-    "name": container.name ?? "",
+    "name": container.name,
     "id": container.identifier,
     "type": encodeContainerType(container.type)
   ]

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -70,7 +70,7 @@ private func getRandomValues(array: TypedArray) throws -> TypedArray {
 
 private func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
   let outputPtr = output.rawPointer.assumingMemoryBound(to: UInt8.self)
-  let _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
+  _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
 }
 
 private class LossyConversionException: Exception {

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -69,9 +69,8 @@ private func getRandomValues(array: TypedArray) throws -> TypedArray {
 }
 
 private func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
-  let length = Int(algorithm.digestLength)
   let outputPtr = output.rawPointer.assumingMemoryBound(to: UInt8.self)
-  algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
+  let _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
 }
 
 private class LossyConversionException: Exception {

--- a/packages/expo-crypto/ios/DigestAlgorithm.swift
+++ b/packages/expo-crypto/ios/DigestAlgorithm.swift
@@ -9,7 +9,7 @@ typealias DigestFunction = (
   _ md: UnsafeMutablePointer<UInt8>?
 ) -> UnsafeMutablePointer<UInt8>?
 
-internal enum DigestAlgorithm: String, EnumArgument {
+internal enum DigestAlgorithm: String, Enumerable {
   case md2 = "MD2"
   case md4 = "MD4"
   case md5 = "MD5"

--- a/packages/expo-crypto/ios/DigestOptions.swift
+++ b/packages/expo-crypto/ios/DigestOptions.swift
@@ -6,7 +6,7 @@ internal struct DigestOptions: Record {
   @Field
   var encoding: Encoding = .hex
 
-  internal enum Encoding: String, EnumArgument {
+  internal enum Encoding: String, Enumerable {
     case hex = "hex"
     case base64 = "base64"
   }

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -116,7 +116,7 @@ public class DocumentPickerModule: Module, PickingResultHandler {
       throw Exceptions.FileSystemModuleNotFound()
     }
 
-    guard let fileSize = try? getFileSize(path: documentUrl) else {
+    guard let fileSize = getFileSize(path: documentUrl) else {
       throw InvalidFileException()
     }
 

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -26,7 +26,7 @@ public class HapticsModule: Module {
     .runOnQueue(.main)
   }
 
-  enum NotificationType: String, EnumArgument {
+  enum NotificationType: String, Enumerable {
     case success
     case warning
     case error
@@ -43,7 +43,7 @@ public class HapticsModule: Module {
     }
   }
 
-  enum ImpactStyle: String, EnumArgument {
+  enum ImpactStyle: String, Enumerable {
     case light
     case medium
     case heavy

--- a/packages/expo-image-manipulator/ios/ImageManipulatorArguments.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorArguments.swift
@@ -69,7 +69,7 @@ internal struct ManipulateOptions: Record {
 /**
  Possible options for flip action.
  */
-internal enum FlipType: String, EnumArgument {
+internal enum FlipType: String, Enumerable {
   case vertical
   case horizontal
 }
@@ -77,7 +77,7 @@ internal enum FlipType: String, EnumArgument {
 /**
  Enum with supported image formats.
  */
-internal enum ImageFormat: String, EnumArgument {
+internal enum ImageFormat: String, Enumerable {
   case jpeg
   case jpg
   case png

--- a/packages/expo-image-picker/ios/ImagePickerOptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerOptions.swift
@@ -57,7 +57,7 @@ internal struct ImagePickerOptions: Record {
   var orderedSelection: Bool = false
 }
 
-internal enum PresentationStyle: String, EnumArgument {
+internal enum PresentationStyle: String, Enumerable {
   case fullScreen
   case pageSheet
   case formSheet
@@ -96,7 +96,7 @@ internal enum PresentationStyle: String, EnumArgument {
   }
 }
 
-internal enum PreferredAssetRepresentationMode: String, EnumArgument {
+internal enum PreferredAssetRepresentationMode: String, Enumerable {
   case automatic
   case compatible
   case current
@@ -114,7 +114,7 @@ internal enum PreferredAssetRepresentationMode: String, EnumArgument {
   }
 }
 
-internal enum VideoQuality: Int, EnumArgument {
+internal enum VideoQuality: Int, Enumerable {
   case typeHigh = 0
   case typeMedium = 1
   case typeLow = 2
@@ -140,7 +140,7 @@ internal enum VideoQuality: Int, EnumArgument {
   }
 }
 
-internal enum MediaType: String, EnumArgument {
+internal enum MediaType: String, Enumerable {
   case all = "All"
   case videos = "Videos"
   case images = "Images"
@@ -170,7 +170,7 @@ internal enum MediaType: String, EnumArgument {
   }
 }
 
-internal enum VideoExportPreset: Int, EnumArgument {
+internal enum VideoExportPreset: Int, Enumerable {
   case passthrough = 0
   case lowQuality = 1
   case mediumQuality = 2
@@ -211,7 +211,7 @@ internal enum VideoExportPreset: Int, EnumArgument {
   }
 }
 
-internal enum CameraType: String, EnumArgument {
+internal enum CameraType: String, Enumerable {
   case back
   case front
 }

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -127,7 +127,7 @@ internal struct MediaHandler {
       do {
         guard error == nil,
               let rawData = rawData,
-              let image = try? UIImage(data: rawData) else {
+              let image = UIImage(data: rawData) else {
           return completion(index, .failure(FailedToReadImageException().causedBy(error)))
         }
 
@@ -237,7 +237,7 @@ internal struct MediaHandler {
     itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [self] url, error in
       do {
         guard error == nil,
-              let videoUrl = url as? URL else {
+              let videoUrl = url else {
           return completion(index, .failure(FailedToReadVideoException().causedBy(error)))
         }
 
@@ -618,9 +618,7 @@ private struct ImageUtils {
       if cropRect != nil {
         cgImage = cgImage.cropping(to: cropRect!)!
       }
-      if quality != nil {
-        frameProperties[kCGImageDestinationLossyCompressionQuality as String] = quality
-      }
+      frameProperties[kCGImageDestinationLossyCompressionQuality as String] = quality
       CGImageDestinationAddImage(imageDestination, cgImage, frameProperties as CFDictionary)
     }
 

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -237,7 +237,7 @@ internal struct MediaHandler {
     itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { [self] url, error in
       do {
         guard error == nil,
-              let videoUrl = url else {
+        let videoUrl = url else {
           return completion(index, .failure(FailedToReadVideoException().causedBy(error)))
         }
 

--- a/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
+++ b/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
@@ -59,10 +59,10 @@ public class LocalAuthenticationModule: Module {
 
     AsyncFunction("authenticateAsync") { (options: LocalAuthenticationOptions, promise: Promise) -> Void in
       var warningMessage: String?
-      var reason = options.promptMessage
-      var cancelLabel = options.cancelLabel
-      var fallbackLabel = options.fallbackLabel
-      var disableDeviceFallback = options.disableDeviceFallback
+      let reason = options.promptMessage
+      let cancelLabel = options.cancelLabel
+      let fallbackLabel = options.fallbackLabel
+      let disableDeviceFallback = options.disableDeviceFallback
 
       if isFaceIdDevice() {
         let usageDescription = Bundle.main.object(forInfoDictionaryKey: "NSFaceIDUsageDescription")
@@ -94,7 +94,7 @@ public class LocalAuthenticationModule: Module {
           return promise.resolve([
             "success": false,
             "error": "missing_usage_description",
-            "warning": warningMessage
+            "warning": warningMessage as Any
           ])
         }
       }
@@ -108,8 +108,8 @@ public class LocalAuthenticationModule: Module {
 
         return promise.resolve([
           "success": success,
-          "error": err,
-          "warning": warningMessage
+          "error": err as Any,
+          "warning": warningMessage as Any
         ])
       }
     }

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -203,7 +203,7 @@ public class LocalizationModule: Module {
   }
 
   static func getCalendars() -> [[String: Any?]] {
-    var calendar = Locale.current.calendar
+    let calendar = Locale.current.calendar
     return [
       [
         "calendar": getUnicodeCalendarIdentifier(calendar: calendar),

--- a/packages/expo-mail-composer/ios/MailComposerModule.swift
+++ b/packages/expo-mail-composer/ios/MailComposerModule.swift
@@ -20,7 +20,7 @@ public class MailComposerModule: Module {
         throw OperationInProgressException()
       }
       guard let appContext = self.appContext else {
-        throw AppContextLostException()
+        throw Exceptions.AppContextLost()
       }
 
       let session = MailComposingSession(appContext)

--- a/packages/expo-maps/ios/ExpoMaps/PropsData.swift
+++ b/packages/expo-maps/ios/ExpoMaps/PropsData.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-enum MapType: String, EnumArgument {
+enum MapType: String, Enumerable {
   case normal
   case hybrid
   case satellite
@@ -8,7 +8,7 @@ enum MapType: String, EnumArgument {
 }
 
 // TODO: unify with google maps
-enum POICategoryType: String, EnumArgument {
+enum POICategoryType: String, Enumerable {
   case airport
   case atm
   case bank
@@ -70,18 +70,18 @@ struct PatternItem: Record {
   @Field var length: Float = 1.0
 }
 
-enum PatternType: String, EnumArgument {
+enum PatternType: String, Enumerable {
   case stroke
   case gap
 }
 
-enum Joint: String, EnumArgument {
+enum Joint: String, Enumerable {
   case miter
   case round
   case bevel
 }
 
-enum Cap: String, EnumArgument {
+enum Cap: String, Enumerable {
   case butt
   case round
   case square

--- a/packages/expo-media-library/ios/MediaLibraryModule.swift
+++ b/packages/expo-media-library/ios/MediaLibraryModule.swift
@@ -419,7 +419,6 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
       promise.reject(MediaLibraryPermissionsException())
       return false
     }
-    let permission = permissions.hasGrantedPermission(usingRequesterClass: requesterClass(self.writeOnly))
     if !permissions.hasGrantedPermission(usingRequesterClass: requesterClass(self.writeOnly)) {
       promise.reject(MediaLibraryPermissionsException())
       return false

--- a/packages/expo-modules-core/ios/Core/Events/EventDispatcher.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventDispatcher.swift
@@ -63,7 +63,7 @@ internal func installEventDispatcher<ViewType>(forEvent eventName: String, onVie
     return isEventDispatcherWithName($0, eventName)
   }
 
-  if var eventDispatcher = child?.value as? EventDispatcher {
+  if let eventDispatcher = child?.value as? EventDispatcher {
     eventDispatcher.handler = handler
   } else if let view = view as? UIView, view.responds(to: Selector(eventName)) {
     // This is to handle events in legacy views written in Objective-C.

--- a/packages/expo-modules-core/ios/Core/Events/LegacyEventEmitterCompat.swift
+++ b/packages/expo-modules-core/ios/Core/Events/LegacyEventEmitterCompat.swift
@@ -11,7 +11,7 @@ public final class LegacyEventEmitterCompat: EXEventEmitterService {
   // swiftlint:disable:next implicitly_unwrapped_optional
   public func sendEvent(withName name: String!, body: Any!) {
     guard let appContext, let runtime = try? appContext.runtime else {
-      log.warn("Unable to send an event '\(name)' because the runtime is not available")
+      log.warn("Unable to send an event '\(String(describing: name))' because the runtime is not available")
       return
     }
 

--- a/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
@@ -40,7 +40,7 @@ public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptVal
    */
   private func call(withArguments arguments: [Any] = [], asConstructor: Bool = false, usingThis this: JavaScriptObject? = nil) throws -> ReturnType {
     guard let appContext else {
-      throw AppContextLostException()
+      throw Exceptions.AppContextLost()
     }
     let value = rawFunction.call(withArguments: arguments, thisObject: this, asConstructor: false)
     let dynamicType = ~ReturnType.self

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -68,7 +68,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   }
 
   public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
-    let _ = try appContext.runtime
+    _ = try appContext.runtime
 
     decorateWithConstants(object: object)
     try decorateWithFunctions(object: object, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -68,7 +68,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   }
 
   public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
-    let runtime = try appContext.runtime
+    let _ = try appContext.runtime
 
     decorateWithConstants(object: object)
     try decorateWithFunctions(object: object, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -68,8 +68,6 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   }
 
   public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
-    _ = try appContext.runtime
-
     decorateWithConstants(object: object)
     try decorateWithFunctions(object: object, appContext: appContext)
     try decorateWithProperties(object: object, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -46,7 +46,7 @@ public extension SharedObject { // swiftlint:disable:this no_grouping_extension
   /**
    Schedules an event with the given name and arguments to be emitted to the associated JavaScript object.
    */
-  public func emit<each A: AnyArgument>(event: String, arguments: repeat each A) {
+  func emit<each A: AnyArgument>(event: String, arguments: repeat each A) {
     guard let appContext, let runtime = try? appContext.runtime else {
       log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
       return

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -87,7 +87,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
       fatalError(Exceptions.AppContextLost().reason)
     }
     guard let view = wrappedModuleHolder.definition.view?.createView(appContext: appContext) else {
-      fatalError("Cannot create a view from module '\(self.name)'")
+      fatalError("Cannot create a view from module '\(String(describing: self.name))'")
     }
     return view
   }
@@ -112,7 +112,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
       // so there is no other way to pass it to the instances.
       let wrappedModuleBlock: @convention(block) () -> ViewModuleWrapper = { module }
       let wrappedModuleImp: IMP = imp_implementationWithBlock(wrappedModuleBlock)
-      class_addMethod(wrapperClass, Selector("wrappedModule"), wrappedModuleImp, "@@:")
+      class_addMethod(wrapperClass, #selector(DynamicModuleWrapperProtocol.wrappedModule), wrappedModuleImp, "@@:")
 
       return wrapperClass as? ViewModuleWrapper.Type
     }

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
@@ -75,6 +75,7 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
   }
 
   @objc
+  @discardableResult
   public func ensureDirExists(withPath path: String) -> Bool {
     let url = URL(fileURLWithPath: path)
     return FileSystemUtilities.ensureDirExists(at: url)

--- a/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptRuntime.swift
@@ -64,7 +64,7 @@ public extension JavaScriptRuntime {
   /**
    Schedules a block to be executed with granted synchronized access to the JS runtime.
    */
-  public func schedule(priority: SchedulerPriority = .normal, _ closure: @escaping () -> Void) {
+  func schedule(priority: SchedulerPriority = .normal, _ closure: @escaping () -> Void) {
     __schedule(closure, priority: priority.rawValue)
   }
 }

--- a/packages/expo-print/ios/ExpoPrintToFile.swift
+++ b/packages/expo-print/ios/ExpoPrintToFile.swift
@@ -33,18 +33,17 @@ public class ExpoPrintToFile {
       }
 
       let uri = URL(fileURLWithPath: filePath)
-      let error: Error
 
       guard let data = data else {
         promise.resolve(PdfSavingException())
         return
       }
       do {
-        let success = try data.write(to: uri)
+        try data.write(to: uri)
         let base64Data = options.base64 ? data.base64EncodedString(options: Data.Base64EncodingOptions.endLineWithLineFeed) : nil
         let result = FilePrintResult(uri: uri.absoluteString, numberOfPages: pagesNumber, base64: base64Data)
         promise.resolve(result)
-      } catch let error {
+      } catch {
         promise.reject(PdfSavingException())
       }
     }
@@ -74,7 +73,7 @@ public class ExpoPrintToFile {
     printableRect: CGRect,
     onFinished: @escaping (_: Data, _: Int, _: Error?, _: ExpoWKPDFRenderer?) -> Void
   ) {
-    let formatter = UIMarkupTextPrintFormatter(markupText: htmlString ?? "")
+    let formatter = UIMarkupTextPrintFormatter(markupText: htmlString)
     let renderer = UIPrintPageRenderer()
     renderer.addPrintFormatter(formatter, startingAtPageAt: 0)
 

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -192,8 +192,6 @@ public final class SecureStoreModule: Module {
       return kSecAttrAccessibleAlwaysThisDeviceOnly
     case .whenUnlockedThisDeviceOnly:
       return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-    default:
-      return kSecAttrAccessibleWhenUnlocked
     }
   }
 

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -39,7 +39,7 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      appContext?.permissions?.getPermissionUsingRequesterClass(
+      permissionsManager.getPermissionUsingRequesterClass(
         EXMotionPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
@@ -50,7 +50,7 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      appContext?.permissions?.askForPermission(
+      permissionsManager.askForPermission(
         usingRequesterClass: EXMotionPermissionRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
@@ -61,7 +61,7 @@ public final class PedometerModule: Module {
       guard let permissionsManager = appContext?.permissions else {
         return
       }
-      appContext?.permissions?.register([EXMotionPermissionRequester()])
+      permissionsManager.register([EXMotionPermissionRequester()])
     }
 
     OnStartObserving {

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -57,7 +57,7 @@ public class VideoThumbnailsModule: Module {
     }
 
     guard let fileUrl else {
-      throw ImageWriteFailedException("Unrecognized url \(fileUrl?.path)")
+      throw ImageWriteFailedException("Unrecognized url \(String(describing: fileUrl?.path))")
     }
 
     do {

--- a/packages/expo-video/ios/ContentKeyDelegate.swift
+++ b/packages/expo-video/ios/ContentKeyDelegate.swift
@@ -57,7 +57,7 @@ internal class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
       let assetIdString = findAssetIdString(keyRequest: keyRequest, videoSource: videoSource),
       let assetIdData = assetIdString.data(using: .utf8)
     else {
-      throw DRMLoadException("Failed to find the asset id for request: \(keyRequest.identifier)")
+      throw DRMLoadException("Failed to find the asset id for request: \(String(describing: keyRequest.identifier))")
     }
 
     let applicationCertificate = try self.requestApplicationCertificate(keyRequest: keyRequest)
@@ -123,7 +123,7 @@ internal class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
       throw DRMLoadException("Application certificate data received from \(url.absoluteString) is empty")
     }
 
-    guard let applicationCertificate = SecCertificateCreateWithData(nil, data as CFData) else {
+    guard SecCertificateCreateWithData(nil, data as CFData) != nil else {
       throw DRMLoadException("The application certificate received from the server is invalid")
     }
 
@@ -153,17 +153,17 @@ internal class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
 
     if let headers = videoSource?.drm?.headers {
       for item in headers {
-        guard let key = item.key as? String, let value = item.value as? String else {
+        guard let value = item.value as? String else {
           continue
         }
-        ckcRequest.setValue(value, forHTTPHeaderField: key)
+        ckcRequest.setValue(value, forHTTPHeaderField: item.key)
       }
     }
 
     let (data, response, error) = URLSession.shared.synchronousDataTask(with: ckcRequest)
 
     guard error == nil else {
-      throw DRMLoadException("Fetching the content key has failed with error: \(error?.localizedDescription)")
+      throw DRMLoadException("Fetching the content key has failed with error: \(String(describing: error?.localizedDescription))")
     }
 
     if let httpResponse = response as? HTTPURLResponse {
@@ -191,7 +191,7 @@ internal class ContentKeyDelegate: NSObject, AVContentKeySessionDelegate {
 
 // https://stackoverflow.com/questions/26784315/can-i-somehow-do-a-synchronous-http-request-via-nsurlsession-in-swift
 private extension URLSession {
-  internal func synchronousDataTask(with urlRequest: URLRequest) -> (data: Data?, response: URLResponse?, error: Error?) {
+  func synchronousDataTask(with urlRequest: URLRequest) -> (data: Data?, response: URLResponse?, error: Error?) {
     var data: Data?
     var response: URLResponse?
     var error: Error?

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -155,7 +155,7 @@ class VideoPlayerObserver {
     playbackLikelyToKeepUpObserver?.invalidate()
     playbackBufferEmptyObserver?.invalidate()
     playerItemStatusObserver?.invalidate()
-    NotificationCenter.default.removeObserver(playerItemObserver)
+    NotificationCenter.default.removeObserver(playerItemObserver as Any)
   }
 
   // MARK: - VideoPlayerObserverDelegate

--- a/packages/expo-web-browser/ios/WebBrowserOptions.swift
+++ b/packages/expo-web-browser/ios/WebBrowserOptions.swift
@@ -29,7 +29,7 @@ struct AuthSessionOptions: Record {
   var preferEphemeralSession: Bool = false
 }
 
-enum DismissButtonStyle: String, EnumArgument {
+enum DismissButtonStyle: String, Enumerable {
   case done
   case close
   case cancel
@@ -46,7 +46,7 @@ enum DismissButtonStyle: String, EnumArgument {
   }
 }
 
-internal enum PresentationStyle: String, EnumArgument {
+internal enum PresentationStyle: String, Enumerable {
   case fullScreen
   case pageSheet
   case formSheet


### PR DESCRIPTION
# Why
Follow up of #29677. There is a lot of warnings coming from our packages. Most of these are simple fixes.

# How
- Swap `var` for `let`
- Remove unnecessary casts
- Use `Enumerable` instead of `EnumArgument` (we can drop this?)
- Unnecessary `try`
- Incomplete switch statements (there is still a lot of these)
- Implicit string casts
- Some deprecations
- Redundant access modifiers

This isn't everything but a good start. Many of the warnings come from react native

# Test Plan
Tested all affected modules in bare-expo. Everything seems fine

