### PR TITLE
chore: do not sort search results alphabetically

### DIFF
--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -69,7 +69,7 @@ function SearchScreen({ route }: StackScreenProps<SearchStack, 'search'>) {
     []
   );
 
-  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} />;
+  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} sort={false} />;
 }
 
 type SearchStack = {


### PR DESCRIPTION
# Why

search results in the bare-expo app are sorted alphabetically (after being returned from the search algo which already provides them in the right order), which kinda doesn't make sense :)

# How

disable sorting using an existing prop

# Test Plan

tested locally

# Checklist

N/A

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
