### PR TITLE
[docs] Fix incorrect Platform order usage in multiple docs

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/PlatformsOrder.yml
+++ b/docs/.vale/writing-styles/expo-docs/PlatformsOrder.yml
@@ -8,3 +8,4 @@ tokens:
   - iOS, Android, and web
   - web, iOS and Android
   - iOS and Android
+  - iOS, Android

--- a/docs/pages/archive/expo-cli.mdx
+++ b/docs/pages/archive/expo-cli.mdx
@@ -315,7 +315,7 @@ Alias: `expo update`
 | ------------------------------------ | --------------------------------------------------------------------- |
 | `--no-install`                       | Skip installing npm packages and CocoaPods.                           |
 | `--npm`                              | Use npm to install dependencies. (default when Yarn is not installed) |
-| `-p, --platform [all\|android\|ios]` | Platforms to sync: ios, android, all. Default: all                    |
+| `-p, --platform [all\|android\|ios]` | Platforms to sync: Android, iOS, all. Default: all                    |
 | `--config [file]`                    | Deprecated: Use app.config.js to switch config files instead.         |
 
 </Collapsible>
@@ -328,7 +328,7 @@ Alias: `expo update`
 | `--clean`                                 | Delete the native folders and regenerate them before applying changes                   |
 | `--npm`                                   | Use npm to install dependencies. (default when Yarn is not installed)                   |
 | `--template [template]`                   | Project template to clone from. File path pointing to a local tar file or a github repo |
-| `-p, --platform [all\|android\|ios]`      | Platforms to sync: ios, android, all. Default: all                                      |
+| `-p, --platform [all\|android\|ios]`      | Platforms to sync: Android, iOS, all. Default: all                                      |
 | `--skip-dependency-update [dependencies]` | Preserves versions of listed packages in package.json (comma separated list)            |
 | `--config [file]`                         | Deprecated: Use app.config.js to switch config files instead.                           |
 

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -476,7 +476,7 @@ Here is what the serialized config would look like:
 ## Why app.plugin.js for plugins
 
 Config resolution searches for a file named **app.plugin.js** first when a Node module ID is provided as a plugin.
-This is because Node environments are often different to iOS, Android, or web JS environments and therefore require different transpilation presets (for example, `module.exports` instead of `import/export`).
+This is because Node environments are often different to Android, iOS, or web JS environments and therefore require different transpilation presets (for example, `module.exports` instead of `import/export`).
 
 Because of this reasoning, the root of a Node module is searched instead of right next to the **index.js**.
 Imagine you had a TypeScript Node module where the transpiled main file was located at **build/index.js**,

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CALLOUT } from '~/ui/components/Text';
 
-URLs are the most powerful way to launch native applications. Native operating systems like macOS, iOS, Android, Windows, and so on, have built-in link handling which chooses an app to handle a URL based on the _URL scheme_. The most common _URL schemes_ are `https` and `http` which are delegated to web browsers like Chrome, or Safari. Native apps, like the ones built with React Native, can implement any _URL scheme_, and the JavaScript React layer can handle the URL used to launch the corresponding native app.
+URLs are the most powerful way to launch native applications. Native operating systems like macOS, Android, iOS, Windows, and so on, have built-in link handling which chooses an app to handle a URL based on the _URL scheme_. The most common _URL schemes_ are `https` and `http` which are delegated to web browsers like Chrome, or Safari. Native apps, like the ones built with React Native, can implement any _URL scheme_, and the JavaScript React layer can handle the URL used to launch the corresponding native app.
 
 ## Linking from your app
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Sets the initial React component to render natively in the app's root React Native view on iOS, Android, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
+Sets the initial React component to render natively in the app's root React Native view on Android, iOS, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/url.mdx
+++ b/docs/pages/versions/unversioned/sdk/url.mdx
@@ -35,4 +35,4 @@ console.log(new URL('http://🥓').toString());
 This outputs the following:
 
 - Web, Node.js: `http://xn--pr9h/`
-- iOS, Android: `http://🥓/`
+- Android, iOS: `http://🥓/`

--- a/docs/pages/versions/v49.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/register-root-component.mdx
@@ -8,7 +8,7 @@ packageName: 'expo'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-Sets the initial React component to render natively in the app's root React Native view on iOS, Android, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
+Sets the initial React component to render natively in the app's root React Native view on Android, iOS, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/register-root-component.mdx
@@ -8,7 +8,7 @@ packageName: 'expo'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-Sets the initial React component to render natively in the app's root React Native view on iOS, Android, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
+Sets the initial React component to render natively in the app's root React Native view on Android, iOS, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v51.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/register-root-component.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios', 'web']
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Sets the initial React component to render natively in the app's root React Native view on iOS, Android, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
+Sets the initial React component to render natively in the app's root React Native view on Android, iOS, and the web. It also adds dev-only debugging tools for use with `npx expo start`.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/url.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/url.mdx
@@ -35,4 +35,4 @@ console.log(new URL('http://🥓').toString());
 This outputs the following:
 
 - Web, Node.js: `http://xn--pr9h/`
-- iOS, Android: `http://🥓/`
+- Android, iOS: `http://🥓/`


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix incorrect usage of Platform Order guideline as per our [writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-android-ios-and-web) in multiple docs.

Also update Vale's `PlatformOrders` rule to add `iOS, Android` pattern.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By updating Vale's rule and then running `yarn run lint-prose`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
