### PR TITLE
fix(cli): resolve module specifiers to posix paths on Windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Fix source map generation in development. ([#29463](https://github.com/expo/expo/pull/29463) by [@EvanBacon](https://github.com/EvanBacon))
+- Resolve module specifiers to posix paths for Metro. ([#29696](https://github.com/expo/expo/pull/29696) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -62,6 +62,7 @@ import {
 import { ServeStaticMiddleware } from '../middleware/ServeStaticMiddleware';
 import {
   ExpoMetroOptions,
+  convertPathToModuleSpecifier,
   createBundleUrlPath,
   getAsyncRoutesFromExpoConfig,
   getBaseUrlFromExpoConfig,
@@ -168,7 +169,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
                   typeof source === 'string' && source.startsWith(this.projectRoot)
                     ? path.relative(this.projectRoot, source)
                     : source;
-                return source.split(path.sep).join('/');
+                return convertPathToModuleSpecifier(source);
               }),
               sourcesContent: new Array(parsedMap.sources.length).fill(null),
               names: parsedMap.names,
@@ -261,7 +262,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const platform = 'web';
 
     const resolvedMainModuleName =
-      mainModuleName ?? '.' + path.sep + resolveMainModuleName(this.projectRoot, { platform });
+      mainModuleName ?? './' + resolveMainModuleName(this.projectRoot, { platform });
     return await this.metroImportAsArtifactsAsync(resolvedMainModuleName, {
       splitChunks: isExporting && !env.EXPO_NO_BUNDLE_SPLITTING,
       platform,
@@ -476,7 +477,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
     const opts: ExpoMetroOptions = {
       // TODO: Possibly issues with using an absolute path here...
-      mainModuleName: filePath,
+      mainModuleName: convertPathToModuleSpecifier(filePath),
       lazy: false,
       asyncRoutes: false,
       inlineSourceMap: false,
@@ -545,8 +546,8 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     };
 
     // https://github.com/facebook/metro/blob/2405f2f6c37a1b641cc379b9c733b1eff0c1c2a1/packages/metro/src/lib/parseOptionsFromUrl.js#L55-L87
-    if (!opts.mainModuleName.startsWith(path.sep)) {
-      opts.mainModuleName = '.' + path.sep + opts.mainModuleName;
+    if (!opts.mainModuleName.startsWith('/')) {
+      opts.mainModuleName = './' + opts.mainModuleName;
     }
 
     const output = await this.metroLoadModuleContents(opts.mainModuleName, opts, extraOptions);
@@ -1204,7 +1205,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     }
   ) {
     assert(this.metro, 'cannot invoke resolveRelativePathAsync without metro instance');
-    return await this.metro._resolveRelativePath(moduleId, {
+    return await this.metro._resolveRelativePath(convertPathToModuleSpecifier(moduleId), {
       relativeTo: 'server',
       resolverOptions,
       transformOptions,

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -17,6 +17,7 @@ import {
   getBaseUrlFromExpoConfig,
   getAsyncRoutesFromExpoConfig,
   createBundleUrlPathFromExpoConfig,
+  convertPathToModuleSpecifier,
 } from './metroOptions';
 import { resolveGoogleServicesFile, resolveManifestAssets } from './resolveAssets';
 import { parsePlatformHeader, RuntimePlatform } from './resolvePlatform';
@@ -77,7 +78,7 @@ export function resolveMainModuleName(
 
   debug(`Resolved entry point: ${entryPoint} (project root: ${projectRoot})`);
 
-  return stripExtension(entryPoint, 'js');
+  return convertPathToModuleSpecifier(stripExtension(entryPoint, 'js'));
 }
 
 /** Info about the computer hosting the dev server. */

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -298,3 +298,15 @@ export function createBundleUrlPath(options: ExpoMetroOptions): string {
 
   return `/${encodeURI(mainModuleName)}.bundle?${queryParams.toString()}`;
 }
+
+/**
+ * Convert all path separators to `/`, including on Windows.
+ * Metro asumes that all module specifiers are posix paths.
+ * References to directories can still be Windows-style paths in Metro.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#importing_features_into_your_script
+ * @see https://github.com/facebook/metro/pull/1286
+ */
+export function convertPathToModuleSpecifier(pathLike: string) {
+  return pathLike.replaceAll('\\', '/');
+}


### PR DESCRIPTION
# Why

Fixes #29631
Related https://github.com/facebook/metro/pull/1286

# How

- Added `convertPathToModuleSpecifier` to **src/start/server/middleware/metroOptions.ts**
- Replaced all `'.' + path.sep + ...` statements with posix notation (`'./' + ...`) in **src/start/server/metro/MetroBundlerDevServer.ts**
- Added `convertPathToModuleSpecifier` to all module references related to resolve in **src/start/server/metro/MetroBundlerDevServer.ts**

# Test Plan

Run this PR on Windows.

- `$ npx create-expo-app ./test-windows`
- `$ cd ./test-windows`
- `$ npx expo export --platform web`
- Should work without throwing errors like #29631

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
