### PR TITLE
[docs] Update dynamic-routes.mdx

### DIFF
--- a/docs/pages/develop/dynamic-routes.mdx
+++ b/docs/pages/develop/dynamic-routes.mdx
@@ -83,7 +83,7 @@ export default function HomeScreen() {
       <Text>Home</Text>
       <Link
         href={{
-          pathname: '/user/[id]',
+          pathname: '/details/[id]',
           params: { id: 'bacon' },
         }}>
         View user details


### PR DESCRIPTION
Link pathName typo fix

# Why

Typo fix for the pathName in the Expo Link example

# How

I was creating an Expo app, noticed this minor typo.

# Test Plan

This is a text update

