### PR TITLE
[tools] Fix publishing packages on the CI

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -4,6 +4,7 @@ import { glob } from 'glob';
 import { spawnAsync, spawnJSONCommandAsync, SpawnOptions } from './Utils';
 
 export const EXPO_DEVELOPERS_TEAM_NAME = 'expo:developers';
+export const EXPO_BOT_ACCOUNT_NAME = 'expo-bot';
 
 export type PackageViewType = null | {
   name: string;

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -25,6 +25,11 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
       return Task.STOP;
     }
 
+    // `npm team ls` command fails on the access token that we use on the CI.
+    // We're actually sure that expo-bot account is in the team, so we can skip this check.
+    if (process.env.CI && npmUser === Npm.EXPO_BOT_ACCOUNT_NAME) {
+      return;
+    }
     const teamMembers = await Npm.getTeamMembersAsync(Npm.EXPO_DEVELOPERS_TEAM_NAME);
 
     if (!teamMembers.includes(npmUser)) {

--- a/tools/src/publish-packages/tasks/checkPackageAccess.ts
+++ b/tools/src/publish-packages/tasks/checkPackageAccess.ts
@@ -20,6 +20,11 @@ export const checkPackageAccess = new Task<TaskArgs>(
     ],
   },
   async (parcels: Parcel[]) => {
+    // The access token for our CI is not allowing to check the access to packages.
+    if (process.env.CI) {
+      return;
+    }
+
     return await runWithSpinner(
       'Checking write access to the packages',
       async (step): Promise<any> => {


### PR DESCRIPTION
# Why

The workflow that publishes canaries fails on running some commands – looks like the access is somehow forbidden

# How

Skip running `npm team ls` and `npm access list packages` commands on the CI.

# Test Plan

I manually dispatched the workflow: https://github.com/expo/expo/actions/runs/9700604698/job/26772404261 that successfully published canaries