### PR TITLE
[docs] always show supported platforms in API reference entries

### DIFF
--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -139,16 +139,18 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
 
   private handleLinkClick = (
     event: React.MouseEvent<HTMLAnchorElement>,
-    { slug, ref }: Heading
+    { slug, ref, type }: Heading
   ) => {
     event.preventDefault();
 
     // disable sidebar scrolling until we reach that slug
     this.slugScrollingTo = slug;
 
+    const scrollOffset = type === 'inlineCode' ? 50 : 26;
+
     this.props.contentRef?.current?.getScrollRef().current?.scrollTo({
       behavior: isDynamicScrollAvailable() ? 'smooth' : 'instant',
-      top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR - 28,
+      top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR - scrollOffset,
     });
 
     if (history?.replaceState) {

--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -37,6 +37,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                   platforms={[
                     { content: [{ kind: 'text', text: property.platform }], tag: 'platform' },
                   ]}
+                  prefix="Only for:"
                 />
               )}
               <ReactMarkdown components={mdComponents}>{property.description}</ReactMarkdown>

--- a/docs/components/plugins/PlatformIcon.tsx
+++ b/docs/components/plugins/PlatformIcon.tsx
@@ -17,18 +17,18 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return (
         <AppleIcon
           className={mergeClasses(
-            'icon-xs text-palette-blue12',
+            'opacity-80 icon-xs text-palette-blue12',
             platform === 'macos' && 'text-palette-purple12',
             platform === 'tvos' && 'text-palette-pink12'
           )}
         />
       );
     case 'android':
-      return <AndroidIcon className="icon-xs text-palette-green12" />;
+      return <AndroidIcon className="opacity-80 icon-xs text-palette-green12" />;
     case 'web':
-      return <AtSignIcon className="icon-xs text-palette-orange12" />;
+      return <AtSignIcon className="opacity-80 icon-xs text-palette-orange12" />;
     case 'expo':
-      return <ExpoGoLogo className="icon-xs text-palette-purple12" />;
+      return <ExpoGoLogo className="opacity-80 icon-xs text-palette-purple12" />;
     default:
       return null;
   }

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-15gi84a"
+    class="!shadow-none css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -328,7 +328,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -405,7 +405,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -482,7 +482,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -567,7 +567,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -663,7 +663,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2373,7 +2373,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2911,7 +2911,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3259,7 +3259,7 @@ may be
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3566,7 +3566,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3890,7 +3890,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4127,7 +4127,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4300,7 +4300,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4565,7 +4565,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4785,7 +4785,7 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none !rounded-full css-7sgr13-PlatformTag"
+            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-kk7wp3-PlatformTag"
           >
             <svg
               class="icon-xs text-palette-blue12"
@@ -4805,7 +4805,7 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="css-1q9zso2-PlatformTag"
+              class="css-103dp5g-PlatformTag"
             >
               iOS 13.2+
             </span>
@@ -4873,7 +4873,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5228,7 +5228,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5518,7 +5518,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5807,7 +5807,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -6158,7 +6158,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-15gi84a"
+    class="!shadow-none css-gxnqn3"
   >
     <div
       class="css-1avgxs7-APISectionDeprecationNote"
@@ -6370,7 +6370,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6486,7 +6486,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6640,7 +6640,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-1vwg38e"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8217,7 +8217,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8527,7 +8527,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8646,7 +8646,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8815,7 +8815,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8923,7 +8923,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9195,7 +9195,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9479,7 +9479,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -9771,7 +9771,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9896,7 +9896,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -9913,7 +9913,7 @@ exports[`APISection expo-pedometer 1`] = `
            
         </span>
         <div
-          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none !rounded-full css-7sgr13-PlatformTag"
+          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-kk7wp3-PlatformTag"
         >
           <svg
             class="icon-xs text-palette-blue12"
@@ -9933,7 +9933,7 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="css-1q9zso2-PlatformTag"
+            class="css-103dp5g-PlatformTag"
           >
             iOS
           </span>
@@ -10261,7 +10261,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10399,7 +10399,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10524,7 +10524,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-1vwg38e"
+    class="css-qg659h"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11129,7 +11129,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11244,7 +11244,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11358,7 +11358,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11460,7 +11460,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-15gi84a"
+    class="css-gxnqn3"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11633,7 +11633,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1xslh56-APISectionEnum"
+    class="!p-0 css-1t05vdz-APISectionEnum"
   >
     <div
       class="px-5 pt-4"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#component"
       id="component"
     >
@@ -50,7 +50,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationbutton"
         id="appleauthenticationbutton"
       >
@@ -287,7 +287,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="scroll-m-5 relative decoration-0 text-inherit flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-inherit flex flex-row gap-2 items-center"
             href="#appleauthenticationbuttonprops"
             id="appleauthenticationbuttonprops"
           >
@@ -335,7 +335,7 @@ for more details.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#buttonstyle"
             id="buttonstyle"
           >
@@ -412,7 +412,7 @@ for more details.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#buttontype"
             id="buttontype"
           >
@@ -489,7 +489,7 @@ for more details.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#cornerradius"
             id="cornerradius"
           >
@@ -574,7 +574,7 @@ for more details.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#onpress"
             id="onpress"
           >
@@ -670,7 +670,7 @@ in here.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#style"
             id="style"
           >
@@ -817,7 +817,7 @@ properties.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
           href="#inherited-props"
           id="inherited-props"
         >
@@ -881,7 +881,7 @@ properties.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#methods"
       id="methods"
     >
@@ -924,7 +924,7 @@ properties.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#getcredentialstateasyncuser"
         id="getcredentialstateasyncuser"
       >
@@ -1200,7 +1200,7 @@ value depending on the state of the credential.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -1344,7 +1344,7 @@ value depending on the state of the credential.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#refreshasyncoptions"
         id="refreshasyncoptions"
       >
@@ -1585,7 +1585,7 @@ refresh operation.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#signinasyncoptions"
         id="signinasyncoptions"
       >
@@ -1873,7 +1873,7 @@ sign-in operation.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#signoutasyncoptions"
         id="signoutasyncoptions"
       >
@@ -2145,7 +2145,7 @@ sign-out operation.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#event-subscriptions"
       id="event-subscriptions"
     >
@@ -2188,7 +2188,7 @@ sign-out operation.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#addrevokelistenerlistener"
         id="addrevokelistenerlistener"
       >
@@ -2337,7 +2337,7 @@ sign-out operation.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#types"
       id="types"
     >
