### PR TITLE
chore: Change `sideEffects` to use `src` folder.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 💡 Others
 
-- Change `sideEffects` to use `src` folder.
+- Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))
 - [web] Use global `crypto` object for UUID. ([#29828](https://github.com/expo/expo/pull/29828) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Send open url event to all matching subscribers. ([#29645](https://github.com/expo/expo/pull/29645) by [@aleqsio](https://github.com/aleqsio))
 - Use `process.env.EXPO_OS` for `Platform.OS` and `Platform.select`, when available. ([#29429](https://github.com/expo/expo/pull/29429) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 💡 Others
 
+- Change `sideEffects` to use `src` folder.
 - [web] Use global `crypto` object for UUID. ([#29828](https://github.com/expo/expo/pull/29828) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Send open url event to all matching subscribers. ([#29645](https://github.com/expo/expo/pull/29645) by [@aleqsio](https://github.com/aleqsio))
 - Use `process.env.EXPO_OS` for `Platform.OS` and `Platform.select`, when available. ([#29429](https://github.com/expo/expo/pull/29429) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "build/index.d.ts",
   "sideEffects": [
-    "*.fx.js"
+    "*.fx.ts"
   ],
   "scripts": {
     "build": "expo-module build",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Change `sideEffects` to use `src` folder.
+- Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))
 - Keep using the legacy event emitter for the `DevLoadingView` in Expo Go. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - Re-exported `EventEmitter`, `SharedObject` and `NativeModule` classes from `expo-modules-core`. ([#28994](https://github.com/expo/expo/pull/28994) by [@tsapeta](https://github.com/tsapeta))
 - Use the `src` folder as the Metro target. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 💡 Others
 
+- Change `sideEffects` to use `src` folder.
 - Keep using the legacy event emitter for the `DevLoadingView` in Expo Go. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - Re-exported `EventEmitter`, `SharedObject` and `NativeModule` classes from `expo-modules-core`. ([#28994](https://github.com/expo/expo/pull/28994) by [@tsapeta](https://github.com/tsapeta))
 - Use the `src` folder as the Metro target. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -6,9 +6,9 @@
   "module": "src/Expo.ts",
   "types": "build/Expo.d.ts",
   "sideEffects": [
-    "*.fx.js",
-    "*.fx.web.js",
-    "./build/winter/*.js"
+    "*.fx.tsx",
+    "*.fx.web.tsx",
+    "./src/winter/*.ts"
   ],
   "bin": "bin/cli",
   "files": [


### PR DESCRIPTION
# Why

- I noticed in my tree-shaking prototype that the side effects weren't being recognized. Updating to account for #29702
