### PR TITLE
fix(dev-launcher): Fix `"launchMode": "launcher"` support.

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `"launchMode": "launcher"` support.
+- [Android] Fix `"launchMode": "launcher"` support. ([#30004](https://github.com/expo/expo/pull/30004) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `"launchMode": "launcher"` support.
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherMetadataHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherMetadataHelper.kt
@@ -8,8 +8,11 @@ object DevLauncherMetadataHelper {
     val packageManager = context.packageManager
     val packageName = context.packageName
     val applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
-    var metaDataValue = if (applicationInfo.metaData != null) {
-      applicationInfo.metaData.getString(key, defaultValue)
+    var metaDataValue = if (applicationInfo.metaData != null && applicationInfo.metaData.containsKey(key)) {
+      // The key could be a boolean, if so we should return it as a string
+      @Suppress("DEPRECATION")
+      val value = applicationInfo.metaData.get(key)
+      value.toString()
     } else {
       defaultValue
     }


### PR DESCRIPTION
# Why

The check was broken because the metadata is typed as a boolean, this meant the fallback value was always used.
