### PR TITLE
[docs] Add info about App submissions for federated Apple Developer accounts

### DIFF
--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -73,4 +73,4 @@ The associated provisioning profile needs to be updated if certain [iOS capabili
 
 ### App submissions for federated Apple Developer accounts
 
-When using a [Federated Apple Developer account](https://support.apple.com/en-in/guide/apple-business-manager/axmb19317543/web), submitting a [production build](/build/eas-json/#production-builds) to the Apple App Store will result in a failure. To submit the app for Apple App Store, follow the steps in [Provide an ASC API Token for your Apple Team](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team).
+When using a [Federated Apple Developer account](https://support.apple.com/en-in/guide/apple-business-manager/axmb19317543/web), submitting a [production build](/build/eas-json/#production-builds) to the Apple App Store will result in a failure. To submit the app to the Apple App Store, follow the steps in [Provide an ASC API Token for your Apple Team](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team).

--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -71,6 +71,14 @@ When uploading the credentials, you will need the **.p12** and **.mobileprovisio
 
 The associated provisioning profile needs to be updated if certain [iOS capabilities](/build-reference/ios-capabilities/) (such as, entitlements) are added or removed, or at the annual expiry of the profile. This step is handled by the Apple Developer account's authorized user.
 
-### App submissions for federated Apple Developer accounts
+### Federated Apple Developer accounts
 
-When using a [Federated Apple Developer account](https://support.apple.com/en-in/guide/apple-business-manager/axmb19317543/web), submitting a [production build](/build/eas-json/#production-builds) to the Apple App Store will result in a failure. To submit the app to the Apple App Store, follow the steps in [Provide an ASC API Token for your Apple Team](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team).
+#### EAS Build
+
+EAS CLI can only accept an Apple account's email and password to login into your Apple Developer account. You cannot login into [Federated Apple Developer account](https://support.apple.com/en-in/guide/apple-business-manager/axmb19317543/web) and make updates to the distribution certificate or provisioning profile. If your build credentials do not require any changes, you can skip logging in. Then, you can proceed with the build and EAS CLI will continue using your current uploaded credentials.
+
+However, you can provide an Apple Store Connect (ASC) API token with Admin access to check and update Apple credentials when running `eas build` command. Follow the steps in [Provide an ASC API Token for your Apple Team](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team) to create a build by passing the required token value to the `eas build` command.
+
+#### EAS Submit
+
+EAS Submit uses the ASC API token for submitting to TestFlight. If you have a Federated Apple Developer account, you can follow the standard EAS Submit setup. It lets you automatically submit your builds using `eas build --auto-submit`.

--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -70,3 +70,7 @@ When uploading the credentials, you will need the **.p12** and **.mobileprovisio
 ### Provisioning profile expiry and updates
 
 The associated provisioning profile needs to be updated if certain [iOS capabilities](/build-reference/ios-capabilities/) (such as, entitlements) are added or removed, or at the annual expiry of the profile. This step is handled by the Apple Developer account's authorized user.
+
+### App submissions for federated Apple Developer accounts
+
+When using a [Federated Apple Developer account](https://support.apple.com/en-in/guide/apple-business-manager/axmb19317543/web), submitting a [production build](/build/eas-json/#production-builds) to the Apple App Store will result in a failure. To submit the app for Apple App Store, follow the steps in [Provide an ASC API Token for your Apple Team](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-11089

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a section about Federated develop apple accounts that provides info that the user will see a submission error and link to the https://docs.expo.dev/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team section as suggested by @keith-kurak.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
