### PR TITLE
[docs] Fix typo in warning callout in Expo Symbols

### DIFF
--- a/docs/pages/versions/unversioned/sdk/symbols.mdx
+++ b/docs/pages/versions/unversioned/sdk/symbols.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-> **warning** This is library is currently in beta and subject to breaking changes.
+> **warning** This library is currently in beta and subject to breaking changes.
 
 `expo-symbols` provides access to the [SF Symbols](https://developer.apple.com/sf-symbols/) library on iOS.
 

--- a/docs/pages/versions/v51.0.0/sdk/symbols.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/symbols.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-> **warning** This is library is currently in beta and subject to breaking changes.
+> **warning** This library is currently in beta and subject to breaking changes.
 
 `expo-symbols` provides access to the [SF Symbols](https://developer.apple.com/sf-symbols/) library on iOS.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up: https://x.com/eluewisdom_/status/1805289877958709678

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing the typo in the callout. Changes applied to unversioned and backported to SDK 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
