### PR TITLE
docs: move Promise import comment to right place

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -133,7 +133,6 @@ AsyncFunction("asyncFunction") { (message: String) in
 
 // or
 
-// Make sure to import `Promise` class from `expo.modules.kotlin` instead of `expo.modules.core`.
 AsyncFunction("asyncFunction") { (message: String, promise: Promise) in
   promise.resolve(message)
 }
@@ -147,6 +146,7 @@ AsyncFunction("asyncFunction") { message: String ->
 
 // or
 
+// Make sure to import `Promise` class from `expo.modules.kotlin` instead of `expo.modules.core`.
 AsyncFunction("asyncFunction") { message: String, promise: Promise ->
   promise.resolve(message)
 }


### PR DESCRIPTION
# Why

Pretty sure it should be in the Kotlin code snippet, not Swift 😁 
