### PR TITLE
[tools] Resolve version bump based only on the changelog

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -300,19 +300,6 @@ export class Package {
   }
 
   /**
-   * Checks whether package has any native code (iOS, Android, C++).
-   */
-  async isNativeModuleAsync(): Promise<boolean> {
-    const dirs = ['ios', 'android', 'cpp'].map((dir) => path.join(this.path, dir));
-    for (const dir of dirs) {
-      if (await fs.pathExists(dir)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Checks whether the package contains native unit tests on the given platform.
    */
   async hasNativeTestsAsync(platform: Platform): Promise<boolean> {

--- a/tools/src/publish-packages/constants.ts
+++ b/tools/src/publish-packages/constants.ts
@@ -31,11 +31,6 @@ export const BACKUPABLE_OPTIONS_FIELDS = [
 ] as const;
 
 /**
- * An array of directories treated as containing native code.
- */
-export const NATIVE_DIRECTORIES = ['ios', 'android', 'cpp'];
-
-/**
  * An array of release types in the order from patch to major.
  */
 export const RELEASE_TYPES_ASC_ORDER = [ReleaseType.PATCH, ReleaseType.MINOR, ReleaseType.MAJOR];

--- a/tools/src/publish-packages/tasks/loadRequestedParcels.ts
+++ b/tools/src/publish-packages/tasks/loadRequestedParcels.ts
@@ -6,7 +6,7 @@ import { getListOfPackagesAsync, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { PackagesGraph, PackagesGraphNode } from '../../packages-graph';
-import { getMinReleaseTypeAsync, getPackageGitLogsAsync } from '../helpers';
+import { getMinReleaseType, getPackageGitLogsAsync } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { green } = chalk;
@@ -147,7 +147,7 @@ export async function createParcelAsync(packageNode: PackagesGraphNode): Promise
     dependencies: new Set<Parcel>(),
     logs,
     changelogChanges,
-    minReleaseType: await getMinReleaseTypeAsync(pkg, logs, changelogChanges),
+    minReleaseType: getMinReleaseType(changelogChanges),
     state: {},
   };
 }


### PR DESCRIPTION
# Why

Closes ENG-12533

# How

- Removed checking whether the package has any unreleased native changes
- Native changes will no longer cause at least minor version bump
- Suggested version bump will be based only on the changelog entries
- Removed code that is no longer used

# Test Plan

