### PR TITLE
[core] fix SSE response blocking issue

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed `getPathPermissions` permission error for local path with spaces on iOS 16 and older. ([#29958](https://github.com/expo/expo/pull/29958) by [@kudo](https://github.com/kudo))
 - Fixed `RCTTriggerReloadCommandListeners` not found build error on iOS. ([#30014](https://github.com/expo/expo/pull/30014) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed broken `addUIBlock` and `executeUIBlock` on New Architecture mode. ([#30030](https://github.com/expo/expo/pull/30030) by [@kudo](https://github.com/kudo))
+- Fixed blocking SSE responses from network interceptor on Android. ([#30062](https://github.com/expo/expo/pull/30062) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
@@ -127,10 +127,10 @@ internal fun peekResponseBody(
 internal fun shouldParseBody(response: Response): Boolean {
   // Check for Content-Type
   val skipContentTypes = listOf(
-    "text/event-stream",    // Server Sent Events
-    "text/x-component",     // React Server Components
-    "audio",                // Media might be streaming and not inspectable in DevTools
-    "video"                 // Media might be streaming and not inspectable in DevTools
+    "text/event-stream", // Server Sent Events
+    "text/x-component", // React Server Components
+    "audio", // Media might be streaming and not inspectable in DevTools
+    "video" // Media might be streaming and not inspectable in DevTools
   )
   val contentType = response.header("Content-Type") ?: ""
   if (skipContentTypes.any { contentType.startsWith(it) }) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
@@ -35,8 +35,8 @@ class ExpoNetworkInspectOkHttpNetworkInterceptor : Interceptor {
           it.requestId = requestId
           it.priorResponse = response
         }
-      } else if (shouldParseBody(response)) {
-        val body = peekResponseBody(response)
+      } else {
+        val body = if (shouldParseBody(response)) peekResponseBody(response) else null
         delegate.didReceiveResponse(requestId, request, response, body)
         body?.close()
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
@@ -35,7 +35,7 @@ class ExpoNetworkInspectOkHttpNetworkInterceptor : Interceptor {
           it.requestId = requestId
           it.priorResponse = response
         }
-      } else {
+      } else if (shouldParseBody(response)) {
         val body = peekResponseBody(response)
         delegate.didReceiveResponse(requestId, request, response, body)
         body?.close()
@@ -122,4 +122,28 @@ internal fun peekResponseBody(
   val buffer = okio.Buffer()
   buffer.write(source, minOf(byteCount, source.buffer.size))
   return buffer.asResponseBody(body.contentType(), buffer.size)
+}
+
+internal fun shouldParseBody(response: Response): Boolean {
+  // Check for Content-Type
+  val skipContentTypes = listOf(
+    "text/event-stream",    // Server Sent Events
+    "text/x-component",     // React Server Components
+    "audio",                // Media might be streaming and not inspectable in DevTools
+    "video"                 // Media might be streaming and not inspectable in DevTools
+  )
+  val contentType = response.header("Content-Type") ?: ""
+  if (skipContentTypes.any { contentType.startsWith(it) }) {
+    return false
+  }
+
+  // HTTP 1.1 chunked encoding
+  val transferEncoding = response.header("Transfer-Encoding")
+  if ("chunked".equals(transferEncoding, ignoreCase = true)) {
+    return false
+  }
+
+  // If Content-Length is known to exceed the limit
+  val contentLength = response.header("Content-Length")?.toLong() ?: -1
+  return contentLength < 1 || contentLength <= ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptorsTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptorsTest.kt
@@ -97,3 +97,77 @@ class PeekResponseBodyTest {
       .build()
   }
 }
+
+class ShouldParseBodyTest {
+  @Test
+  fun `should return true from plain text response`() {
+    val plaintext = "hello"
+    val response = createResponse(
+      body = plaintext.toResponseBody("text/plain".toMediaType()),
+      headers = mapOf(
+        "Content-Type" to "text/plain",
+        "content-length" to plaintext.length.toString(),
+      ).toHeaders(),
+    )
+    Truth.assertThat(shouldParseBody(response)).isTrue()
+  }
+
+  @Test
+  fun `should return true from JSON response`() {
+    val response = createResponse(
+      body = "{\"hello\":\"hello\"}".toResponseBody("application/json".toMediaType()),
+      headers = mapOf("Content-Type" to "application/json").toHeaders(),
+    )
+    Truth.assertThat(shouldParseBody(response)).isTrue()
+  }
+
+  @Test
+  fun `should return false from SSE response`() {
+    val response = createResponse(
+      body = "0".toResponseBody("text/event-stream".toMediaType()),
+      headers = mapOf("Content-Type" to "text/event-stream").toHeaders(),
+    )
+    Truth.assertThat(shouldParseBody(response)).isFalse()
+  }
+
+  @Test
+  fun `should return false from chunked encoding transfer`() {
+    val response = createResponse(
+      body = null,
+      headers = mapOf("transfer-encoding" to "chunked").toHeaders(),
+    )
+    Truth.assertThat(shouldParseBody(response)).isFalse()
+  }
+
+  @Test
+  fun `should return false from large response`() {
+    val length = (ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE + 1).toInt()
+    val largeString = String(CharArray(length) { '0' })
+    val response = createResponse(
+      body = largeString.toResponseBody("text/plain".toMediaType()),
+      headers = mapOf(
+        "Content-Type" to "text/plain",
+        "content-length" to length.toString(),
+      ).toHeaders(),
+    )
+    Truth.assertThat(shouldParseBody(response)).isFalse()
+  }
+
+  private fun createResponse(body: ResponseBody?, headers: Headers? = null): Response {
+    val request = Request.Builder().url("https://example.org").build()
+    return Response.Builder()
+      .request(request)
+      .protocol(Protocol.HTTP_1_1)
+      .code(200)
+      .message("OK")
+      .apply {
+        if (body != null) {
+          this.body(body)
+        }
+        if (headers != null) {
+          this.headers(headers)
+        }
+      }
+      .build()
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptorsTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptorsTest.kt
@@ -106,8 +106,8 @@ class ShouldParseBodyTest {
       body = plaintext.toResponseBody("text/plain".toMediaType()),
       headers = mapOf(
         "Content-Type" to "text/plain",
-        "content-length" to plaintext.length.toString(),
-      ).toHeaders(),
+        "content-length" to plaintext.length.toString()
+      ).toHeaders()
     )
     Truth.assertThat(shouldParseBody(response)).isTrue()
   }
@@ -116,7 +116,7 @@ class ShouldParseBodyTest {
   fun `should return true from JSON response`() {
     val response = createResponse(
       body = "{\"hello\":\"hello\"}".toResponseBody("application/json".toMediaType()),
-      headers = mapOf("Content-Type" to "application/json").toHeaders(),
+      headers = mapOf("Content-Type" to "application/json").toHeaders()
     )
     Truth.assertThat(shouldParseBody(response)).isTrue()
   }
@@ -125,7 +125,7 @@ class ShouldParseBodyTest {
   fun `should return false from SSE response`() {
     val response = createResponse(
       body = "0".toResponseBody("text/event-stream".toMediaType()),
-      headers = mapOf("Content-Type" to "text/event-stream").toHeaders(),
+      headers = mapOf("Content-Type" to "text/event-stream").toHeaders()
     )
     Truth.assertThat(shouldParseBody(response)).isFalse()
   }
@@ -134,7 +134,7 @@ class ShouldParseBodyTest {
   fun `should return false from chunked encoding transfer`() {
     val response = createResponse(
       body = null,
-      headers = mapOf("transfer-encoding" to "chunked").toHeaders(),
+      headers = mapOf("transfer-encoding" to "chunked").toHeaders()
     )
     Truth.assertThat(shouldParseBody(response)).isFalse()
   }
@@ -147,8 +147,8 @@ class ShouldParseBodyTest {
       body = largeString.toResponseBody("text/plain".toMediaType()),
       headers = mapOf(
         "Content-Type" to "text/plain",
-        "content-length" to length.toString(),
-      ).toHeaders(),
+        "content-length" to length.toString()
+      ).toHeaders()
     )
     Truth.assertThat(shouldParseBody(response)).isFalse()
   }


### PR DESCRIPTION
# Why

fixes #27526

# How

the network interceptor has a call to block streaming requests. it waits for more bytes than the current response
https://github.com/expo/expo/blob/58287a19c8ab2d29c5569eefe13348bfc79a0777/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt#L104-L106

this pr tries to skip streaming requests and some other known response that we don't support response body inspection 

# Test Plan

add unit test and ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
