### PR TITLE
[docs][video] Add Expo Go support note

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -12,6 +12,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** `expo-video` is a new, experimental library that aims to replace the `Video` component from `expo-av` with a more modern and reliable implementation. If you are looking for a more stable API, use [`expo-av`](av.mdx) until this library has stabilized.
 
+> **info** To provide quicker updates, `expo-video` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
+
 `expo-video` is a cross-platform, performant video component for React Native and Expo with Web support.
 
 ## Installation

--- a/docs/pages/versions/v51.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/video.mdx
@@ -12,6 +12,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** `expo-video` is a new, experimental library that aims to replace the `Video` component from `expo-av` with a more modern and reliable implementation. If you are looking for a more stable API, use [`expo-av`](av.mdx) until this library has stabilized.
 
+> **info** To provide quicker updates, `expo-video` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
+
 `expo-video` is a cross-platform, performant video component for React Native and Expo with Web support.
 
 ## Installation


### PR DESCRIPTION
# Why

A lot of people are unaware that `expo-video` is unsupported in Expo Go, and Snack and end up reporting issues on discord and GitHub e.g. https://github.com/expo/expo/issues/30006

# How

Added a note on top of the docs that informs about the support

