### PR TITLE
[docs] Update example snippet in Usage section in Font API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -67,35 +67,35 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
 
 <SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
-```jsx
-import { useCallback } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+```tsx
 /* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
 /* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+import { useEffect } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
 
 /* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
 SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
-  const [fontsLoaded, fontError] = useFonts({
+  const [loaded, error] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
 
-  /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
-  const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded || fontError) {
-      await SplashScreen.hideAsync();
+  useEffect(() => {
+    if (loaded || error) {
+      /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
+      SplashScreen.hideAsync();
+      /* @end */
     }
-  }, [fontsLoaded, fontError]);
-  /* @end */
+  }, [loaded, error]);
 
-  if (!fontsLoaded && !fontError) {
+  if (!loaded && !error) {
     return null;
   }
 
   return (
-    <View style={styles.container} onLayout={onLayoutRootView}>
+    <View style={styles.container}>
       <Text style={{ fontFamily: 'Inter-Black', fontSize: 30 }}>Inter Black</Text>
       <Text style={{ fontSize: 30 }}>Platform Default</Text>
     </View>

--- a/docs/pages/versions/v51.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/font.mdx
@@ -67,35 +67,35 @@ You can configure `expo-font` using its built-in [config plugin](/config-plugins
 
 <SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
-```jsx
-import { useCallback } from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+```tsx
 /* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
 /* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+import { useEffect } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
 
 /* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
 SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
-  const [fontsLoaded, fontError] = useFonts({
+  const [loaded, error] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
 
-  /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
-  const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded || fontError) {
-      await SplashScreen.hideAsync();
+  useEffect(() => {
+    if (loaded || error) {
+      /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
+      SplashScreen.hideAsync();
+      /* @end */
     }
-  }, [fontsLoaded, fontError]);
-  /* @end */
+  }, [loaded, error]);
 
-  if (!fontsLoaded && !fontError) {
+  if (!loaded && !error) {
     return null;
   }
 
   return (
-    <View style={styles.container} onLayout={onLayoutRootView}>
+    <View style={styles.container}>
       <Text style={{ fontFamily: 'Inter-Black', fontSize: 30 }}>Inter Black</Text>
       <Text style={{ fontSize: 30 }}>Platform Default</Text>
     </View>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There's a difference between how [Fonts guide shows the example](https://docs.expo.dev/develop/user-interface/fonts/#minimal-example) using a Custom Font vs how Font API reference does in Usage section.

We should keep the same pattern of using examples in both places so that a developer can easily use it in their app, especially with the new default template which uses `useEffect` instead of `useCallback`.

Follow-up #29903

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the example in Usage section of Font API reference.

Changes applied to `unversioned` and SDK 51 references.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By updating example snippets and then running Snack to test it.

![CleanShot 2024-06-20 at 20 28 29@2x](https://github.com/expo/expo/assets/10234615/66928778-d517-4338-a255-273ccd53c131)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
