### PR TITLE
[gha] update few actions which still were using Node 16

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -100,7 +100,7 @@ jobs:
         run: ./deploy.sh
       - name: 🔍 Find old comment if it exists
         if: contains(github.event.pull_request.labels.*.name, 'preview')
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: old_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -108,7 +108,7 @@ jobs:
           body-includes: 📘 Your docs
       - name: 💬 Add comment with preview URL
         if: contains(github.event.pull_request.labels.*.name, 'preview') && steps.old_comment.outputs.comment-id == ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -120,7 +120,7 @@ jobs:
             });
       - name: 💬 Update comment with preview URL
         if: contains(github.event.pull_request.labels.*.name, 'preview') && steps.old_comment.outputs.comment-id != ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -11,7 +11,7 @@ jobs:
   check-if-trusted:
     runs-on: ubuntu-22.04
     steps:
-      - uses: 8398a7/action-slack@v3.8.0
+      - uses: 8398a7/action-slack@v3
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_expo_support }}
@@ -22,7 +22,7 @@ jobs:
           text: 'This issue should be triaged ASAP: ${{ github.event.issue.html_url }}'
           author_name: ${{ github.event.issue.user.login }}
           fields: repo
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -86,7 +86,7 @@ jobs:
     if: github.event.label.name == 'issue accepted'
     steps:
       - name: Comment on issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -99,7 +99,7 @@ jobs:
               However, we can’t promise any sort of timeline for resolution. We prioritize issues based on severity, breadth of impact, and alignment with our roadmap. If you’d like to help move it more quickly, you can continue to investigate it more deeply and/or you can open a pull request that fixes the cause.
             `})
       - name: Remove "Needs Review" label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             try {
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ github.event.label.name == 'Comments on closed issue' }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: "${{ github.event.label.name == 'Version bump PR' }}"
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -73,7 +73,7 @@ jobs:
           echo "isPreviousFingerprintEmpty=${{ steps.fingerprint.outputs.previous-fingerprint == '' }}"
 
       - name: 🏷️ Labeling PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff == '[]' }}
         with:
           script: |
@@ -96,7 +96,7 @@ jobs:
               labels: ['bot: fingerprint compatible']
             })
       - name: 🏷️ Labeling PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' }}
         with:
           script: |
@@ -120,7 +120,7 @@ jobs:
             })
 
       - name: 🔍 Find old comment if it exists
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         if: ${{ github.event_name == 'pull_request' }}
         id: old_comment
         with:
@@ -129,7 +129,7 @@ jobs:
           body-includes: <!-- pr-labeler comment -->
       - name: 💬 Add comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -156,7 +156,7 @@ jobs:
             });
       - name: 💬 Update comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -184,7 +184,7 @@ jobs:
             });
       - name: 💬 Delete comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff == '[]' && steps.old_comment.outputs.comment-id != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
# Why

![Screenshot 2024-06-20 at 18 49 59](https://github.com/expo/expo/assets/719641/ce0953fa-a6de-4d95-b099-e05019ab2843)

I.e: https://github.com/expo/expo/actions/runs/9600224283

# How

Update `actions/github-script` and `peter-evans/find-comment` to the latest major versions to stop using deprecated Node 16 runner.

# Test Plan

Run the CI.