### PR TITLE
[docs] Fix typos on fonts guide

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -62,7 +62,7 @@ To embed a font in a project, follow the steps below:
 
 After adding a custom font file in your project, install the `expo-font` library.
 
-<Terminal cmd={['$ npm expo install expo-font']} />
+<Terminal cmd={['$ npx expo install expo-font']} />
 
 </Step>
 
@@ -134,7 +134,7 @@ It works with all Expo SDK versions and with Expo Go. To load a font in a projec
 
 After adding a custom font file in your project, install the `expo-font` and `expo-splash-screen` libraries.
 
-<Terminal cmd={['$ npm expo install expo-font expo-splash-screen']} />
+<Terminal cmd={['$ npx expo install expo-font expo-splash-screen']} />
 
 The [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) library provides `SplashScreen` component that you can use to prevent rendering the app until the font is loaded and ready.
 
@@ -268,7 +268,7 @@ Each google Fonts package provides the `useFonts` hook to load the fonts asynchr
 
 Install the Google Fonts package, `expo-font` and `expo-splash-screen` libraries.
 
-<Terminal cmd={['$ npm expo install @expo-google-fonts/inter expo-font expo-splash-screen']} />
+<Terminal cmd={['$ npx expo install @expo-google-fonts/inter expo-font expo-splash-screen']} />
 
 The [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) library provides `SplashScreen` component that you can use to prevent rendering the app until the font is loaded and ready.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Wrong guide for fonts

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fixed `npm expo` to  `npx expo`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
