### PR TITLE
[capture][Android] Fix module was crashing in the dev-client when going back to the home screen

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `ScreenCaptureModule` was crashing in the dev-client when going back to the home screen.
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `ScreenCaptureModule` was crashing in the dev-client when going back to the home screen.
+- [Android] Fix `ScreenCaptureModule` was crashing in the dev-client when going back to the home screen. ([#29694](https://github.com/expo/expo/pull/29694) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -17,8 +17,10 @@ const val eventName = "onScreenshot"
 class ScreenCaptureModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
+  private val safeCurrentActivity
+    get() = appContext.currentActivity
   private val currentActivity
-    get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = safeCurrentActivity ?: throw Exceptions.MissingActivity()
   private var screenCaptureCallback: Activity.ScreenCaptureCallback? = null
   private var screenshotEventEmitter: ScreenshotEventEmitter? = null
   private var isRegistered = false
@@ -78,7 +80,7 @@ class ScreenCaptureModule : Module() {
       screenshotEventEmitter?.onHostDestroy()
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         screenCaptureCallback?.let {
-          currentActivity.unregisterScreenCaptureCallback(it)
+          safeCurrentActivity?.unregisterScreenCaptureCallback(it)
         }
       }
     }


### PR DESCRIPTION
# Why

Fixes module was crashing in the dev-client when going back to the home screen.

# How

When we go to the home screen, the current activity might not be available anymore.
