### PR TITLE
[Docs] Use Sentry: clarify what type of auth token is needed

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -47,7 +47,7 @@ them later:
 
 <Step label="1.2">
 
-Go to the [Developer Settings > Auth Tokens](https://sentry.io/settings/auth-tokens/) page and create a new (organization, not user) token. The token is automatically scoped for Source Map Upload and Release Creation. Save it.
+Go to the [Developer Settings > Auth Tokens](https://sentry.io/settings/auth-tokens/) page and create a new [Organization Auth Token](https://docs.sentry.io/account/auth-tokens/#organization-auth-tokens). The token is automatically scoped for Source Map Upload and Release Creation. Save it.
 
 </Step>
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -47,7 +47,7 @@ them later:
 
 <Step label="1.2">
 
-Go to the [Developer Settings > Auth Tokens](https://sentry.io/settings/) page and create a new token. The token is automatically scoped for Source Map Upload and Release Creation. Save it.
+Go to the [Developer Settings > Auth Tokens](https://sentry.io/settings/auth-tokens/) page and create a new (organization, not user) token. The token is automatically scoped for Source Map Upload and Release Creation. Save it.
 
 </Step>
 


### PR DESCRIPTION
# Why

I was confused between organization and user auth token. Unfortunately it is not possible to directly link to the correct page, since it's prefixed with your organization slug.

# How

Visit [this page](https://docs.expo.dev/guides/using-sentry/) during setup of Sentry.

# Test Plan

- View the changed documentation page and read the changed text and hopefully understand it

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
