### PR TITLE
fix(cli): disable incorrect source map url from `export:embed`

### DIFF
--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -128,7 +128,9 @@ export async function exportEmbedBundleAndAssetsAsync(
         reactCompiler: !!exp.experiments?.reactCompiler,
       },
       {
-        sourceMapUrl,
+        // TODO(cedric): temporarily disable the incorrect source map basename generation.
+        // This unblocks people from issue #29656 while we can revalidate this later.
+        // sourceMapUrl,
         unstable_transformProfile: (options.unstableTransformProfile ||
           (isHermes ? 'hermes-stable' : 'default')) as BundleOptions['unstable_transformProfile'],
       }


### PR DESCRIPTION
# Why

Temporarily fixes #29656

# How

Disabled passing through the incorrect source map URL from `export:embed`. At least until we can revalidate this properly.

Right now, this result in `export:embed` creating bundles (with source maps):

```
... code ...

//# sourceMappingURL=http://localhost:8081/_expo/static/js/android/AppEntry-91c73c5bf2ca7973626146066cf16317.js.map
//# sourceURL=http://localhost:8081/Users/cedric/Desktop/test-expo-29656/node_modules/expo/AppEntry.js.bundle?platform=android&dev=false&hot=false&transform.engine=hermes&transform.routerRoot=app&resolver.environment=client&transform.environment=client&serializer.output=static&serializer.map=true
//# debugId=802db04b-02eb-4416-8b83-1e9d9b9d7694
```

</details>

# Test Plan

- `$ bun create expo ./test-29656`
- `$ cd ./test-29656`
- `$ bun expo run android --variant Release`
- Should pass without failure

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
