### PR TITLE
[docs] Fix typo and broken link in `create-expo-app` reference

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -121,7 +121,7 @@ See [Yarn documentation](https://yarnpkg.com/getting-started/install) for instal
 
 Yarn 2+ handles package management differently than Yarn 1. One of the core changes in Yarn 2+ is the [Pug'n'Play (PnP)](https://yarnpkg.com/features/pnp) node linking model that does not work with React Native.
 
-By default, a project created with `create-expo-app` and Yarn 2+ uses [`node-linker`](https://yarnpkg.com/features/node-linker) with its value set to `node-modules` to install dependencies.
+By default, a project created with `create-expo-app` and Yarn 2+ uses [`nodeLinker`](https://yarnpkg.com/features/linkers#nodelinker-node-modules) with its value set to `node-modules` to install dependencies.
 
 ```yml .yarnrc.yml
 nodeLinker: node-modules


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Looks like Yarn 2+ documentation link isn't working. Also, their docs mentions `nodeLinker` instead of `node-linker`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the broken and the typo.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
