### PR TITLE
refactor(secure-store): check SecAccessControlCreateWithFlags return value

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [iOS] check return value of SecAccessControlCreateWithFlags ([#29983](https://github.com/expo/expo/pull/29983) by [@vonovak](https://github.com/vonovak))
+
 ## 13.0.1 — 2024-04-23
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-secure-store/ios/SecureStoreExceptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreExceptions.swift
@@ -12,6 +12,12 @@ internal class MissingPlistKeyException: Exception {
   }
 }
 
+internal class SecAccessControlError: GenericException<Int?> {
+  override var reason: String {
+    return "Unable to construct SecAccessControl: \(param.map { "code " + String($0) } ?? "unknown error")"
+  }
+}
+
 internal class KeyChainException: GenericException<OSStatus> {
   override var reason: String {
     switch param {

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -96,7 +96,12 @@ public final class SecureStoreModule: Module {
       guard let _ = Bundle.main.infoDictionary?["NSFaceIDUsageDescription"] as? String else {
         throw MissingPlistKeyException()
       }
-      let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, SecAccessControlCreateFlags.biometryCurrentSet, nil)
+
+      var error: Unmanaged<CFError>? = nil
+      guard let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, .biometryCurrentSet, &error) else {
+        let errorCode = error.map { CFErrorGetCode($0.takeRetainedValue()) }
+        throw SecAccessControlError(errorCode)
+      }
       setItemQuery[kSecAttrAccessControl as String] = accessOptions
     }
 


### PR DESCRIPTION
# Why

Follow-up on https://github.com/expo/expo/pull/29981

The value returned by `SecAccessControlCreateWithFlags` is an optional, and we should check that it's not `nil` to make sure it was created successfully before we use it further. In practice, the `nil` value probably almost never occurs but it's best to cover this.

# How

using `guard let` assignment

# Test Plan

You can trigger the error by providing an invalid `protection` parameter, such as with

`SecAccessControlCreateWithFlags(kCFAllocatorDefault, "Hello there" as CFString, .biometryCurrentSet, &error)`

I tested this on a real device. The resulting error contains a code (that I'm returning to JS), and also a message. I could return the message which might be more helpful but I thought in case it contains something sensitive it's best stick with the code only. The error should be extremely rare. Happy to change this though.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
