### PR TITLE
refactor(cli): add debug logs when dev servers fail to stop

### DIFF
--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -235,8 +235,8 @@ export class DevServerManager {
       // Stop all dev servers
       ...devServers.map((server) =>
         server.stopAsync().catch((error) => {
-          debug(`Failed to stop server: ${server.name}`, error);
-          throw error;
+          Log.error(`Failed to stop dev server (bundler: ${server.name})`);
+          Log.exception(error);
         })
       ),
     ]);

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -230,10 +230,15 @@ export class DevServerManager {
   async stopAsync(): Promise<void> {
     await Promise.allSettled([
       this.notifier?.stopObserving(),
-      // Stop all dev servers
-      ...devServers.map((server) => server.stopAsync()),
       // Stop ADB
       AndroidDebugBridge.getServer().stopAsync(),
+      // Stop all dev servers
+      ...devServers.map((server) =>
+        server.stopAsync().catch((error) => {
+          debug(`Failed to stop server: ${server.name}`, error);
+          throw error;
+        })
+      ),
     ]);
   }
 }


### PR DESCRIPTION
# Why

This is the first PR to resolve an issue on EAS with SDK 51.

- https://github.com/expo/expo/pull/30045
- https://github.com/expo/expo/pull/30046

In this PR: Add more verbose `debug` logs when a dev server fails to stop.

# How

- Updated `DevServerManager.ts`'s `stopAsync` to output `debug` logs when it fails

# Test Plan

See [this EAS Build](https://expo.dev/accounts/brents/projects/microfoam/builds/2ed49024-ac2a-43b6-b440-69afb2301bbe), this explicitly mentions that the dev server wasn't fully shutdown (and therefore hangs the process)

<img width="1136" alt="image" src="https://github.com/expo/expo/assets/1203991/182f1f48-9d49-404c-b46f-17ab9994d81e">

Edit: I made this a normal `Log`, so it's visible whenever this process fails unexpectedly.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
