### PR TITLE
[video][ios] Fix crashes on iOS 16 and lower when source HTTP headers are undefined

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Web] Fix `AudioContext` being created before user interaction causing playback issues. ([#29695](https://github.com/expo/expo/pull/29695) by [@behenate](https://github.com/behenate))
+- [iOS] Fix crashes on iOS 16 and lower when source HTTP headers are undefined. ([#30104](https://github.com/expo/expo/pull/30104) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -98,7 +98,11 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       return
     }
 
-    let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": videoSource.headers])
+    let asset = if let headers = videoSource.headers {
+      AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+    } else {
+      AVURLAsset(url: url)
+    }
     let playerItem = VideoPlayerItem(asset: asset, videoSource: videoSource)
 
     if let drm = videoSource.drm {


### PR DESCRIPTION
# Why

On iOS 16 and lower having a nil value in `AVURLAssetHTTPHeaderFieldsKey` causes a crash. We should only pass the headers if they are defined.

# How


# Test Plan

Tested in BareExpo in iOS 16 simulator

