### PR TITLE
fix(media-library/android): throw if asset not deleted

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, add back image loader to handle `ph://` and `assets-library://` schemes. ([#29747](https://github.com/expo/expo/pull/29747) by [@alanjhughes](https://github.com/alanjhughes))
+- On `Android`, throw an error when deleting an asset was unsuccessful. ([#29777](https://github.com/expo/expo/pull/29777) by [@mathieupost](https://github.com/mathieupost))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -93,7 +93,10 @@ object MediaLibraryUtils {
               val columnId = filesToDelete.getColumnIndex(MediaStore.MediaColumns._ID)
               val id = filesToDelete.getLong(columnId)
               val assetUri = ContentUris.withAppendedId(EXTERNAL_CONTENT_URI, id)
-              context.contentResolver.delete(assetUri, null)
+              val rowsDeleted = context.contentResolver.delete(assetUri, null)
+              if (rowsDeleted == 0) {
+                throw AssetFileException("Could not delete file.")
+              }
             } else {
               val dataColumnIndex = filesToDelete.getColumnIndex(MediaStore.MediaColumns.DATA)
               val filePath = filesToDelete.getString(dataColumnIndex)


### PR DESCRIPTION
# Why

The `expo-media-library` contained a bug where `MediaLibrary.deleteAssetsAsync(assetIds)` resolves to `true` even if the files are not deleted.

# How

The `rowsDeleted` is now checked to be zero.
