### PR TITLE
chore(cli): add more tools to standard terminal logs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 💡 Others
 
+- Add "more tools" to terminal UI all the time.
 - Add more tests for export:embed. ([#29811](https://github.com/expo/expo/pull/29811) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce unused server code in exports. ([#29619](https://github.com/expo/expo/pull/29619) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce export code paths. ([#29218](https://github.com/expo/expo/pull/29218) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- Add "more tools" to terminal UI all the time.
+- Add "more tools" to terminal UI all the time. ([#29837](https://github.com/expo/expo/pull/29837) by [@EvanBacon](https://github.com/EvanBacon))
 - Add more tests for export:embed. ([#29811](https://github.com/expo/expo/pull/29811) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce unused server code in exports. ([#29619](https://github.com/expo/expo/pull/29619) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce export code paths. ([#29218](https://github.com/expo/expo/pull/29218) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -76,6 +76,7 @@ export function printUsage(
       { key: 'j', msg: 'open debugger' },
       { key: 'r', msg: 'reload app' },
       !!options.isWebSocketsEnabled && { key: 'm', msg: 'toggle menu' },
+      !!options.isWebSocketsEnabled && { key: 'shift+m', msg: 'more tools' },
       { key: 'o', msg: 'open project code in your editor' },
       {},
     ]);


### PR DESCRIPTION
# Why

Make it a little easier to find atlas.

