### PR TITLE
[video] fix `loadMetadata` availability check for tvOS

### DIFF
--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -177,7 +177,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   }
 
   private func loadMetadata(for mediaItem: AVPlayerItem) async throws -> [AVMetadataItem] {
-    if #available(iOS 15.0, *) {
+    if #available(iOS 15.0, tvOS 15.0, *) {
       return try await mediaItem.asset.loadMetadata(for: .iTunesMetadata)
     }
 


### PR DESCRIPTION
# Why

tvOS compile workflow (https://github.com/expo/expo/actions/workflows/tvos-compile-test.yml) started to fail recently:

![Screenshot 2024-06-18 at 21 43 32](https://github.com/expo/expo/assets/719641/47cae48a-0808-4f85-b022-659e25323ebd)

# How

Add tvOS to the availability check in `loadMetadata`.

# Test Plan

Run the CI.