### PR TITLE
docs: add 1 day cache control header for server side redirects

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -375,6 +375,7 @@ for i in "${!redirects[@]}" # iterate over keys
 do
   aws s3 cp \
     --no-progress \
+    --cache-control "max-age=86400" \
     --metadata-directive REPLACE \
     --website-redirect "/${redirects[$i]}" \
     "$target/404.html" \
@@ -385,6 +386,7 @@ do
   if [[ $i != *".html" ]] && [[ $i != *"/" ]]; then
     aws s3 cp \
       --no-progress \
+      --cache-control "max-age=86400" \
       --metadata-directive REPLACE \
       --website-redirect "/${redirects[$i]}" \
       "$target/404.html" \

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -375,7 +375,7 @@ for i in "${!redirects[@]}" # iterate over keys
 do
   aws s3 cp \
     --no-progress \
-    --cache-control "max-age=86400" \
+    --cache-control "public, max-age=86400" \
     --metadata-directive REPLACE \
     --website-redirect "/${redirects[$i]}" \
     "$target/404.html" \
@@ -386,7 +386,7 @@ do
   if [[ $i != *".html" ]] && [[ $i != *"/" ]]; then
     aws s3 cp \
       --no-progress \
-      --cache-control "max-age=86400" \
+      --cache-control "public, max-age=86400" \
       --metadata-directive REPLACE \
       --website-redirect "/${redirects[$i]}" \
       "$target/404.html" \

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -313,7 +313,7 @@ redirects[push-notifications]=push-notifications/overview
 redirects[eas/submit]=submit/introduction
 redirects[development/tools/expo-dev-client]=develop/development-builds/introduction
 redirects[develop/user-interface/custom-fonts]=develop/user-interface/fonts
-redirects[workflow/snack]=/more/glossary-of-terms
+redirects[workflow/snack]=more/glossary-of-terms
 redirects[accounts/teams-and-accounts]=accounts/account-types
 redirects[push-notifications/fcm]=push-notifications/sending-notifications-custom
 redirects[troubleshooting/clear-cache-mac]=troubleshooting/clear-cache-macos-linux
@@ -356,16 +356,16 @@ redirects[guides/customizing-webpack]=archive/customizing-webpack
 redirects[bare/using-expo-client]=archive/using-expo-client
 
 # May 2024 home / get started section
-redirects[/overview]=get-started/introduction
-redirects[/get-started/installation]=get-started/create-a-project
-redirects[/get-started/expo-go]=get-started/set-up-your-environment
+redirects[overview]=get-started/introduction
+redirects[get-started/installation]=get-started/create-a-project
+redirects[get-started/expo-go]=get-started/set-up-your-environment
 
 # Redirect for /learn URL
-redirects[/learn]=tutorial/introduction
+redirects[learn]=tutorial/introduction
 
 # May 2024 home / develop section
-redirects[/develop/user-interface/app-icons]=develop/user-interface/splash-screen-and-app-icon
-redirects[/develop/user-interface/splash-screen]=develop/user-interface/splash-screen-and-app-icon
+redirects[develop/user-interface/app-icons]=develop/user-interface/splash-screen-and-app-icon
+redirects[develop/user-interface/splash-screen]=develop/user-interface/splash-screen-and-app-icon
 
 # Temporary redirects
 redirects[guides/react-compiler]=preview/react-compiler


### PR DESCRIPTION
# Why

Follow-up of #29970

Unfortunately, this faulty server-side redirect seems to be cached locally, without any cache control headers. Meaning that some browsers might cache this permanently.

Cloudfront | AWS S3 
--- | ---
![image](https://github.com/expo/expo/assets/1203991/3cf8a386-4f0c-478e-8a07-651bdbc6b857) | ![image](https://github.com/expo/expo/assets/1203991/6c25e5be-d5f5-45dd-bf03-85a71ab3e89d)

It also seems that S3 does not allow us to change this redirect to a temporary redirect (302) ([see here]())

# How

- Added `cache-control` headers to avoid permanent redirects being cached indefinitely
- Fixed more faulty redirects

# Test Plan

See docs deployment

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
