### PR TITLE
[docs] Add missing next step after obtaining device token

### DIFF
--- a/docs/pages/push-notifications/obtaining-a-device-token-for-fcm-or-apns.mdx
+++ b/docs/pages/push-notifications/obtaining-a-device-token-for-fcm-or-apns.mdx
@@ -14,6 +14,6 @@ import * as Notifications from 'expo-notifications';
 // send token to your server
 ```
 
-After getting the native device token, you can start implementing the servers.
+After getting the native device token, you can start [implementing the servers](/push-notifications/sending-notifications-custom).
 
 {/* Below are some minimal examples of communicating with FCM and APNs: */}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Add the missing next step after Obtaining a device token for sending to FCM or APNs, as confirmed by @douglowder.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
