### PR TITLE
[docs] Remove additional step around .npmrc in pnpm section as its created by create-expo-app

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -149,11 +149,9 @@ Yarn Modern on EAS requires an [additional configuration step](#additional-confi
 
 Requires installing Node.js. See [pnpm documentation](https://pnpm.io/installation) for installation instructions.
 
-#### Additional configuration steps
+#### `node-linker` configuration in `.npmrc`
 
-After installing pnpm on your local development environment, you've to specify the type linker to install npm packages using [`node-linker`](https://pnpm.io/npmrc#node-linker).
-
-Create **.npmrc** in your project's root directory and add the following configuration:
+When using `pnpm` to run `create-expo-app`, an `.npmrc` file will be created for you in your project to configure the [`node-linker`](https://pnpm.io/npmrc#node-linker) with the value `hoisted`:
 
 ```ini .npmrc
 node-linker=hoisted

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -149,9 +149,7 @@ Yarn Modern on EAS requires an [additional configuration step](#additional-confi
 
 Requires installing Node.js. See [pnpm documentation](https://pnpm.io/installation) for installation instructions.
 
-#### `node-linker` configuration in `.npmrc`
-
-When using `pnpm` to run `create-expo-app`, an `.npmrc` file will be created for you in your project to configure the [`node-linker`](https://pnpm.io/npmrc#node-linker) with the value `hoisted`:
+By default, a project created with pnpm uses [`node-linker`](https://pnpm.io/npmrc#node-linker) with its value set to `hoisted` to install dependencies.
 
 ```ini .npmrc
 node-linker=hoisted


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Docs are incorrect - `create-expo-app` creates the `.npmrc` file for the user, according to:

- the `configurePackageManager()` function https://github.com/expo/expo/blob/6431a40710c7c40007613d87d083c07b28e85233/packages/create-expo/src/resolvePackageManager.ts#L109
- the e2e tests in 28521: https://github.com/expo/expo/pull/28521/#issuecomment-2179239718

# How

<!--
How did you build this feature or fix this bug and why?
-->

Edit the docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Visually tested, checked against e2e tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
