### PR TITLE
chore: let all CLI shards finish testing when one fails

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,6 +45,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         shard: [1, 2, 3]
     steps:


### PR DESCRIPTION
# Why

This is a workflow patch to allow all CLI test shards to finish, even when one fails. E.g. this run: https://github.com/expo/expo/actions/runs/9715664058/job/26817792966

# How

- Disabled `matrix.fail-fast` for CLI shards

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
