### PR TITLE
[core][sqlite] close shared object without waiting GC

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [Android] Switch to the JS thread when sending an event. ([#29753](https://github.com/expo/expo/pull/29753) by [@lukmccall](https://github.com/lukmccall))
 - Moved `process` object declaration to global declaration. ([#29745](https://github.com/expo/expo/pull/29745) by [@tsapeta](https://github.com/tsapeta))
 - Use the `src` folder as the Metro target. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Added `SharedObject.close()` to release shared objects without waiting for JavaScript GC. ([#29893](https://github.com/expo/expo/pull/29893) by [@kudo](https://github.com/kudo))
 
 ## 1.12.13 - 2024-06-05
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -6,6 +6,7 @@
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
+#include "JavaScriptWeakObject.h"
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
@@ -175,6 +176,10 @@ private:
   void jniSetNativeStateForSharedObject(
     int id,
     jni::alias_ref<JavaScriptObject::javaobject> jsObject
+  );
+
+  void jniResetNativeStateForSharedObject(
+    jni::alias_ref<JavaScriptWeakObject::javaobject> jsWeakObject
   );
 };
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -122,6 +122,8 @@ class JSIContext : Destructible {
 
   external fun setNativeStateForSharedObject(id: Int, js: JavaScriptObject)
 
+  external fun resetNativeStateForSharedObject(jsWeakObject: JavaScriptWeakObject)
+
   /**
    * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]
    * and HostObject exported via JSI.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -71,9 +71,12 @@ class SharedObjectRegistry(appContext: AppContext) {
   internal fun delete(id: SharedObjectId) {
     synchronized(this) {
       pairs.remove(id)
-    }?.let { (native, _) ->
+    }?.let { (native, jsWeakObject) ->
+      appContextHolder.get()
+        ?.jsiInterop
+        ?.resetNativeStateForSharedObject(jsWeakObject)
       native.sharedObjectId = SharedObjectId(0)
-      native.deallocate()
+      native.emitDeallocate()
     }
   }
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android `global reference table overflow` crash. ([#29893](https://github.com/expo/expo/pull/29893) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -17,8 +17,8 @@ internal class NativeDatabase(val databaseName: String, val openOptions: OpenDat
     return other is NativeDatabase && this.ref == other.ref
   }
 
-  override fun deallocate() {
-    super.deallocate()
+  override fun onDeallocate() {
+    super.onDeallocate()
     val shouldClose = refCount.decrementAndGet() <= 0
     if (shouldClose) {
       this.ref.close()

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
@@ -7,8 +7,8 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 internal class NativeStatement : SharedRef<NativeStatementBinding>(NativeStatementBinding()) {
   var isFinalized = false
 
-  override fun deallocate() {
-    super.deallocate()
+  override fun onDeallocate() {
+    super.onDeallocate()
     this.ref.close()
   }
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModuleNext.kt
@@ -337,6 +337,7 @@ class SQLiteModuleNext : Module() {
     if (statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
       throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
     }
+    statement.close()
     statement.isFinalized = true
   }
 
@@ -376,6 +377,7 @@ class SQLiteModuleNext : Module() {
     maybeThrowForClosedDatabase(database)
     maybeRemoveAllCachedStatements(database).forEach {
       it.ref.sqlite3_finalize()
+      it.close()
     }
     if (database.openOptions.enableCRSQLite) {
       database.ref.sqlite3_exec("SELECT crsql_finalize()")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -223,8 +223,8 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     lastLoadedSource = null
   }
 
-  override fun deallocate() {
-    super.deallocate()
+  override fun onDeallocate() {
+    super.onDeallocate()
     close()
   }
 


### PR DESCRIPTION
# Why

from some stress test of expo-sqlite, the app is crashed because we allocated too many global references for JSIContext and NativeStatementBinding
https://github.com/expo/expo/blob/4455794312292e70eef6d633ee0e85d62c9b06f6/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp#L371-L384

the crash log
```
        expo.kudo.sdk51  F  java_vm_ext.cc:702] JNI ERROR (app bug): global reference table overflow (max=51200)global reference table dump:
                         F  java_vm_ext.cc:702]   Last 10 entries (of 51200):
                         F  java_vm_ext.cc:702]     51199: 0x12ccf270 java.lang.Object[] (3 elements)
                         F  java_vm_ext.cc:702]     51198: 0x12ccf028 expo.modules.sqlite.NativeStatementBinding
                         F  java_vm_ext.cc:702]     51197: 0x13909148 expo.modules.kotlin.jni.JSIContext
                         F  java_vm_ext.cc:702]     51196: 0x12cce358 expo.modules.sqlite.NativeStatementBinding
                         F  java_vm_ext.cc:702]     51195: 0x13909148 expo.modules.kotlin.jni.JSIContext
                         F  java_vm_ext.cc:702]     51194: 0x12ccd680 expo.modules.sqlite.NativeStatementBinding
                         F  java_vm_ext.cc:702]     51193: 0x13909148 expo.modules.kotlin.jni.JSIContext
                         F  java_vm_ext.cc:702]     51192: 0x12ccc9a8 expo.modules.sqlite.NativeStatementBinding
                         F  java_vm_ext.cc:702]     51191: 0x13909148 expo.modules.kotlin.jni.JSIContext
                         F  java_vm_ext.cc:702]     51190: 0x12ccbcd0 expo.modules.sqlite.NativeStatementBinding
                         F  java_vm_ext.cc:702]   Summary:
                         F  java_vm_ext.cc:702]     25286 of expo.modules.kotlin.jni.JSIContext (2 unique instances)
                         F  java_vm_ext.cc:702]     25281 of expo.modules.sqlite.NativeStatementBinding (25281 unique instances)
                         F  java_vm_ext.cc:702]       421 of java.lang.Class (302 unique instances)
                         F  java_vm_ext.cc:702]        83 of com.facebook.react.bridge.JavaModuleWrapper (83 unique instances)
```

# How

- introduce `SharedObject.close()` to developers to release the resources without waiting JS GC.
- deprecate `SharedObject.deallocate()` with `SharedObject.onDeallocate()`. that is to prevent ambiguous between close() and deallocate().

# Test Plan

test repro from https://github.com/mugikhan/test-expo-sqlite

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
