### PR TITLE
[tools] Use next changelog-based version for canary releases

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -22,6 +22,7 @@ import {
 import { sdkVersionAsync } from '../../ProjectVersions';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
+import { resolveReleaseTypeAndVersion } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, green } = chalk;
@@ -48,10 +49,11 @@ export const prepareCanaries = new Task<TaskArgs>(
     const canarySuffix = await getCurrentCanaryVersionSuffix();
     const nextSdkVersion = await getNextSdkVersion();
 
-    for (const { pkg, state, pkgView } of parcels) {
+    for (const parcel of parcels) {
+      const { pkg, state, pkgView } = parcel;
       const baseVersion = SDK_CONSTRAINED_PACKAGES.includes(pkg.packageName)
         ? nextSdkVersion
-        : '0.0.1';
+        : resolveReleaseTypeAndVersion(parcel, options);
 
       state.releaseVersion = findNextAvailableCanaryVersion(
         `${baseVersion}-${canarySuffix}`,


### PR DESCRIPTION
# Why

Currently all canary releases are using `0.0.1-canary-*` versions (except SDK-constrained packages). It was not very clear what version should be used though. Since #29781 the version suggested by the publish script is no longer depending on the native changes, so the suggested version should be more accurate.

# How

Instead of a hardcoded `0.0.1` version, use the same version that the non-canary publish script suggests.

# Test Plan

I ran `et publish --canary --dry` locally and it seemed to use correct, changelog-based versions.

It also handles the case when the version on `main` is lower than the latest one (i.e. released from the SDK branch). See `expo-video` below – on `main` it is `1.1.9`, `1.2.0` was released from `sdk-51`, so the next minor from `main` should actually be `1.3.0`.

![Screenshot 2024-06-21 at 11 54 09](https://github.com/expo/expo/assets/1714764/e7eff12e-be5b-43f2-a507-1ea4f2987f22)
