### PR TITLE
[module-scripts] increase default test timeout from 5s to 15s

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
+- Extend default test timeout from 5s to 15s.
 
 ## 3.5.2 - 2024-05-29
 

--- a/packages/expo-module-scripts/createJestPreset.js
+++ b/packages/expo-module-scripts/createJestPreset.js
@@ -49,6 +49,7 @@ function _createJestPreset(basePreset) {
     ...basePreset,
     clearMocks: true,
     roots: ['<rootDir>/src'],
+    testTimeout: 15000,
     transform: {
       '^.+\\.tsx?$': [
         'ts-jest',


### PR DESCRIPTION
# Why

At the beginning I was thinking that test timeouts are the side-effect of `@testing-library` stack bump, but it looks like the GHA have a bad day, since the timeouts also started to pop on in test suites of packages which use `expo-module-scripts` presets. I'm also not able to reproduce those timeouts locally.

Saying that, I think that it would be nice to be a little bit more prone to CI slowness and lenient, so the GHA state do not affect the tests results that easily.

Refs: https://github.com/expo/expo/actions/runs/9582963645/job/26424467464?pr=29873

# How

Increase the default test timeout from 5s to 15s in Jest preset generated by `expo-module-scripts`  package.

# Test Plan

Run the CI.
