### PR TITLE
[workspace] update packages README files and the template

### DIFF
--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -4,8 +4,8 @@ This library provides Apple authentication for iOS standalone apps in the manage
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/apple-authentication.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/apple-authentication/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/apple-authentication/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-application/README.md
+++ b/packages/expo-application/README.md
@@ -4,7 +4,8 @@ Gets native application information such as its ID, app name, and build version 
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/application.md)
+- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/application/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/application/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-asset/README.md
+++ b/packages/expo-asset/README.md
@@ -4,8 +4,8 @@ An Expo universal module to download assets and pass them into other APIs
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/asset.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/asset/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/asset/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -4,8 +4,8 @@
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/auth-session.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/auth-session)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/auth-session/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -11,8 +11,8 @@ Expo universal module for Audio and Video playback
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/av.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/av/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/av/)
 
 # Installation in managed Expo projects
 
@@ -28,6 +28,14 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-av
 ```
 
+### Configure for Android
+
+Add `android.permission.RECORD_AUDIO` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+```
+
 ### Configure for iOS
 
 Add `NSMicrophoneUsageDescription` key to your `Info.plist`:
@@ -38,14 +46,6 @@ Add `NSMicrophoneUsageDescription` key to your `Info.plist`:
 ```
 
 Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-Add `android.permission.RECORD_AUDIO` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
-
-```xml
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
-```
 
 # Contributing
 

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -4,8 +4,8 @@ Expo universal module for BackgroundFetch API
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/background-fetch.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/background-fetch/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/background-fetch/)
 
 # Installation in managed Expo projects
 
@@ -21,12 +21,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-background-fetch
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
-In order to use `BackgroundFetch` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
-
 ### Configure for Android
 
 No additional set up necessary.
@@ -38,6 +32,12 @@ This module might listen when the device is starting up. It's necessary to conti
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 <uses-permission android:name="android.permission.WAKE_LOCK" />
 ```
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+In order to use `BackgroundFetch` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
 
 # Contributing
 

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -11,8 +11,8 @@ Allows scanning variety of supported barcodes both as standalone module and as e
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/bar-code-scanner/)
 
 # Installation in managed Expo projects
 
@@ -28,6 +28,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-barcode-scanner
 ```
 
+### Configure for Android
+
+This package automatically adds the `CAMERA` permission to your app.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.CAMERA" />
+```
+
 ### Configure for iOS
 
 Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` key to your `Info.plist`:
@@ -41,14 +50,6 @@ Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` key to your `I
 
 Run `npx pod-install` after installing the npm package.
 
-### Configure for Android
-
-This package automatically adds the `CAMERA` permission to your app.
-
-```xml
-<!-- Added permissions -->
-<uses-permission android:name="android.permission.CAMERA" />
-```
 
 # Contributing
 

--- a/packages/expo-battery/README.md
+++ b/packages/expo-battery/README.md
@@ -11,7 +11,8 @@ Provide battery information for the physical device.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/battery.mdx)
+- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/battery/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/battery/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -11,8 +11,8 @@ A component that renders a native blur view on iOS and falls back to a semi-tran
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/blur-view.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/blur-view/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/blur-view/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,14 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-blur
 ```
 
+### Configure for Android
+
+> [!note]
+> This package only supports iOS. On Android, a plain `View` with a translucent background will be rendered.
+
 ### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-This package only supports iOS. On Android, a plain `View` with a translucent background will be rendered.
 
 # Contributing
 

--- a/packages/expo-brightness/README.md
+++ b/packages/expo-brightness/README.md
@@ -11,8 +11,8 @@ Provides an API to get and set screen brightness.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/brightness.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/brightness/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/brightness/)
 
 # Installation in managed Expo projects
 
