### PR TITLE
fix(cli): add connection tracking to close server entirely

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Ensure Metro dev server closes fully after connecting to clients.
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Resolve module specifiers to posix paths for Metro. ([#29696](https://github.com/expo/expo/pull/29696) by [@byCedric](https://github.com/byCedric))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Ensure Metro dev server closes fully after connecting to clients.
+- Ensure Metro dev server closes fully after connecting to clients. ([#30057](https://github.com/expo/expo/pull/30057) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Resolve module specifiers to posix paths for Metro. ([#29696](https://github.com/expo/expo/pull/29696) by [@byCedric](https://github.com/byCedric))

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -352,7 +352,7 @@ export abstract class BundlerDevServer {
         }),
       {
         // NOTE(Bacon): Metro dev server doesn't seem to be closing in time.
-        timeout: 1000,
+        timeout: 3000,
         errorMessage: `Timeout waiting for '${this.name}' dev server to close`,
       }
     );


### PR DESCRIPTION
# Why

- There was a hidden bug where the server would hang due to lingering socket connections.
- Thanks to @byCedric's new error logging we were able to identify this issue and add this new cleanup process.
- We'll now track all connections and clean them up instantly when the server closes, this means the server will now close nearly instantly.

# Test Plan

- `npx expo -i -w -a` (important to connect both iOS and web) then do a few HMRs to ensure all connects are established.
- cmd+c -> closes instantly with no hanging.
