### PR TITLE
fix typo in expo-modules-core (SharedObject.ts)

### DIFF
--- a/packages/expo-modules-core/src/ts-declarations/SharedObject.ts
+++ b/packages/expo-modules-core/src/ts-declarations/SharedObject.ts
@@ -9,7 +9,7 @@ export declare class SharedObject<
 > extends EventEmitter<TEventsMap> {
   /**
    * A function that detaches the JS and native objects to let the native object deallocate
-   * before the JS object gets deallocated by the JS garbagge collector. Any subsequent calls to native
+   * before the JS object gets deallocated by the JS garbage collector. Any subsequent calls to native
    * functions of the object will throw an error as it is no longer associated with its native counterpart.
    */
   release(): void;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
