### PR TITLE
[docs] exclude methods passed type in Table of Content links

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -79,13 +79,15 @@ const DocumentationSidebarRightLink = forwardRef<HTMLAnchorElement, SidebarLinkP
 );
 
 /**
- * Replaces `Module.someFunction(arguments: argType)` with `someFunction()`
+ * Replaces `Module.someFunction<T>(arguments: argType)` with `someFunction()`
  */
 const trimCodedTitle = (str: string) => {
   if (!str.includes('...')) {
     const dotIdx = str.indexOf('.');
     if (dotIdx > 0) str = str.substring(dotIdx + 1);
   }
+
+  str = str.replace(/<.+>/g, '');
 
   const parIdx = str.indexOf('(');
   if (parIdx > 0) str = str.substring(0, parIdx + 1) + ')';


### PR DESCRIPTION
# Why

In some case we pass lengthy type names in definitions, which hurt the readability, let's hide the types in Table of Content entries, as we do for params.

# How

Exclude passed type annotation when rendering Table of Content link display text.

# Test Plan

The changes have been reviewed locally, all lint checks are passing.

# Preview

![Screenshot 2024-06-12 at 19 47 43](https://github.com/expo/expo/assets/719641/ec130525-1897-49f9-a88f-3a80667be637)