@@ -28,10 +28,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-brightness
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 Add `android.permission.WRITE_SETTINGS` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
@@ -39,6 +35,10 @@ Add `android.permission.WRITE_SETTINGS` permission to your manifest (`android/ap
 ```xml
 <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 ```
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-build-properties/README.md
+++ b/packages/expo-build-properties/README.md
@@ -4,8 +4,8 @@
 
 ## API documentation
 
-- [Documentation for the main branch][docs-main]
-- [Documentation for the latest stable release][docs-stable]
+- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/build-properties/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/build-properties/)
 
 ### Installation
 
@@ -39,9 +39,4 @@ Add plugin to `app.json`. For example:
 
 ## Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide][../../contributing.md].
-
-[docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/build-properties.mdx
-[docs-stable]: https://docs.expo.dev/versions/latest/sdk/build-properties/
-[contributing]: https://github.com/expo/expo#contributing
-[config-plugins]: https://docs.expo.dev/config-plugins/introduction
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide][https://github.com/expo/expo#contributing].

--- a/packages/expo-calendar/README.md
+++ b/packages/expo-calendar/README.md
@@ -11,8 +11,8 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/calendar.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/calendar/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/calendar/)
 
 # Installation in managed Expo projects
 
@@ -28,6 +28,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-calendar
 ```
 
+### Configure for Android
+
+Add `android.permission.READ_CALENDAR` and `android.permission.WRITE_CALENDAR` permissions to your manifest (`android/app/src/main/AndroidManifest.xml`):
+
+```xml
+<uses-permission android:name="android.permission.READ_CALENDAR" />
+<uses-permission android:name="android.permission.WRITE_CALENDAR" />
+```
+
 ### Configure for iOS
 
 Add `NSCalendarsUsageDescription`, and `NSRemindersUsageDescription` keys to your `Info.plist`:
@@ -40,15 +49,6 @@ Add `NSCalendarsUsageDescription`, and `NSRemindersUsageDescription` keys to you
 ```
 
 Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-Add `android.permission.READ_CALENDAR` and `android.permission.WRITE_CALENDAR` permissions to your manifest (`android/app/src/main/AndroidManifest.xml`):
-
-```xml
-<uses-permission android:name="android.permission.READ_CALENDAR" />
-<uses-permission android:name="android.permission.WRITE_CALENDAR" />
-```
 
 # Contributing
 

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -11,8 +11,8 @@ A React component that renders a preview for the device's either front or back c
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/camera.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/camera/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/camera/)
 
 # Installation in managed Expo projects
 
@@ -27,19 +27,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 ```
 npx expo install expo-camera
 ```
-
-### Configure for iOS
-
-Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` keys to your `Info.plist`:
-
-```xml
-<key>NSCameraUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the camera</string>
-<key>NSMicrophoneUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the microphone</string>
-```
-
-Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -71,6 +58,19 @@ allprojects {
 ```
 
 The sourcecode for `cameraview` can be found at [`expo/cameraview`](https://github.com/expo/cameraview).
+
+### Configure for iOS
+
+Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` keys to your `Info.plist`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use the microphone</string>
+```
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-cellular/README.md
+++ b/packages/expo-cellular/README.md
@@ -11,8 +11,8 @@ Information about the user’s cellular service provider, such as its unique ide
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/cellular.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/cellular/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/cellular/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-constants/README.md
+++ b/packages/expo-constants/README.md
@@ -4,8 +4,8 @@ Provides system information that remains constant throughout the lifetime of you
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/constants.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/constants/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/constants/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-contacts/README.md
+++ b/packages/expo-contacts/README.md
@@ -11,8 +11,8 @@ Provides access to the phone's system contacts.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/contacts.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/contacts/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/contacts/)
 
 # Installation in managed Expo projects
 
@@ -28,6 +28,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-contacts
 ```
 
+### Configure for Android
+
+Add `android.permission.READ_CONTACTS` and optionally `android.permission.WRITE_CONTACTS` permissions to your manifest (`android/app/src/main/AndroidManifest.xml`):
+
+```xml
+<uses-permission android:name="android.permission.READ_CONTACTS" />
+<uses-permission android:name="android.permission.WRITE_CONTACTS" />
+```
+
 ### Configure for iOS
 
 Add `NSContactsUsageDescription` key to your `Info.plist`:
@@ -38,15 +47,6 @@ Add `NSContactsUsageDescription` key to your `Info.plist`:
 ```
 
 Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-Add `android.permission.READ_CONTACTS` and optionally `android.permission.WRITE_CONTACTS` permissions to your manifest (`android/app/src/main/AndroidManifest.xml`):
-
-```xml
-<uses-permission android:name="android.permission.READ_CONTACTS" />
-<uses-permission android:name="android.permission.WRITE_CONTACTS" />
-```
 
 # Contributing
 

--- a/packages/expo-crypto/README.md
+++ b/packages/expo-crypto/README.md
@@ -11,8 +11,8 @@ Provides cryptography primitives.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/crypto.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/crypto/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/crypto/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-crypto
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-device/README.md
+++ b/packages/expo-device/README.md
@@ -11,8 +11,8 @@ Provides specific information about the device running the application.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/device.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/device/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/device/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -11,8 +11,8 @@ Provides access to the system's UI for selecting documents from the available pr
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/document-picker.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/document-picker/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/document-picker/)
 
 # Installation in managed Expo projects
 
@@ -24,17 +24,17 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
+```bash
 npx expo install expo-document-picker
 ```
-
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 ### Plugin
 

--- a/packages/expo-face-detector/README.md
+++ b/packages/expo-face-detector/README.md
@@ -4,8 +4,8 @@ Lets you use the power of MLKit (https://firebase.google.com/docs/ml-kit/detect-
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/facedetector.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/facedetector/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/facedetector/)
 
 # Installation in managed Expo projects
 
@@ -21,13 +21,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-face-detector
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -11,8 +11,8 @@ Provides access to the local file system on the device.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/filesystem.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/filesystem/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/filesystem/)
 
 # Installation in managed Expo projects
 
@@ -21,10 +21,6 @@ For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, ple
 # Installation in bare React Native projects
 
 For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-## Installation in bare iOS React Native project
-
-No additional set up necessary.
 
 ## Installation in bare Android React Native project
 
@@ -36,6 +32,10 @@ This module requires permissions to interact with the filesystem and create resu
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 <uses-permission android:name="android.permission.INTERNET" />
 ```
+
+## Installation in bare iOS React Native project
+
+No additional set up necessary.
 
 # Contributing
 

--- a/packages/expo-font/README.md
+++ b/packages/expo-font/README.md
@@ -11,8 +11,8 @@ Load fonts at runtime and use them in React Native components.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/font.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/font/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/font/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-font
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -11,8 +11,8 @@ Provides GLView that acts as OpenGL ES render target and gives GL context object
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/gl-view.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/gl-view/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/gl-view/)
 
 # Installation in managed Expo projects
 
@@ -45,13 +45,13 @@ To use reanimated worklets you will need compatible version of `react-native-rea
 | <11.3.0  | <=2.8.0                 |
 | >=11.3.0 | >2.8.0                  |
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -11,8 +11,8 @@ Provides access to the system's haptics engine on iOS and vibration effects on A
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/haptics.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/haptics/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/haptics/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-haptics
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 This module requires permission to control vibration on the device, it's added automatically.
 

--- a/packages/expo-image-manipulator/README.md
+++ b/packages/expo-image-manipulator/README.md
@@ -11,8 +11,8 @@ Provides functions that let you manipulation images on the local file system, eg
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagemanipulator/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/imagemanipulator/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-image-manipulator
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -11,8 +11,8 @@ Provides access to the system's UI for selecting images and videos from the phon
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/imagepicker.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagepicker/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/imagepicker/)
 
 # Installation in managed Expo projects
 
@@ -26,6 +26,19 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ```
 npx expo install expo-image-picker
+```
+
+### Configure for Android
+
+> This is only required for usage in bare React Native apps.
+
+This package automatically adds the `CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRITE_EXTERNAL_STORAGE` permissions. They are used when picking images from the camera directly, or from the camera roll.
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
 ### Configure for iOS
@@ -44,19 +57,6 @@ Add `NSPhotoLibraryUsageDescription`, `NSCameraUsageDescription`, and `NSMicroph
 ```
 
 Run `npx pod-install` after installing the npm package.
-
-### Configure for Android
-
-> This is only required for usage in bare React Native apps.
-
-This package automatically adds the `CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRITE_EXTERNAL_STORAGE` permissions. They are used when picking images from the camera directly, or from the camera roll.
-
-```xml
-<!-- Added permissions -->
-<uses-permission android:name="android.permission.CAMERA" />
-<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-```
 
 ## Config Plugin
 

--- a/packages/expo-intent-launcher/README.md
+++ b/packages/expo-intent-launcher/README.md
@@ -4,8 +4,8 @@ Provides a way to launch Android intents, e.g. opening a specific activity.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/intent-launcher.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/intent-launcher/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/intent-launcher/)
 
 # Installation in managed Expo projects
 
@@ -21,13 +21,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-intent-launcher
 ```
 
-### Configure for iOS
-
-This package does not make sense on iOS as there is no equivalent API, so it is not supported.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+This package does not make sense on iOS as there is no equivalent API, so it is not supported.
 
 # Contributing
 

--- a/packages/expo-keep-awake/README.md
+++ b/packages/expo-keep-awake/README.md
@@ -11,8 +11,8 @@ Provides a React component that prevents the screen sleeping when rendered. It a
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/keep-awake.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/keep-awake/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/keep-awake/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-keep-awake
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-linear-gradient/README.md
+++ b/packages/expo-linear-gradient/README.md
@@ -11,8 +11,8 @@ Provides a React component that renders a gradient view.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/linear-gradient.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linear-gradient/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/linear-gradient/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-linear-gradient
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-linking/README.md
+++ b/packages/expo-linking/README.md
@@ -4,8 +4,8 @@ Create and open deep links universally.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/linking.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linking/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/linking/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -11,8 +11,8 @@ Provides an API for FaceID and TouchID (iOS) or the Fingerprint API (Android) to
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/local-authentication.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/local-authentication/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/local-authentication/)
 
 # Installation in managed Expo projects
 
