### PR TITLE
Use `globalThis` instead of `global` in the URL implementation

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 - Keep using the legacy event emitter for the `DevLoadingView` in Expo Go. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/src/winter/url.ts
+++ b/packages/expo/src/winter/url.ts
@@ -20,11 +20,11 @@ function getBlobUrlPrefix() {
 
   // Pull the blob module without importing React Native.
   const BlobModule =
-    global.RN$Bridgeless !== true
+    globalThis.RN$Bridgeless !== true
       ? // Legacy RN implementation
-        global.nativeModuleProxy['BlobModule']
+        globalThis.nativeModuleProxy['BlobModule']
       : // Newer RN implementation
-        global.__turboModuleProxy('BlobModule');
+        globalThis.__turboModuleProxy('BlobModule');
 
   const constants = 'BLOB_URI_SCHEME' in BlobModule ? BlobModule : BlobModule.getConstants();
 


### PR DESCRIPTION
# Why

Fixes failures in Jest tests in `expo-asset`

# How

On native, we should use `globalThis` instead of `global`. I'm not exactly sure why, but also TS is complaining about `global`. We use `globalThis` elsewhere.

![Screenshot 2024-06-20 at 14 01 34](https://github.com/expo/expo/assets/1714764/4da8e1b8-ca85-4174-b68f-32894a5767fa)

# Test Plan

`expotools check-packages expo-asset` passes
