### PR TITLE
[core] fix local path paring error on ios version lower than 17

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Fix the event emitter, which might crash during the reloads. ([#29176](https:/github.com/expo/expo/pull/29176) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix random conversion errors when converting JavaScript floating point numbers to `Swift.Float`. ([#29053](https://github.com/expo/expo/pull/29053) by [@behenate](https://github.com/behenate))
 - [Android] Reduce the number of global references to JSIContext. ([#29936](https://github.com/expo/expo/pull/29936) by [@lukmccall](https://github.com/lukmccall))
+- Fixed `getPathPermissions` permission error for local path with spaces on iOS 16 and older. ([#29958](https://github.com/expo/expo/pull/29958) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemLegacyUtilities.swift
@@ -83,7 +83,7 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
 
   @objc
   public func getPathPermissions(_ path: String) -> EXFileSystemPermissionFlags {
-    guard let url = URL(string: path) else {
+    guard let url = convertToUrl(string: path) else {
       return []
     }
     let permissionsForInternalDirectories = getInternalPathPermissions(url)

--- a/packages/expo-modules-core/ios/Tests/FileSystemLegacyUtilitiesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FileSystemLegacyUtilitiesSpec.swift
@@ -10,16 +10,16 @@ final class FileSystemLegacyUtilitiesSpec: ExpoSpec {
 
     describe("getPathPermissions") {
       it("should return read/write permissions for filePath with `file:` scheme") {
-        let docRootUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let fileUrl = docRootUrl.appendingPathComponent("test.txt")
+        let dirUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let fileUrl = dirUrl.appendingPathComponent("dir/test.txt")
         let filePath = fileUrl.absoluteString
         expect(filePath.starts(with: "file:")) == true
         expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]
       }
 
       it("should return read/write permissions for filePath without `file:` scheme") {
-        let docRootUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        let fileUrl = docRootUrl.appendingPathComponent("test.txt")
+        let dirUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let fileUrl = dirUrl.appendingPathComponent("dir/test.txt")
         let filePath = fileUrl.path
         expect(filePath.starts(with: "file:")) == false
         expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]

--- a/packages/expo-modules-core/ios/Tests/FileSystemLegacyUtilitiesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FileSystemLegacyUtilitiesSpec.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class FileSystemLegacyUtilitiesSpec: ExpoSpec {
+  override class func spec() {
+    let fsUtils = FileSystemLegacyUtilities()
+
+    describe("getPathPermissions") {
+      it("should return read/write permissions for filePath with `file:` scheme") {
+        let docRootUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let fileUrl = docRootUrl.appendingPathComponent("test.txt")
+        let filePath = fileUrl.absoluteString
+        expect(filePath.starts(with: "file:")) == true
+        expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]
+      }
+
+      it("should return read/write permissions for filePath without `file:` scheme") {
+        let docRootUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let fileUrl = docRootUrl.appendingPathComponent("test.txt")
+        let filePath = fileUrl.path
+        expect(filePath.starts(with: "file:")) == false
+        expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities.swift
@@ -61,14 +61,19 @@ internal func isFileUrlPath(_ path: String) -> Bool {
 
 internal func convertToUrl(string value: String) -> URL? {
   let url: URL?
-
   if #available(iOS 17, *) {
     // URL(string:) supports RFC 3986 as URLComponents from iOS 17
     url = URL(string: value)
-  } else {
+  } else if #available(iOS 16, *) {
     // URLComponents parses and constructs URLs according to RFC 3986.
     // For some unusual urls URL(string:) will fail incorrectly
     url = URLComponents(string: value)?.url ?? URL(string: value)
+  } else {
+    // URLComponents on iOS 15 and lower does not well support RFC 3986.
+    // We have to fallback URL(fileURLWithPath:) first.
+    url = value.first == "/"
+      ? URL(fileURLWithPath: value)
+      : URLComponents(string: value)?.url ?? URL(string: value)
   }
 
   guard let url else {

--- a/packages/expo-modules-core/ios/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities.swift
@@ -60,9 +60,18 @@ internal func isFileUrlPath(_ path: String) -> Bool {
 }
 
 internal func convertToUrl(string value: String) -> URL? {
-  // URLComponents parses and constructs URLs according to RFC 3986.
-  // For some unusual urls URL(string:) will fail incorrectly
-  guard let url = URLComponents(string: value)?.url ?? URL(string: value) else {
+  let url: URL?
+
+  if #available(iOS 17, *) {
+    // URL(string:) supports RFC 3986 as URLComponents from iOS 17
+    url = URL(string: value)
+  } else {
+    // URLComponents parses and constructs URLs according to RFC 3986.
+    // For some unusual urls URL(string:) will fail incorrectly
+    url = URLComponents(string: value)?.url ?? URL(string: value)
+  }
+
+  guard let url else {
     return nil
   }
   // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.


### PR DESCRIPTION
# Why

possibly fix for #29759

# How

on ios < 17, the `URL(string:)` cannot parse an URL that has spaces and without scheme, it returns nil instead. before SDK 51, we used `URL(fileURLWithPath:)` instead. that's a regression from #27069.
this pr tries to use the `URLComponents(string:)` as fallback for ios < 16 which supports RFC 3986 with spaces.

# Test Plan

i first tried to add an unit test for `FileSystemLegacyUtilities.getPathPermissions`. our ios-unit-test ci job is running on ios 16, so there was an expected failed test: https://github.com/expo/expo/actions/runs/9634505045/job/26570225509
then revised the code to use the `convertToUrl(string:)` to fix the broken test.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
