### PR TITLE
[ci] fix error for pr-labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: 🏷️ Labeling PR
         uses: actions/github-script@v7
-        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff == '[]' }}
+        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff == '[]' }}
         with:
           script: |
             try {
@@ -97,7 +97,7 @@ jobs:
             })
       - name: 🏷️ Labeling PR
         uses: actions/github-script@v7
-        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' }}
+        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' }}
         with:
           script: |
             try {
@@ -128,7 +128,7 @@ jobs:
           comment-author: 'expo-bot'
           body-includes: <!-- pr-labeler comment -->
       - name: 💬 Add comment with fingerprint
-        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
               body: body,
             });
       - name: 💬 Update comment with fingerprint
-        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id != '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id != '' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
               body: body,
             });
       - name: 💬 Delete comment with fingerprint
-        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff == '[]' && steps.old_comment.outputs.comment-id != '' }}
+        if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff == '[]' && steps.old_comment.outputs.comment-id != '' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
# Why

prevent pr-labeler error like https://github.com/expo/expo/actions/runs/9601099919/job/26479882439

# How

it happens when the latest main commit has `[skip ci]` and no previous fingerprint found in the database. in this case, the diff will be huge and not able to send as github comment.
we just skip pr-labeler if previous fingerprint is not found.

# Test Plan

ci passed