### PR TITLE
fix(expo-av): loadAsync promise never settles given an invalid file uri

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] `loadAsync()` never settles for an invalid file uri ([#30020](https://github.com/expo/expo/pull/30020) by [@vonovak](https://github.com/vonovak))
+
 - Fixed putting app to background stops non-mixable audio playback in other apps on iOS ([#20380](https://github.com/expo/expo/pull/20380) by [@de1acr0ix](https://github.com/de1acr0ix))
 
 ### 💡 Others

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] `loadAsync()` never settles for an invalid file uri ([#30020](https://github.com/expo/expo/pull/30020) by [@vonovak](https://github.com/vonovak))
+- [iOS] `loadAsync()` promise never settled when given an invalid file uri ([#30020](https://github.com/expo/expo/pull/30020) by [@vonovak](https://github.com/vonovak))
 
 - Fixed putting app to background stops non-mixable audio playback in other apps on iOS ([#20380](https://github.com/expo/expo/pull/20380) by [@de1acr0ix](https://github.com/de1acr0ix))
 


### PR DESCRIPTION
# Why

Closes #25842. The issue exposes one problem: when user tries to load an asset that doesn't exist:

```ts
const playRecording = async (fileName: string) => {  // does-not-exist.m4a 
  const sound = new Audio.Sound();
  await sound.loadAsync({ uri: `${FileSystem.documentDirectory}${fileName}` });
  await sound.playAsync();
}
```

Nothing happens. The `loadAsync` promise doesn't settle. It should reject.

There's a lot going on in Expo AV so I hope I got this right. Using key-value observing we subscribe to receive info about some changes taking place. [Here](https://github.com/expo/expo/blob/5e6fd955ba3c859dbd36691a7d63820961bb1cc0/packages/expo-av/ios/EXAV/EXAVPlayerData.m#L755) we try to match the source using 2 conditions: `object == strongSelf.player` or `object == strongSelf.player.currentItem`.

However, in this case neither of these two conditions evaluates to true:

at first, in `_loadNewPlayer`, the `items` are

```
(lldb) po  self.player.items
<__NSArrayI 0x600000c701b0>(
<AVPlayerItem: 0x60000010b9e0, asset = <AVURLAsset: 0x6000003eee20, URL = ..F7.m4a>>,
<AVPlayerItem: 0x60000010ba50, asset = <AVURLAsset: 0x6000003eee20, URL = ..F7.m4a>>,
<AVPlayerItem: 0x60000010bb10, asset = <AVURLAsset: 0x6000003eee20, URL = ..F7.m4a>>
)
```
Then there are 2 events. When the first event is received, `object == strongSelf.player` is true and `currentItem` is the one with index 1.

```
(lldb) po strongSelf.player.currentItem
<AVPlayerItem: 0x60000010ba50, asset = <AVURLAsset: 0x6000003eee20, URL = ..F7.m4a>>
```

When the second event is received, neither condition is true: the target object is `AVPlayerItem` with index 0, but `strongSelf.player.currentItem` is the one with index 2.

```
(lldb) po strongSelf.player.currentItem
<AVPlayerItem: 0x60000010bb10, asset = <AVURLAsset: 0x6000003eee20, URL = ..F7.m4a>>
```

and so nothing happens.

# How

There are 2 ways to fix the specific issue at hand:

(1) the way in this PR

(2) relax the `object == strongSelf.player.currentItem` condition as in [here](https://github.com/expo/expo/pull/30020/commits/8358b3d4f2360822a9d95301f6c399ae4b57dd00)

This works because the underlying asset is the same reference. However, I worry it'd run more than we want.


Additionally, I added a warning for people who use file uris, because the promise is rejected with `[Error: The operation could not be completed]` which is not incredibly helpful.

# Test Plan

Tested manually. The promise rejects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
