### PR TITLE
[docs] Fix typo in guide page for using hermes

### DIFF
--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -41,7 +41,7 @@ To debug JavaScript code running with Hermes, you can start your project with `n
 Alternatively, you can use the JavaScript inspector from the following tools:
 
 - [Open Google Chrome DevTools manually](https://reactnative.dev/docs/hermes#debugging-js-on-hermes-using-google-chromes-devtools)
-- [Experimentsl new React Native debugger](https://reactnative.dev/docs/debugging?js-debugger=new-debugger)
+- [Experimental new React Native debugger](https://reactnative.dev/docs/debugging?js-debugger=new-debugger)
 
 ### Troubleshooting
 


### PR DESCRIPTION
on the page: [guides/using hermes](https://docs.expo.dev/guides/using-hermes/)
line number 44: The spelling of experimental is misspelled as experimentsl.

# Why

The spelling of experimental is misspelled as experimentsl.
on line number 44.

# How

Changed the spelling

# Test Plan

No testing is required

# Checklist


- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
