### PR TITLE
chore(package-manager): drop unused `@types/rimraf`

### DIFF
--- a/packages/@expo/package-manager/package.json
+++ b/packages/@expo/package-manager/package.json
@@ -54,7 +54,6 @@
     "@types/js-yaml": "^3.12.5",
     "@types/micromatch": "^4.0.2",
     "@types/npm-package-arg": "^6.1.0",
-    "@types/rimraf": "^3.0.0",
     "@types/split": "^1.0.0",
     "expo-module-scripts": "^3.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,14 +4727,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/rimraf@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
-  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
-
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"


### PR DESCRIPTION
# Why

Part of the `glob`/`rimraf` clean up from #29808

# How

We don't use `rimraf` in `@expo/package-manager`, but we do include the type. This removes that.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
