### PR TITLE
[workspace] align Testing Library dependencies, fix tests

### DIFF
--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -36,8 +36,8 @@
   "dependencies": {},
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/react-native": "^11.3.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/react-native": "^12.5.1",
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-blur/src/__tests__/BlurView-test.web.tsx
+++ b/packages/expo-blur/src/__tests__/BlurView-test.web.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, getByTestId } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Animated } from 'react-native';
 
@@ -26,8 +26,8 @@ afterAll(() => {
 });
 
 it(`prefers filters to background color`, () => {
-  const withNativeBlur = render(<BlurView tint="light" testID="blur" />);
-  const view = getByTestId(withNativeBlur.container, 'blur');
+  render(<BlurView tint="light" testID="blur" />);
+  const view = screen.getByTestId('blur');
 
   expect(view.style['backdropFilter']).toBeDefined();
 });
@@ -39,8 +39,8 @@ it(`supports Animated API`, () => {
 });
 
 it(`intensity is capped at 100`, () => {
-  const withNativeBlur = render(<BlurView intensity={3737} tint="light" testID="blur" />);
-  const view = getByTestId(withNativeBlur.container, 'blur');
+  render(<BlurView intensity={3737} tint="light" testID="blur" />);
+  const view = screen.getByTestId('blur');
 
   expect(view.style['backdropFilter']).toContain('blur(20px)');
   expect(view.style['backgroundColor']).toContain('0.78');

--- a/packages/expo-checkbox/package.json
+++ b/packages/expo-checkbox/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://docs.expo.dev/versions/latest/sdk/checkbox",
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/react-native": "^11.3.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/react-native": "^12.5.1",
     "expo-module-scripts": "^3.0.0"
   },
   "jest": {

--- a/packages/expo-dev-client-components/package.json
+++ b/packages/expo-dev-client-components/package.json
@@ -32,13 +32,11 @@
     "expo-module-scripts": "^3.0.0"
   },
   "devDependencies": {
-    "@testing-library/jest-native": "^4.0.4",
-    "@testing-library/react-native": "^8.0.0"
+    "@testing-library/react-native": "^12.5.1"
   },
   "jest": {
     "preset": "@testing-library/react-native",
     "setupFilesAfterEnv": [
-      "@testing-library/jest-native/extend-expect",
       "./setupTests.js"
     ]
   }

--- a/packages/expo-dev-launcher/bundle/components/__tests__/DeepLinkModal.test.tsx
+++ b/packages/expo-dev-launcher/bundle/components/__tests__/DeepLinkModal.test.tsx
@@ -65,10 +65,11 @@ describe('<DeepLinkModal />', () => {
 
     await act(async () => {
       expect(loadApp).not.toHaveBeenCalled();
+    });
 
+    await act(async () => {
       const [button] = await waitFor(() => getAllByText(fakeLocalDevSession.description));
       fireEvent.press(button);
-
       expect(loadApp).toHaveBeenCalled();
     });
   });

--- a/packages/expo-dev-launcher/bundle/providers/ToastStackProvider.tsx
+++ b/packages/expo-dev-launcher/bundle/providers/ToastStackProvider.tsx
@@ -104,13 +104,10 @@ function ToastItem(props: StackItem<ToastStackItem>) {
     }
 
     if (status === 'settled') {
-      timerRef.current = setTimeout(
-        () => {
-          pop();
-          timerRef.current = null;
-        },
-        toastProps?.durationMs || 2000
-      );
+      timerRef.current = setTimeout(() => {
+        pop();
+        timerRef.current = null;
+      }, toastProps?.durationMs || 2000);
     }
 
     return () => {

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
@@ -7,7 +7,7 @@ import { BranchesScreen, getIncompatibleBranchMessage } from '../BranchesScreen'
 
 jest.mock('graphql-request', () => {
   return {
-    GraphQLClient(apiUrl: string) {
+    GraphQLClient() {
       return {
         request: jest.fn(),
       };
@@ -200,12 +200,10 @@ describe.skip('<BranchesScreen />', () => {
       },
     });
 
-    const { getByText, queryByText } = renderBranchesScreen(mockNavigation);
+    const { findByText, queryByText } = renderBranchesScreen(mockNavigation);
 
-    await act(async () => {
-      expect(queryByText(getCompatibleBranchMessage(1))).toBe(null);
-      await waitFor(() => getByText(getCompatibleBranchMessage(1)));
-    });
+    expect(queryByText(getCompatibleBranchMessage(1))).toBe(null);
+    await findByText(getCompatibleBranchMessage(1));
   });
 
   test.todo('recent empty branches are visible in the footer');

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/ExtensionsScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/ExtensionsScreen.test.tsx
@@ -100,11 +100,11 @@ describe.skip('<ExtensionsScreen />', () => {
       },
     });
 
-    const { getByA11yLabel } = render(<ExtensionsScreen navigation={mockNavigation} />);
+    const { getByLabelText } = render(<ExtensionsScreen navigation={mockNavigation} />);
 
     await act(async () => {
-      await waitFor(() => getByA11yLabel(/log in/i));
-      await waitFor(() => getByA11yLabel(/sign up/i));
+      await waitFor(() => getByLabelText(/log in/i));
+      await waitFor(() => getByLabelText(/sign up/i));
     });
   });
 

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/ExtensionsScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/ExtensionsScreen.test.tsx
@@ -21,7 +21,7 @@ jest.mock('../../native-modules/DevLauncherInternal', () => {
 
 jest.mock('graphql-request', () => {
   return {
-    GraphQLClient(apiUrl: string) {
+    GraphQLClient() {
       return {
         request: jest.fn(),
       };
@@ -127,14 +127,14 @@ describe.skip('<ExtensionsScreen />', () => {
       compatibleUpdates: [testUpdate],
     });
 
-    const { getByText } = renderAuthenticatedScreen({ mockNavigation });
+    const { findByText } = renderAuthenticatedScreen({ mockNavigation });
 
     await act(async () => {
-      await waitFor(() => getByText(/branch: testBranch/i));
-      await waitFor(() => getByText(/Update "Hello joe"/i));
+      await findByText(/branch: testBranch/i);
+      await findByText(/Update "Hello joe"/i);
       expect(mockNavigation.navigate).not.toHaveBeenCalledTimes(1);
 
-      fireEvent.press(getByText(/hello joe/i));
+      fireEvent.press(await findByText(/hello joe/i));
 
       expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
       expect(mockNavigation.navigate).toHaveBeenCalledWith('Updates', { branchName: 'testBranch' });
@@ -175,12 +175,12 @@ describe.skip('<ExtensionsScreen />', () => {
       },
     });
 
-    const { getByText } = renderAuthenticatedScreen({ mockNavigation });
+    const { findByText } = renderAuthenticatedScreen({ mockNavigation });
 
     await act(async () => {
-      await waitFor(() => getByText(/see all branches/i));
+      await findByText(/see all branches/i);
 
-      fireEvent.press(getByText(/all branches/i));
+      fireEvent.press(await findByText(/all branches/i));
 
       expect(mockNavigation.navigate).toHaveBeenCalledTimes(1);
       expect(mockNavigation.navigate).toHaveBeenCalledWith('Branches');
@@ -206,11 +206,9 @@ describe.skip('<ExtensionsScreen />', () => {
       compatibleUpdates: [],
     });
 
-    const { getByText } = renderAuthenticatedScreen({ mockNavigation });
+    const { findByText } = renderAuthenticatedScreen({ mockNavigation });
 
-    await act(async () => {
-      await waitFor(() => getByText(getCompatibleBranchMessage(1)));
-    });
+    await findByText(getCompatibleBranchMessage(1));
   });
 
   test('eas updates no branches state', async () => {
@@ -226,11 +224,9 @@ describe.skip('<ExtensionsScreen />', () => {
       },
     });
 
-    const { getByText } = renderAuthenticatedScreen({ mockNavigation });
+    const { findByText } = renderAuthenticatedScreen({ mockNavigation });
 
-    await act(async () => {
-      await waitFor(() => getByText(/no published updates yet/i));
-    });
+    await findByText(/no published updates yet/i);
   });
 
   test.todo('eas updates shows error toast');

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/HomeScreen.test.tsx
@@ -40,12 +40,18 @@ describe('<HomeScreen />', () => {
 
   test('displays instructions on starting DevSession when none are found', async () => {
     const { getByText } = renderHomeScreen({ initialDevSessions: [] });
-    await waitFor(() => getByText(devSessionInstructionsRegex));
+
+    await act(async () => {
+      await waitFor(() => getByText(devSessionInstructionsRegex));
+    });
   });
 
   test('displays refetch button', async () => {
     const { getByText } = renderHomeScreen();
-    await waitFor(() => getByText(refetchDevSessionsRegex));
+
+    await act(async () => {
+      await waitFor(() => getByText(refetchDevSessionsRegex));
+    });
   });
 
   test('fetching local DevSessions on mount', async () => {
@@ -71,11 +77,13 @@ describe('<HomeScreen />', () => {
     expect(() => getByText(fakeDevSessions[0].description)).toThrow();
     expect(getDevSessionsAsync).not.toHaveBeenCalled();
 
-    await refetch();
-    expect(getByText(fetchingDevSessionsRegex));
-    expect(getDevSessionsAsync).toHaveBeenCalled();
+    await act(async () => {
+      await refetch();
+      expect(getByText(fetchingDevSessionsRegex));
+      expect(getDevSessionsAsync).toHaveBeenCalled();
 
-    await waitFor(() => getByText(fakeDevSessions[0].description));
+      await waitFor(() => getByText(fakeDevSessions[0].description));
+    });
   });
 
   test('refetching enabled after polling is completed', async () => {
@@ -155,10 +163,10 @@ describe('<HomeScreen />', () => {
   });
 
   test('navigate to user profile', async () => {
-    const { getByA11yLabel } = renderHomeScreen();
+    const { getByLabelText } = renderHomeScreen();
     expect(fakeNavigation.navigate).not.toHaveBeenCalled();
 
-    const button = getByA11yLabel(/to user profile/i);
+    const button = getByLabelText(/to user profile/i);
 
     await act(async () => {
       fireEvent.press(button);

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/SettingsScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/SettingsScreen.test.tsx
@@ -22,17 +22,15 @@ describe('<SettingsScreen />', () => {
       showsAtLaunch: false,
     };
 
-    const { getByLabelText, findAllByRole } = render(<SettingsScreen />, {
+    const { findByLabelText, findAllByRole } = render(<SettingsScreen />, {
       initialAppProviderProps: { initialDevMenuPreferences: testPreferences },
     });
 
-    await act(async () => {
-      const showsAtLaunchButton = getByLabelText(/toggle showing menu/i);
-      expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
+    const showsAtLaunchButton = await findByLabelText(/toggle showing menu/i);
+    expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
 
-      const activeCheckmarks = await findAllByRole('button', { checked: true });
-      expect(activeCheckmarks.length).toEqual(2);
-    });
+    const activeCheckmarks = await findAllByRole('button', { checked: true });
+    expect(activeCheckmarks.length).toEqual(2);
   });
 
   test('shows the correct settings on mount 2', async () => {
@@ -42,81 +40,82 @@ describe('<SettingsScreen />', () => {
       showsAtLaunch: true,
     };
 
-    const { getByLabelText, findAllByRole } = render(<SettingsScreen />, {
+    const { findByLabelText, findAllByRole } = render(<SettingsScreen />, {
       initialAppProviderProps: { initialDevMenuPreferences: testPreferences },
     });
 
-    await act(async () => {
-      const showsAtLaunchButton = getByLabelText(/toggle showing menu/i);
-      expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
+    const showsAtLaunchButton = await findByLabelText(/toggle showing menu/i);
+    expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
 
-      const activeCheckmarks = await findAllByRole('button', { checked: true });
-      expect(activeCheckmarks.length).toEqual(1);
-    });
+    const activeCheckmarks = await findAllByRole('button', { checked: true });
+    expect(activeCheckmarks.length).toEqual(1);
   });
 
   test('toggling shake device', async () => {
-    const { getByText } = render(<SettingsScreen />);
+    const { findByText } = render(<SettingsScreen />);
+
+    const toggle = await findByText(/shake device/i);
 
     await act(async () => {
-      const toggle = getByText(/shake device/i);
       fireEvent.press(toggle);
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ motionGestureEnabled: true });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ motionGestureEnabled: true });
 
     await act(async () => {
-      const toggle = getByText(/shake device/i);
       fireEvent.press(toggle);
-
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ motionGestureEnabled: false });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ motionGestureEnabled: false });
   });
 
   test('toggling gesture press', async () => {
-    const { getByText } = render(<SettingsScreen />);
+    const { findByText } = render(<SettingsScreen />);
+
+    const toggle = await findByText(/three-finger long-press/i);
 
     await act(async () => {
-      const toggle = getByText(/three-finger long-press/i);
       fireEvent.press(toggle);
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ touchGestureEnabled: true });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ touchGestureEnabled: true });
 
     await act(async () => {
-      const toggle = getByText(/three-finger long-press/i);
       fireEvent.press(toggle);
-
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ touchGestureEnabled: false });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ touchGestureEnabled: false });
   });
 
   test('toggling show menu at launch press', async () => {
-    const { getByLabelText } = render(<SettingsScreen />);
+    const { findByLabelText } = render(<SettingsScreen />);
+
+    const toggle = await findByLabelText(/toggle showing menu at launch/i);
 
     await act(async () => {
-      const toggle = getByLabelText(/toggle showing menu at launch/i);
       fireEvent.press(toggle);
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ showsAtLaunch: true });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ showsAtLaunch: true });
 
     await act(async () => {
-      const toggle = getByLabelText(/toggle showing menu at launch/i);
       fireEvent.press(toggle);
-
-      expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
-      expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ showsAtLaunch: false });
     });
+
+    expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
+    expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ showsAtLaunch: false });
   });
 
-  test('displays runtime version when available', () => {
+  test('displays runtime version when available', async () => {
     const fakeRTV = 'TESTING FAKE RTV';
     const fakeSDKVersion = 'TESTING FAKE SDKVersion';
 
-    const { getByText, queryByText } = render(<SettingsScreen />, {
+    const { findByText, queryByText } = render(<SettingsScreen />, {
       initialAppProviderProps: {
         initialBuildInfo: {
           runtimeVersion: fakeRTV,
@@ -125,7 +124,7 @@ describe('<SettingsScreen />', () => {
       },
     });
 
-    getByText(fakeRTV);
+    await findByText(fakeRTV);
     // should not be visible if RTV is there
     expect(queryByText(fakeSDKVersion)).toBe(null);
   });
@@ -154,7 +153,7 @@ describe('<SettingsScreen />', () => {
       sdkVersion: fakeSDKVersion,
     };
 
-    const { getByText } = render(<SettingsScreen />, {
+    const { findByText } = render(<SettingsScreen />, {
       initialAppProviderProps: {
         initialBuildInfo: fakeAppInfo,
       },
@@ -162,7 +161,7 @@ describe('<SettingsScreen />', () => {
 
     expect(copyToClipboardAsync).not.toHaveBeenCalled();
 
-    const button = getByText(/tap to copy all/i);
+    const button = await findByText(/tap to copy all/i);
 
     await act(async () => {
       fireEvent.press(button);

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/SettingsScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/SettingsScreen.test.tsx
@@ -22,15 +22,17 @@ describe('<SettingsScreen />', () => {
       showsAtLaunch: false,
     };
 
-    const { getByA11yLabel, findAllByA11yState } = render(<SettingsScreen />, {
+    const { getByLabelText, findAllByRole } = render(<SettingsScreen />, {
       initialAppProviderProps: { initialDevMenuPreferences: testPreferences },
     });
 
-    const showsAtLaunchButton = getByA11yLabel(/toggle showing menu/i);
-    expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
+    await act(async () => {
+      const showsAtLaunchButton = getByLabelText(/toggle showing menu/i);
+      expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
 
-    const activeCheckmarks = await findAllByA11yState({ checked: true });
-    expect(activeCheckmarks.length).toEqual(2);
+      const activeCheckmarks = await findAllByRole('button', { checked: true });
+      expect(activeCheckmarks.length).toEqual(2);
+    });
   });
 
   test('shows the correct settings on mount 2', async () => {
@@ -40,15 +42,17 @@ describe('<SettingsScreen />', () => {
       showsAtLaunch: true,
     };
 
-    const { getByA11yLabel, findAllByA11yState } = render(<SettingsScreen />, {
+    const { getByLabelText, findAllByRole } = render(<SettingsScreen />, {
       initialAppProviderProps: { initialDevMenuPreferences: testPreferences },
     });
 
-    const showsAtLaunchButton = getByA11yLabel(/toggle showing menu/i);
-    expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
+    await act(async () => {
+      const showsAtLaunchButton = getByLabelText(/toggle showing menu/i);
+      expect(showsAtLaunchButton.props.value).toBe(testPreferences.showsAtLaunch);
 
-    const activeCheckmarks = await findAllByA11yState({ checked: true });
-    expect(activeCheckmarks.length).toEqual(1);
+      const activeCheckmarks = await findAllByRole('button', { checked: true });
+      expect(activeCheckmarks.length).toEqual(1);
+    });
   });
 
   test('toggling shake device', async () => {
@@ -90,17 +94,17 @@ describe('<SettingsScreen />', () => {
   });
 
   test('toggling show menu at launch press', async () => {
-    const { getByA11yLabel } = render(<SettingsScreen />);
+    const { getByLabelText } = render(<SettingsScreen />);
 
     await act(async () => {
-      const toggle = getByA11yLabel(/toggle showing menu at launch/i);
+      const toggle = getByLabelText(/toggle showing menu at launch/i);
       fireEvent.press(toggle);
       expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(1);
       expect(setMenuPreferencesAsync).toHaveBeenLastCalledWith({ showsAtLaunch: true });
     });
 
     await act(async () => {
-      const toggle = getByA11yLabel(/toggle showing menu at launch/i);
+      const toggle = getByLabelText(/toggle showing menu at launch/i);
       fireEvent.press(toggle);
 
       expect(setMenuPreferencesAsync).toHaveBeenCalledTimes(2);
@@ -141,7 +145,7 @@ describe('<SettingsScreen />', () => {
     getByText(fakeSDKVersion);
   });
 
-  test('copies app info to clipboard', () => {
+  test('copies app info to clipboard', async () => {
     const fakeRTV = 'TESTING FAKE RTV';
     const fakeSDKVersion = 'TESTING FAKE SDKVersion';
 
@@ -159,7 +163,10 @@ describe('<SettingsScreen />', () => {
     expect(copyToClipboardAsync).not.toHaveBeenCalled();
 
     const button = getByText(/tap to copy all/i);
-    fireEvent.press(button);
+
+    await act(async () => {
+      fireEvent.press(button);
+    });
 
     expect(copyToClipboardAsync).toHaveBeenCalled();
     expect(copyToClipboardAsync).toHaveBeenLastCalledWith(

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/UpdatesScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/UpdatesScreen.test.tsx
@@ -7,7 +7,7 @@ import { UpdatesScreen } from '../UpdatesScreen';
 
 jest.mock('graphql-request', () => {
   return {
-    GraphQLClient(apiUrl: string) {
+    GraphQLClient() {
       return {
         request: jest.fn(),
       };
@@ -62,7 +62,9 @@ describe('<UpdatesScreen />', () => {
       manifestPermalink: '123',
     };
 
-    mockUpdatesResponse([testUpdate]);
+    act(() => {
+      mockUpdatesResponse([testUpdate]);
+    });
 
     const { queryByText, getByText } = render(
       <UpdatesScreen
@@ -85,7 +87,9 @@ describe('<UpdatesScreen />', () => {
       navigate: jest.fn(),
     };
 
-    mockUpdatesResponse([]);
+    act(() => {
+      mockUpdatesResponse([]);
+    });
 
     const { queryByText, getByText } = render(
       <UpdatesScreen

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
@@ -57,13 +57,13 @@ describe('<UserProfileScreen />', () => {
 
   test('login button starts oauth session and fetches user profile', async () => {
     const sessionSecret = '321';
-    const { getByA11yLabel, getByText } = renderProfileScreen({ sessionSecret });
+    const { getByLabelText, getByText } = renderProfileScreen({ sessionSecret });
 
     expect(startAuthSessionAsync).not.toHaveBeenCalled();
     expect(getUserProfileAsync).not.toHaveBeenCalled();
 
     await act(async () => {
-      const loginButton = getByA11yLabel(/log in/i);
+      const loginButton = getByLabelText(/log in/i);
 
       expect(() => getByText(fakeAccounts[0].ownerUserActor!.username)).toThrow();
 
@@ -83,13 +83,13 @@ describe('<UserProfileScreen />', () => {
   });
 
   test('signup button starts oauth session and fetches user profile', async () => {
-    const { getByA11yLabel, getByText } = renderProfileScreen();
+    const { getByLabelText, getByText } = renderProfileScreen();
 
     expect(startAuthSessionAsync).not.toHaveBeenCalled();
     expect(getUserProfileAsync).not.toHaveBeenCalled();
 
     await act(async () => {
-      const signupButton = getByA11yLabel(/sign up/i);
+      const signupButton = getByLabelText(/sign up/i);
 
       expect(() => getByText(fakeAccounts[0].ownerUserActor!.username)).toThrow();
 
@@ -108,25 +108,25 @@ describe('<UserProfileScreen />', () => {
   });
 
   test('back button navigates to previous screen', async () => {
-    const { getByA11yLabel } = renderProfileScreen();
+    const { getByLabelText } = renderProfileScreen();
 
     expect(mockNavigation.goBack).not.toHaveBeenCalled();
 
     await act(async () => {
-      fireEvent.press(getByA11yLabel(/go back/i));
+      fireEvent.press(getByLabelText(/go back/i));
       expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
     });
   });
 
   test('displays multiple accounts', async () => {
-    const { getByA11yLabel, getByText } = renderProfileScreen();
+    const { getByLabelText, getByText } = renderProfileScreen();
 
     fakeAccounts.forEach((account) => {
       expect(() => getByText(account.ownerUserActor!.username)).toThrow();
     });
 
     await act(async () => {
-      const loginButton = getByA11yLabel(/log in/i);
+      const loginButton = getByLabelText(/log in/i);
       fireEvent.press(loginButton);
 
       await waitFor(() => getByText(fakeAccounts[0].ownerUserActor!.username));
@@ -138,9 +138,9 @@ describe('<UserProfileScreen />', () => {
   });
 
   test('pressing an account changes the selected account', async () => {
-    const { getByA11yLabel, getByText, getByTestId } = renderProfileScreen();
+    const { getByLabelText, getByText, getByTestId } = renderProfileScreen();
 
-    const loginButton = getByA11yLabel(/log in/i);
+    const loginButton = getByLabelText(/log in/i);
 
     await act(async () => {
       fireEvent.press(loginButton);
@@ -155,10 +155,10 @@ describe('<UserProfileScreen />', () => {
   });
 
   test('logout', async () => {
-    const { getByA11yLabel, getByText } = renderProfileScreen();
+    const { getByLabelText, getByText } = renderProfileScreen();
 
     await act(async () => {
-      const loginButton = getByA11yLabel(/log in/i);
+      const loginButton = getByLabelText(/log in/i);
       fireEvent.press(loginButton);
 
       const logoutButton = await waitFor(() => getByText(/log out/i));
@@ -167,7 +167,7 @@ describe('<UserProfileScreen />', () => {
       fireEvent.press(logoutButton);
 
       await waitFor(() => getByText(/are you sure you want to log out/i));
-      const button = getByA11yLabel(/log out/i);
+      const button = getByLabelText(/log out/i);
 
       fireEvent.press(button);
       expect(setSessionAsync).toHaveBeenCalledTimes(1);

--- a/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/UserProfileScreen.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { getUserProfileAsync, UserAccount, UserData } from '../../functions/getUserProfileAsync';
 import { startAuthSessionAsync } from '../../functions/startAuthSessionAsync';
 import { setSessionAsync } from '../../native-modules/DevLauncherAuth';
-import { render, act, fireEvent, waitFor } from '../../test-utils';
+import { render, act, fireEvent } from '../../test-utils';
 import { UserProfileScreen } from '../UserProfileScreen';
 
 jest.mock('../../functions/startAuthSessionAsync');
@@ -57,41 +57,39 @@ describe('<UserProfileScreen />', () => {
 
   test('login button starts oauth session and fetches user profile', async () => {
     const sessionSecret = '321';
-    const { getByLabelText, getByText } = renderProfileScreen({ sessionSecret });
+    const { getByLabelText, getByText, findByText } = renderProfileScreen({ sessionSecret });
 
     expect(startAuthSessionAsync).not.toHaveBeenCalled();
     expect(getUserProfileAsync).not.toHaveBeenCalled();
 
+    const loginButton = getByLabelText(/log in/i);
+    expect(() => getByText(fakeAccounts[0].ownerUserActor!.username)).toThrow();
+
     await act(async () => {
-      const loginButton = getByLabelText(/log in/i);
-
-      expect(() => getByText(fakeAccounts[0].ownerUserActor!.username)).toThrow();
-
       fireEvent.press(loginButton);
-
       expect(startAuthSessionAsync).toHaveBeenCalledTimes(1);
       expect(startAuthSessionAsync).toHaveBeenCalledWith('login');
       expect(getUserProfileAsync).toHaveBeenCalledTimes(0);
       expect(setSessionAsync).toHaveBeenCalledTimes(0);
-
-      await waitFor(() => getByText(fakeAccounts[0].ownerUserActor!.username));
-
-      expect(setSessionAsync).toHaveBeenCalledTimes(1);
-      expect(setSessionAsync).toHaveBeenCalledWith(sessionSecret);
-      expect(getUserProfileAsync).toHaveBeenCalledTimes(1);
     });
+
+    await findByText(fakeAccounts[0].ownerUserActor!.username);
+
+    expect(setSessionAsync).toHaveBeenCalledTimes(1);
+    expect(setSessionAsync).toHaveBeenCalledWith(sessionSecret);
+    expect(getUserProfileAsync).toHaveBeenCalledTimes(1);
   });
 
   test('signup button starts oauth session and fetches user profile', async () => {
-    const { getByLabelText, getByText } = renderProfileScreen();
+    const { findByLabelText, queryByText, findByText } = renderProfileScreen();
 
     expect(startAuthSessionAsync).not.toHaveBeenCalled();
     expect(getUserProfileAsync).not.toHaveBeenCalled();
 
-    await act(async () => {
-      const signupButton = getByLabelText(/sign up/i);
+    const signupButton = await findByLabelText(/sign up/i);
 
-      expect(() => getByText(fakeAccounts[0].ownerUserActor!.username)).toThrow();
+    await act(async () => {
+      expect(queryByText(fakeAccounts[0].ownerUserActor!.username)).toBe(null);
 
       fireEvent.press(signupButton);
 
@@ -100,7 +98,7 @@ describe('<UserProfileScreen />', () => {
       expect(getUserProfileAsync).toHaveBeenCalledTimes(0);
       expect(setSessionAsync).toHaveBeenCalledTimes(0);
 
-      await waitFor(() => getByText(fakeAccounts[0].ownerUserActor!.username));
+      await findByText(fakeAccounts[0].ownerUserActor!.username);
       expect(setSessionAsync).toHaveBeenCalledTimes(1);
       expect(setSessionAsync).toHaveBeenCalledWith(fakeSessionSecret);
       expect(getUserProfileAsync).toHaveBeenCalledTimes(1);
@@ -108,71 +106,80 @@ describe('<UserProfileScreen />', () => {
   });
 
   test('back button navigates to previous screen', async () => {
-    const { getByLabelText } = renderProfileScreen();
+    const { findByLabelText } = renderProfileScreen();
 
     expect(mockNavigation.goBack).not.toHaveBeenCalled();
 
     await act(async () => {
-      fireEvent.press(getByLabelText(/go back/i));
+      fireEvent.press(await findByLabelText(/go back/i));
       expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
     });
   });
 
   test('displays multiple accounts', async () => {
-    const { getByLabelText, getByText } = renderProfileScreen();
+    const { findByLabelText, findByText, queryByText } = renderProfileScreen();
 
     fakeAccounts.forEach((account) => {
-      expect(() => getByText(account.ownerUserActor!.username)).toThrow();
+      expect(queryByText(account.ownerUserActor!.username)).toBe(null);
     });
 
     await act(async () => {
-      const loginButton = getByLabelText(/log in/i);
+      const loginButton = await findByLabelText(/log in/i);
       fireEvent.press(loginButton);
 
-      await waitFor(() => getByText(fakeAccounts[0].ownerUserActor!.username));
+      await findByText(fakeAccounts[0].ownerUserActor!.username);
 
-      fakeAccounts.forEach((account) => {
-        getByText(account.ownerUserActor!.username);
+      fakeAccounts.forEach(async (account) => {
+        await findByText(account.ownerUserActor!.username);
       });
     });
   });
 
   test('pressing an account changes the selected account', async () => {
-    const { getByLabelText, getByText, getByTestId } = renderProfileScreen();
+    const { findByLabelText, findByText, findByTestId, queryByTestId } = renderProfileScreen();
 
-    const loginButton = getByLabelText(/log in/i);
+    const loginButton = await findByLabelText(/log in/i);
 
     await act(async () => {
       fireEvent.press(loginButton);
-      await waitFor(() => getByTestId(`active-account-checkmark-${fakeAccounts[0].id}`));
-
-      expect(() => getByTestId(`active-account-checkmark-${fakeAccounts[1].id}`)).toThrow();
-
-      fireEvent.press(getByText(fakeAccounts[1].ownerUserActor!.username));
-      await waitFor(() => getByTestId(`active-account-checkmark-${fakeAccounts[1].id}`));
-      expect(() => getByTestId(`active-account-checkmark-${fakeAccounts[0].id}`)).toThrow();
     });
+
+    await findByTestId(`active-account-checkmark-${fakeAccounts[0].id}`);
+    expect(queryByTestId(`active-account-checkmark-${fakeAccounts[1].id}`)).toBe(null);
+
+    await act(async () => {
+      fireEvent.press(await findByText(fakeAccounts[1].ownerUserActor!.username));
+    });
+
+    await findByTestId(`active-account-checkmark-${fakeAccounts[1].id}`);
+    expect(queryByTestId(`active-account-checkmark-${fakeAccounts[0].id}`)).toBe(null);
   });
 
   test('logout', async () => {
-    const { getByLabelText, getByText } = renderProfileScreen();
+    const { findByLabelText, findByText } = renderProfileScreen();
+
+    const loginButton = await findByLabelText(/log in/i);
 
     await act(async () => {
-      const loginButton = getByLabelText(/log in/i);
       fireEvent.press(loginButton);
+    });
 
-      const logoutButton = await waitFor(() => getByText(/log out/i));
+    const logoutButton = await findByText(/log out/i);
 
+    await act(async () => {
       mockSetSessionAsync.mockClear();
       fireEvent.press(logoutButton);
-
-      await waitFor(() => getByText(/are you sure you want to log out/i));
-      const button = getByLabelText(/log out/i);
-
-      fireEvent.press(button);
-      expect(setSessionAsync).toHaveBeenCalledTimes(1);
-      expect(setSessionAsync).toHaveBeenLastCalledWith(null);
     });
+
+    await findByText(/are you sure you want to log out/i);
+    const button = await findByLabelText(/log out/i);
+
+    await act(async () => {
+      fireEvent.press(button);
+    });
+
+    expect(setSessionAsync).toHaveBeenCalledTimes(1);
+    expect(setSessionAsync).toHaveBeenLastCalledWith(null);
   });
 
   test.todo('failed login / signup response');

--- a/packages/expo-dev-launcher/bundle/test-utils.tsx
+++ b/packages/expo-dev-launcher/bundle/test-utils.tsx
@@ -11,7 +11,7 @@ type AppProviderOptions = {
 };
 
 export function render(
-  component: React.ReactElement<any>,
+  component: React.ReactElement,
   options: RenderOptions & AppProviderOptions = {}
 ) {
   const { initialAppProviderProps = {}, ...renderOptions } = options;

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -43,7 +43,7 @@
     "@react-navigation/native": "6.0.13",
     "@react-navigation/stack": "6.3.2",
     "@testing-library/jest-native": "^4.0.4",
-    "@testing-library/react-native": "^8.0.0",
+    "@testing-library/react-native": "^12.5.1",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-expo": "~11.0.0",
     "date-fns": "^2.28.0",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -54,7 +54,7 @@
     "@apollo/client": "^3.4.10",
     "@babel/preset-typescript": "^7.7.4",
     "@testing-library/jest-native": "^4.0.4",
-    "@testing-library/react-native": "^8.0.0",
+    "@testing-library/react-native": "^12.5.1",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-expo": "~11.0.0",
     "expo-dev-client-components": "1.8.1",

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -35,8 +35,8 @@
   "homepage": "https://docs.expo.dev/versions/latest/sdk/linear-gradient/",
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/react-native": "^11.3.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/react-native": "^12.5.1",
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-linear-gradient/src/__tests__/LinearGradient-test.web.tsx
+++ b/packages/expo-linear-gradient/src/__tests__/LinearGradient-test.web.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, getByTestId } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { LinearGradient } from '../LinearGradient';
@@ -10,8 +10,8 @@ import { getLinearGradientBackgroundImage } from '../NativeLinearGradient.web';
 
 it(`renders`, () => {
   const colors = ['cyan', '#ff00ff', 'rgba(0,0,0,0)', 'rgba(0,255,255,0.5)'];
-  const component = render(<LinearGradient colors={colors} testID="gradient" />);
-  const view = getByTestId(component.container, 'gradient');
+  render(<LinearGradient colors={colors} testID="gradient" />);
+  const view = screen.getByTestId('gradient');
 
   expect(view).toMatchInlineSnapshot(`
     <div

--- a/packages/expo-localization/src/__tests__/Localization-test.web.ts
+++ b/packages/expo-localization/src/__tests__/Localization-test.web.ts
@@ -96,7 +96,7 @@ describe(`Localization defines constants`, () => {
   it('Gets ISO currency codes', async () => {
     const result = Localization.isoCurrencyCodes;
     validateStringArray(result);
-    result.forEach(res => validateString(res));
+    result.forEach((res) => validateString(res));
   });
   it('Gets the timezone', async () => {
     validateString(Localization.timezone);

--- a/packages/expo-localization/src/__tests__/Localization-test.web.ts
+++ b/packages/expo-localization/src/__tests__/Localization-test.web.ts
@@ -2,9 +2,11 @@ import { Platform } from 'expo-modules-core';
 
 import * as Localization from '../Localization';
 
-function validateString(result) {
+function validateString(result, allowEmpty = false) {
   expect(typeof result).toBe('string');
-  expect(result.length).toBeGreaterThan(0);
+  if (!allowEmpty) {
+    expect(result.length).toBeGreaterThan(0);
+  }
 }
 
 function validateStringArray(result) {
@@ -37,7 +39,7 @@ if (Platform.isDOMAvailable) {
       expect(typeof isRTL).toBe('boolean');
       expect(typeof isMetric).toBe('boolean');
       validateString(decimalSeparator);
-      validateString(digitGroupingSeparator);
+      validateString(digitGroupingSeparator, true);
       expect(currency).toBe(null);
     });
   });
@@ -94,7 +96,7 @@ describe(`Localization defines constants`, () => {
   it('Gets ISO currency codes', async () => {
     const result = Localization.isoCurrencyCodes;
     validateStringArray(result);
-    result.forEach(validateString);
+    result.forEach(res => validateString(res));
   });
   it('Gets the timezone', async () => {
     validateString(Localization.timezone);

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -87,8 +87,8 @@
   "devDependencies": {
     "@react-navigation/drawer": "^6.5.0",
     "@testing-library/jest-native": "^5.4.2",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/react-native": "^12.0.1",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/react-native": "^12.5.1",
     "tsd": "^0.28.1",
     "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610",
     "immer": "^8"

--- a/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
+++ b/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
@@ -34,7 +34,7 @@ describe(useSQLiteContext, () => {
       });
     });
     const firstResult = result.current;
-    await rerender({});
+    rerender({});
     expect(result.current).toBe(firstResult);
   });
 
@@ -64,7 +64,7 @@ describe(useSQLiteContext, () => {
         </View>
       );
     }
-    const wrapper = ({ children }) => (
+    const wrapper = () => (
       <React.Suspense fallback={<LoadingFallback />}>
         <SQLiteProvider databaseName=":memory:" useSuspense>
           <View />
@@ -72,11 +72,8 @@ describe(useSQLiteContext, () => {
       </React.Suspense>
     );
     const { result } = renderHook(() => useSQLiteContext(), { wrapper });
-    await act(async () => {
-      await waitFor(() => {
-        expect(screen.queryByText(loadingText)).not.toBeNull();
-      });
-    });
+
+    expect(screen.queryByText(loadingText)).not.toBeNull();
 
     // Ensure that the loading fallback is removed after the database is ready
     await act(async () => {
@@ -88,16 +85,14 @@ describe(useSQLiteContext, () => {
   });
 
   it('should call onError from SQLiteProvider if failed to open database', async () => {
-    const mockErroHandler = jest.fn();
+    const mockErrorHandler = jest.fn();
     render(
-      <SQLiteProvider databaseName="/nonexistent/nonexistent.db" onError={mockErroHandler}>
+      <SQLiteProvider databaseName="/nonexistent/nonexistent.db" onError={mockErrorHandler}>
         <View />
       </SQLiteProvider>
     );
-    await act(async () => {
-      await waitFor(() => {
-        expect(mockErroHandler).toHaveBeenCalled();
-      });
+    await waitFor(() => {
+      expect(mockErrorHandler).toHaveBeenCalled();
     });
   });
 
@@ -130,24 +125,22 @@ describe(useSQLiteContext, () => {
 
   it('should throw when using `onError` and `useSuspense` together', async () => {
     const restoreConsole = suppressErrorOutput();
-    const mockErroHandler = jest.fn();
+    const mockErrorHandler = jest.fn();
     render(
-      <ErrorBoundary fallback={<View />} onError={mockErroHandler}>
+      <ErrorBoundary fallback={<View />} onError={mockErrorHandler}>
         <SQLiteProvider
           databaseName="/nonexistent/nonexistent.db"
-          onError={mockErroHandler}
+          onError={mockErrorHandler}
           useSuspense>
           <View />
         </SQLiteProvider>
       </ErrorBoundary>
     );
-    await act(async () => {
-      await waitFor(() => {
-        expect(mockErroHandler).toHaveBeenCalled();
-        expect(mockErroHandler.mock.calls[0][0].toString()).toMatch(
-          /Cannot use `onError` with `useSuspense`, use error boundaries instead./
-        );
-      });
+    await waitFor(() => {
+      expect(mockErrorHandler).toHaveBeenCalled();
+      expect(mockErrorHandler.mock.calls[0][0].toString()).toMatch(
+        /Cannot use `onError` with `useSuspense`, use error boundaries instead./
+      );
     });
     restoreConsole();
   });

--- a/packages/expo-status-bar/package.json
+++ b/packages/expo-status-bar/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://docs.expo.dev/versions/latest/sdk/status-bar/",
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/react-native": "^11.3.0",
+    "@testing-library/react": "^15.0.7",
+    "@testing-library/react-native": "^12.5.1",
     "expo-module-scripts": "^3.0.0"
   },
   "jest": {

--- a/packages/expo-status-bar/src/__tests__/Helpers.tsx
+++ b/packages/expo-status-bar/src/__tests__/Helpers.tsx
@@ -26,5 +26,5 @@ export function renderedPropValue(element: any, prop: string) {
   // @ts-ignore: brentvatne: I'm not sure how else to read the props off of a
   // component that renders null in testing-library, so I'm using this fairly
   // brittle internal API.
-  return result.container._fiber.return.child.child.pendingProps[prop];
+  return result.UNSAFE_root._fiber.return.child.child.pendingProps[prop];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,29 +3850,15 @@
   dependencies:
     chokidar "^1.7.0"
 
-"@testing-library/dom@^8.5.0":
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
-  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
-"@testing-library/dom@^9.0.0":
-  version "9.3.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.3.tgz#108c23a5b0ef51121c26ae92eb3179416b0434f5"
-  integrity sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==
+"@testing-library/dom@^10.0.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.1.0.tgz#2d073e49771ad614da999ca48f199919e5176fb6"
+  integrity sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^5.0.1"
-    aria-query "5.1.3"
+    aria-query "5.3.0"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.9"
     lz-string "^1.5.0"
@@ -3927,43 +3913,22 @@
     "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react-native@^11.3.0":
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-11.3.0.tgz#2fedc63ef3a01d80203471e54649c0192b56c965"
-  integrity sha512-wCbH7TJ2uVwtkQPRQTZbM3Y/mzwK5zxwkOPKfR2UdVdz/RtCC2UVyDnJMaBNwG/cNle5tc92sQDfp3Gn2oyftg==
+"@testing-library/react-native@^12.5.1":
+  version "12.5.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-12.5.1.tgz#8ff67e87589d7d3307fce8ec41131c898c9dbd98"
+  integrity sha512-PApr3f6DmSJF/EIiWYZfcBzuy6w7fK8TW4a6KfQHTeAcfZ6lADtRO7R0QM5WI+b7tJ33JvIPgzCg1MiuRz4v0g==
   dependencies:
-    pretty-format "^29.0.3"
+    jest-matcher-utils "^29.7.0"
+    pretty-format "^29.7.0"
+    redent "^3.0.0"
 
-"@testing-library/react-native@^12.0.1":
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-12.1.3.tgz#a4496ad8fa5bf71f7a8728b0cacd61b6b1b24c84"
-  integrity sha512-kQcvhNgGT0bxBwLllCk7zysgYbvN4HcYCvA1ng0L59Mjic8pmSqdX9VdIJ1MmSojGyLjRi5gO8Pe1p8k/B9k6A==
-  dependencies:
-    pretty-format "^29.0.0"
-
-"@testing-library/react-native@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-8.0.0.tgz#f1b8f6bcc9f0ef6026b0ec7d072faf4af0e622fa"
-  integrity sha512-XwQIv4Amj8AYsPjASo+1XLFWY7qMm+FyV4+QU5j97CpRd+YasCBNnvfyDAZoudm/5Y0Yx55DYjAX36RugxasPQ==
-  dependencies:
-    pretty-format "^27.0.0"
-
-"@testing-library/react@^13.4.0":
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
-  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
+"@testing-library/react@^15.0.7":
+  version "15.0.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-15.0.7.tgz#ff733ce0893c875cb5a47672e8e772897128f4ae"
+  integrity sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.5.0"
-    "@types/react-dom" "^18.0.0"
-
-"@testing-library/react@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
-  integrity sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^9.0.0"
+    "@testing-library/dom" "^10.0.0"
     "@types/react-dom" "^18.0.0"
 
 "@tootallnate/once@2":
@@ -4012,11 +3977,6 @@
   integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
   dependencies:
     "@types/node" "*"
-
-"@types/aria-query@^4.2.0":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
-  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/aria-query@^5.0.1":
   version "5.0.2"
@@ -5385,12 +5345,12 @@ argsarray@^0.0.1:
   resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
   integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
 
-aria-query@5.1.3, aria-query@^5.0.0:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
-  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+aria-query@5.3.0, aria-query@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
   dependencies:
-    deep-equal "^2.0.5"
+    dequal "^2.0.3"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -7365,27 +7325,6 @@ dedent@^1.0.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff"
   integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
 
-deep-equal@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.5.tgz#55cd2fe326d83f9cbf7261ef0e060b3f724c5cb9"
-  integrity sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==
-  dependencies:
-    call-bind "^1.0.0"
-    es-get-iterator "^1.1.1"
-    get-intrinsic "^1.0.1"
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.2"
-    is-regex "^1.1.1"
-    isarray "^2.0.5"
-    object-is "^1.1.4"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.3"
-    which-boxed-primitive "^1.0.1"
-    which-collection "^1.0.1"
-    which-typed-array "^1.1.2"
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -7526,6 +7465,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -7920,20 +7864,6 @@ es-errors@^1.1.0, es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-es-get-iterator@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
-  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.0"
-    has-symbols "^1.0.1"
-    is-arguments "^1.1.0"
-    is-map "^2.0.2"
-    is-set "^2.0.2"
-    is-string "^1.0.5"
-    isarray "^2.0.5"
 
 es-iterator-helpers@^1.0.19:
   version "1.0.19"
@@ -9251,7 +9181,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
+get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
   integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
@@ -9659,7 +9589,7 @@ has-symbol-support-x@^1.4.1:
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
+has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -10140,7 +10070,7 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-arguments@^1.0.4, is-arguments@^1.1.0:
+is-arguments@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
   integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
@@ -10240,7 +10170,7 @@ is-data-view@^1.0.1:
   dependencies:
     is-typed-array "^1.1.13"
 
-is-date-object@^1.0.1, is-date-object@^1.0.2, is-date-object@^1.0.5:
+is-date-object@^1.0.1, is-date-object@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -10386,7 +10316,7 @@ is-lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
-is-map@^2.0.1, is-map@^2.0.2:
+is-map@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
@@ -10502,7 +10432,7 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
-is-regex@^1.1.1, is-regex@^1.1.4:
+is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -10522,7 +10452,7 @@ is-retry-allowed@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
-is-set@^2.0.1, is-set@^2.0.2:
+is-set@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
   integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
@@ -11867,7 +11797,7 @@ lru-queue@^0.1.0:
   dependencies:
     es5-ext "~0.10.2"
 
-lz-string@^1.4.4, lz-string@^1.5.0:
+lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
@@ -12982,7 +12912,7 @@ object-inspect@^1.13.1:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
-object-is@^1.0.1, object-is@^1.1.4:
+object-is@^1.0.1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
@@ -13773,7 +13703,7 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.3.1:
+pretty-format@^27.0.2, pretty-format@^27.3.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
@@ -14615,7 +14545,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp.prototype.flags@^1.3.0, regexp.prototype.flags@^1.5.2:
+regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
   integrity sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==
@@ -15285,7 +15215,7 @@ shell-quote@^1.6.1, shell-quote@^1.7.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
-side-channel@^1.0.3, side-channel@^1.0.4, side-channel@^1.0.6:
+side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
   integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
@@ -15758,7 +15688,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15774,15 +15704,6 @@ string-width@^2.0.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15853,7 +15774,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15873,13 +15794,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -17499,7 +17413,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
+which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
@@ -17604,7 +17518,7 @@ wordwrap@0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
   integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17617,15 +17531,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

We should use the same version of testing tools/libraries across the whole workspace.

In preparation for: 
* https://github.com/testing-library/react-testing-library/releases/tag/v16.0.0

> [!note]
> Sorry for so many review request but it felt bad to cut some of you from the default list based on arbitrary rules 😉 Also it was way easier to perform the changes at the same time, so I was able to verify the lock changes too.

# How

Update/align `@testing-library/react` and `@testing-library/react-native` version in the workspace and prepare for the migration to new majors, with extracted `@testing-library/dom` package. 

Improve and fix few tests failing due to breaking changes after upgrades.

# Test Plan

Tests in affected packages by the changes are passing, lint checks are passing.

Confirm the results on the CI.
