### PR TITLE
[docs] Update modal status bar example with fallback for other platforms

### DIFF
--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -68,7 +68,7 @@ export default function Modal() {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       {/* Use `../` as a simple way to navigate to the root. This is not analogous to "goBack". */}
       {!isPresented && <Link href="../">Dismiss</Link>}
-      {/* Native modals have dark backgrounds on iOS, set the status bar to light content and add a fallback for other platforms with auto. */}
+      {/* Native modals have dark backgrounds on iOS. Set the status bar to light content and add a fallback for other platforms with auto. */}
       <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
     </View>
   );

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -57,7 +57,7 @@ export default function Home() {
 Now create a modal that adds a back button when the modal has lost its previous context and must be presented as a standalone page.
 
 ```jsx app/modal.js
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import { Link, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 export default function Modal() {
@@ -68,8 +68,8 @@ export default function Modal() {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       {/* Use `../` as a simple way to navigate to the root. This is not analogous to "goBack". */}
       {!isPresented && <Link href="../">Dismiss</Link>}
-      {/* Native modals have dark backgrounds on iOS, set the status bar to light content. */}
-      <StatusBar style="light" />
+      {/* Native modals have dark backgrounds on iOS, set the status bar to light content and add a fallback for other platforms with auto. */}
+      <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
     </View>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The current docs example sets the status bar style to "light", making it nearly invisible on Android devices in light mode.

I updated the modal example to set the status bar to "light" on iOS and fallback to "auto" on other platforms so it matches the currently active theme.

# Screenshots
![modal-statusbar-before-after-android](https://github.com/expo/expo/assets/78776152/9663f70a-47d3-44ee-b2ad-25ab8d7c85e9)

# Checklist
<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
