### PR TITLE
fix(cli): close all websocket endpoint servers and client connections when closing Metro

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Resolve module specifiers to posix paths for Metro. ([#29696](https://github.com/expo/expo/pull/29696) by [@byCedric](https://github.com/byCedric))
+- Ensure Metro dev server closes fully when clients are connected.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix resolver fields for SSR + native platforms. ([#29701](https://github.com/expo/expo/pull/29701) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix assetId for static web assets. ([#29686](https://github.com/expo/expo/pull/29686) by [@EvanBacon](https://github.com/EvanBacon))
 - Resolve module specifiers to posix paths for Metro. ([#29696](https://github.com/expo/expo/pull/29696) by [@byCedric](https://github.com/byCedric))
-- Ensure Metro dev server closes fully when clients are connected.
+- Ensure Metro dev server closes fully when clients are connected. ([#30067](https://github.com/expo/expo/pull/30067) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -108,7 +108,7 @@ export const runServer = async (
       endpoint.clients.forEach((client) => client.terminate());
     }
 
-    // Ensure all connections are closed
+    // Forcibly close active connections
     this.closeAllConnections();
     return this;
   };

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -11,6 +11,7 @@ import MetroHmrServer from 'metro/src/HmrServer';
 import createWebsocketServer from 'metro/src/lib/createWebsocketServer';
 import { ConfigT } from 'metro-config';
 import { parse } from 'url';
+import type { WebSocketServer } from 'ws';
 
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { Log } from '../../../log';
@@ -94,6 +95,23 @@ export const runServer = async (
   httpServer.on('close', () => {
     end();
   });
+
+  // Extend the close method to ensure all websocket servers are closed, and connections are terminated
+  const originalClose = httpServer.close.bind(httpServer);
+
+  httpServer.close = function closeHttpServer(callback) {
+    originalClose(callback);
+
+    // Close all websocket servers, including possible client connections (see: https://github.com/websockets/ws/issues/2137#issuecomment-1507469375)
+    for (const endpoint of Object.values(websocketEndpoints) as WebSocketServer[]) {
+      endpoint.close();
+      endpoint.clients.forEach((client) => client.terminate());
+    }
+
+    // Ensure all connections are closed
+    this.closeAllConnections();
+    return this;
+  };
 
   if (mockServer) {
     return { server: httpServer, metro: metroServer };


### PR DESCRIPTION
# Why

Superseeds #30057 (Closes #30057)

Not closing the websocket servers (and [client connections](https://github.com/websockets/ws/issues/2137#issuecomment-1507469375)) was the blocking factor of using `.closeAllConnections`.

This PR does the same thing as #30057, but without having to keep track of all connections manually.

# How

- Closed all websocket endpoint servers and clients when Metro is closing down

# Test Plan

- `npx expo -i -w -a` (important to connect both iOS and web) then do a few HMRs to ensure all connects are established.
- cmd+c -> closes instantly with no hanging.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
