### PR TITLE
[docs] Fix icons not showing in BoxLink in Fonts guide

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -11,7 +11,7 @@ import { Step } from '~/ui/components/Step';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { CODE } from '~/ui/components/Text';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 Android and iOS come with their own set of platform fonts. To provide a consistent user experience and enhance your app's branding, you can use custom fonts.
 
@@ -328,7 +328,11 @@ Use the font on the `<Text>` by using `fontFamily` style prop in a React compone
 ### Minimal example
 
 <BoxLink
-  title="Expo Fonts usage"
+  title={
+    <>
+      <CODE>expo-font</CODE> usage
+    </>
+  }
   description="See usage section in Expo Fonts API reference for a minimal example of using a custom font."
   href="/versions/latest/sdk/font/#usage"
   Icon={BookOpen02Icon}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR:
- Fixes import statement for using `BookOpen02Icon` not displaying in `BoxLink`.
- Also uses syntax highlight when referencing library name in the `BoxLink` title

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and visiting: http://localhost:3002/develop/user-interface/fonts/#additional-information

## Preview

![CleanShot 2024-06-30 at 03 09 55](https://github.com/expo/expo/assets/10234615/a38b9edd-dbfa-46eb-b957-bbe99c84b270)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
