### PR TITLE
[dev-client] Fix homepage link in `package.json`

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fix homepage link in `package.json`. ([#30163](https://github.com/expo/expo/pull/30163) by [@amandeepmittal](https://github.com/amandeepmittal))
+
 ## 4.0.18 - 2024-06-13
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -30,7 +30,7 @@
   },
   "author": "650 Industries, Inc.",
   "license": "MIT",
-  "homepage": "https://docs.expo.dev/clients/introduction/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/dev-client/",
   "dependencies": {
     "expo-dev-launcher": "4.0.15",
     "expo-dev-menu": "5.0.14",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #30162

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `clients/introduction` link and update it with Expo Dev Client API reference under `homepage` field in `package.json`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Manually check the link in `package.json`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
