### PR TITLE
[docs] change @expo/vector-icons examples to default imports

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -58,7 +58,7 @@ In the example below, the `glyphMap` object is defined and then passed as the fi
 
 ```jsx createIconSet example
 import * as React from 'react';
-import { createIconSet } from '@expo/vector-icons';
+import createIconSet from '@expo/vector-icons/createIconSet';
 
 const glyphMap = { 'icon-name': 1234, test: '∆' };
 const CustomIcon = createIconSet(glyphMap, 'fontFamily', 'custom-icon-font.ttf');
@@ -87,7 +87,7 @@ dependencies={['@expo/vector-icons', 'expo-font']}>
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useFonts } from 'expo-font';
-import { createIconSetFromIcoMoon } from '@expo/vector-icons';
+import createIconSetFromIcoMoon from '@expo/vector-icons/createIconSetFromIcoMoon';
 
 /* @info */
 const Icon = createIconSetFromIcoMoon(
@@ -137,7 +137,7 @@ It follows a similar configuration as `createIconSetFromIcoMoon` as shown in the
 
 ```js Fontello Icons
 // Import the createIconSetFromFontello method
-import { createIconSetFromFontello } from '@expo/vector-icons';
+import createIconSetFromFontello from '@expo/vector-icons/createIconSetFromFontello';
 
 // Import the config file
 import fontelloConfig from './config.json';


### PR DESCRIPTION
# Why

Due to the way the barrel file of `@expo/vector-icons` works it will import a bunch of assets (glyphmaps) that are not needed in most use cases. In development this is fine but if you want to minimize your bundle size, it might be better to only import the functions you actually need.

Before and after with Expo Atlas:

![Screenshot 2024-06-25 at 09 30 53](https://github.com/expo/expo/assets/8158765/e124a715-c834-4506-bd09-ea002a5e4e6a)
![Screenshot 2024-06-25 at 09 31 49](https://github.com/expo/expo/assets/8158765/4fe7eef1-2694-4633-a579-ef95cf9798bb)



