### PR TITLE
fix: compile getFreeDiskStorage on tvOS

### DIFF
--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -258,7 +258,7 @@ public final class FileSystemModule: Module {
       // Uses required reason API based on the following reason: E174.1 85F4.1
       var capacityKey: URLResourceKey
       var extractCapacity: (URLResourceValues?) -> Int64?
-      
+
 #if !os(tvOS)
       capacityKey = .volumeAvailableCapacityForImportantUsageKey
       extractCapacity = { $0?.volumeAvailableCapacityForImportantUsage }
@@ -266,7 +266,7 @@ public final class FileSystemModule: Module {
       capacityKey = .volumeAvailableCapacityKey
       extractCapacity = { $0?.volumeAvailableCapacity }
 #endif
-      
+
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [capacityKey])
       let maybeCapacity = extractCapacity(resourceValues)
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -255,18 +255,22 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("getFreeDiskStorageAsync") { () -> Int64 in
-    // Uses required reason API based on the following reason: E174.1 85F4.1
-      var keyToQuery: URLResourceKey {
+      // Uses required reason API based on the following reason: E174.1 85F4.1
+      var capacityKey: URLResourceKey
+      var extractCapacity: (URLResourceValues?) -> Int64?
+      
 #if !os(tvOS)
-        return .volumeAvailableCapacityForImportantUsageKey
+      capacityKey = .volumeAvailableCapacityForImportantUsageKey
+      extractCapacity = { $0?.volumeAvailableCapacityForImportantUsage }
 #else
-        return .volumeAvailableCapacity
+      capacityKey = .volumeAvailableCapacityKey
+      extractCapacity = { $0?.volumeAvailableCapacity }
 #endif
-      }
+      
+      let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [capacityKey])
+      let maybeCapacity = extractCapacity(resourceValues)
 
-      let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [keyToQuery])
-
-      guard let availableCapacity = resourceValues?.volumeAvailableCapacityForImportantUsage else {
+      guard let availableCapacity = maybeCapacity else {
         throw CannotDetermineDiskCapacity()
       }
       return availableCapacity

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -264,7 +264,12 @@ public final class FileSystemModule: Module {
       extractCapacity = { $0?.volumeAvailableCapacityForImportantUsage }
 #else
       capacityKey = .volumeAvailableCapacityKey
-      extractCapacity = { $0?.volumeAvailableCapacity }
+      extractCapacity = {
+        guard let capacityInt = $0?.volumeAvailableCapacity else {
+          return nil
+        }
+        return Int64(capacityInt)
+      }
 #endif
 
       let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [capacityKey])

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -263,7 +263,7 @@ public final class FileSystemModule: Module {
       }
       return availableCapacity
 #else
-      let resourceValues = try getResourceValues(from: documentDirectory, forKeys: [.volumeAvailableCapacityKey])
+      let resourceValues = try getResourceValues(from: cacheDirectory, forKeys: [.volumeAvailableCapacityKey])
       guard let availableCapacity = resourceValues?.volumeAvailableCapacity else {
         throw CannotDetermineDiskCapacity()
       }


### PR DESCRIPTION
# Why

well, I was being sloppy and merged https://github.com/expo/expo/pull/29873 prematurely

# How

use only symbols available on the platform

# Test Plan

- I tested both branches on iOS by flipping the condition. 
- [CI passes ][(https://github.com/expo/expo/actions/runs/9596172690)](https://github.com/expo/expo/actions/runs/9599685060)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
