### PR TITLE
[docs] Update warning callout in React Compiler guide

### DIFF
--- a/docs/pages/preview/react-compiler.mdx
+++ b/docs/pages/preview/react-compiler.mdx
@@ -6,7 +6,7 @@ description: Learn how to enable and use the React Compiler in Expo apps.
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **warning** **Warning:** React Compiler is experimental. Available from Expo SDK 51.
+> **warning** **Warning:** React Compiler is experimental. Currently, it is on hold and we'll soon provide more updates on its usage.
 
 The new [React Compiler](https://react.dev/learn/react-compiler) automatically memoizes components and hooks to enable fine-grained reactivity. This can lead to significant performance improvements in your app. The React Compiler is currently experimental and is not enabled by default. You can enable it in your app by following the instructions below.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Reference: https://x.com/ludwig_vaan/status/1808134991248793797

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the callout to communicate that this is on hold. I've asked in the [Expo CLI channel](https://exponent-internal.slack.com/archives/C5ERY0TAR/p1719929324648159?thread_ts=1718722142.206709&cid=C5ERY0TAR) whether it is available with canary release. Will update this warning once that's confirmed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
