### PR TITLE
[docs]: Use updated pod name DGCharts

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -259,7 +259,7 @@ Now you can implement the native functionality by editing the placeholder files 
 
 ```swift ios/ExpoRadialChartView.swift
 import ExpoModulesCore
-import Charts
+import DGCharts
 
 struct Series: Record {
   @Field

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -90,7 +90,7 @@ dependencies {
     s.static_framework = true
 
     s.dependency 'ExpoModulesCore'
-+   s.dependency 'Charts', '~> 4.1.0'
++   s.dependency 'DGCharts', '~> 5.1.0'
 
     # Swift/Objective-C compatibility
 ```


### PR DESCRIPTION
The Chart library for iOS used as example in "Wrap third-party native libraries"  has been renamed.

> Charts is now called DGCharts to prevent conflicts with Apple's SwiftUI Charts.

- https://github.com/ChartsOrg/Charts/releases/tag/5.0.0

# Why
The example suggest a pod library that is renamed
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
update the podspec dependency
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
