### PR TITLE
[go][Android] Bump NDK

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     gradleDownloadTaskVersion = '5.0.1'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
 
-    ndkVersion = "26.1.10909125"
+    ndkVersion = "26.3.11579264"
   }
   repositories {
     google()


### PR DESCRIPTION
# Why

@vonovak and I faced the same issue where we couldn't build the expo go. The error is similar to the issue posted in the react-native repo: https://github.com/facebook/react-native/issues/44681. The attached fix didn't help. 

# How

I figured out that the issue was resolved when we changed the NDK. I don't think it's an excellent long-term solution, but to unblock everyone, we probably should do something about it. 

# Test Plan

- build expo go ✅
