### PR TITLE
[docs] Remove React Native Express additional resourrce

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -38,7 +38,6 @@ The following resources are useful for learning about Expo tooling and services.
 ### React Native
 
 - [React Native Directory](https://reactnative.directory/) - An interactive directory to find packages for your React Native apps.
-- [React Native Express](http://www.reactnativeexpress.com/) - The best way to get started with React Native! It's a walkthrough of the building blocks of React and React Native.
 - [Intermediate React Native](https://frontendmasters.com/courses/intermediate-react-native/) - Paid course by Frontend Masters.
 
 ### Animation and gestures


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

React Native Express is outdated. We should recommend it as an additional resource.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
