### PR TITLE
[core][Android] Decouple modules state from `AppContext`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -41,7 +41,7 @@
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - [iOS] Stop throwing runtime errors when the promise is settled more than once. ([#30000](https://github.com/expo/expo/pull/30000) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android. ([#30061](https://github.com/expo/expo/pull/30061) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Decouple the modules state from the `AppContext`
+- [Android] Decouple the modules state from the `AppContext` ([#30098](https://github.com/expo/expo/pull/30098) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [iOS] Exposed `Utilities` class for Expo Modules common tasks. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
 - [iOS] Stop throwing runtime errors when the promise is settled more than once. ([#30000](https://github.com/expo/expo/pull/30000) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android. ([#30061](https://github.com/expo/expo/pull/30061) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Decouple the modules state from the `AppContext`
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
@@ -15,7 +15,7 @@ class JNIDeallocatorTest {
   ) {
     val moduleObject = evaluateScript("expo.modules.TestModule")
 
-    val deallocator = appContextHolder.get()!!.jniDeallocator
+    val deallocator = runtimeContextHolder.get()!!.jniDeallocator
 
     Truth.assertThat(deallocator.inspectMemory()).contains(moduleObject)
   }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -41,7 +41,7 @@ private fun defaultAppContextMock(): Pair<AppContext, RuntimeContext> {
   every { runtimeContext.classRegistry } answers { ClassRegistry() }
   every { runtimeContext.appContext } answers { appContextMock }
   every { appContextMock.findView<View>(capture(slot())) } answers { mockk() }
-  every { appContextMock.hostingContext } answers { runtimeContext }
+  every { appContextMock.hostingRuntimeContext } answers { runtimeContext }
 
   return appContextMock to runtimeContext
 }
@@ -86,12 +86,12 @@ internal inline fun withJSIInterop(
     functionSlot.captured.invoke()
   }
 
-  val registry = ModuleRegistry(appContextMock.hostingContext.weak()).apply {
+  val registry = ModuleRegistry(appContextMock.hostingRuntimeContext.weak()).apply {
     modules.forEach {
       register(it)
     }
   }
-  val sharedObjectRegistry = SharedObjectRegistry(appContextMock.hostingContext)
+  val sharedObjectRegistry = SharedObjectRegistry(appContextMock.hostingRuntimeContext)
   every { appContextMock.registry } answers { registry }
   every { runtimeContext.registry } answers { registry }
   every { runtimeContext.sharedObjectRegistry } answers { sharedObjectRegistry }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -90,8 +90,8 @@ class JavaScriptClassTest {
       val jsObject = callClass("MySharedObject").getObject()
       val id = SharedObjectId(jsObject.getProperty(sharedObjectIdPropertyName).getInt())
 
-      val appContext = jsiInterop.appContextHolder.get()!!
-      val (native, _) = appContext.sharedObjectRegistry.pairs[id]!!
+      val runtimeContext = jsiInterop.runtimeContextHolder.get()!!
+      val (native, _) = runtimeContext.sharedObjectRegistry.pairs[id]!!
       Truth.assertThat(native).isSameInstanceAs(mySharedObject)
     }
   }
@@ -155,7 +155,7 @@ class JavaScriptClassTest {
     }) {
       val jsObject = callClass("MySharedObject").getObject()
       id = SharedObjectId(jsObject.getProperty(sharedObjectIdPropertyName).getInt())
-      registry = jsiInterop.appContextHolder.get()?.sharedObjectRegistry
+      registry = jsiInterop.runtimeContextHolder.get()?.sharedObjectRegistry
     }
 
     Truth.assertThat(registry!!.pairs[id!!]).isNull()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -53,7 +53,7 @@ class SharedObjectTest {
     val sharedObject = callClass("SharedObjectExampleClass")
     val sharedObjectId = sharedObject.getObject().getProperty(sharedObjectIdPropertyName).getInt()
     val containSharedObject = jsiInterop
-      .appContextHolder
+      .runtimeContextHolder
       .get()
       ?.sharedObjectRegistry
       ?.pairs
@@ -94,7 +94,7 @@ class SharedObjectTest {
 
     // Get the native instance
     val nativeObject = jsiInterop
-      .appContextHolder
+      .runtimeContextHolder
       .get()
       ?.sharedObjectRegistry
       ?.toNativeObject(jsObject)

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "RuntimeHolder.h"
 #include "JSIContext.h"
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
@@ -27,6 +28,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaReferencesCache::instance()->loadJClasses(jni::Environment::current());
     expo::FrontendConverterProvider::instance()->createConverters();
 
+    expo::RuntimeHolder::registerNatives();
     expo::JSIContext::registerNatives();
     expo::JavaScriptModuleObject::registerNatives();
     expo::JavaScriptValue::registerNatives();

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -72,13 +72,6 @@ public:
 #endif
 
   /**
-   * Initializes the test runtime. Shouldn't be used in the production.
-   */
-  void installJSIForTests(
-    jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator
-  );
-
-  /**
    * Gets a module for a given name. It will throw an exception if the module doesn't exist.
    *
    * @param moduleName

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -30,13 +30,6 @@ class JSIContext;
  */
 class JavaScriptRuntime : public std::enable_shared_from_this<JavaScriptRuntime> {
 public:
-  /**
-   * Initializes a runtime that is independent from React Native and its runtime initialization.
-   * This flow is mostly intended for tests. The JS call invoker is set to `SyncCallInvoker`.
-   * See **JavaScriptRuntime.cpp** for the `SyncCallInvoker` implementation.
-   */
-  JavaScriptRuntime();
-
   JavaScriptRuntime(
     jsi::Runtime *runtime,
     std::shared_ptr<react::CallInvoker> jsInvoker

--- a/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.cpp
@@ -1,0 +1,111 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "RuntimeHolder.h"
+
+#if UNIT_TEST
+
+#include "TestingSyncJSCallInvoker.h"
+
+#if USE_HERMES
+
+#include <hermes/hermes.h>
+
+#include <utility>
+
+#else
+
+#include <jsc/JSCRuntime.h>
+
+#endif
+
+#endif // UNIT_TEST
+
+namespace expo {
+
+void RuntimeHolder::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("initHybrid", RuntimeHolder::initHybrid),
+                   makeNativeMethod("createRuntime", RuntimeHolder::createRuntime),
+                   makeNativeMethod("createCallInvoker", RuntimeHolder::createCallInvoker),
+                   makeNativeMethod("release", RuntimeHolder::release),
+                 });
+}
+
+jni::local_ref<RuntimeHolder::jhybriddata> RuntimeHolder::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance();
+}
+
+jlong RuntimeHolder::createRuntime() {
+#if !UNIT_TEST
+  throw std::logic_error(
+    "The RuntimeHolder constructor is only available when UNIT_TEST is defined.");
+#else
+#if USE_HERMES
+  auto config = ::hermes::vm::RuntimeConfig::Builder()
+    .withEnableSampleProfiling(false);
+  runtime = facebook::hermes::makeHermesRuntime(config.build());
+
+  // This version of the Hermes uses a Promise implementation that is provided by the RN.
+  // The `setImmediate` function isn't defined, but is required by the Promise implementation.
+  // That's why we inject it here.
+  auto setImmediatePropName = jsi::PropNameID::forUtf8(*runtime, "setImmediate");
+  runtime->global().setProperty(
+    *runtime,
+    setImmediatePropName,
+    jsi::Function::createFromHostFunction(
+      *runtime,
+      setImmediatePropName,
+      1,
+      [](jsi::Runtime &rt,
+         const jsi::Value &thisVal,
+         const jsi::Value *args,
+         size_t count) {
+        args[0].asObject(rt).asFunction(rt).call(rt);
+        return jsi::Value::undefined();
+      }
+    )
+  );
+#else
+  runtime = facebook::jsc::makeJSCRuntime();
+#endif
+
+  // By default "global" property isn't set.
+  runtime->global().setProperty(
+    *runtime,
+    jsi::PropNameID::forUtf8(*runtime, "global"),
+    runtime->global()
+  );
+
+  // Mock the CodedError that in a typical scenario will be defined by the `expo-modules-core`.
+  // Note: we can't use `class` syntax here, because Hermes doesn't support it.
+  runtime->evaluateJavaScript(
+    std::make_shared<jsi::StringBuffer>(
+      "function CodedError(code, message) {\n"
+      "    this.code = code;\n"
+      "    this.message = message;\n"
+      "    this.stack = (new Error).stack;\n"
+      "}\n"
+      "CodedError.prototype = new Error;\n"
+      "global.ExpoModulesCore_CodedError = CodedError"
+    ),
+    "<<evaluated>>"
+  );
+
+  return reinterpret_cast<jlong>(runtime.get());
+#endif
+}
+
+void RuntimeHolder::release() {
+  runtime.reset();
+}
+
+jni::local_ref<react::CallInvokerHolder::javaobject> RuntimeHolder::createCallInvoker() {
+#if !UNIT_TEST
+  throw std::logic_error(
+    "The RuntimeHolder::createCallInvoker is only available when UNIT_TEST is defined.");
+#else
+  return react::CallInvokerHolder::newObjectCxxArgs(std::make_shared<TestingSyncJSCallInvoker>(runtime));
+#endif
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.h
@@ -1,0 +1,39 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <ReactCommon/CallInvokerHolder.h>
+#include <ReactCommon/CallInvoker.h>
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+class RuntimeHolder : public jni::HybridClass<RuntimeHolder> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/tests/RuntimeHolder;";
+  static auto constexpr TAG = "RuntimeHolder";
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+  static void registerNatives();
+
+  jlong createRuntime();
+
+  void release();
+
+  jni::local_ref<react::CallInvokerHolder::javaobject> createCallInvoker();
+
+private:
+  friend HybridBase;
+
+  std::shared_ptr<jsi::Runtime> runtime;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -9,8 +9,6 @@ import android.view.View
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.common.annotations.FrameworkAPI
-import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.common.UIManagerType
@@ -18,7 +16,6 @@ import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.core.errors.ContextDestroyedException
 import expo.modules.core.errors.ModuleNotFoundException
 import expo.modules.core.interfaces.ActivityProvider
-import expo.modules.core.utilities.ifNull
 import expo.modules.interfaces.barcodescanner.BarCodeScannerInterface
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -30,7 +27,6 @@ import expo.modules.interfaces.permissions.Permissions
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.activityresult.ActivityResultsManager
 import expo.modules.kotlin.activityresult.DefaultAppContextActivityResultCaller
-import expo.modules.kotlin.defaultmodules.CoreModule
 import expo.modules.kotlin.defaultmodules.ErrorManagerModule
 import expo.modules.kotlin.defaultmodules.NativeModulesProxyModule
 import expo.modules.kotlin.events.EventEmitter
@@ -39,12 +35,8 @@ import expo.modules.kotlin.events.KEventEmitterWrapper
 import expo.modules.kotlin.events.KModuleEventEmitterWrapper
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.exception.Exceptions
-import expo.modules.kotlin.jni.JNIDeallocator
-import expo.modules.kotlin.jni.JSIContext
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.providers.CurrentActivityProvider
-import expo.modules.kotlin.sharedobjects.ClassRegistry
-import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -58,30 +50,16 @@ import java.lang.ref.WeakReference
 class AppContext(
   modulesProvider: ModulesProvider,
   val legacyModuleRegistry: expo.modules.core.ModuleRegistry,
-  private val reactContextHolder: WeakReference<ReactApplicationContext>
+  reactContextHolder: WeakReference<ReactApplicationContext>
 ) : CurrentActivityProvider {
-  val registry = ModuleRegistry(WeakReference(this))
+
+  // The main context used in the app.
+  // Modules attached to this context will be available on the main js context.
+  val hostingContext = RuntimeContext(this, reactContextHolder)
+
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
 
   private var hostWasDestroyed = false
-
-  // We postpone creating the `JSIContext` to not load so files in unit tests.
-  internal lateinit var jsiInterop: JSIContext
-
-  /**
-   * The core module that defines the `expo` object in the global scope of the JS runtime.
-   *
-   * Note: in current implementation this module won't receive any events.
-   */
-  internal val coreModule = run {
-    val module = CoreModule()
-    module._appContext = this
-    ModuleHolder(module)
-  }
-
-  internal val sharedObjectRegistry = SharedObjectRegistry(this)
-
-  internal val classRegistry = ClassRegistry()
 
   private val modulesQueueDispatcher = HandlerThread("expo.modules.AsyncFunctionQueue")
     .apply { start() }
@@ -112,7 +90,8 @@ class AppContext(
       CoroutineName("expo.modules.MainQueue")
   )
 
-  val jniDeallocator: JNIDeallocator = JNIDeallocator()
+  val registry
+    get() = hostingContext.registry
 
   internal var legacyModulesProxyHolder: WeakReference<NativeModulesProxy>? = null
 
@@ -129,62 +108,24 @@ class AppContext(
       // Registering modules has to happen at the very end of `AppContext` creation. Some modules need to access
       // `AppContext` during their initialisation, so we need to ensure all `AppContext`'s
       // properties are initialized first. Not having that would trigger NPE.
-      registry.register(ErrorManagerModule())
-      registry.register(NativeModulesProxyModule())
-      registry.register(modulesProvider)
+      hostingContext.registry.register(ErrorManagerModule())
+      hostingContext.registry.register(NativeModulesProxyModule())
+      hostingContext.registry.register(modulesProvider)
 
       logger.info("✅ AppContext was initialized")
     }
   }
 
   fun onCreate() = trace("AppContext.onCreate") {
-    registry.postOnCreate()
+    hostingContext.registry.postOnCreate()
   }
 
   /**
    * Initializes a JSI part of the module registry.
    * It will be a NOOP if the remote debugging was activated.
    */
-  @OptIn(FrameworkAPI::class)
-  fun installJSIInterop() = synchronized(this) {
-    if (::jsiInterop.isInitialized) {
-      logger.warn("⚠️ JSI interop was already installed")
-      return
-    }
-
-    trace("AppContext.installJSIInterop") {
-      try {
-        jsiInterop = JSIContext()
-        val reactContext = reactContextHolder.get() ?: return@trace
-        val jsContextHolder = reactContext.javaScriptContextHolder?.get() ?: return@trace
-
-        val jsRuntimePointer = jsContextHolder.takeIf { it != 0L }.ifNull {
-          logger.error("❌ Cannot install JSI interop - JS runtime pointer is null")
-          return@trace
-        }
-
-        @Suppress("DEPRECATION")
-        if (reactContext.isBridgeless) {
-          jsiInterop.installJSIForBridgeless(
-            this,
-            jsRuntimePointer,
-            jniDeallocator,
-            reactContext.runtimeExecutor!!
-          )
-        } else {
-          jsiInterop.installJSI(
-            this,
-            jsRuntimePointer,
-            jniDeallocator,
-            reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl
-          )
-        }
-
-        logger.info("✅ JSI interop was installed")
-      } catch (e: Throwable) {
-        logger.error("❌ Cannot install JSI interop: $e", e)
-      }
-    }
+  fun installJSIInterop() {
+    hostingContext.installJSIContext()
   }
 
   /**
@@ -276,13 +217,13 @@ class AppContext(
    * Provides access to the react application context
    */
   val reactContext: Context?
-    get() = reactContextHolder.get()
+    get() = hostingContext.reactContext
 
   /**
    * @return true if there is an non-null, alive react native instance
    */
   val hasActiveReactInstance: Boolean
-    get() = reactContextHolder.get()?.hasActiveReactInstance() ?: false
+    get() = hostingContext.reactContext?.hasActiveReactInstance() ?: false
 
   /**
    * Provides access to the event emitter
@@ -291,11 +232,11 @@ class AppContext(
     val legacyEventEmitter = legacyModule<expo.modules.core.interfaces.services.EventEmitter>()
       ?: return null
     return KModuleEventEmitterWrapper(
-      requireNotNull(registry.getModuleHolder(module)) {
+      requireNotNull(hostingContext.registry.getModuleHolder(module)) {
         "Cannot create an event emitter for the module that isn't present in the module registry."
       },
       legacyEventEmitter,
-      reactContextHolder
+      hostingContext.reactContextHolder
     )
   }
 
@@ -303,21 +244,20 @@ class AppContext(
     get() {
       val legacyEventEmitter = legacyModule<expo.modules.core.interfaces.services.EventEmitter>()
         ?: return null
-      return KEventEmitterWrapper(legacyEventEmitter, reactContextHolder)
+      return KEventEmitterWrapper(legacyEventEmitter, hostingContext.reactContextHolder)
     }
 
   val errorManager: ErrorManagerModule?
-    get() = registry.getModule()
+    get() = hostingContext.registry.getModule()
 
   internal fun onDestroy() = trace("AppContext.onDestroy") {
-    reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
-    registry.post(EventName.MODULE_DESTROY)
-    registry.cleanUp()
-    coreModule.module._appContext = null
+    hostingContext.reactContext?.removeLifecycleEventListener(reactLifecycleDelegate)
+    hostingContext.registry.post(EventName.MODULE_DESTROY)
+    hostingContext.registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
     backgroundCoroutineScope.cancel(ContextDestroyedException())
-    jniDeallocator.deallocate()
+    hostingContext.deallocate()
     logger.info("✅ AppContext was destroyed")
   }
 
@@ -330,15 +270,15 @@ class AppContext(
     // We need to re-register activity contracts when reusing AppContext with new Activity after host destruction.
     if (hostWasDestroyed) {
       hostWasDestroyed = false
-      registry.registerActivityContracts()
+      hostingContext.registry.registerActivityContracts()
     }
 
     activityResultsManager.onHostResume(activity)
-    registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
+    hostingContext.registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
   }
 
   internal fun onHostPause() {
-    registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
+    hostingContext.registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
   }
 
   internal fun onHostDestroy() {
@@ -349,7 +289,7 @@ class AppContext(
 
       activityResultsManager.onHostDestroy(it)
     }
-    registry.post(EventName.ACTIVITY_DESTROYS)
+    hostingContext.registry.post(EventName.ACTIVITY_DESTROYS)
     // The host (Activity) was destroyed, but it doesn't mean that modules will be destroyed too.
     // So we save that information, and we will re-register activity contracts when the host will be resumed with new Activity.
     hostWasDestroyed = true
@@ -357,7 +297,7 @@ class AppContext(
 
   internal fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
     activityResultsManager.onActivityResult(requestCode, resultCode, data)
-    registry.post(
+    hostingContext.registry.post(
       EventName.ON_ACTIVITY_RESULT,
       activity,
       OnActivityResultPayload(
@@ -369,7 +309,7 @@ class AppContext(
   }
 
   internal fun onNewIntent(intent: Intent?) {
-    registry.post(
+    hostingContext.registry.post(
       EventName.ON_NEW_INTENT,
       intent
     )
@@ -378,12 +318,12 @@ class AppContext(
   @Suppress("UNCHECKED_CAST")
   @UiThread
   fun <T : View> findView(viewTag: Int): T? {
-    val reactContext = reactContextHolder.get() ?: return null
+    val reactContext = hostingContext.reactContext ?: return null
     return UIManagerHelper.getUIManagerForReactTag(reactContext, viewTag)?.resolveView(viewTag) as? T
   }
 
   internal fun dispatchOnMainUsingUIManager(block: () -> Unit) {
-    val reactContext = reactContextHolder.get() ?: throw Exceptions.ReactContextLost()
+    val reactContext = hostingContext.reactContext ?: throw Exceptions.ReactContextLost()
     val uiManager = UIManagerHelper.getUIManagerForReactTag(
       reactContext,
       UIManagerType.DEFAULT
@@ -402,7 +342,7 @@ class AppContext(
    * Runs a code block on the JavaScript thread.
    */
   fun executeOnJavaScriptThread(runnable: Runnable) {
-    reactContextHolder.get()?.runOnJSQueueThread(runnable)
+    hostingContext.reactContext?.runOnJSQueueThread(runnable)
   }
 
 // region CurrentActivityProvider

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -22,7 +22,7 @@ class KotlinInteropModuleRegistry(
   val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
 
   private val registry: ModuleRegistry
-    get() = appContext.registry
+    get() = appContext.hostingContext.registry
 
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -22,7 +22,7 @@ class KotlinInteropModuleRegistry(
   val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
 
   private val registry: ModuleRegistry
-    get() = appContext.hostingContext.registry
+    get() = appContext.hostingRuntimeContext.registry
 
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -39,7 +39,8 @@ class ModuleHolder<T : Module>(val module: T) {
 
     trace("$name.jsObject") {
       val appContext = module.appContext
-      val jniDeallocator = appContext.jniDeallocator
+      val runtimeContext = module.runtimeContext
+      val jniDeallocator = runtimeContext.jniDeallocator
 
       val moduleDecorator = JSDecoratorsBridgingObject(jniDeallocator)
       attachPrimitives(appContext, definition.objectDefinition, moduleDecorator, name)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.SupervisorJob
 import java.lang.ref.WeakReference
 
 class ModuleRegistry(
-  private val appContext: WeakReference<AppContext>
+  private val runtimeContext: WeakReference<RuntimeContext>
 ) : Iterable<ModuleHolder<*>> {
   @PublishedApi
   internal val registry = mutableMapOf<String, ModuleHolder<*>>()
@@ -21,7 +21,7 @@ class ModuleRegistry(
   private var isReadyForPostingEvents = false
 
   fun <T : Module> register(module: T) = trace("ModuleRegistry.register(${module.javaClass})") {
-    module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
+    module._runtimeContext = requireNotNull(runtimeContext.get()) { "Cannot create a module for invalid runtime context." }
 
     val holder = ModuleHolder(module)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
@@ -1,0 +1,103 @@
+package expo.modules.kotlin
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.annotations.FrameworkAPI
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.core.utilities.ifNull
+import expo.modules.kotlin.defaultmodules.CoreModule
+import expo.modules.kotlin.jni.JNIDeallocator
+import expo.modules.kotlin.jni.JSIContext
+import expo.modules.kotlin.sharedobjects.ClassRegistry
+import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
+import expo.modules.kotlin.tracing.trace
+import java.lang.ref.WeakReference
+
+/**
+ * A context that holds the state of modules bounded to the JS runtime.
+ */
+class RuntimeContext(
+  appContext: AppContext,
+  val reactContextHolder: WeakReference<ReactApplicationContext>
+) {
+  private val appContextHolder = appContext.weak()
+
+  val appContext: AppContext?
+    get() = appContextHolder.get()
+
+  inline val reactContext: ReactApplicationContext?
+    get() = reactContextHolder.get()
+
+  val registry = ModuleRegistry(this.weak())
+
+  internal lateinit var jsiContext: JSIContext
+
+  private fun isJSIContextInitialized(): Boolean {
+    return this::jsiContext.isInitialized
+  }
+
+  /**
+   * The core module that defines the `expo` object in the global scope of the JS runtime.
+   *
+   * Note: in current implementation this module won't receive any events.
+   */
+  internal val coreModule = run {
+    val module = CoreModule()
+    module._runtimeContext = this
+    ModuleHolder(module)
+  }
+
+  val jniDeallocator: JNIDeallocator = JNIDeallocator()
+
+  internal val sharedObjectRegistry = SharedObjectRegistry(this)
+
+  internal val classRegistry = ClassRegistry()
+
+  /**
+   * Initializes a JSI part of the module registry.
+   * It will be a NOOP if the remote debugging was activated.
+   */
+  @OptIn(FrameworkAPI::class)
+  fun installJSIContext() = synchronized(this) {
+    if (isJSIContextInitialized()) {
+      logger.warn("⚠️ JSI interop was already installed")
+      return
+    }
+
+    trace("$this.installJSIContext") {
+      try {
+        jsiContext = JSIContext()
+        val reactContext = reactContextHolder.get() ?: return@trace
+        val jsContextHolder = reactContext.javaScriptContextHolder?.get() ?: return@trace
+
+        val jsRuntimePointer = jsContextHolder.takeIf { it != 0L }.ifNull {
+          logger.error("❌ Cannot install JSI interop - JS runtime pointer is null")
+          return@trace
+        }
+
+        @Suppress("DEPRECATION")
+        if (reactContext.isBridgeless) {
+          jsiContext.installJSIForBridgeless(
+            this,
+            jsRuntimePointer,
+            reactContext.runtimeExecutor!!
+          )
+        } else {
+          jsiContext.installJSI(
+            this,
+            jsRuntimePointer,
+            reactContext.catalystInstance.jsCallInvokerHolder as CallInvokerHolderImpl
+          )
+        }
+
+        logger.info("✅ JSI interop was installed")
+      } catch (e: Throwable) {
+        logger.error("❌ Cannot install JSI interop: $e", e)
+      }
+    }
+  }
+
+  fun deallocate() {
+    coreModule.module._runtimeContext = null
+    jniDeallocator.deallocate()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -29,7 +29,7 @@ class CoreModule : Module() {
     }
 
     Function("getViewConfig") { viewName: String ->
-      val holder = appContext.registry.getModuleHolder(viewName)
+      val holder = runtimeContext.registry.getModuleHolder(viewName)
         ?: return@Function null
 
       val viewManagerDefinition = holder.definition.viewManagerDefinition

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -45,10 +45,10 @@ class KModuleEventEmitterWrapper(
   }
 
   private fun emitNative(eventName: String, eventBody: ReadableNativeMap?) {
-    val appContext = moduleHolder.module.appContext
+    val runtimeContext = moduleHolder.module.runtimeContext
     val jsObject = moduleHolder.safeJSObject ?: return
     try {
-      JNIUtils.emitEvent(jsObject, appContext.jsiInterop, eventName, eventBody)
+      JNIUtils.emitEvent(jsObject, runtimeContext.jsiContext, eventName, eventBody)
     } catch (e: Exception) {
       // If the jsObject is valid, we should throw an exception.
       // Otherwise, we should ignore it.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -13,6 +13,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.weak
 import kotlinx.coroutines.launch
 
 /**
@@ -54,7 +55,7 @@ abstract class AsyncFunction(
   internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext)
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
-    val appContextHolder = appContext.jsiInterop.appContextHolder
+    val appContextHolder = appContext.weak()
     jsObject.registerAsyncFunction(
       name,
       takesOwner,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -12,6 +12,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.weak
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -48,7 +49,7 @@ class SuspendFunctionComponent(
   }
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JSDecoratorsBridgingObject, moduleName: String) {
-    val appContextHolder = appContext.jsiInterop.appContextHolder
+    val appContextHolder = appContext.weak()
     jsObject.registerAsyncFunction(
       name,
       takesOwner,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIDeallocator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JNIDeallocator.kt
@@ -11,7 +11,7 @@ interface Destructible {
 }
 
 @DoNotStrip
-class JNIDeallocator(shouldCreateDestructorThread: Boolean = true) {
+class JNIDeallocator(shouldCreateDestructorThread: Boolean = true) : AutoCloseable {
   /**
    * A [PhantomReference] queue managed by JVM
    */
@@ -78,5 +78,9 @@ class JNIDeallocator(shouldCreateDestructorThread: Boolean = true) {
    */
   fun inspectMemory() = synchronized(this) {
     destructorMap.values.mapNotNull { it.get() }
+  }
+
+  override fun close() {
+    deallocate()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -6,7 +6,7 @@ import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.sharedobjects.SharedObjectId
@@ -20,8 +20,9 @@ import java.lang.ref.WeakReference
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JSIContext : Destructible {
-  internal lateinit var appContextHolder: WeakReference<AppContext> // = WeakReference(appContext)
+class JSIContext : Destructible, AutoCloseable {
+  @VisibleForTesting
+  lateinit var runtimeContextHolder: WeakReference<RuntimeContext>
 
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip
@@ -31,29 +32,27 @@ class JSIContext : Destructible {
 
   @OptIn(FrameworkAPI::class)
   fun installJSI(
-    appContext: AppContext,
+    runtimeContext: RuntimeContext,
     jsRuntimePointer: Long,
-    jniDeallocator: JNIDeallocator,
     jsInvokerHolder: CallInvokerHolderImpl
   ) {
-    appContextHolder = appContext.weak()
+    runtimeContextHolder = runtimeContext.weak()
     installJSI(
       jsRuntimePointer,
-      jniDeallocator,
+      runtimeContext.jniDeallocator,
       jsInvokerHolder
     )
   }
 
   fun installJSIForBridgeless(
-    appContext: AppContext,
+    runtimeContext: RuntimeContext,
     jsRuntimePointer: Long,
-    jniDeallocator: JNIDeallocator,
     runtimeExecutor: RuntimeExecutor
   ) {
-    appContextHolder = appContext.weak()
+    runtimeContextHolder = runtimeContext.weak()
     installJSIForBridgeless(
       jsRuntimePointer,
-      jniDeallocator,
+      runtimeContext.jniDeallocator,
       runtimeExecutor
     )
   }
@@ -72,30 +71,6 @@ class JSIContext : Destructible {
     jsRuntimePointer: Long,
     jniDeallocator: JNIDeallocator,
     runtimeExecutor: RuntimeExecutor
-  )
-
-  @OptIn(FrameworkAPI::class)
-  fun installJSIForTests(
-    appContext: AppContext,
-    jniDeallocator: JNIDeallocator
-  ) {
-    appContextHolder = appContext.weak()
-    installJSIForTests(jniDeallocator)
-  }
-
-  @OptIn(FrameworkAPI::class)
-  fun installJSIForTests(
-    appContext: AppContext
-  ) {
-    appContextHolder = appContext.weak()
-    installJSIForTests(appContext.jniDeallocator)
-  }
-
-  /**
-   * Initializes the test runtime. Shouldn't be used in the production.
-   */
-  private external fun installJSIForTests(
-    jniDeallocator: JNIDeallocator
   )
 
   /**
@@ -132,13 +107,13 @@ class JSIContext : Destructible {
   @Suppress("unused")
   @DoNotStrip
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
-    return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
+    return runtimeContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }
 
   @Suppress("unused")
   @DoNotStrip
   fun hasModule(name: String): Boolean {
-    return appContextHolder.get()?.registry?.hasModule(name) ?: false
+    return runtimeContextHolder.get()?.registry?.hasModule(name) ?: false
   }
 
   /**
@@ -147,13 +122,13 @@ class JSIContext : Destructible {
   @Suppress("unused")
   @DoNotStrip
   fun getJavaScriptModulesName(): Array<String> {
-    return appContextHolder.get()?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
+    return runtimeContextHolder.get()?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
   }
 
   @Suppress("unused")
   @DoNotStrip
   fun registerSharedObject(native: Any, js: JavaScriptObject) {
-    appContextHolder
+    runtimeContextHolder
       .get()
       ?.sharedObjectRegistry
       ?.add(native as SharedObject, js)
@@ -162,7 +137,7 @@ class JSIContext : Destructible {
   @Suppress("unused")
   @DoNotStrip
   fun deleteSharedObject(id: Int) {
-    appContextHolder
+    runtimeContextHolder
       .get()
       ?.sharedObjectRegistry
       ?.delete(SharedObjectId(id))
@@ -171,7 +146,7 @@ class JSIContext : Destructible {
   @Suppress("unused")
   @DoNotStrip
   fun registerClass(native: Class<*>, js: JavaScriptObject) {
-    appContextHolder
+    runtimeContextHolder
       .get()
       ?.classRegistry
       ?.add(native, js)
@@ -179,8 +154,8 @@ class JSIContext : Destructible {
 
   @Suppress("unused")
   @DoNotStrip
-  fun getJavascriptClass(native: java.lang.Class<*>): JavaScriptObject? {
-    return appContextHolder
+  fun getJavascriptClass(native: Class<*>): JavaScriptObject? {
+    return runtimeContextHolder
       .get()
       ?.classRegistry
       ?.toJavaScriptObject(native)
@@ -189,7 +164,7 @@ class JSIContext : Destructible {
   @Suppress("unused")
   @DoNotStrip
   fun getCoreModuleObject(): JavaScriptModuleObject? {
-    return appContextHolder.get()?.coreModule?.jsObject
+    return runtimeContextHolder.get()?.coreModule?.jsObject
   }
 
   @Throws(Throwable::class)
@@ -205,5 +180,9 @@ class JSIContext : Destructible {
     init {
       SoLoader.loadLibrary("expo-modules-core")
     }
+  }
+
+  override fun close() {
+    deallocate()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -21,7 +21,6 @@ import java.lang.ref.WeakReference
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JSIContext : Destructible, AutoCloseable {
-  @VisibleForTesting
   lateinit var runtimeContextHolder: WeakReference<RuntimeContext>
 
   // Has to be called "mHybridData" - fbjni uses it via reflection

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
@@ -1,0 +1,39 @@
+@file:Suppress("KotlinJniMissingFunction")
+
+package expo.modules.kotlin.jni.tests
+
+import com.facebook.jni.HybridData
+import com.facebook.react.common.annotations.FrameworkAPI
+import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
+import expo.modules.core.interfaces.DoNotStrip
+
+/**
+ * Provides a way to create a new JSI runtime and a dummy call invoker.
+ * Used for testing purposes only.
+ * It can't be moved to test package, because it uses the cpp code.
+ * We don't want to generate another cpp library just to export those functions.
+ */
+internal class RuntimeHolder : AutoCloseable {
+  // Has to be called "mHybridData" - fbjni uses it via reflection
+  @DoNotStrip
+  private val mHybridData = initHybrid()
+
+  private external fun initHybrid(): HybridData
+
+  external fun createRuntime(): Long
+
+  @OptIn(FrameworkAPI::class)
+  external fun createCallInvoker(): CallInvokerHolderImpl
+
+  private external fun release()
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    close()
+  }
+
+  override fun close() {
+    release()
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.modules
 
 import android.os.Bundle
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.providers.AppContextProvider
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.types.Enumerable
@@ -12,17 +13,23 @@ import kotlin.reflect.full.primaryConstructor
 
 abstract class Module : AppContextProvider {
 
+  @Suppress("PropertyName")
+  internal var _runtimeContext: RuntimeContext? = null
+
+  val runtimeContext: RuntimeContext
+    get() = requireNotNull(_runtimeContext) { "The module wasn't created! You can't access the runtime context." }
+
   // region AppContextProvider
 
-  @Suppress("PropertyName")
-  internal var _appContext: AppContext? = null
-
   override val appContext: AppContext
-    get() = requireNotNull(_appContext) { "The module wasn't created! You can't access the app context." }
+    get() = requireNotNull(_runtimeContext?.appContext) { "The module wasn't created! You can't access the app context." }
 
   // endregion
 
   private val moduleEventEmitter by lazy { appContext.eventEmitter(this) }
+
+  val registry
+    get() = runtimeContext.registry
 
   @PublishedApi
   internal lateinit var coroutineScopeDelegate: Lazy<CoroutineScope>

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -542,7 +542,7 @@ inline fun Module.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptM
   val convertedConstants = Arguments.makeNativeMap(constants)
   val moduleName = "[Anonymous Object]"
 
-  val decorator = JSDecoratorsBridgingObject(appContext.jniDeallocator)
+  val decorator = JSDecoratorsBridgingObject(runtimeContext.jniDeallocator)
   decorator.registerConstants(convertedConstants)
 
   objectData
@@ -557,7 +557,7 @@ inline fun Module.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptM
       prop.attachToJSObject(appContext, decorator)
     }
 
-  return JavaScriptModuleObject(appContext.jniDeallocator, moduleName).apply {
+  return JavaScriptModuleObject(runtimeContext.jniDeallocator, moduleName).apply {
     decorate(decorator)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.weak
 
 @DoNotStrip
 open class SharedObject(runtimeContext: RuntimeContext? = null) {
-  constructor(appContext: AppContext) : this(appContext.hostingContext)
+  constructor(appContext: AppContext) : this(appContext.hostingRuntimeContext)
 
   /**
    * An identifier of the native shared object that maps to the JavaScript object.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -11,19 +11,19 @@ import expo.modules.kotlin.weak
 value class SharedObjectId(val value: Int) {
   @Deprecated("Use toNativeObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toNativeObject(runtimeContext: RuntimeContext)"))
   fun toNativeObject(appContext: AppContext): SharedObject? {
-    return appContext.hostingContext.sharedObjectRegistry.toNativeObject(this)
+    return appContext.hostingRuntimeContext.sharedObjectRegistry.toNativeObject(this)
   }
 
   @Deprecated("Use toJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toJavaScriptObject(runtimeContext: RuntimeContext)"))
   fun toJavaScriptObject(appContext: AppContext): JavaScriptObject? {
     val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.hostingContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
+    return appContext.hostingRuntimeContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
   }
 
   @Deprecated("Use toWeakJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toWeakJavaScriptObject(runtimeContext: RuntimeContext)"))
   fun toWeakJavaScriptObject(appContext: AppContext): JavaScriptWeakObject? {
     val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.hostingContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
+    return appContext.hostingRuntimeContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
   }
 
   fun toNativeObject(runtimeContext: RuntimeContext): SharedObject? {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -1,26 +1,43 @@
 package expo.modules.kotlin.sharedobjects
 
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptWeakObject
-import java.lang.ref.WeakReference
+import expo.modules.kotlin.weak
 
 @JvmInline
 value class SharedObjectId(val value: Int) {
-
+  @Deprecated("Use toNativeObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toNativeObject(runtimeContext: RuntimeContext)"))
   fun toNativeObject(appContext: AppContext): SharedObject? {
-    return appContext.sharedObjectRegistry.toNativeObject(this)
+    return appContext.hostingContext.sharedObjectRegistry.toNativeObject(this)
   }
 
+  @Deprecated("Use toJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toJavaScriptObject(runtimeContext: RuntimeContext)"))
   fun toJavaScriptObject(appContext: AppContext): JavaScriptObject? {
     val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
+    return appContext.hostingContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
   }
 
+  @Deprecated("Use toWeakJavaScriptObject(runtimeContext: RuntimeContext) instead.", ReplaceWith("toWeakJavaScriptObject(runtimeContext: RuntimeContext)"))
   fun toWeakJavaScriptObject(appContext: AppContext): JavaScriptWeakObject? {
     val nativeObject = toNativeObject(appContext) ?: return null
-    return appContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
+    return appContext.hostingContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
+  }
+
+  fun toNativeObject(runtimeContext: RuntimeContext): SharedObject? {
+    return runtimeContext.sharedObjectRegistry.toNativeObject(this)
+  }
+
+  fun toJavaScriptObject(runtimeContext: RuntimeContext): JavaScriptObject? {
+    val nativeObject = toNativeObject(runtimeContext) ?: return null
+    return runtimeContext.sharedObjectRegistry.toJavaScriptObject(nativeObject)
+  }
+
+  fun toWeakJavaScriptObject(runtimeContext: RuntimeContext): JavaScriptWeakObject? {
+    val nativeObject = toNativeObject(runtimeContext) ?: return null
+    return runtimeContext.sharedObjectRegistry.toWeakJavaScriptObject(nativeObject)
   }
 }
 
@@ -28,8 +45,8 @@ typealias SharedObjectPair = Pair<SharedObject, JavaScriptWeakObject>
 
 const val sharedObjectIdPropertyName = "__expo_shared_object_id__"
 
-class SharedObjectRegistry(appContext: AppContext) {
-  private val appContextHolder = WeakReference(appContext)
+class SharedObjectRegistry(runtimeContext: RuntimeContext) {
+  private val runtimeContextHolder = runtimeContext.weak()
 
   private var currentId: SharedObjectId = SharedObjectId(1)
 
@@ -50,10 +67,10 @@ class SharedObjectRegistry(appContext: AppContext) {
     // but with the current implementation it's possible to use a raw object for registration.
     js.defineProperty(sharedObjectIdPropertyName, id.value)
 
-    val appContext = appContextHolder.get() ?: throw Exceptions.AppContextLost()
+    val runtimeContext = runtimeContextHolder.get() ?: throw Exceptions.AppContextLost()
 
-    appContext
-      .jsiInterop
+    runtimeContext
+      .jsiContext
       .setNativeStateForSharedObject(id.value, js)
 
     val jsWeakObject = js.createWeak()
@@ -61,8 +78,8 @@ class SharedObjectRegistry(appContext: AppContext) {
       pairs[id] = native to jsWeakObject
     }
 
-    if (native.appContextHolder.get() == null) {
-      native.appContextHolder = WeakReference(appContext)
+    if (native.runtimeContextHolder.get() == null) {
+      native.runtimeContextHolder = runtimeContext.weak()
     }
 
     return id

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -10,4 +10,4 @@ import expo.modules.kotlin.AppContext
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 open class SharedRef<RefType>(val ref: RefType, appContext: AppContext? = null) :
-  SharedObject(appContext)
+  SharedObject(appContext?.hostingContext)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -10,4 +10,4 @@ import expo.modules.kotlin.AppContext
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 open class SharedRef<RefType>(val ref: RefType, appContext: AppContext? = null) :
-  SharedObject(appContext?.hostingContext)
+  SharedObject(appContext?.hostingRuntimeContext)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -26,7 +26,7 @@ open class ViewEvent<T>(
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
     if (!isValidated) {
-      val holder = appContext.hostingContext.registry.getModuleHolder(view::class.java).ifNull {
+      val holder = appContext.hostingRuntimeContext.registry.getModuleHolder(view::class.java).ifNull {
         logger.warn("⚠️ Cannot get module holder for ${view::class.java}")
         return
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -26,7 +26,7 @@ open class ViewEvent<T>(
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
     if (!isValidated) {
-      val holder = appContext.registry.getModuleHolder(view::class.java).ifNull {
+      val holder = appContext.hostingContext.registry.getModuleHolder(view::class.java).ifNull {
         logger.warn("⚠️ Cannot get module holder for ${view::class.java}")
         return
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -66,7 +66,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder<*>) {
       val key = iterator.nextKey()
       expoProps[key]?.let { expoProp ->
         try {
-          expoProp.set(propsMap.getDynamic(key), view, moduleHolder.module._appContext)
+          expoProp.set(propsMap.getDynamic(key), view, moduleHolder.module._runtimeContext?.appContext)
         } catch (exception: Throwable) {
           // The view wasn't constructed correctly, so errors are expected.
           // We can ignore them.

--- a/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
@@ -6,6 +6,10 @@
 
 #include <ReactCommon/CallInvoker.h>
 
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
 namespace expo {
 
 /**
@@ -18,11 +22,11 @@ public:
 
 #if REACT_NATIVE_TARGET_VERSION >= 75
   void invokeAsync(react::CallFunc &&func) noexcept override {
-    func(*runtime);
+    func(*runtime.lock());
   }
 
   void invokeSync(react::CallFunc &&func) override {
-    func(*runtime);
+    func(*runtime.lock());
   }
 #else
   void invokeAsync(std::function<void()> &&func) noexcept override {
@@ -36,7 +40,7 @@ public:
 
   ~TestingSyncJSCallInvoker() override = default;
 
-  std::shared_ptr<jsi::Runtime> runtime;
+  std::weak_ptr<jsi::Runtime> runtime;
 };
 
 } // namespace expo


### PR DESCRIPTION
# Why

Decouples the modules state from `AppContext` allowing us to attach to multiple runtimes.
Needed by reanimated integration. 

# How

I've made a controversial change by introducing another context called `RuntimeContext` (I'm open to changing that name). The main purpose of this class is to store modules outside of the `AppContext`. This structure allows us to manage multiple runtimes with different sets of modules, each with its own lifecycle. Additionally, it will help us to support brownfields in the future.

Beside those changes, I've improved our test setup to closely resemble the final app environment. Now, it's possible to test reloads that will be added later.

# Test Plan

- bare-expo ✅ 
- unit tests ✅ 