### PR TITLE
Add rive files

### DIFF
--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 export const IMAGE_TYPES = ['.png', '.jpg', '.gif'];
 export const FONT_TYPES = ['.otf', '.ttf'];
-export const MEDIA_TYPES = ['.mp4', '.mp3', '.lottie'];
+export const MEDIA_TYPES = ['.mp4', '.mp3', '.lottie','.riv'];
 export const ACCEPTED_TYPES = ['.json', '.db', ...IMAGE_TYPES, ...MEDIA_TYPES, ...FONT_TYPES];
 
 export async function resolveAssetPaths(assets: string[], projectRoot: string) {


### PR DESCRIPTION


# Why
Adding `.riv` for rive.app files, I tired to add it to custom extensions in metro config but with the current check it won't pass

<img width="1001" alt="image" src="https://github.com/expo/expo/assets/43112535/fbe55ca3-ac12-4cd1-88e1-a02d573f2948">


# How

added it to accepted types 

# Test Plan

run a prebuild with the updated plugin 
seems the warning was resolved but the assets was not generated maybe I'm missing something I'm open for help and suggestions 

<img width="859" alt="image" src="https://github.com/expo/expo/assets/43112535/9787b299-2f26-4367-8713-51808c871148">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
