### PR TITLE
[core][Android] Refactor how the js objects are decorated

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -19,6 +19,7 @@ set(COMMON_DIR ${CMAKE_SOURCE_DIR}/../common/cpp)
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 file(GLOB sources_android_types "${SRC_DIR}/main/cpp/types/*.cpp")
 file(GLOB sources_android_javaclasses "${SRC_DIR}/main/cpp/javaclasses/*.cpp")
+file(GLOB sources_android_javaclasses "${SRC_DIR}/main/cpp/decorators/*.cpp")
 file(GLOB common_sources "${COMMON_DIR}/*.cpp")
 
 # shared

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -11,6 +11,7 @@
 #include "JavaCallback.h"
 #include "JNIUtils.h"
 #include "types/FrontendConverterProvider.h"
+#include "decorators/JSDecoratorsBridgingObject.h"
 
 #if RN_FABRIC_ENABLED
 #include "FabricComponentsRegistry.h"
@@ -35,6 +36,10 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptTypedArray::registerNatives();
     expo::JavaCallback::registerNatives();
     expo::JNIUtils::registerNatives();
+
+    // Decorators
+    expo::JSDecoratorsBridgingObject::registerNatives();
+
 #if RN_FABRIC_ENABLED
     expo::FabricComponentsRegistry::registerNatives();
 #endif

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
@@ -4,6 +4,7 @@
 #include "EventEmitter.h"
 #include "JSIUtils.h"
 #include "types/JNIToJSIConverter.h"
+#include <jsi/JSIDynamic.h>
 
 namespace expo {
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -8,6 +8,7 @@
 #include <fbjni/fbjni.h>
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
+#include <jsi/JSIDynamic.h>
 
 #include <functional>
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -1,82 +1,11 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaScriptModuleObject.h"
-#include "JSIContext.h"
-#include "JSIUtils.h"
-#include "EventEmitter.h"
-#include "SharedObject.h"
 #include "NativeModule.h"
 
-#include <folly/dynamic.h>
-#include <jni.h>
-#include <jsi/JSIDynamic.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <fbjni/detail/Hybrid.h>
-#include <ReactCommon/TurboModuleUtils.h>
-#include <jni/JCallback.h>
-#include <jsi/JSIDynamic.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <utility>
-#include <tuple>
-#include <algorithm>
-#include <sstream>
-
-namespace jni = facebook::jni;
-namespace jsi = facebook::jsi;
-namespace react = facebook::react;
+#include "decorators/JSDecoratorsBridgingObject.h"
 
 namespace expo {
-
-void decorateObjectWithFunctions(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData) {
-  for (auto &[name, method]: objectData->methodsMetadata) {
-    jsObject->setProperty(
-      runtime,
-      jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *method->toJSFunction(runtime))
-    );
-  }
-}
-
-void decorateObjectWithProperties(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData) {
-  for (auto &[name, property]: objectData->properties) {
-    auto &[getter, setter] = property;
-
-    auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime,
-                                                                  1 << 1 /* enumerable */);
-    descriptor.setProperty(
-      runtime,
-      "get",
-      jsi::Value(runtime, *getter->toJSFunction(runtime))
-    );
-    descriptor.setProperty(
-      runtime,
-      "set",
-      jsi::Value(runtime, *setter->toJSFunction(runtime))
-    );
-    common::defineProperty(runtime, jsObject, name.c_str(), std::move(descriptor));
-  }
-}
-
-void decorateObjectWithConstants(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData) {
-  for (const auto &[name, value]: objectData->constants) {
-    jsObject->setProperty(
-      runtime,
-      jsi::String::createFromUtf8(runtime, name),
-      jsi::valueFromDynamic(runtime, value)
-    );
-  }
-}
 
 jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
 JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
@@ -86,17 +15,7 @@ JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
 void JavaScriptModuleObject::registerNatives() {
   registerHybrid({
                    makeNativeMethod("initHybrid", JavaScriptModuleObject::initHybrid),
-                   makeNativeMethod("exportConstants", JavaScriptModuleObject::exportConstants),
-                   makeNativeMethod("registerSyncFunction",
-                                    JavaScriptModuleObject::registerSyncFunction),
-                   makeNativeMethod("registerAsyncFunction",
-                                    JavaScriptModuleObject::registerAsyncFunction),
-                   makeNativeMethod("registerProperty",
-                                    JavaScriptModuleObject::registerProperty),
-                   makeNativeMethod("registerClass",
-                                    JavaScriptModuleObject::registerClass),
-                   makeNativeMethod("registerViewPrototype",
-                                    JavaScriptModuleObject::registerViewPrototype)
+                   makeNativeMethod("decorate", JavaScriptModuleObject::decorate)
                  });
 }
 
@@ -107,251 +26,20 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
 
   auto moduleObject = std::make_shared<jsi::Object>(NativeModule::createInstance(runtime));
 
-  decorate(runtime, moduleObject.get());
+  for (const auto& decorator : this->decorators) {
+    decorator->decorate(runtime, *moduleObject);
+  }
 
   jsiObject = moduleObject;
   return moduleObject;
 }
 
