### PR TITLE
[docs] fix API ToC rendering for single Classes and Namespaces

### DIFF
--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,13 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
 import type { PropsWithChildren } from 'react';
 
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import {
   H3Code,
   STYLES_APIBOX,
   STYLES_APIBOX_WRAPPER,
 } from '~/components/plugins/api/APISectionUtils';
 import { PlatformName } from '~/types/common';
-import { PlatformTags } from '~/ui/components/Tag';
 import { MONOSPACE } from '~/ui/components/Text';
 
 type APIBoxProps = PropsWithChildren<{
@@ -21,7 +21,7 @@ export const APIBox = ({ header, platforms, children, className }: APIBoxProps) 
     <div
       css={[STYLES_APIBOX, STYLES_APIBOX_WRAPPER]}
       className={mergeClasses(className, '!pb-4 last:[&>*]:!mb-1')}>
-      {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
+      {platforms && <APISectionPlatformTags prefix="Only for:" userProvidedPlatforms={platforms} />}
       {header && (
         <H3Code tags={platforms}>
           <MONOSPACE weight="medium" className="wrap-anywhere">

--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -28,12 +28,6 @@ type Props = {
   forceVersion?: string;
   testRequire?: any;
   headersMapping?: Record<string, string>;
-
-  /**
-   * Whether to expose all classes props in the sidebar.
-   * @default true when the api has only one class, false otherwise.
-   */
-  exposeAllClassPropsInSidebar?: boolean;
 };
 
 const filterDataByKind = (
@@ -106,7 +100,6 @@ const renderAPI = (
     apiName,
     testRequire = undefined,
     headersMapping = {},
-    ...restProps
   }: Omit<Props, 'forceVersion'>
 ): JSX.Element => {
   try {
@@ -284,11 +277,7 @@ const renderAPI = (
         />
         <APISectionConstants data={constants} apiName={apiName} sdkVersion={sdkVersion} />
         <APISectionMethods data={hooks} header="Hooks" sdkVersion={sdkVersion} />
-        <APISectionClasses
-          data={classes}
-          sdkVersion={sdkVersion}
-          exposeAllClassPropsInSidebar={restProps.exposeAllClassPropsInSidebar}
-        />
+        <APISectionClasses data={classes} sdkVersion={sdkVersion} />
         {props && !componentsProps.length ? (
           <APISectionProps data={props} sdkVersion={sdkVersion} defaultProps={defaultProps} />
         ) : null}

--- a/docs/components/plugins/api/APIMethod.tsx
+++ b/docs/components/plugins/api/APIMethod.tsx
@@ -1,0 +1,65 @@
+import { MethodParamData } from './APIDataTypes';
+import { renderMethod } from './APISectionMethods';
+import { TypeDocKind } from './APISectionUtils';
+
+type Props = {
+  exposeInSidebar?: boolean;
+  name: string;
+  sdkVersion: string;
+  comment: string;
+  returnTypeName: string;
+  isProperty: boolean;
+  isReturnTypeReference: boolean;
+  platforms: ('Android' | 'iOS' | 'Web')[];
+  parameters: {
+    name: string;
+    comment?: string;
+    typeName: string;
+    isReference?: boolean;
+  }[];
+};
+
+export function APIMethod({
+  name,
+  sdkVersion,
+  comment,
+  returnTypeName,
+  isProperty = false,
+  isReturnTypeReference = false,
+  exposeInSidebar = false,
+  parameters = [],
+  platforms = [],
+}: Props) {
+  const parsedParameters = parameters.map(
+    param =>
+      ({
+        name: param.name,
+        type: { name: param.typeName, type: param.isReference ? 'reference' : 'literal' },
+
+        comment: {
+          summary: [{ kind: 'text', text: param.comment }],
+        },
+      }) as MethodParamData
+  );
+  return renderMethod(
+    {
+      name,
+      signatures: [
+        {
+          name,
+          parameters: parsedParameters,
+          comment: {
+            summary: [{ kind: 'text', text: comment }],
+            blockTags: platforms.map(text => ({
+              tag: 'platform',
+              content: [{ kind: 'text', text }],
+            })),
+          },
+          type: { name: returnTypeName, type: isReturnTypeReference ? 'reference' : 'literal' },
+        },
+      ],
+      kind: isProperty ? TypeDocKind.Property : TypeDocKind.Function,
+    },
+    { sdkVersion, exposeInSidebar }
+  );
+}

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -29,17 +29,9 @@ import { H2, CODE, MONOSPACE, CALLOUT, SPAN } from '~/ui/components/Text';
 export type APISectionClassesProps = {
   data: GeneratedData[];
   sdkVersion: string;
-
-  /**
-   * Whether to expose all classes props in the sidebar.
-   * @default true when `data` has only one class, false otherwise.
-   *
-   * > **Note:** When you have multiple classes and want to enable this option, you should also set the mdx `maxHeadingDepth` at least to 3.
-   */
-  exposeAllClassPropsInSidebar?: boolean;
 };
 
-const classNamesMap: Record<string, string> = {
+const CLASS_NAMES_MAP: Record<string, string> = {
   AccelerometerSensor: 'Accelerometer',
   BarometerSensor: 'Barometer',
   DeviceMotionSensor: 'DeviceMotion',
@@ -61,8 +53,8 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   !child?.implementationOf;
 
 const remapClass = (clx: ClassDefinitionData) => {
-  clx.isSensor = !!classNamesMap[clx.name] || Object.values(classNamesMap).includes(clx.name);
-  clx.name = classNamesMap[clx.name] ?? clx.name;
+  clx.isSensor = !!CLASS_NAMES_MAP[clx.name] || Object.values(CLASS_NAMES_MAP).includes(clx.name);
+  clx.name = CLASS_NAMES_MAP[clx.name] ?? clx.name;
 
   if (clx.isSensor && clx.extendedTypes) {
     clx.extendedTypes = clx.extendedTypes.map(type => ({
@@ -75,19 +67,16 @@ const remapClass = (clx: ClassDefinitionData) => {
 };
 
 const renderClass = (
-  clx: ClassDefinitionData,
-  options: { hasOnlyOneClass: boolean },
+  { name, comment, type, extendedTypes, children, implementedTypes, isSensor }: ClassDefinitionData,
   sdkVersion: string
 ): JSX.Element => {
-  const { name, comment, type, extendedTypes, children, implementedTypes, isSensor } = clx;
-
   const properties = children?.filter(isProp);
   const methods = children
     ?.filter(child => isMethod(child, isSensor))
     .sort((a: PropData, b: PropData) => a.name.localeCompare(b.name));
   const returnComment = getTagData('returns', comment);
 
-  const linksNestingLevel = DEFAULT_BASE_NESTING_LEVEL + 2 + (options.hasOnlyOneClass ? 1 : 0);
+  const linksNestingLevel = DEFAULT_BASE_NESTING_LEVEL + 2;
 
   return (
     <div key={`class-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
@@ -154,7 +143,7 @@ const renderClass = (
           <BoxSectionHeader
             text={`${name} Properties`}
             className="!text-secondary !font-medium"
-            exposeInSidebar={options.hasOnlyOneClass}
+            exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
           <div>
@@ -172,7 +161,7 @@ const renderClass = (
           <BoxSectionHeader
             text={`${name} Methods`}
             className="!text-secondary !font-medium !text-sm"
-            exposeInSidebar={options.hasOnlyOneClass}
+            exposeInSidebar={false}
             baseNestingLevel={DEFAULT_BASE_NESTING_LEVEL + 2}
           />
           {methods.map(method =>
@@ -190,19 +179,10 @@ const renderClass = (
 
 const APISectionClasses = ({ data, sdkVersion }: APISectionClassesProps) => {
   if (data?.length) {
-    const hasOnlyOneClass = data.length === 1;
     return (
       <>
         <H2>Classes</H2>
-        {data.map(clx =>
-          renderClass(
-            remapClass(clx),
-            {
-              hasOnlyOneClass,
-            },
-            sdkVersion
-          )
-        )}
+        {data.map(clx => renderClass(remapClass(clx), sdkVersion))}
       </>
     );
   }

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -5,7 +5,6 @@ import { APIDataType } from '~/components/plugins/api/APIDataType';
 import {
   AccessorDefinitionData,
   MethodDefinitionData,
-  MethodParamData,
   PropData,
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
@@ -18,7 +17,6 @@ import {
   STYLES_APIBOX,
   STYLES_APIBOX_NESTED,
   STYLES_NOT_EXPOSED_HEADER,
-  TypeDocKind,
   getH3CodeWithBaseNestingLevel,
   getTagData,
   getAllTagData,
@@ -151,63 +149,3 @@ const APISectionMethods = ({
   ) : null;
 
 export default APISectionMethods;
-
-export const APIMethod = ({
-  name,
-  sdkVersion,
-  comment,
-  returnTypeName,
-  isProperty = false,
-  isReturnTypeReference = false,
-  exposeInSidebar = false,
-  parameters = [],
-  platforms = [],
-}: {
-  exposeInSidebar?: boolean;
-  name: string;
-  sdkVersion: string;
-  comment: string;
-  returnTypeName: string;
-  isProperty: boolean;
-  isReturnTypeReference: boolean;
-  platforms: ('Android' | 'iOS' | 'Web')[];
-  parameters: {
-    name: string;
-    comment?: string;
-    typeName: string;
-    isReference?: boolean;
-  }[];
-}) => {
-  const parsedParameters = parameters.map(
-    param =>
-      ({
-        name: param.name,
-        type: { name: param.typeName, type: param.isReference ? 'reference' : 'literal' },
-
-        comment: {
-          summary: [{ kind: 'text', text: param.comment }],
-        },
-      }) as MethodParamData
-  );
-  return renderMethod(
-    {
-      name,
-      signatures: [
-        {
-          name,
-          parameters: parsedParameters,
-          comment: {
-            summary: [{ kind: 'text', text: comment }],
-            blockTags: platforms.map(text => ({
-              tag: 'platform',
-              content: [{ kind: 'text', text }],
-            })),
-          },
-          type: { name: returnTypeName, type: isReturnTypeReference ? 'reference' : 'literal' },
-        },
-      ],
-      kind: isProperty ? TypeDocKind.Property : TypeDocKind.Function,
-    },
-    { sdkVersion, exposeInSidebar }
-  );
-};

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -33,16 +33,16 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   !child.name.startsWith('_') &&
   !child?.implementationOf;
 
-const renderNamespace = (
-  namespace: ClassDefinitionData,
-  exposeInSidebar: boolean,
-  sdkVersion: string
-): JSX.Element => {
-  const { name, comment, children } = namespace;
-
-  const methods = children
+function getValidMethods(children: PropData[]) {
+  return children
     ?.filter(child => isMethod(child))
     .sort((a: PropData, b: PropData) => a.name.localeCompare(b.name));
+}
+
+const renderNamespace = (namespace: ClassDefinitionData, sdkVersion: string): JSX.Element => {
+  const { name, comment, children } = namespace;
+
+  const methods = getValidMethods(children);
   const returnComment = getTagData('returns', comment);
 
   return (
@@ -65,8 +65,8 @@ const renderNamespace = (
       )}
       {methods?.length ? (
         <>
-          <BoxSectionHeader text={`${name} Methods`} exposeInSidebar={exposeInSidebar} />
-          {methods.map(method => renderMethod(method, { exposeInSidebar, sdkVersion }))}
+          <BoxSectionHeader text={`${name} Methods`} exposeInSidebar={false} />
+          {methods.map(method => renderMethod(method, { sdkVersion, baseNestingLevel: 4 }))}
         </>
       ) : undefined}
     </div>
@@ -75,11 +75,10 @@ const renderNamespace = (
 
 const APISectionNamespaces = ({ data, sdkVersion }: APISectionNamespacesProps) => {
   if (data?.length) {
-    const exposeInSidebar = data.length < 2;
     return (
       <>
         <H2>Namespaces</H2>
-        {data.map(namespace => renderNamespace(namespace, exposeInSidebar, sdkVersion))}
+        {data.map(namespace => renderNamespace(namespace, sdkVersion))}
       </>
     );
   }

--- a/docs/components/plugins/api/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/APISectionPlatformTags.tsx
@@ -9,6 +9,7 @@ type Props = {
   comment?: CommentData;
   prefix?: string;
   platforms?: CommentTagData[];
+  userProvidedPlatforms?: string[];
   disableFallback?: boolean;
 };
 
@@ -16,6 +17,7 @@ export const APISectionPlatformTags = ({
   comment,
   platforms,
   prefix,
+  userProvidedPlatforms,
   disableFallback = false,
 }: Props) => {
   const { platforms: defaultPlatforms } = usePageMetadata();
@@ -25,8 +27,9 @@ export const APISectionPlatformTags = ({
   const platformsData = platforms || getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 
-  const platformNames =
-    platformsData.length > 0
+  const platformNames = userProvidedPlatforms
+    ? userProvidedPlatforms
+    : platformsData.length > 0
       ? platformsData?.map(platformData => getCommentContent(platformData.content))
       : isUnversionedVersion && !disableFallback
         ? defaultPlatforms?.map(platform => platform.replace('*', ''))

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -240,7 +240,7 @@ const renderWithLink = ({
 }: {
   name: string;
   type?: string;
-  typePackage: string | undefined;
+  typePackage?: string;
   sdkVersion: string;
 }) => {
   const replacedName = replaceableTypes[name] ?? name;

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -6,7 +6,7 @@ sidebar_title: Module API
 
 import { APIBox } from '~/components/plugins/APIBox';
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-import { APIMethod } from '~/components/plugins/api/APISectionMethods';
+import { APIMethod } from '~/components/plugins/api/APIMethod';
 import { FileTree } from '~/ui/components/FileTree';
 import { PlatformTags, StatusTag } from '~/ui/components/Tag';
 import { A, CALLOUT } from '~/ui/components/Text';

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -3,7 +3,6 @@ title: SQLite
 description: A library that provides access to a database that can be queried through a SQLite API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-sqlite'
 packageName: 'expo-sqlite'
-maxHeadingDepth: 5
 iconUrl: '/static/images/packages/expo-sqlite.png'
 platforms: ['android', 'ios']
 ---


### PR DESCRIPTION
# Why

The last chunk of Table of Content improvements, which tackles the leftovers from migrations.

# How

Update the display and nesting of single Classes and Namespaces in API Reference docs.

Fix Expo Modules API spacing, extract `APIMethod` to a separate file, remove no longer needed code.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

<img src="https://github.com/expo/expo/assets/719641/055c849d-5caf-419b-9108-c3298a82b1be" align="left" width="340"/>
<img src="https://github.com/expo/expo/assets/719641/13f449fc-4b60-4d6f-b0ed-a17995ddb764"  width="340"/>

