### PR TITLE
fix(expo-apple-authentication): Xcode 16 beta "switch must be exhaustive" in AppleAuthenticationExceptions

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Added exhaustive switch cases to AppleAuthenticationExceptions.swift. ([#30125](https://github.com/expo/expo/pull/30125) by [@Kureev](https://github.com/Kureev))
+
 ### 💡 Others
 
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -70,7 +70,7 @@ func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception 
   case .notInteractive:
     return RequestNotInteractiveException()
   case .matchedExcludedCredential:
-    return MarchedExcludedCredential()
+    return MatchedExcludedCredential()
   @unknown default:
     return RequestUnknownException()
   }

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -49,7 +49,7 @@ final class RequestUnknownException: Exception {
   }
 }
 
-final class MarchedExcludedCredential: Exception {
+final class MatchedExcludedCredential: Exception {
   override var reason: String {
     "The authorization attempt failed due to matched excluded credential"
   }

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift
@@ -49,6 +49,12 @@ final class RequestUnknownException: Exception {
   }
 }
 
+final class MarchedExcludedCredential: Exception {
+  override var reason: String {
+    "The authorization attempt failed due to matched excluded credential"
+  }
+}
+
 func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception {
   switch error.code {
   case .unknown:
@@ -63,6 +69,8 @@ func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception 
     return RequestFailedException()
   case .notInteractive:
     return RequestNotInteractiveException()
+  case .matchedExcludedCredential:
+    return MarchedExcludedCredential()
   @unknown default:
     return RequestUnknownException()
   }


### PR DESCRIPTION
# Why

Xcode 16.0 beta (16A5171c) complains regarding "switch must be exhaustive":

```
❌  (node_modules/expo-apple-authentication/ios/AppleAuthenticationExceptions.swift:53:3)

  51 |
  52 | func exceptionForAuthorizationError(_ error: ASAuthorizationError) -> Exception {
> 53 |   switch error.code {
     |   ^ switch must be exhaustive
  54 |   case .unknown:
  55 |     return RequestUnknownException()
  56 |   case .canceled:
```

More info about the missed case: https://developer.apple.com/documentation/authenticationservices/asauthorizationerror-swift.struct/code/matchedexcludedcredential

# How

- Added unmatched switch cases

# Test Plan

- Check if Xcode 16 (beta) builds without issues

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
