### PR TITLE
[docs] Guide to sending notifications direct to FCMv1

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -389,7 +389,9 @@ const general = [
     makeGroup(
       'Reference',
       [
+        makePage('push-notifications/obtaining-a-device-token-for-fcm-or-apns.mdx'),
         makePage('push-notifications/sending-notifications-custom.mdx'),
+        makePage('push-notifications/sending-notifications-custom-fcm-legacy.mdx'),
         makePage('push-notifications/faq.mdx'),
       ],
       { expanded: false }

--- a/docs/pages/push-notifications/obtaining-a-device-token-for-fcm-or-apns.mdx
+++ b/docs/pages/push-notifications/obtaining-a-device-token-for-fcm-or-apns.mdx
@@ -1,0 +1,16 @@
+---
+title: Obtaining a device token for sending to FCM or APNs
+hideFromSearch: true
+description: Learn how to obtain native device tokens.
+---
+Before communicating directly with FCM and APNs, there is one client-side change you'll need to make in your app. When using Expo's notification service, you collect the `ExponentPushToken` with [`getExpoPushTokenAsync`](/versions/latest/sdk/notifications/#getexpopushtokenasyncoptions-expotokenoptions-expopushtoken). Now that you're not using Expo's notification service, you'll need to collect the native device token instead with [`getDevicePushTokenAsync`](/versions/latest/sdk/notifications/#getdevicepushtokenasync-devicepushtoken).
+
+```diff
+import * as Notifications from 'expo-notifications';
+...
+- const token = (await Notifications.getExpoPushTokenAsync()).data;
++ const token = (await Notifications.getDevicePushTokenAsync()).data;
+// send token to your server
+```
+
+After getting the native device token, you can start implementing the servers. Below are some minimal examples of communicating with FCM and APNs:

--- a/docs/pages/push-notifications/sending-notifications-custom-fcm-legacy.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom-fcm-legacy.mdx
@@ -1,0 +1,119 @@
+---
+title: Send notifications with FCM legacy server
+hideFromSearch: true
+description: Learn how to send notifications with FCM legacy server.
+---
+
+> *info* For documentation on communicating with the newer FCMv1 service, see [Send notifications with FCMv1 and APNs](/push-notifications/sending-notifications-custom). This guide is based on [Google's documentation](https://firebase.google.com/docs/cloud-messaging/http-server-ref), and this section covers the basics to get you started.
+
+> *info* Before sending a notification directly through FCM, you will need to [obtain a device token](/push-notifications/obtaining-a-device-token-for-fcm-or-apns).
+
+Communicating with FCM is done by sending a POST request. However, before sending or receiving any notifications, you'll need to follow the steps to [configure FCM](/push-notifications/push-notifications-setup/#android) to configure FCM and get your `FCM-SERVER-KEY`.
+
+```js
+await fetch('https://fcm.googleapis.com/fcm/send', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `key=<FCM-SERVER-KEY>`,
+  },
+  body: JSON.stringify({
+    to: '<NATIVE-DEVICE-PUSH-TOKEN>',
+    priority: 'normal',
+    data: {
+      experienceId: '@yourExpoUsername/yourProjectSlug',
+      scopeKey: '@yourExpoUsername/yourProjectSlug',
+      title: "\uD83D\uDCE7 You've got mail",
+      message: 'Hello world! \uD83C\uDF10',
+    },
+  }),
+});
+```
+
+**The `experienceId` and `scopeKey` fields are required**. Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
+
+FCM also provides some [server-side libraries in a few different languages](https://firebase.google.com/docs/cloud-messaging/send-message#node.js) you can use instead of raw `fetch` requests.
+
+### How to find FCM server key
+
+Your FCM server key can be found by making sure you've followed the [configuration steps](/push-notifications/push-notifications-setup/#android), and instead of uploading your FCM key to Expo, you would use that key directly in your server (as the `FCM-SERVER-KEY` in the previous example).
+
+## Payload format
+
+```json
+{
+  "token": native device token string,
+  "collapse_key": string that identifies notification as collapsible,
+  "priority": "normal" || "high",
+  "data": {
+    "experienceId": "@yourExpoUsername/yourProjectSlug",
+    "scopeKey": "@yourExpoUsername/yourProjectSlug",
+    "title": title of your message,
+    "message": body of your message,
+    "channelId": the android channel ID associated with this notification,
+    "categoryId": the category associated with this notification,
+    "icon": the icon to show with this notification,
+    "link": the link this notification should open,
+    "sound": boolean or the custom sound file you'd like to play,
+    "vibrate": "true" | "false" | number[],
+    "priority": AndroidNotificationPriority, // https://docs.expo.dev/versions/latest/sdk/notifications/#androidnotificationpriority
+    "badge": the number to set the icon badge to,
+    "body": { object of key-value pairs }
+  }
+}
+```
+
+### Firebase notification types
+
+There are two types of Firebase Cloud Messaging messages: [notification and data messages](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages).
+
+1. **Notification** messages are only handled (and displayed) by the Firebase library. They don't necessarily wake the app, and `expo-notifications` will not be made aware that your app has received any notification.
+
+2. **Data** messages are not handled by the Firebase library. They are immediately handed off to your app for processing. That's where `expo-notifications` interprets the data payload and takes action based on that data. **In almost all cases, this is the type of notification you have to send.**
+
+If you send a message of type **notification** instead of **data** directly through Firebase, you won't know if a user interacted with the notification (no `onNotificationResponse` event available), and you won't be able to parse the notification payload for any data in your notification event-related listeners.
+
+> Using notification-type messages may have upsides when you need a configuration option that has not been exposed by `expo-notifications` yet. In general, it may lead to less predictable situations than using only data-type messages, and it's not our responsibility that you'll have to go to Google to report issues.
+
+Below is an example of each type using Node.js Firebase Admin SDK to send data-type messages instead of notification-type:
+
+```js
+const devicePushToken = /* ... */;
+const options = /* ... */;
+
+// ❌ The following payload has a root-level notification object and
+// it will not trigger expo-notifications and may not work as expected.
+admin.messaging().sendToDevice(
+  devicePushToken,
+  {
+    notification: {
+      title: "This is a notification-type message",
+      body: "`expo-notifications` will never see this 😢",
+    },
+    data: {
+      photoId: 42,
+    },
+  },
+  options
+);
+
+// ✅ There is no "notification" key in the root level of the payload
+// so the message is a "data" message, thus triggering expo-notifications.
+admin.messaging().sendToDevice(
+  devicePushToken,
+  {
+    data: {
+      title: "This is a data-type message",
+      message: "`expo-notifications` events will be triggered 🤗",
+      // ⚠️ Notice the schema of this payload is different
+      // than that of Firebase SDK. What is there called "body"
+      // here is a "message". For more info see:
+      // https://docs.expo.dev/versions/latest/sdk/notifications/#android-push-notification-payload-specification
+
+      body:                              // As per Android payload format specified above, the
+        JSON.stringify({ photoId: 42 }), // additional "data" should be placed under "body" key.
+    },
+  },
+  options
+);
+```

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -1,51 +1,98 @@
 ---
-title: Send notifications with FCM & APNs
+title: Send notifications with FCMv1 & APNs
 hideFromSearch: true
-description: Learn how to send notifications with FCM and APNs.
+description: Learn how to send notifications with FCMv1 and APNs.
 ---
 
 You may need finer-grained control over your notifications, so communicating directly with FCM and APNs may be necessary. The Expo platform does not lock you into using Expo's application services, and the `expo-notifications` API is push-service agnostic.
 
-## How to write FCM and APNs servers
+> *info* For documentation on communicating with the legacy FCM service, see [Send notifications with FCM legacy server](/push-notifications/sending-notifications-custom-fcm-legacy).
 
-Before communicating directly with FCM and APNs, there is one client-side change you'll need to make in your app. When using Expo's notification service, you collect the `ExponentPushToken` with [`getExpoPushTokenAsync`](/versions/latest/sdk/notifications/#getexpopushtokenasyncoptions-expotokenoptions-expopushtoken). Now that you're not using Expo's notification service, you'll need to collect the native device token instead with [`getDevicePushTokenAsync`](/versions/latest/sdk/notifications/#getdevicepushtokenasync-devicepushtoken).
+> *info* Before sending a notification directly through FCMv1 or APNs, you will need to [obtain a device token](/push-notifications/obtaining-a-device-token-for-fcm-or-apns).
 
-```diff
-import * as Notifications from 'expo-notifications';
-...
-- const token = (await Notifications.getExpoPushTokenAsync()).data;
-+ const token = (await Notifications.getDevicePushTokenAsync()).data;
-// send token to your server
+## FCMv1 server
+
+This guide is based on [Firebase official documentation](https://firebase.google.com/docs/cloud-messaging/migrate-v1).
+
+Communicating with FCM is done by sending a POST request. However, before sending or receiving any notifications, you'll need to follow the steps to [configure FCMv1](/push-notifications/fcm-credentials/) and get your `FCM-SERVER-KEY`.
+
+### Getting an authentication token
+
+FCMv1 requires an Oauth 2.0 access token, which must be obtained via one of the methods described in ["Update authorization of send requests"](https://firebase.google.com/docs/cloud-messaging/migrate-v1#update-authorization-of-send-requests).
+
+For testing purposes, you can use the Google Auth Library and your private key file obtained above, to obtain a short lived token for a single notification, as in this Node example adapted from Firebase documentation:
+
+```ts
+import { JWT } from 'google-auth-library';
+
+function getAccessTokenAsync(
+  key: string // Contents of your FCM private key file
+) {
+  return new Promise(function (resolve, reject) {
+    const jwtClient = new JWT(
+      key.client_email,
+      null,
+      key.private_key,
+      ['https://www.googleapis.com/auth/cloud-platform'],
+      null
+    );
+    jwtClient.authorize(function (err, tokens) {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(tokens.access_token)
+    });
+  })
+}
 ```
+### Sending the notification
 
-After getting the native device token, you can start implementing the servers. Below are some minimal examples of communicating with FCM and APNs:
+The example code below calls `getAccessTokenAsync()` above to get the Oauth 2.0 token, then constructs and sends the notification POST request. Note that unlike FCM legacy protocol, the endpoint for the request includes the name of your Firebase project.
 
-## FCM server
+```ts
+// FCM_SERVER_KEY: Environment variable with the path to your FCM private key file
+// FCM_PROJECT_NAME: Your Firebase project name
+// FCM_DEVICE_TOKEN: The client's device token (see above in this document)
 
-> This documentation is based on [Google's documentation](https://firebase.google.com/docs/cloud-messaging/http-server-ref), and this section covers the basics to get you started.
+async function sendFCMv1Notification() {
+  const key = require(process.env.FCM_SERVER_KEY);
+  const firebaseAccessToken = await getAccessTokenAsync(key);
+  const deviceToken = process.env.FCM_DEVICE_TOKEN;
 
-Communicating with FCM is done by sending a POST request. However, before sending or receiving any notifications, you'll need to follow the steps to [configure FCM](/push-notifications/push-notifications-setup/#android) to configure FCM and get your `FCM-SERVER-KEY`.
-
-> The following example uses FCM's legacy HTTP API, since the credentials setup for that is the same as it is for the Expo notifications service, so there's no additional work needed on your part. If you'd rather use FCM's HTTP V1 API, see [Firebase official documentation](https://firebase.google.com/docs/cloud-messaging/migrate-v1).
-
-```js
-await fetch('https://fcm.googleapis.com/fcm/send', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    Authorization: `key=<FCM-SERVER-KEY>`,
-  },
-  body: JSON.stringify({
-    to: '<NATIVE-DEVICE-PUSH-TOKEN>',
-    priority: 'normal',
-    data: {
-      experienceId: '@yourExpoUsername/yourProjectSlug',
-      scopeKey: '@yourExpoUsername/yourProjectSlug',
-      title: "\uD83D\uDCE7 You've got mail",
-      message: 'Hello world! \uD83C\uDF10',
+  const messageBody = {
+    message: {
+      token: deviceToken,
+      data: {
+        channelId: 'default',
+        message: 'Testing',
+        title: `This is an FCM notification message`,
+        body: JSON.stringify({ title: 'bodyTitle', body: 'bodyBody' }),
+        scopeKey: '@yourExpoUsername/yourProjectSlug',
+        experienceId: '@yourExpoUsername/yourProjectSlug'
+      },
     },
-  }),
-});
+  };
+  
+  const response = await fetch(
+    `https://fcm.googleapis.com/v1/projects/${process.env.FCM_PROJECT_NAME}/messages:send`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${firebaseAccessToken}`,
+        Accept: 'application/json',
+        'Accept-encoding': 'gzip, deflate',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(messageBody),
+    }
+  );
+
+  const readResponse = (response: Response) => response.json();
+  const json = await readResponse(response);
+
+  console.log(`Response JSON: ${JSON.stringify(json, null, 2)}`);
+}
 ```
 
 **The `experienceId` and `scopeKey` fields are required**. Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
@@ -58,7 +105,7 @@ Your FCM server key can be found by making sure you've followed the [configurati
 
 ## APNs server
 
-> This documentation is based on [Apple's documentation](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html), and this section covers the basics to get you started.
+> *info* This documentation is based on [Apple's documentation](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html), and this section covers the basics to get you started.
 
 Communicating with APNs is a little more complicated than with FCM. Some libraries wrap all of this functionality into one or two function calls such as [`node-apn`](https://github.com/node-apn/node-apn). However, in the examples below, a minimum set of libraries are used.
 


### PR DESCRIPTION
# Why

Since Firebase is transitioning to FCMv1, we need to replace the guide for sending notifications direct to FCM.

# How

- Rewrite the FCM guide for FCMv1
- Move the old FCM guide to a new FCM legacy page
- Move the guide for getting a native device token to its own page so that both FCM guides can reference it

# Test Plan

- Docs CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
