### PR TITLE
[docs] Update info about eas.json generation and link its config info in the eas.json reference page

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon } from '@expo/styleguide-icons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**eas.json** is the configuration file for EAS CLI and services. It is generated when you run the [`eas build:configure` command](/build/setup/#configure-the-project) for the first time in your project and is located next to **package.json** at the root of your project.  Configuration for EAS Build all belongs under the `build` key.
+**eas.json** is the configuration file for EAS CLI and services. It is generated when the [`eas build:configure` command](/build/setup/#configure-the-project) runs for the first time in your project and is located next to **package.json** at the root of your project. Configuration for EAS Build all belongs under the `build` key.
 
 The default configuration for **eas.json** generated in a new project is shown below:
 

--- a/docs/pages/eas/json.mdx
+++ b/docs/pages/eas/json.mdx
@@ -13,7 +13,9 @@ import iosSchema from '~/public/static/schemas/unversioned/eas-json-build-ios-sc
 import submitAndroidSchema from '~/public/static/schemas/unversioned/eas-json-submit-android-schema.js';
 import submitIosSchema from '~/public/static/schemas/unversioned/eas-json-submit-ios-schema.js';
 
-**eas.json** is the configuration file for EAS CLI and services. It is located at the root of a project next to the **package.json**. You can find the complete reference of all available schema properties for [EAS Build](/build/introduction) and [EAS Submit](/submit/introduction) on this page.
+**eas.json** is the configuration file for EAS CLI and services. You can find the complete reference of all available schema properties for [EAS Build](/build/introduction) and [EAS Submit](/submit/introduction) on this page.
+
+> **info** To learn more about how a project using EAS services is configured with **eas.json**, see [Configure EAS Build with eas.json](/build/eas-json/) and [Configure EAS Submit with eas.json](/submit/eas-json/).
 
 ## EAS Build
 

--- a/docs/pages/submit/eas-json.mdx
+++ b/docs/pages/submit/eas-json.mdx
@@ -7,7 +7,7 @@ description: Learn how to configure your project for EAS Submit with eas.json.
 import { BoxLink } from '~/ui/components/BoxLink';
 import { EasSubmitIcon } from '@expo/styleguide-icons';
 
-**eas.json** is your go-to place for configuring EAS Submit (and [EAS Build](/build/eas-json)). It is located at the root of your project next to your **package.json**. Even though **eas.json** is not mandatory for using EAS Submit, it makes your life easier if you need to switch between different configurations.
+**eas.json** is the configuration file for EAS CLI and services. It is generated when the [`eas build:configure` command](/build/setup/#configure-the-project) runs for the first time in your project and is located next to **package.json** at the root of your project. Even though **eas.json** is not mandatory for using EAS Submit, it makes your life easier if you need to switch between different configurations.
 
 ## Production profile
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #29901

As mentioned in the above PR, it was a bit confusing as to when the **eas.json** file was generated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Improves verbiage in Configure EAS Build with eas.json when mentioning how **eas.json** file is generated.
- Update Configure EAS Submit with eas.json to mention how **eas.json** file is generated. (this page is is not linked with the EAS Build introduction guide, so based on the feedback received, I think it's okay to add that context about an **eas.json** file being generated
- Updates **eas.json** reference to link to "Configure EAS Build with eas.json" and "Configure EAS Submit with eas.json" guides.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
