### PR TITLE
[menu][Android] Fix `disableOnboarding=1` wasn't working when using the dev-client

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -10,10 +10,10 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactContext
+import expo.interfaces.devmenu.ReactHostWrapper
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.modules.devlauncher.helpers.DevLauncherMetadataHelper
 import expo.modules.devlauncher.helpers.DevLauncherUrl
-import expo.interfaces.devmenu.ReactHostWrapper
 import expo.modules.devlauncher.helpers.getFieldInClassHierarchy
 import expo.modules.devlauncher.helpers.hasUrlQueryParam
 import expo.modules.devlauncher.helpers.isDevLauncherUrl
@@ -157,7 +157,7 @@ class DevLauncherController private constructor() :
       manifest = appLoaderFactory.getManifest()
       manifestURL = parsedUrl
 
-      setupDevMenu()
+      setupDevMenu(url.toString())
 
       val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
       lifecycle.addListener(appLoaderListener)
@@ -292,14 +292,16 @@ class DevLauncherController private constructor() :
     }
   }
 
-  private fun setupDevMenu() {
+  private fun setupDevMenu(launchUrl: String) {
     devMenuManager.currentManifest = manifest
     devMenuManager.currentManifestURL = manifestURL.toString()
+    devMenuManager.launchUrl = launchUrl
   }
 
   private fun invalidateDevMenu() {
     devMenuManager.currentManifest = null
     devMenuManager.currentManifestURL = null
+    devMenuManager.launchUrl = null
   }
 
   @UiThread

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client.
+- [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client.
+
 ### 💡 Others
 
 ## 5.0.14 — 2024-05-09

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -70,6 +70,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   var currentManifest: Manifest? = null
   var currentManifestURL: String? = null
+  var launchUrl: String? = null
 
   //region helpers
 
@@ -223,7 +224,7 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
       testInterceptor.overrideSettings()
         ?: DevMenuPreferencesHandle(reactContext)
       ).also {
-      if (hasDisableOnboardingQueryParam(currentManifestURL.orEmpty())) {
+      if (hasDisableOnboardingQueryParam(currentManifestURL.orEmpty()) || hasDisableOnboardingQueryParam(launchUrl.orEmpty())) {
         it.isOnboardingFinished = true
       }
     }.also {


### PR DESCRIPTION
# Why

Fixes `disableOnboarding=1` that didn't work when dev-menu was hosted by dev client controller.    

# Test Plan

- bare-expo started using:
```
adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d 'exp+bare-expo://expo-development-client/?url=<url>&disableOnboarding=1'
```
