### PR TITLE
[docs] Improve Preview section introduction

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -469,5 +469,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/develop/user-interface/splash-screen/': '/develop/user-interface/splash-screen-and-app-icon/',
 
   // Temporary redirects
-  '/guides/react-compiler': '/preview/react-compiler',
+  '/guides/react-compiler/': '/preview/react-compiler/',
 };

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -468,6 +468,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/develop/user-interface/app-icons/': '/develop/user-interface/splash-screen-and-app-icon/',
   '/develop/user-interface/splash-screen/': '/develop/user-interface/splash-screen-and-app-icon/',
 
+  // Preview section
+  '/preview/support/': '/preview/introduction/',
+
   // Temporary redirects
   '/guides/react-compiler/': '/preview/react-compiler/',
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -515,7 +515,6 @@ const learn = [
 const preview = [
   makeSection('Preview', [
     makePage('preview/introduction.mdx'),
-    makePage('preview/support.mdx'),
     makePage('preview/react-compiler.mdx'),
     { expanded: true },
   ]),

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -371,7 +371,7 @@ redirects[/develop/user-interface/splash-screen]=develop/user-interface/splash-s
 redirects[/preview/support]=preview/introduction
 
 # Temporary redirects
-redirects[guides/react-compiler]=/preview/react-compiler
+redirects[guides/react-compiler]=preview/react-compiler
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -367,6 +367,9 @@ redirects[/learn]=tutorial/introduction
 redirects[/develop/user-interface/app-icons]=develop/user-interface/splash-screen-and-app-icon
 redirects[/develop/user-interface/splash-screen]=develop/user-interface/splash-screen-and-app-icon
 
+# Preview section
+redirects[/preview/support]=preview/introduction
+
 # Temporary redirects
 redirects[guides/react-compiler]=/preview/react-compiler
 

--- a/docs/pages/preview/introduction.mdx
+++ b/docs/pages/preview/introduction.mdx
@@ -12,7 +12,7 @@ We just ask that you please keep the following in mind when exploring preview fe
 1. **Don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
 2. **You probably should not depend on preview features in production**. Unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
 3. **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
-4. **Please provide us with detailed feedback from your experiences using experimental features**. From documentation to API interfaces to CLI commands, we want to hear your feedback because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and feedback](/preview/support/).
+4. **Please provide us with detailed feedback from your experiences using experimental features**. From documentation to API interfaces to CLI commands, we want to hear your feedback because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and feedback](#support-and-feedback).
 
 ## Support and feedback
 

--- a/docs/pages/preview/introduction.mdx
+++ b/docs/pages/preview/introduction.mdx
@@ -3,15 +3,21 @@ title: Introduction
 hideTOC: true
 ---
 
-This section of the documentation provides a preview of experimental new features that we're working on at Expo. It is not linked from the main documentation but it is also not particularly well hidden &mdash; if you want to find it, [you can](https://github.com/expo/expo/tree/main/docs/pages/preview/introduction.mdx).
+This section of the documentation provides a preview of experimental new features that we're working on at Expo. It is not linked from the main documentation but it is also not particularly well hidden.
 
 > **info** Pages behind `/preview` are not indexed on search engines.
 
 We just ask that you please keep the following in mind when exploring preview features:
 
-1. **Please don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
-2. **You probably should not depend on preview features in production** unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
+1. **Don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
+2. **You probably should not depend on preview features in production**. Unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
 3. **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
-4. **Please provide us with detailed feedback from your experiences using experimental features** &mdash; from documentation to API interfaces to CLI commands, we want to hear your feedback now, because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and Feedback](/preview/support/).
+4. **Please provide us with detailed feedback from your experiences using experimental features**. From documentation to API interfaces to CLI commands, we want to hear your feedback because it will never be quite as easy to change it as during the preview phase. More information on this in [Support and feedback](/preview/support/).
 
-Thank you! Now take a look at the sidebar (or the `...` menu on mobile) to explore.
+## Support and feedback
+
+The purpose of feature previews is to gather feedback to polish and improve products before we ship them to a broader audience. We want you to kick the tires on these features and let us know how it goes. Try them with your largest app, your smaller app, a new app, an old app, and everything in between that you have the patience and curiosity to experiment with.
+
+Direct all of your support questions and feedback to either a partner Slack channel (if you have one, you know what it is) or use **Share your feedback** or email us at [preview@expo.dev](mailto:preview@expo.dev).
+
+Thank you! Now take a look at the navigation menu to explore the preview features.

--- a/docs/pages/preview/support.mdx
+++ b/docs/pages/preview/support.mdx
@@ -1,7 +1,0 @@
----
-title: Support and feedback
----
-
-The purpose of feature previews is to gather feedback to polish and improve products before we ship them to a broader audience. We want you to kick the tires on these features and let us know how it goes. Try them with your largest app, your smaller app, a new app, an old app, and everything in between that you have the patience and curiosity to experiment with.
-
-Please direct all of your support questions and feedback to either a partner Slack channel (if you have one, you know what it is) or to [preview@expo.dev](mailto:preview@expo.dev).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Let's improve Preview section introduction to follow some of the guidelines from our writing style guide and also include "Support and feedback" within the same page. I don't think we need two separate pages to convey this information.

The Support and feedback now also includes info about using **Share your feedback** modal.

This PR also:
- Adds redirects for `/preview/support/`.
- Fixes redirect URL for `/preview/react-compiler/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

## Preview of the changes

![CleanShot 2024-06-23 at 22 25 47](https://github.com/expo/expo/assets/10234615/fc1d9308-6832-4698-add2-11d64d1d20e8)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
