### PR TITLE
[dev-launcher] extend the default tests timeout from 5s to 15s

### DIFF
--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -64,6 +64,7 @@
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect",
       "./setupTests.ts"
-    ]
+    ],
+    "testTimeout": 15000
   }
 }


### PR DESCRIPTION
# Why

Looks like the `dev-launcher` tests can time out after the latest test stack bump:
https://github.com/expo/expo/actions/runs/9582963645/job/26423108663?pr=29873#step:7:298

# How

Extend the default tests timeout from 5s to 15s for the package.

# Test Plan

Locally, tests are stable and are passing on consecutive runs. Let's try the CI now.
