### PR TITLE
[docs] Add EAS Tutorial button

### DIFF
--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -46,10 +46,16 @@ export function QuickStart() {
             Create a universal Android, iOS, and web app
           </RawH2>
           <HomeButton
-            className="hocus:bg-button-primary"
+            className="mb-12 hocus:bg-button-primary"
             href="/tutorial/introduction/"
             rightSlot={<ArrowRightIcon className="icon-md" />}>
-            Start Tutorial
+            Start Expo Tutorial
+          </HomeButton>
+          <HomeButton
+            className="hocus:bg-button-primary"
+            href="/tutorial/eas/introduction/"
+            rightSlot={<ArrowRightIcon className="icon-md" />}>
+            Start EAS Tutorial
           </HomeButton>
         </GridCell>
       </GridContainer>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in marketing office hours with Dan today that when launching EAS Tutorial, adding a button on the home page was skipped. We should add it for better visibility.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Adds "Start EAS Tutorial" button
- Updates "Start Tutorial" button to "Start EAS Tutorial"

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

## Preview

![CleanShot 2024-06-19 at 01 02 40@2x](https://github.com/expo/expo/assets/10234615/1c98319e-051e-4589-9f47-bccec325a5b4)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
