### PR TITLE
[docs] Remove additional config steps from `create-expo-app` reference

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -117,15 +117,11 @@ Supported by default if the project directory contains **yarn.lock**.
 
 #### Local installation
 
-Yarn 2+ handles package management differently than Yarn 1. One of the core changes in Yarn 2+ is the PnP node linking model that does not work with React Native.
-
 See [Yarn documentation](https://yarnpkg.com/getting-started/install) for installation instructions.
 
-#### Additional configuration steps
+Yarn 2+ handles package management differently than Yarn 1. One of the core changes in Yarn 2+ is the [Pug'n'Play (PnP)](https://yarnpkg.com/features/pnp) node linking model that does not work with React Native.
 
-After installing Yarn Modern on your local development environment, you've to specify the type linker to install npm packages using [`nodeLinker`](https://yarnpkg.com/features/linkers#nodelinker-node-modules).
-
-Create **.yarnrc.yml** in your project's root directory with the following configuration:
+By default, a project created with `create-expo-app` and Yarn 2+ uses [`node-linker`](https://yarnpkg.com/features/node-linker) with its value set to `node-modules` to install dependencies.
 
 ```yml .yarnrc.yml
 nodeLinker: node-modules
@@ -133,7 +129,7 @@ nodeLinker: node-modules
 
 #### EAS installation
 
-Yarn Modern on EAS requires an [additional configuration step](#additional-configuration-steps) and adding [`eas-build-pre-install` hook](/build-reference/npm-hooks/) in your project's **package.json**, add the following configuration:
+Yarn Modern on EAS requires requires adding [`eas-build-pre-install` hook](/build-reference/npm-hooks/). In your project's **package.json**, add the following configuration:
 
 ```json package.json
 {
@@ -149,7 +145,7 @@ Yarn Modern on EAS requires an [additional configuration step](#additional-confi
 
 Requires installing Node.js. See [pnpm documentation](https://pnpm.io/installation) for installation instructions.
 
-By default, a project created with pnpm uses [`node-linker`](https://pnpm.io/npmrc#node-linker) with its value set to `hoisted` to install dependencies.
+By default, a project created with `create-expo-app` and pnpm uses [`node-linker`](https://pnpm.io/npmrc#node-linker) with its value set to `hoisted` to install dependencies.
 
 ```ini .npmrc
 node-linker=hoisted
@@ -157,7 +153,7 @@ node-linker=hoisted
 
 #### EAS installation
 
-Supported by default if the project directory contains **pnpm-lock.yaml** and the [additional configuration step](#additional-configuration-steps-1) followed.
+Supported by default if the project directory contains **pnpm-lock.yaml**.
 
 ### Bun
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Follow up changes from #29884

# How

<!--
How did you build this feature or fix this bug and why?
-->

`create-expo-app` creates required **.npmrc** or **.yarnrc.yml** file when using pnpm or Yarn 2+. This makes additional config steps outdated. this PR removes these sub-sections and updates the context around node linking module strategies these package managers use.

Due to these changes, also update subsequent EAS installation sections for both of these package managers.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally. Also, manually tested and confirmed the existence of these files by creating new projects with `pnpm create expo-app` and yarn create expo-app`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
