### PR TITLE
fix(media-library): getAssets crashes when result is empty

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -397,6 +397,8 @@ PODS:
     - ExpoModulesCore
   - ExpoLinearGradient (13.0.2):
     - ExpoModulesCore
+  - ExpoLinking (6.3.1):
+    - ExpoModulesCore
   - ExpoLocalAuthentication (14.0.1):
     - ExpoModulesCore
   - ExpoLocalization (15.0.3):
@@ -409,6 +411,10 @@ PODS:
     - GooglePlaces (= 7.3.0)
   - ExpoMediaLibrary (16.0.3):
     - ExpoModulesCore
+    - React-Core
+  - ExpoMediaLibrary/Tests (16.0.3):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
     - React-Core
   - ExpoModulesCore (1.12.11):
     - DoubleConversion
@@ -2036,11 +2042,13 @@ DEPENDENCIES:
   - ExpoInsights (from `../../../packages/expo-insights/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
+  - ExpoLinking (from `../../../packages/expo-linking/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - ExpoLocalization (from `../../../packages/expo-localization/ios`)
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
   - ExpoMaps (from `../../../packages/expo-maps/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
+  - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoModulesCore/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
@@ -2283,6 +2291,9 @@ EXTERNAL SOURCES:
   ExpoLinearGradient:
     inhibit_warnings: false
     :path: "../../../packages/expo-linear-gradient/ios"
+  ExpoLinking:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-linking/ios"
   ExpoLocalAuthentication:
     inhibit_warnings: false
     :path: "../../../packages/expo-local-authentication/ios"
@@ -2553,11 +2564,12 @@ SPEC CHECKSUMS:
   ExpoInsights: e88a27cb4ba1b644f8f6bbb2473a5a8204767948
   ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
   ExpoLinearGradient: 8cec4a09426d8934c433e83cb36262d72c667fce
+  ExpoLinking: 82ccf130af1ebeb4bcdb0e7e101a2be36dbdd335
   ExpoLocalAuthentication: f119167649d0465a06fa7c5b44c6c70f43f477ee
   ExpoLocalization: f04eeec2e35bed01ab61c72ee1768ec04d093d01
   ExpoMailComposer: e6da16de4682fba919051b2e680f804af00341f3
   ExpoMaps: 664ff9a93fe6b461976136327d7231ac78d87af7
-  ExpoMediaLibrary: acbb23f74a6047b9b9b5a5ef00ffee28bfe466da
+  ExpoMediaLibrary: d94d530648c1051a09fa906e93b9b6eb225d70db
   ExpoModulesCore: 4eb2165cde325c8c121d495bb8beb0da9b30c92e
   ExpoModulesTestCore: 3d1007a5db579e867829b0f9cd4be07e29cf7c0c
   ExpoNetwork: 0d2c2504d56096fe8be3930d5c70cb3390dac5bf

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -111,6 +111,8 @@ PODS:
     - ExpoModulesCore
   - ExpoLinearGradient (13.0.2):
     - ExpoModulesCore
+  - ExpoLinking (6.3.1):
+    - ExpoModulesCore
   - ExpoLocalAuthentication (14.0.1):
     - ExpoModulesCore
   - ExpoLocalization (15.0.3):
@@ -119,6 +121,10 @@ PODS:
     - ExpoModulesCore
   - ExpoMediaLibrary (16.0.3):
     - ExpoModulesCore
+    - React-Core
+  - ExpoMediaLibrary/Tests (16.0.3):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
     - React-Core
   - ExpoModulesCore (1.12.11):
     - DoubleConversion
@@ -1895,10 +1901,12 @@ DEPENDENCIES:
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
+  - ExpoLinking (from `../../../packages/expo-linking/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - ExpoLocalization (from `../../../packages/expo-localization/ios`)
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
+  - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoModulesCore/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
@@ -2121,6 +2129,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-keep-awake/ios"
   ExpoLinearGradient:
     :path: "../../../packages/expo-linear-gradient/ios"
+  ExpoLinking:
+    :path: "../../../packages/expo-linking/ios"
   ExpoLocalAuthentication:
     :path: "../../../packages/expo-local-authentication/ios"
   ExpoLocalization:
@@ -2374,10 +2384,11 @@ SPEC CHECKSUMS:
   ExpoImagePicker: dc3e6f221ce5717e6e0a771780e6e7d50a790189
   ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
   ExpoLinearGradient: 8cec4a09426d8934c433e83cb36262d72c667fce
+  ExpoLinking: 82ccf130af1ebeb4bcdb0e7e101a2be36dbdd335
   ExpoLocalAuthentication: f119167649d0465a06fa7c5b44c6c70f43f477ee
   ExpoLocalization: f04eeec2e35bed01ab61c72ee1768ec04d093d01
   ExpoMailComposer: e6da16de4682fba919051b2e680f804af00341f3
-  ExpoMediaLibrary: acbb23f74a6047b9b9b5a5ef00ffee28bfe466da
+  ExpoMediaLibrary: d94d530648c1051a09fa906e93b9b6eb225d70db
   ExpoModulesCore: 4eb2165cde325c8c121d495bb8beb0da9b30c92e
   ExpoModulesTestCore: 3d1007a5db579e867829b0f9cd4be07e29cf7c0c
   ExpoNetwork: 0d2c2504d56096fe8be3930d5c70cb3390dac5bf
@@ -2412,7 +2423,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: c8cd6a144dc677b571369ef3ccbeeb852d4e75d4
+  hermes-engine: 56c453c4b73b7954fb38d24fdb899191dc6470ec
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, getAssets crashed when result was is empty
+- On `iOS`, getAssets crashed when result was is empty ([#29969](https://github.com/expo/expo/pull/29969) by [@vonovak](https://github.com/vonovak))
 - On `Android`, throw an error when deleting an asset was unsuccessful. ([#29777](https://github.com/expo/expo/pull/29777) by [@mathieupost](https://github.com/mathieupost))
 
 ### 💡 Others

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, getAssets crashed when result was is empty
 - On `Android`, throw an error when deleting an asset was unsuccessful. ([#29777](https://github.com/expo/expo/pull/29777) by [@mathieupost](https://github.com/mathieupost))
 
 ### 💡 Others

--- a/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
@@ -26,4 +26,11 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = "**/*.{h,m,swift}"
+
+  s.exclude_files = 'Tests/'
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.dependency 'ExpoModulesTestCore'
+
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
+  end
 end

--- a/packages/expo-media-library/ios/MediaLibraryExceptions.swift
+++ b/packages/expo-media-library/ios/MediaLibraryExceptions.swift
@@ -102,7 +102,7 @@ internal class DeleteAlbumFailedException: Exception {
   }
 }
 
-internal class CusrorException: Exception {
+internal class CursorException: Exception {
   override var reason: String {
     "Couldn't find cursor"
   }

--- a/packages/expo-media-library/ios/MediaLibraryModule.swift
+++ b/packages/expo-media-library/ios/MediaLibraryModule.swift
@@ -183,7 +183,6 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
           }
           let assets = getAssetsBy(assetIds: assetIds)
 
-          let collectionAssets = PHAsset.fetchAssets(in: collection, options: nil)
           let albumChangeRequest = PHAssetCollectionChangeRequest(for: collection, assets: assets)
           albumChangeRequest?.removeAssets(assets)
         } completionHandler: { success, _ in
@@ -456,9 +455,9 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
         self.allAssetsFetchResult = changeDetails.fetchResultAfterChanges
 
         if changeDetails.hasIncrementalChanges && !changeDetails.insertedObjects.isEmpty || !changeDetails.removedObjects.isEmpty {
-          var insertedAssets = [[String: Any]?]()
-          var deletedAssets = [[String: Any]?]()
-          var updatedAssets = [[String: Any]?]()
+          var insertedAssets = [[String: Any?]?]()
+          var deletedAssets = [[String: Any?]?]()
+          var updatedAssets = [[String: Any?]?]()
           let body: [String: Any] = [
             "hasIncrementalChanges": true,
             "insertedAssets": insertedAssets,

--- a/packages/expo-media-library/ios/MediaLibraryRecords.swift
+++ b/packages/expo-media-library/ios/MediaLibraryRecords.swift
@@ -39,3 +39,9 @@ struct AssetWithOptions: Record {
   @Field var createdAfter: Double?
   @Field var createdBefore: Double?
 }
+
+struct GetAssetsResponse {
+  let assets: Array<[String: Any?]>
+  let totalCount: Int
+  let hasNextPage: Bool
+}

--- a/packages/expo-media-library/ios/MediaLibraryRecords.swift
+++ b/packages/expo-media-library/ios/MediaLibraryRecords.swift
@@ -41,7 +41,7 @@ struct AssetWithOptions: Record {
 }
 
 struct GetAssetsResponse {
-  let assets: Array<[String: Any?]>
+  let assets: [[String: Any?]]
   let totalCount: Int
   let hasNextPage: Bool
 }

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -410,12 +410,16 @@ func getAssetsWithAfter(options: AssetWithOptions, collection: PHAssetCollection
   var cursorIndex: Int {
     if let cursor {
       return fetchResult.index(of: cursor)
-    } else {
-      return NSNotFound
     }
+    return NSNotFound
   }
-  
-  let resultingAssets = getAssets(fetchResult: fetchResult, cursorIndex: cursorIndex, numOfRequestedItems: options.first, sortDescriptors: fetchOptions.sortDescriptors)
+
+  let resultingAssets = getAssets(
+    fetchResult: fetchResult,
+    cursorIndex: cursorIndex,
+    numOfRequestedItems: options.first,
+    sortDescriptors: fetchOptions.sortDescriptors
+  )
 
   let lastAsset = resultingAssets.assets.last
 
@@ -428,17 +432,21 @@ func getAssetsWithAfter(options: AssetWithOptions, collection: PHAssetCollection
   promise.resolve(response)
 }
 
-func getAssets(fetchResult: PHFetchResult<PHAsset>, cursorIndex: Int, numOfRequestedItems: Int, sortDescriptors: [NSSortDescriptor]? = nil) -> GetAssetsResponse {
+func getAssets(
+  fetchResult: PHFetchResult<PHAsset>,
+  cursorIndex: Int,
+  numOfRequestedItems: Int,
+  sortDescriptors: [NSSortDescriptor]? = nil
+) -> GetAssetsResponse {
   let totalCount = fetchResult.count
-  if (totalCount == 0) {
+  if totalCount == 0 {
     return GetAssetsResponse(assets: [], totalCount: totalCount, hasNextPage: false)
   }
-
 
   var assets: [[String: Any?]] = []
   assets.reserveCapacity(numOfRequestedItems)
   var hasNextPage: Bool
-  
+
   // If we don't use any sort descriptors (nil, or empty array), the assets are sorted just like in Photos app.
   // That means the most recent assets are at the start of the array.
   if sortDescriptors?.isEmpty ?? true {
@@ -446,10 +454,10 @@ func getAssets(fetchResult: PHFetchResult<PHAsset>, cursorIndex: Int, numOfReque
     let lowerIndex = max(upperIndex - numOfRequestedItems, -1)
 
     for i in stride(from: upperIndex, to: lowerIndex, by: -1) {
-        let asset = fetchResult.object(at: i)
-        if let exportedAsset = exportAsset(asset: asset) {
-            assets.append(exportedAsset)
-        }
+      let asset = fetchResult.object(at: i)
+      if let exportedAsset = exportAsset(asset: asset) {
+        assets.append(exportedAsset)
+      }
     }
 
     hasNextPage = lowerIndex >= 0

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -344,15 +344,13 @@ func assetTypeExtension(for fileExtension: String) -> PHAssetMediaType {
 func getAssetsWithAfter(options: AssetWithOptions, collection: PHAssetCollection?, promise: Promise) {
   let fetchOptions = PHFetchOptions()
   var predicates: [NSPredicate] = []
-  var response = [String: Any?]()
-  var assets: [[String: Any?]] = []
 
   var cursor: PHAsset?
   if let after = options.after {
     cursor = getAssetBy(id: after)
 
     if cursor == nil {
-      promise.reject(CusrorException())
+      promise.reject(CursorException())
       return
     }
   }
@@ -409,31 +407,55 @@ func getAssetsWithAfter(options: AssetWithOptions, collection: PHAssetCollection
     fetchResult = PHAsset.fetchAssets(with: fetchOptions)
   }
 
-  var cursorIndex: Int
-  if let cursor {
-    cursorIndex = fetchResult.index(of: cursor)
-  } else {
-    cursorIndex = NSNotFound
+  var cursorIndex: Int {
+    if let cursor {
+      return fetchResult.index(of: cursor)
+    } else {
+      return NSNotFound
+    }
+  }
+  
+  let resultingAssets = getAssets(fetchResult: fetchResult, cursorIndex: cursorIndex, numOfRequestedItems: options.first, sortDescriptors: fetchOptions.sortDescriptors)
+
+  let lastAsset = resultingAssets.assets.last
+
+  let response: [String: Any?] = [
+    "assets": resultingAssets.assets,
+    "endCursor": lastAsset?["id"] ?? options.after,
+    "hasNextPage": resultingAssets.hasNextPage,
+    "totalCount": resultingAssets.totalCount
+  ]
+  promise.resolve(response)
+}
+
+func getAssets(fetchResult: PHFetchResult<PHAsset>, cursorIndex: Int, numOfRequestedItems: Int, sortDescriptors: [NSSortDescriptor]? = nil) -> GetAssetsResponse {
+  let totalCount = fetchResult.count
+  if (totalCount == 0) {
+    return GetAssetsResponse(assets: [], totalCount: totalCount, hasNextPage: false)
   }
 
-  let totalCount = fetchResult.count
+
+  var assets: [[String: Any?]] = []
+  assets.reserveCapacity(numOfRequestedItems)
   var hasNextPage: Bool
+  
+  // If we don't use any sort descriptors (nil, or empty array), the assets are sorted just like in Photos app.
+  // That means the most recent assets are at the start of the array.
+  if sortDescriptors?.isEmpty ?? true {
+    let upperIndex = max(cursorIndex == NSNotFound ? totalCount - 1 : cursorIndex - 1, -1)
+    let lowerIndex = max(upperIndex - numOfRequestedItems, -1)
 
-  if fetchOptions.sortDescriptors?.isEmpty == true {
-    let startIndex = max(cursorIndex == NSNotFound ? totalCount - 1 : cursorIndex - 1, -1)
-    let endIndex = max(startIndex - options.first + 1, 0)
-
-    for i in (endIndex...startIndex).reversed() {
-      let asset = fetchResult.object(at: i)
-      if let exportedAsset = exportAsset(asset: asset) {
-        assets.append(exportedAsset)
-      }
+    for i in stride(from: upperIndex, to: lowerIndex, by: -1) {
+        let asset = fetchResult.object(at: i)
+        if let exportedAsset = exportAsset(asset: asset) {
+            assets.append(exportedAsset)
+        }
     }
 
-    hasNextPage = endIndex > 0
+    hasNextPage = lowerIndex >= 0
   } else {
     let startIndex = cursorIndex == NSNotFound ? 0 : cursorIndex + 1
-    let endIndex = min(startIndex + options.first, totalCount)
+    let endIndex = min(startIndex + numOfRequestedItems, totalCount)
 
     for index in startIndex..<endIndex {
       let asset = fetchResult.object(at: index)
@@ -444,15 +466,7 @@ func getAssetsWithAfter(options: AssetWithOptions, collection: PHAssetCollection
 
     hasNextPage = endIndex < totalCount
   }
-
-  let lastAsset = assets.last
-
-  response["assets"] = assets
-  response["endCursor"] = lastAsset != nil ? lastAsset?["id"] : options.after
-  response["hasNextPage"] = hasNextPage
-  response["totalCount"] = totalCount
-
-  promise.resolve(response)
+  return GetAssetsResponse(assets: assets, totalCount: totalCount, hasNextPage: hasNextPage)
 }
 
 func prepareSortDescriptors(sortBy: [String]) throws -> [NSSortDescriptor] {
@@ -473,10 +487,7 @@ private func sortDescriptor(from config: String) throws -> NSSortDescriptor? {
     return nil
   }
 
-  var ascending = false
-  if parts.count > 1 && parts[1] == "ASC" {
-    ascending = true
-  }
+  let ascending = parts.count > 1 && parts[1] == "ASC"
 
   return NSSortDescriptor(key: key, ascending: ascending)
 }

--- a/packages/expo-media-library/ios/TestSupport.swift
+++ b/packages/expo-media-library/ios/TestSupport.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Photos
+
+class MockPHAsset: PHAsset {
+  private var id: Int
+
+  init(id: Int) {
+    self.id = id
+  }
+
+  override var localIdentifier: String {
+    return String(self.id)
+  }
+}
+
+// we override exactly those methods that `getAssets()` uses, imitating Apple's implementation
+class MockFetchResult: PHFetchResult<PHAsset> {
+
+  private var assets: [PHAsset]
+
+  init(assets: [PHAsset]) {
+    self.assets = assets
+  }
+
+  override var count: Int {
+    return assets.count
+  }
+
+  override func object(at index: Int) -> PHAsset {
+    assert(index >= 0 && index < assets.count, "Index out of range. Index \(index) but only \(assets.count) items are available.")
+    return assets[index]
+  }
+}

--- a/packages/expo-media-library/ios/TestSupport.swift
+++ b/packages/expo-media-library/ios/TestSupport.swift
@@ -15,7 +15,6 @@ class MockPHAsset: PHAsset {
 
 // we override exactly those methods that `getAssets()` uses, imitating Apple's implementation
 class MockFetchResult: PHFetchResult<PHAsset> {
-
   private var assets: [PHAsset]
 
   init(assets: [PHAsset]) {

--- a/packages/expo-media-library/ios/Tests/MediaLibrarySpec.swift
+++ b/packages/expo-media-library/ios/Tests/MediaLibrarySpec.swift
@@ -3,21 +3,21 @@ import Photos
 @testable import ExpoMediaLibrary
 
 class MediaLibrarySpec: ExpoSpec {
-  
+
   static func createTestAssets(_ numOfMockAssets: Int) -> [PHAsset] {
     return (0..<numOfMockAssets).map { index in
       return MockPHAsset(id: index)
     }
   }
-  
+
   override class func spec() {
-    
+
     describe("getAssets") {
       let cursorPositionNotProvided = NSNotFound
       let numOfMockAssets = 4
       let mockAssets = createTestAssets(numOfMockAssets)
       let sorter = [NSSortDescriptor(key: "pixelWidth", ascending: false)]
-      
+
       context("given empty fetch result") {
         it("returns no assets and indicates there is no next page") {
           let emptyFetchResult = PHFetchResult<PHAsset>()
@@ -32,7 +32,7 @@ class MediaLibrarySpec: ExpoSpec {
           }
         }
       }
-      
+
       context("given a non-empty result") {
         let fetchResult = MockFetchResult(assets: mockAssets)
 
@@ -50,7 +50,7 @@ class MediaLibrarySpec: ExpoSpec {
 
         it("asking fewer items than available in fetchResult returns assets and indicates there is a next page") {
           let requestedItems = 2
-          
+
           for config in [(sortDescriptor: nil, expectedIds: ("3", "2")), // most recent first
                          (sortDescriptor: sorter, expectedIds: ("0", "1")) // insertion order
           ] {
@@ -65,10 +65,10 @@ class MediaLibrarySpec: ExpoSpec {
             expect(response.hasNextPage).to(beTrue())
           }
         }
-        
+
         it("requesting full number of items / more items than in fetchResult, returns all assets and indicates there is NO next page") {
           let expectedItems = 4
-          
+
           for requestedItems in [numOfMockAssets, numOfMockAssets * 5] {
             for config in [(sortDescriptor: nil, expectedIds: ("3", "0")), // most recent first
                            (sortDescriptor: sorter, expectedIds: ("0", "3")) // insertion order

--- a/packages/expo-media-library/ios/Tests/MediaLibrarySpec.swift
+++ b/packages/expo-media-library/ios/Tests/MediaLibrarySpec.swift
@@ -1,0 +1,116 @@
+import ExpoModulesTestCore
+import Photos
+@testable import ExpoMediaLibrary
+
+class MediaLibrarySpec: ExpoSpec {
+  
+  static func createTestAssets(_ numOfMockAssets: Int) -> [PHAsset] {
+    return (0..<numOfMockAssets).map { index in
+      return MockPHAsset(id: index)
+    }
+  }
+  
+  override class func spec() {
+    
+    describe("getAssets") {
+      let cursorPositionNotProvided = NSNotFound
+      let numOfMockAssets = 4
+      let mockAssets = createTestAssets(numOfMockAssets)
+      let sorter = [NSSortDescriptor(key: "pixelWidth", ascending: false)]
+      
+      context("given empty fetch result") {
+        it("returns no assets and indicates there is no next page") {
+          let emptyFetchResult = PHFetchResult<PHAsset>()
+          for sortDescriptor in [nil, sorter] {
+            let response = getAssets(fetchResult: emptyFetchResult,
+                                     cursorIndex: cursorPositionNotProvided,
+                                     numOfRequestedItems: 5,
+                                     sortDescriptors: sortDescriptor)
+            expect(response.assets).to(beEmpty())
+            expect(response.totalCount).to(equal(0))
+            expect(response.hasNextPage).to(beFalse())
+          }
+        }
+      }
+      
+      context("given a non-empty result") {
+        let fetchResult = MockFetchResult(assets: mockAssets)
+
+        it("requesting 0 items returns 0 assets and indicates there is a next page") {
+          for sortDescriptor in [nil, sorter] {
+            let response = getAssets(fetchResult: fetchResult,
+                                     cursorIndex: cursorPositionNotProvided,
+                                     numOfRequestedItems: 0,
+                                     sortDescriptors: sortDescriptor)
+            expect(response.assets).to(beEmpty())
+            expect(response.totalCount).to(equal(numOfMockAssets))
+            expect(response.hasNextPage).to(beTrue())
+          }
+        }
+
+        it("asking fewer items than available in fetchResult returns assets and indicates there is a next page") {
+          let requestedItems = 2
+          
+          for config in [(sortDescriptor: nil, expectedIds: ("3", "2")), // most recent first
+                         (sortDescriptor: sorter, expectedIds: ("0", "1")) // insertion order
+          ] {
+            let response = getAssets(fetchResult: fetchResult,
+                                     cursorIndex: cursorPositionNotProvided,
+                                     numOfRequestedItems: requestedItems,
+                                     sortDescriptors: config.sortDescriptor)
+            expect(response.assets.count).to(equal(requestedItems))
+            expect(response.assets[0]["id"] as? String).to(equal(config.expectedIds.0))
+            expect(response.assets[1]["id"] as? String).to(equal(config.expectedIds.1))
+            expect(response.totalCount).to(equal(numOfMockAssets))
+            expect(response.hasNextPage).to(beTrue())
+          }
+        }
+        
+        it("requesting full number of items / more items than in fetchResult, returns all assets and indicates there is NO next page") {
+          let expectedItems = 4
+          
+          for requestedItems in [numOfMockAssets, numOfMockAssets * 5] {
+            for config in [(sortDescriptor: nil, expectedIds: ("3", "0")), // most recent first
+                           (sortDescriptor: sorter, expectedIds: ("0", "3")) // insertion order
+            ] {
+              let response = getAssets(fetchResult: fetchResult,
+                                       cursorIndex: cursorPositionNotProvided,
+                                       numOfRequestedItems: requestedItems,
+                                       sortDescriptors: config.sortDescriptor)
+              expect(response.assets.count).to(equal(expectedItems))
+              expect(response.assets[0]["id"] as? String).to(equal(config.expectedIds.0))
+              expect(response.assets[3]["id"] as? String).to(equal(config.expectedIds.1))
+              expect(response.totalCount).to(equal(numOfMockAssets))
+              expect(response.hasNextPage).to(beFalse())
+            }
+          }
+        }
+
+        context("custom cursor position is taken into account") {
+          it("without sorting") {
+            let response = getAssets(fetchResult: fetchResult,
+                                     cursorIndex: 3,
+                                     numOfRequestedItems: 2)
+            expect(response.assets.count).to(equal(2))
+            expect(response.assets[0]["id"] as? String).to(equal("2"))
+            expect(response.assets[1]["id"] as? String).to(equal("1"))
+            expect(response.totalCount).to(equal(numOfMockAssets))
+            expect(response.hasNextPage).to(beTrue())
+          }
+
+          it("with sorting") {
+            let response = getAssets(fetchResult: fetchResult,
+                                     cursorIndex: 0,
+                                     numOfRequestedItems: 2,
+                                     sortDescriptors: sorter)
+            expect(response.assets.count).to(equal(2))
+            expect(response.assets[0]["id"] as? String).to(equal("1"))
+            expect(response.assets[1]["id"] as? String).to(equal("2"))
+            expect(response.totalCount).to(equal(numOfMockAssets))
+            expect(response.hasNextPage).to(beTrue())
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

resolves [ENG-12563](https://linear.app/expo/issue/ENG-12563)

# How

There was a off-by-one index issue in the previous implementation.

# Test Plan

Added unit tests for the method that does the asset pagination.

# Checklist

doesn't apply

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
