### PR TITLE
[docs] Fix formatting issue in Supabase guide

### DIFF
--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -1,6 +1,5 @@
 ---
 title: Use Supabase
-maxHeadingDepth: 4
 description: Add a Postgres Database and user authentication to your React Native app with Supabase.
 ---
 
@@ -32,17 +31,15 @@ Using [`supabase-js`](https://supabase.com/docs/reference/javascript/introductio
 ### Install and initialize the Supabase TypeScript SDK
 
 <Step label="1">
-#### Install supabase-js and dependencies
 
-After you have created your [Expo project](/get-started/create-a-project/), you can install `supabase-js` and the required dependencies using the following command:
+After you have created your [Expo project](/get-started/create-a-project/), install `@supabase/supabase-js` and the required dependencies using the following command:
 
 <Terminal cmd={['$ npx expo install @supabase/supabase-js @react-native-async-storage/async-storage react-native-url-polyfill']} />
 </Step>
 
 <Step label="2">
-#### Initialize `supabase-js` in your project
 
-Create a helper file to initialize the Supabase client. We need the API URL and the `anon` key you copied [earlier](#get-the-api-keys). These variables are safe to expose in your Expo app since Supabase has [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) enabled on our Database.
+Create a helper file to initialize the Supabase client (`@supabase/supabase-js`). You need the API URL and the `anon` key copied [earlier](#get-the-api-keys). These variables are safe to expose in your Expo app since Supabase has [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) enabled in the Database.
 
 ```ts utils/supabase.ts
 import 'react-native-url-polyfill/auto';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix formatting issue when H4 and Step components are used together, in Supbase guide. I don't think we need separate section on these steps.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing H4 headings. Also, fix other writing issues (such as using second person voice) as per our writing style guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

## Preview

![CleanShot 2024-06-27 at 22 02 47@2x](https://github.com/expo/expo/assets/10234615/4cccd640-de7c-4e77-a25b-6881eb11ff9b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
