### PR TITLE
fix(jest-expo): avoid adding wildcard typescript paths as module mapping

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixes jest spitting console error caused by ref stubbing. ([#29420](https://github.com/expo/expo/pull/29420) by [@aleqsio](https://github.com/aleqsio))
+- Avoid adding typescript wildcard paths as jest module mapping.
 
 ### 💡 Others
 

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixes jest spitting console error caused by ref stubbing. ([#29420](https://github.com/expo/expo/pull/29420) by [@aleqsio](https://github.com/aleqsio))
-- Avoid adding typescript wildcard paths as jest module mapping.
+- Avoid adding typescript wildcard paths as jest module mapping. ([#29836](https://github.com/expo/expo/pull/29836) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/jest-expo/src/preset/withTypescriptMapping.js
+++ b/packages/jest-expo/src/preset/withTypescriptMapping.js
@@ -12,6 +12,9 @@ function jestMappingFromTypescriptPaths(paths, prefix = '<rootDir>') {
   const mapping = {};
 
   for (const path in paths) {
+    // Abort when path is just a wildcard
+    if (path === '*') continue;
+
     if (!paths[path].length) {
       console.warn(`Skipping empty typescript path map: ${path}`);
       continue;


### PR DESCRIPTION
# Why

Fixes #29775

This is a workaround to make `jest-expo` ts mappings compatible with this [Expo FYI document](https://github.com/expo/fyi/blob/main/absolute-path-expo-modules.md).

# How

- Avoid adding `*` as path to module mapping (thanks to @Kudo)

# Test Plan

See #29775 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
