### PR TITLE
[docs]: Document use of __dirname in Expo Router

### DIFF
--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -183,6 +183,26 @@ export async function generateStaticParams(params: {
 
 </APIBox>
 
+### Reading files: Use process.cwd()
+
+Since Expo Router compiles your code into a separate directory you can't use \_\_dirname to form a path as its value will be different than expected.
+
+Instead you can use process.cwd() which gives you the directory where project is being compiled.
+
+```tsx app/[id].tsx
+export async function generateStaticParams(params: {
+  id: string;
+}): Promise<Record<string, string>[]> {
+  const postPath = path.join(process.cwd(), './posts/', id, '.md');
+  const content = await fs.readFile(postPath);
+
+  return {
+    id,
+    content,
+  };
+}
+```
+
 ## Root HTML
 
 By default, every page is wrapped with some small HTML boilerplate, this is known as the **root HTML**.

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -189,16 +189,19 @@ Since Expo Router compiles your code into a separate directory you cannot use `_
 
 Instead, use `process.cwd()`, which gives you the directory where the project is being compiled.
 
-```tsx app/[id].tsx
+```tsx app/[category].tsx
+import fs from 'fs/promises';
+import path from 'path';
+
 export async function generateStaticParams(params: {
   id: string;
 }): Promise<Record<string, string>[]> {
-  const postPath = path.join(process.cwd(), './posts/', id, '.md');
-  const content = await fs.readFile(postPath);
+  const directory = await fs.readdir(path.join(process.cwd(), './posts/', category));
+  const posts = directory.filter(fileOrSubDirectory => return path.extname(fileOrSubDirectory) === '.md')
 
   return {
     id,
-    content,
+    posts,
   };
 }
 ```

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -185,7 +185,7 @@ export async function generateStaticParams(params: {
 
 ### Reading files: Use process.cwd()
 
-Since Expo Router compiles your code into a separate directory you can't use \_\_dirname to form a path as its value will be different than expected.
+Since Expo Router compiles your code into a separate directory you cannot use \_\_dirname to form a path as its value will be different than expected.
 
 Instead you can use process.cwd() which gives you the directory where project is being compiled.
 

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -183,11 +183,11 @@ export async function generateStaticParams(params: {
 
 </APIBox>
 
-### Reading files: Use process.cwd()
+### Read files using `process.cwd()`
 
-Since Expo Router compiles your code into a separate directory you cannot use \_\_dirname to form a path as its value will be different than expected.
+Since Expo Router compiles your code into a separate directory you cannot use `__dirname` to form a path as its value will be different than expected.
 
-Instead you can use process.cwd() which gives you the directory where project is being compiled.
+Instead, use `process.cwd()`, which gives you the directory where the project is being compiled.
 
 ```tsx app/[id].tsx
 export async function generateStaticParams(params: {


### PR DESCRIPTION
# Why

Document issue described in https://github.com/expo/expo/issues/29688

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
