### PR TITLE
chore(cli): add robots e2e export test

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 💡 Others
 
+- Add robot export e2e test.
 - Add internal externals to prevent bundling `source-map-support` in development. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove webpack dependency in repo. ([#29840](https://github.com/expo/expo/pull/29840) by [@EvanBacon](https://github.com/EvanBacon))
 - Add "more tools" to terminal UI all the time. ([#29837](https://github.com/expo/expo/pull/29837) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 💡 Others
 
-- Add robot export e2e test.
+- Add robot export e2e test. ([#30049](https://github.com/expo/expo/pull/30049) by [@EvanBacon](https://github.com/EvanBacon))
 - Add internal externals to prevent bundling `source-map-support` in development. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove webpack dependency in repo. ([#29840](https://github.com/expo/expo/pull/29840) by [@EvanBacon](https://github.com/EvanBacon))
 - Add "more tools" to terminal UI all the time. ([#29837](https://github.com/expo/expo/pull/29837) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -258,8 +258,7 @@ it(
         cwd: projectRoot,
         env: {
           NODE_ENV: 'production',
-          EXPO_USE_STATIC: 'static',
-          E2E_ROUTER_SRC: 'static-rendering',
+          E2E_ROUTER_SRC: 'react-native-canary',
           E2E_ROUTER_ASYNC: 'development',
           EXPO_USE_FAST_RESOLVER: '1',
 
@@ -294,12 +293,10 @@ it(
 
     // If this changes then everything else probably changed as well.
     expect(files).toEqual([
-      'assets/__e2e__/static-rendering/sweet.ttf',
       'assets/__packages/expo-router/assets/error.png',
       'assets/__packages/expo-router/assets/file.png',
       'assets/__packages/expo-router/assets/forward.png',
       'assets/__packages/expo-router/assets/pkg.png',
-      'assets/assets/icon.png',
       'output.js',
     ]);
   },

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -300,8 +300,7 @@ it(
       'output.js',
     ]);
   },
-  // Add shorter timeout since this test has the chance to timeout.
-  25 * 1000
+  120 * 1000
 );
 
 it(

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -231,6 +231,83 @@ it(
 );
 
 it(
+  'runs `npx expo export:embed --platform ios` with a robot user',
+  async () => {
+    const projectRoot = ensureTesterReady('react-native-canary');
+    const output = 'dist-export-embed-robot-user';
+    await fs.remove(path.join(projectRoot, output));
+    await fs.ensureDir(path.join(projectRoot, output));
+
+    await execa(
+      'node',
+      [
+        bin,
+        'export:embed',
+        '--entry-file',
+        path.join(projectRoot, './index.js'),
+        '--bundle-output',
+        `./${output}/output.js`,
+        '--assets-dest',
+        output,
+        '--platform',
+        'ios',
+        '--dev',
+        'false',
+      ],
+      {
+        cwd: projectRoot,
+        env: {
+          NODE_ENV: 'production',
+          EXPO_USE_STATIC: 'static',
+          E2E_ROUTER_SRC: 'static-rendering',
+          E2E_ROUTER_ASYNC: 'development',
+          EXPO_USE_FAST_RESOLVER: '1',
+
+          // Most important part:
+          // NOTE(EvanBacon): This is a robot user token for an expo-managed account that can authenticate with view-only permission.
+          // The token is not secret and can be used to authenticate with the Expo API.
+          EXPO_TOKEN: '4awlFlcNYg7qOFa8J3a7d5Uaph8FaTsD1SP2xWEf',
+
+          // Ensure EXPO_OFFLINE is not set!
+          // EXPO_OFFLINE
+        },
+        // stdio: 'inherit',
+      }
+    );
+
+    const outputDir = path.join(projectRoot, output);
+    // List output files with sizes for snapshotting.
+    // This is to make sure that any changes to the output are intentional.
+    // Posix path formatting is used to make paths the same across OSes.
+    const files = klawSync(outputDir)
+      .map((entry) => {
+        if (entry.path.includes('node_modules') || !entry.stats.isFile()) {
+          return null;
+        }
+        return path.posix.relative(outputDir, entry.path);
+      })
+      .filter(Boolean);
+
+    // Ensure output.js is a utf8 encoded file
+    const outputJS = fs.readFileSync(path.join(outputDir, 'output.js'), 'utf8');
+    expect(outputJS.slice(0, 5)).toBe('var _');
+
+    // If this changes then everything else probably changed as well.
+    expect(files).toEqual([
+      'assets/__e2e__/static-rendering/sweet.ttf',
+      'assets/__packages/expo-router/assets/error.png',
+      'assets/__packages/expo-router/assets/file.png',
+      'assets/__packages/expo-router/assets/forward.png',
+      'assets/__packages/expo-router/assets/pkg.png',
+      'assets/assets/icon.png',
+      'output.js',
+    ]);
+  },
+  // Add shorter timeout since this test has the chance to timeout.
+  25 * 1000
+);
+
+it(
   'runs `npx expo export:embed --platform android` with source maps',
   async () => {
     const projectRoot = ensureTesterReady('static-rendering');


### PR DESCRIPTION
# Why

Add a test to cover running export with a robot user enabled.

# How

Unlike a standard test where we use a private key, this key is public to allow for testing the same locally and in the cloud and across all PRs (not just from the team). The key is view-only for a burner account and can be easily rotated.

# Test Plan

Was able to repro the hanging process by moving the line where we connect the dev session. This test should hopefully catch instances in the future when a process hangs and the export cannot close successfully.