### PR TITLE
refactor(cli): monitor and exit `expo export` after delay

### DIFF
--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -6,6 +6,7 @@ import * as Log from '../log';
 import { waitUntilAtlasExportIsReadyAsync } from '../start/server/metro/debugging/attachAtlas';
 import { FileNotifier } from '../utils/FileNotifier';
 import { ensureDirectoryAsync, removeAsync } from '../utils/dir';
+import { ensureProcessExitsAfterDelay } from '../utils/exit';
 
 export async function exportAsync(projectRoot: string, options: Options) {
   // Ensure the output directory is created
@@ -28,5 +29,5 @@ export async function exportAsync(projectRoot: string, options: Options) {
   Log.log(`App exported to: ${options.outputDir}`);
 
   // Exit the process to stop any hanging processes from reading the app.config.js or server rendering.
-  process.exit(0);
+  ensureProcessExitsAfterDelay();
 }


### PR DESCRIPTION
# Why

Instead of force-closing the process, this gives the process a bit of time before exiting. With this, we could catch problems around open handles and send telemetry info if they start happening again.

The telemetry would be more useful if we also capture dependencies whenever this happens, e.g. `@sentry/react-native` was known to freeze static rendering export ([fixed here](https://github.com/getsentry/sentry-react-native/pull/3730))

# How

- Added `ensureProcessExitsAfterDelay`
  - This is a simple `setTimeout` with a maximum delay of 10s
  - It uses [`process.getActiveResourcesInfo()`](https://nodejs.org/docs/latest-v18.x/api/process.html#processgetactiveresourcesinfo)
  - Logs resource information through debug logs (no telemetry yet)


# Test Plan

`DEBUG=expo:utils:exit expod export ...` should show:

![image](https://github.com/expo/expo/assets/1203991/9c7a0a8f-33aa-4a9c-9894-427e3c4786fe)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
