### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,15 +31,15 @@ body:
       required: false
   - type: dropdown
     attributes:
-      label: Did you reproduce this issue in a development build?
-      multiple: false
+      label: Where did you reproduce the issue?
+      multiple: true
       options:
-        - "Yes"
-        - No (tested in Expo Go)
-        - No (only happens in a standalone build)
-        - No (web-only issue)
+        - in a development build
+        - in Expo Go
+        - in a standalone app
+        - on web
       description: |
-        While we accept reports for possible bugs within Expo Go itself, if you are reporting an issue within your standalone app that is not reproducible in Expo Go, you should test your code in a [development build](https://docs.expo.dev/develop/development-builds/introduction/) before submitting an issue. A development build is a much more accurate representation of how your standalone app will work, and many such issues can be resolved by troubleshooting with a development build.
+        If you are reporting an issue within your standalone app that is not reproducible in Expo Go, you should test your code in a [development build](https://docs.expo.dev/develop/development-builds/introduction/) before submitting an issue. A development build is a much more accurate representation of how your standalone app will work, and many such issues can be resolved by troubleshooting with a development build.
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
# Why

Last week, I spent some time on an issue that was reported to be happening on a development build, though it fact, the person was using Expo Go. It took me some time to figure this out because I trusted the provided information more than I should've 🙈 .

I thought if there's a way to change the issue template to make these less likely, and suggest these changes:

- "Yes" is no longer the default value. I changed the input to be a multiSelect, so that (1) people need to actively select a value and (2) potentially can report that they were able to reproduce it in multiple setups (though this isn't too important)
- I changed `Did you reproduce this issue in a development build?` to `Where did you reproduce the issue?` because with the multi-select the old question doesn't make sense
- I removed "While we accept reports for possible bugs within Expo Go itself..." because I believe the shortened sentence serves its purpose just as well. In my experience people don't read the templates much and less text is better.

Additionally, there's this template https://github.com/expo/expo/blob/main/.github/ISSUE_TEMPLATE/dev_client_bug_report.yml that 21 currently open issues were created with. There's an overlap with the two templates, and maybe `dev_client_bug_report.yml` could be removed? 🤷 

# How

changed the template

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


