### PR TITLE
refactor(expo-module-scripts): upgrade `glob@7` to `glob@10`

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
-- Update `glob@7` to `glob@10`.
+- Update `glob@7` to `glob@10`. ([#29931](https://github.com/expo/expo/pull/29931) by [@byCedric](https://github.com/byCedric))
 
 ## 3.5.2 - 2024-05-29
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Update `commander` dependency. ([#29603](https://github.com/expo/expo/pull/29603) by [@Simek](https://github.com/Simek))
+- Update `glob@7` to `glob@10`.
 
 ## 3.5.2 - 2024-05-29
 

--- a/packages/expo-module-scripts/bin/expo-module-readme
+++ b/packages/expo-module-scripts/bin/expo-module-readme
@@ -2,7 +2,7 @@
 'use strict';
 
 const fs = require('fs');
-const glob = require('glob');
+const { globSync } = require('glob');
 const path = require('path');
 
 function replaceAll(current, replacement, content) {
@@ -58,7 +58,7 @@ function generateREADME() {
   readme = replaceAll('description', description, readme);
 
   if (isIOS) {
-    const podspecs = glob.sync('{ios/**/,}*.podspec');
+    const podspecs = globSync('{ios/**/,}*.podspec');
     const podspecPath = podspecs[0];
     const podName = (() => {
       const parts = podspecPath.split('/');
@@ -92,7 +92,7 @@ function generateREADME() {
     }
     readme = replaceAll('docName', docName, readme);
     if (isAndroid) {
-      const androidPackages = glob.sync('android/src/**/*Package.{java,kt}');
+      const androidPackages = globSync('android/src/**/*Package.{java,kt}');
       let androidPackage;
       let androidPackagePath = 'expo.modules.yourModule.YourPackage';
       let androidPackageName = 'YourPackage';

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -39,7 +39,7 @@
     "commander": "^12.1.0",
     "eslint-config-universe": "^13.0.0",
     "find-yarn-workspace-root": "^2.0.0",
-    "glob": "^7.1.7",
+    "glob": "^10.4.2",
     "jest-expo": "~51.0.0-unreleased",
     "jest-snapshot-prettier": "npm:prettier@^2",
     "jest-watch-typeahead": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9309,15 +9309,16 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.1.tgz#0cfb01ab6a6b438177bfe6a58e2576f6efe909c2"
-  integrity sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==
+glob@^10.2.2, glob@^10.3.10, glob@^10.3.12, glob@^10.4.1, glob@^10.4.2:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.2.tgz#bed6b95dade5c1f80b4434daced233aee76160e5"
+  integrity sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
     minimatch "^9.0.4"
     minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
 glob@^5.0.14:
@@ -13211,6 +13212,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
+  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
 
 pako@~0.2.0:
   version "0.2.9"


### PR DESCRIPTION
# Why

Split off from #29808, specific to `expo-module-scripts`

# How

- Upgraded `glob@7` to `glob@10`

# Test Plan

See if CI and tests passes, specifically the readme command:

- `$ expo-module readme` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
