### PR TITLE
[expo-updates][iOS] fix embedded file map for audio issue

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -99,7 +99,9 @@ public final class UpdatesUtils: NSObject {
         let absolutePath = path(forBundledAsset: asset)
         let message = "AppLauncherWithDatabase: embedded asset key = \(asset.key ?? ""), main bundle filename = \(asset.mainBundleFilename ?? ""), path = \(absolutePath ?? "")"
         logger.debug(message: message)
-        assetFilesMap[assetKey] = absolutePath
+        if let absolutePath = absolutePath {
+          assetFilesMap[assetKey] = URL(fileURLWithPath: absolutePath).absoluteString
+        }
       }
     }
 


### PR DESCRIPTION
# Why

On iOS, because the updates embedded asset map stores paths and not `file://` URLs, code elsewhere that expects URLs may not work. The issue does not seem to affect Android.

Test case: https://github.com/douglowder/AudioUpdatesBug/blob/main/README.md

# How

Modify the code in `UpdatesUtils.swift`.

# Test Plan

- Test case above should be fixed
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
