### PR TITLE
[docs] remove redundant Tabs on few pages, small tweaks

### DIFF
--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -25,7 +25,8 @@ module.exports = {
         'react-player',
         'dark-theme',
         'dialog-.+',
-        'terminal-snippet'
+        'terminal-snippet',
+        'table-wrapper'
       ],
       cssFiles: [
         "node_modules/@expo/styleguide/dist/global.css"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -965,7 +965,7 @@ properties.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -1385,7 +1385,7 @@ value depending on the state of the credential.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -1626,7 +1626,7 @@ refresh operation.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -1914,7 +1914,7 @@ sign-in operation.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -2229,7 +2229,7 @@ sign-out operation.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -2518,7 +2518,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -2973,7 +2973,7 @@ may be
       . Only applicable fields that the user has allowed your app to access will be nonnull.
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -3379,7 +3379,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -3686,7 +3686,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -4010,7 +4010,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -4181,7 +4181,7 @@ OAuth 2.0 protocol
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -6930,7 +6930,7 @@ Same as
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -7641,7 +7641,7 @@ This uses both
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -7998,7 +7998,7 @@ code.
       </span>
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -8265,7 +8265,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -8455,7 +8455,7 @@ in order to enable/disable the permission.
     </p>
     <br />
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -8575,7 +8575,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -8701,7 +8701,7 @@ in order to enable/disable the permission.
 are using the barcode scanner view, these values are adjusted to the dimensions of the view).
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -8865,7 +8865,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </h3>
     <div>
       <div
-        class="css-1uyflf8-Table"
+        class="table-wrapper css-1uyflf8-Table"
       >
         <table
           class="css-e41t9x-Table"
@@ -8971,7 +8971,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -9243,7 +9243,7 @@ you don't get this value.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -9987,7 +9987,7 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -10572,7 +10572,7 @@ available on this device.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -10910,7 +10910,7 @@ On iOS, the
       </span>
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -11177,7 +11177,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"
@@ -11300,7 +11300,7 @@ in order to enable/disable the permission.
     </p>
     <div>
       <div
-        class="css-1uyflf8-Table"
+        class="table-wrapper css-1uyflf8-Table"
       >
         <table
           class="css-e41t9x-Table"
@@ -11514,7 +11514,7 @@ in order to enable/disable the permission.
       A subscription object that allows to conveniently remove an event listener from the emitter.
     </p>
     <div
-      class="css-1uyflf8-Table"
+      class="table-wrapper css-1uyflf8-Table"
     >
       <table
         class="css-e41t9x-Table"

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -142,12 +142,8 @@ export default function App() {
 - Make sure to check `Public Client` option in the console.
 - Choose the intended grant in the Allowed grant types section.
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Asgardeo Auth Example
 import { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button, Alert } from 'react-native';
 import * as AuthSession from "expo-auth-session";
@@ -248,9 +244,6 @@ const styles = StyleSheet.create({
 });
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Asgardeo */}
 
