### PR TITLE
Upgrade CocoaPods to 1.15.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "fastlane", "~> 2.221.0"
-gem "cocoapods", "~> 1.14.3"
+gem "cocoapods", "~> 1.15.2"
 
 gem "xcpretty", "~> 0.3.0" # used by bare-expo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,10 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.8)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -60,7 +60,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -285,7 +285,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.14.3)
+  cocoapods (~> 1.15.2)
   fastlane (~> 2.221.0)
   xcpretty (~> 0.3.0)
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2519,10 +2519,10 @@ SPEC CHECKSUMS:
   EXBarCodeScanner: e2dd9b42c1b522a2adc9202b1dfbc64cb34456d1
   EXConstants: 9a008dbf262550884e6280dea95b81b51f65ea6f
   EXImageLoader: ab589d67d6c5f2c33572afea9917304418566334
-  EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
+  EXJSONUtils: fa6c5cd41afdcec8f0eca28a78b96abb86c28493
   EXLocation: 43e9b582ca63a23c6f0a18d8cbe2145b3a388b55
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  EXNotifications: 43b19f2672dcfa6923484ecce6c65ce3b126a11d
+  EXNotifications: a01203397855862df7e4ac3bcf9fc7bc6914893e
   Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
   expo-dev-client: 5a76dfdc64875a076212f9d3ee9a897bdd735105
   expo-dev-launcher: 752312abcf346045aac32cf1bde006f45faf4a04
@@ -2530,7 +2530,7 @@ SPEC CHECKSUMS:
   expo-dev-menu-interface: 3e97a7c7d79caff5f62acb00d053d4ec86d0ca1f
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
   ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
-  ExpoAudio: 5e7d15c9b6901eb32913a220b0e99590739f4db3
+  ExpoAudio: 7a5deb52fb0691bb3f51f573013ffbc962fec2d0
   ExpoBackgroundFetch: a06c553ecaf0bade0acd691042d996b9ce926327
   ExpoBattery: 4b21f628f2b70af3af66e83c566949ba9cc65eb1
   ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
@@ -2538,9 +2538,9 @@ SPEC CHECKSUMS:
   ExpoCalendar: 135beb39ea3795f854a4ea287a49f74c9203ce51
   ExpoCamera: 73221bf7176a6271c7367ac12b5c52b07c3e4175
   ExpoCellular: c903c51bb54cc7d3fa9f5c572d77e302b73203f1
-  ExpoClipboard: 23d203f5d4843699fbc45be1cc4fe1fbd811a6fa
+  ExpoClipboard: 6483bd23f5868c9e0a481f261f36aaa5d4f70082
   ExpoContacts: 605d517d1e7a8a3f12f736db67cc502c0dd22b53
-  ExpoCrypto: 156078f266bf28f80ecf5e2a9c3a0d6ffce07a1c
+  ExpoCrypto: 68fa06e232e1413199b5131a47bbb428d38016f8
   ExpoDevice: fc94f0e42ecdfd897e7590f2874fc64dfa7e9b1c
   ExpoDocumentPicker: 326d1d098a574d621ed2cc05296c9895f10eea44
   ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
@@ -2556,26 +2556,26 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: f119167649d0465a06fa7c5b44c6c70f43f477ee
   ExpoLocalization: f04eeec2e35bed01ab61c72ee1768ec04d093d01
   ExpoMailComposer: e6da16de4682fba919051b2e680f804af00341f3
-  ExpoMaps: ae5f30377143632c3e18368c7e0b73409dce975b
+  ExpoMaps: 664ff9a93fe6b461976136327d7231ac78d87af7
   ExpoMediaLibrary: acbb23f74a6047b9b9b5a5ef00ffee28bfe466da
   ExpoModulesCore: 4eb2165cde325c8c121d495bb8beb0da9b30c92e
   ExpoModulesTestCore: 3d1007a5db579e867829b0f9cd4be07e29cf7c0c
   ExpoNetwork: 0d2c2504d56096fe8be3930d5c70cb3390dac5bf
-  ExpoPrint: 9e221bf0988c77c8a270a7df7135c65c2a396e0a
-  ExpoScreenCapture: ece7593264d1384aff2481eea29f9a238b484090
+  ExpoPrint: 0acb8b37c43634602ef20eec38dd108111736ef0
+  ExpoScreenCapture: b4e8b8a5ceeedfaed0a0572d8d6f55b4191feb98
   ExpoScreenOrientation: 5d6a977177dc2f904cc072b51a0d37d0983c0d6a
   ExpoSecureStore: 5f6b712785986b54d95a92bd365aabb82a52088e
