### PR TITLE
[ios][camera] Fix `takePicture` in simulator

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fix calling `takePicture` from the simulator.
+- On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fix calling `takePicture` from the simulator.
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-camera/ios/CameraViewLegacyModule.swift
+++ b/packages/expo-camera/ios/CameraViewLegacyModule.swift
@@ -3,7 +3,7 @@
 import AVFoundation
 import ExpoModulesCore
 
-let cameraEvents = ["onCameraReady", "onMountError", "onPictureSaved", "onBarCodeScanned", "onFacesDetected", "onResponsiveOrientationChanged"]
+let cameraLegacyEvents = ["onCameraReady", "onMountError", "onPictureSaved", "onBarCodeScanned", "onFacesDetected", "onResponsiveOrientationChanged"]
 
 public final class CameraViewLegacyModule: Module {
   public func definition() -> ModuleDefinition {
@@ -69,7 +69,7 @@ public final class CameraViewLegacyModule: Module {
 
     // swiftlint:disable:next closure_body_length
     View(CameraViewLegacy.self) {
-      Events(cameraEvents)
+      Events(cameraLegacyEvents)
 
       Prop("type") { (view, type: CameraTypeLegacy) in
         if view.presetCamera.rawValue != type.rawValue {

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -4,7 +4,7 @@ import AVFoundation
 import ExpoModulesCore
 import VisionKit
 
-let cameraNextEvents = ["onCameraReady", "onMountError", "onPictureSaved", "onBarcodeScanned", "onResponsiveOrientationChanged"]
+let cameraEvents = ["onCameraReady", "onMountError", "onPictureSaved", "onBarcodeScanned", "onResponsiveOrientationChanged"]
 
 struct ScannerContext {
   var controller: Any?
@@ -70,7 +70,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
     // swiftlint:disable:next closure_body_length
     View(CameraView.self) {
-      Events(cameraNextEvents)
+      Events(cameraEvents)
 
       Prop("facing") { (view, type: CameraType?) in
         if let type, view.presetCamera != type.toPosition() {
@@ -152,12 +152,12 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         }
       }
 
-      AsyncFunction("takePicture") { (view, options: TakePictureOptions, promise: Promise) in
-        #if targetEnvironment(simulator)
+      AsyncFunction("takePicture") { (view: CameraView, options: TakePictureOptions, promise: Promise) in
+        #if targetEnvironment(simulator) // simulator
         try takePictureForSimulator(self.appContext, view, options, promise)
-        #else // simulator
+        #else // not simulator
         view.takePicture(options: options, promise: promise)
-        #endif // not simulator
+        #endif
       }.runOnQueue(.main)
 
       AsyncFunction("record") { (view, options: CameraRecordingOptions, promise: Promise) in

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -152,7 +152,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         }
       }
 
-      AsyncFunction("takePicture") { (view: CameraView, options: TakePictureOptions, promise: Promise) in
+      AsyncFunction("takePicture") { (view, options: TakePictureOptions, promise: Promise) in
         #if targetEnvironment(simulator) // simulator
         try takePictureForSimulator(self.appContext, view, options, promise)
         #else // not simulator

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -3,7 +3,7 @@ import ExpoModulesCore
 import CoreMotion
 
 public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
-  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate {
+  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate, CameraEvent {
   public var session = AVCaptureSession()
   public var sessionQueue = DispatchQueue(label: "captureSessionQueue")
 

--- a/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
+++ b/packages/expo-camera/ios/Legacy/CameraViewLegacy.swift
@@ -4,7 +4,7 @@ import CoreMotion
 
 // swiftlint:disable:next type_body_length
 public class CameraViewLegacy: ExpoView, EXCameraInterface, EXAppLifecycleListener,
-  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate {
+  AVCaptureFileOutputRecordingDelegate, AVCapturePhotoCaptureDelegate, CameraEvent {
   public var session = AVCaptureSession()
   public var sessionQueue = DispatchQueue(label: "captureSessionQueue")
   private var motionManager = CMMotionManager()

--- a/packages/expo-camera/ios/SimulatorUtils.swift
+++ b/packages/expo-camera/ios/SimulatorUtils.swift
@@ -1,8 +1,12 @@
 import ExpoModulesCore
 
+protocol CameraEvent {
+  var onPictureSaved: EventDispatcher { get }
+}
+
 func takePictureForSimulator(
   _ appContext: AppContext?,
-  _ view: CameraViewLegacy,
+  _ event: CameraEvent,
   _ options: TakePictureOptions,
   _ promise: Promise
 ) throws {
@@ -12,7 +16,7 @@ func takePictureForSimulator(
   let result = try generatePictureForSimulator(appContext: appContext, options: options)
 
   if options.fastMode {
-    view.onPictureSaved([
+    event.onPictureSaved([
       "data": result,
       "id": options.id
     ])


### PR DESCRIPTION
# Why
Close #29987
`takePictureForSimulator` accepted a `CameraViewLegacy` type as an argument which caused the wrong type of view to be passed to the AsyncFunction body. Because of this an error was thrown for an invalid number of arguments being passed to the legacy version of `takePicture`.

# How
Conform both new and legacy views to a protocol with the `onPictureSaved` dispatcher so `takePictureForSimulator` will accept either type of view

# Test Plan
Bare expo on a physical device and simulator ✅
