### PR TITLE
[bare-expo] Change default web bundler to metro

### DIFF
--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -32,6 +32,9 @@
       "supportsTablet": true,
       "requireFullScreen": false
     },
+    "web": {
+      "bundler": "metro"
+    },
     "notification": {
       "serviceWorkerPath": "/expo-service-worker.js",
       "vapidPublicKey": "BNHvR05XkY5LH9GdN0GreLx2wZnK9IwNJGVmo3jujIkFni4of26E3U3fnt9nUrZfM7h0omdIHKM0eshkzTSFOWQ"


### PR DESCRIPTION
# Why

Webpack results in an empty page.
Metro works and allows easy testing on web.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
