### PR TITLE
[dev-menu][iOS] Don't close the dev menu when hovering with the mouse

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
-- [macOS] don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
+- [macOS] Don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `disableOnboarding=1` wasn't working when using the dev-client. ([#29697](https://github.com/expo/expo/pull/29697) by [@lukmccall](https://github.com/lukmccall))
+- [macOS] don't hide the dev menu when hovering the window with the mouse. ([#30066](https://github.com/expo/expo/pull/30066) by [@343max](https://github.com/343max))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -73,7 +73,7 @@ class DevMenuWindow: UIWindow, OverlayContainerViewControllerDelegate {
 
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
     let view = super.hitTest(point, with: event)
-    if view == self {
+    if view == self && event?.type == .touches {
       bottomSheetController.moveOverlay(toNotchAt: OverlayNotch.hidden.rawValue, animated: true)
     }
 


### PR DESCRIPTION
# Why

On macOS the dev menu will close simply by hovering the mouse over parts of the window that aren't covered by the dev menu.

# How

The `DevMenuWindow` is hiding the bottom sheet whenever a `hitTest` hits the window, no matter what kind of event triggered the hitTest. Honestly I don't think a hitTest should ever trigger a side effect but because I don't know why this feature was implemented this way I decided to fix this issue in a way with the minimal chances for side effects. Therefore I just added a check to make sure the bottom sheet is only hidden when the event is a touch event.

# Test Plan

- setup a app in development mode with an expo dev client
- pick "My Mac" as the target device from the target device picker menu in Xcode
- run the app on macOS
- open the dev menu somehow. If all fails I built a [expo plugin](https://github.com/343max/dev-client-mac-tools) specifically for that purpose 😀
- see how hovering the mouse over a part of the window that isn't covered by the dev menu closes the dev menu

https://github.com/expo/expo/assets/33906/8ec9338b-950b-4df7-8e6b-117169551ee4

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
