### PR TITLE
[create-expo] Update help menu to list the currently available templates

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- Update list of available templates ([#29955](https://github.com/expo/expo/pull/29955] by [@kadikraman](https://github.com/kadikraman))
+- Update list of available templates ([#29955](https://github.com/expo/expo/pull/29955) by [@kadikraman](https://github.com/kadikraman))
 
 ### 💡 Others
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Update list of available templates ([#29955](https://github.com/expo/expo/pull/29955] by [@kadikraman](https://github.com/kadikraman))
 
 ### 💡 Others
 

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -39,7 +39,7 @@ async function run() {
       [
         `-y, --yes             Use the default options for creating a project`,
         `    --no-install      Skip installing npm packages or CocoaPods`,
-        chalk`-t, --template {gray [pkg]}  NPM template to use: blank, tabs, bare-minimum. Default: blank`,
+        chalk`-t, --template {gray [pkg]}  NPM template to use: default, blank, blank-typescript, tabs, bare-minimum. Default: default`,
         chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,


### PR DESCRIPTION
# Why

The list of available templates for `npx create-expo-app --help` was out of date.

# How

Update to include an accurate list of templates.

# Test Plan

## Before
<img width="925" alt="Screenshot 2024-06-22 at 13 54 17" src="https://github.com/expo/expo/assets/6534400/24dec091-544c-49f3-a6d6-10b43b3645cf">  

## After
<img width="1212" alt="Screenshot 2024-06-22 at 13 54 06" src="https://github.com/expo/expo/assets/6534400/c8098aa2-0298-4b5a-9565-b9d812615998">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