@@ -2380,7 +2380,7 @@ sign-out operation.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationcredential"
         id="appleauthenticationcredential"
       >
@@ -2918,7 +2918,7 @@ developers.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationfullname"
         id="appleauthenticationfullname"
       >
@@ -3266,7 +3266,7 @@ may be
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationrefreshoptions"
         id="appleauthenticationrefreshoptions"
       >
@@ -3573,7 +3573,7 @@ OAuth 2.0 protocol
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationsigninoptions"
         id="appleauthenticationsigninoptions"
       >
@@ -3897,7 +3897,7 @@ OAuth 2.0 protocol
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#appleauthenticationsignoutoptions"
         id="appleauthenticationsignoutoptions"
       >
@@ -4134,7 +4134,7 @@ OAuth 2.0 protocol
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#subscription"
         id="subscription"
       >
@@ -4264,7 +4264,7 @@ After calling this function, the listener will no longer receive any events from
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#enums"
       id="enums"
     >
@@ -4300,7 +4300,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4310,7 +4310,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationbuttonstyle"
           id="appleauthenticationbuttonstyle"
         >
@@ -4388,7 +4388,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#white"
           id="white"
         >
@@ -4449,7 +4449,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#white_outline"
           id="white_outline"
         >
@@ -4510,7 +4510,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#black"
           id="black"
         >
@@ -4565,7 +4565,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4575,7 +4575,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationbuttontype"
           id="appleauthenticationbuttontype"
         >
@@ -4653,7 +4653,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#sign_in"
           id="sign_in"
         >
@@ -4714,7 +4714,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#continue"
           id="continue"
         >
@@ -4785,7 +4785,7 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-7sgr13-PlatformTag"
+            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none !rounded-full css-7sgr13-PlatformTag"
           >
             <svg
               class="icon-xs text-palette-blue12"
@@ -4818,7 +4818,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#sign_up"
           id="sign_up"
         >
@@ -4873,7 +4873,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4883,7 +4883,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationcredentialstate"
           id="appleauthenticationcredentialstate"
         >
@@ -5014,7 +5014,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#revoked"
           id="revoked"
         >
@@ -5069,7 +5069,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#authorized"
           id="authorized"
         >
@@ -5124,7 +5124,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#not_found"
           id="not_found"
         >
@@ -5179,7 +5179,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#transferred"
           id="transferred"
         >
@@ -5228,7 +5228,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5238,7 +5238,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationoperation"
           id="appleauthenticationoperation"
         >
@@ -5298,7 +5298,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#implicit"
           id="implicit"
         >
@@ -5359,7 +5359,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#login"
           id="login"
         >
@@ -5414,7 +5414,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#refresh"
           id="refresh"
         >
@@ -5469,7 +5469,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#logout"
           id="logout"
         >
@@ -5518,7 +5518,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5528,7 +5528,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationscope"
           id="appleauthenticationscope"
         >
@@ -5703,7 +5703,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#full_name"
           id="full_name"
         >
@@ -5758,7 +5758,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#email"
           id="email"
         >
@@ -5807,7 +5807,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5817,7 +5817,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#appleauthenticationuserdetectionstatus"
           id="appleauthenticationuserdetectionstatus"
         >
@@ -5936,7 +5936,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#unsupported"
           id="unsupported"
         >
@@ -5997,7 +5997,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#unknown"
           id="unknown"
         >
@@ -6058,7 +6058,7 @@ for more details.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#likely_real"
           id="likely_real"
         >
@@ -6122,7 +6122,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#component"
       id="component"
     >
@@ -6242,7 +6242,7 @@ for more details.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescanner"
         id="barcodescanner"
       >
@@ -6329,7 +6329,7 @@ for more details.
           data-text="true"
         >
           <a
-            class="scroll-m-5 relative decoration-0 text-inherit flex flex-row gap-2 items-center"
+            class="relative decoration-0 scroll-m-6 text-inherit flex flex-row gap-2 items-center"
             href="#barcodescannerprops"
             id="barcodescannerprops"
           >
@@ -6377,7 +6377,7 @@ for more details.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#barcodetypes"
             id="barcodetypes"
           >
@@ -6493,7 +6493,7 @@ minimize battery usage.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#onbarcodescanned"
             id="onbarcodescanned"
           >
@@ -6647,7 +6647,7 @@ data has been retrieved.
           data-heading="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
             href="#type"
             id="type"
           >
@@ -6782,7 +6782,7 @@ Same as
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
           href="#inherited-props"
           id="inherited-props"
         >
@@ -6846,7 +6846,7 @@ Same as
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#hooks"
       id="hooks"
     >
@@ -6889,7 +6889,7 @@ Same as
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#usepermissionsoptions"
         id="usepermissionsoptions"
       >
@@ -7241,7 +7241,7 @@ This uses both
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#methods"
       id="methods"
     >
@@ -7284,7 +7284,7 @@ This uses both
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescannergetpermissionsasync"
         id="barcodescannergetpermissionsasync"
       >
@@ -7431,7 +7431,7 @@ This uses both
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescannerrequestpermissionsasync"
         id="barcodescannerrequestpermissionsasync"
       >
@@ -7600,7 +7600,7 @@ This uses both
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescannerscanfromurlasyncurl-barcodetypes"
         id="barcodescannerscanfromurlasyncurl-barcodetypes"
       >
@@ -7897,7 +7897,7 @@ code.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#interfaces"
       id="interfaces"
     >
@@ -7940,7 +7940,7 @@ code.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#permissionresponse"
         id="permissionresponse"
       >
@@ -8181,7 +8181,7 @@ in order to enable/disable the permission.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#types"
       id="types"
     >
@@ -8224,7 +8224,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodebounds"
         id="barcodebounds"
       >
@@ -8382,7 +8382,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodeevent"
         id="barcodeevent"
       >
@@ -8534,7 +8534,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodeeventcallbackarguments"
         id="barcodeeventcallbackarguments"
       >
@@ -8653,7 +8653,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodepoint"
         id="barcodepoint"
       >
@@ -8822,7 +8822,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescannedcallback"
         id="barcodescannedcallback"
       >
@@ -8930,7 +8930,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodescannerresult"
         id="barcodescannerresult"
       >
@@ -9202,7 +9202,7 @@ you don't get this value.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#barcodesize"
         id="barcodesize"
       >
@@ -9350,7 +9350,7 @@ you don't get this value.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#permissionhookoptions"
         id="permissionhookoptions"
       >
@@ -9443,7 +9443,7 @@ you don't get this value.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#enums"
       id="enums"
     >
