### PR TITLE
[docs] Archive Use Flipper guide

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -358,6 +358,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/web-performance/': '/guides/analyzing-bundles/',
   '/guides/assets/': '/develop/user-interface/assets/',
   '/router/reference/search-parameters/': '/router/reference/url-parameters/',
+  '/guides/using-flipper': '/archive/using-flipper/',
 
   // Classic updates moved to archive
   '/guides/configuring-ota-updates/': '/archive/classic-updates/getting-started/',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -426,7 +426,6 @@ const general = [
         makePage('guides/facebook-authentication.mdx'),
         makePage('guides/using-supabase.mdx'),
         makePage('guides/using-firebase.mdx'),
-        makePage('guides/using-flipper.mdx'),
         makePage('guides/google-authentication.mdx'),
         makePage('guides/using-eslint.mdx'),
         makePage('guides/using-nextjs.mdx'),
@@ -552,6 +551,7 @@ const archive = [
     makePage('archive/publishing-websites-webpack.mdx'),
     makePage('archive/customizing-webpack.mdx'),
     makePage('archive/using-expo-client.mdx'),
+    makePage('archive/using-flipper.mdx'),
     makePage('archive/glossary.mdx'),
   ]),
 ];

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -371,6 +371,9 @@ redirects[develop/user-interface/splash-screen]=develop/user-interface/splash-sc
 # Preview section
 redirects[/preview/support]=preview/introduction
 
+# Archived
+redirects[guides/using-flipper]=archive/using-flipper
+
 # Temporary redirects
 redirects[guides/react-compiler]=preview/react-compiler
 

--- a/docs/pages/archive/using-flipper.mdx
+++ b/docs/pages/archive/using-flipper.mdx
@@ -7,7 +7,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **Warning** React Native no longer recommends Flipper ([RFC0641](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0641-decoupling-flipper-from-react-native-core.md)). We do not recommend using it. Features from Flipper, such as React Developer Tools and the network inspector, are available directly through Expo CLI in SDK 49 and greater. [Learn more](/debugging/tools.mdx).
+> **Warning** **Deprecated:** React Native no longer recommends Flipper ([RFC0641](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0641-decoupling-flipper-from-react-native-core.md)). We do not recommend using it. Features from Flipper, such as React Developer Tools and the network inspector, are available directly through Expo CLI in SDK 49 and above. See [Debugging and profiling tools](/debugging/tools) for more details.
 
 [Flipper](https://fbflipper.com/) is a platform tool for debugging React Native projects on an emulator/simulator or a physical device. It supports projects running on Android and iOS and is available as a desktop application on macOS, Windows, and Linux.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Since Flipper is not recommended, let's move it to Archive.

# How

<!--
How did you build this feature or fix this bug and why?
-->
This PR:
- Updates the navigation structure to move the "Use Flipper" guide to the archive.
- Add redirects (client and server-side) accordingly.
- Update verbiage in the warning callout.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
