### PR TITLE
[docs] Add info about adding last update date manually in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -427,6 +427,21 @@ Four different types of callouts can be used with markdown syntax for `> ...` bl
 > **error** Callout that is used for errors and breaking changes or deprecated changes in the archive.
 ```
 
+### Add last update date manually
+
+All docs pages are automatically updated with the last update date of the file based on their Git commit history. This information is reflected in the footer of a docs page with **Last updated on ...**.
+
+If you need to add the date manually, add `modificationDate` to the frontmatter of the **.mdx** file. For example:
+
+```mdx
+---
+modificationDate: April 8th, 2024
+{/* Other frontmatter fields */}
+---
+```
+
+This pattern is used for some of the pages where we manually update the modification date, such as [Build server infrastructure](https://github.com/expo/expo/edit/main/docs/pages/build-reference/infrastructure.mdx).
+
 ### Prettier
 
 Please commit any sizeable diffs that are the result of `prettier` separately to make reviews as easy as possible.

--- a/docs/README.md
+++ b/docs/README.md
@@ -442,6 +442,8 @@ modificationDate: April 8th, 2024
 
 This pattern is used for some of the pages where we manually update the modification date, such as [Build server infrastructure](https://github.com/expo/expo/edit/main/docs/pages/build-reference/infrastructure.mdx).
 
+> Docs areas that are excluded or do not include an updated date are SDK API references and Tutorials sections under Learn.
+
 ### Prettier
 
 Please commit any sizeable diffs that are the result of `prettier` separately to make reviews as easy as possible.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We recently started displaying "Last updated on ..." date for most of the docs pages. Some of the pages include a manual frontmatter field for adding a modification date.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a section on
- Info about last updated date
- Add a date manually using `modificationDate` in the frontmatter of a `.mdx` file
- Add a note about excluded docs areas and sections

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running Markdown preview in the VS Code editor.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