@@ -9479,7 +9479,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -9489,7 +9489,7 @@ you don't get this value.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#permissionstatus"
           id="permissionstatus"
         >
@@ -9549,7 +9549,7 @@ you don't get this value.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#denied"
           id="denied"
         >
@@ -9610,7 +9610,7 @@ you don't get this value.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#granted"
           id="granted"
         >
@@ -9671,7 +9671,7 @@ you don't get this value.
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#undetermined"
           id="undetermined"
         >
@@ -9735,7 +9735,7 @@ exports[`APISection expo-pedometer 1`] = `
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#methods"
       id="methods"
     >
@@ -9778,7 +9778,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#getpermissionsasync"
         id="getpermissionsasync"
       >
@@ -9913,7 +9913,7 @@ exports[`APISection expo-pedometer 1`] = `
            
         </span>
         <div
-          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-7sgr13-PlatformTag"
+          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none !rounded-full css-7sgr13-PlatformTag"
         >
           <svg
             class="icon-xs text-palette-blue12"
@@ -9946,7 +9946,7 @@ exports[`APISection expo-pedometer 1`] = `
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#getstepcountasyncstart-end"
         id="getstepcountasyncstart-end"
       >
@@ -10268,7 +10268,7 @@ a start date that is more than seven days in the past returns only the available
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#isavailableasync"
         id="isavailableasync"
       >
@@ -10406,7 +10406,7 @@ available on this device.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#requestpermissionsasync"
         id="requestpermissionsasync"
       >
@@ -10531,7 +10531,7 @@ available on this device.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#watchstepcountcallback"
         id="watchstepcountcallback"
       >
@@ -10809,7 +10809,7 @@ On iOS, the
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#interfaces"
       id="interfaces"
     >
@@ -10852,7 +10852,7 @@ On iOS, the
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#permissionresponse"
         id="permissionresponse"
       >
@@ -11093,7 +11093,7 @@ in order to enable/disable the permission.
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#types"
       id="types"
     >
@@ -11136,7 +11136,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#pedometerresult"
         id="pedometerresult"
       >
@@ -11251,7 +11251,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#pedometerupdatecallback"
         id="pedometerupdatecallback"
       >
@@ -11365,7 +11365,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#permissionexpiration"
         id="permissionexpiration"
       >
@@ -11467,7 +11467,7 @@ in order to enable/disable the permission.
       data-heading="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
         href="#subscription"
         id="subscription"
       >
@@ -11597,7 +11597,7 @@ After calling this function, the listener will no longer receive any events from
     data-heading="true"
   >
     <a
-      class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+      class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6"
       href="#enums"
       id="enums"
     >
@@ -11633,7 +11633,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-15gi84a"
+    class="!p-0 css-1xslh56-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -11643,7 +11643,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12"
           href="#permissionstatus"
           id="permissionstatus"
         >
@@ -11703,7 +11703,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#denied"
           id="denied"
         >
@@ -11764,7 +11764,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#granted"
           id="granted"
         >
@@ -11825,7 +11825,7 @@ After calling this function, the listener will no longer receive any events from
         data-heading="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 !mt-0"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-6 !mt-0"
           href="#undetermined"
           id="undetermined"
         >

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -4785,7 +4785,7 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-kk7wp3-PlatformTag"
+            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-1e5tu91-PlatformTag"
           >
             <svg
               class="icon-xs text-palette-blue12"
@@ -7135,7 +7135,7 @@ This uses both
       </p>
     </div>
     <div
-      class="mb-3.5"
+      class="mb-3.5 last:[&>*]:mb-0"
     >
       <p
         class="!mt-1 css-1xg9efr-BoxSectionHeader"
@@ -9913,7 +9913,7 @@ exports[`APISection expo-pedometer 1`] = `
            
         </span>
         <div
-          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-kk7wp3-PlatformTag"
+          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-1e5tu91-PlatformTag"
         >
           <svg
             class="icon-xs text-palette-blue12"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-gxnqn3"
+    class="!shadow-none css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -279,7 +279,7 @@ for more details.
     </blockquote>
     <div>
       <p
-        class="!text-secondary !font-medium css-1xg9efr-BoxSectionHeader"
+        class="!text-secondary !font-medium css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -328,7 +328,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -405,7 +405,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -482,7 +482,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -567,7 +567,7 @@ for more details.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -663,7 +663,7 @@ in here.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -917,7 +917,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1193,7 +1193,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1337,7 +1337,7 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1578,7 +1578,7 @@ refresh operation.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -1866,7 +1866,7 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2181,7 +2181,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2373,7 +2373,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -2911,7 +2911,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3259,7 +3259,7 @@ may be
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3566,7 +3566,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -3890,7 +3890,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4127,7 +4127,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -4300,7 +4300,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4369,7 +4369,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -4565,7 +4565,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4634,7 +4634,7 @@ After calling this function, the listener will no longer receive any events from
         .
       </p>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -4785,10 +4785,10 @@ After calling this function, the listener will no longer receive any events from
              
           </span>
           <div
-            class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-1e5tu91-PlatformTag"
+            class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none css-1e5tu91-PlatformTag"
           >
             <svg
-              class="icon-xs text-palette-blue12"
+              class="opacity-80 icon-xs text-palette-blue12"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -4873,7 +4873,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -4995,7 +4995,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -5228,7 +5228,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5279,7 +5279,7 @@ for more details.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -5518,7 +5518,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5684,7 +5684,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -5807,7 +5807,7 @@ for more details.
     </div>
   </div>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -5917,7 +5917,7 @@ for more details.
         </div>
       </blockquote>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -6158,13 +6158,13 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="!shadow-none css-gxnqn3"
+    class="!shadow-none css-7sex76"
   >
     <div
-      class="css-1avgxs7-APISectionDeprecationNote"
+      class="[table_&]:mt-0 [table_&]:mb-3.5 [table_&]:last:mb-0 mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]"
     >
       <blockquote
-        class="flex gap-2 rounded-md shadow-xs py-3 px-4 mb-4 [table_&]:last-of-type:mb-0 [&_p]:!mb-0 css-16xozm6-Callout"
+        class="flex gap-2 rounded-md py-3 px-4 mb-4 [&_p]:!mb-0 [table_&]:last-of-type:mb-2.5 pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4 css-16xozm6-Callout"
         data-testid="callout-container"
       >
         <div
@@ -6199,7 +6199,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
             <strong
               class="css-bvflvn-TextComponent"
             >
-              Deprecated.
+              Deprecated
             </strong>
              BarCodeScanner has been deprecated and will be removed in a future SDK version. Use 
             <code
