### PR TITLE
[core][Android] Switch to the js thread when sending an event

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Use `process.env.EXPO_OS` for `Platform.OS` and `Platform.select`, when available. ([#29429](https://github.com/expo/expo/pull/29429) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Removed unneeded in-between function call when resolving promise without arguments. ([#28944](https://github.com/expo/expo/pull/28944) by [@lukmccall](https://github.com/lukmccall))
 - Exported some TypeScript declarations (e.g. `EventEmitter`) from `expo-modules-core/types`. ([#28994](https://github.com/expo/expo/pull/28994) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Switch to the JS thread when sending an event.
+- [Android] Switch to the JS thread when sending an event. ([#29753](https://github.com/expo/expo/pull/29753) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.12.13 - 2024-06-05
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Use `process.env.EXPO_OS` for `Platform.OS` and `Platform.select`, when available. ([#29429](https://github.com/expo/expo/pull/29429) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Removed unneeded in-between function call when resolving promise without arguments. ([#28944](https://github.com/expo/expo/pull/28944) by [@lukmccall](https://github.com/lukmccall))
 - Exported some TypeScript declarations (e.g. `EventEmitter`) from `expo-modules-core/types`. ([#28994](https://github.com/expo/expo/pull/28994) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Switch to the JS thread when sending an event.
 
 ## 1.12.13 - 2024-06-05
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -100,7 +100,7 @@ class SharedObjectTest {
       ?.toNativeObject(jsObject)
 
     // Send an event from the native object to JS
-    nativeObject?.sendEvent("test event", 1, 2, 3)
+    nativeObject?.emit("test event", 1, 2, 3)
 
     // Check the value that is set by the listener
     val total = evaluateScript("total")

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -9,6 +9,7 @@
 #include "JavaScriptTypedArray.h"
 #include "JavaReferencesCache.h"
 #include "JavaCallback.h"
+#include "JNIUtils.h"
 #include "types/FrontendConverterProvider.h"
 
 #if RN_FABRIC_ENABLED
@@ -33,6 +34,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptFunction::registerNatives();
     expo::JavaScriptTypedArray::registerNatives();
     expo::JavaCallback::registerNatives();
+    expo::JNIUtils::registerNatives();
 #if RN_FABRIC_ENABLED
     expo::FabricComponentsRegistry::registerNatives();
 #endif

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
@@ -1,0 +1,167 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JNIUtils.h"
+#include "EventEmitter.h"
+#include "JSIUtils.h"
+#include "types/JNIToJSIConverter.h"
+
+namespace expo {
+
+void JNIUtils::registerNatives() {
+  javaClassStatic()->registerNatives({
+                                       makeNativeMethod("emitEvent",
+                                                        JNIUtils::emitEventOnJavaScriptObject),
+                                       makeNativeMethod("emitEvent",
+                                                        JNIUtils::emitEventOnJavaScriptModule),
+                                       makeNativeMethod("emitEvent",
+                                                        JNIUtils::emitEventOnWeakJavaScriptObject)
+                                     });
+}
+
+void JNIUtils::emitEventOnWeakJavaScriptObject(
+  [[maybe_unused]] jni::alias_ref<jni::JClass> clazz,
+  jni::alias_ref<JavaScriptWeakObject::javaobject> jsiThis,
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  jni::alias_ref<jni::JArrayClass<jobject>> args
+) {
+  jni::global_ref<jni::JArrayClass<jobject>> globalArgs = jni::make_global(args);
+
+  JNIUtils::emitEventOnJSIObject(
+    jsiThis->cthis()->getWeak(),
+    jsiContextRef,
+    eventName,
+    [args = globalArgs](jsi::Runtime &rt) -> std::vector<jsi::Value> {
+      auto localArgs = jni::static_ref_cast<jni::JArrayClass<jobject>>(args);
+
+      JNIEnv *env = jni::Environment::current();
+
+      size_t size = localArgs->size();
+      std::vector<jsi::Value> convertedArgs;
+      convertedArgs.reserve(size);
+
+      for (size_t i = 0; i < size; i++) {
+        jni::local_ref<jobject> arg = localArgs->getElement(i);
+        convertedArgs.push_back(convert(env, rt, std::move(arg)));
+      }
+
+      return convertedArgs;
+    }
+  );
+}
+
+void JNIUtils::emitEventOnJavaScriptObject(
+  [[maybe_unused]] jni::alias_ref<jni::JClass> clazz,
+  jni::alias_ref<JavaScriptObject::javaobject> jsiThis,
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  jni::alias_ref<jni::JArrayClass<jobject>> args
+) {
+  jni::global_ref<jni::JArrayClass<jobject>> globalArgs = jni::make_global(args);
+
+  JNIUtils::emitEventOnJSIObject(
+    jsiThis->cthis()->get(),
+    jsiContextRef,
+    eventName,
+    [args = globalArgs](jsi::Runtime &rt) -> std::vector<jsi::Value> {
+      auto localArgs = jni::static_ref_cast<jni::JArrayClass<jobject>>(args);
+
+      JNIEnv *env = jni::Environment::current();
+
+      size_t size = localArgs->size();
+      std::vector<jsi::Value> convertedArgs;
+      convertedArgs.reserve(size);
+
+      for (size_t i = 0; i < size; i++) {
+        jni::local_ref<jobject> arg = localArgs->getElement(i);
+        convertedArgs.push_back(convert(env, rt, std::move(arg)));
+      }
+
+      return convertedArgs;
+    }
+  );
+}
+
+void JNIUtils::emitEventOnJavaScriptModule(
+  [[maybe_unused]] jni::alias_ref<jni::JClass> clazz,
+  jni::alias_ref<JavaScriptModuleObject::javaobject> jsiThis,
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
+) {
+  folly::dynamic arg;
+  if (eventBody) {
+    arg = eventBody->cthis()->consume();
+  }
+
+  JNIUtils::emitEventOnJSIObject(
+    jsiThis->cthis()->getCachedJSIObject(),
+    jsiContextRef,
+    eventName,
+    [arg = std::move(arg)](jsi::Runtime &rt) -> std::vector<jsi::Value> {
+      jsi::Value convertedBody = jsi::valueFromDynamic(rt, arg);
+      std::vector<jsi::Value> args;
+      args.emplace_back(std::move(convertedBody));
+      return args;
+    }
+  );
+}
+
+
+void JNIUtils::emitEventOnJSIObject(
+  std::weak_ptr<jsi::WeakObject> jsiThis,
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  ArgsProvider argsProvider
+) {
+  const std::string name = eventName->toStdString();
+
+  const JSIContext *jsiContext = jsiContextRef->cthis();
+
+  jsiContext->runtimeHolder->jsInvoker->invokeAsync([
+                                                      jsiContext,
+                                                      name = std::move(name),
+                                                      argsProvider = std::move(argsProvider),
+                                                      weakThis = std::move(jsiThis)
+                                                    ]() {
+    std::shared_ptr<jsi::WeakObject> jsWeakThis = weakThis.lock();
+    if (!jsWeakThis) {
+      return;
+    }
+
+    // TODO(@lukmccall): refactor when jsInvoker receives a runtime as a parameter
+    jsi::Runtime &rt = jsiContext->runtimeHolder->get();
+
+    jsi::Object jsThis = jsWeakThis->lock(rt).asObject(rt);
+    EventEmitter::emitEvent(rt, jsThis, name, argsProvider(rt));
+  });
+}
+
+void JNIUtils::emitEventOnJSIObject(
+  std::weak_ptr<jsi::Object> jsiThis,
+  jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+  jni::alias_ref<jstring> eventName,
+  ArgsProvider argsProvider
+) {
+  const std::string name = eventName->toStdString();
+
+  const JSIContext *jsiContext = jsiContextRef->cthis();
+
+  jsiContext->runtimeHolder->jsInvoker->invokeAsync([
+                                                      jsiContext,
+                                                      name = std::move(name),
+                                                      weakThis = std::move(jsiThis),
+                                                      argsProvider = std::move(argsProvider)
+                                                    ]() {
+    std::shared_ptr<jsi::Object> jsThis = weakThis.lock();
+    if (!jsThis) {
+      return;
+    }
+
+    // TODO(@lukmccall): refactor when jsInvoker receives a runtime as a parameter
+    jsi::Runtime &rt = jsiContext->runtimeHolder->get();
+
+    EventEmitter::emitEvent(rt, *jsThis, name, argsProvider(rt));
+  });
+}
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
@@ -1,0 +1,72 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <vector>
+#include <functional>
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+#include <react/jni/ReadableNativeMap.h>
+
+#include "JSIContext.h"
+#include "JavaScriptObject.h"
+#include "JavaScriptModuleObject.h"
+#include "JavaScriptWeakObject.h"
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+class JNIUtils : public jni::JavaClass<JNIUtils> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIUtils;";
+  static auto constexpr TAG = "JNIUtils";
+
+  static void registerNatives();
+
+  static void emitEventOnWeakJavaScriptObject(
+    jni::alias_ref<jni::JClass> clazz,
+    jni::alias_ref<JavaScriptWeakObject::javaobject> jsiThis,
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    jni::alias_ref<jni::JArrayClass<jobject>> args
+  );
+
+  static void emitEventOnJavaScriptObject(
+    jni::alias_ref<jni::JClass> clazz,
+    jni::alias_ref<JavaScriptObject::javaobject> jsiThis,
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    jni::alias_ref<jni::JArrayClass<jobject>> args
+  );
+
+  static void emitEventOnJavaScriptModule(
+    jni::alias_ref<jni::JClass> clazz,
+    jni::alias_ref<JavaScriptModuleObject::javaobject> jsiThis,
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
+  );
+
+private:
+  using ArgsProvider = std::function<std::vector<jsi::Value>(jsi::Runtime &rt)>;
+
+  static void emitEventOnJSIObject(
+    std::weak_ptr<jsi::Object> jsiThis,
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    ArgsProvider argsProvider
+  );
+
+  static void emitEventOnJSIObject(
+    std::weak_ptr<jsi::WeakObject> jsiThis,
+    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
+    jni::alias_ref<jstring> eventName,
+    ArgsProvider argsProvider
+  );
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
@@ -45,7 +45,7 @@ jobject JavaScriptFunction::invoke(
   convertedArgs.reserve(size);
 
   for (size_t i = 0; i < size; i++) {
-    jni::local_ref<jni::JObject> arg = args->getElement(i);
+    jni::local_ref<jobject> arg = args->getElement(i);
     convertedArgs.push_back(convert(env, rt, std::move(arg)));
   }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -64,6 +64,8 @@ public:
    */
   std::shared_ptr<jsi::Object> getJSIObject(jsi::Runtime &runtime);
 
+  std::weak_ptr<jsi::Object> getCachedJSIObject();
+
   /**
    * Decorates the given object with properties and functions provided in the module definition.
    */
@@ -124,17 +126,6 @@ public:
     jboolean setterTakesOwner,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> setter
-  );
-
-  /**
-   * Emits an event using cached jsi::Object with the given name and body.
-   * @param eventName
-   * @param eventBody
-   */
-  void emitEvent(
-    jni::alias_ref<jni::HybridClass<JSIContext>::javaobject> jsiContextRef,
-    jni::alias_ref<jstring> eventName,
-    jni::alias_ref<react::ReadableNativeMap::javaobject> eventBody
   );
 
 private:

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.cpp
@@ -11,6 +11,10 @@ void JavaScriptWeakObject::registerNatives() {
   });
 }
 
+std::shared_ptr<jsi::WeakObject> JavaScriptWeakObject::getWeak() {
+  return _weakObject;
+}
+
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptWeakObject::lock() {
   jsi::Runtime &rt = _runtimeHolder.getJSRuntime();
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
@@ -38,6 +38,8 @@ public:
 
   jni::local_ref<JavaScriptObject::javaobject> lock();
 
+  std::shared_ptr<jsi::WeakObject> getWeak();
+
 private:
   JavaScriptWeakObject(WeakRuntimeHolder runtime,
                        std::shared_ptr<jsi::Object> jsObject);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.facebook.react.uimanager.UIManagerHelper
 import expo.modules.kotlin.ModuleHolder
+import expo.modules.kotlin.jni.JNIUtils
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.toJSValue
@@ -47,7 +48,7 @@ class KModuleEventEmitterWrapper(
     val appContext = moduleHolder.module.appContext
     val jsObject = moduleHolder.safeJSObject ?: return
     try {
-      jsObject.emitEvent(appContext.jsiInterop, eventName, eventBody)
+      JNIUtils.emitEvent(jsObject, appContext.jsiInterop, eventName, eventBody)
     } catch (e: Exception) {
       // If the jsObject is valid, we should throw an exception.
       // Otherwise, we should ignore it.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIUtils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIUtils.kt
@@ -1,0 +1,32 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.react.bridge.ReadableNativeMap
+
+@Suppress("KotlinJniMissingFunction")
+class JNIUtils {
+  companion object {
+    @JvmStatic
+    external fun emitEvent(
+      jsiThis: JavaScriptObject,
+      jsiContext: JSIContext,
+      eventName: String,
+      eventBody: Array<Any?>
+    )
+
+    @JvmStatic
+    external fun emitEvent(
+      jsiThis: JavaScriptWeakObject,
+      jsiContext: JSIContext,
+      eventName: String,
+      eventBody: Array<Any?>
+    )
+
+    @JvmStatic
+    external fun emitEvent(
+      jsiThis: JavaScriptModuleObject,
+      jsiContext: JSIContext,
+      eventName: String,
+      eventBody: ReadableNativeMap?
+    )
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.jni
 import com.facebook.jni.HybridData
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.NativeMap
-import com.facebook.react.bridge.ReadableNativeMap
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.objects.ObjectDefinitionData
@@ -89,8 +88,6 @@ class JavaScriptModuleObject(
   external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, ownerClass: Class<*>?, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
-
-  external fun emitEvent(jsiContext: JSIContext, eventName: String, eventBody: ReadableNativeMap?)
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -17,6 +17,11 @@ value class SharedObjectId(val value: Int) {
     val nativeObject = toNativeObject(appContext) ?: return null
     return appContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
   }
+
+  fun toWeakJavaScriptObject(appContext: AppContext): JavaScriptWeakObject? {
+    val nativeObject = toNativeObject(appContext) ?: return null
+    return appContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
+  }
 }
 
 typealias SharedObjectPair = Pair<SharedObject, JavaScriptWeakObject>
@@ -90,6 +95,12 @@ class SharedObjectRegistry(appContext: AppContext) {
   internal fun toJavaScriptObject(native: SharedObject): JavaScriptObject? {
     return synchronized(this) {
       pairs[native.sharedObjectId]?.second?.lock()
+    }
+  }
+
+  internal fun toWeakJavaScriptObject(nativeObject: SharedObject): JavaScriptWeakObject? {
+    return synchronized(this) {
+      pairs[nativeObject.sharedObjectId]?.second
     }
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -45,7 +45,7 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
   var playing = false
     set(value) {
       if (field != value) {
-        sendEventOnJSThread("playingChange", value, field)
+        emit("playingChange", value, field)
       }
       field = value
     }
@@ -54,7 +54,7 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
   private var lastLoadedSource: VideoSource? = null
     set(value) {
       if (field != value && value != null) {
-        sendEventOnJSThread("sourceChange", value, field)
+        emit("sourceChange", value, field)
       }
       field = value
     }
@@ -85,14 +85,14 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
     set(volume) {
       if (player.volume == volume) return
       player.volume = if (muted) 0f else volume
-      sendEventOnJSThread("volumeChange", VolumeEvent(volume, muted), VolumeEvent(field, muted))
+      emit("volumeChange", VolumeEvent(volume, muted), VolumeEvent(field, muted))
       field = volume
     }
 
   var muted = false
     set(muted) {
       if (field == muted) return
-      sendEventOnJSThread("volumeChange", VolumeEvent(volume, muted), VolumeEvent(volume, field))
+      emit("volumeChange", VolumeEvent(volume, muted), VolumeEvent(volume, field))
       player.volume = if (muted) 0f else userVolume
       field = muted
       audioFocusManager.onPlayerChangedAudioFocusProperty(this@VideoPlayer)
@@ -101,7 +101,7 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
   var playbackParameters: PlaybackParameters = PlaybackParameters.DEFAULT
     set(newPlaybackParameters) {
       if (playbackParameters.speed != newPlaybackParameters.speed) {
-        sendEventOnJSThread("playbackRateChange", newPlaybackParameters.speed, playbackParameters.speed)
+        emit("playbackRateChange", newPlaybackParameters.speed, playbackParameters.speed)
       }
       val pitchCorrectedPlaybackParameters = applyPitchCorrection(newPlaybackParameters)
       field = pitchCorrectedPlaybackParameters
@@ -125,7 +125,7 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
       this@VideoPlayer.duration = 0f
       this@VideoPlayer.isLive = false
       if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
-        sendEventOnJSThread("playToEnd")
+        emit("playToEnd")
       }
       super.onMediaItemTransition(mediaItem, reason)
     }
@@ -276,18 +276,12 @@ class VideoPlayer(context: Context, appContext: AppContext, source: VideoSource?
     }
 
     if (playbackError == null && player.playbackState == Player.STATE_ENDED) {
-      sendEventOnJSThread("playToEnd")
+      emit("playToEnd")
     }
 
     if (this.status != status) {
-      sendEventOnJSThread("statusChange", status.value, this.status.value, playbackError)
+      emit("statusChange", status.value, this.status.value, playbackError)
     }
     this.status = status
-  }
-
-  private fun sendEventOnJSThread(eventName: String, vararg args: Any?) {
-    appContext?.executeOnJavaScriptThread {
-      sendEvent(eventName, *args)
-    }
   }
 }


### PR DESCRIPTION
# Why

Switches to the JS thread when sending an event. 

# How

When sending an event from the `SharedObject`, users have to switch the thread manually. It was confusing. I've decided to switch the thread automatically.  


# Test Plan

- bare-expo ✅ 
- unit tests ✅ 