-  ExpoSensors: 017b194af3c77db4dd552bc2763bddc24f1f6ae8
-  ExpoSharing: 8db05dd85081219f75989a3db2c92fe5e9741033
+  ExpoSensors: 3b5afeda6a10f062c7d071d984f890384b6d29ce
+  ExpoSharing: 97225e76c5261bec2d9bfce75cc35b589fb1fbba
   ExpoSMS: a5184fc4d4b33071b2dd9d43bb9ac8ef952b1dd7
   ExpoSpeech: 258ea713923eb70ef63d3bdb14f47a462d0b6f0e
   ExpoSQLite: 0091da247fdd8095f2cc213d98f812dba0ec7ca3
-  ExpoStoreReview: 15f9a636b62ff00bb21cbe9a9fe22f0239da4481
-  ExpoSymbols: 5adb1166f2929fc8d2497b98d5c48c4b94effe33
+  ExpoStoreReview: 3906c48e9b11eaee2f288a353eb69605fe17aeab
+  ExpoSymbols: fc85d6e697e3cc9b5e591a1913920266d7db8299
   ExpoSystemUI: b5ecc4b6781b6369fb8b3a0903bea36fae3dd090
   ExpoTrackingTransparency: 005340638bbd48449066a6c1a54ee44ae65ed7b4
   ExpoVideo: 73a2ca98c0c432fe81ede97816656d4246c0b450
-  ExpoVideoThumbnails: 40c737b2507a7470b14e9452e286513beb9a7d77
+  ExpoVideoThumbnails: 2ae80bf49c7e0b5cc65483d409e492b746d10881
   ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
   EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
@@ -2668,6 +2668,6 @@ SPEC CHECKSUMS:
   Yoga: 2f71ecf38d934aecb366e686278102a51679c308
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: b083013bb3fe8f21e7821b4130830ffd56a8416c
+PODFILE CHECKSUM: 0fc98953198511e28868729fa83918f7888b9425
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2344,14 +2344,14 @@ SPEC CHECKSUMS:
   EXBarCodeScanner: e2dd9b42c1b522a2adc9202b1dfbc64cb34456d1
   EXConstants: 9a008dbf262550884e6280dea95b81b51f65ea6f
   EXImageLoader: ab589d67d6c5f2c33572afea9917304418566334
-  EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
+  EXJSONUtils: fa6c5cd41afdcec8f0eca28a78b96abb86c28493
   EXLocation: 43e9b582ca63a23c6f0a18d8cbe2145b3a388b55
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
-  EXNotifications: 43b19f2672dcfa6923484ecce6c65ce3b126a11d
+  EXNotifications: a01203397855862df7e4ac3bcf9fc7bc6914893e
   Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
   ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
-  ExpoAudio: 5e7d15c9b6901eb32913a220b0e99590739f4db3
+  ExpoAudio: 7a5deb52fb0691bb3f51f573013ffbc962fec2d0
   ExpoBackgroundFetch: a06c553ecaf0bade0acd691042d996b9ce926327
   ExpoBattery: 4b21f628f2b70af3af66e83c566949ba9cc65eb1
   ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
@@ -2359,9 +2359,9 @@ SPEC CHECKSUMS:
   ExpoCalendar: 135beb39ea3795f854a4ea287a49f74c9203ce51
   ExpoCamera: 73221bf7176a6271c7367ac12b5c52b07c3e4175
   ExpoCellular: c903c51bb54cc7d3fa9f5c572d77e302b73203f1
-  ExpoClipboard: 23d203f5d4843699fbc45be1cc4fe1fbd811a6fa
+  ExpoClipboard: 6483bd23f5868c9e0a481f261f36aaa5d4f70082
   ExpoContacts: 605d517d1e7a8a3f12f736db67cc502c0dd22b53
-  ExpoCrypto: 156078f266bf28f80ecf5e2a9c3a0d6ffce07a1c
+  ExpoCrypto: 68fa06e232e1413199b5131a47bbb428d38016f8
   ExpoDevice: fc94f0e42ecdfd897e7590f2874fc64dfa7e9b1c
   ExpoDocumentPicker: 326d1d098a574d621ed2cc05296c9895f10eea44
   ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
@@ -2381,21 +2381,21 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 4eb2165cde325c8c121d495bb8beb0da9b30c92e
   ExpoModulesTestCore: 3d1007a5db579e867829b0f9cd4be07e29cf7c0c
   ExpoNetwork: 0d2c2504d56096fe8be3930d5c70cb3390dac5bf
