### PR TITLE
[sensors][ios] Allow excluding motion permission APIs

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Allow excluding motion permission APIs. ([#29845](https://github.com/expo/expo/pull/29845) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-sensors/ios/BarometerModule.swift
+++ b/packages/expo-sensors/ios/BarometerModule.swift
@@ -24,7 +24,11 @@ public final class BarometerModule: Module {
 
     OnStartObserving {
       if CMAltimeter.authorizationStatus() == .notDetermined {
-        CMSensorRecorder().recordAccelerometer(forDuration: 0.1)
+        if #available(iOS 17.4, *) {
+          // There's a bug in iOS 17.4 where the motion permissions popup won't display
+          // even when the NSMotionUsageDescription is in the plist while using the altimeter.
+          CMSensorRecorder().recordAccelerometer(forDuration: 0.1)
+        }
       }
 
       altimeter.startRelativeAltitudeUpdates(to: operationQueue) { [weak self] data, _ in

--- a/packages/expo-sensors/ios/ExpoSensors.podspec
+++ b/packages/expo-sensors/ios/ExpoSensors.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoSensors'
@@ -18,4 +19,11 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+
+  if podfile_properties['MOTION_PERMISSION'] == 'false'
+    s.ios.exclude_files  = "**/EXMotionPermissionRequester.m",
+                           "**/PedometerModule.swift"
+  else
+    s.ios.exclude_files  = "**/PedometerModuleDisabled.swift"
+  end
 end

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -5,6 +5,7 @@ import ExpoModulesCore
 
 private let EVENT_PEDOMETER_UPDATE = "Exponent.pedometerUpdate"
 
+// This class should always be kept in sync with PedometerModuleDisabled
 public final class PedometerModule: Module {
   private lazy var pedometer = CMPedometer()
 

--- a/packages/expo-sensors/ios/PedometerModuleDisabled.swift
+++ b/packages/expo-sensors/ios/PedometerModuleDisabled.swift
@@ -10,7 +10,7 @@ public final class PedometerModule: Module {
       return false
     }
 
-    AsyncFunction("getStepCountAsync") { (startTime: Double, endTime: Double, promise: Promise) in
+    AsyncFunction("getStepCountAsync") { (_: Double, _: Double, promise: Promise) in
       promise.reject(PedometerDisabledException())
     }
 

--- a/packages/expo-sensors/ios/PedometerModuleDisabled.swift
+++ b/packages/expo-sensors/ios/PedometerModuleDisabled.swift
@@ -1,0 +1,31 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+public final class PedometerModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExponentPedometer")
+
+    AsyncFunction("isAvailableAsync") {
+      return false
+    }
+
+    AsyncFunction("getStepCountAsync") { (startTime: Double, endTime: Double, promise: Promise) in
+      promise.reject(PedometerDisabledException())
+    }
+
+    AsyncFunction("getPermissionsAsync") { (promise: Promise) in
+      promise.reject(PedometerDisabledException())
+    }
+
+    AsyncFunction("requestPermissionsAsync") { (promise: Promise) in
+      promise.reject(PedometerDisabledException())
+    }
+  }
+}
+
+internal final class PedometerDisabledException: Exception {
+  override var reason: String {
+    "This app has disabled motionPermission and CMPedometer services will fail. If you want to use CMPedometer services set a custom motionPermission string."
+  }
+}

--- a/packages/expo-sensors/plugin/build/withSensors.js
+++ b/packages/expo-sensors/plugin/build/withSensors.js
@@ -4,6 +4,12 @@ const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-sensors/package.json');
 const MOTION_USAGE = 'Allow $(PRODUCT_NAME) to access your device motion';
 const withSensors = (config, { motionPermission } = {}) => {
+    if (motionPermission === false) {
+        config = (0, config_plugins_1.withPodfileProperties)(config, (config) => {
+            config.modResults.MOTION_PERMISSION = 'false';
+            return config;
+        });
+    }
     return config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
         NSMotionUsageDescription: MOTION_USAGE,
     })(config, {

--- a/packages/expo-sensors/plugin/src/withSensors.ts
+++ b/packages/expo-sensors/plugin/src/withSensors.ts
@@ -1,4 +1,9 @@
-import { ConfigPlugin, createRunOncePlugin, IOSConfig } from 'expo/config-plugins';
+import {
+  ConfigPlugin,
+  createRunOncePlugin,
+  IOSConfig,
+  withPodfileProperties,
+} from 'expo/config-plugins';
 
 const pkg = require('expo-sensors/package.json');
 const MOTION_USAGE = 'Allow $(PRODUCT_NAME) to access your device motion';
@@ -7,6 +12,13 @@ const withSensors: ConfigPlugin<{ motionPermission?: string | false } | void> = 
   config,
   { motionPermission } = {}
 ) => {
+  if (motionPermission === false) {
+    config = withPodfileProperties(config, (config) => {
+      config.modResults.MOTION_PERMISSION = 'false';
+      return config;
+    });
+  }
+
   return IOSConfig.Permissions.createPermissionsPlugin({
     NSMotionUsageDescription: MOTION_USAGE,
   })(config, {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/29618

# How

- If users disable motion permission by setting it to false through the config plugin, replace  `PedometerModule` with a mock version that throws a warning 
- Add test case for PedometerSensor inside NCL

# Test Plan

- BareExpo on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