-void JavaScriptModuleObject::decorate(jsi::Runtime &runtime, jsi::Object *moduleObject) {
-  decorateObjectWithConstants(
-    runtime,
-    moduleObject,
-    this
-  );
-  decorateObjectWithProperties(
-    runtime,
-    moduleObject,
-    this
-  );
-  decorateObjectWithFunctions(
-    runtime,
-    moduleObject,
-    this
-  );
-
-  if (viewPrototype) {
-    auto viewPrototypeObject = viewPrototype->cthis();
-    auto viewPrototypeJSIObject = viewPrototypeObject->getJSIObject(runtime);
-    moduleObject->setProperty(
-      runtime,
-      "ViewPrototype",
-      jsi::Value(runtime, *viewPrototypeJSIObject)
-    );
-  }
-
-  for (auto &[name, classInfo]: classes) {
-    auto &[classRef, constructor, ownerClass] = classInfo;
-    auto classObject = classRef->cthis();
-    auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
-    auto klass = SharedObject::createClass(
-      runtime,
-      name.c_str(),
-      [classObject, weakConstructor = std::move(weakConstructor)](
-        jsi::Runtime &runtime,
-        const jsi::Value &thisValue,
-        const jsi::Value *args,
-        size_t count
-      ) -> jsi::Value {
-        // We need to check if the constructor is still alive.
-        // If not we can just ignore the call. We're destroying the module.
-        auto ctr = weakConstructor.lock();
-        if (ctr == nullptr) {
-          return jsi::Value::undefined();
-        }
-
-        auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
-        decorateObjectWithProperties(runtime, thisObject.get(),
-                                     classObject);
-        try {
-          JNIEnv *env = jni::Environment::current();
-          /**
-          * This will push a new JNI stack frame for the LocalReferences in this
-          * function call. When the stack frame for this lambda is popped,
-          * all LocalReferences are deleted.
-          */
-          jni::JniLocalScope scope(env, (int) count);
-          auto result = ctr->callJNISync(
-            env,
-            runtime,
-            thisValue,
-            args,
-            count
-          );
-          if (result == nullptr) {
-            return jsi::Value(runtime, thisValue);
-          }
-          jobject unpackedResult = result.get();
-          jclass resultClass = env->GetObjectClass(unpackedResult);
-          if (env->IsAssignableFrom(
-            resultClass,
-            JavaReferencesCache::instance()->getJClass(
-              "expo/modules/kotlin/sharedobjects/SharedObject").clazz
-          )) {
-            JSIContext *jsiContext = getJSIContext(runtime);
-            auto jsThisObject = JavaScriptObject::newInstance(
-              jsiContext,
-              jsiContext->runtimeHolder,
-              thisObject
-            );
-            jsiContext->registerSharedObject(result, jsThisObject);
-          }
-          return jsi::Value(runtime, thisValue);
-        } catch (jni::JniException &jniException) {
-          rethrowAsCodedError(runtime, jniException);
-        }
-      }
-    );
-
-    auto klassSharedPtr = std::make_shared<jsi::Function>(std::move(klass));
-
-    JSIContext *jsiContext = getJSIContext(runtime);
-
-    auto jsThisObject = JavaScriptObject::newInstance(
-      jsiContext,
-      jsiContext->runtimeHolder,
-      klassSharedPtr
-    );
-
-    if (ownerClass != nullptr) {
-      jsiContext->registerClass(jni::make_local(ownerClass), jsThisObject);
-    }
-
-    moduleObject->setProperty(
-      runtime,
-      jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *klassSharedPtr.get())
-    );
-
-    jsi::PropNameID prototypePropNameId = jsi::PropNameID::forAscii(runtime, "prototype", 9);
-    jsi::Object klassPrototype = klassSharedPtr
-      ->getProperty(runtime, prototypePropNameId)
-      .asObject(runtime);
-
-    decorateObjectWithFunctions(
-      runtime,
-      &klassPrototype,
-      classObject
-    );
-  }
+void JavaScriptModuleObject::decorate(jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject) {
+  this->decorators = jsDecoratorsBridgingObject->cthis()->bridge();
 }
 
 std::weak_ptr<jsi::Object> JavaScriptModuleObject::getCachedJSIObject() {
   return jsiObject;
 }
 
-void JavaScriptModuleObject::exportConstants(
-  jni::alias_ref<react::NativeMap::javaobject> constants
-) {
-  auto dynamic = constants->cthis()->consume();
-  assert(dynamic.isObject());
-
-  for (const auto &[key, value]: dynamic.items()) {
-    this->constants[key.asString()] = value;
-  }
-}
-
-void JavaScriptModuleObject::registerSyncFunction(
-  jni::alias_ref<jstring> name,
-  jboolean takesOwner,
-  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-  jni::alias_ref<JNIFunctionBody::javaobject> body
-) {
-  std::string cName = name->toStdString();
-  auto methodMetadata = std::make_shared<MethodMetadata>(
-    cName,
-    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(expectedArgTypes),
-    jni::make_global(body)
-  );
-  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
-}
-
-void JavaScriptModuleObject::registerAsyncFunction(
-  jni::alias_ref<jstring> name,
-  jboolean takesOwner,
-  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-  jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
-) {
-  std::string cName = name->toStdString();
-  auto methodMetadata = std::make_shared<MethodMetadata>(
-    cName,
-    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    true,
-    jni::make_local(expectedArgTypes),
-    jni::make_global(body)
-  );
-  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
-}
-
-void JavaScriptModuleObject::registerClass(
-  jni::alias_ref<jstring> name,
-  jni::alias_ref<JavaScriptModuleObject::javaobject> classObject,
-  jboolean takesOwner,
-  jni::alias_ref<jclass> ownerClass,
-  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-  jni::alias_ref<JNIFunctionBody::javaobject> body
-) {
-  std::string cName = name->toStdString();
-  auto constructor = std::make_shared<MethodMetadata>(
-    "constructor",
-    takesOwner & 0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(expectedArgTypes),
-    jni::make_global(body)
-  );
-
-  auto classTuple = std::make_tuple(
-    jni::make_global(classObject),
-    std::move(constructor),
-    jni::make_global(ownerClass)
-  );
-
-  classes.try_emplace(
-    cName,
-    std::move(classTuple)
-  );
-}
-
-void JavaScriptModuleObject::registerViewPrototype(
-  jni::alias_ref<JavaScriptModuleObject::javaobject> viewPrototype
-) {
-  this->viewPrototype = jni::make_global(viewPrototype);
-}
-
-void JavaScriptModuleObject::registerProperty(
-  jni::alias_ref<jstring> name,
-  jboolean getterTakesOwner,
-  jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
-  jni::alias_ref<JNIFunctionBody::javaobject> getter,
-  jboolean setterTakesOwner,
-  jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
-  jni::alias_ref<JNIFunctionBody::javaobject> setter
-) {
-  auto cName = name->toStdString();
-
-  auto getterMetadata = make_shared<MethodMetadata>(
-    cName,
-    getterTakesOwner & 0x1, // We're unsure if getterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(getterExpectedArgsTypes),
-    jni::make_global(getter)
-  );
-
-  auto setterMetadata = make_shared<MethodMetadata>(
-    cName,
-    setterTakesOwner & 0x1, // We're unsure if setterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
-    false,
-    jni::make_local(setterExpectedArgsTypes),
-    jni::make_global(setter)
-  );
-
-  auto functions = std::make_pair(
-    std::move(getterMetadata),
-    std::move(setterMetadata)
-  );
-
-  properties.insert_or_assign(cName, std::move(functions));
-}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -4,42 +4,23 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <react/jni/ReadableNativeMap.h>
-#include <jni/JCallback.h>
 
