### PR TITLE
[CI] Publish canaries without --dry flag on workflow dispatch

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  publish-canaries:
     runs-on: ubuntu-22.04
     env:
       NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
         run: yarn install --ignore-scripts --frozen-lockfile
         working-directory: tools
       - name: 📦 Publish canaries
-        run: ./bin/expotools publish-packages --canary --dry
+        run: ./bin/expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }}
         env:
           FORCE_COLOR: '2'
       - name: 🔔 Notify on Slack

--- a/tools/src/GitHubActions.ts
+++ b/tools/src/GitHubActions.ts
@@ -30,6 +30,10 @@ export async function getWorkflowsAsync(): Promise<Workflow[]> {
   const response = await octokit.actions.listRepoWorkflows({
     owner,
     repo,
+    // By default this API returns only 25 results per page.
+    // We're already much beyond this number, but there is no chance we'll ever reach
+    // the max number of results per page, so we just hardcode it.
+    per_page: 100,
   });
 
   // We need to filter out some workflows because they might have


### PR DESCRIPTION
# Why

Would be great if the CI workflow can publish canaries for us

# How

Don't use `--dry` flag for `workflow_dispatch` event

# Test Plan

Workflow triggered by this PR used `--dry` flag: https://github.com/expo/expo/actions/runs/9661163875/job/26648309028?pr=29988

Workflow dispatched manually didn't use `--dry` flag and successfully published all packages and templates: https://github.com/expo/expo/actions/runs/9663071148/job/26654358470

Also `et dispatch publish-canaries` should work just fine