### PR TITLE
[modules-core][docs] Fix link to module overview page in README

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android. ([#30061](https://github.com/expo/expo/pull/30061) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using `noexcept`. ([#30128](https://github.com/expo/expo/pull/30128) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Decouple the modules state from the `AppContext` ([#30098](https://github.com/expo/expo/pull/30098) by [@lukmccall](https://github.com/lukmccall))
+- Fix and update link for Expo Modules Overview docs page in package's README. ([#30164](https://github.com/expo/expo/pull/30164) by [@amandeepmittal](https://github.com/amandeepmittal)).
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/README.md
+++ b/packages/expo-modules-core/README.md
@@ -1,5 +1,5 @@
 <p>
-  <a href="https://docs.expo.dev/modules/">
+  <a href="https://docs.expo.dev/modules/overview/">
     <img
       src="../../.github/resources/expo-modules-core.svg"
       alt="expo-modules-core"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is a follow-up PR for cleaning up old redirects. Found out that the README for Expo Modules Core is referencing an old link.



# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `modules/` link and update it with `/modules/overview`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By going through README.md manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
