### PR TITLE
[sql][Android] Reduce the number of global references to `NativeStatementBinding`

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Reduce the number of global references to `NativeStatementBinding`.
+- [Android] Reduce the number of global references to `NativeStatementBinding`. ([#29937](https://github.com/expo/expo/pull/29937) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Reduce the number of global references to `NativeStatementBinding`.
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.h
@@ -35,9 +35,7 @@ public:
   jni::local_ref<jni::JArrayList<jni::JObject>> getColumnValues();
 
 private:
-  explicit NativeStatementBinding(
-      jni::alias_ref<NativeStatementBinding::jhybridobject> jThis)
-      : javaPart_(jni::make_global(jThis)) {}
+  explicit NativeStatementBinding(jni::alias_ref<NativeStatementBinding::jhybridobject> jThis) {}
 
   jni::local_ref<jni::JObject> getColumnValue(int index);
 
@@ -49,7 +47,6 @@ private:
   friend HybridBase;
   friend NativeDatabaseBinding;
 
-  jni::global_ref<NativeStatementBinding::javaobject> javaPart_;
   sqlite3_stmt *stmt;
 };
 


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/29893.
I don't think holding global reference to `NativeStatementBinding` is needed. 

# How

Removed the global references to `NativeStatementBinding`.

# Test Plan

- bare-expo sql tests ✅ 