### PR TITLE
Add note about what is generating `eas.json`

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -9,9 +9,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**, if you have run `expo build:configure`. Configuration for EAS Build all belongs under the `build` key.
+**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**, if you have run `eas build:configure`. Configuration for EAS Build all belongs under the `build` key.
 
-The default configuration for **eas.json** generated when running `expo build:configure` in a new project is shown below:
+The default configuration for **eas.json** generated when running `eas build:configure` in a new project is shown below:
 
 ```json eas.json
 {

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -9,9 +9,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**, if you have run `eas build:configure`. Configuration for EAS Build all belongs under the `build` key.
+**eas.json** is the configuration file for EAS CLI and services. It is generated when you run the [`eas build:configure` command](/build/setup/#configure-the-project) for the first time in your project and is located next to **package.json** at the root of your project.  Configuration for EAS Build all belongs under the `build` key.
 
-The default configuration for **eas.json** generated when running `eas build:configure` in a new project is shown below:
+The default configuration for **eas.json** generated in a new project is shown below:
 
 ```json eas.json
 {

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**. Configuration for EAS Build all belongs under the `build` key.
+**eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**, if you have run `expo build:configure`. Configuration for EAS Build all belongs under the `build` key.
 
 The default configuration for **eas.json** generated when running `expo build:configure` in a new project is shown below:
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -11,7 +11,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 **eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to the **package.json**. Configuration for EAS Build all belongs under the `build` key.
 
-The default configuration for **eas.json** in a new project is shown below:
+The default configuration for **eas.json** generated when running `expo build:configure` in a new project is shown below:
 
 ```json eas.json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This docs page appears to be missing information about where `eas.json` is coming from.

When generating a project using the commands below, there is no `eas.json` file:

```bash
mkdir abc
cd abc
pnpm create expo-app@latest --template blank-typescript .
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Checked the docs for correctness and against the style guide

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

cc @amandeepmittal 