### PR TITLE
feat(babel): add process.env.EXPO_SERVER for detecting universal server environments.

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 ### 🎉 New features
 
+- Add `process.env.EXPO_SERVER` for detecting when the JS was bundled for a server or react server environment.
 - Update React Compiler version to latest. ([#29635](https://github.com/expo/expo/pull/29635) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🐛 Bug fixes
+
+- Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native.
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### 🎉 New features
 
-- Add `process.env.EXPO_SERVER` for detecting when the JS was bundled for a server or react server environment.
+- Add `process.env.EXPO_SERVER` for detecting when the JS was bundled for a server or react server environment. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 - Update React Compiler version to latest. ([#29635](https://github.com/expo/expo/pull/29635) by [@reichhartd](https://github.com/reichhartd))
 
 ### 🐛 Bug fixes
 
-- Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native.
+- Remove `@babel/plugin-transform-parameters` plugin when bundling for server environments that target native. ([#30147](https://github.com/expo/expo/pull/30147) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -73,7 +73,7 @@ function reactClientReferencesPlugin() {
                                     pushProxy(exportName);
                                 }
                             }
-                            else if (!['InterfaceDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)) {
+                            else if (!['InterfaceDeclaration', 'TSTypeAliasDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)) {
                                 // TODO: What is this type?
                                 console.warn('[babel-preset-expo] Unsupported export specifier for "use client":', exportPath.node.declaration.type);
                             }

--- a/packages/babel-preset-expo/build/environment-restricted-imports.js
+++ b/packages/babel-preset-expo/build/environment-restricted-imports.js
@@ -7,7 +7,7 @@ const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
 /** Prevent importing certain known imports in given environments. This is for sanity to ensure a module never accidentally gets imported unexpectedly. */
 function environmentRestrictedImportsPlugin(api) {
     const { types: t } = api;
-    const isReactServer = api.caller(common_1.getIsReactServer);
+    const isReactServer = api.caller(common_1.getIsReactServer) || api.caller(common_1.getIsServer);
     const forbiddenPackages = isReactServer
         ? FORBIDDEN_REACT_SERVER_IMPORTS
         : FORBIDDEN_CLIENT_IMPORTS;

--- a/packages/babel-preset-expo/build/environment-restricted-imports.js
+++ b/packages/babel-preset-expo/build/environment-restricted-imports.js
@@ -7,14 +7,14 @@ const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
 /** Prevent importing certain known imports in given environments. This is for sanity to ensure a module never accidentally gets imported unexpectedly. */
 function environmentRestrictedImportsPlugin(api) {
     const { types: t } = api;
-    const isReactServer = api.caller(common_1.getIsReactServer) || api.caller(common_1.getIsServer);
-    const forbiddenPackages = isReactServer
+    const isAnyServerEnvironment = api.caller(common_1.getIsReactServer) || api.caller(common_1.getIsServer);
+    const forbiddenPackages = isAnyServerEnvironment
         ? FORBIDDEN_REACT_SERVER_IMPORTS
         : FORBIDDEN_CLIENT_IMPORTS;
     function checkSource(source, path) {
         forbiddenPackages.forEach((forbiddenImport) => {
             if (source === forbiddenImport) {
-                if (isReactServer) {
+                if (isAnyServerEnvironment) {
                     throw path.buildCodeFrameError(`Importing '${forbiddenImport}' module is not allowed in a React server bundle. Add the "use client" directive to this file or one of the parent modules to allow importing this module.`);
                 }
                 else {

--- a/packages/babel-preset-expo/build/expo-router-plugin.d.ts
+++ b/packages/babel-preset-expo/build/expo-router-plugin.d.ts
@@ -1,3 +1,6 @@
+/**
+ * Copyright © 2024 650 Industries.
+ */
 import { ConfigAPI, types } from '@babel/core';
 /**
  * Inlines environment variables to configure the process:

--- a/packages/babel-preset-expo/build/expo-router-plugin.js
+++ b/packages/babel-preset-expo/build/expo-router-plugin.js
@@ -4,6 +4,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoRouterBabelPlugin = void 0;
+/**
+ * Copyright © 2024 650 Industries.
+ */
 const core_1 = require("@babel/core");
 const path_1 = __importDefault(require("path"));
 const resolve_from_1 = __importDefault(require("resolve-from"));

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -89,15 +89,18 @@ function babelPresetExpo(api, options = {}) {
         // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
         extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
     }
-    else if (!isServerEnv) {
-        // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
-        // JSX is used in a function body. This is technically not required in production, but we
-        // should retain the same behavior since it's hard to debug the differences.
-        extraPlugins.push(require('@babel/plugin-transform-parameters'));
+    else {
+        if (platform !== 'web' && !isServerEnv) {
+            // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
+            // JSX is used in a function body. This is technically not required in production, but we
+            // should retain the same behavior since it's hard to debug the differences.
+            extraPlugins.push(require('@babel/plugin-transform-parameters'));
+        }
     }
     const inlines = {
         'process.env.EXPO_OS': platform,
         // 'typeof document': isServerEnv ? 'undefined' : 'object',
+        'process.env.EXPO_SERVER': !!isServerEnv,
     };
     // `typeof window` is left in place for native + client environments.
     const minifyTypeofWindow = (platformOptions.minifyTypeofWindow ?? isServerEnv) || platform === 'web';

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -82,7 +82,9 @@ export function reactClientReferencesPlugin(): babel.PluginObj {
                   pushProxy(exportName);
                 }
               } else if (
-                !['InterfaceDeclaration', 'TypeAlias'].includes(exportPath.node.declaration.type)
+                !['InterfaceDeclaration', 'TSTypeAliasDeclaration', 'TypeAlias'].includes(
+                  exportPath.node.declaration.type
+                )
               ) {
                 // TODO: What is this type?
                 console.warn(

--- a/packages/babel-preset-expo/src/environment-restricted-imports.ts
+++ b/packages/babel-preset-expo/src/environment-restricted-imports.ts
@@ -3,7 +3,7 @@
  */
 import { ConfigAPI, NodePath, types } from '@babel/core';
 
-import { getIsReactServer } from './common';
+import { getIsReactServer, getIsServer } from './common';
 
 const FORBIDDEN_CLIENT_IMPORTS = ['server-only'];
 const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
@@ -14,7 +14,7 @@ export function environmentRestrictedImportsPlugin(
 ): babel.PluginObj {
   const { types: t } = api;
 
-  const isReactServer = api.caller(getIsReactServer);
+  const isReactServer = api.caller(getIsReactServer) || api.caller(getIsServer);
 
   const forbiddenPackages = isReactServer
     ? FORBIDDEN_REACT_SERVER_IMPORTS

--- a/packages/babel-preset-expo/src/environment-restricted-imports.ts
+++ b/packages/babel-preset-expo/src/environment-restricted-imports.ts
@@ -14,16 +14,16 @@ export function environmentRestrictedImportsPlugin(
 ): babel.PluginObj {
   const { types: t } = api;
 
-  const isReactServer = api.caller(getIsReactServer) || api.caller(getIsServer);
+  const isAnyServerEnvironment = api.caller(getIsReactServer) || api.caller(getIsServer);
 
-  const forbiddenPackages = isReactServer
+  const forbiddenPackages = isAnyServerEnvironment
     ? FORBIDDEN_REACT_SERVER_IMPORTS
     : FORBIDDEN_CLIENT_IMPORTS;
 
   function checkSource(source: string, path: NodePath<any>) {
     forbiddenPackages.forEach((forbiddenImport) => {
       if (source === forbiddenImport) {
-        if (isReactServer) {
+        if (isAnyServerEnvironment) {
           throw path.buildCodeFrameError(
             `Importing '${forbiddenImport}' module is not allowed in a React server bundle. Add the "use client" directive to this file or one of the parent modules to allow importing this module.`
           );

--- a/packages/babel-preset-expo/src/expo-router-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-router-plugin.ts
@@ -1,12 +1,15 @@
+/**
+ * Copyright © 2024 650 Industries.
+ */
 import { ConfigAPI, NodePath, types } from '@babel/core';
 import nodePath from 'path';
 import resolveFrom from 'resolve-from';
 
 import {
-  getAsyncRoutes,
   getExpoRouterAbsoluteAppRoot,
   getPlatform,
   getPossibleProjectRoot,
+  getAsyncRoutes,
 } from './common';
 
 const debug = require('debug')('expo:babel:router');

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -204,16 +204,19 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // getters and setters in spread objects. We need to add this plugin ourself without that option.
     // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
     extraPlugins.push([require('@babel/plugin-transform-object-rest-spread'), { loose: false }]);
-  } else if (!isServerEnv) {
-    // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
-    // JSX is used in a function body. This is technically not required in production, but we
-    // should retain the same behavior since it's hard to debug the differences.
-    extraPlugins.push(require('@babel/plugin-transform-parameters'));
+  } else {
+    if (platform !== 'web' && !isServerEnv) {
+      // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
+      // JSX is used in a function body. This is technically not required in production, but we
+      // should retain the same behavior since it's hard to debug the differences.
+      extraPlugins.push(require('@babel/plugin-transform-parameters'));
+    }
   }
 
-  const inlines: Record<string, boolean | string> = {
+  const inlines: Record<string, null | boolean | string> = {
     'process.env.EXPO_OS': platform,
     // 'typeof document': isServerEnv ? 'undefined' : 'object',
+    'process.env.EXPO_SERVER': !!isServerEnv,
   };
 
   // `typeof window` is left in place for native + client environments.


### PR DESCRIPTION
# Why

- Required for React Server Components.
- Throw no use of `client-only` in Node.js (API Route) bundles.
- Add `process.env.EXPO_SERVER` to detect server environments on all platforms (`typeof window` is ambiguous on native (and only run during minification)).
- Only add `@babel/plugin-transform-parameters` when bundling for native client environments (due to react JSX dev plugin limitation).
- Account for `TSTypeAliasDeclaration` usage in client boundary plugin.

# Test Plan

- Added some unit tests.