### PR TITLE
[docs] Fix section optional section headings in TypeScript guide and accordingly internal broken links

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -156,6 +156,7 @@ exceptions:
   - '.*OTA.*'
   - '.*OTF.*'
   - '.*Organizations.*'
+  - '.*Optional.*'
   - '.*Package.*'
   - '.*Personal Accounts.*'
   - '.*Performance Monitor.*'

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -33,7 +33,7 @@ Expo CLI commands provide several benefits over the similar commands in `@react-
 - View native logs directly in the terminal alongside JavaScript logs.
 - Improved native build log formatting using Expo CLI's `xcpretty`-style tool built specifically for React Native apps. For example, when compiling a Pod, you can see which Node module included it.
 - [First-class TypeScript support](/guides/typescript).
-- Support for **tsconfig.json** aliases with `paths` and `baseUrl` [built-in to Metro](/guides/typescript#path-aliases).
+- Support for **tsconfig.json** aliases with `paths` and `baseUrl` [built-in to Metro](/guides/typescript/#path-aliases-optional).
 - [Web support](/guides/customizing-metro/#adding-web-support-to-metro) with Metro. Fully typed for React Native Web.
 - Modern [CSS support](/versions/latest/config/metro#css) with Tailwind, PostCSS, CSS Modules, SASS, and more.
 - Static site generation with Expo Router and Metro web.

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -90,7 +90,7 @@ The default configuration in **tsconfig.json** is user-friendly and encourages a
 
 <Step label="4">
 
-### (Optional) Path aliases
+### Path aliases (Optional)
 
 Expo CLI supports [path aliases](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) in **tsconfig.json** automatically. It allows importing modules with custom aliases instead of relative paths.
 
@@ -153,7 +153,7 @@ When using path aliases, consider the following:
 
 <Step label="5">
 
-### (Optional) Absolute imports
+### Absolute imports (Optional)
 
 To enable absolute imports from a project's root directory, define [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) the **tsconfig.json** file:
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -24,8 +24,8 @@ If your app uses a custom `getPathFromState` or `getStateFromPath` component, it
 We recommend making the following modifications to your codebase before beginning the migration:
 
 - Split React Navigation screen components into individual files. For example, if you have `<Stack.Screen component={HomeScreen} />`, then ensure the `HomeScreen` class is in its own file.
-- Convert the project to [TypeScript](/guides/typescript#path-aliases). This will make it easier to spot errors that may occur during the migration.
-- Convert relative imports to [typed aliases](/guides/typescript#path-aliases). For example, `../../components/button.tsx` to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
+- Convert the project to [TypeScript](/guides/typescript/#path-aliases-optional). This will make it easier to spot errors that may occur during the migration.
+- Convert relative imports to [typed aliases](/guides/typescript/#path-aliases-optional). For example, `../../components/button.tsx` to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
 - Migrate away from `resetRoot`. This is used to "restart" the app while running. This is generally considered bad practice, and you should restructure your app's navigation so this never needs to happen.
 - Rename the initial route to `index`. Expo Router considers the route that is opened on launch to match `/`, React Navigation users will generally use something such as "Home" for the initial route.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -167,7 +167,7 @@ Making requests with an undefined method will automatically return `405: Method 
 
 API Routes are bundled with Expo CLI and [Metro bundler](/guides/customizing-metro). They have access to all of the language features as your client code:
 
-- [TypeScript](/guides/typescript) &mdash; types and [**tsconfig.json** paths](/guides/typescript#path-aliases).
+- [TypeScript](/guides/typescript) &mdash; types and [**tsconfig.json** paths](/guides/typescript/#path-aliases-optional).
 - [Environment variables](/guides/environment-variables) &mdash; server routes have access to all environment variables, not just the ones prefixed with `EXPO_PUBLIC_`.
 - Node.js standard library &mdash; ensure that you are using the correct version of Node.js locally for your server environment.
 - **babel.config.js** and **metro.config.js** support &mdash; settings work across both client and server code.

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -595,7 +595,7 @@ The `debugId` is a deterministic hash of the bundle's contents without the exter
 
 Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
-{/* If this isn't done, then features like [aliases](/guides/typescript#path-aliases), [absolute imports](/guides/typescript#absolute-imports), asset hashing, and more will not work. */}
+{/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 

--- a/docs/pages/versions/v49.0.0/config/metro.mdx
+++ b/docs/pages/versions/v49.0.0/config/metro.mdx
@@ -337,7 +337,7 @@ export default function Page() {
 
 Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
-{/* If this isn't done, then features like [aliases](/guides/typescript#path-aliases), [absolute imports](/guides/typescript#absolute-imports), asset hashing, and more will not work. */}
+{/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -587,7 +587,7 @@ The `debugId` is a deterministic hash of the bundle's contents without the exter
 
 Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
-{/* If this isn't done, then features like [aliases](/guides/typescript#path-aliases), [absolute imports](/guides/typescript#absolute-imports), asset hashing, and more will not work. */}
+{/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -595,7 +595,7 @@ The `debugId` is a deterministic hash of the bundle's contents without the exter
 
 Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
-{/* If this isn't done, then features like [aliases](/guides/typescript#path-aliases), [absolute imports](/guides/typescript#absolute-imports), asset hashing, and more will not work. */}
+{/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through Expo CLI guide in Bare section, found out that internal link to a section in TypeScript guide was broken (probably due to recent changes with the TypeScript guide). Found other instances too.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Fixes section headings for Path alias and Absolute imports which are optional to follow the pattern we do in other docs for consistency.
- Update `HeadingCase` guideline in Vale accordingly.
- Update broken internal links to fix links to these section in other docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
