### PR TITLE
[gha] bump deprecated artifacts actions

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -82,7 +82,7 @@ jobs:
           script: expotools android-native-unit-tests --type instrumented
       - name: 💾 Save test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: packages/**/build/outputs/androidTest-results/**/*

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: expotools native-unit-tests --platform android
       - name: 💾 Save test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: packages/**/build/test-results/**/*xml

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -42,7 +42,7 @@ jobs:
           author_name: Check for Changes in Bare Diffs
       - name: 💾 Store artifacts of diff failures
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: template-bare-minimum-bare-diff-failure
           path: docs/public/static/diffs/template-bare-minimum/raw

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -135,7 +135,7 @@ jobs:
       - name: E2E (playwright) Test CLI
         run: yarn test:playwright
         working-directory: packages/@expo/cli
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -36,7 +36,7 @@ jobs:
       #     swift build -c release
       #     cp .build/release/swiftlint /usr/local/bin/
       # - name: 📦 Make an artifact
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: swiftlint
       #     path: SwiftLint/.build

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: 💾 Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: expo-dev-client-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: 💾 Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: expo-dev-client-latest-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -73,7 +73,7 @@ jobs:
           NODE_ENV: production
           CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: ios-builds-oldArch-${{ matrix.build-type }}
@@ -92,7 +92,7 @@ jobs:
           NODE_ENV: production
           CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: ios-builds-newArch-${{ matrix.build-type }}
@@ -158,7 +158,7 @@ jobs:
           NODE_ENV: production
           VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: android-builds-oldArch-${{ matrix.build-type }}
@@ -176,7 +176,7 @@ jobs:
           NODE_ENV: production
           VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: android-builds-newArch-${{ matrix.build-type }}

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -61,7 +61,7 @@ jobs:
           EXPO_DEBUG: 1
           NODE_ENV: production
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
@@ -91,7 +91,7 @@ jobs:
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
@@ -116,7 +116,7 @@ jobs:
         working-directory: apps/bare-expo
       - name: Store images of build failures
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-artifacts
           path: |
@@ -174,7 +174,7 @@ jobs:
         run: ./gradlew -DtestBuildType=release :app:assembleRelease :app:assembleAndroidTest --no-daemon
         working-directory: apps/bare-expo/android
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
@@ -201,7 +201,7 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
@@ -221,7 +221,7 @@ jobs:
           working-directory: ./apps/bare-expo
       - name: 📸 Store images of test failures
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-artifacts
           path: apps/bare-expo/artifacts

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -76,7 +76,7 @@ jobs:
           EXPO_DEBUG: 1
           NODE_ENV: production
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
@@ -106,7 +106,7 @@ jobs:
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 30
       - name: Store testing artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-artifacts
           path: |
@@ -197,7 +197,7 @@ jobs:
           EXPO_DEBUG: 1
           NODE_ENV: production
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
@@ -224,7 +224,7 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
@@ -244,7 +244,7 @@ jobs:
           working-directory: ./apps/bare-expo
       - name: 📸 Store images of test failures
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bare-expo-artifacts
           path: apps/bare-expo/artifacts

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -138,6 +138,7 @@ jobs:
           path: |
             ~/.maestro/tests
             ~/Library/Logs/maestro
+          overwrite: true
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))


### PR DESCRIPTION
# Why

![Screenshot 2024-06-21 at 11 32 13](https://github.com/expo/expo/assets/719641/c3786f30-7a7f-4d9e-91df-76dea4e36061)

# How

Bump `actions/upload-artifact` and `actions/download-artifact` actions in our workflows.

# Test Plan

Run and monitor the CI, apply the fixes for file overwrites, if we perform any (might have miss that):
* https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md