### PR TITLE
[docs] typo: babel-expo-preset > babel-preset-expo (2)

### DIFF
--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -18,7 +18,7 @@ To install `react-native-reanimated`, run the following command:
 
 <Tab label="SDK 50 and higher">
 
-No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
+No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
 
 </Tab>
 

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -20,7 +20,7 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigati
 
 <Tab label="SDK 50 and higher">
 
-No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-expo-preset` when you install the library.
+No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
 
 </Tab>
 


### PR DESCRIPTION
# Why

Plugin is called `babel-preset-expo` (not `babel-expo-preset`)

(Did [the same fix in another merged PR for another file](https://github.com/expo/expo/pull/29591) -- came across the typo again, and this time did a global search/replace to ensure all instances of the typo will now be fixed.) 

# How

N/A

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
