### PR TITLE
feat(cli): automatically set app IDs on prebuild

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Automatically use valid default app identifiers in prebuild.
 - Add microsecond format for bundling. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `.eslintrc.js` to `expo customize`. ([#29570](https://github.com/expo/expo/pull/29570) by [@EvanBacon](https://github.com/EvanBacon))
 - Support web imports of `react-native/Libraries/Image/resolveAssetSource` in Metro. ([#29685](https://github.com/expo/expo/pull/29685) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Automatically use valid default app identifiers in prebuild.
+- Automatically use valid default app identifiers in prebuild. ([#30023](https://github.com/expo/expo/pull/30023) by [@EvanBacon](https://github.com/EvanBacon))
 - Add microsecond format for bundling. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `.eslintrc.js` to `expo customize`. ([#29570](https://github.com/expo/expo/pull/29570) by [@EvanBacon](https://github.com/EvanBacon))
 - Support web imports of `react-native/Libraries/Image/resolveAssetSource` in Metro. ([#29685](https://github.com/expo/expo/pull/29685) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
@@ -9,6 +9,8 @@ import {
   validateBundleId,
   validatePackage,
   validatePackageWithWarning,
+  getSanitizedPackage,
+  assertValidPackage,
 } from '../validateApplicationId';
 
 jest.mock('node-fetch');
@@ -48,12 +50,49 @@ describe(validatePackageWithWarning, () => {
     );
   });
 });
+
+describe(getSanitizedPackage, () => {
+  [
+    // Sanity
+    ['bacon.com.hey', 'bacon.com.hey'],
+    // Most likely outcome
+    ['com.my-expo-username.june-34', 'com.myexpousername.june34'],
+
+    // Also possible
+    ['jun25-d..ev @la0_0.0._uncher', 'jun25d.evla0_0.x0.x_uncher'],
+
+    ['native.android', 'xnative.android'],
+    ['com.native', 'com.xnative'],
+    // Appends correct number of segments
+    ['a', 'com.a'],
+    ['a.b', 'a.b'],
+    // Ensures that each dot starts with a letter
+    ['_', 'com.x_'],
+    // Strips extra dots
+    ['a.b...c.', 'a.b.c'],
+    ['a.b_..c', 'a.b_.c'],
+    // Should likely never happen given how we use the function.
+    ['.', 'com.app'],
+    ['.', 'com.app'],
+    ['. ..', 'com.app'],
+    [',', 'com.app'],
+    ['...b.a.-c.0.n...', 'b.a.c.x0.n'],
+  ].forEach(([input, output]) => {
+    it(`sanitizes ${input} to valid "${output}"`, () => {
+      const sanitized = getSanitizedPackage(input);
+      expect(sanitized).toBe(output);
+      assertValidPackage(sanitized);
+    });
+  });
+});
 describe(validatePackage, () => {
   it(`validates`, () => {
     expect(validatePackage('bacon.com.hey')).toBe(true);
     expect(validatePackage('bacon')).toBe(false);
     expect(validatePackage('com.native')).toBe(false);
     expect(validatePackage('native.android')).toBe(false);
+    expect(validatePackage('foo.native.foo.bar')).toBe(false);
+    expect(validatePackage('native.foo.bar')).toBe(false);
     expect(validatePackage('...b.a.-c.0.n...')).toBe(false);
     expect(validatePackage('.')).toBe(false);
     expect(validatePackage('. ..')).toBe(false);

--- a/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
@@ -9,6 +9,7 @@ import {
   validateBundleId,
   validatePackage,
   validatePackageWithWarning,
+  getSanitizedBundleIdentifier,
   getSanitizedPackage,
   assertValidPackage,
 } from '../validateApplicationId';
@@ -48,6 +49,34 @@ describe(validatePackageWithWarning, () => {
     expect(validatePackageWithWarning(',')).toEqual(
       `Package name must contain more than one segment, separated by ".", e.g. com.,`
     );
+  });
+});
+
+describe(getSanitizedBundleIdentifier, () => {
+  [
+    // Sanity
+    ['bacon.com.hey', 'bacon.com.hey'],
+    // Most likely outcome
+    ['com.my-expo-username.june-34', 'com.my-expo-username.june-34'],
+    // Also possible
+    [
+      // Dropped this string in Xcode (accounting for escape characters) and got the output string...
+      '1234567890-=qwertyuiop[]\\asdfghjkl;\'zxcvbnm,./!@#$%^&*()_+`~QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?',
+      '-234567890--qwertyuiop---asdfghjkl--zxcvbnm-.---------------QWERTYUIOP---ASDFGHJKL--ZXCVBNM---',
+    ],
+    ['7', '-'],
+    ['#', '-'],
+    ['P', 'P'],
+    ['...', '...'],
+    ['native.ios', 'native.ios'],
+    ['com.native', 'com.native'],
+    ['a.b', 'a.b'],
+  ].forEach(([input, output]) => {
+    it(`sanitizes ${input} to valid "${output}"`, () => {
+      const sanitized = getSanitizedBundleIdentifier(input);
+      expect(sanitized).toBe(output);
+      expect(validateBundleId(sanitized)).toBe(true);
+    });
   });
 });
 

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -14,11 +14,11 @@ import {
   validatePackageWithWarning,
 } from './validateApplicationId';
 import * as Log from '../log';
+import { memoize } from './fn';
 
-function getUsernameAsync(exp: ExpoConfig) {
-  // TODO: Use XDL's UserManager
-  // import { UserManager } from 'xdl';
-  return getAccountUsername(exp);
+function getExpoUsername(exp: ExpoConfig) {
+  // Account for if the environment variable was an empty string.
+  return getAccountUsername(exp) || 'anonymous';
 }
 
 const NO_BUNDLE_ID_MESSAGE = `Project must have a \`ios.bundleIdentifier\` set in the Expo config (app.json or app.config.js).`;
@@ -40,39 +40,48 @@ export async function getOrPromptForBundleIdentifier(
     return current;
   }
 
-  Log.log(
-    chalk`\n{bold 📝  iOS Bundle Identifier} {dim ${learnMore(
-      'https://expo.fyi/bundle-identifier'
-    )}}\n`
-  );
-
-  return await promptForBundleIdAsync(projectRoot, exp);
+  return promptForBundleIdWithInitialAsync(projectRoot, exp, getRecommendedBundleId(exp));
 }
 
-async function promptForBundleIdAsync(projectRoot: string, exp: ExpoConfig): Promise<string> {
-  // Prompt the user for the bundle ID.
-  // Even if the project is using a dynamic config we can still
-  // prompt a better error message, recommend a default value, and help the user
-  // validate their custom bundle ID upfront.
-  const { bundleIdentifier } = await prompt(
-    {
-      type: 'text',
-      name: 'bundleIdentifier',
-      initial: (await getRecommendedBundleIdAsync(exp)) ?? undefined,
-      // The Apple helps people know this isn't an EAS feature.
-      message: `What would you like your iOS bundle identifier to be?`,
-      validate: validateBundleId,
-    },
-    {
-      nonInteractiveHelp: NO_BUNDLE_ID_MESSAGE,
-    }
-  );
+const memoLog = memoize(Log.log);
+
+async function promptForBundleIdWithInitialAsync(
+  projectRoot: string,
+  exp: ExpoConfig,
+  bundleIdentifier?: string
+): Promise<string> {
+  if (!bundleIdentifier) {
+    memoLog(
+      chalk`\n{bold 📝  iOS Bundle Identifier} {dim ${learnMore(
+        'https://expo.fyi/bundle-identifier'
+      )}}\n`
+    );
+
+    // Prompt the user for the bundle ID.
+    // Even if the project is using a dynamic config we can still
+    // prompt a better error message, recommend a default value, and help the user
+    // validate their custom bundle ID upfront.
+    const { input } = await prompt(
+      {
+        type: 'text',
+        name: 'input',
+        // The Apple helps people know this isn't an EAS feature.
+        message: `What would you like your iOS bundle identifier to be?`,
+        validate: validateBundleId,
+      },
+      {
+        nonInteractiveHelp: NO_BUNDLE_ID_MESSAGE,
+      }
+    );
+    bundleIdentifier = input as string;
+  }
 
   // Warn the user if the bundle ID is already in use.
   const warning = await getBundleIdWarningAsync(bundleIdentifier);
+
   if (warning && !(await warnAndConfirmAsync(warning))) {
     // Cycle the Bundle ID prompt to try again.
-    return await promptForBundleIdAsync(projectRoot, exp);
+    return await promptForBundleIdWithInitialAsync(projectRoot, exp);
   }
 
   // Apply the changes to the config.
@@ -103,35 +112,35 @@ async function warnAndConfirmAsync(warning: string): Promise<boolean> {
 }
 
 // Recommend a bundle identifier based on the username and project slug.
-async function getRecommendedBundleIdAsync(exp: ExpoConfig): Promise<string | null> {
+function getRecommendedBundleId(exp: ExpoConfig): string | undefined {
   // Attempt to use the android package name first since it's convenient to have them aligned.
   if (exp.android?.package && validateBundleId(exp.android?.package)) {
     return exp.android?.package;
   } else {
-    const username = await getUsernameAsync(exp);
+    const username = getExpoUsername(exp);
     const possibleId = `com.${username}.${exp.slug}`;
-    if (username && validateBundleId(possibleId)) {
+    if (validateBundleId(possibleId)) {
       return possibleId;
     }
   }
 
-  return null;
+  return undefined;
 }
 
 // Recommend a package name based on the username and project slug.
-async function getRecommendedPackageNameAsync(exp: ExpoConfig): Promise<string | null> {
+function getRecommendedPackageName(exp: ExpoConfig): string | undefined {
   // Attempt to use the ios bundle id first since it's convenient to have them aligned.
   if (exp.ios?.bundleIdentifier && validatePackage(exp.ios.bundleIdentifier)) {
     return exp.ios.bundleIdentifier;
   } else {
-    const username = await getUsernameAsync(exp);
+    const username = getExpoUsername(exp);
     // It's common to use dashes in your node project name, strip them from the suggested package name.
     const possibleId = `com.${username}.${exp.slug}`.split('-').join('');
-    if (username && validatePackage(possibleId)) {
+    if (validatePackage(possibleId)) {
       return possibleId;
     }
   }
-  return null;
+  return undefined;
 }
 
 /**
@@ -149,36 +158,46 @@ export async function getOrPromptForPackage(
     return current;
   }
 
-  Log.log(
-    chalk`\n{bold 📝  Android package} {dim ${learnMore('https://expo.fyi/android-package')}}\n`
-  );
-
   return await promptForPackageAsync(projectRoot, exp);
 }
 
-async function promptForPackageAsync(projectRoot: string, exp: ExpoConfig): Promise<string> {
-  // Prompt the user for the android package.
-  // Even if the project is using a dynamic config we can still
-  // prompt a better error message, recommend a default value, and help the user
-  // validate their custom android package upfront.
-  const { packageName } = await prompt(
-    {
-      type: 'text',
-      name: 'packageName',
-      initial: (await getRecommendedPackageNameAsync(exp)) ?? undefined,
-      message: `What would you like your Android package name to be?`,
-      validate: validatePackageWithWarning,
-    },
-    {
-      nonInteractiveHelp: NO_PACKAGE_MESSAGE,
-    }
-  );
+function promptForPackageAsync(projectRoot: string, exp: ExpoConfig): Promise<string> {
+  return promptForPackageWithInitialAsync(projectRoot, exp, getRecommendedPackageName(exp));
+}
+
+async function promptForPackageWithInitialAsync(
+  projectRoot: string,
+  exp: ExpoConfig,
+  packageName?: string
+): Promise<string> {
+  if (!packageName) {
+    memoLog(
+      chalk`\n{bold 📝  Android package} {dim ${learnMore('https://expo.fyi/android-package')}}\n`
+    );
+
+    // Prompt the user for the android package.
+    // Even if the project is using a dynamic config we can still
+    // prompt a better error message, recommend a default value, and help the user
+    // validate their custom android package upfront.
+    const { input } = await prompt(
+      {
+        type: 'text',
+        name: 'input',
+        message: `What would you like your Android package name to be?`,
+        validate: validatePackageWithWarning,
+      },
+      {
+        nonInteractiveHelp: NO_PACKAGE_MESSAGE,
+      }
+    );
+    packageName = input as string;
+  }
 
   // Warn the user if the package name is already in use.
   const warning = await getPackageNameWarningAsync(packageName);
   if (warning && !(await warnAndConfirmAsync(warning))) {
     // Cycle the Package name prompt to try again.
-    return await promptForPackageAsync(projectRoot, exp);
+    return promptForPackageWithInitialAsync(projectRoot, exp);
   }
 
   // Apply the changes to the config.

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -10,6 +10,7 @@ import {
   assertValidPackage,
   getBundleIdWarningAsync,
   getPackageNameWarningAsync,
+  getSanitizedBundleIdentifier,
   getSanitizedPackage,
   validateBundleId,
   validatePackage,
@@ -116,13 +117,15 @@ async function warnAndConfirmAsync(warning: string): Promise<boolean> {
 
 // Recommend a bundle identifier based on the username and project slug.
 function getRecommendedBundleId(exp: ExpoConfig): string | undefined {
+  const possibleIdFromAndroid = exp.android?.package
+    ? getSanitizedBundleIdentifier(exp.android.package)
+    : undefined;
   // Attempt to use the android package name first since it's convenient to have them aligned.
-  if (exp.android?.package && validateBundleId(exp.android?.package)) {
-    return exp.android?.package;
+  if (possibleIdFromAndroid && validateBundleId(possibleIdFromAndroid)) {
+    return possibleIdFromAndroid;
   } else {
     const username = getExpoUsername(exp);
-    // TODO: Maybe sanitize this value too?
-    const possibleId = `com.${username}.${exp.slug}`;
+    const possibleId = getSanitizedBundleIdentifier(`com.${username}.${exp.slug}`);
     if (validateBundleId(possibleId)) {
       return possibleId;
     }
@@ -133,9 +136,13 @@ function getRecommendedBundleId(exp: ExpoConfig): string | undefined {
 
 // Recommend a package name based on the username and project slug.
 function getRecommendedPackageName(exp: ExpoConfig): string | undefined {
+  const possibleIdFromApple = exp.ios?.bundleIdentifier
+    ? getSanitizedPackage(exp.ios.bundleIdentifier)
+    : undefined;
+
   // Attempt to use the ios bundle id first since it's convenient to have them aligned.
-  if (exp.ios?.bundleIdentifier && validatePackage(exp.ios.bundleIdentifier)) {
-    return exp.ios.bundleIdentifier;
+  if (possibleIdFromApple && validatePackage(possibleIdFromApple)) {
+    return possibleIdFromApple;
   } else {
     const username = getExpoUsername(exp);
     const possibleId = getSanitizedPackage(`com.${username}.${exp.slug}`);

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -52,7 +52,7 @@ export async function validateGitStatusAsync(): Promise<boolean> {
     return true;
   } else if (workingTreeStatus === 'dirty') {
     logWarning(
-      'Current git branch has uncommited file changes',
+      'Git branch has uncommited file changes',
       `It's recommended to commit all changes before proceeding in case you want to revert generated changes.`
     );
   } else {

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -26,7 +26,7 @@ export async function maybeBailOnGitStatusAsync(): Promise<boolean> {
 
     Log.log();
     const answer = await confirmAsync({
-      message: `Would you like to proceed?`,
+      message: `Continue with uncommited changes?`,
     });
 
     if (!answer) {
@@ -49,21 +49,23 @@ export async function validateGitStatusAsync(): Promise<boolean> {
   }
 
   if (workingTreeStatus === 'clean') {
-    Log.log(`Your git working tree is ${chalk.green('clean')}`);
-    Log.log('To revert the changes after this command completes, you can run the following:');
-    Log.log('  git clean --force && git reset --hard');
     return true;
   } else if (workingTreeStatus === 'dirty') {
-    Log.log(`${chalk.bold('Warning!')} Your git working tree is ${chalk.red('dirty')}.`);
-    Log.log(
-      `It's recommended to ${chalk.bold(
-        'commit all your changes before proceeding'
-      )}, so you can revert the changes made by this command if necessary.`
+    logWarning(
+      'Current git branch has uncommited file changes',
+      `It's recommended to commit all changes before proceeding in case you want to revert generated changes.`
     );
   } else {
-    Log.log("We couldn't find a git repository in your project directory.");
-    Log.log("It's recommended to back up your project before proceeding.");
+    logWarning(
+      'No git repo found in current directory',
+      `Use git to track file changes before running commands that modify project files.`
+    );
   }
 
   return false;
+}
+
+function logWarning(warning: string, hint: string) {
+  Log.warn(chalk.bold`! ` + warning);
+  Log.log(chalk.gray`\u203A ` + chalk.gray(hint));
 }

--- a/packages/@expo/cli/src/utils/modifyConfigAsync.ts
+++ b/packages/@expo/cli/src/utils/modifyConfigAsync.ts
@@ -13,9 +13,7 @@ export async function attemptModification(
   const modification = await modifyConfigAsync(projectRoot, edits, {
     skipSDKVersionRequirement: true,
   });
-  if (modification.type === 'success') {
-    Log.log();
-  } else {
+  if (modification.type !== 'success') {
     warnAboutConfigAndThrow(modification.type, modification.message!, exactEdits);
   }
 }

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -10,6 +10,7 @@ import { Log } from '../log';
 
 const debug = require('debug')('expo:utils:validateApplicationId') as typeof console.log;
 
+// TODO: Adjust to indicate that the bundle identifier must start with a letter, period, or hyphen.
 const IOS_BUNDLE_ID_REGEX = /^[a-zA-Z0-9-.]+$/;
 const ANDROID_PACKAGE_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
 
@@ -77,6 +78,14 @@ export function getSanitizedPackage(value: string) {
     .join('.');
 
   return output;
+}
+
+export function getSanitizedBundleIdentifier(value: string) {
+  // According to the behavior observed when using the UI in Xcode.
+  // Must start with a letter, period, or hyphen (not number).
+  // Can only contain alphanumeric characters, periods, and hyphens.
+  // Can have empty segments (e.g. com.example..app).
+  return value.replace(/(^[^a-zA-Z.-]|[^a-zA-Z0-9-.])/g, '-');
 }
 
 // https://en.wikipedia.org/wiki/List_of_Java_keywords

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -1,17 +1,17 @@
 import assert from 'assert';
 import chalk from 'chalk';
+import fetch from 'node-fetch';
 
 import { env } from './env';
 import { memoize } from './fn';
 import { learnMore } from './link';
 import { isUrlAvailableAsync } from './url';
-import { fetchAsync } from '../api/rest/client';
 import { Log } from '../log';
 
 const debug = require('debug')('expo:utils:validateApplicationId') as typeof console.log;
 
 const IOS_BUNDLE_ID_REGEX = /^[a-zA-Z0-9-.]+$/;
-const ANDROID_PACKAGE_REGEX = /^(?!.*\bnative\b)[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
+const ANDROID_PACKAGE_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
 
 /** Validate an iOS bundle identifier. */
 export function validateBundleId(value: string): boolean {
@@ -35,10 +35,48 @@ export function validatePackageWithWarning(value: string): true | string {
     return `Package name must contain more than one segment, separated by ".", e.g. com.${value}`;
   }
   if (!ANDROID_PACKAGE_REGEX.test(value)) {
-    return 'Invalid characters in Android package name. Only alphanumeric characters, "." and "_" are allowed, and each "." must be followed by a letter or number.';
+    return 'Invalid characters in Android package name. Only alphanumeric characters, "." and "_" are allowed, and each segment start with a letter.';
   }
 
   return true;
+}
+
+export function getSanitizedPackage(value: string) {
+  // It's common to use dashes in your node project name, strip them from the suggested package name.
+  let output = value
+    // Oracle recommends package names are "legalized" by converting hyphen to an underscore and removing unsupported characters
+    // https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
+    // However, life is much nicer when the bundle identifier and package name are the same and iOS has the inverse rule— converting underscores to hyphens.
+    // So we'll simply remove hyphens and illegal characters for Android.
+    .replace(/[^a-zA-Z0-9_.]/g, '')
+    // Prevent multiple '.' in a row (e.g. no zero-length segments).
+    .replace(/\.+/g, '.')
+    // Prevent '.' from the start or end.
+    .replace(/^\.|\.$/g, '');
+
+  output ||= 'app';
+
+  // Prepend extra segments
+  let segments = output.split('.').length;
+  while (segments < 2) {
+    output = `com.${output}`;
+    segments += 1;
+  }
+
+  // Ensure each dot has a letter or number after it
+  output = output
+    .split('.')
+    .map((segment) => {
+      segment = /^[a-zA-Z]/.test(segment) ? segment : 'x' + segment;
+
+      if (RESERVED_ANDROID_PACKAGE_NAME_SEGMENTS.includes(segment)) {
+        segment = 'x' + segment;
+      }
+      return segment;
+    })
+    .join('.');
+
+  return output;
 }
 
 // https://en.wikipedia.org/wiki/List_of_Java_keywords
@@ -118,7 +156,7 @@ export function assertValidPackage(value: string) {
   assert.match(
     value,
     ANDROID_PACKAGE_REGEX,
-    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is not allowed.`
+    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter. Reserved Java keywords are not allowed.`
   );
 }
 
@@ -140,7 +178,7 @@ export async function getBundleIdWarningInternalAsync(bundleId: string): Promise
   const url = `http://itunes.apple.com/lookup?bundleId=${bundleId}`;
   try {
     debug(`Checking iOS bundle ID '${bundleId}' at: ${url}`);
-    const response = await fetchAsync(url);
+    const response = await fetch(url);
     const json = await response.json();
     if (json.resultCount > 0) {
       const firstApp = json.results[0];
@@ -176,7 +214,7 @@ export async function getPackageNameWarningInternalAsync(
   const url = `https://play.google.com/store/apps/details?id=${packageName}`;
   try {
     debug(`Checking Android package name '${packageName}' at: ${url}`);
-    const response = await fetchAsync(url);
+    const response = await fetch(url);
     // If the page exists, then warn the user.
     if (response.status === 200) {
       // There is no JSON API for the Play Store so we can't concisely

--- a/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
+++ b/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="node" />
 /// <reference types="metro" />
+/// <reference types="node" />
 import type { TransformResultDependency } from 'metro/src/DeltaBundler';
 import { JsOutput, JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker';
 export { JsTransformOptions };

--- a/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
+++ b/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.d.ts
@@ -1,5 +1,5 @@
-/// <reference types="metro" />
 /// <reference types="node" />
+/// <reference types="metro" />
 import type { TransformResultDependency } from 'metro/src/DeltaBundler';
 import { JsOutput, JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker';
 export { JsTransformOptions };


### PR DESCRIPTION
# Why

Prompting for the bundle identifier and package name is a relic from over 4-5 years ago where it was hard to change these values after running `exp eject`. Now you can simply re-run `npx expo prebuild` to update them whenever.

Similarly, we don't validate or manually prompt users to choose the project name before generating a bunch of files with the default value that Expo CLI infers from the project.

Currently we only prompt for the IDs when none can be found in the project already, if we can guess at a generally unique value then we recommend it as the default ('mash the enter key' flow).


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How


This new change will perform validation on the default identifier and check against the store for any existing app with the same identifier, if all checks pass then we'll attempt to write the bundle identifier to the project (this will fail if the project is using a dynamic Expo config like app.config.js). 

> A possible future iteration of this functionality could lazily infer the app identifiers during prebuild so as to remove the constraint on needing a static config.

If any of the validation fails, then we'll fallback to the original behavior of prompting for an application identifier with no default value.

- resolve ENG-12484
- I've also reworked the git messages that show when you use `--clean` to better reflect our confidence with how this command will execute.
- Reworked the default value system to sanitize according to the package name selector UI in Android Studio and the bundle identifier UI in Xcode. This should greatly reduce the chances of having a prompt.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Manual testing of different workflows:
- `rm -rf ios app.json android; nexpo prebuild --no-install --clean`
  - prompts about uncommited changes.
  - no prompts for app IDs
- force the suggested ID to be `com.evanbacon.pillarvalley` and run  `rm -rf ios app.json android; nexpo prebuild --no-install --clean` -> warn about name in use.
  - continue -> no -> prompt as usual. Any valid name for one platform will automatically be used for the other.
  - continue -> yes -> use invalid bundle identifier anyways (this is useful for when you're the owner of the already registered app ID, and migrating to Expo).
- force the suggested ID to be an invalid package name: `com.evan-bacon.pillarvalley`
  - silently prompts with no default value. 
