### PR TITLE
fix: volumeAvailableCapacityForImportantUsageKey not available on tvOS

### DIFF
--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -257,10 +257,10 @@ public final class FileSystemModule: Module {
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int64 in
     // Uses required reason API based on the following reason: E174.1 85F4.1
       var keyToQuery: URLResourceKey {
-#if os(tvOS)
-        return .volumeAvailableCapacity
-#else
+#if !os(tvOS)
         return .volumeAvailableCapacityForImportantUsageKey
+#else
+        return .volumeAvailableCapacity
 #endif
       }
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -256,7 +256,15 @@ public final class FileSystemModule: Module {
 
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int64 in
     // Uses required reason API based on the following reason: E174.1 85F4.1
-      let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+      var keyToQuery: URLResourceKey {
+#if os(tvOS)
+        return .volumeAvailableCapacity
+#else
+        return .volumeAvailableCapacityForImportantUsageKey
+#endif
+      }
+
+      let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [keyToQuery])
 
       guard let availableCapacity = resourceValues?.volumeAvailableCapacityForImportantUsage else {
         throw CannotDetermineDiskCapacity()


### PR DESCRIPTION
# Why

Follow up on https://github.com/expo/expo/pull/29732 - volumeAvailableCapacityForImportantUsageKey doesn't exist on tvOS

# How

use `volumeAvailableCapacityForImportantUsageKey` conditionally

# Test Plan

haven't tested yet because I don't have the tvOS simulator but it's a simple change so should work

