### PR TITLE
[docs] Minor fixes to Linking and Deep Linking guides

### DIFF
--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
-Universal links are different from standard deep links as they use regular HTTPS links to direct users to a specific route in your app. If a user doesn't have your app installed, the link will take them to the associated website. This allows you to send notification emails with links that work seamlessly on desktop web browsers while opening the content in your app on mobile. Android refers to this concept as **app links**, and iOS refers to it as **universal links**. This guide specifically discusses universal links that do not use a custom URL scheme.
+Universal links are different from [standard deep links](/guides/linking/#linking-to-your-app) as they use regular HTTPS links to direct users to a specific route in your app. If a user doesn't have your app installed, the link will take them to the associated website. This allows you to send notification emails with links that work seamlessly on desktop web browsers while opening the content in your app on mobile. Android refers to this concept as **app links**, and iOS refers to it as **universal links**. This guide specifically discusses universal links that do not use a custom URL scheme.
 
 > Deferred deep links can be implemented with [`react-native-branch`](https://github.com/expo/config-plugins/tree/main/packages/react-native-branch).
 

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -3,6 +3,8 @@ title: Linking
 description: Learn how to use Linking to handle a URL based on the URL scheme.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
@@ -301,18 +303,21 @@ You can _also_ open a URL by searching for it on the device's native browser. Fo
   title="Deep linking"
   description="Setup iOS universal links and Android deep links."
   href="/guides/deep-linking"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Authentication"
   description="Use linking to implement web-based authentication."
   href="/guides/authentication"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Routing"
   description="Setup React Navigation linking for in-app routing."
   href="https://reactnavigation.org/docs/configuring-links"
+  Icon={BookOpen02Icon}
 />
 
 [expo-go]: https://expo.dev/go


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR:
- Adds icons to BoxLinks used in Linking doc
- Add a link to [Linking your app](https://docs.expo.dev/guides/linking/#linking-to-your-app) section from the Deep linking guide where [standard deep links] are mentioned (based on feedback from @kadikraman -- since the Deep Linking guide didn't provide a definition of standard deep links).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
