### PR TITLE
[core][Android] Reduce the number of global references to JSIContext

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [iOS] Fix data race in `PersistentFileLogSpec.swift`. ([#28924](https://github.com/expo/expo/pull/28924) by [@hakonk](https://github.com/hakonk))
 - [Android] Fix the event emitter, which might crash during the reloads. ([#29176](https:/github.com/expo/expo/pull/29176) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix random conversion errors when converting JavaScript floating point numbers to `Swift.Float`. ([#29053](https://github.com/expo/expo/pull/29053) by [@behenate](https://github.com/behenate))
-- [Android] Reduce the number of global references to JSIContext.
+- [Android] Reduce the number of global references to JSIContext. ([#29936](https://github.com/expo/expo/pull/29936) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix data race in `PersistentFileLogSpec.swift`. ([#28924](https://github.com/expo/expo/pull/28924) by [@hakonk](https://github.com/hakonk))
 - [Android] Fix the event emitter, which might crash during the reloads. ([#29176](https:/github.com/expo/expo/pull/29176) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix random conversion errors when converting JavaScript floating point numbers to `Swift.Float`. ([#29053](https://github.com/expo/expo/pull/29053) by [@behenate](https://github.com/behenate))
+- [Android] Reduce the number of global references to JSIContext.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -29,42 +29,6 @@ namespace expo {
 
 #endif
 
-/*
- * A wrapper for a global reference that can be deallocated on any thread.
- * It should be used with smart pointer. That structure can't be copied or moved.
- */
-template <typename T>
-class ThreadSafeJNIGlobalRef {
-public:
-  ThreadSafeJNIGlobalRef(jobject globalRef) : globalRef(globalRef) {}
-  ThreadSafeJNIGlobalRef(const ThreadSafeJNIGlobalRef &other) = delete;
-  ThreadSafeJNIGlobalRef(ThreadSafeJNIGlobalRef &&other) = delete;
-  ThreadSafeJNIGlobalRef &operator=(const ThreadSafeJNIGlobalRef &other) = delete;
-  ThreadSafeJNIGlobalRef &operator=(ThreadSafeJNIGlobalRef &&other) = delete;
-
-  void use(std::function<void(jni::alias_ref<T> globalRef)> &&action) {
-    if (globalRef == nullptr) {
-      throw std::runtime_error("ThreadSafeJNIGlobalRef: globalRef is null");
-    }
-
-    jni::ThreadScope::WithClassLoader([this, action = std::move(action)]() {
-      jni::alias_ref<jobject> aliasRef = jni::wrap_alias(globalRef);
-      jni::alias_ref<T> jsiContextRef = jni::static_ref_cast<T>(aliasRef);
-      action(jsiContextRef);
-    });
-  }
-
-  ~ThreadSafeJNIGlobalRef() {
-    if (globalRef != nullptr) {
-      jni::ThreadScope::WithClassLoader([this] {
-        jni::Environment::current()->DeleteGlobalRef(this->globalRef);
-      });
-    }
-  }
-
-  jobject globalRef;
-};
-
 jni::local_ref<JSIContext::jhybriddata>
 JSIContext::initHybrid(jni::alias_ref<jhybridobject> jThis) {
   return makeCxxInstance(jThis);
@@ -90,7 +54,10 @@ void JSIContext::registerNatives() {
 }
 
 JSIContext::JSIContext(jni::alias_ref<jhybridobject> jThis)
-  : javaPart_(jni::make_global(jThis)) {}
+  : javaPart_(jni::make_global(jThis)),
+    threadSafeJThis(std::make_shared<ThreadSafeJNIGlobalRef<JSIContext::javaobject>>(
+      jni::Environment::current()->NewGlobalRef(javaPart_.get())
+    )) {}
 
 JSIContext::~JSIContext() {
   if (runtimeHolder) {
@@ -368,15 +335,11 @@ void JSIContext::jniSetNativeStateForSharedObject(
   int id,
   jni::alias_ref<JavaScriptObject::javaobject> jsObject
 ) {
-  auto threadSafeRef = std::make_shared<ThreadSafeJNIGlobalRef<JSIContext::javaobject>>(
-    jni::Environment::current()->NewGlobalRef(javaPart_.get())
-  );
-
   auto nativeState = std::make_shared<expo::SharedObject::NativeState>(
     id,
     // We can't predict the order of deallocation of the JSIContext and the SharedObject.
     // So we need to pass a new ref to retain the JSIContext to make sure it's not deallocated before the SharedObject.
-    [threadSafeRef = std::move(threadSafeRef)](const SharedObject::ObjectId objectId) {
+    [threadSafeRef = threadSafeJThis](const SharedObject::ObjectId objectId) {
       threadSafeRef->use([objectId](jni::alias_ref<JSIContext::javaobject> globalRef) {
         JSIContext::deleteSharedObject(globalRef, objectId);
       });

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -150,11 +150,19 @@ public:
 
 private:
   friend HybridBase;
+
+  /*
+   * We stores two global references to the java part of the JSIContext.
+   * However, one is wrapped in additional abstraction to make it thread-safe,
+   * which increase the access time. For most operations, we should use the bare reference.
+   * Only for operations that are executed on different threads that aren't attached to JVM,
+   * we should use the thread-safe reference.
+   */
   jni::global_ref<JSIContext::javaobject> javaPart_;
+  std::shared_ptr<ThreadSafeJNIGlobalRef<JSIContext::javaobject>> threadSafeJThis;
 
   bool wasDeallocated_ = false;
 
-  std::shared_ptr<ThreadSafeJNIGlobalRef<JSIContext::javaobject>> threadSafeJThis;
 
   explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -9,6 +9,7 @@
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
+#include "ThreadSafeJNIGlobalRef.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -152,6 +153,8 @@ private:
   jni::global_ref<JSIContext::javaobject> javaPart_;
 
   bool wasDeallocated_ = false;
+
+  std::shared_ptr<ThreadSafeJNIGlobalRef<JSIContext::javaobject>> threadSafeJThis;
 
   explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -152,7 +152,7 @@ private:
   friend HybridBase;
 
   /*
-   * We stores two global references to the java part of the JSIContext.
+   * We store two global references to the Java part of the JSIContext.
    * However, one is wrapped in additional abstraction to make it thread-safe,
    * which increase the access time. For most operations, we should use the bare reference.
    * Only for operations that are executed on different threads that aren't attached to JVM,

--- a/packages/expo-modules-core/android/src/main/cpp/ThreadSafeJNIGlobalRef.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ThreadSafeJNIGlobalRef.h
@@ -1,0 +1,49 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <android/log.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+/*
+ * A wrapper for a global reference that can be deallocated on any thread.
+ * It should be used with smart pointer. That structure can't be copied or moved.
+ */
+template<typename T>
+class ThreadSafeJNIGlobalRef {
+public:
+  ThreadSafeJNIGlobalRef(jobject globalRef) : globalRef(globalRef) {}
+  ThreadSafeJNIGlobalRef(const ThreadSafeJNIGlobalRef &other) = delete;
+  ThreadSafeJNIGlobalRef(ThreadSafeJNIGlobalRef &&other) = delete;
+  ThreadSafeJNIGlobalRef &operator=(const ThreadSafeJNIGlobalRef &other) = delete;
+  ThreadSafeJNIGlobalRef &operator=(ThreadSafeJNIGlobalRef &&other) = delete;
+
+  void use(std::function<void(jni::alias_ref<T> globalRef)> &&action) {
+    if (globalRef == nullptr) {
+      __android_log_print(ANDROID_LOG_WARN, "ExpoModulesCore", "ThreadSafeJNIGlobalRef was used after deallocation.");
+      return;
+    }
+
+    jni::ThreadScope::WithClassLoader([this, action = std::move(action)]() {
+      jni::alias_ref<jobject> aliasRef = jni::wrap_alias(globalRef);
+      jni::alias_ref<T> jsiContextRef = jni::static_ref_cast<T>(aliasRef);
+      action(jsiContextRef);
+    });
+  }
+
+  ~ThreadSafeJNIGlobalRef() {
+    if (globalRef != nullptr) {
+      jni::ThreadScope::WithClassLoader([this] {
+        jni::Environment::current()->DeleteGlobalRef(this->globalRef);
+      });
+    }
+  }
+
+  jobject globalRef;
+};
+
+} // namespace expo


### PR DESCRIPTION
# Why

Reduces the number of global references to `JSIContext`. 
A better version of https://github.com/expo/expo/pull/29893.

# How

Instead of creating multiple references to `JSIContext`, we can just reuse one. 

# Test Plan

- bare-expo ✅ 