@@ -368,7 +361,6 @@ export default function App() {
 <Tabs tabs={["Auth Code with automatic invocation", "Auth Code with manual invocation"]}>
 <Tab>
 - Set your Beyond Identity [Authenticator Config's](https://developer.beyondidentity.com/docs/v1/platform-overview/authenticator-config) Invocation Type to **Automatic**.
-
 - If **Automatic** is selected, Beyond Identity will automatically redirect to your application using the **Invoke URL** (the App Scheme or Universal URL pointing to your application).
 
 {/* prettier-ignore */}
@@ -498,16 +490,13 @@ export default function App() {
 | Website                   | Provider  | PKCE      | Auto Discovery |
 | ------------------------- | --------- | --------- | -------------- |
 | [Get Your Config](https://developer.calendly.com/getting-started) | OAuth 2.0 | Supported | Not Available  |
-- `redirectUri` requires 2 slashes (`://`).
+- `redirectUri` requires two slashes (`://`).
 - Example redirectUri:
   - Standalone / development build: `myapp://*`
   - Web: `https://yourwebsite.com/*`
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
 
 {/* prettier-ignore */}
-```jsx Calendly Example
+```jsx Calendly Auth Example
 import * as WebBrowser from 'expo-web-browser';
 import {
   makeRedirectUri,
@@ -595,8 +584,6 @@ export default function App() {
 
 ```
 
-</Tab>
-</Tabs>
 </Box>
 {/* End Calendly*/}
 
@@ -623,12 +610,8 @@ extraParams: {
 }
 ```
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Cognito Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { useAuthRequest, exchangeCodeAsync, revokeAsync, ResponseType } from 'expo-auth-session';
@@ -713,10 +696,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
-
 </Box>
 
 {/* End Cognito */}
@@ -733,22 +712,22 @@ export default function App() {
 
 [c-coinbase]: https://www.coinbase.com/oauth/applications/new
 
-- The `redirectUri` requires 2 slashes (`://`).
-- Scopes must be joined with ':' so just create one long string.
+- The `redirectUri` requires two slashes (`://`).
+- Scopes must be joined with `:` so just create one long string.
 - Setup redirect URIs: Your Project > Permitted Redirect URIs: (be sure to save after making changes).
-  - _Web dev_: `https://localhost:19006`
+
+  **Web dev**: `https://localhost:19006`
     - Run `expo start --web --https` to run with **https**, auth won't work otherwise.
     - Adding a slash to the end of the URL doesn't matter.
-  - _Standalone / development build_: `your-scheme://`
+
+  **Standalone / development build**: `your-scheme://`
     - Scheme should be specified in app.json `expo.scheme: 'your-scheme'`, then added to the app code with `makeRedirectUri({ native: 'your-scheme://' })`)
-  - _Web production_: `https://yourwebsite.com`
+
+  **Web production**: `https://yourwebsite.com`
     - Set this to whatever your deployed website URL is.
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Coinbase Auth Example
 import {
   exchangeCodeAsync,
   makeRedirectUri,
@@ -877,9 +856,6 @@ function useMounted() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Coinbase */}
 
@@ -898,12 +874,8 @@ function useMounted() {
 - Leverages the Hosted Descope Flow app [Auth-Hosting App](https://github.com/descope/auth-hosting).
 - Requests code after successfully authenticating, followed by exchanging code for the auth tokens (PKCE).
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Descope Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import * as AuthSession from 'expo-auth-session';
@@ -999,10 +971,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
-
 </Box>
 
 {/* End Descope */}
@@ -1021,12 +989,8 @@ export default function App() {
 
 - Scopes must be an empty array.
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Dropbox Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1081,8 +1045,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-</Tabs>
 </Box>
 {/* End Dropbox */}
 
@@ -1101,13 +1063,10 @@ export default function App() {
 - Provider only allows one redirect URI per app. You'll need an individual app for every method you want to use:
   - Standalone / development build: `com.your.app://*`
   - Web: `https://yourwebsite.com/*`
-- The `redirectUri` requires 2 slashes (`://`).
-
-<Tabs tabs={["Auth Code"]}>
-<Tab>
+- The `redirectUri` requires two slashes (`://`).
 
 {/* prettier-ignore */}
-```tsx
+```tsx Fitbit Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1162,9 +1121,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End FitBit */}
 
@@ -1183,14 +1139,11 @@ export default function App() {
 - Provider only allows one redirect URI per app. You'll need an individual app for every method you want to use:
   - Standalone / development build: `com.your.app://*`
   - Web: `https://yourwebsite.com/*`
-- The `redirectUri` requires 2 slashes (`://`).
+- The `redirectUri` requires two slashes (`://`).
 - `revocationEndpoint` is dynamic and requires your `config.clientId`.
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx GitHub Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1245,9 +1198,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 
 <Box
@@ -1265,10 +1215,7 @@ export default function App() {
 - You will need to create a different provider app for each platform (dynamically choosing your `clientId`).
 - Learn more here: [imgur.com/oauth2](https://api.imgur.com/oauth2)
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
-```tsx
+```tsx Imgur Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1324,9 +1271,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Imgur */}
 
@@ -1340,7 +1284,7 @@ export default function App() {
 | -       | OpenID   | Required | Available      |
 
 {/* prettier-ignore */}
-```tsx Keycloak Example
+```tsx Keycloak Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
@@ -1395,7 +1339,7 @@ export default function App() {
 - For web platform, a `http(s)://` scheme is required for `redirectUri`.
 
 {/* prettier-ignore */}
-```jsx Auth code
+```jsx Logto Auth Example
 import { LogtoProvider, useLogto } from "@logto/rn";
 
 // Use `useLogto()` hook to sign in and sign out
@@ -1442,11 +1386,8 @@ const App = () => {
 
 - You cannot define a custom `redirectUri`, Okta will provide you with one.
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Okta Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
@@ -1495,9 +1436,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Okta */}
 
@@ -1516,14 +1454,10 @@ export default function App() {
 - Provider only allows one redirect URI per app. You'll need an individual app for every method you want to use:
   - Standalone / development build: `com.your.app://*`
   - Web: `https://yourwebsite.com/*`
-- The `redirectUri` requires 2 slashes (`://`).
-
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
+- The `redirectUri` requires two slashes (`://`).
 
 {/* prettier-ignore */}
-```tsx
+```tsx Reddit Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1575,9 +1509,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Reddit */}
 
@@ -1593,19 +1524,15 @@ export default function App() {
 
 [c-slack]: https://api.slack.com/apps
 
-- The `redirectUri` requires 2 slashes (`://`).
+- The `redirectUri` requires two slashes (`://`).
 - `redirectUri` can be defined under the "OAuth & Permissions" section of the website.
 - `clientId` and `clientSecret` can be found in the **"App Credentials"** section.
 - Scopes must be joined with ':' so just create one long string.
 - Navigate to the **"Scopes"** section to enable scopes.
 - `revocationEndpoint` is not available.
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Slack Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1659,9 +1586,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Slack */}
 
@@ -1687,11 +1611,8 @@ export default function App() {
     - Set this to whatever your deployed website URL is.
 - Learn more about the [Spotify API](https://developer.spotify.com/documentation/web-api/).
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Spotify Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1748,9 +1669,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Spotify */}
 
@@ -1770,11 +1688,8 @@ export default function App() {
 - The "Authorization Callback Domain" refers to the final path component of your redirect URI. Ex: In the URI `com.bacon.myapp://redirect` the domain would be `redirect`.
 - No Implicit auth flow is provided by Strava.
 
-<Tabs tabs={["Auth Code"]}>
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Strava Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1848,8 +1763,6 @@ const { accessToken } = await AuthSession.exchangeCodeAsync(
 );
 ```
 
-</Tab>
-</Tabs>
 </Box>
 {/* End Strava */}
 
@@ -1868,12 +1781,8 @@ const { accessToken } = await AuthSession.exchangeCodeAsync(
 
 - You will need to enable 2FA on your Twitch account to create an application.
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Twitch Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -1928,9 +1837,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Twitch */}
 
@@ -1952,14 +1858,10 @@ export default function App() {
 - Example redirects:
   - Standalone / development build: `com.your.app://`
   - Web (dev `expo start --https`): `https://localhost:19006` (no ending slash)
-- The `redirectUri` requires 2 slashes (`://`).
-
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
+- The `redirectUri` requires two slashes (`://`).
 
 {/* prettier-ignore */}
-```tsx
+```tsx Twitter Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -2017,8 +1919,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-</Tabs>
 </Box>
 {/* End Twitter */}
 
@@ -2034,15 +1934,11 @@ export default function App() {
 
 [c-uber]: https://developer.uber.com/docs/riders/guides/authentication/introduction
 
-- The `redirectUri` requires 2 slashes (`://`).
+- The `redirectUri` requires two slashes (`://`).
 - `scopes` can be difficult to get approved.
 
-<Tabs tabs={["Auth Code"]}>
-
-<Tab>
-
 {/* prettier-ignore */}
-```tsx
+```tsx Uber Auth Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
@@ -2097,9 +1993,6 @@ export default function App() {
 }
 ```
 
-</Tab>
-
-</Tabs>
 </Box>
 {/* End Uber */}
 

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -66,21 +66,13 @@ You'll need to install the following dependencies:
 
 ### Setup entry point
 
-<Tabs>
+For the property `main`, use the `expo-router/entry` as its value in the **package.json**. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
 
-<Tab label="SDK 49 and above">
-
-    For the property `main`, use the `expo-router/entry` as its value in the **package.json**. The initial client file is [**app/_layout.js**](/router/advanced/root-layout).
-
-    ```json package.json
-    {
-      "main": "expo-router/entry"
-    }
-    ```
-
-</Tab>
-
-</Tabs>
+```json package.json
+{
+  "main": "expo-router/entry"
+}
+```
 
 </Step>
 

--- a/docs/ui/components/Authentication/Box.tsx
+++ b/docs/ui/components/Authentication/Box.tsx
@@ -1,12 +1,9 @@
-import { css } from '@emotion/react';
-import { spacing } from '@expo/styleguide-base';
 import type { PropsWithChildren } from 'react';
 
 import { CreateAppButton } from './CreateAppButton';
 import { Icon } from './Icon';
 
 import { APIBox } from '~/components/plugins/APIBox';
-import { tableWrapperStyle } from '~/ui/components/Table/Table';
 import { H3 } from '~/ui/components/Text';
 
 type BoxProps = PropsWithChildren<{
@@ -16,20 +13,14 @@ type BoxProps = PropsWithChildren<{
 }>;
 
 export const Box = ({ name, image, createUrl, children }: BoxProps) => (
-  <APIBox className="mt-6" css={boxStyle}>
-    <div className="inline-flex flex-row items-center gap-4 pb-4 w-full max-medium:gap-3 max-medium:flex-col">
-      <div className="flex flex-row gap-3 items-center w-[inherit]">
+  <APIBox className="mt-6 [&_.table-wrapper]:!mb-4">
+    <div className="inline-flex flex-row items-center gap-4 pb-4 w-full max-md-gutters::gap-3 max-md-gutters::flex-col">
+      <div className="flex flex-row gap-3 items-center w-[inherit] [&>h3]:!mb-0">
         <Icon title={name} image={image} size={48} />
-        <H3 style={{ marginBottom: 0 }}>{name}</H3>
+        <H3>{name}</H3>
       </div>
       {createUrl && <CreateAppButton name={name} href={createUrl} />}
     </div>
     {children}
   </APIBox>
 );
-
-const boxStyle = css({
-  [`.css-${tableWrapperStyle.name}`]: {
-    marginBottom: spacing[4],
-  },
-});

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -13,7 +13,7 @@ type TableProps = PropsWithChildren<{
 }>;
 
 export const Table = ({ children, headers = [], headersAlign, className }: TableProps) => (
-  <div css={tableWrapperStyle}>
+  <div css={tableWrapperStyle} className="table-wrapper">
     <table css={tableStyle} className={className}>
       {headers.length ? (
         <>


### PR DESCRIPTION
# Why

while working on other task I have spotted that there are places where we use `Tabs` component with just one tab.

# How

Replace all usages that of single tab setup I was able to find with just regular, inline content.

Small appearance fixes for the Auth Box component, wording tweaks.

# Test Plan

The changes have been reviewed locally. All lint checks and tests are passing.

# Preview

![Screenshot 2024-06-27 at 21 38 27](https://github.com/expo/expo/assets/719641/b02c0fd8-7190-48de-b3e7-17277fa8b8cb)
