### PR TITLE
[docs] make unversioned docs easier to access on PROD deploy

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -12,13 +12,19 @@ import DocumentationSidebarRight, {
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
+import versions from '~/public/static/constants/versions.json';
 import { PageMetadata } from '~/types/common';
+import { Callout } from '~/ui/components/Callout';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { PagePlatformTags } from '~/ui/components/PagePlatformTags';
 import { PageTitle } from '~/ui/components/PageTitle';
 import { Separator } from '~/ui/components/Separator';
 import { Sidebar } from '~/ui/components/Sidebar';
+import { versionToText } from '~/ui/components/Sidebar/ApiVersionSelect';
+import { A } from '~/ui/components/Text';
+
+const { LATEST_VERSION } = versions;
 
 export type DocPageProps = PropsWithChildren<PageMetadata>;
 
@@ -134,6 +140,13 @@ export default function DocumentationPage({
           'mx-auto py-10 px-14',
           'max-lg-gutters:px-4 max-lg-gutters:pt-5 max-lg-gutters:pb-12'
         )}>
+        {version && version === 'unversioned' && (
+          <Callout type="default" size="sm" className="!inline-flex w-full !mb-5">
+            This is documentation for the next SDK version. For up-to-date documentation, see the{' '}
+            <A href={pathname.replace('unversioned', 'latest')}>latest version</A> (
+            {versionToText(LATEST_VERSION)}).
+          </Callout>
+        )}
         {title && (
           <PageTitle
             title={title}

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -225,7 +225,7 @@ button.
 not appear on the screen.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -1053,7 +1053,7 @@ This should come from the user field of an
     
 
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -2465,7 +2465,7 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3326,7 +3326,7 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3633,7 +3633,7 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -3957,7 +3957,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
@@ -4942,7 +4942,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
@@ -5589,7 +5589,7 @@ for more details.
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
@@ -5631,7 +5631,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
@@ -5864,7 +5864,7 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
@@ -6164,7 +6164,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       class="css-1avgxs7-APISectionDeprecationNote"
     >
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-16xozm6-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-16xozm6-Callout"
         data-testid="callout-container"
       >
         <div
@@ -6577,7 +6577,7 @@ provided with an
         
 
         <blockquote
-          class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+          class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
           data-testid="callout-container"
         >
           <div
@@ -7744,7 +7744,7 @@ the platform.
               
 
               <blockquote
-                class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+                class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
                 data-testid="callout-container"
               >
                 <div
@@ -10217,7 +10217,7 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
@@ -10739,7 +10739,7 @@ provided with a single argument that is
       
 
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -225,11 +225,11 @@ button.
 not appear on the screen.
     </p>
     <blockquote
-      class="!mb-3.5 css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -251,7 +251,7 @@ not appear on the screen.
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         <p
           class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -1053,11 +1053,11 @@ This should come from the user field of an
     
 
     <blockquote
-      class="css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -1079,7 +1079,7 @@ This should come from the user field of an
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         
 
@@ -2465,11 +2465,11 @@ sign-out operation.
 which contains all of the pertinent user and credential information.
     </p>
     <blockquote
-      class="!mb-3.5 css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -2491,7 +2491,7 @@ which contains all of the pertinent user and credential information.
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         <p
           class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3326,11 +3326,11 @@ may be
 You must include the ID string of the user whose credentials you'd like to refresh.
     </p>
     <blockquote
-      class="!mb-3.5 css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3352,7 +3352,7 @@ You must include the ID string of the user whose credentials you'd like to refre
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         <p
           class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3633,11 +3633,11 @@ OAuth 2.0 protocol
 None of these options are required.
     </p>
     <blockquote
-      class="!mb-3.5 css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3659,7 +3659,7 @@ None of these options are required.
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         <p
           class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -3957,11 +3957,11 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
     </p>
     <blockquote
-      class="!mb-3.5 css-zknray-Callout"
+      class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
       data-testid="callout-container"
     >
       <div
-        class="css-7jywx8-Callout"
+        class="select-none mt-[5px] [table_&]:mt-[3px]"
       >
         <svg
           class="icon-sm text-icon-default"
@@ -3983,7 +3983,7 @@ You must include the ID string of the user to sign out.
         </svg>
       </div>
       <div
-        class="css-1ohc0ia-Callout"
+        class="text-default w-full last:mb-0 css-mt3buo-Callout"
       >
         <p
           class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -4942,11 +4942,11 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <blockquote
-        class="!mb-3.5 css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -4968,7 +4968,7 @@ After calling this function, the listener will no longer receive any events from
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           <p
             class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -5589,11 +5589,11 @@ for more details.
       
 
       <blockquote
-        class="css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5615,7 +5615,7 @@ for more details.
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           
 
@@ -5631,11 +5631,11 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="!mb-3.5 css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5657,7 +5657,7 @@ You will still need to handle null values for any fields you request.
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           <p
             class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -5864,11 +5864,11 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="!mb-3.5 css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 !mb-3.5 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -5890,7 +5890,7 @@ for more details.
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           <p
             class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -6164,11 +6164,11 @@ exports[`APISection expo-barcode-scanner 1`] = `
       class="css-1avgxs7-APISectionDeprecationNote"
     >
       <blockquote
-        class="css-dmb9uy-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-16xozm6-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-warning"
@@ -6190,7 +6190,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           <p
             class="mb-3.5 css-1kfqm4n-TextComponent"
@@ -6577,11 +6577,11 @@ provided with an
         
 
         <blockquote
-          class="css-zknray-Callout"
+          class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
           data-testid="callout-container"
         >
           <div
-            class="css-7jywx8-Callout"
+            class="select-none mt-[5px] [table_&]:mt-[3px]"
           >
             <svg
               class="icon-sm text-icon-default"
@@ -6603,7 +6603,7 @@ provided with an
             </svg>
           </div>
           <div
-            class="css-1ohc0ia-Callout"
+            class="text-default w-full last:mb-0 css-mt3buo-Callout"
           >
             
 
@@ -7744,11 +7744,11 @@ the platform.
               
 
               <blockquote
-                class="css-zknray-Callout"
+                class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
                 data-testid="callout-container"
               >
                 <div
-                  class="css-7jywx8-Callout"
+                  class="select-none mt-[5px] [table_&]:mt-[3px]"
                 >
                   <svg
                     class="icon-sm text-icon-default"
@@ -7770,7 +7770,7 @@ the platform.
                   </svg>
                 </div>
                 <div
-                  class="css-1ohc0ia-Callout"
+                  class="text-default w-full last:mb-0 css-mt3buo-Callout"
                 >
                   
 
@@ -10217,11 +10217,11 @@ exports[`APISection expo-pedometer 1`] = `
       
 
       <blockquote
-        class="css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -10243,7 +10243,7 @@ exports[`APISection expo-pedometer 1`] = `
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           
 
@@ -10739,11 +10739,11 @@ provided with a single argument that is
       
 
       <blockquote
-        class="css-zknray-Callout"
+        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-18a3llt-Callout"
         data-testid="callout-container"
       >
         <div
-          class="css-7jywx8-Callout"
+          class="select-none mt-[5px] [table_&]:mt-[3px]"
         >
           <svg
             class="icon-sm text-icon-default"
@@ -10765,7 +10765,7 @@ provided with a single argument that is
           </svg>
         </div>
         <div
-          class="css-1ohc0ia-Callout"
+          class="text-default w-full last:mb-0 css-mt3buo-Callout"
         >
           
 

--- a/docs/scripts/generate-static-resources.js
+++ b/docs/scripts/generate-static-resources.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import navigation from '../constants/navigation.js';
 import * as versions from '../constants/versions.js';
@@ -8,26 +8,11 @@ import * as versions from '../constants/versions.js';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const basePath = path.join(dirname, '../', 'public', 'static', 'constants');
 
-const env = process.argv.slice(2)[0] || 'development';
-
 function writeResource(filename, data) {
   fs.writeFileSync(path.join(basePath, filename), JSON.stringify(data), { flag: 'wx' });
 }
 
-function getVersionForEnvironment(environment) {
-  switch (environment) {
-    case 'production':
-      return versions.VERSIONS.filter(v => v !== 'unversioned');
-    case 'preview':
-    default:
-      return versions.VERSIONS;
-  }
-}
-
 fs.mkdirSync(basePath);
 
-writeResource('versions.json', {
-  ...versions,
-  VERSIONS: getVersionForEnvironment(env),
-});
+writeResource('versions.json', versions);
 writeResource('navigation.json', navigation);

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -1,13 +1,18 @@
 import { css } from '@emotion/react';
 import { mergeClasses, theme, typography } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
 import {
   XSquareSolidIcon,
   InfoCircleSolidIcon,
   AlertTriangleSolidIcon,
 } from '@expo/styleguide-icons';
-import { Children, HTMLAttributes, isValidElement } from 'react';
-import type { PropsWithChildren, ReactNode, ComponentType } from 'react';
+import {
+  Children,
+  HTMLAttributes,
+  isValidElement,
+  type ComponentType,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react';
 
 type CalloutType = 'default' | 'warning' | 'error' | 'info';
 
@@ -15,6 +20,7 @@ type CalloutProps = PropsWithChildren<{
   type?: CalloutType;
   className?: string;
   icon?: ComponentType<any> | string;
+  size?: 'sm' | 'md';
 }>;
 
 const extractType = (childrenArray: ReactNode[]) => {
@@ -32,7 +38,13 @@ const extractType = (childrenArray: ReactNode[]) => {
   return false;
 };
 
-export const Callout = ({ type = 'default', icon, children, className }: CalloutProps) => {
+export const Callout = ({
+  type = 'default',
+  size = 'md',
+  icon,
+  children,
+  className,
+}: CalloutProps) => {
   const content = Children.toArray(children).filter(child => isValidElement(child))[0];
   const contentChildren = Children.toArray(isValidElement(content) && content?.props?.children);
 
@@ -43,16 +55,29 @@ export const Callout = ({ type = 'default', icon, children, className }: Callout
   return (
     <blockquote
       css={[containerStyle, getCalloutColor(finalType)]}
-      className={className}
+      className={mergeClasses(
+        'flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1',
+        '[table_&]:last-of-type:mb-0',
+        // TODO(simek): remove after migration to new components is completed
+        '[&_p]:!mb-0',
+        className
+      )}
       data-testid="callout-container">
-      <div css={iconStyle}>
+      <div
+        className={mergeClasses(
+          'select-none mt-[5px]',
+          '[table_&]:mt-[3px]',
+          size === 'sm' && 'mt-[3px]'
+        )}>
         {typeof icon === 'string' ? (
           icon
         ) : (
           <Icon className={mergeClasses('icon-sm', getCalloutIconColor(finalType))} />
         )}
       </div>
-      <div css={contentStyle}>
+      <div
+        css={size === 'sm' ? contentSmStyle : contentMdStyle}
+        className={mergeClasses('text-default w-full', 'last:mb-0')}>
         {type === finalType ? children : contentChildren.filter((_, i) => i !== 0)}
       </div>
     </blockquote>
@@ -99,46 +124,18 @@ function getCalloutIconColor(type: CalloutType) {
 const containerStyle = css({
   backgroundColor: theme.background.subtle,
   border: `1px solid ${theme.border.default}`,
-  borderRadius: borderRadius.md,
-  display: 'flex',
-  gap: spacing[2],
-  padding: `${spacing[3]}px ${spacing[4]}px`,
-  marginBottom: spacing[4],
-
-  'table &': {
-    ':last-of-type': {
-      marginBottom: 0,
-    },
-  },
 
   code: {
     backgroundColor: theme.background.element,
   },
-
-  // TODO(simek): remove after migration to new components is completed
-  p: {
-    marginBottom: `0 !important`,
-  },
 });
 
-const iconStyle = css({
-  fontStyle: 'normal',
-  marginTop: 5,
-  userSelect: 'none',
-
-  'table &': {
-    marginTop: 3,
-  },
-});
-
-const contentStyle = css({
+const contentMdStyle = css({
   ...typography.fontSizes[16],
-  color: theme.text.default,
-  width: '100%',
+});
 
-  '*:last-child': {
-    marginBottom: 0,
-  },
+const contentSmStyle = css({
+  ...typography.fontSizes[14],
 });
 
 const warningColorStyle = css({

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -56,7 +56,7 @@ export const Callout = ({
     <blockquote
       css={[containerStyle, getCalloutColor(finalType)]}
       className={mergeClasses(
-        'flex gap-2 rounded-md shadow-xs py-3 px-4 mb-1',
+        'flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4',
         '[table_&]:last-of-type:mb-0',
         // TODO(simek): remove after migration to new components is completed
         '[&_p]:!mb-0',

--- a/docs/ui/components/Sidebar/ApiVersionSelect.tsx
+++ b/docs/ui/components/Sidebar/ApiVersionSelect.tsx
@@ -46,9 +46,9 @@ export function ApiVersionSelect() {
   );
 }
 
-function versionToText(version: string): string {
+export function versionToText(version: string): string {
   if (version === 'unversioned') {
-    return 'Unversioned';
+    return 'Next (unversioned)';
   } else if (version === 'latest') {
     return `${formatSdkVersion(LATEST_VERSION)} (latest)`;
   } else if (BETA_VERSION && version === BETA_VERSION.toString()) {


### PR DESCRIPTION
# Why

We deploy the `unversioned` files for a while, but we were still hiding the option in the API reference version selector.

With enough clarification for the docs user, I think we can exposed them a bit more, so looking at current state of docs/package and upcoming features is easier.

# How

Simplify the versions constants generation logic, add the note at the top of unversioned page with link to the latest version of the documentation, partially rewrite the `Callout` to Tailwind, add `size` prop support.

# Test Plan

The changes have been reviewed locally. Test snapshots have been regenerated.

# Preview

![Screenshot 2024-06-21 at 10 36 17](https://github.com/expo/expo/assets/719641/826e7033-a882-4fb3-a5c7-a0267d3259db)

