### PR TITLE
[image-picker][ios] Fix crash when using popover presentation on iPad

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
 - Support removing microphone permissions through config plugin. ([#29749](https://github.com/expo/expo/pull/29749) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad.
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
 - Support removing microphone permissions through config plugin. ([#29749](https://github.com/expo/expo/pull/29749) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad.
+- [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad. ([#29892](https://github.com/expo/expo/pull/29892) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -175,6 +175,18 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     }
 
     picker.modalPresentationStyle = context.options.presentationStyle.toPresentationStyle()
+
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      let viewFrame = currentViewController.view.frame
+      picker.popoverPresentationController?.sourceRect = CGRect(
+        x: viewFrame.midX,
+        y: viewFrame.maxY,
+        width: 0,
+        height: 0
+      )
+      picker.popoverPresentationController?.sourceView = currentViewController.view
+    }
+
     picker.setResultHandler(context.imagePickerHandler)
 
     // Store picking context as we're navigating to the different view controller (starting asynchronous flow)


### PR DESCRIPTION
# Why
Same problem as #22192. Using the popover presentation style needs to have the `sourceView` and `sourceRect` set on iPad. This problem was mentioned here https://github.com/expo/expo/issues/22192#issuecomment-2180033611

# How
Check we are running on iPad and set the properties

# Test Plan
Tested in a repro project. 
