### PR TITLE
[core][iOS] Rename `pointer` to `ref` in SharedRef for parity

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -38,7 +38,7 @@
 - Make it possible for TypeScript to infer EventEmitter's events map. ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - [iOS] Stop throwing runtime errors when the promise is settled more than once. ([#30000](https://github.com/expo/expo/pull/30000) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android.
+- [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android. ([#30061](https://github.com/expo/expo/pull/30061) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Make it possible for TypeScript to infer EventEmitter's events map. ([#29056](https://github.com/expo/expo/pull/29056) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - [iOS] Stop throwing runtime errors when the promise is settled more than once. ([#30000](https://github.com/expo/expo/pull/30000) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android.
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedRef.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedRef.swift
@@ -1,12 +1,17 @@
 /**
- Shared object (ref) that holds a pointer to any native object. Allows passing references
+ Shared object that holds a reference to any native object. Allows passing references
  to native instances among different independent libraries.
  */
-open class SharedRef<PointerType>: SharedObject {
-  public let pointer: PointerType
+open class SharedRef<RefType>: SharedObject {
+  public let ref: RefType
 
-  public init(_ pointer: PointerType) {
-    self.pointer = pointer
+  @available(*, deprecated, renamed: "ref", message: "it has been renamed to 'ref' in Expo SDK 52")
+  public var pointer: RefType {
+    return ref
+  }
+
+  public init(_ ref: RefType) {
+    self.ref = ref
     super.init()
   }
 }


### PR DESCRIPTION
# Why

On Android the `SharedRef` class uses a property called `ref` to access the underlying native object that it holds. iOS used a `pointer`. This PR deprecated `pointer` on iOS in favor of `ref` for parity.

# How

Replaced `pointer` with `ref` and marked the former as deprecated.

# Test Plan

Xcode properly recognizes `pointer` as deprecated and suggests renaming it to `ref`