### PR TITLE
fix(cli): make `DevelopmentSession.closeAsync` non-throwing

### DIFF
--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -235,8 +235,8 @@ export class DevServerManager {
       // Stop all dev servers
       ...devServers.map((server) =>
         server.stopAsync().catch((error) => {
-          debug(`Failed to stop server: ${server.name}`, error);
-          throw error;
+          Log.error(`Failed to stop dev server (bundler: ${server.name})`);
+          Log.exception(error);
         })
       ),
     ]);

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -230,10 +230,15 @@ export class DevServerManager {
   async stopAsync(): Promise<void> {
     await Promise.allSettled([
       this.notifier?.stopObserving(),
-      // Stop all dev servers
-      ...devServers.map((server) => server.stopAsync()),
       // Stop ADB
       AndroidDebugBridge.getServer().stopAsync(),
+      // Stop all dev servers
+      ...devServers.map((server) =>
+        server.stopAsync().catch((error) => {
+          debug(`Failed to stop server: ${server.name}`, error);
+          throw error;
+        })
+      ),
     ]);
   }
 }


### PR DESCRIPTION
# Why

Second stacked PR, on top of #30043

# How

- Wrapped `closeAsync` in a try-catch, invoking the `onError` callback
- Added tests to ensure `closeAsync` does not throw (and block execution)

# Test Plan

- See added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
