### PR TITLE
refactor(cli): add `--atlas` option to `expo start` and `expo export`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support passing `--port 0` to use any free port. ([#29466](https://github.com/expo/expo/pull/29466) by [@EvanBacon](https://github.com/EvanBacon))
 - Deep link to simulators without prompting for permissions first. ([#29468](https://github.com/expo/expo/pull/29468) by [@EvanBacon](https://github.com/EvanBacon))
 - Support web imports of `react-native/Libraries/Image/resolveAssetSource` in Metro. ([#29685](https://github.com/expo/expo/pull/29685) by [@EvanBacon](https://github.com/EvanBacon))
+- Add `--atlas` flags to `expo start` and `expo export` to enable Atlas. ([#29848](https://github.com/expo/expo/pull/29848) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -43,6 +43,7 @@ export async function exportAppAsync(
     minify,
     bytecode,
     maxWorkers,
+    atlas,
   }: Pick<
     Options,
     | 'dumpAssetmap'
@@ -54,6 +55,7 @@ export async function exportAppAsync(
     | 'minify'
     | 'bytecode'
     | 'maxWorkers'
+    | 'atlas'
   >
 ): Promise<void> {
   setNodeEnv(dev ? 'development' : 'production');
@@ -106,6 +108,7 @@ export async function exportAppAsync(
     location: {},
     resetDevServer: clear,
     maxWorkers,
+    enableAtlas: atlas,
   });
 
   const devServer = devServerManager.getDefaultDevServer();
@@ -264,4 +267,11 @@ export async function exportAppAsync(
 
   // Write all files at the end for unified logging.
   await persistMetroFilesAsync(files, outputPath);
+
+  // Log information about the Atlas file, when enabled
+  if (atlas) {
+    await import('../start/server/metro/debugging/attachAtlas.js').then(({ logAtlasExport }) =>
+      logAtlasExport()
+    );
+  }
 }

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -20,9 +20,12 @@ export async function exportAsync(projectRoot: string, options: Options) {
 
   // Stop any file watchers to prevent the CLI from hanging.
   FileNotifier.stopAll();
-  // Wait until Atlas is ready, when enabled
-  // NOTE(cedric): this is a workaround, remove when `process.exit` is removed
-  await waitUntilAtlasExportIsReadyAsync(projectRoot);
+
+  if (options.atlas) {
+    // Wait until Atlas is ready, when enabled
+    // NOTE(cedric): this is a workaround, remove when `process.exit` is removed
+    await waitUntilAtlasExportIsReadyAsync(projectRoot);
+  }
 
   // Final notes
   Log.log(`App exported to: ${options.outputDir}`);

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -19,6 +19,7 @@ export const expoExport: Command = async (argv) => {
       '--platform': [String],
       '--no-minify': Boolean,
       '--no-bytecode': Boolean,
+      '--atlas': Boolean,
 
       // Hack: This is added because EAS CLI always includes the flag.
       // If supplied, we'll do nothing with the value, but at least the process won't crash.
@@ -54,6 +55,7 @@ export const expoExport: Command = async (argv) => {
         `--dump-assetmap            Emit an asset map for further processing`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
         `-s, --source-maps          Emit JavaScript source maps`,
+        `--atlas                    Gather information about the exported bundles and emit an Atlas file`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -13,6 +13,7 @@ export type Options = {
   bytecode: boolean;
   dumpAssetmap: boolean;
   sourceMaps: boolean;
+  atlas: boolean;
 };
 
 /** Returns an array of platforms based on the input platform identifier and runtime constraints. */
@@ -88,5 +89,6 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     maxWorkers: args['--max-workers'],
     dumpAssetmap: !!args['--dump-assetmap'],
     sourceMaps: !!args['--source-maps'],
+    atlas: !!args['--atlas'],
   };
 }

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -28,6 +28,7 @@ export const expoStart: Command = async (argv) => {
       '--localhost': Boolean,
       '--offline': Boolean,
       '--go': Boolean,
+      '--atlas': Boolean,
       // Aliases
       '-h': '--help',
       '-c': '--clear',
@@ -61,6 +62,7 @@ export const expoStart: Command = async (argv) => {
         `--max-workers <number>          Maximum number of tasks to allow Metro to spawn`,
         `--no-dev                        Bundle in production mode`,
         `--minify                        Minify JavaScript`,
+        `--atlas                         Gather information about the exported bundles and emit an Atlas file`,
         ``,
         chalk`-m, --host <string>             Dev server hosting type. {dim Default: lan}`,
         chalk`                                {bold lan}: Use the local network`,

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -62,7 +62,7 @@ export const expoStart: Command = async (argv) => {
         `--max-workers <number>          Maximum number of tasks to allow Metro to spawn`,
         `--no-dev                        Bundle in production mode`,
         `--minify                        Minify JavaScript`,
-        `--atlas                         Gather information about the exported bundles and emit an Atlas file`,
+        `--atlas                         Enable JavaScript bundle exploration (shift+m)`,
         ``,
         chalk`-m, --host <string>             Dev server hosting type. {dim Default: lan}`,
         chalk`                                {bold lan}: Use the local network`,

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -23,6 +23,8 @@ export type Options = {
   devClient: boolean;
   scheme: string | null;
   host: 'localhost' | 'lan' | 'tunnel';
+  /** Gather information about the exported bundles */
+  atlas: boolean;
 };
 
 export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
@@ -70,6 +72,7 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     maxWorkers: args['--max-workers'],
     port: args['--port'],
     minify: !!args['--minify'],
+    atlas: !!args['--atlas'],
 
     devClient: isDevClient,
 

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -70,6 +70,9 @@ export interface BundlerStartOptions {
   /** Will the bundler be used for exporting. NOTE: This is an odd option to pass to the dev server. */
   isExporting?: boolean;
 
+  /** Enable Atlas to gather information about Metro's dependency graph */
+  enableAtlas?: boolean;
+
   // Webpack options
   /** Should modify and create PWA icons. */
   isImageEditingEnabled?: boolean;

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -630,6 +630,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       parsedOptions,
       {
         isExporting: !!options.isExporting,
+        enableAtlas: options.enableAtlas,
         exp,
       }
     );

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -168,7 +168,8 @@ export async function instantiateMetroAsync(
     exp = getConfig(metroBundler.projectRoot, {
       skipSDKVersionRequirement: true,
     }).exp,
-  }: { isExporting: boolean; exp?: ExpoConfig }
+    enableAtlas = false,
+  }: { isExporting: boolean; exp?: ExpoConfig; enableAtlas?: boolean }
 ): Promise<{
   metro: Metro.Server;
   server: http.Server;
@@ -232,15 +233,17 @@ export async function instantiateMetroAsync(
   }
 
   // Attach Expo Atlas if enabled
-  const atlas = await attachAtlasAsync({
-    isExporting,
-    exp,
-    projectRoot,
-    middleware,
-    metroConfig,
-    // NOTE(cedric): reset the Atlas file once, and reuse it for static exports
-    resetAtlasFile: isExporting,
-  });
+  const atlas = !enableAtlas
+    ? null
+    : await attachAtlasAsync({
+        isExporting,
+        exp,
+        projectRoot,
+        middleware,
+        metroConfig,
+        // NOTE(cedric): reset the Atlas file once, and reuse it for static exports
+        resetAtlasFile: isExporting,
+      });
 
   const { server, metro } = await runServer(
     metroBundler,

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -34,6 +34,7 @@ async function getMultiBundlerStartOptions(
     maxWorkers: options.maxWorkers,
     resetDevServer: options.clear,
     minify: options.minify,
+    enableAtlas: options.atlas,
     location: {
       hostType: options.host,
       scheme: options.scheme,

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -1,4 +1,5 @@
 import { boolish, int, string } from 'getenv';
+import { Log } from '../log';
 
 // @expo/webpack-config -> expo-pwa -> @expo/image-utils: EXPO_IMAGE_UTILS_NO_SHARP
 
@@ -195,7 +196,10 @@ class Env {
     return boolish('EXPO_NO_BUNDLE_SPLITTING', false);
   }
 
-  /** Enable unstable/experimental Atlas to gather bundle information during development or export */
+  /**
+   * Enable unstable/experimental Atlas to gather bundle information during development or export
+   * @deprecated This has been replaced by `npx expo start --atlas` and `npx expo export --atlas`
+   */
   get EXPO_UNSTABLE_ATLAS() {
     return boolish('EXPO_UNSTABLE_ATLAS', false);
   }


### PR DESCRIPTION
# Why

This "promotes" Expo Atlas from unstable feature to an integrated stable feature.

<details><summary><code>npx expo start</code> previews</summary>

help | start | shift+m
--- | --- | ---
![expo start --help](https://github.com/expo/expo/assets/1203991/4e6cb9d9-ee6d-4858-b3b8-ed4b7264f2f0) | ![expo start --atlas](https://github.com/expo/expo/assets/1203991/b453ff8f-cb61-40c8-8dcb-57c414d27c06) | ![shift+m](https://github.com/expo/expo/assets/1203991/28262906-2e6f-4328-8b7d-aad4cd71d8a4)

</details>

<details><summary><code>npx expo export</code> previews</summary>

help | export
--- | ---
![expo export --help](https://github.com/expo/expo/assets/1203991/453b541c-1f78-4055-8ce7-b3f3ba540235) | ![expo export --atlas](https://github.com/expo/expo/assets/1203991/9d0f9e8f-d049-4600-992c-5208a8517b70)

</details>

Using `EXPO_UNSTABLE_ATLAS=true` results in:

![deprecated-envvar](https://github.com/expo/expo/assets/1203991/3c1b7ee1-8b72-40ca-9f96-e9001ff39f6d)


# TODOs

- [ ] Release `expo-atlas@1.0.0`
- [ ] Update version constraints to match any `1.x.x` range with `npx expo-atlas`
- [ ] Add tests to [expo/expo-atlas](https://github.com/expo/expo-atlas)

# How

- Dropped `EXPO_UNSTABLE_ATLAS` environment variable
- Added `EXPO_UNSTABLE_ATLAS` usage check with warning 
- Added `enableAtlas` to Metro bundling options
- Added `--atlas` to `npx expo start --atlas`
- Added `--atlas` to `npx expo export --atlas`
- Added logs when enabling `npx expo export --atlas`

# Test Plan

- `npx expo start --atlas` should boot up the dev server with Atlas enabled (<kbd>shift</kbd>+<kbd>m</kbd> → `open expo-atlas`)
- `npx expo export --atlas` should log the Atlas file export (and how to open it)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
