### PR TITLE
chore(cli): enable playwright tests on Windows for smoke testing

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -117,7 +117,14 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
+        if: ${{ runner.os != 'Windows' }}
         run: yarn install --prefer-offline --frozen-lockfile
+        env:
+          YARN_IGNORE_SCRIPTS: true
+
+      - name: 🧶 Install node modules in root dir (Windows network fix)
+        if: ${{ runner.os == 'Windows' }}
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 100000
         env:
           YARN_IGNORE_SCRIPTS: true
       

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -88,7 +88,11 @@ jobs:
         working-directory: packages/@expo/cli
 
   web:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -113,7 +117,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        run: YARN_IGNORE_SCRIPTS=true yarn install --prefer-offline --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
+        env:
+          YARN_IGNORE_SCRIPTS: true
       
       - name: Build Expo CLI
         run: yarn workspace @expo/cli prepare


### PR DESCRIPTION
# Why

#29696 turned out to be caused by Windows-specific incompatibilities with Metro. Having just the playwright tests enabled might help us validate these issues earlier on.

# How

- Only enabled playwright tests on Windows

# Test Plan

See GitHub Actions

- Before Windows patch: https://github.com/expo/expo/actions/runs/9484576260/job/26134384348
- After Windows patch: TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
