### PR TITLE
[android][camera] Fix image rendering when exif is true

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Allow starting the camera with the torch enabled. ([#29217](https://github.com/expo/expo/pull/29217) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, return the correct orientation in the exif data. ([#29681](https://github.com/expo/expo/pull/29681) by [@alanjhughes](https://github.com/alanjhughes))
 - Prevent shutter sound when device volume is muted. ([#29638](https://github.com/expo/expo/pull/29638) by [@frederikocmr](https://github.com/frederikocmr))
-- On `Android`, correct image orientation when `exif` is set to true in `takePictureAsync`.
+- On `Android`, correct image orientation when `exif` is set to true in `takePictureAsync`. ([#29712](https://github.com/expo/expo/pull/29712) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Allow starting the camera with the torch enabled. ([#29217](https://github.com/expo/expo/pull/29217) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, return the correct orientation in the exif data. ([#29681](https://github.com/expo/expo/pull/29681) by [@alanjhughes](https://github.com/alanjhughes))
 - Prevent shutter sound when device volume is muted. ([#29638](https://github.com/expo/expo/pull/29638) by [@frederikocmr](https://github.com/frederikocmr))
+- On `Android`, correct image orientation when `exif` is set to true in `takePictureAsync`.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/tasks/ResolveTakenPictureAsyncTask.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/tasks/ResolveTakenPictureAsyncTask.kt
@@ -84,7 +84,7 @@ class ResolveTakenPictureAsyncTask(
         // If OOM exception was thrown, we try to use downsampling to recover.
         while (bitmapOptions.inSampleSize <= options.maxDownsampling) {
           try {
-            bitmap = decodeBitmap(imageData, orientation, bitmapOptions)
+            bitmap = decodeBitmap(imageData, orientation, options.exif, bitmapOptions)
             break
           } catch (exception: OutOfMemoryError) {
             bitmapOptions.inSampleSize *= 2
@@ -218,9 +218,9 @@ class ResolveTakenPictureAsyncTask(
     return null
   }
 
-  private fun decodeBitmap(imageData: ByteArray, orientation: Int, bitmapOptions: BitmapFactory.Options): Bitmap {
+  private fun decodeBitmap(imageData: ByteArray, orientation: Int, exif: Boolean, bitmapOptions: BitmapFactory.Options): Bitmap {
     // Rotate the bitmap to the proper orientation if needed
-    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED && !exif) {
       decodeAndRotateBitmap(imageData, getImageRotation(orientation), bitmapOptions)
     } else {
       BitmapFactory.decodeByteArray(imageData, 0, imageData.size, bitmapOptions)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/tasks/ResolveTakenPictureAsyncTask.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/tasks/ResolveTakenPictureAsyncTask.kt
@@ -220,7 +220,7 @@ class ResolveTakenPictureAsyncTask(
 
   private fun decodeBitmap(imageData: ByteArray, orientation: Int, exif: Boolean, bitmapOptions: BitmapFactory.Options): Bitmap {
     // Rotate the bitmap to the proper orientation if needed
-    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED && !exif) {
+    return if (!exif) {
       decodeAndRotateBitmap(imageData, getImageRotation(orientation), bitmapOptions)
     } else {
       BitmapFactory.decodeByteArray(imageData, 0, imageData.size, bitmapOptions)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -90,7 +90,7 @@ class ResolveTakenPicture(
         // If OOM exception was thrown, we try to use downsampling to recover.
         while (bitmapOptions.inSampleSize <= options.maxDownsampling) {
           try {
-            bitmap = decodeBitmap(imageData, orientation, bitmapOptions)
+            bitmap = decodeBitmap(imageData, orientation, options.exif, bitmapOptions)
             break
           } catch (exception: OutOfMemoryError) {
             bitmapOptions.inSampleSize *= 2
@@ -222,9 +222,9 @@ class ResolveTakenPicture(
     return null
   }
 
-  private fun decodeBitmap(imageData: ByteArray, orientation: Int, bitmapOptions: BitmapFactory.Options): Bitmap {
+  private fun decodeBitmap(imageData: ByteArray, orientation: Int, exif: Boolean, bitmapOptions: BitmapFactory.Options): Bitmap {
     // Rotate the bitmap to the proper orientation if needed
-    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED) {
+    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED && !exif) {
       decodeAndRotateBitmap(imageData, getImageRotation(orientation), bitmapOptions)
     } else {
       BitmapFactory.decodeByteArray(imageData, 0, imageData.size, bitmapOptions)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -224,7 +224,7 @@ class ResolveTakenPicture(
 
   private fun decodeBitmap(imageData: ByteArray, orientation: Int, exif: Boolean, bitmapOptions: BitmapFactory.Options): Bitmap {
     // Rotate the bitmap to the proper orientation if needed
-    return if (orientation != ExifInterface.ORIENTATION_UNDEFINED && !exif) {
+    return if (!exif) {
       decodeAndRotateBitmap(imageData, getImageRotation(orientation), bitmapOptions)
     } else {
       BitmapFactory.decodeByteArray(imageData, 0, imageData.size, bitmapOptions)


### PR DESCRIPTION
# Why
When setting `exif` to true in `takePictureAsync` the image renders in the incorrect orientation on android. This is because this check will never be false and so the image is always rotated even when not necessary. 

https://github.com/expo/expo/blob/f98aa172cd55980a49d472f02fd92b77252e5de4/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt#L227

# How
We only need to manually handle the image rotation when we don't add the exif data to it. 
Fixed in both versions of the package. 

# Test Plan
Tested in an example project based on a [snack](https://snack.expo.dev/@titozzz/supportive-indigo-carrot) from @Titozzz 