### PR TITLE
Activate the native fetch feature with the use of remix/node

### DIFF
--- a/packages/@expo/server/src/environment.ts
+++ b/packages/@expo/server/src/environment.ts
@@ -26,7 +26,7 @@ export const ExpoRequest = Request;
 export const ExpoResponse = Response;
 
 export function installGlobals() {
-  installRemixGlobals();
+  installRemixGlobals({ nativeFetch: true });
 
   global.ExpoRequest = Request;
   global.ExpoResponse = Response;


### PR DESCRIPTION
# Why

rewrite: Per Remix documentation fetch polyfill is deprecated

According to the Remix documentation, the fetch polyfill is no longer recommended for use.

# How


As per the guidance in the documentation (https://remix.run/docs/en/main/guides/single-fetch#enabling-single-fetch), we should activate the native fetch feature.

# Test Plan


# Checklist


- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
