### PR TITLE
[router] bump `immer` dev dependency, fix import

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -89,9 +89,9 @@
     "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react": "^15.0.7",
     "@testing-library/react-native": "^12.5.1",
-    "tsd": "^0.28.1",
+    "immer": "^10.1.1",
     "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610",
-    "immer": "^8"
+    "tsd": "^0.28.1"
   },
   "dependencies": {
     "@expo/metro-runtime": "3.2.1",

--- a/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.web.ts
+++ b/packages/expo-router/src/fork/__tests__/getStateFromPath-upstream.test.web.ts
@@ -1,6 +1,6 @@
 import { findFocusedRoute } from '@react-navigation/native';
 import type { InitialState } from '@react-navigation/routers';
-import produce from 'immer';
+import { produce } from 'immer';
 
 import { getMockConfig } from '../../testing-library';
 import getPathFromState from '../getPathFromState';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9874,10 +9874,10 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@^8:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
-  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
+immer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 immutable@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Why

Refs: https://github.com/expo/expo/pull/29861

# How

Bump lately added `immer` development dependency and fix import to make dependabot a happy bot.

# Test Plan

After the changes all tests are passing.
