### PR TITLE
refactor(cli): disable development session on CI

### DIFF
--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -46,9 +46,11 @@ export class DevelopmentSession {
     runtime: 'native' | 'web';
   }): Promise<void> {
     try {
-      if (env.EXPO_OFFLINE) {
+      if (env.CI || env.EXPO_OFFLINE) {
         debug(
-          'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in offline-mode.'
+          env.CI
+            ? 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in CI.'
+            : 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in offline-mode.'
         );
         this.stopNotifying();
         return;
@@ -102,6 +104,10 @@ export class DevelopmentSession {
   /** Try to close any pending development sessions, but always resolve */
   public async closeAsync(): Promise<boolean> {
     this.stopNotifying();
+
+    if (env.CI || env.EXPO_OFFLINE) {
+      return false;
+    }
 
     try {
       const deviceIds = await this.getDeviceInstallationIdsAsync();


### PR DESCRIPTION
# Why

Third (optional) PR, stacked on top of #30045

# How

- Disable development sessions on any CI
- Log (in debug mode) that development sessions are disabled

# Test Plan

- Run `CI=true EXPO_DEBUG=true expo start`, should show the debug log

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