-#include <unordered_map>
+#include <vector>
+#include <memory>
 
-#include "MethodMetadata.h"
-#include "JNIFunctionBody.h"
-#include "types/ExpectedType.h"
+#include "decorators/JSDecorator.h"
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 namespace expo {
 class JSIContext;
 
 class JavaScriptModuleObject;
 
-void decorateObjectWithFunctions(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData
-);
+class JSDecoratorsBridgingObject;
 
-void decorateObjectWithProperties(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData
-);
-
-void decorateObjectWithConstants(
-  jsi::Runtime &runtime,
-  jsi::Object *jsObject,
-  JavaScriptModuleObject *objectData
-);
+class JavaScriptRuntime;
 
 /**
  * A CPP part of the module.
@@ -69,85 +50,11 @@ public:
   /**
    * Decorates the given object with properties and functions provided in the module definition.
    */
-  void decorate(jsi::Runtime &runtime, jsi::Object *moduleObject);
-
-  /**
-   * Exports constants that will be assigned to the underlying HostObject.
-   */
-  void exportConstants(jni::alias_ref<react::NativeMap::javaobject> constants);
-
-  /**
-   * Registers a sync function.
-   * That function can be called via the `JavaScriptModuleObject.callSyncMethod` method.
-   */
-  void registerSyncFunction(
-    jni::alias_ref<jstring> name,
-    jboolean takesOwner,
-    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-    jni::alias_ref<JNIFunctionBody::javaobject> body
-  );
-
-  /**
-   * Registers a async function.
-   * That function can be called via the `JavaScriptModuleObject.callAsyncMethod` method.
-   */
-  void registerAsyncFunction(
-    jni::alias_ref<jstring> name,
-    jboolean takesOwner,
-    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-    jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
-  );
-
-  void registerClass(
-    jni::alias_ref<jstring> name,
-    jni::alias_ref<JavaScriptModuleObject::javaobject> classObject,
-    jboolean takesOwner,
-    jni::alias_ref<jclass> ownerClass,
-    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
-    jni::alias_ref<JNIFunctionBody::javaobject> body
-  );
-
-  void registerViewPrototype(
-    jni::alias_ref<JavaScriptModuleObject::javaobject> viewPrototype
-  );
-
-  /**
-   * Registers a property
-   * @param name of the property
-   * @param desiredType of the setter argument
-   * @param getter body for the get method - can be nullptr
-   * @param setter body for the set method - can be nullptr
-   */
-  void registerProperty(
-    jni::alias_ref<jstring> name,
-    jboolean getterTakesOwner,
-    jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
-    jni::alias_ref<JNIFunctionBody::javaobject> getter,
-    jboolean setterTakesOwner,
-    jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
-    jni::alias_ref<JNIFunctionBody::javaobject> setter
-  );
+  void decorate(jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> jsDecoratorsBridgingObject);
 
 private:
   friend HybridBase;
-
-  friend void decorateObjectWithFunctions(
-    jsi::Runtime &runtime,
-    jsi::Object *jsObject,
-    JavaScriptModuleObject *objectData
-  );
-
-  friend void decorateObjectWithProperties(
-    jsi::Runtime &runtime,
-    jsi::Object *jsObject,
-    JavaScriptModuleObject *objectData
-  );
-
-  friend void decorateObjectWithConstants(
-    jsi::Runtime &runtime,
-    jsi::Object *jsObject,
-    JavaScriptModuleObject *objectData
-  );
+  friend JavaScriptRuntime;
 
   /**
    * A reference to the `jsi::Object`.
@@ -157,27 +64,6 @@ private:
    */
   std::weak_ptr<jsi::Object> jsiObject;
 
-  /**
-   * Metadata map that stores information about all available methods on this module.
-   */
-  std::unordered_map<std::string, std::shared_ptr<MethodMetadata>> methodsMetadata;
-
-  /**
-   * A constants map.
-   */
-  std::unordered_map<std::string, folly::dynamic> constants;
-
-  /**
-   * A registry of properties
-   * The first MethodMetadata points to the getter and the second one to the setter.
-   */
-  std::map<std::string, std::pair<std::shared_ptr<MethodMetadata>, std::shared_ptr<MethodMetadata>>> properties;
-
-  std::map<
-    std::string,
-    std::tuple<jni::global_ref<JavaScriptModuleObject::javaobject>, std::shared_ptr<MethodMetadata>, jni::global_ref<jclass>>
-  > classes;
-
-  jni::global_ref<JavaScriptModuleObject::javaobject> viewPrototype;
+  std::vector<std::unique_ptr<JSDecorator>> decorators;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -150,7 +150,9 @@ void JavaScriptRuntime::installMainObject() {
   mainObject = std::make_shared<jsi::Object>(*runtime);
 
   // Decorate the core object based on the module definition.
-  coreModule->cthis()->decorate(*runtime, mainObject.get());
+  for (const auto &decorator : coreModule->cthis()->decorators) {
+    decorator->decorate(*runtime, *mainObject);
+  }
 
   auto global = runtime->global();
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
@@ -1,0 +1,140 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSClassesDecorator.h"
+
+#include "SharedObject.h"
+#include "JSDecoratorsBridgingObject.h"
+#include "../JavaReferencesCache.h"
+#include "../JSIContext.h"
+#include "../JavaScriptObject.h"
+
+namespace expo {
+
+void JSClassesDecorator::registerClass(
+  jni::alias_ref<jstring> name,
+  jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> prototypeDecorator,
+  jboolean takesOwner,
+  jni::alias_ref<jclass> ownerClass,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> body
+) {
+  std::string cName = name->toStdString();
+  auto constructor = std::make_shared<MethodMetadata>(
+    "constructor",
+    takesOwner &
+    0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    false,
+    jni::make_local(expectedArgTypes),
+    jni::make_global(body)
+  );
+
+  ClassEntry classTuple{
+    prototypeDecorator->cthis()->bridge(),
+    std::move(constructor),
+    jni::make_global(ownerClass)
+  };
+
+  classes.try_emplace(
+    cName,
+    std::move(classTuple)
+  );
+}
+
+void JSClassesDecorator::decorate(
+  jsi::Runtime &runtime,
+  jsi::Object &jsObject
+) {
+  for (auto &[name, classInfo]: classes) {
+    auto &[prototypeDecorators, constructor, ownerClass] = classInfo;
+
+    auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
+    auto klass = SharedObject::createClass(
+      runtime,
+      name.c_str(),
+      [weakConstructor = std::move(weakConstructor)](
+        jsi::Runtime &runtime,
+        const jsi::Value &thisValue,
+        const jsi::Value *args,
+        size_t count
+      ) -> jsi::Value {
+        // We need to check if the constructor is still alive.
+        // If not we can just ignore the call. We're destroying the module.
+        auto ctr = weakConstructor.lock();
+        if (ctr == nullptr) {
+          return jsi::Value::undefined();
+        }
+
+        auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
+
+        try {
+          JNIEnv *env = jni::Environment::current();
+          /**
+          * This will push a new JNI stack frame for the LocalReferences in this
+          * function call. When the stack frame for this lambda is popped,
+          * all LocalReferences are deleted.
+          */
+          jni::JniLocalScope scope(env, (int) count);
+          auto result = ctr->callJNISync(
+            env,
+            runtime,
+            thisValue,
+            args,
+            count
+          );
+          if (result == nullptr) {
+            return { runtime, thisValue };
+          }
+          jobject unpackedResult = result.get();
+          jclass resultClass = env->GetObjectClass(unpackedResult);
+          if (env->IsAssignableFrom(
+            resultClass,
+            JavaReferencesCache::instance()->getJClass(
+              "expo/modules/kotlin/sharedobjects/SharedObject").clazz
+          )) {
+            JSIContext *jsiContext = getJSIContext(runtime);
+            auto jsThisObject = JavaScriptObject::newInstance(
+              jsiContext,
+              jsiContext->runtimeHolder,
+              thisObject
+            );
+            jsiContext->registerSharedObject(result, jsThisObject);
+          }
+          return { runtime, thisValue };
+        } catch (jni::JniException &jniException) {
+          rethrowAsCodedError(runtime, jniException);
+        }
+      }
+    );
+
+    auto klassSharedPtr = std::make_shared<jsi::Function>(std::move(klass));
+
+    JSIContext *jsiContext = getJSIContext(runtime);
+
+    auto jsThisObject = JavaScriptObject::newInstance(
+      jsiContext,
+      jsiContext->runtimeHolder,
+      klassSharedPtr
+    );
+
+    if (ownerClass != nullptr) {
+      jsiContext->registerClass(jni::make_local(ownerClass), jsThisObject);
+    }
+
+    jsObject.setProperty(
+      runtime,
+      jsi::String::createFromUtf8(runtime, name),
+      jsi::Value(runtime, *klassSharedPtr)
+    );
+
+    jsi::PropNameID prototypePropNameId = jsi::PropNameID::forAscii(runtime, "prototype", 9);
+    jsi::Object klassPrototype = klassSharedPtr
+      ->getProperty(runtime, prototypePropNameId)
+      .asObject(runtime);
+
+    for (const auto &decorator: prototypeDecorators) {
+      decorator->decorate(runtime, klassPrototype);
+    }
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -1,0 +1,48 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+#include <map>
+
+#include "JSDecorator.h"
+#include "../MethodMetadata.h"
+#include "../JNIFunctionBody.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class JSDecoratorsBridgingObject;
+
+class JSClassesDecorator : public JSDecorator {
+public:
+  void registerClass(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> prototypeDecorator,
+    jboolean takesOwner,
+    jni::alias_ref<jclass> ownerClass,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> body
+  );
+
+  void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) override;
+
+private:
+  struct ClassEntry {
+    std::vector<std::unique_ptr<JSDecorator>> prototypeDecorators;
+    std::shared_ptr<MethodMetadata> constructor;
+    jni::global_ref<jclass> ownerClass;
+  };
+
+  std::unordered_map<
+    std::string,
+    ClassEntry
+  > classes;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.cpp
@@ -1,0 +1,36 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSConstantsDecorator.h"
+
+#include <jsi/jsi.h>
+#include <jsi/JSIDynamic.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+void JSConstantsDecorator::registerConstants(
+  jni::alias_ref<react::NativeMap::javaobject> constants
+) {
+  auto dynamic = constants->cthis()->consume();
+  assert(dynamic.isObject());
+
+  for (const auto &[key, value]: dynamic.items()) {
+    this->constants[key.asString()] = value;
+  }
+}
+
+void JSConstantsDecorator::decorate(
+  jsi::Runtime &runtime,
+  jsi::Object &jsObject
+) {
+  for (const auto &[name, value]: this->constants) {
+    jsObject.setProperty(
+      runtime,
+      jsi::String::createFromUtf8(runtime, name),
+      jsi::valueFromDynamic(runtime, value)
+    );
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.h
@@ -1,0 +1,32 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <folly/dynamic.h>
+
+#include "JSDecorator.h"
+
+namespace jni = facebook::jni;
+namespace react = facebook::react;
+
+namespace expo {
+
+class JSConstantsDecorator : public JSDecorator {
+public:
+  void registerConstants(jni::alias_ref<react::NativeMap::javaobject> constants);
+
+  void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) override;
+
+private:
+  /**
+  * A constants map.
+  */
+  std::unordered_map<std::string, folly::dynamic> constants;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
@@ -1,0 +1,28 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+/**
+ * A base interface for all decorators.
+ * Used decorators should be retained by the object that is decorated.
+ * The decorator should only be used by a single object.
+ */
+class JSDecorator {
+public:
+  virtual ~JSDecorator() = default;
+
+  virtual void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) = 0;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -1,0 +1,149 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSDecoratorsBridgingObject.h"
+
+#include "JSClassesDecorator.h"
+
+namespace expo {
+
+jni::local_ref<jni::HybridClass<JSDecoratorsBridgingObject>::jhybriddata>
+JSDecoratorsBridgingObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance();
+}
+
+void JSDecoratorsBridgingObject::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("initHybrid", JSDecoratorsBridgingObject::initHybrid),
+                   makeNativeMethod("registerConstants",
+                                    JSDecoratorsBridgingObject::registerConstants),
+                   makeNativeMethod("registerSyncFunction",
+                                    JSDecoratorsBridgingObject::registerSyncFunction),
+                   makeNativeMethod("registerAsyncFunction",
+                                    JSDecoratorsBridgingObject::registerAsyncFunction),
+                   makeNativeMethod("registerProperty",
+                                    JSDecoratorsBridgingObject::registerProperty),
+                   makeNativeMethod("registerObject",
+                                    JSDecoratorsBridgingObject::registerObject),
+                   makeNativeMethod("registerClass",
+                                    JSDecoratorsBridgingObject::registerClass)
+                 });
+}
+
+void JSDecoratorsBridgingObject::registerSyncFunction(
+  jni::alias_ref<jstring> name,
+  jboolean takesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> body
+) {
+  if (!functionDecorator) {
+    functionDecorator = std::make_unique<JSFunctionsDecorator>();
+  }
+
+  functionDecorator->registerSyncFunction(name, takesOwner, expectedArgTypes, body);
+}
+
+void JSDecoratorsBridgingObject::registerAsyncFunction(
+  jni::alias_ref<jstring> name,
+  jboolean takesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
+) {
+  if (!functionDecorator) {
+    functionDecorator = std::make_unique<JSFunctionsDecorator>();
+  }
+
+  functionDecorator->registerAsyncFunction(name, takesOwner, expectedArgTypes, body);
+}
+
+void JSDecoratorsBridgingObject::registerProperty(
+  jni::alias_ref<jstring> name,
+  jboolean getterTakesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> getter,
+  jboolean setterTakesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> setter
+) {
+  if (!propertiesDecorator) {
+    propertiesDecorator = std::make_unique<JSPropertiesDecorator>();
+  }
+
+  propertiesDecorator->registerProperty(
+    name,
+    getterTakesOwner,
+    getterExpectedArgsTypes,
+    getter,
+    setterTakesOwner,
+    setterExpectedArgsTypes,
+    setter
+  );
+}
+
+void JSDecoratorsBridgingObject::registerConstants(jni::alias_ref<react::NativeMap::javaobject> constants) {
+  if (!constantsDecorator) {
+    constantsDecorator = std::make_unique<JSConstantsDecorator>();
+  }
+
+  constantsDecorator->registerConstants(constants);
+}
+
+void JSDecoratorsBridgingObject::registerObject(
+  jni::alias_ref<jstring> name,
+  jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject
+) {
+  if (!objectDecorator) {
+    objectDecorator = std::make_unique<JSObjectDecorator>();
+  }
+
+  objectDecorator->registerObject(name, jsDecoratorsBridgingObject);
+}
+
+void JSDecoratorsBridgingObject::registerClass(
+  jni::alias_ref<jstring> name,
+  jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
+  jboolean takesOwner,
+  jni::alias_ref<jclass> ownerClass,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> body
+) {
+  if (!classDecorator) {
+    classDecorator = std::make_unique<JSClassesDecorator>();
+  }
+
+  classDecorator->registerClass(
+    name,
+    jsDecoratorsBridgingObject,
+    takesOwner,
+    ownerClass,
+    expectedArgTypes,
+    body
+  );
+}
+
+std::vector<std::unique_ptr<JSDecorator>> JSDecoratorsBridgingObject::bridge() {
+  std::vector<std::unique_ptr<JSDecorator>> decorators;
+
+  if (functionDecorator) {
+    decorators.push_back(std::move(functionDecorator));
+  }
+
+  if (propertiesDecorator) {
+    decorators.push_back(std::move(propertiesDecorator));
+  }
+
+  if (constantsDecorator) {
+    decorators.push_back(std::move(constantsDecorator));
+  }
+
+  if (objectDecorator) {
+    decorators.push_back(std::move(objectDecorator));
+  }
+
+  if (classDecorator) {
+    decorators.push_back(std::move(classDecorator));
+  }
+
+  return decorators;
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -1,0 +1,90 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+#include <vector>
+
+#include "JSDecorator.h"
+#include "../MethodMetadata.h"
+#include "../JNIFunctionBody.h"
+#include "../types/ExpectedType.h"
+
+#include "JSFunctionsDecorator.h"
+#include "JSPropertiesDecorator.h"
+#include "JSConstantsDecorator.h"
+#include "JSObjectDecorator.h"
+#include "JSClassesDecorator.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class JSDecoratorsBridgingObject : public jni::HybridClass<JSDecoratorsBridgingObject> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject;";
+  static auto constexpr TAG = "JSDecoratorsBridgingObject";
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+  static void registerNatives();
+
+  void registerProperty(
+    jni::alias_ref<jstring> name,
+    jboolean getterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> getter,
+    jboolean setterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> setter
+  );
+
+  void registerSyncFunction(
+    jni::alias_ref<jstring> name,
+    jboolean takesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> body
+  );
+
+  void registerAsyncFunction(
+    jni::alias_ref<jstring> name,
+    jboolean takesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
+  );
+
+  void registerConstants(jni::alias_ref<react::NativeMap::javaobject> constants);
+
+  void registerObject(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject
+  );
+
+  void registerClass(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
+    jboolean takesOwner,
+    jni::alias_ref<jclass> ownerClass,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> body
+  );
+
+  /**
+   * Converts and consume all registered java decorators to C++
+   * @return vector of unique pointers to decorators
+   */
+  std::vector<std::unique_ptr<JSDecorator>> bridge();
+
+private:
+  friend HybridBase;
+
+  std::unique_ptr<JSFunctionsDecorator> functionDecorator;
+  std::unique_ptr<JSConstantsDecorator> constantsDecorator;
+  std::unique_ptr<JSPropertiesDecorator> propertiesDecorator;
+  std::unique_ptr<JSObjectDecorator> objectDecorator;
+  std::unique_ptr<JSClassesDecorator> classDecorator;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
@@ -1,0 +1,60 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSFunctionsDecorator.h"
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+void JSFunctionsDecorator::registerSyncFunction(
+  jni::alias_ref<jstring> name,
+  jboolean takesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> body
+) {
+  std::string cName = name->toStdString();
+  auto methodMetadata = std::make_shared<MethodMetadata>(
+    cName,
+    takesOwner &
+    0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    false,
+    jni::make_local(expectedArgTypes),
+    jni::make_global(body)
+  );
+  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
+}
+
+void JSFunctionsDecorator::registerAsyncFunction(
+  jni::alias_ref<jstring> name,
+  jboolean takesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
+) {
+  std::string cName = name->toStdString();
+  auto methodMetadata = std::make_shared<MethodMetadata>(
+    cName,
+    takesOwner &
+    0x1, // We're unsure if takesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    true,
+    jni::make_local(expectedArgTypes),
+    jni::make_global(body)
+  );
+  methodsMetadata.insert_or_assign(cName, std::move(methodMetadata));
+}
+
+void JSFunctionsDecorator::decorate(
+  jsi::Runtime &runtime,
+  jsi::Object &jsObject
+) {
+  for (auto &[name, method]: this->methodsMetadata) {
+    jsObject.setProperty(
+      runtime,
+      jsi::String::createFromUtf8(runtime, name),
+      jsi::Value(runtime, *method->toJSFunction(runtime))
+    );
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
@@ -1,0 +1,50 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <unordered_map>
+#include <memory>
+
+#include "JSDecorator.h"
+#include "../MethodMetadata.h"
+#include "../JNIFunctionBody.h"
+#include "../types/ExpectedType.h"
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+class JSFunctionsDecorator : public JSDecorator {
+public:
+
+  void registerSyncFunction(
+    jni::alias_ref<jstring> name,
+    jboolean takesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> body
+  );
+
+  void registerAsyncFunction(
+    jni::alias_ref<jstring> name,
+    jboolean takesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
+  );
+
+  void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) override;
+
+private:
+  /**
+  * Metadata map that stores information about all available methods on this module.
+  */
+  std::unordered_map<std::string, std::shared_ptr<MethodMetadata>> methodsMetadata;
+};
+
+}

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSObjectDecorator.h"
+#include "JSDecoratorsBridgingObject.h"
+
+namespace expo {
+
+void JSObjectDecorator::registerObject(
+  jni::alias_ref<jstring> name,
+  jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject
+) {
+  auto nameStr = name->toStdString();
+  objects.emplace(nameStr, jsDecoratorsBridgingObject->cthis()->bridge());
+}
+
+void JSObjectDecorator::decorate(
+  jsi::Runtime &runtime,
+  jsi::Object &jsObject
+) {
+  for (const auto &[name, decorators]: this->objects) {
+    auto object = jsi::Object(runtime);
+    for (const auto &decorator: decorators) {
+      decorator->decorate(runtime, object);
+    }
+
+    jsObject.setProperty(
+      runtime,
+      name.c_str(),
+      jsi::Value(runtime, object)
+    );
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.h
@@ -1,0 +1,31 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+#include "JSDecorator.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class JSDecoratorsBridgingObject;
+
+class JSObjectDecorator : public JSDecorator {
+public:
+  void registerObject(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> jsDecoratorsBridgingObject
+  );
+
+  void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) override;
+
+private:
+  std::unordered_map<std::string, std::vector<std::unique_ptr<JSDecorator>>> objects;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
@@ -1,0 +1,74 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JSPropertiesDecorator.h"
+#include "../JavaScriptObject.h"
+#include "JSIUtils.h"
+
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+void JSPropertiesDecorator::registerProperty(
+  jni::alias_ref<jstring> name,
+  jboolean getterTakesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> getter,
+  jboolean setterTakesOwner,
+  jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
+  jni::alias_ref<JNIFunctionBody::javaobject> setter
+) {
+  auto cName = name->toStdString();
+
+  auto getterMetadata = make_shared<MethodMetadata>(
+    cName,
+    getterTakesOwner &
+    0x1, // We're unsure if getterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    false,
+    jni::make_local(getterExpectedArgsTypes),
+    jni::make_global(getter)
+  );
+
+  auto setterMetadata = make_shared<MethodMetadata>(
+    cName,
+    setterTakesOwner &
+    0x1, // We're unsure if setterTakesOwner can be greater than 1, so we're using bitwise AND to ensure it's 0 or 1.
+    false,
+    jni::make_local(setterExpectedArgsTypes),
+    jni::make_global(setter)
+  );
+
+  auto functions = std::make_pair(
+    std::move(getterMetadata),
+    std::move(setterMetadata)
+  );
+
+  properties.insert_or_assign(cName, std::move(functions));
+}
+
+void JSPropertiesDecorator::decorate(
+  jsi::Runtime &runtime,
+  jsi::Object &jsObject
+) {
+  for (auto &[name, property]: this->properties) {
+    auto &[getter, setter] = property;
+
+    auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime,
+                                                                  1 << 1 /* enumerable */);
+    descriptor.setProperty(
+      runtime,
+      "get",
+      jsi::Value(runtime, *getter->toJSFunction(runtime))
+    );
+    descriptor.setProperty(
+      runtime,
+      "set",
+      jsi::Value(runtime, *setter->toJSFunction(runtime))
+    );
+    common::defineProperty(runtime, &jsObject, name.c_str(), std::move(descriptor));
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.h
@@ -1,0 +1,41 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include <fbjni/fbjni.h>
+
+#include <unordered_map>
+
+#include "../MethodMetadata.h"
+#include "../JNIFunctionBody.h"
+#include "../types/ExpectedType.h"
+#include "JSDecorator.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class JSPropertiesDecorator : public JSDecorator {
+public:
+  void registerProperty(
+    jni::alias_ref<jstring> name,
+    jboolean getterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> getter,
+    jboolean setterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> setter
+  );
+
+  void decorate(
+    jsi::Runtime &runtime,
+    jsi::Object &jsObject
+  ) override;
+
+private:
+  /**
+  * A registry of properties
+  * The first MethodMetadata points to the getter and the second one to the setter.
+  */
+  std::unordered_map<std::string, std::pair<std::shared_ptr<MethodMetadata>, std::shared_ptr<MethodMetadata>>> properties;
+};
+
+}

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -8,6 +8,7 @@
 #include <react/jni/ReadableNativeArray.h>
 #include <react/jni/WritableNativeArray.h>
 #include <react/jni/WritableNativeMap.h>
+#include <jsi/JSIDynamic.h>
 
 namespace react = facebook::react;
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -9,7 +10,9 @@ import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.MethodNotFoundException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.objects.ObjectDefinitionData
 import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
@@ -38,46 +41,72 @@ class ModuleHolder<T : Module>(val module: T) {
       val appContext = module.appContext
       val jniDeallocator = appContext.jniDeallocator
 
-      JavaScriptModuleObject(jniDeallocator, name).apply {
-        initUsingObjectDefinition(appContext, definition.objectDefinition)
+      val moduleDecorator = JSDecoratorsBridgingObject(jniDeallocator)
+      attachPrimitives(appContext, definition.objectDefinition, moduleDecorator, name)
 
-        // Give the module object a name. It's used for compatibility reasons, see `EventEmitter.ts`.
-        registerProperty("__expo_module_name__", false, emptyArray(), { name }, false, emptyArray(), null)
+      // Give the module object a name. It's used for compatibility reasons, see `EventEmitter.ts`.
+      moduleDecorator.registerProperty("__expo_module_name__", false, emptyArray(), { name }, false, emptyArray(), null)
 
-        val viewFunctions = definition.viewManagerDefinition?.asyncFunctions
-        if (viewFunctions?.isNotEmpty() == true) {
-          trace("Attaching view prototype") {
-            val viewPrototype = JavaScriptModuleObject(jniDeallocator, "${name}_${definition.viewManagerDefinition?.viewType?.name}")
-            appContext.jniDeallocator.addReference(viewPrototype)
-
-            viewFunctions.forEach { function ->
-              function.attachToJSObject(appContext, viewPrototype)
-            }
-
-            registerViewPrototype(viewPrototype)
+      val viewFunctions = definition.viewManagerDefinition?.asyncFunctions
+      if (viewFunctions?.isNotEmpty() == true) {
+        trace("Attaching view prototype") {
+          val viewDecorator = JSDecoratorsBridgingObject(jniDeallocator)
+          viewFunctions.forEach { function ->
+            function.attachToJSObject(appContext, viewDecorator, "${name}_${definition.viewManagerDefinition?.viewType?.name}")
           }
-        }
 
-        trace("Attaching classes") {
-          definition.classData.forEach { clazz ->
-            val clazzModuleObject = JavaScriptModuleObject(jniDeallocator, clazz.name)
-              .initUsingObjectDefinition(module.appContext, clazz.objectDefinition)
-            appContext.jniDeallocator.addReference(clazzModuleObject)
-            val constructor = clazz.constructor
-
-            val ownerClass = (constructor.ownerType?.classifier as? KClass<*>)?.java
-
-            registerClass(
-              clazz.name,
-              clazzModuleObject,
-              constructor.takesOwner,
-              ownerClass,
-              constructor.getCppRequiredTypes().toTypedArray(),
-              constructor.getJNIFunctionBody(clazz.name, appContext)
-            )
-          }
+          moduleDecorator.registerObject("ViewPrototype", viewDecorator)
         }
       }
+
+      trace("Attaching classes") {
+        definition.classData.forEach { clazz ->
+          val prototypeDecorator = JSDecoratorsBridgingObject(jniDeallocator)
+
+          attachPrimitives(appContext, clazz.objectDefinition, prototypeDecorator, clazz.name)
+
+          val constructor = clazz.constructor
+          val ownerClass = (constructor.ownerType?.classifier as? KClass<*>)?.java
+
+          moduleDecorator.registerClass(
+            clazz.name,
+            prototypeDecorator,
+            constructor.takesOwner,
+            ownerClass,
+            constructor.getCppRequiredTypes().toTypedArray(),
+            constructor.getJNIFunctionBody(clazz.name, appContext)
+          )
+        }
+      }
+
+      JavaScriptModuleObject(jniDeallocator, name).apply {
+        decorate(moduleDecorator)
+      }
+    }
+  }
+
+  private fun attachPrimitives(appContext: AppContext, definition: ObjectDefinitionData, moduleDecorator: JSDecoratorsBridgingObject, name: String) {
+    trace("Exporting constants") {
+      val constants = definition.constantsProvider()
+      val convertedConstants = Arguments.makeNativeMap(constants)
+
+      moduleDecorator.registerConstants(convertedConstants)
+    }
+
+    trace("Attaching functions") {
+      definition
+        .functions
+        .forEach { function ->
+          function.attachToJSObject(appContext, moduleDecorator, name)
+        }
+    }
+
+    trace("Attaching properties") {
+      definition
+        .properties
+        .forEach { (_, prop) ->
+          prop.attachToJSObject(appContext, moduleDecorator)
+        }
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -8,8 +8,8 @@ import expo.modules.kotlin.exception.InvalidArgsNumberException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.jni.ExpectedType
-import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
 import kotlin.reflect.KClass
@@ -117,7 +117,7 @@ abstract class AnyFunction(
   /**
    * Attaches current function to the provided js object.
    */
-  abstract fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
+  abstract fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String)
 
   fun getCppRequiredTypes(): List<ExpectedType> {
     return desiredArgsTypes.map { it.getCppRequiredTypes() }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
-import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.launch
 
@@ -53,9 +53,8 @@ abstract class AsyncFunction(
 
   internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext)
 
-  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+  override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
     val appContextHolder = appContext.jsiInterop.appContextHolder
-    val moduleName = jsObject.name
     jsObject.registerAsyncFunction(
       name,
       takesOwner,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -10,7 +10,7 @@ import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
-import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
@@ -47,9 +47,8 @@ class SuspendFunctionComponent(
     }
   }
 
-  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+  override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
     val appContextHolder = appContext.jsiInterop.appContextHolder
-    val moduleName = jsObject.name
     jsObject.registerAsyncFunction(
       name,
       takesOwner,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -6,7 +6,7 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JNIFunctionBody
-import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.JSTypeConverter
 
@@ -35,12 +35,12 @@ class SyncFunctionComponent(
     }
   }
 
-  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+  override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
     jsObject.registerSyncFunction(
       name,
       takesOwner,
       getCppRequiredTypes().toTypedArray(),
-      getJNIFunctionBody(jsObject.name, appContext)
+      getJNIFunctionBody(moduleName, appContext)
     )
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -1,12 +1,8 @@
 package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.NativeMap
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.objects.ObjectDefinitionData
-import expo.modules.kotlin.tracing.trace
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 
 /**
  * A class to communicate with CPP part of the [expo.modules.kotlin.modules.Module] class.
@@ -34,60 +30,7 @@ class JavaScriptModuleObject(
   val isValid: Boolean
     get() = mHybridData.isValid
 
-  fun initUsingObjectDefinition(appContext: AppContext, definition: ObjectDefinitionData) = apply {
-    val constants = definition.constantsProvider()
-    val convertedConstants = Arguments.makeNativeMap(constants)
-    trace("Exporting constants") {
-      exportConstants(convertedConstants)
-    }
-
-    trace("Attaching functions") {
-      definition
-        .functions
-        .forEach { function ->
-          function.attachToJSObject(appContext, this)
-        }
-    }
-
-    trace("Attaching properties") {
-      definition
-        .properties
-        .forEach { (_, prop) ->
-          prop.attachToJSObject(appContext, this)
-        }
-    }
-  }
-
-  /**
-   * Exports constants
-   */
-  external fun exportConstants(constants: NativeMap)
-
-  /**
-   * Register a promise-less function on the CPP module representation.
-   * After calling this function, user can access the exported function in the JS code.
-   */
-  external fun registerSyncFunction(name: String, takesOwner: Boolean, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
-
-  /**
-   * Register a promise function on the CPP module representation.
-   * After calling this function, user can access the exported function in the JS code.
-   */
-  external fun registerAsyncFunction(name: String, takesOwner: Boolean, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
-
-  external fun registerProperty(
-    name: String,
-    getterTakesOwner: Boolean,
-    getterExpectedType: Array<ExpectedType>,
-    getter: JNIFunctionBody?,
-    setterTakesOwner: Boolean,
-    setterExpectedType: Array<ExpectedType>,
-    setter: JNIFunctionBody?
-  )
-
-  external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, ownerClass: Class<*>?, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
-
-  external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
+  external fun decorate(decorator: JSDecoratorsBridgingObject)
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -1,0 +1,77 @@
+@file:Suppress("KotlinJniMissingFunction")
+
+package expo.modules.kotlin.jni.decorators
+
+import com.facebook.jni.HybridData
+import com.facebook.react.bridge.NativeMap
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.jni.Destructible
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.jni.JNIAsyncFunctionBody
+import expo.modules.kotlin.jni.JNIDeallocator
+import expo.modules.kotlin.jni.JNIFunctionBody
+
+/**
+ * This class was introduced to bridge the gap between Kotlin and cpp only once.
+ * Dealing with JNI for each type of decorator was hard to get right.
+ */
+class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible {
+
+  @DoNotStrip
+  private val mHybridData = initHybrid()
+
+  private external fun initHybrid(): HybridData
+
+  init {
+    jniDeallocator.addReference(this)
+  }
+
+  external fun registerConstants(constants: NativeMap)
+
+  external fun registerSyncFunction(
+    name: String,
+    takesOwner: Boolean,
+    desiredTypes: Array<ExpectedType>,
+    body: JNIFunctionBody
+  )
+
+  external fun registerAsyncFunction(
+    name: String,
+    takesOwner: Boolean,
+    desiredTypes: Array<ExpectedType>,
+    body: JNIAsyncFunctionBody
+  )
+
+  external fun registerProperty(
+    name: String,
+    getterTakesOwner: Boolean,
+    getterExpectedType: Array<ExpectedType>,
+    getter: JNIFunctionBody?,
+    setterTakesOwner: Boolean,
+    setterExpectedType: Array<ExpectedType>,
+    setter: JNIFunctionBody?
+  )
+
+  external fun registerObject(
+    name: String,
+    jsDecoratorsBridgingObject: JSDecoratorsBridgingObject
+  )
+
+  external fun registerClass(
+    name: String,
+    prototypeDecorator: JSDecoratorsBridgingObject,
+    takesOwner: Boolean,
+    ownerClass: Class<*>?,
+    desiredTypes: Array<ExpectedType>,
+    body: JNIFunctionBody
+  )
+
+  override fun deallocate() {
+    mHybridData.resetNative()
+  }
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    deallocate()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -3,7 +3,7 @@ package expo.modules.kotlin.objects
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.jni.JNIFunctionBody
-import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.JSTypeConverter
 
 class PropertyComponent(
@@ -25,7 +25,7 @@ class PropertyComponent(
   /**
    * Attaches property to the provided js object.
    */
-  fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+  fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject) {
     val jniGetter = if (getter != null) {
       JNIFunctionBody { args ->
         val result = getter.call(args, appContext)

--- a/packages/expo-modules-core/common/cpp/NativeModule.h
+++ b/packages/expo-modules-core/common/cpp/NativeModule.h
@@ -6,6 +6,8 @@
 
 #include <jsi/jsi.h>
 
+#include "JSIUtils.h"
+
 namespace jsi = facebook::jsi;
 
 namespace expo::NativeModule {


### PR DESCRIPTION
# Why

This refactoring is aimed at improving how the JS objects are decorated, aligning them more closely with our desired outcomes.
Prerequisite to reanimated integration. 

# How

We didn't have a good model for decorating the JS objects from our DSL output. I've made a new abstraction that avoids using JNI as much as possible to convert data gathered from DSL components into CPP decorators. 

# Test Plan

- bare-expo ✅ 
- unit tests ✅ 