@@ -28,17 +28,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-local-authentication
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
-Add `NSFaceIDUsageDescription` to your `Info.plist`:
-
-```xml
-<key>NSFaceIDUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use FaceID</string>
-```
-
 ### Configure for Android
 
 No additional set up necessary.
@@ -49,6 +38,17 @@ This module requires permissions to access the biometric data for authentication
 <!-- Added permissions -->
 <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+```
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+Add `NSFaceIDUsageDescription` to your `Info.plist`:
+
+```xml
+<key>NSFaceIDUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use FaceID</string>
 ```
 
 # Contributing

--- a/packages/expo-localization/README.md
+++ b/packages/expo-localization/README.md
@@ -11,8 +11,8 @@ Provides an interface for native user localization information.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/localization.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/localization/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/localization/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-localization
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -11,8 +11,8 @@ Allows reading geolocation information from the device. Your app can poll for th
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/location.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/location/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/location/)
 
 # Installation in managed Expo projects
 
@@ -27,21 +27,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 ```
 npx expo install expo-location
 ```
-
-### Configure for iOS
-
-Add `NSLocationAlwaysAndWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescription` and `NSLocationWhenInUseUsageDescription` keys to your `Info.plist`:
-
-```xml
-<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use your location</string>
-<key>NSLocationAlwaysUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use your location</string>
-<key>NSLocationWhenInUseUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use your location</string>
-```
-
-Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -58,7 +43,23 @@ This module requires the permissions for approximate and exact device location. 
 <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
-> **Note:** on Android, you have to [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en) or [foreground location permissions](https://support.google.com/googleplay/android-developer/answer/13392821?hl=en).
+> [!note]
+> On Android, you have to [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en) or [foreground location permissions](https://support.google.com/googleplay/android-developer/answer/13392821?hl=en).
+
+### Configure for iOS
+
+Add `NSLocationAlwaysAndWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescription` and `NSLocationWhenInUseUsageDescription` keys to your `Info.plist`:
+
+```xml
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use your location</string>
+<key>NSLocationAlwaysUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use your location</string>
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to use your location</string>
+```
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-mail-composer/README.md
+++ b/packages/expo-mail-composer/README.md
@@ -11,8 +11,8 @@ Provides an API to compose mails using OS specific UI
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/mail-composer.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/mail-composer/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/mail-composer/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-mail-composer
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -11,8 +11,8 @@ Provides access to user's media library.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/media-library.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/media-library/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/media-library/)
 
 # Installation in managed Expo projects
 
@@ -27,19 +27,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 ```
 npx expo install expo-media-library
 ```
-
-### Configure for iOS
-
-Add `NSPhotoLibraryUsageDescription`, and `NSPhotoLibraryAddUsageDescription` keys to your `Info.plist`:
-
-```xml
-<key>NSPhotoLibraryUsageDescription</key>
-<string>Give $(PRODUCT_NAME) permission to access your photos</string>
-<key>NSPhotoLibraryAddUsageDescription</key>
-<string>Give $(PRODUCT_NAME) permission to save photos</string>
-```
-
-Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
@@ -67,6 +54,19 @@ Starting with Android 10, the concept of [scoped storage](https://developer.andr
   </application>
 </manifest>
 ```