@@ -6321,7 +6321,7 @@ for more details.
     </p>
     <div>
       <p
-        class="!text-secondary !font-medium css-1xg9efr-BoxSectionHeader"
+        class="!text-secondary !font-medium css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -6370,7 +6370,7 @@ for more details.
       class="[&>*:last-child]:!mb-0"
     >
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6486,7 +6486,7 @@ minimize battery usage.
         </p>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6640,7 +6640,7 @@ data has been retrieved.
         </blockquote>
       </div>
       <div
-        class="!pb-4 [&>*:last-child]:!mb-0 css-qg659h"
+        class="!pb-4 [&>*:last-child]:!mb-0 css-17cktl8"
       >
         <h3
           class="group css-eynke-TextComponent"
@@ -6882,7 +6882,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7138,7 +7138,7 @@ This uses both
       class="mb-3.5 last:[&>*]:mb-0"
     >
       <p
-        class="!mt-1 css-1xg9efr-BoxSectionHeader"
+        class="!mt-1 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -7277,7 +7277,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7424,7 +7424,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7593,7 +7593,7 @@ This uses both
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7933,7 +7933,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -7987,7 +7987,7 @@ code.
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-1xg9efr-BoxSectionHeader"
+      class="css-19qci8h-BoxSectionHeader"
       data-text="true"
     >
       <span
@@ -8217,7 +8217,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8375,7 +8375,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8527,7 +8527,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8646,7 +8646,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8815,7 +8815,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -8923,7 +8923,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9195,7 +9195,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9343,7 +9343,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9479,7 +9479,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -9530,7 +9530,7 @@ you don't get this value.
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span
@@ -9771,7 +9771,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -9896,7 +9896,7 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <div
       class="flex flex-row items-center mb-2"
@@ -9913,10 +9913,10 @@ exports[`APISection expo-pedometer 1`] = `
            
         </span>
         <div
-          class="!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5 select-none css-1e5tu91-PlatformTag"
+          class="!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4 select-none css-1e5tu91-PlatformTag"
         >
           <svg
-            class="icon-xs text-palette-blue12"
+            class="opacity-80 icon-xs text-palette-blue12"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -10261,7 +10261,7 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10399,7 +10399,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10524,7 +10524,7 @@ available on this device.
     </div>
   </div>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10845,7 +10845,7 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="css-qg659h"
+    class="css-17cktl8"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -10899,7 +10899,7 @@ On iOS, the
       An object obtained by permissions get and request functions.
     </p>
     <p
-      class="css-1xg9efr-BoxSectionHeader"
+      class="css-19qci8h-BoxSectionHeader"
       data-text="true"
     >
       <span
@@ -11129,7 +11129,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11244,7 +11244,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11358,7 +11358,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11460,7 +11460,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-gxnqn3"
+    class="css-7sex76"
   >
     <h3
       class="group css-eynke-TextComponent"
@@ -11633,7 +11633,7 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="!p-0 css-1t05vdz-APISectionEnum"
+    class="!p-0 css-gz86c1-APISectionEnum"
   >
     <div
       class="px-5 pt-4"
@@ -11684,7 +11684,7 @@ After calling this function, the listener will no longer receive any events from
         </a>
       </h3>
       <p
-        class="!mb-0 !border-b-0 css-1xg9efr-BoxSectionHeader"
+        class="!mb-0 !border-b-0 css-19qci8h-BoxSectionHeader"
         data-text="true"
       >
         <span

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -148,7 +148,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -370,7 +370,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </details>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -523,7 +523,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -600,7 +600,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -691,7 +691,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -862,7 +862,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </span>
     </span>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -938,7 +938,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </p>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -1007,7 +1007,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-1vn7kkx-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       data-text="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
         href="#name"
         id="name"
       >
@@ -155,7 +155,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       data-text="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
         href="#androidnavigationbar"
         id="androidnavigationbar"
       >
@@ -377,7 +377,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
           href="#visible"
           id="visible"
         >
@@ -530,7 +530,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
             href="#always"
             id="always"
           >
@@ -607,7 +607,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
           href="#backgroundcolor"
           id="backgroundcolor"
         >
@@ -698,7 +698,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       data-text="true"
     >
       <a
-        class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+        class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
         href="#intentfilters"
         id="intentfilters"
       >
@@ -869,7 +869,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
           href="#autoverify"
           id="autoverify"
         >
@@ -945,7 +945,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         data-text="true"
       >
         <a
-          class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+          class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
           href="#data"
           id="data"
         >
@@ -1014,7 +1014,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           data-text="true"
         >
           <a
-            class="inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0 css-pvem2h-PropertyName"
+            class="inline-flex gap-1.5 items-center relative text-[inherit] decoration-0 scroll-m-12 css-pvem2h-PropertyName"
             href="#host"
             id="host"
           >

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -148,7 +148,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -370,7 +370,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </details>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -523,7 +523,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"
@@ -600,7 +600,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -691,7 +691,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+    class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
   >
     <p
       class="group css-1kfqm4n-TextComponent"
@@ -862,7 +862,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </span>
     </span>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -938,7 +938,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </p>
     </div>
     <div
-      class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+      class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
     >
       <p
         class="group css-1kfqm4n-TextComponent"
@@ -1007,7 +1007,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </code>
       </p>
       <div
-        class="!pb-4 last:[&>*]:!mb-1 css-izfeyc-AppConfigProperty"
+        class="!pb-4 last:[&>*]:!mb-1 css-13k2qmh-AppConfigProperty"
       >
         <p
           class="group css-1kfqm4n-TextComponent"

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -91,7 +91,7 @@ const renderClass = (
 
   return (
     <div key={`class-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
