### PR TITLE
[video][ios] Fix a race condition causing crashes when deallocating the player

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Web] Fix `AudioContext` being created before user interaction causing playback issues. ([#29695](https://github.com/expo/expo/pull/29695) by [@behenate](https://github.com/behenate))
 - [iOS] Fix crashes on iOS 16 and lower when source HTTP headers are undefined. ([#30104](https://github.com/expo/expo/pull/30104) by [@behenate](https://github.com/behenate))
+- [iOS] Fix a race condition causing crashes when deallocating the player. ([#30022](https://github.com/expo/expo/pull/30022) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -181,9 +181,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
       return try await mediaItem.asset.loadMetadata(for: .iTunesMetadata)
     }
 
-    return await withCheckedContinuation { continuation in
-      return continuation.resume(returning: mediaItem.asset.metadata)
-    }
+    return mediaItem.asset.metadata
   }
 
   // Updates nowPlaying information that changes dynamically during playback e.g. progress

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -86,7 +86,10 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     observer.cleanup()
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
-    pointer.replaceCurrentItem(with: nil)
+
+    DispatchQueue.main.async { [pointer] in
+      pointer.replaceCurrentItem(with: nil)
+    }
   }
 
   func replaceCurrentItem(with videoSource: VideoSource?) throws {

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -87,6 +87,9 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
 
+    // The current item has to be replaced with nil from the main thread. When replacing from the SharedObjectRegistry queue
+    // sometimes the KVOs used by AVPlayerViewController would try to deliver updates about the item being changed to nil after the
+    // player was deallocated, which caused crashes.
     DispatchQueue.main.async { [pointer] in
       pointer.replaceCurrentItem(with: nil)
     }


### PR DESCRIPTION
# Why

We were setting the player item to nil during the deallocation on a thread different than main, this caused KVO related race conditions, which lead to crashes.

Fixes https://github.com/expo/expo/issues/29950

# How

Wrapped the line into `DispatchQueue.main.async` to run on the main queue, did some updates to the code changed in https://github.com/expo/expo/pull/29428 as it's not necessary to create a different queue now.

# Test Plan

Tested in BareExpo and custom test apps in iOS simulator and physical device.

