### PR TITLE
[docs] Fix Yarn 1 vs 2 caching behavior instruction

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -13,7 +13,7 @@ The `cache` field on build profiles in [eas.json](/build/eas-json) can be used t
 
 ## JavaScript dependencies
 
-EAS Build runs an npm cache server that can speed up downloaing avaScript dependencies for your build jobs. By default, projects using npm or Yarn 2+ will use the cache. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache in your project's **package.json**.
+EAS Build runs an npm cache server that can speed up downloading JavaScript dependencies for your build jobs. By default, projects using npm or Yarn 2+ will use the cache. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache in your project's **package.json**.
 
 To disable using our npm cache server for your builds set the `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in **eas.json**.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -13,7 +13,7 @@ The `cache` field on build profiles in [eas.json](/build/eas-json) can be used t
 
 ## JavaScript dependencies
 
-EAS Build runs an npm cache server that can speed up the download of JavaScript dependencies for your build jobs. Projects using npm or Yarn 2+ will use the cache by default. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache.
+EAS Build runs an npm cache server that can speed up downloaing avaScript dependencies for your build jobs. By default, projects using npm or Yarn 2+ will use the cache. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache in your project's **package.json**.
 
 To disable using our npm cache server for your builds set the `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in **eas.json**.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -13,7 +13,7 @@ The `cache` field on build profiles in [eas.json](/build/eas-json) can be used t
 
 ## JavaScript dependencies
 
-EAS Build runs a npm cache server that can speed up downloading JavaScript dependencies for your build jobs. Projects using npm or Yarn v1 (Classic) will use the cache by default. However, Yarn 2+ will require that you apply [this workaround](/build-reference/npm-cache-with-yarn).
+EAS Build runs an npm cache server that can speed up the download of JavaScript dependencies for your build jobs. Projects using npm or Yarn 2+ will use the cache by default. However, Yarn 1 (Classic) requires that you apply this [workaround](/build-reference/npm-cache-with-yarn) to use the cache.
 
 To disable using our npm cache server for your builds set the `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in **eas.json**.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix based on feedback [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1718317063878009).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Revert the change applied by this [diff](https://github.com/expo/expo/pull/29567/files#diff-01560a4f87c847e0236a6242eac4c343be52ef18a0b4e55ac259492a2c4d87a9L16) and improve verbiage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