-  ExpoPrint: 9e221bf0988c77c8a270a7df7135c65c2a396e0a
-  ExpoScreenCapture: ece7593264d1384aff2481eea29f9a238b484090
+  ExpoPrint: 0acb8b37c43634602ef20eec38dd108111736ef0
+  ExpoScreenCapture: b4e8b8a5ceeedfaed0a0572d8d6f55b4191feb98
   ExpoScreenOrientation: 5d6a977177dc2f904cc072b51a0d37d0983c0d6a
   ExpoSecureStore: 5f6b712785986b54d95a92bd365aabb82a52088e
-  ExpoSensors: 017b194af3c77db4dd552bc2763bddc24f1f6ae8
-  ExpoSharing: 8db05dd85081219f75989a3db2c92fe5e9741033
+  ExpoSensors: 3b5afeda6a10f062c7d071d984f890384b6d29ce
+  ExpoSharing: 97225e76c5261bec2d9bfce75cc35b589fb1fbba
   ExpoSMS: a5184fc4d4b33071b2dd9d43bb9ac8ef952b1dd7
   ExpoSpeech: 258ea713923eb70ef63d3bdb14f47a462d0b6f0e
   ExpoSQLite: 0091da247fdd8095f2cc213d98f812dba0ec7ca3
-  ExpoStoreReview: 15f9a636b62ff00bb21cbe9a9fe22f0239da4481
-  ExpoSymbols: 5adb1166f2929fc8d2497b98d5c48c4b94effe33
+  ExpoStoreReview: 3906c48e9b11eaee2f288a353eb69605fe17aeab
+  ExpoSymbols: fc85d6e697e3cc9b5e591a1913920266d7db8299
   ExpoSystemUI: b5ecc4b6781b6369fb8b3a0903bea36fae3dd090
   ExpoTrackingTransparency: 005340638bbd48449066a6c1a54ee44ae65ed7b4
   ExpoVideo: 73a2ca98c0c432fe81ede97816656d4246c0b450
-  ExpoVideoThumbnails: 40c737b2507a7470b14e9452e286513beb9a7d77
+  ExpoVideoThumbnails: 2ae80bf49c7e0b5cc65483d409e492b746d10881
   ExpoWebBrowser: 7595ccac6938eb65b076385fd23d035db9ecdc8e
   EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
@@ -2407,12 +2407,12 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 99a495094b10a57eeb3ae8efa1665700ad0bdaa6
   FirebaseCoreInternal: bca76517fe1ed381e989f5e7d8abb0da8d85bed3
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   Google-Maps-iOS-Utils: f77eab4c4326d7e6a277f8e23a0232402731913a
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: c8cd6a144dc677b571369ef3ccbeeb852d4e75d4
+  hermes-engine: 7ce5de1ca9c176b95a2134cf880d7759ea2b4cea
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -2511,4 +2511,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 08d42139077d6c9a60951d31532300d7f641d419
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -1780,18 +1780,18 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: d3f49c53809116a5d38da093a8aa78bf551aed09
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
+  boost: 26fad476bfa736552bbfa698a06cc530475c1505
+  DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   EASClient: 1509a9a6b48b932ec61667644634daf2562983b8
   EXAV: cb6e8dbcc40873d8a386af357e6c2eb55d6d739e
   EXConstants: 9a008dbf262550884e6280dea95b81b51f65ea6f
-  EXJSONUtils: 30c17fd9cc364d722c0946a550dfbf1be92ef6a4
+  EXJSONUtils: fa6c5cd41afdcec8f0eca28a78b96abb86c28493
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
   Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
   expo-dev-client: 5a76dfdc64875a076212f9d3ee9a897bdd735105
   expo-dev-launcher: 1aeeb4b01eedb074c02595e5ebdf36e614dbbb12
   expo-dev-menu: c2a473ef4478a775eb6f52d6c516141529ce2d33
-  expo-dev-menu-interface: be32c09f1e03833050f0ee290dcc86b3ad0e73e4
+  expo-dev-menu-interface: 3e97a7c7d79caff5f62acb00d053d4ec86d0ca1f
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
   ExpoAsset: 9b7433ecc5f1b608ccbb823492e062bde944abd2
   ExpoBlur: fa53f874e7b208bc3756d1bf07903c12e790beb1
@@ -1808,7 +1808,7 @@ SPEC CHECKSUMS:
   EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
   FBLazyVector: 4bc164e5b5e6cfc288d2b5ff28643ea15fa1a589
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 01d3e052018c2a13937aca1860fbedbccd4a41b7
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -1872,4 +1872,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 25935755ed1c35429ec96bdebc2a729def741e31
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2


### PR DESCRIPTION
# Why

Upgrading CocoaPods to the latest version

# How

- Updated version in `Gemfile`
- `bundle install`
- `pod install` in our apps

# Test Plan

CI passes