### PR TITLE
[sensors][iOS] Fix pedometer sensors when app goes to background then foreground

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix incorrect event emitting tests. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Remove usage of deprecated internal modules API. ([#28715](https://github.com/expo/expo/pull/28715) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods))
+- [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods)) ([#29957](https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods))
 
 ## 13.0.8 - 2024-05-29
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix incorrect event emitting tests. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Remove usage of deprecated internal modules API. ([#28715](https://github.com/expo/expo/pull/28715) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods)) ([#29957](https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods))
+- [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods)) 
 
 ## 13.0.8 - 2024-05-29
 

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix incorrect event emitting tests. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Remove usage of deprecated internal modules API. ([#28715](https://github.com/expo/expo/pull/28715) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods))
 
 ## 13.0.8 - 2024-05-29
 

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -82,6 +82,8 @@ public final class PedometerModule: Module {
 
     OnStopObserving {
       stopUpdates()
+      watchStartDate = nil
+      watchHandler = nil
     }
 
     OnAppEntersBackground {
@@ -108,8 +110,6 @@ public final class PedometerModule: Module {
     }
 
     pedometer.stopUpdates()
-    watchStartDate = nil
-    watchHandler = nil
   }
 }
 


### PR DESCRIPTION
# Why

On iOS, Pedometer sensor is currently broken if app goes to background then comes back in foreground.

It's very easy to reproduce:
- subscribe to `Pedometer.watchStepCount`
- confirm steps are received
- put app in background
- put app in foreground
- no more steps are received even if `Pedometer.watchStepCount` is subscribed again

# How

The issue is that sensor reference values `watchStartDate` and `watchHandler` are reset in stopUpdates

While they should only be reset in `OnStopObserving`, which is also cleaner since both values are set in the opposite function `OnStartObserving`

# Test Plan

Manually tested

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
