### PR TITLE
fix: duplicate appBuildVersion

### DIFF
--- a/docs/pages/eas/webhooks.mdx
+++ b/docs/pages/eas/webhooks.mdx
@@ -69,7 +69,6 @@ The build webhook payload may look as the example below:
     "channel": "default", // available for EAS Update
     "releaseChannel": "default", // available for legacy updates
     "reactNativeVersion": "0.60.0",
-    "appBuildVersion": "6",
     "trackingContext": {
       "platform": "android",
       "account_id": "7c34cbf1-efd4-4964-84a1-c13ed297aaf9",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The JSON is invalid because of a duplication of a key.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing the duplicated key: appBuildVersion.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By removing the key the JSON is visibly valid.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