-      <APISectionDeprecationNote comment={comment} />
+      <APISectionDeprecationNote comment={comment} sticky />
       <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -59,7 +59,7 @@ const renderComponent = (
   const extractedComment = getComponentComment(comment, signatures);
   return (
     <div key={`component-definition-${resolvedName}`} css={STYLES_APIBOX} className="!shadow-none">
-      <APISectionDeprecationNote comment={extractedComment} />
+      <APISectionDeprecationNote comment={extractedComment} sticky />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {resolvedName}

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -22,7 +22,7 @@ const renderConstant = (
   apiName?: string
 ): JSX.Element => (
   <div key={`constant-definition-${name}`} css={STYLES_APIBOX} className="[&>*:last-child]:!mb-0">
-    <APISectionDeprecationNote comment={comment} />
+    <APISectionDeprecationNote comment={comment} sticky />
     <APISectionPlatformTags comment={comment} />
     <H3Code tags={getTagNamesList(comment)}>
       <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -1,5 +1,4 @@
-import { css } from '@emotion/react';
-import { spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import ReactMarkdown from 'react-markdown';
 
 import { CommentData } from '~/components/plugins/api/APIDataTypes';
@@ -8,14 +7,16 @@ import {
   getTagData,
   mdComponents,
 } from '~/components/plugins/api/APISectionUtils';
+import { ELEMENT_SPACING } from '~/components/plugins/api/styles';
 import { Callout } from '~/ui/components/Callout';
 import { BOLD } from '~/ui/components/Text';
 
 type Props = {
   comment?: CommentData;
+  sticky?: boolean;
 };
 
-export const APISectionDeprecationNote = ({ comment }: Props) => {
+export const APISectionDeprecationNote = ({ comment, sticky = false }: Props) => {
   const deprecation = getTagData('deprecated', comment);
 
   if (!deprecation) {
@@ -24,10 +25,20 @@ export const APISectionDeprecationNote = ({ comment }: Props) => {
 
   const content = getCommentContent(deprecation.content);
   return (
-    <div css={deprecationNoticeStyle}>
-      <Callout type="warning" key="deprecation-note">
+    <div
+      className={mergeClasses(
+        `[table_&]:mt-0 [table_&]:${ELEMENT_SPACING} [table_&]:last:mb-0`,
+        sticky && 'mx-[-21px] mt-[-21px] max-md-gutters:mx-[-17px]'
+      )}>
+      <Callout
+        type="warning"
+        key="deprecation-note"
+        className={mergeClasses(
+          '[table_&]:last-of-type:mb-2.5',
+          sticky && 'pl-6 pr-4 shadow-none rounded-b-none rounded-t-lg max-md-gutters:px-4'
+        )}>
         {content.length ? (
-          <ReactMarkdown components={mdComponents}>{`**Deprecated.** ${content}`}</ReactMarkdown>
+          <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>
         ) : (
           <BOLD>Deprecated</BOLD>
         )}
@@ -35,10 +46,3 @@ export const APISectionDeprecationNote = ({ comment }: Props) => {
     </div>
   );
 };
-
-const deprecationNoticeStyle = css({
-  'table &': {
-    marginTop: 0,
-    marginBottom: spacing[3],
-  },
-});

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -28,43 +28,47 @@ const sortByValue = (a: EnumValueData, b: EnumValueData) => {
 const renderEnumValue = (value: any, fallback?: string) =>
   typeof value === 'string' ? `"${value}"` : value ?? fallback;
 
-const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Element => (
-  <div key={`enum-definition-${name}`} css={STYLES_APIBOX} className="!p-0">
-    <div className="px-5 pt-4">
-      <APISectionDeprecationNote comment={comment} />
-      <APISectionPlatformTags comment={comment} />
-      <H3Code tags={getTagNamesList(comment)}>
-        <MONOSPACE weight="medium" className="wrap-anywhere">
-          {name}
-        </MONOSPACE>
-      </H3Code>
-      <CommentTextBlock comment={comment} includePlatforms={false} />
-      <BoxSectionHeader text={`${name} Values`} className="!mb-0 !border-b-0" />
-    </div>
-    {children.sort(sortByValue).map((enumValue: EnumValueData) => (
-      <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
-        <APISectionDeprecationNote comment={enumValue.comment} />
-        <APISectionPlatformTags comment={enumValue.comment} />
-        <H4 className="!mt-0" hideInSidebar>
-          <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
-        </H4>
-        <CODE theme="secondary" className="mb-3">
-          {`${name}.${enumValue.name} ＝ ${renderEnumValue(
-            enumValue.type.value,
-            enumValue.type.name
-          )}`}
-        </CODE>
-        <CommentTextBlock comment={enumValue.comment} includePlatforms={false} />
+function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefinitionData }) {
+  return (
+    <div key={`enum-definition-${name}`} css={STYLES_APIBOX} className="!p-0">
+      <div className="px-5 pt-4">
+        <APISectionDeprecationNote comment={comment} />
+        <APISectionPlatformTags comment={comment} />
+        <H3Code tags={getTagNamesList(comment)}>
+          <MONOSPACE weight="medium" className="wrap-anywhere">
+            {name}
+          </MONOSPACE>
+        </H3Code>
+        <CommentTextBlock comment={comment} includePlatforms={false} />
+        <BoxSectionHeader text={`${name} Values`} className="!mb-0 !border-b-0" />
       </div>
-    ))}
-  </div>
-);
+      {children.sort(sortByValue).map((enumValue: EnumValueData) => (
+        <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
+          <APISectionDeprecationNote comment={enumValue.comment} />
+          <APISectionPlatformTags comment={enumValue.comment} disableFallback />
+          <H4 className="!mt-0" hideInSidebar>
+            <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
+          </H4>
+          <CODE theme="secondary" className="mb-3">
+            {`${name}.${enumValue.name} ＝ ${renderEnumValue(
+              enumValue.type.value,
+              enumValue.type.name
+            )}`}
+          </CODE>
+          <CommentTextBlock comment={enumValue.comment} includePlatforms={false} />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 const APISectionEnums = ({ data }: APISectionEnumsProps) =>
   data?.length ? (
     <>
       <H2 key="enums-header">Enums</H2>
-      {data.map(renderEnum)}
+      {data.map(enumData => (
+        <APISectionEnum key={enumData.name} data={enumData} />
+      ))}
     </>
   ) : null;
 

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -45,7 +45,7 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div className="border-t border-t-secondary p-5 pb-0 pt-4" key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-          <APISectionPlatformTags comment={enumValue.comment} disableFallback />
+          <APISectionPlatformTags comment={enumValue.comment} prefix="Only for:" disableFallback />
           <H4 className="!mt-0" hideInSidebar>
             <MONOSPACE className="!text-inherit">{enumValue.name}</MONOSPACE>
           </H4>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -116,7 +116,7 @@ const renderInterface = (
 
   return (
     <div key={`interface-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
-      <APISectionDeprecationNote comment={comment} />
+      <APISectionDeprecationNote comment={comment} sticky />
       <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -76,7 +76,7 @@ export const renderMethod = (
       <div
         key={`method-signature-${method.name || name}-${parameters?.length || 0}`}
         css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <HeaderComponent>
           <MONOSPACE

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -7,6 +7,7 @@ import {
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { renderMethod } from '~/components/plugins/api/APISectionMethods';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   CommentTextBlock,
   getTagData,
@@ -47,12 +48,13 @@ const renderNamespace = (
   return (
     <div key={`class-definition-${name}`} css={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} />
+      <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">
           {name}
         </MONOSPACE>
       </H3Code>
-      <CommentTextBlock comment={comment} />
+      <CommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>
           <BoxSectionHeader text="Returns" />

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -47,7 +47,7 @@ const renderNamespace = (
 
   return (
     <div key={`class-definition-${name}`} css={STYLES_APIBOX}>
-      <APISectionDeprecationNote comment={comment} />
+      <APISectionDeprecationNote comment={comment} sticky />
       <APISectionPlatformTags comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
         <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -133,7 +133,7 @@ export const renderProp = (
       key={`prop-entry-${name}`}
       css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}
       className="!pb-4 [&>*:last-child]:!mb-0">
-      <APISectionDeprecationNote comment={extractedComment} />
+      <APISectionDeprecationNote comment={extractedComment} sticky />
       <APISectionPlatformTags comment={comment} />
       <HeaderComponent tags={getTagNamesList(comment)}>
         <MONOSPACE

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -105,7 +105,7 @@ const renderType = (
     // Object Types
     return (
       <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -133,7 +133,7 @@ const renderType = (
     if (propTypes.length) {
       return (
         <div key={`prop-type-definition-${name}`} css={STYLES_APIBOX}>
-          <APISectionDeprecationNote comment={comment} />
+          <APISectionDeprecationNote comment={comment} sticky />
           <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -175,7 +175,7 @@ const renderType = (
       const acceptedLiteralTypes = defineLiteralType(literalTypes);
       return (
         <div key={`type-definition-${name}`} css={STYLES_APIBOX}>
-          <APISectionDeprecationNote comment={comment} />
+          <APISectionDeprecationNote comment={comment} sticky />
           <APISectionPlatformTags comment={comment} />
           <H3Code tags={getTagNamesList(comment)}>
             <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -215,7 +215,7 @@ const renderType = (
   ) {
     return (
       <div key={`record-definition-${name}`} css={STYLES_APIBOX} className="[&>*:last-child]:!mb-0">
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -234,7 +234,7 @@ const renderType = (
   } else if (type.type === 'intrinsic') {
     return (
       <div key={`generic-type-definition-${name}`} css={STYLES_APIBOX}>
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -253,7 +253,7 @@ const renderType = (
   } else if (type.type === 'conditional' && type.checkType) {
     return (
       <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">
@@ -298,7 +298,7 @@ const renderType = (
 
     return (
       <div key={`conditional-type-definition-${name}`} css={STYLES_APIBOX}>
-        <APISectionDeprecationNote comment={comment} />
+        <APISectionDeprecationNote comment={comment} sticky />
         <APISectionPlatformTags comment={comment} />
         <H3Code tags={getTagNamesList(comment)}>
           <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -789,7 +789,12 @@ export const CommentTextBlock = ({
 
   return (
     <>
-      {includePlatforms && hasPlatforms && <APISectionPlatformTags comment={comment} />}
+      {includePlatforms && hasPlatforms && (
+        <APISectionPlatformTags
+          comment={comment}
+          prefix={emptyCommentFallback ? 'Only for:' : undefined}
+        />
+      )}
       {paramTags && (
         <>
           <DEMI theme="secondary">Only for:&ensp;</DEMI>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { shadows, theme, typography } from '@expo/styleguide';
+import { shadows, theme, typography, mergeClasses } from '@expo/styleguide';
 import { borderRadius, breakpoints, spacing } from '@expo/styleguide-base';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
 import { slug } from 'github-slugger';
@@ -761,7 +761,7 @@ export const CommentTextBlock = ({
 
   const examples = getAllTagData('example', comment);
   const exampleText = examples?.map((example, index) => (
-    <div key={'example-' + index} className={ELEMENT_SPACING}>
+    <div key={'example-' + index} className={mergeClasses(ELEMENT_SPACING, 'last:[&>*]:mb-0')}>
       {inlineHeaders ? (
         <DEMI theme="secondary" className="flex flex-row gap-1.5 items-center mb-1.5">
           <CodeSquare01Icon className="icon-sm" />

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -837,10 +837,10 @@ export function getPossibleComponentPropsNames(name?: string, children: PropData
 }
 
 export const STYLES_APIBOX = css({
-  borderRadius: borderRadius.md,
+  borderRadius: borderRadius.lg,
   borderWidth: 1,
   borderStyle: 'solid',
-  borderColor: theme.border.default,
+  borderColor: theme.border.secondary,
   padding: spacing[5],
   boxShadow: shadows.xs,
   marginBottom: spacing[6],

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -844,7 +844,6 @@ export const STYLES_APIBOX = css({
   padding: spacing[5],
   boxShadow: shadows.xs,
   marginBottom: spacing[6],
-  overflowX: 'hidden',
 
   h3: {
     marginBottom: spacing[2.5],
@@ -884,7 +883,7 @@ export const STYLES_APIBOX_NESTED = css({
 });
 
 export const STYLES_APIBOX_WRAPPER = css({
-  marginBottom: spacing[4],
+  marginBottom: spacing[3.5],
   padding: `${spacing[4]}px ${spacing[5]}px 0`,
 
   [`.css-${tableWrapperStyle.name}:last-child`]: {
@@ -906,6 +905,10 @@ export const STYLES_NESTED_SECTION_HEADER = css({
     marginBottom: 0,
     marginTop: 0,
     color: theme.text.secondary,
+  },
+
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    marginInline: -spacing[4],
   },
 });
 

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
          
       </span>
       <div
-        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-kk7wp3-PlatformTag"
+        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-1e5tu91-PlatformTag"
       >
         <svg
           class="icon-xs text-palette-green12"
@@ -78,7 +78,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
   <div
-    class="mb-3.5"
+    class="mb-3.5 last:[&>*]:mb-0"
   >
     <p
       class="!mt-1 css-1xg9efr-BoxSectionHeader"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
          
       </span>
       <div
-        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-7sgr13-PlatformTag"
+        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none !rounded-full css-7sgr13-PlatformTag"
       >
         <svg
           class="icon-xs text-palette-green12"

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
          
       </span>
       <div
-        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none !rounded-full css-7sgr13-PlatformTag"
+        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-kk7wp3-PlatformTag"
       >
         <svg
           class="icon-xs text-palette-green12"
@@ -48,7 +48,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
           </g>
         </svg>
         <span
-          class="css-1q9zso2-PlatformTag"
+          class="css-103dp5g-PlatformTag"
         >
           Android
         </span>

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -28,10 +28,10 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
          
       </span>
       <div
-        class="!bg-palette-green4 !text-palette-green12 !border-palette-green5 select-none css-1e5tu91-PlatformTag"
+        class="!bg-palette-green3 !text-palette-green12 !border-palette-green4 select-none css-1e5tu91-PlatformTag"
       >
         <svg
-          class="icon-xs text-palette-green12"
+          class="opacity-80 icon-xs text-palette-green12"
           fill="none"
           role="img"
           viewBox="0 0 24 24"
@@ -81,7 +81,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
     class="mb-3.5 last:[&>*]:mb-0"
   >
     <p
-      class="!mt-1 css-1xg9efr-BoxSectionHeader"
+      class="!mt-1 css-19qci8h-BoxSectionHeader"
       data-text="true"
     >
       <span

--- a/docs/providers/TutorialChapterCompletionProvider.tsx
+++ b/docs/providers/TutorialChapterCompletionProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext } from 'react';
+import { createContext, useContext, PropsWithChildren } from 'react';
 
 import { useLocalStorage } from '~/common/useLocalStorage';
 import {
@@ -6,10 +6,10 @@ import {
   Chapter,
 } from '~/ui/components/ProgressTracker/TutorialData';
 
-interface ChapterContextType {
+type ChapterContextType = {
   chapters: Chapter[];
   setChapters: (chapters: Chapter[]) => void;
-}
+};
 
 // Provide initial values matching the type
 const defaultValues: ChapterContextType = {
@@ -17,13 +17,9 @@ const defaultValues: ChapterContextType = {
   setChapters: () => {},
 };
 
-interface ChapterCompletionProviderProps {
-  children: ReactNode;
-}
-
 const TutorialChapterCompletionContext = createContext<ChapterContextType>(defaultValues);
 
-export const TutorialChapterCompletionProvider = ({ children }: ChapterCompletionProviderProps) => {
+export const TutorialChapterCompletionProvider = ({ children }: PropsWithChildren) => {
   const [chapters, setChapters] = useLocalStorage<Chapter[]>({
     name: 'EAS_TUTORIAL',
     defaultValue: EAS_TUTORIAL_INITIAL_CHAPTERS,

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -37,7 +37,8 @@ const Permalink: ComponentType<Props> = withHeadingManager((props: Props & Headi
     <PermalinkBase component={component} className="group">
       <LinkBase
         className={mergeClasses(
-          'inline-flex gap-1.5 items-center scroll-m-5 relative text-[inherit] decoration-0',
+          'inline-flex gap-1.5 items-center relative text-[inherit] decoration-0',
+          props.additionalProps?.sidebarType === 'text' ? 'scroll-m-6' : 'scroll-m-12',
           props.additionalProps?.className
         )}
         href={'#' + heading.slug}

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -24,7 +24,7 @@ export const PlatformTag = ({ platform, type, className }: PlatformTagProps) => 
           platformName === 'macos' ||
           platformName === 'tvos') &&
           TAG_CLASSES[platformName],
-        'select-none',
+        'select-none !rounded-full',
         className
       )}>
       {type !== 'toc' && <PlatformIcon platform={platformName} />}

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -1,33 +1,24 @@
 import { mergeClasses } from '@expo/styleguide';
 
 import { TagProps } from './Tag';
-import { labelStyle, tagStyle, tagToCStyle } from './styles';
+import { labelStyle, tagStyle } from './styles';
 
 import { PlatformIcon } from '~/components/plugins/PlatformIcon';
 import { PlatformName } from '~/types/common';
-import { formatName, getPlatformName, TAG_CLASSES } from '~/ui/components/Tag/helpers';
+import { formatName, getPlatformName, getTagClasses } from '~/ui/components/Tag/helpers';
 
 type PlatformTagProps = Omit<TagProps, 'name'> & {
   platform: PlatformName;
 };
 
-export const PlatformTag = ({ platform, type, className }: PlatformTagProps) => {
+export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
   const platformName = getPlatformName(platform);
 
   return (
     <div
-      css={[tagStyle, type === 'toc' && tagToCStyle]}
-      className={mergeClasses(
-        (platformName === 'android' ||
-          platformName === 'ios' ||
-          platformName === 'web' ||
-          platformName === 'macos' ||
-          platformName === 'tvos') &&
-          TAG_CLASSES[platformName],
-        'select-none',
-        className
-      )}>
-      {type !== 'toc' && <PlatformIcon platform={platformName} />}
+      css={tagStyle}
+      className={mergeClasses(getTagClasses(platformName), 'select-none', className)}>
+      <PlatformIcon platform={platformName} />
       <span css={labelStyle}>{formatName(platform)}</span>
     </div>
   );

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -24,7 +24,7 @@ export const PlatformTag = ({ platform, type, className }: PlatformTagProps) => 
           platformName === 'macos' ||
           platformName === 'tvos') &&
           TAG_CLASSES[platformName],
-        'select-none !rounded-full',
+        'select-none',
         className
       )}>
       {type !== 'toc' && <PlatformIcon platform={platformName} />}

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -2,25 +2,25 @@ import { mergeClasses } from '@expo/styleguide';
 import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
 
 import { TagProps } from './Tag';
-import { labelStyle, tagStyle, tagToCStyle } from './styles';
+import { labelStyle, tagStyle } from './styles';
 
-import { formatName, TAG_CLASSES } from '~/ui/components/Tag/helpers';
+import { formatName, getTagClasses } from '~/ui/components/Tag/helpers';
 
 type StatusTagProps = Omit<TagProps, 'name'> & {
   status: 'deprecated' | 'experimental' | string;
   note?: string;
 };
 
-export const StatusTag = ({ status, type, note, className }: StatusTagProps) => {
+export const StatusTag = ({ status, note, className }: StatusTagProps) => {
   return (
     <div
       className={mergeClasses(
-        status === 'deprecated' && TAG_CLASSES['deprecated'],
-        status === 'experimental' && TAG_CLASSES['experimental'],
+        status === 'deprecated' && getTagClasses('deprecated'),
+        status === 'experimental' && getTagClasses('experimental'),
         'select-none',
         className
       )}
-      css={[tagStyle, type === 'toc' && tagToCStyle]}>
+      css={tagStyle}>
       {status === 'experimental' && <Star06Icon className="icon-xs text-palette-pink12" />}
       <span css={labelStyle}>{status ? formatName(status) + (note ? `: ${note}` : '') : note}</span>
     </div>

--- a/docs/ui/components/Tag/Tag.tsx
+++ b/docs/ui/components/Tag/Tag.tsx
@@ -8,7 +8,6 @@ import { getPlatformName } from '~/ui/components/Tag/helpers';
 export type TagProps = {
   name: string;
   firstElement?: boolean;
-  type?: 'regular' | 'toc';
 } & HTMLAttributes<HTMLDivElement>;
 
 export const Tag = ({ name, ...rest }: TagProps) => {

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -1,24 +1,35 @@
 import { capitalize } from '~/components/plugins/api/APISectionUtils';
 import { PlatformName } from '~/types/common';
 
-export const getPlatformName = (text: string): PlatformName => {
+export function getPlatformName(text: string): PlatformName {
   if (text.toLowerCase().includes('ios')) return 'ios';
   if (text.toLowerCase().includes('android')) return 'android';
   if (text.toLowerCase().includes('web')) return 'web';
   if (text.toLowerCase().includes('macos')) return 'macos';
   if (text.toLowerCase().includes('tvos')) return 'tvos';
   return '';
-};
+}
 
-export const TAG_CLASSES = {
-  android: '!bg-palette-green4 !text-palette-green12 !border-palette-green5',
-  ios: '!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5',
-  web: '!bg-palette-orange4 !text-palette-orange12 !border-palette-orange5',
-  macos: '!bg-palette-purple4 !text-palette-purple12 !border-palette-purple5',
-  tvos: '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5',
-  deprecated: '!bg-palette-yellow3 !text-palette-yellow12 !border-palette-yellow5',
-  experimental: '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5',
-};
+export function getTagClasses(type: string) {
+  switch (type) {
+    case 'android':
+      return '!bg-palette-green4 !text-palette-green12 !border-palette-green5';
+    case 'ios':
+      return '!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5';
+    case 'web':
+      return '!bg-palette-orange4 !text-palette-orange12 !border-palette-orange5';
+    case 'macos':
+      return '!bg-palette-purple4 !text-palette-purple12 !border-palette-purple5';
+    case 'tvos':
+      return '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5';
+    case 'deprecated':
+      return '!bg-palette-yellow3 !text-palette-yellow12 !border-palette-yellow5';
+    case 'experimental':
+      return '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5';
+    default:
+      return undefined;
+  }
+}
 
 export const formatName = (name: PlatformName) => {
   const cleanName = name.toLowerCase().replace('\n', '');

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -13,19 +13,19 @@ export function getPlatformName(text: string): PlatformName {
 export function getTagClasses(type: string) {
   switch (type) {
     case 'android':
-      return '!bg-palette-green4 !text-palette-green12 !border-palette-green5';
+      return '!bg-palette-green3 !text-palette-green12 !border-palette-green4';
     case 'ios':
-      return '!bg-palette-blue4 !text-palette-blue12 !border-palette-blue5';
+      return '!bg-palette-blue3 !text-palette-blue12 !border-palette-blue4';
     case 'web':
-      return '!bg-palette-orange4 !text-palette-orange12 !border-palette-orange5';
+      return '!bg-palette-orange3 !text-palette-orange12 !border-palette-orange4';
     case 'macos':
-      return '!bg-palette-purple4 !text-palette-purple12 !border-palette-purple5';
+      return '!bg-palette-purple3 !text-palette-purple12 !border-palette-purple4';
     case 'tvos':
-      return '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5';
+      return '!bg-palette-pink3 !text-palette-pink12 !border-palette-pink4';
     case 'deprecated':
-      return '!bg-palette-yellow3 !text-palette-yellow12 !border-palette-yellow5';
+      return '!bg-palette-yellow2 !text-palette-yellow12 !border-palette-yellow4';
     case 'experimental':
-      return '!bg-palette-pink4 !text-palette-pink12 !border-palette-pink5';
+      return '!bg-palette-pink3 !text-palette-pink12 !border-palette-pink4';
     default:
       return undefined;
   }

--- a/docs/ui/components/Tag/styles.ts
+++ b/docs/ui/components/Tag/styles.ts
@@ -33,11 +33,3 @@ export const labelStyle = css({
   fontWeight: 'normal',
   fontSize: 'inherit !important',
 });
-
-export const tagToCStyle = css({
-  fontSize: '0.7rem',
-  marginBottom: 0,
-  marginRight: 0,
-  marginLeft: spacing[1],
-  padding: `0 ${spacing[1.5]}px`,
-});

--- a/docs/ui/components/Tag/styles.ts
+++ b/docs/ui/components/Tag/styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { theme } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
+import { spacing } from '@expo/styleguide-base';
 
 export const tagStyle = css({
   display: 'inline-flex',
@@ -9,7 +9,7 @@ export const tagStyle = css({
   fontSize: '90%',
   padding: `${spacing[1]}px ${spacing[2]}px`,
   marginRight: spacing[2],
-  borderRadius: borderRadius.sm,
+  borderRadius: 999,
   border: `1px solid ${theme.border.default}`,
   alignItems: 'center',
   gap: spacing[1],
@@ -29,7 +29,7 @@ export const tagStyle = css({
 });
 
 export const labelStyle = css({
-  lineHeight: `${spacing[4]}px`,
+  lineHeight: `${spacing[4]}px !important`,
   fontWeight: 'normal',
   fontSize: 'inherit !important',
 });


### PR DESCRIPTION
# Why

An experiment to improve our API Reference documentation, the changes for now will only apply to the `unversioned` docs.

# How

Add a fallback for supported platforms to default package supported platforms list, if platforms were not specified manually in packages source comments before.

Add a stick display mode for the deprecation notes, fix appearance of few components to better fit the pattern, fix scroll offset mismatch.

# Test Plan

The changes have been tested locally. All lint checks and tests are passing.

# Sneak Peek

![Screenshot 2024-07-02 at 12 51 33](https://github.com/expo/expo/assets/719641/9320521c-3b35-4c27-b49e-8da3006cedef)
![Screenshot 2024-07-03 at 11 15 16](https://github.com/expo/expo/assets/719641/a06fc5d2-a832-4693-bb79-8a7ed4150b8d)
![Screenshot 2024-07-02 at 15 01 24](https://github.com/expo/expo/assets/719641/7a48c143-741b-4994-8d3f-703828da3a1e)
![Screenshot 2024-07-02 at 14 01 38](https://github.com/expo/expo/assets/719641/92d5e0ab-776d-461a-ae2c-688bd0e1a665)

