### PR TITLE
Add missing IS_ENV_WITH_LOCAL_ASSETS export in PlatfomUtils web

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `export 'IS_ENV_WITH_LOCAL_ASSETS' (imported as 'IS_ENV_WITH_LOCAL_ASSETS') was not found in './PlatformUtils'` ([#29839](https://github.com/expo/expo/pull/29839) by [@d4rky-pl](https://github.com/d4rky-pl))
+
 ### 💡 Others
 
 - Removed @react-native/assets-registry dependency. ([#29541](https://github.com/expo/expo/pull/29541) by [@kudo](https://github.com/kudo))

--- a/packages/expo-asset/build/PlatformUtils.web.js
+++ b/packages/expo-asset/build/PlatformUtils.web.js
@@ -1,4 +1,5 @@
 export const IS_ENV_WITH_UPDATES_ENABLED = false;
+export const IS_ENV_WITH_LOCAL_ASSETS = false;
 // Compute manifest base URL if available
 export const manifestBaseUrl = null;
 export function getManifest() {

--- a/packages/expo-asset/src/PlatformUtils.web.ts
+++ b/packages/expo-asset/src/PlatformUtils.web.ts
@@ -1,5 +1,5 @@
 export const IS_ENV_WITH_UPDATES_ENABLED = false;
-
+export const IS_ENV_WITH_LOCAL_ASSETS = false;
 // Compute manifest base URL if available
 export const manifestBaseUrl = null;
 


### PR DESCRIPTION
# Why

This PR fixes the warning:

```
export 'IS_ENV_WITH_LOCAL_ASSETS' (imported as 'IS_ENV_WITH_LOCAL_ASSETS') was not found in './PlatformUtils'
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
