### PR TITLE
[iOS] Stop throwing runtime errors when the promise is settled more than once

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Use the `src` folder as the Metro target. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))
 - Make it possible for TypeScript to infer EventEmitter's events map. ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
+- [iOS] Stop throwing runtime errors when the promise is settled more than once.
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Use the `src` folder as the Metro target. ([#29702](https://github.com/expo/expo/pull/29702) by [@tsapeta](https://github.com/tsapeta))
 - Make it possible for TypeScript to infer EventEmitter's events map. ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
-- [iOS] Stop throwing runtime errors when the promise is settled more than once.
+- [iOS] Stop throwing runtime errors when the promise is settled more than once. ([#30000](https://github.com/expo/expo/pull/30000) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -16,16 +16,12 @@ void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoke
   auto weakResolveWrapper = react::CallbackWrapper::createWeak(promise->resolve_.getFunction(runtime), runtime, jsInvoker);
   auto weakRejectWrapper = react::CallbackWrapper::createWeak(promise->reject_.getFunction(runtime), runtime, jsInvoker);
 
-  __block BOOL resolveWasCalled = NO;
-  __block BOOL rejectWasCalled = NO;
+  __block BOOL isSettled = NO;
 
   RCTPromiseResolveBlock resolveBlock = ^(id result) {
-    if (rejectWasCalled) {
-      throw std::runtime_error("Tried to resolve a promise after it's already been rejected.");
-    }
-
-    if (resolveWasCalled) {
-      throw std::runtime_error("Tried to resolve a promise more than once.");
+    if (isSettled) {
+      // The promise is already either resolved or rejected.
+      return;
     }
 
     auto strongResolveWrapper = weakResolveWrapper.lock();
@@ -49,16 +45,13 @@ void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoke
       strongRejectWrapper2->destroy();
     });
 
-    resolveWasCalled = YES;
+    isSettled = YES;
   };
 
   RCTPromiseRejectBlock rejectBlock = ^(NSString *code, NSString *message, NSError *error) {
-    if (resolveWasCalled) {
-      throw std::runtime_error("Tried to reject a promise after it's already been resolved.");
-    }
-
-    if (rejectWasCalled) {
-      throw std::runtime_error("Tried to reject a promise more than once.");
+    if (isSettled) {
+      // The promise is already either resolved or rejected.
+      return;
     }
 
     auto strongResolveWrapper = weakResolveWrapper.lock();
@@ -83,7 +76,7 @@ void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<CallInvoke
       strongRejectWrapper2->destroy();
     });
 
-    rejectWasCalled = YES;
+    isSettled = YES;
   };
 
   setupBlock(resolveBlock, rejectBlock);


### PR DESCRIPTION
# Why

We've got some reports about production apps crashing because of a library that mistakenly settled a promise more than once. I'm removing the runtime errors that were being thrown in this case and instead just ignoring the resolve and reject blocks.

I was considering printing a warning in this case, but this would be different behavior than on web and cause a log box to appear which is not perfect for app developers as it is a problem to solve in the library, not in the app.
Instead, I'm leaning towards using our internal native logger, but on the Swift side (I'll do this in a separate PR).

# How

Removed throwing `std::runtime_error` when the promise is already settled (either resolved or rejected)

# Test Plan

