### PR TITLE
chore: inhibit warnings in ci

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -16,7 +16,9 @@ install! 'cocoapods',
   :incremental_installation => true,
   :deterministic_uuids => false
 source 'https://cdn.cocoapods.org/'
-
+if ENV['CI']
+  inhibit_all_warnings!
+end
 prepare_react_native_project!
 
 abstract_target 'BareExpoMain' do


### PR DESCRIPTION
# Why

to make builds faster. Right now some of my builds are failing by exceeding 45 minute timeout.

# How

by using CI env var, and reducing the log length


# Test Plan

the ios build logs should be shorter

This is a follow-up on https://github.com/expo/expo/pull/29677: previously the ios build logs had about 5.9k lines e.g. [here](https://github.com/expo/expo/actions/runs/9430061689/job/26013000966). On current `main` they have ~53k [see here](https://github.com/expo/expo/actions/runs/9598696517/job/26470651685) though in this particular case the build took 17 minutes, so maybe something else is at play as well. Either way, it's an improvement imho.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
