### PR TITLE
[ios][image-picker] Handle microphone permissions being disabled

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
+- Support removing microphone permissions through config plugin. ([#29749](https://github.com/expo/expo/pull/29749) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImagePickerExceptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerExceptions.swift
@@ -26,6 +26,12 @@ internal class MissingCameraPermissionException: Exception {
   }
 }
 
+internal class MissingMicrophonePermissionException: Exception {
+  override var reason: String {
+    "Missing microphone permission. Please enable it with the `expo-image-picker` config plugin"
+  }
+}
+
 internal class MissingPhotoLibraryPermissionException: Exception {
   override var reason: String {
     "Missing photo library permission"

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -146,7 +146,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
   }
 
   private func checkMicrophonePermissions() throws {
-    guard let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription") else {
+    guard Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription") != nil else {
       throw MissingMicrophonePermissionException()
     }
   }

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -118,6 +118,16 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     }
 
     picker.mediaTypes = options.mediaTypes.toArray()
+    
+    if options.mediaTypes.requiresMicrophonePermission() && sourceType == .camera {
+      do {
+        try checkMicrophonePermissions()
+      } catch {
+        pickingContext.promise.reject(error)
+        return
+      }
+    }
+    
     picker.videoExportPreset = options.videoExportPreset.toAVAssetExportPreset()
     picker.videoQuality = options.videoQuality.toQualityType()
     picker.videoMaximumDuration = options.videoMaxDuration
@@ -133,6 +143,13 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     }
 
     presentPickerUI(picker, pickingContext: pickingContext)
+  }
+  
+  private func checkMicrophonePermissions() throws {
+    let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription")
+    if microphoneUsageDescription == nil {
+      throw MissingMicrophonePermissionException()
+    }
   }
 
   @available(iOS 14, *)

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -118,7 +118,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     }
 
     picker.mediaTypes = options.mediaTypes.toArray()
-    
+
     if options.mediaTypes.requiresMicrophonePermission() && sourceType == .camera {
       do {
         try checkMicrophonePermissions()
@@ -127,7 +127,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
         return
       }
     }
-    
+
     picker.videoExportPreset = options.videoExportPreset.toAVAssetExportPreset()
     picker.videoQuality = options.videoQuality.toQualityType()
     picker.videoMaximumDuration = options.videoMaxDuration
@@ -144,7 +144,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
 
     presentPickerUI(picker, pickingContext: pickingContext)
   }
-  
+
   private func checkMicrophonePermissions() throws {
     let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription")
     if microphoneUsageDescription == nil {

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -146,8 +146,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
   }
 
   private func checkMicrophonePermissions() throws {
-    let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription")
-    if microphoneUsageDescription == nil {
+    guard let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription") else {
       throw MissingMicrophonePermissionException()
     }
   }

--- a/packages/expo-image-picker/ios/ImagePickerOptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerOptions.swift
@@ -155,6 +155,17 @@ internal enum MediaType: String, Enumerable {
       return [kUTTypeImage as String, kUTTypeMovie as String]
     }
   }
+  
+  func requiresMicrophonePermission() -> Bool {
+    switch self {
+    case .images:
+      return false
+    case .videos:
+      return true
+    case .all:
+      return true
+    }
+  }
 
   @available(iOS 14, *)
   func toPickerFilter() -> PHPickerFilter {

--- a/packages/expo-image-picker/ios/ImagePickerOptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerOptions.swift
@@ -155,7 +155,7 @@ internal enum MediaType: String, Enumerable {
       return [kUTTypeImage as String, kUTTypeMovie as String]
     }
   }
-  
+
   func requiresMicrophonePermission() -> Bool {
     switch self {
     case .images:

--- a/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
+++ b/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
@@ -20,7 +20,7 @@ public class CameraPermissionRequester: NSObject, EXPermissionsRequester {
     let cameraUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSCameraUsageDescription")
     if cameraUsageDescription == nil {
       EXFatal(EXErrorWithMessage("""
-      This app is missing either 'NSCameraUsageDescription', video services will fail. \
+      This app is missing 'NSCameraUsageDescription', video services will fail. \
       Ensure this key exists in the app's Info.plist
       """))
       systemStatus = AVAuthorizationStatus.denied

--- a/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
+++ b/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
@@ -18,11 +18,10 @@ public class CameraPermissionRequester: NSObject, EXPermissionsRequester {
     var systemStatus: AVAuthorizationStatus
     var status: EXPermissionStatus
     let cameraUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSCameraUsageDescription")
-    let microphoneUsageDescription = Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription")
-    if cameraUsageDescription == nil || microphoneUsageDescription == nil {
+    if cameraUsageDescription == nil {
       EXFatal(EXErrorWithMessage("""
-      This app is missing either 'NSCameraUsageDescription' or 'NSMicrophoneUsageDescription', so audio/video services will fail. \
-      Ensure both of these keys exist in app's Info.plist.
+      This app is missing either 'NSCameraUsageDescription', video services will fail. \
+      Ensure this key exists in the app's Info.plist
       """))
       systemStatus = AVAuthorizationStatus.denied
     } else {

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Support removing microphone permissions through config plugin. ([#29749](https://github.com/expo/expo/pull/29749) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Support removing microphone permissions through config plugin. ([#29749](https://github.com/expo/expo/pull/29749) by [@alanjhughes](https://github.com/alanjhughes))
-
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))


### PR DESCRIPTION
# Why
Closes #29692
#17168 added the ability to remove microphone permissions but on the native side we required both camera and microphone permissions to be present.

# How
Inspect the media types and if we are using the camera to determine if we need microphone permissions and throw and error when we do.

# Test Plan
Tested against the provided repro
