### PR TITLE
[docs] Fix warnings produced by `yarn run lint-prose`

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -68,7 +68,7 @@ Save all of your changes. In Xcode, update the iOS Deployment Target under `Targ
   hideBareInstructions
 />
 
-### Configure Expo CLI for bundling on iOS and Android
+### Configure Expo CLI for bundling on Android and iOS
 
 We recommend using Expo CLI to bundle your app JavaScript code and assets. This adds support for using the `"main"` field in **package.json** supports [Expo Router](/router/introduction/). Not using Expo CLI for bundling may result in unexpected behavior. [Learn more about Expo CLI](/bare/using-expo-cli/).
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -11,7 +11,7 @@ import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
 ## Builder IP addresses
 
-A list of the IP addresses of the build servers is available [here](https://expo.dev/eas-build-worker-ips.txt). We do not expect to change the list often. Every time we improve the infrastructure and do need to update the IPs, we will also update the timestamp in the header of the file.
+A list of the IP addresses of the build servers is available [in this file](https://expo.dev/eas-build-worker-ips.txt). We do not expect to change the list often. Every time we improve the infrastructure and do need to update the IPs, we will also update the timestamp in the header of the file.
 
 Linux runners are hosted in Google Cloud Platform. macOS runners are hosted in our own macOS cloud.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix existing warnings produced by Vale linting process.

![CleanShot 2024-06-30 at 01 56 54](https://github.com/expo/expo/assets/10234615/4380d1f3-b87e-4bd4-89c7-d00a9f677892)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running `yarn run lint-prose`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
