### PR TITLE
refactor(fingerprint): upgrade `glob@7` to `glob@10`

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Upgrade `glob@7` to `glob@10`.
+
 ## 0.10.0 - 2024-06-20
 
 ### 🛠 Breaking changes

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Upgrade `glob@7` to `glob@10`.
+- Upgrade `glob@7` to `glob@10`. ([#29927](https://github.com/expo/expo/pull/29927) by [@byCedric](https://github.com/byCedric))
 
 ## 0.10.0 - 2024-06-20
 

--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@types/find-up": "^4.0.0",
     "expo-module-scripts": "^3.3.0",
-    "glob": "^7.1.7",
+    "glob": "^10.4.2",
     "require-from-string": "^2.0.2",
     "temp-dir": "^2.0.0"
   }

--- a/packages/@expo/fingerprint/scripts/createFixture.ts
+++ b/packages/@expo/fingerprint/scripts/createFixture.ts
@@ -4,21 +4,9 @@
  * Usage: npx ts-node scripts/createFixture /path/to/app /path/to/output.json
  */
 import realFS from 'fs';
-import glob from 'glob';
+import { glob as globAsync } from 'glob';
 import { fs, vol } from 'memfs';
 import path from 'path';
-
-function globAsync(pattern: string, options: Parameters<typeof glob>[1]): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    glob(pattern, options, (err, matches) => {
-      if (err != null) {
-        reject(err);
-      } else {
-        resolve(matches);
-      }
-    });
-  });
-}
 
 async function createFixtureAsync(targetDir: string, outputFile: string) {
   const files = await globAsync('**/*', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9309,15 +9309,16 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.1.tgz#0cfb01ab6a6b438177bfe6a58e2576f6efe909c2"
-  integrity sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==
+glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.1, glob@^10.4.2:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.2.tgz#bed6b95dade5c1f80b4434daced233aee76160e5"
+  integrity sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
     minimatch "^9.0.4"
     minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
 glob@^5.0.14:
@@ -13211,6 +13212,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
+  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
 
 pako@~0.2.0:
   version "0.2.9"


### PR DESCRIPTION
# Why

Split off from #29808, specific to `@expo/fingerprint`

# How

- Upgraded `glob@7` to `glob@10`
- Removed `globAsync` wrapper in favor of default `import { glob as globAsync } from 'glob'`

# Test Plan

See if CI and tests passes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