+
+### Configure for iOS
+
+Add `NSPhotoLibraryUsageDescription`, and `NSPhotoLibraryAddUsageDescription` keys to your `Info.plist`:
+
+```xml
+<key>NSPhotoLibraryUsageDescription</key>
+<string>Give $(PRODUCT_NAME) permission to access your photos</string>
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>Give $(PRODUCT_NAME) permission to save photos</string>
+```
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-module-scripts/templates/README.md
+++ b/packages/expo-module-scripts/templates/README.md
@@ -5,8 +5,8 @@ ${description}
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/${docName}.md)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/${docName}/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/${docName}/)
 
 <!--- end remove for interfaces --->
 # Installation in managed Expo projects
@@ -23,13 +23,6 @@ For bare React Native projects, you must ensure that you have [installed and con
 npm install ${packageName}
 ```
 
-<!--- remove for no-ios --->
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
-<!--- end remove for no-ios --->
-
 <!--- remove for no-android --->
 ### Configure for Android
 
@@ -41,6 +34,13 @@ No additional setup necessary.
 <!--- end remove for no-package --->
 <!--- end remove for interfaces --->
 <!--- end remove for no-android --->
+
+<!--- remove for no-ios --->
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+<!--- end remove for no-ios --->
 # Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).

--- a/packages/expo-modules-autolinking/README.md
+++ b/packages/expo-modules-autolinking/README.md
@@ -11,8 +11,8 @@ Scripts that autolink Expo modules.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/module-autolinking.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/module-autolinking/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/module-autolinking/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-modules-autolinking/README.md
+++ b/packages/expo-modules-autolinking/README.md
@@ -11,8 +11,7 @@ Scripts that autolink Expo modules.
 
 # API documentation
 
-- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/module-autolinking/)
-- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/module-autolinking/)
+- [Documentation for the latest stable release](https://docs.expo.dev/modules/autolinking/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-navigation-bar/README.md
+++ b/packages/expo-navigation-bar/README.md
@@ -6,8 +6,8 @@ Properties are named after style properties; visibility, position, backgroundCol
 
 ## API documentation
 
-- [Documentation for the main branch][docs-main]
 - [Documentation for the latest stable release][docs-stable]
+- [Documentation for the main branch][docs-main]
 
 ## Installation in managed Expo projects
 
@@ -27,7 +27,7 @@ npx expo install expo-navigation-bar
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide][contributing].
 
-[docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+[docs-main]: https://docs.expo.dev/versions/unversioned/sdk/navigation-bar/
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/navigation-bar/
 [docs-workflows]: https://docs.expo.dev/archive/managed-vs-bare/
 [contributing]: https://github.com/expo/expo#contributing

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -12,8 +12,8 @@ See [Expo Network docs](https://docs.expo.dev/versions/latest/sdk/network/) for 
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/network.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/network/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/network/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-print/README.md
+++ b/packages/expo-print/README.md
@@ -11,8 +11,8 @@ Provides an API for Android and iOS (AirPrint) printing functionality.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/print.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/print/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/print/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-print
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-screen-orientation/README.md
+++ b/packages/expo-screen-orientation/README.md
@@ -11,8 +11,8 @@ Allows you to manage the orientation of your app's interface.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/screen-orientation.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/screen-orientation/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/screen-orientation/)
 
 # Installation in managed Expo projects
 
@@ -28,6 +28,10 @@ For bare React Native projects, you must ensure that you have [installed and con
 npm install expo-screen-orientation
 ```
 
+### Configure for Android
+
+No additional set up necessary.
+
 ### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.
@@ -38,10 +42,6 @@ The default [UIInterfaceOrientationMask](https://developer.apple.com/documentati
 <key>EXDefaultScreenOrientationMask</key>
 <string>UIInterfaceOrientationMaskAllButUpsideDown</string>
 ```
-
-### Configure for Android
-
-No additional set up necessary.
 
 # Contributing
 

--- a/packages/expo-secure-store/README.md
+++ b/packages/expo-secure-store/README.md
@@ -11,8 +11,8 @@ Provides a way to encrypt and securely store key–value pairs locally on the de
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/securestore.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/securestore/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/securestore/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-secure-store
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -11,8 +11,8 @@ Provides access to a hardware device's accelerometer, gyroscope, magnetometer, a
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/sensors.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sensors/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/sensors/)
 
 # Installation in managed Expo projects
 
@@ -28,17 +28,17 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-sensors
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
-**Note:** to access DeviceMotion stats on iOS, the NSMotionUsageDescription key must be present in your Info.plist.
-
 ### Configure for Android
 
 No additional set up necessary for basic usage.
 
 **Note:** Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates. If you need a update interval less than 200ms, you should add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
+
+**Note:** to access DeviceMotion stats on iOS, the NSMotionUsageDescription key must be present in your Info.plist.
 
 # Contributing
 

--- a/packages/expo-sharing/README.md
+++ b/packages/expo-sharing/README.md
@@ -11,8 +11,8 @@ Provides a way to share files directly with other compatible applications.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/sharing.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sharing/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/sharing/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-sms/README.md
+++ b/packages/expo-sms/README.md
@@ -11,8 +11,8 @@ Provides access to the system's UI/app for sending SMS messages.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/sms.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sms/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/sms/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-sms
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-speech/README.md
+++ b/packages/expo-speech/README.md
@@ -11,8 +11,8 @@ Provides text-to-speech functionality.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/speech.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/speech/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/speech/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-speech
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -11,8 +11,8 @@ Provides access to a database that can be queried through a WebSQL-like API (htt
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/sqlite.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sqlite/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/sqlite/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-sqlite
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-status-bar/README.md
+++ b/packages/expo-status-bar/README.md
@@ -14,8 +14,8 @@ Provides the same interface as the React Native [StatusBar API](https://reactnat
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/status-bar.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/status-bar/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/status-bar/)
 
 # Installation in managed Expo projects
 
@@ -29,13 +29,13 @@ Please refer to the [React Native StatusBar API documentation](https://reactnati
 npm install expo-status-bar
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional setup necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-store-review/README.md
+++ b/packages/expo-store-review/README.md
@@ -11,8 +11,8 @@
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/storereview.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/storereview/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/storereview/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-symbols/README.md
+++ b/packages/expo-symbols/README.md
@@ -11,8 +11,8 @@ Provides access to the SF Symbols library on iOS for React Native and Expo apps.
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/symbols.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/symbols/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/symbols/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-system-ui/README.md
+++ b/packages/expo-system-ui/README.md
@@ -4,8 +4,8 @@
 
 ## API documentation
 
-- [Documentation for the main branch][docs-main]
 - [Documentation for the latest stable release][docs-stable]
+- [Documentation for the main branch][docs-main]
 
 ### Installation
 
@@ -21,7 +21,7 @@ For bare React Native projects, ensure that you have the [native `expo` package]
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide][contributing].
 
-[docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/system-ui.mdx
+[docs-main]: https://docs.expo.dev/versions/unversioned/sdk/system-ui/
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/system-ui/
 [contributing]: https://github.com/expo/expo#contributing
 [expo-modules]: https://docs.expo.dev/bare/installing-expo-modules/

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -4,8 +4,8 @@ Expo universal module for TaskManager API.
 
 ## API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/task-manager.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/task-manager/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/task-manager/)
 
 ## Installation
 
@@ -21,15 +21,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-task-manager
 ```
 
+#### Configure for Android
+
+No additional set up necessary.
+
 #### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.
 
 To use `TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
-
-#### Configure for Android
-
-No additional set up necessary.
 
 # Contributing
 

--- a/packages/expo-tracking-transparency/README.md
+++ b/packages/expo-tracking-transparency/README.md
@@ -6,8 +6,8 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 ## API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/tracking-transparency/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/tracking-transparency/)
 
 ## Installation in managed Expo projects
 
@@ -23,6 +23,15 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-tracking-transparency
 ```
 
+### Configure for Android
+
+Add `com.google.android.gms.permission.AD_ID` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
+
+```xml
+<!-- Added permissions -->
+<uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+```
+
 ### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.
@@ -32,15 +41,6 @@ Add `NSUserTrackingUsageDescription` key to your `Info.plist`:
 ```xml
 <key>NSUserTrackingUsageDescription</key>
 <string>Your custom usage description string here.</string>
-```
-
-### Configure for Android
-
-Add `com.google.android.gms.permission.AD_ID` permission to your manifest (`android/app/src/main/AndroidManifest.xml`):
-
-```xml
-<!-- Added permissions -->
-<uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 ```
 
 ## Contributing

--- a/packages/expo-video-thumbnails/README.md
+++ b/packages/expo-video-thumbnails/README.md
@@ -4,8 +4,8 @@ Provides function that let you generate an image from video. This can be used fo
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/video-thumbnails/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/video-thumbnails/)
 
 # Installation in managed Expo projects
 
@@ -21,13 +21,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-video-thumbnails
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 

--- a/packages/expo-video/README.md
+++ b/packages/expo-video/README.md
@@ -11,8 +11,8 @@ A cross-platform, performant video component for React Native and Expo with Web 
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/video.md)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/video/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/video/)
 
 # Installation in managed Expo projects
 

--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -11,8 +11,8 @@ Provides access to the system's web browser and supports handling redirects. On 
 
 # API documentation
 
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/webbrowser.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/webbrowser/)
+- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/webbrowser/)
 
 # Installation in managed Expo projects
 
@@ -28,13 +28,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 npx expo install expo-web-browser
 ```
 
-### Configure for iOS
-
-Run `npx pod-install` after installing the npm package.
-
 ### Configure for Android
 
 No additional set up necessary.
+
+### Configure for iOS
+
+Run `npx pod-install` after installing the npm package.
 
 # Contributing
 


### PR DESCRIPTION
# Why

With documentation for the upcoming SDK version is exposed in the docs now we can switch to link to the deployment in the packages README files.

# How

Update unversioned documentation links, reorder links so the latest version is at the top, reorder configuration sections, so platforms are ordered alphabetically, correct few spotted typos.

In the process I have also updated the base template:
* https://github.com/expo/expo/pull/30042/files#diff-3a29e6a7434a4f5cd57f26e447f8a73e27d18a165f4e1c8c9fed00e8d1593c57

# Test Plan

Check the changes via GH UI on [`@simek/packages-update-reademe-files`](https://github.com/expo/expo/tree/%40simek/packages-update-reademe-files/packages) branch.
