### PR TITLE
[docs] minor tweaks for API Reference pages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -17,6 +17,7 @@ import {
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { PlatformTag } from '~/ui/components/Tag';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -105,8 +106,8 @@ Learn how to configure the native projects in the [installation instructions in 
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
-- **(_iOS only_)** `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
+- <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -51,7 +51,7 @@ Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`)
 
 #### iOS
 
-You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+You can redirect an app user to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
 
 ```ts iOS App Store example
 const itunesItemId = 982107779;

--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -35,25 +35,11 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 
 ### Write reviews
 
-#### iOS
-
-You can redirect someone to the "Write a Review" screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
-
-```ts
-const itunesItemId = 982107779;
-// Open the iOS App Store in the browser -> redirects to App Store on iOS
-Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
-// Open the iOS App Store directly
-Linking.openURL(
-  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
-);
-```
-
 #### Android
 
 There is no equivalent redirect on Android, you can still open the Play Store to the reviews sections using the query parameter `showAllReviews=true` like this:
 
-```ts
+```ts Android Play Store example
 const androidPackageName = 'host.exp.exponent';
 // Open the Android Play Store in the browser -> redirects to Play Store on Android
 Linking.openURL(
@@ -61,6 +47,20 @@ Linking.openURL(
 );
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
+```
+
+#### iOS
+
+You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+
+```ts iOS App Store example
+const itunesItemId = 982107779;
+// Open the iOS App Store in the browser -> redirects to App Store on iOS
+Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
+// Open the iOS App Store directly
+Linking.openURL(
+  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
+);
 ```
 
 ## API

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -17,6 +17,7 @@ import {
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { PlatformTag } from '~/ui/components/Tag';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -99,8 +100,8 @@ Learn how to configure the native projects in the [installation instructions in 
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
-- **(_iOS only_)** `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/v49.0.0/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
+- <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/v49.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/storereview.mdx
@@ -39,25 +39,11 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 
 ### Write reviews
 
-#### iOS
-
-You can redirect someone to the "Write a Review" screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
-
-```ts
-const itunesItemId = 982107779;
-// Open the iOS App Store in the browser -> redirects to App Store on iOS
-Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
-// Open the iOS App Store directly
-Linking.openURL(
-  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
-);
-```
-
 #### Android
 
 There is no equivalent redirect on Android, you can still open the Play Store to the reviews sections using the query parameter `showAllReviews=true` like this:
 
-```ts
+```ts Android Play Store example
 const androidPackageName = 'host.exp.exponent';
 // Open the Android Play Store in the browser -> redirects to Play Store on Android
 Linking.openURL(
@@ -65,6 +51,20 @@ Linking.openURL(
 );
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
+```
+
+#### iOS
+
+You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+
+```ts iOS App Store example
+const itunesItemId = 982107779;
+// Open the iOS App Store in the browser -> redirects to App Store on iOS
+Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
+// Open the iOS App Store directly
+Linking.openURL(
+  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
+);
 ```
 
 ## API

--- a/docs/pages/versions/v49.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/storereview.mdx
@@ -55,7 +55,7 @@ Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`)
 
 #### iOS
 
-You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+You can redirect an app user to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
 
 ```ts iOS App Store example
 const itunesItemId = 982107779;

--- a/docs/pages/versions/v50.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/location.mdx
@@ -17,6 +17,7 @@ import {
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { PlatformTag } from '~/ui/components/Tag';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -107,8 +108,8 @@ Learn how to configure the native projects in the [installation instructions in 
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
-- **(_iOS only_)** `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/v50.0.0/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
+- <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/v50.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/storereview.mdx
@@ -37,25 +37,11 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 
 ### Write reviews
 
-#### iOS
-
-You can redirect someone to the "Write a Review" screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
-
-```ts
-const itunesItemId = 982107779;
-// Open the iOS App Store in the browser -> redirects to App Store on iOS
-Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
-// Open the iOS App Store directly
-Linking.openURL(
-  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
-);
-```
-
 #### Android
 
 There is no equivalent redirect on Android, you can still open the Play Store to the reviews sections using the query parameter `showAllReviews=true` like this:
 
-```ts
+```ts Android Play Store example
 const androidPackageName = 'host.exp.exponent';
 // Open the Android Play Store in the browser -> redirects to Play Store on Android
 Linking.openURL(
@@ -63,6 +49,20 @@ Linking.openURL(
 );
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
+```
+
+#### iOS
+
+You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+
+```ts iOS App Store example
+const itunesItemId = 982107779;
+// Open the iOS App Store in the browser -> redirects to App Store on iOS
+Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
+// Open the iOS App Store directly
+Linking.openURL(
+  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
+);
 ```
 
 ## API

--- a/docs/pages/versions/v50.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/storereview.mdx
@@ -53,7 +53,7 @@ Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`)
 
 #### iOS
 
-You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+You can redirect an app user to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
 
 ```ts iOS App Store example
 const itunesItemId = 982107779;

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -17,6 +17,7 @@ import {
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { PlatformTag } from '~/ui/components/Tag';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -105,8 +106,8 @@ Learn how to configure the native projects in the [installation instructions in 
 To use Background Location methods, the following requirements apply:
 
 - Location permissions must be granted. On iOS it must be granted with `Always` option.
-- **(_iOS only_)** `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 - Background location task must be defined in the top-level scope, using [`TaskManager.defineTask`](task-manager.mdx#taskmanagerdefinetasktaskname-taskexecutor).
+- <PlatformTag platform="ios" className="float-left" /> `"location"` background mode must be specified in **Info.plist** file. See [background tasks configuration guide](/versions/latest/sdk/task-manager/#configuration-in-appjsonappconfigjs).
 
 ### Geofencing methods
 

--- a/docs/pages/versions/v51.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/storereview.mdx
@@ -51,7 +51,7 @@ Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`)
 
 #### iOS
 
-You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+You can redirect an app user to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
 
 ```ts iOS App Store example
 const itunesItemId = 982107779;

--- a/docs/pages/versions/v51.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/storereview.mdx
@@ -35,25 +35,11 @@ It is important that you follow the [Human Interface Guidelines](https://develop
 
 ### Write reviews
 
-#### iOS
-
-You can redirect someone to the "Write a Review" screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
-
-```ts
-const itunesItemId = 982107779;
-// Open the iOS App Store in the browser -> redirects to App Store on iOS
-Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
-// Open the iOS App Store directly
-Linking.openURL(
-  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
-);
-```
-
 #### Android
 
 There is no equivalent redirect on Android, you can still open the Play Store to the reviews sections using the query parameter `showAllReviews=true` like this:
 
-```ts
+```ts Android Play Store example
 const androidPackageName = 'host.exp.exponent';
 // Open the Android Play Store in the browser -> redirects to Play Store on Android
 Linking.openURL(
@@ -61,6 +47,20 @@ Linking.openURL(
 );
 // Open the Android Play Store directly
 Linking.openURL(`market://details?id=${androidPackageName}&showAllReviews=true`);
+```
+
+#### iOS
+
+You can redirect someone to the **"Write a Review"** screen for an app in the iOS App Store by using the query parameter `action=write-review`. For example:
+
+```ts iOS App Store example
+const itunesItemId = 982107779;
+// Open the iOS App Store in the browser -> redirects to App Store on iOS
+Linking.openURL(`https://apps.apple.com/app/apple-store/id${itunesItemId}?action=write-review`);
+// Open the iOS App Store directly
+Linking.openURL(
+  `itms-apps://itunes.apple.com/app/viewContentsUserReviews/id${itunesItemId}?action=write-review`
+);
 ```
 
 ## API


### PR DESCRIPTION
# Why

Set of minor tweaks for API Reference pages based on things spotted when working on API rendering improvements.

# How

The following changes have been made:
* reorder StoreReview platform requirements and examples, add titles to the code blocks
* replace italic label with inline platform tag on Location pages

# Test Plan

The changes have been reviewed locally. All lint checks are passing.

# Preview

![Screenshot 2024-06-12 at 14 41 06](https://github.com/expo/expo/assets/719641/b8b8aeb7-a63d-4229-9487-5e2704261434)
![Screenshot 2024-06-12 at 14 41 25](https://github.com/expo/expo/assets/719641/ac246249-3787-462d-8858-a1a83d1d5807)
