### PR TITLE
[docs] add local caching for lint command

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -28,8 +28,6 @@ concurrency:
 jobs:
   docs-pr:
     runs-on: ubuntu-22.04
-    env:
-      NODE_ENV: production
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -50,6 +48,8 @@ jobs:
       - name: 🧪 Run Docs tests
         run: yarn test
       - name: 🚨 Lint Docs website code
+        env:
+          NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
         run: yarn lint-prose

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -28,6 +28,8 @@ concurrency:
 jobs:
   docs-pr:
     runs-on: ubuntu-22.04
+    env:
+      NODE_ENV: production
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,6 @@ concurrency:
 jobs:
   docs:
     runs-on: ubuntu-22.04
-    env:
-      NODE_ENV: production
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -53,6 +51,8 @@ jobs:
         run: yarn test
       - name: 🚨 Lint Docs website code
         working-directory: docs
+        env:
+          NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,8 @@ concurrency:
 jobs:
   docs:
     runs-on: ubuntu-22.04
+    env:
+      NODE_ENV: production
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 out/
 *.tsbuildinfo
+.eslintcache
 
 # copied in next.config.js
 pages/versions/latest/

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
-    "lint": "tsc --noEmit && eslint . --ext js,cjs,ts,jsx,tsx,md,mdx",
+    "lint": "tsc --noEmit && node scripts/lint.js",
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "vale .",
     "watch": "tsc --noEmit -w",

--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+
+const isDev = process.env.NODE_ENV !== 'production';
+const scriptArgs = process.argv.slice(2);
+
+const { status, stderr } = spawnSync(
+  'eslint',
+  isDev
+    ? [
+        process.cwd(),
+        '--ext=js,cjs,ts,jsx,tsx,md,mdx',
+        '--exit-on-fatal-error',
+        '--cache',
+        '--cache-location',
+        '.eslintcache',
+        ...scriptArgs,
+      ]
+    : [process.cwd(), '--ext=js,cjs,ts,jsx,tsx,md,mdx', '--exit-on-fatal-error', ...scriptArgs],
+  { stdio: ['inherit', 'inherit', 'pipe'] }
+);
+
+if (stderr.byteLength > 0) {
+  console.error(`\x1b[31m${stderr.toString()}\x1b[0m`);
+}
+
+process.exit(status);


### PR DESCRIPTION
# Why

With recent Prettier merge with ESLint and adding MDX files to lint scopes the check locally can take between 20-25s. We can speed this us by starting leveraging ESLint cache option, however, we cannot relay on that on CI checks.

Refs:
* #30064

# How

Introduce simple lint script, which based on the Node environment variable appends the cache parameters before executing lint command.

# Test Plan

Correct files are linted, all checks are passing.

Now it's time to confirm that CI works as expected.

# Preview

Initial run on `main`, then run using locally created cache. The cache will be partially invalidated on branch switch, or when modifying a lot of files at the same time, so the check time might vary, but most of the runs should be closer to 3s than 25s.

![Screenshot 2024-07-01 at 13 13 08](https://github.com/expo/expo/assets/719641/0eb940f9-69df-474d-8e96-b0f27ff6499c)

