### PR TITLE
Import React into BlurView.web.tsx

### DIFF
--- a/packages/expo-blur/src/BlurView.web.tsx
+++ b/packages/expo-blur/src/BlurView.web.tsx
@@ -1,6 +1,6 @@
 // Copyright © 2024 650 Industries.
 'use client';
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import { View } from 'react-native';
 
 import { BlurViewProps } from './BlurView.types';


### PR DESCRIPTION
If React is not imported, react-native-web fails on web with an error(At least it does when using this inside of a bit component).

ReferenceError: React is not defined
    at eval (BlurView.web.js:57:3)
   ...

# Why

The component fails to run on react-native-web if React is not imported. I did not test to see if it fails in pure react-native-web, but our company is leveraging expo-blur inside of bit.dev React Native environment and web fails unless React is included.

# How

To test the fix, I just modified the code inside node_modules.