### PR TITLE
docs: fix redirect `/guides/react-compiler` to `/preview/react-compiler`

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -368,7 +368,7 @@ redirects[/develop/user-interface/app-icons]=develop/user-interface/splash-scree
 redirects[/develop/user-interface/splash-screen]=develop/user-interface/splash-screen-and-app-icon
 
 # Temporary redirects
-redirects[guides/react-compiler]=/preview/react-compiler
+redirects[guides/react-compiler]=preview/react-compiler
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
# Why

https://docs.expo.dev/guides/react-compiler redirects to `/preview/react-compiler` (instead of https://docs.expo.dev/preview/react-compiler)

# How

Removed starting `/`

# Test Plan

See deployed docs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
