### PR TITLE
[cellular][android] Fix support for 5G

### DIFF
--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix support for 5G ([#30012](https://github.com/expo/expo/pull/30012) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Update cellular generation comments to specify HSPAP as 3G instead of 4G. ([#30008](https://github.com/expo/expo/pull/30008) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
+++ b/packages/expo-cellular/android/src/main/java/expo/modules/cellular/CellularModule.kt
@@ -118,6 +118,9 @@ class CellularModule : Module() {
       TelephonyManager.NETWORK_TYPE_LTE -> {
         CellularGeneration.CG_4G.value
       }
+      TelephonyManager.NETWORK_TYPE_NR -> {
+        CellularGeneration.CG_5G.value
+      }
       else -> {
         CellularGeneration.UNKNOWN.value
       }


### PR DESCRIPTION
# Why

On Android calling expo-cellular's `getCellularGenerationAsync` function over 5G returns generation `unknown` 

<img width="416" alt="image" src="https://github.com/expo/expo/assets/11707729/34ba5239-84e6-4723-bc45-98b0a05031f4">

This used to be supported on Android a long time ago but got mistakenly removed in a PR refactoring the cellular module (https://github.com/expo/expo/pull/13729)

# How

Map `NETWORK_TYPE_NR` to `CellularGeneration` 5G enum

# Test Plan

Run NCL on Android

https://github.com/expo/expo/assets/11707729/2195623b-bdcc-4743-930d-fb2e0ac75406


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
