### PR TITLE
[docs] Remove outdated callout from MediaLibrary API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -19,8 +19,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and `expo-media-library` won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
-
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v49.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/media-library.mdx
@@ -19,8 +19,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and `expo-media-library` won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
-
 <PlatformsSection android emulator ios simulator />
 
 ## Installation

--- a/docs/pages/versions/v50.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/media-library.mdx
@@ -19,8 +19,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and `expo-media-library` won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
-
 <PlatformsSection android emulator ios simulator />
 
 ## Installation

--- a/docs/pages/versions/v51.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/media-library.mdx
@@ -19,8 +19,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-media-library` provides access to the user's media library, allowing them to access their existing images and videos from your app, as well as save new ones. You can also subscribe to any updates made to the user's media library.
 
-> **warning** If your Android app created an album using SDK &lt;= 40 and you want to add more assets to this album, you may need to migrate it to the new scoped directory. Otherwise, your app won't have access to the old album directory and `expo-media-library` won't be able to add new assets to it. However, all other functions will work without problems. You only need to migrate the old album if you want to add something to it. For more information, check out [Android R changes](https://expo.fyi/android-r) and [`MediaLibrary.migrateAlbumIfNeededAsync`](#medialibrarymigratealbumifneededasyncalbum).
-
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This callout relates to SDK version 40. After discussing with @Simek, we can safely remove this. 

![Screenshot 2024-07-02 at 16 18 45](https://github.com/expo/expo/assets/10234615/79a371ea-dc51-4cf5-9381-c307fe982260)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the callout from the Media Library API reference. Changes applied to unversioned and all other SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
