### PR TITLE
[templates] Add MIT License

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-bare-minimum",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
+  "license": "MIT",
   "version": "51.0.27",
   "main": "index.js",
   "scripts": {

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-blank-typescript",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
+  "license": "MIT",
   "version": "51.0.27",
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-blank",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
+  "license": "MIT",
   "version": "51.0.27",
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-default",
   "main": "expo-router/entry",
+  "license": "MIT",
   "version": "51.0.31",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-tabs",
   "main": "expo-router/entry",
+  "license": "MIT",
   "description": "The Tab Navigation project template includes several example screens.",
   "version": "51.0.28",
   "scripts": {


### PR DESCRIPTION
# Why

To be able to pull a package our organisation requires license information available within the package to ensure we comply with relevant license terms. This can be in the form of an explicit LICENSE file or a license name in the package.json. Although I understand templates might be a special case for templates.

MIT license replicates license information provided in other packages in the repo. As mentioned above, there may be a better fit than MIT for templates.

# How

Add license name to package.json

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
