### PR TITLE
[docs] add live stream recordings section to resources page

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -3,7 +3,7 @@ title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---
 
-import { TALKS, PODCASTS } from '~/public/static/talks';
+import { TALKS, PODCASTS, LIVE_STREAMS } from '~/public/static/talks';
 import { TalkGridWrapper, TalkGridCell } from '~/ui/components/Home/sections';
 
 The following resources are useful for learning about Expo tooling and services.
@@ -23,8 +23,9 @@ The following resources are useful for learning about Expo tooling and services.
 - [expo/config-plugins](https://github.com/expo/config-plugins) - Expo Config Plugins for working with third-party packages.
 - [expo/snack](https://github.com/expo/snack) - Build apps from the browser.
 - [expo/vscode-expo](https://github.com/expo/vscode-expo) - VS Code extension for working with Expo tools.
+- [expo/vscode-expo-theme](https://github.com/expo/vscode-expo-theme) - VS Code theme created by Expo team.
 - [expo/fyi](https://github.com/expo/fyi) - Troubleshooting guides for Expo tools and services.
-- [expo/orbit](https://github.com/expo/orbit) - Launch builds and start simulators from your macOS menu bar.
+- [expo/orbit](https://github.com/expo/orbit) - Launch builds and start simulators from your macOS menu bar and Windows task bar.
 
 ### Documentation
 
@@ -62,5 +63,13 @@ The following resources are useful for learning about Expo tooling and services.
 <TalkGridWrapper>
   {PODCASTS.map(podcast => (
     <TalkGridCell key={podcast.videoId ?? podcast.event} {...podcast} />
+  ))}
+</TalkGridWrapper>
+
+## Live streams recordings
+
+<TalkGridWrapper>
+  {LIVE_STREAMS.map(stream => (
+    <TalkGridCell key={stream.videoId} {...stream} />
   ))}
 </TalkGridWrapper>

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -91,7 +91,7 @@ export const TALKS = [
 
 export const PODCASTS = [
   {
-    title: 'Expo EAS and 100 Snakes ',
+    title: 'Expo EAS and 100 Snakes',
     event: 'Rocket Ship #038',
     description: "Jon Samp",
     videoId: "JKU9JC4nX1k",
@@ -145,13 +145,36 @@ export const PODCASTS = [
     videoId: "yK0UDiLjxNY",
     link: "https://podcast.galaxies.dev/episodes/007-expo-router-debugging-with-cedric-van-putten"
   }
-] as Talk[]
+] as Talk[];
+
+export const LIVE_STREAMS = [
+  {
+    title: 'Expo SDK 51: New Architecture, Router 3.5, expo.new and more',
+    event: 'Expo Live Stream',
+    videoId: "k1ISWPgP4S4"
+  },
+  {
+    title: 'What is Expo Orbit? Live demo of speeding up dev workflow',
+    event: 'Expo Live Stream',
+    videoId: "vUoIoYq8WNM",
+  },
+  {
+    title: 'How to build TV apps from scratch, and with Ignite stack',
+    event: 'Expo Live Stream',
+    videoId: "PUMBWeLVuiw",
+  },
+  {
+    title: 'Expo SDK 50: API Routes, Fingerprint, Dev Tools and SQLite',
+    event: 'Expo Live Stream',
+    videoId: "cKFSVUo3AnI",
+  }
+] as Talk[];
 
 export type Talk = {
   title: string;
   event: string;
-  description: string;
   videoId: string;
+  description?: string;
   home?: boolean;
   thumbnail?: string;
   link?: string;

--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -82,16 +82,18 @@ export function TalkGridCell({
           }}
           className="border-b border-b-default bg-cover bg-center h-[138px] max-sm-gutters:h-[168px]"
         />
-        <div className="flex justify-between items-center bg-default min-h-[30px] px-4 py-3 gap-1">
+        <div className="flex justify-between items-start bg-default min-h-[30px] px-4 py-3 gap-1">
           <LABEL className="block leading-normal">{title}</LABEL>
-          <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm" />
+          <ArrowUpRightIcon className="text-icon-secondary shrink-0 icon-sm mt-1" />
         </div>
       </div>
       <div className="px-4 pb-2 bg-default flex flex-col gap-0.5">
-        <CALLOUT theme="secondary" className="flex gap-2 items-center">
-          <Users02Icon className="icon-xs text-icon-tertiary shrink-0" />
-          {description}
-        </CALLOUT>
+        {description && (
+          <CALLOUT theme="secondary" className="flex gap-2 items-center">
+            <Users02Icon className="icon-xs text-icon-tertiary shrink-0" />
+            {description}
+          </CALLOUT>
+        )}
         <CALLOUT theme="secondary" className="flex gap-2 items-center">
           <AtSignIcon className="icon-xs text-icon-tertiary shrink-0" />
           {event}


### PR DESCRIPTION
# Why

We save the live stream recording on our YouTube channel, so let's link thos videos in new section, so our users can find them easier.

# How

Add "Live streams recordings" section to the Additional Resources page, add `vscode-expo-theme` to the list of our GitHub repositories, and mention Windows in the Orbit description.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-06-13 at 19 12 33](https://github.com/expo/expo/assets/719641/67f3eb4a-39a6-4422-85dc-36d7b0787ab8)

