### PR TITLE
[docs] Remove old client and server-side redirects, fix internal links

### DIFF
--- a/docs/common/error-utilities.test.ts
+++ b/docs/common/error-utilities.test.ts
@@ -59,13 +59,6 @@ test('redirects old versions to latest', () => {
   expect(newPath).toEqual('/versions/latest/sdk/camera/');
 });
 
-test('redirects versionless SDK paths to new version', () => {
-  const redirectPath = '/sdk/admob/';
-  const newPath = getRedirectPath(redirectPath);
-
-  expect(newPath).toEqual('/versions/latest/sdk/admob/');
-});
-
 test('removes null from end of paths', () => {
   const redirectPath = '/debugging/errors-and-warnings/null';
   const newPath = getRedirectPath(redirectPath);
@@ -74,9 +67,5 @@ test('removes null from end of paths', () => {
 });
 
 test('redirect SDK permissions to the permission guide', () => {
-  expect(getRedirectPath('/versions/v40.0.0/sdk/permissions/')).toEqual('/guides/permissions/');
-  expect(getRedirectPath('/versions/v41.0.0/sdk/permissions/')).toEqual('/guides/permissions/');
-  expect(getRedirectPath('/versions/v42.0.0/sdk/permissions/')).toEqual('/guides/permissions/');
-  expect(getRedirectPath('/versions/v43.0.0/sdk/permissions/')).toEqual('/guides/permissions/');
   expect(getRedirectPath('/versions/latest/sdk/permissions/')).toEqual('/guides/permissions/');
 });

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -139,11 +139,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/config-plugins/': '/config-plugins/introduction/',
   '/workflow/debugging/': '/debugging/runtime-issues/',
   '/guides/userinterface/': '/ui-programming/user-interface-libraries/',
-  '/introduction/expo/': '/core-concepts/',
   '/introduction/why-not-expo/': '/faq/#limitations',
-  '/introduction/faq/': '/faq/',
   '/next-steps/community/': '/',
-  '/introduction/managed-vs-bare/': '/archive/managed-vs-bare/',
   '/workflow/expo-go/': '/get-started/set-up-your-environment/',
   '/guides/splash-screens/': '/develop/user-interface/splash-screen/',
   '/guides/app-icons/': '/develop/user-interface/app-icons/',
@@ -157,9 +154,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/debugging/': '/debugging/runtime-issues/',
   '/debugging/runtime-issue/': '/debugging/runtime-issues/',
   '/guides/testing-with-jest/': '/develop/unit-testing/',
-  '/workflow/glossary-of-terms/': '/more/glossary-of-terms/',
   '/develop/development-builds/installation/': '/develop/development-builds/create-a-build/',
-  '/get-started/errors/': '/debugging/errors-and-warnings/',
   '/develop/development-builds/parallel-installation': '/build-reference/variants/',
   '/home/develop/user-interface/safe-areas': '/develop/user-interface/safe-areas/',
   '/home/develop/development-builds/installation': '/develop/development-builds/create-a-build/',
@@ -174,17 +169,12 @@ const RENAMED_PAGES: Record<string, string> = {
   '/home/develop/user-interface/app-icons': '/develop/user-interface/app-icons/',
   '/home/develop/development-builds/introduction/': '/develop/development-builds/introduction/',
 
-  // EAS Build
-  '/build-reference/eas-json/': '/eas/json/#eas-build',
-
   // Old redirects
-  '/introduction/project-lifecycle/': '/archive/managed-vs-bare/',
   '/versions/latest/sdk/': '/versions/latest/',
   '/versions/latest/sdk/overview/': '/versions/latest/',
   '/guides/building-standalone-apps/': '/archive/classic-builds/building-standalone-apps/',
   '/distribution/building-standalone-apps/': '/archive/classic-builds/building-standalone-apps/',
   '/guides/genymotion/': '/workflow/android-studio-emulator/',
-  '/workflow/upgrading-expo/': '/workflow/upgrading-expo-sdk-walkthrough/',
   '/workflow/create-react-native-app/': '/more/glossary-of-terms/#create-react-native-app',
   '/expokit/': '/archive/glossary/#expokit/',
   '/build-reference/migrating/': '/archive/classic-builds/migrating/',
@@ -199,9 +189,6 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Consolidate workflow page
   '/bare/customizing/': '/workflow/customizing/',
-
-  // Expo Accounts
-  '/accounts/working-together/': '/accounts/account-types/',
 
   // Lots of old links pointing to guides when they have moved elsewhere
   '/guides/configuration/': '/workflow/configuration/',
@@ -219,7 +206,6 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Changes from redoing the getting started workflow, SDK35+
   '/workflow/up-and-running/': '/get-started/create-a-project/',
-  '/introduction/additional-resources/': '/next-steps/additional-resources/',
   '/introduction/already-used-react-native/':
     '/faq/#what-is-the-difference-between-expo-and-react-native',
   '/introduction/community/': '/next-steps/community/',
@@ -253,7 +239,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/release-channels/': '/archive/classic-updates/release-channels/',
   '/guides/push-notifications/': '/push-notifications/overview/',
   '/push-notifications/': '/push-notifications/overview/',
-  '/distribution/hosting-your-app/': '/distribution/publishing-websites/',
   '/build-reference/how-tos/': '/build-reference/private-npm-packages/',
   '/get-started/': '/get-started/create-a-project/',
   '/guides/detach/': '/archive/glossary/#detach',
@@ -264,7 +249,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/develop/user-interface/custom-fonts/': '/develop/user-interface/fonts/#add-a-custom-font',
   '/accounts/teams-and-accounts/': '/accounts/account-types/',
   '/push-notifications/fcm/': '/push-notifications/sending-notifications-custom/',
-  '/troubleshooting/clear-cache-mac/': '/troubleshooting/clear-cache-macos-linux/',
 
   // Renaming a submit section
   '/submit/submit-ios': '/submit/ios/',
@@ -276,24 +260,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/how-expo-works/': '/faq/#what-is-the-difference-between-expo-and-react-native',
 
   // Archive unused pages
-  '/guides/notification-channels/': '/archived/notification-channels/',
-
-  // Migrated FAQ pages
-  '/faq/image-background/': '/ui-programming/image-background/',
-  '/faq/react-native-styling-buttons/': '/ui-programming/react-native-styling-buttons/',
-  '/faq/react-native-version-mismatch/': '/troubleshooting/react-native-version-mismatch/',
-  '/faq/clear-cache-windows/': '/troubleshooting/clear-cache-windows/',
-  '/faq/clear-cache-macos-linux/': '/troubleshooting/clear-cache-macos-linux/',
-  '/faq/application-has-not-been-registered/':
-    '/troubleshooting/application-has-not-been-registered/',
+  '/guides/notification-channels/': '/archive/notification-channels/',
 
   // Permissions API is moved to guide
-  '/versions/v40.0.0/sdk/permissions/': '/guides/permissions/',
-  '/versions/v41.0.0/sdk/permissions/': '/guides/permissions/',
-  '/versions/v42.0.0/sdk/permissions/': '/guides/permissions/',
-  '/versions/v43.0.0/sdk/permissions/': '/guides/permissions/',
-  '/versions/v46.0.0/sdk/permissions/': '/guides/permissions/',
-  '/versions/v47.0.0/sdk/permissions/': '/guides/permissions/',
   '/versions/latest/sdk/permissions/': '/guides/permissions/',
 
   // Random API replaced with Crypto
@@ -312,32 +281,18 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Consolidate distribution
   '/distribution/security/': '/app-signing/security/',
-  '/distribution/uploading-apps/': '/submit/introduction/',
-  '/versions/latest/distribution/uploading-apps/': '/submit/introduction/',
 
   // Redirects for removed/archived pages or guides
-  '/archived/': '/archive/',
-  '/guides/using-gatsby/': '/guides/overview',
   '/versions/latest/expokit/eject/': '/archive/glossary/#eject',
   '/expokit/eject/': '/archive/glossary/#eject',
   '/expokit/expokit/': '/archive/glossary/#expokit',
   '/submit/classic-builds/': '/submit/introduction/',
-  '/archive/adhoc-builds/': '/develop/development-builds/introduction/',
   '/technical-specs/expo-updates-0/': '/technical-specs/expo-updates-1/',
   '/technical-specs/latest/': '/technical-specs/expo-updates-1/',
-  '/development/extending-the-dev-menu/': '/develop/development-builds/development-workflows/',
-  '/more/latest': '/versions/latest/',
   '/archive/expokit/overview/': '/archive/glossary/',
   '/expokit/overview/': '/archive/glossary/',
-  '/tutorial/planning/': '/tutorial/introduction/',
-  '/tutorial/sharing/': '/tutorial/introduction/',
-  '/tutorial/text/': '/tutorial/introduction/',
-  '/tutorial/button': '/tutorial/introduction/',
-  '/guides/using-clojurescript/': '/guides/overview',
   '/push-notifications/using-fcm/': '/push-notifications/push-notifications-setup/',
-  '/guides/using-custom-fonts/': '/develop/user-interface/fonts/',
   '/workflow/already-used-react-native/': '/workflow/overview/',
-  '/guides/setup-native-firebase/': '/guides/using-firebase/',
   '/development/installation/': '/develop/development-builds/create-a-build/',
   '/guides/routing-and-navigation/': '/routing/introduction/',
   '/build-reference/custom-build-config/': '/custom-builds/get-started/',
@@ -351,8 +306,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/workflow/run-on-device/': '/build/internal-distribution/',
   '/guides/': '/guides/overview/',
   '/archive/workflow/customizing/': '/workflow/customizing/',
-  '/errors-and-warnings/': '/debugging/errors-and-warnings/',
-  '/guides/education': '/additional-resources/',
   '/versions/latest/sdk/in-app-purchases/': '/guides/in-app-purchases/',
   '/versions/v50.0.0/sdk/in-app-purchases/': '/guides/in-app-purchases/',
   '/guides/web-performance/': '/guides/analyzing-bundles/',
@@ -394,16 +347,12 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/latest/sdk/firebase-recaptcha/': '/guides/using-firebase/',
   '/versions/latest/sdk/amplitude/': '/guides/using-analytics/',
   '/versions/latest/sdk/util/': '/versions/latest/',
-  '/versions/v45.0.0/sdk/google-sign-in': '/guides/google-authentication/',
-  '/versions/v44.0.0/sdk/google/': '/guides/google-authentication/',
-  '/versions/latest/sdk/error-recovery/': '/versions/latest/',
   '/guides/using-preact/': '/guides/overview/',
   '/versions/latest/sdk/shared-element/': '/versions/latest/',
   '/workflow/hermes/': '/guides/using-hermes/',
   '/config/app/': '/workflow/configuration/',
   '/versions/latest/sdk/settings/': '/versions/latest/',
   '/archive/expokit/eject/': '/archive/glossary/#eject',
-  '/versions/latest/sdk/admob/': '/versions/latest/',
   '/versions/latest/sdk/payments/': '/versions/latest/sdk/stripe/',
   '/distribution/app-icons/': '/develop/user-interface/splash-screen-and-app-icon/',
   '/guides/using-libraries/': '/workflow/using-libraries/',
@@ -436,21 +385,11 @@ const RENAMED_PAGES: Record<string, string> = {
   '/workflow/build/building-on-ci': '/build/building-on-ci/',
   'versions/latest/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
   '/versions/v49.0.0/sdk/filesystem.md': '/versions/v49.0.0/sdk/filesystem/',
-  '/versions/v48.0.0/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
-  '/versions/v47.0.0/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
-  '/versions/v46.0.0/sdk/filesystem.md': '/versions/latest/sdk/filesystem/',
   '/versions/v50.0.0/sdk/taskmanager': '/versions/v50.0.0/sdk/task-manager/',
   '/versions/v49.0.0/sdk/taskmanager': '/versions/v49.0.0/sdk/task-manager/',
-  '/versions/v48.0.0/sdk/taskmanager': '/versions/latest/sdk/task-manager/',
-  '/versions/v47.0.0/sdk/taskmanager': '/versions/latest/sdk/task-manager/',
-  '/versions/v46.0.0/sdk/taskmanager': '/versions/latest/sdk/task-manager/',
   '/task-manager/': '/versions/latest/sdk/task-manager',
-  'versions/v48.0.0/sdk': '/versions/latest',
-  'versions/v48.0.0/sdk/config/app': '/versions/latest/sdk/config/app/',
   '/versions/v50.0.0/sdk': '/versions/v50.0.0',
   '/versions/v49.0.0/sdk': '/versions/v49.0.0',
-  '/versions/v47.0.0/sdk': '/versions/latest',
-  '/versions/v46.0.0/sdk': '/versions/latest',
 
   // Deprecated Webpack support
   '/guides/customizing-webpack': '/archive/customizing-webpack',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -67,64 +67,14 @@ declare -A redirects # associative array variable
 # usage:
 # redirects[requests/for/this/path]=are/redirected/to/this/one
 
-# Temporarily create a redirect for a page that Home links to
-redirects[versions/latest/introduction/installation.html]=versions/latest/introduction/installation
-# useful link on x.com
-redirects[versions/latest/guides/app-stores.html]=versions/latest/distribution/app-stores
-# Xdl caches
-redirects[versions/latest/guides/offline-support.html]=versions/latest/guides/offline-support
-# xdl convert comment
-redirects[versions/latest/sdk/index.html]=versions/latest/sdk/overview
-# upgrading expo -> upgrading sdk walkthrough
-redirects[versions/latest/workflow/upgrading-expo]=versions/latest/workflow/upgrading-expo-sdk-walkthrough
-# rename
-redirects[versions/latest/sdk/haptic/index.html]=versions/latest/sdk/haptics
-redirects[development/eas-build]=development/build
-# duplicate docs file, consolidate into one page
-redirects[versions/latest/sdk/introduction/index.html]=versions/latest/sdk/overview
-# project-lifecycle is now covered by managed-vs-bare
-redirects[versions/latest/introduction/project-lifecycle]=archive/managed-vs-bare
-
-# Migrated FAQ pages
-redirects[faq/image-background]=ui-programming/image-background
-redirects[faq/react-native-styling-buttons]=ui-programming/react-native-styling-buttons
-redirects[faq/react-native-version-mismatch]=troubleshooting/react-native-version-mismatch
-redirects[faq/clear-cache-windows]=troubleshooting/clear-cache-windows
-redirects[faq/clear-cache-macos-linux]=troubleshooting/clear-cache-macos-linux
-redirects[faq/application-has-not-been-registered]=troubleshooting/application-has-not-been-registered
+# Old redirects
 redirects[distribution/building-standalone-apps]=archive/classic-builds/building-standalone-apps
-redirects[build-reference/build-webhook]=eas/webhooks
-redirects[distribution/webhooks]=eas/webhooks
-redirects[distribution/turtle-cli]=archive/classic-builds/turtle-cli
-redirects[distribution/app-signing]=app-signing/app-credentials
-redirects[guides/adhoc-builds]=develop/development-builds/introduction
-redirects[archive/adhoc-builds]=develop/development-builds/introduction
 
 # clients is now development
-redirects[clients/distribution-for-ios]=develop/development-builds/create-a-build
-redirects[clients/distribution-for-android]=develop/development-builds/create-a-build
-redirects[clients/compatibility]=develop/development-builds/introduction
-redirects[development/compatibility]=develop/development-builds/introduction
-redirects[clients/development-workflows]=development/development-workflows
-redirects[clients/eas-build]=build/introduction
-redirects[clients/extending-the-dev-menu]=develop/development-builds/development-workflows
-redirects[clients/getting-started]=develop/development-builds/introduction
-redirects[clients/installation]=develop/development-builds/create-a-build
-redirects[clients/introduction]=develop/development-builds/introduction
-redirects[clients/troubleshooting]=development/troubleshooting
-redirects[clients/upgrading]=development/upgrading
+redirects[clients/installation]=versions/latest/sdk/dev-client
 
 # Expo Modules
 redirects[modules]=modules/overview
-redirects[module-api]=modules/module-api
-redirects[module-config]=modules/module-config
-
-# EAS Metadata
-redirects[eas-metadata]=eas/metadata
-redirects[eas-metadata/introduction]=eas/metadata
-redirects[eas-metadata/getting-started]=eas/metadata/getting-started
-# EAS Build
-redirects[build-reference/eas-json]=eas/json
 
 # Development builds
 redirects[development/build]=develop/development-builds/create-a-build
@@ -136,14 +86,7 @@ redirects[development/develop-your-project]=develop/development-builds/use-devel
 redirects[develop/development-builds/installation]=develop/development-builds/create-a-build
 
 # Guides that have been deleted
-redirects[guides/using-gatsby]=guides/overview
-redirects[guides/testing-on-devices]=workflow/run-on-device
-redirects[distribution/uploading-apps]=submit/introduction
-redirects[guides/setup-native-firebase]=guides/using-firebase
-redirects[guides/using-clojurescript]=guides/overview
-redirects[distribution/hosting-your-app]=distribution/publishing-websites
 redirects[guides/web-performance/]=guides/analyzing-bundles
-redirects[accounts/working-together]=accounts/account-types
 
 # Redirects after adding Home to the docs
 redirects[next-steps/additional-resources]=additional-resources
@@ -151,10 +94,7 @@ redirects[get-started/create-a-new-app]=get-started/create-a-project
 redirects[guides/config-plugins]=config-plugins/introduction
 redirects[workflow/debugging]=debugging/runtime-issues
 redirects[guides/userinterface]=ui-programming/user-interface-libraries
-redirects[introduction/expo]=core-concepts
-redirects[introduction/faq]=faq
 redirects[workflow/expo-go]=get-started/set-up-your-environment
-redirects[errors-and-warnings]=debugging/errors-and-warnings
 redirects[guides/splash-screens]=develop/user-interface/splash-screen
 redirects[guides/app-icons]=develop/user-interface/app-icons
 redirects[guides/color-schemes]=develop/user-interface/color-themes
@@ -164,14 +104,11 @@ redirects[development/use-development-builds]=develop/development-builds/use-dev
 redirects[development/development-workflows]=develop/development-builds/development-workflows
 redirects[debugging]=debugging/runtime-issues
 redirects[debugging/runtime-issue]=debugging/runtime-issues
-redirects[workflow/glossary-of-terms]=more/glossary-of-terms
 redirects[develop/development-builds/installation]=develop/development-builds/create-a-build
-redirects[get-started/errors]=debugging/errors-and-warnings
 redirects[develop/development-builds/parallel-installation]=build-reference/variants
 redirects[home/develop/user-interface/safe-areas]=develop/user-interface/safe-areas
 redirects[home/develop/development-builds/introduction]=develop/development-builds/introduction
 redirects[guides/assets]=develop/user-interface/assets
-redirects[router/reference/search-parameters]=router/reference/url-parameters
 
 # Redirects after Guides organization
 redirects[guides]=guides/overview
@@ -186,30 +123,22 @@ redirects[workflow/run-on-device]=build/internal-distribution
 redirects[archive/workflow/customizing]=workflow/customizing
 redirects[guides/building-standalone-apps]=archive/classic-builds/building-standalone-apps
 redirects[versions/latest/sdk/permissions#expopermissionscamera_roll]=guides/permissions
-redirects[introduction/managed-vs-bare]=archive/managed-vs-bare
 redirects[push-notifications/using-fcm]=push-notifications/push-notifications-setup
-redirects[guides/using-custom-fonts]=develop/user-interface/fonts
 
 # Redirects reported from SEO tools list (MOZ, SEMRush, GSC, etc.)
-redirects[versions/v46.0.0/sdk/permissions]=guides/permissions
 redirects[development/development-workflows]=develop/development-builds/development-workflows
 redirects[bare/installing-unimodules]=bare/installing-expo-modules
 redirects[versions/latest/sdk/admob]=versions/latest
 redirects[workflow/publishing]=archive/classic-updates/publishing
 redirects[workflow/already-used-react-native]=workflow/overview
-redirects[guides/setup-native-firebase]=guides/using-firebase
 redirects[eas-update/how-eas-update-works]=eas-update/how-it-works
 redirects[development/installation]=develop/development-builds/create-a-build
 redirects[bare/updating-your-app]=eas-update/updating-your-app
-redirects[versions/latest/introduction/managed-vs-bare]=archive/managed-vs-bare
 redirects[classic/turtle-cli]=archive/classic-builds/turtle-cli
 redirects[technical-specs/expo-updates-0]=technical-specs/expo-updates-1
-redirects[development/extending-the-dev-menu]=develop/development-builds/development-workflows
 redirects[archive/expokit/eject]=archive/glossary
 redirects[archive/expokit/overview]=archive/glossary
 redirects[expokit/overview]=archive/glossary
-redirects[more/latest]=versions/latest
-redirects[versions/latest/sdk/error-recovery]=versions/latest
 redirects[eas-update/eas-update-with-local-build]=eas-update/build-locally
 redirects[bare/existing-apps]=bare/installing-expo-modules
 redirects[bare/exploring-bare-workflow]=bare/overview
@@ -226,21 +155,10 @@ redirects[eas-update/migrate-codepush-to-eas-update]=eas-update/codepush
 redirects[home/get-started/create-a-project]=get-started/create-a-project
 redirects[home/core-concepts]=core-concepts
 redirects[guides/testing-on-devices]=build/internal-distribution
-redirects[router/advance/root-layout]=router/advanced/root-layout
-redirects[router/advance/stack]=router/advanced/stack
-redirects[router/advance/tabs]=router/advanced/tabs
-redirects[router/advance/drawer]=router/advanced/drawer
-redirects[router/advance/nesting-navigators]=router/advanced/nesting-navigators
-redirects[router/advance/modal]=router/advanced/modals
-redirects[router/advance/platform-specific-modules]=router/advanced/platform-specific-modules
-redirects[router/reference/platform-specific-modules]=router/advanced/platform-specific-modules
-redirects[router/advance/shared-routes]=router/advanced/shared-routes
-redirects[router/advance/router-setttings]=router/advanced/router-settings
 redirects[home/config-plugins/plugins-and-mods]=config-plugins/plugins-and-mods
 redirects[home/unit-testing]=develop/unit-testing
 redirects[home/config-plugins/introduction]=config-plugins/introduction
 redirects[technical-specs/latest]=technical-specs/expo-updates-1
-redirects[guides/education]=additional-resources
 
 # We should change this redirect to a more general EAS guide later
 redirects[guides/setting-up-continuous-integration]=build/building-on-ci
@@ -258,15 +176,7 @@ redirects[classic/building-standalone-apps]=archive/classic-builds/building-stan
 redirects[classic/turtle-cli]=archive/classic-builds/turtle-cli
 redirects[build-reference/migrating]=archive/classic-builds/migrating
 redirects[archive/classic-updates/getting-started]=eas-update/getting-started
-redirects[archived]=archive
 redirects[archive/classic-updates/building-standalone-apps]=archive/classic-builds/building-standalone-apps
-
-# Old tutorial pages
-redirects[introduction/walkthrough]=tutorial/introduction
-redirects[tutorial/planning]=tutorial/introduction
-redirects[tutorial/sharing]=tutorial/introduction
-redirects[tutorial/text]=tutorial/introduction
-redirects[tutorial/button]=tutorial/introduction
 
 # EAS Update
 redirects[technical-specs/expo-updates-0]=archive/technical-specs/expo-updates-0
@@ -279,7 +189,7 @@ redirects[eas-update/migrate-to-eas-update]=eas-update/migrate-from-classic-upda
 redirects[distribution/custom-updates-server]=eas-update/custom-updates-server
 redirects[bare/error-recovery]=eas-update/error-recovery
 
-# Redirects after Expo Router docs reorganization from Home to Guides
+# Redirects after Expo Router docs
 redirects[routing/next-steps]=router/introduction
 redirects[routing/introduction]=router/introduction
 redirects[routing/installation]=router/installation
@@ -288,6 +198,17 @@ redirects[routing/navigating-pages]=router/navigating-pages
 redirects[routing/layouts]=router/layouts
 redirects[routing/appearance]=router/appearance
 redirects[routing/error-handling]=router/error-handling
+redirects[router/advance/root-layout]=router/advanced/root-layout
+redirects[router/advance/stack]=router/advanced/stack
+redirects[router/advance/tabs]=router/advanced/tabs
+redirects[router/advance/drawer]=router/advanced/drawer
+redirects[router/advance/nesting-navigators]=router/advanced/nesting-navigators
+redirects[router/advance/modal]=router/advanced/modals
+redirects[router/advance/platform-specific-modules]=router/advanced/platform-specific-modules
+redirects[router/reference/platform-specific-modules]=router/advanced/platform-specific-modules
+redirects[router/advance/shared-routes]=router/advanced/shared-routes
+redirects[router/advance/router-setttings]=router/advanced/router-settings
+redirects[router/reference/search-parameters]=router/reference/url-parameters
 
 # Removed API reference docs
 redirects[versions/latest/sdk/facebook]=guides/authentication
@@ -303,8 +224,6 @@ redirects[versions/latest/sdk/google-sign-in]=guides/authentication
 redirects[versions/latest/sdk/google]=guides/authentication
 redirects[versions/latest/sdk/amplitude]=guides/using-analytics
 redirects[versions/latest/sdk/util]=versions/latest
-redirects[versions/v45.0.0/sdk/google-sign-in]=guides/google-authentication
-redirects[versions/v44.0.0/sdk/google]=guides/google-authentication
 redirects[versions/latest/introduction/faq]=faq
 redirects[versions/v50.0.0/sdk/in-app-purchases]=guides/in-app-purchases/
 redirects[versions/latest/sdk/in-app-purchases]=guides/in-app-purchases/
@@ -324,28 +243,16 @@ redirects[workflow/hermes]=guides/using-hermes
 
 # Redirects based on Algolia 404 report
 redirects[versions/latest/sdk/permissions]=guides/permissions
-redirects[versions/v47.0.0/sdk/permissions]=guides/permissions
-redirects[versions/v46.0.0/sdk/permissions.md]=guides/permissions
 redirects[workflow/build/building-on-ci]=build/building-on-ci
 redirects[versions/v50.0.0/sdk/taskmanager]=versions/v50.0.0/sdk/task-manager
 redirects[versions/v49.0.0/sdk/taskmanager]=versions/v49.0.0/sdk/task-manager
-redirects[versions/v48.0.0/sdk/taskmanager]=versions/latest/sdk/task-manager
-redirects[versions/v47.0.0/sdk/taskmanager]=versions/latest/sdk/task-manager
-redirects[versions/v46.0.0/sdk/taskmanager]=versions/latest/sdk/task-manager
 redirects[task-manager]=versions/latest/sdk/task-manager
 redirects[versions/v49.0.0/sdk/filesystem.md]=versions/v49.0.0/sdk/filesystem
-redirects[versions/v48.0.0/sdk/filesystem.md]=versions/latest/sdk/filesystem
-redirects[versions/v47.0.0/sdk/filesystem.md]=versions/latest/sdk/filesystem
-redirects[versions/v46.0.0/sdk/filesystem.md]=versions/latest/sdk/filesystem
 redirects[versions/latest/sdk/filesystem.md]=versions/latest/sdk/filesystem
-redirects[versions/v48.0.0/sdk]=versions/latest
-redirects[versions/v48.0.0/sdk/config/app]=versions/latest/config/app
 redirects[guides/how-expo-works]=faq
 redirects[config/app]=workflow/configuration
 redirects[versions/v50.0.0/sdk]=versions/v50.0.0
 redirects[versions/v49.0.0/sdk]=versions/v49.0.0
-redirects[versions/v47.0.0/sdk]=versions/latest
-redirects[versions/v46.0.0/sdk]=versions/latest
 redirects[guides/authentication.md]=guides/authentication
 redirects[versions/latest/workflow/linking/]=guides/linking
 redirects[versions/latest/sdk/overview]=versions/latest

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -191,7 +191,7 @@ redirects[eas-update/migrate-to-eas-update]=eas-update/migrate-from-classic-upda
 redirects[distribution/custom-updates-server]=eas-update/custom-updates-server
 redirects[bare/error-recovery]=eas-update/error-recovery
 
-# Redirects after Expo Router docs
+# Redirects for Expo Router docs
 redirects[routing/next-steps]=router/introduction
 redirects[routing/introduction]=router/introduction
 redirects[routing/installation]=router/installation

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -75,6 +75,8 @@ redirects[clients/installation]=versions/latest/sdk/dev-client
 
 # Expo Modules
 redirects[modules]=modules/overview
+redirects[module-api]=modules/module-api
+redirects[module-config]=modules/module-config
 
 # Development builds
 redirects[development/build]=develop/development-builds/create-a-build

--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -25,7 +25,7 @@ Creating an organization account is useful when:
 
 - You think you may need to transfer control of that Organization's projects in the future.
 - Sharing one or multiple projects with a team of collaborators.
-- More than one [Owner](/accounts/working-together/#managing-access) needs to be assigned.
+- More than one [Owner](/accounts/account-types/#manage-access) needs to be assigned.
 - Expenses need to be isolated.
 - Granting different levels of access by assigning a role to each member of the organization.
 - Structuring projects for different contexts. For example, when working for different clients, a new organization may be created for each client.
@@ -101,14 +101,14 @@ When inviting a new member, keep in mind:
 
 ### Change the role of a member
 
-To change the role privileges of a member, make sure you have either an [**Owner** or **Admin** role](/accounts/working-together/#manage-access) and follow the steps below:
+To change the role privileges of a member, make sure you have either an [**Owner** or **Admin** role](/accounts/account-types/#manage-access) and follow the steps below:
 
 - Navigate to [**Members**](https://expo.dev/settings/members) under **Organization settings** in the Expo dashboard.
 - Next to the member whose role you want to change, click on the three-dotted menu icon and change the role.
 
 ### Remove a member
 
-To remove a member, make sure you have either an [**Owner** or **Admin** role](/accounts/working-together/#manage-access) and follow the steps below:
+To remove a member, make sure you have either an [**Owner** or **Admin** role](/accounts/account-types/#manage-access) and follow the steps below:
 
 - Navigate to [**Members**](https://expo.dev/settings/members) under **Organization settings** in the Expo dashboard.
 - Next to the member you want to remove, click on the three-dotted menu icon.

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -13,7 +13,7 @@ You can create Personal access tokens from the [Access tokens](https://expo.dev/
 
 ## Robot users and access tokens
 
-Accounts can create Robot users to take actions on resources owned by the Account. Bot Users can be assigned [a role](/accounts/working-together) to limit the actions they are authorized to perform. Bot users cannot sign in to any Expo products, cannot own any projects themselves, and can only authenticate via an access token.
+Accounts can create Robot users to take actions on resources owned by the Account. Bot Users can be assigned [a role](/accounts/account-types/#manage-access) to limit the actions they are authorized to perform. Bot users cannot sign in to any Expo products, cannot own any projects themselves, and can only authenticate via an access token.
 
 ## Access tokens usage
 

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -31,7 +31,7 @@ You can also set up the Push Notifications key with the `eas credentials` comman
 
 ## Sharing credentials with your team
 
-If you collaborate on your project with other developers, it is often useful to give them access to perform builds on their own. [Ensure that your project is configured for collaboration](/accounts/working-together.mdx) and any teammates that you have added through your [Expo dashboard](https://expo.dev/) will be able to run `eas build` seamlessly, provided that they have sufficient permissions.
+If you collaborate on your project with other developers, it is often useful to give them access to perform builds on their own. [Ensure that your project is configured for collaboration](/accounts/account-types/#organizations) and any teammates that you have added through your [Expo dashboard](https://expo.dev/) will be able to run `eas build` seamlessly, provided that they have sufficient permissions.
 
 After you have generated your iOS credentials, it's no longer necessary to have access to the Apple Developer team to start a build. This means that your collaborators can start new iOS builds with only their Expo accounts.
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -123,7 +123,7 @@ Alternatively, you can use `--platform all` option to build for Android and iOS 
 
 <Terminal cmd={['$ eas build --platform all']} />
 
-> If you have released your app to stores previously and have existing [app signing credentials](/distribution/app-signing) that you want to use, [follow these instructions to configure them](/app-signing/existing-credentials).
+> If you have released your app to stores previously and have existing [app signing credentials](/app-signing/app-credentials/) that you want to use, [follow these instructions to configure them](/app-signing/existing-credentials).
 
 #### Android app signing credentials
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -35,7 +35,7 @@ We recommend using a different [runtime version](/distribution/runtime-versions.
 
 ## Previewing updates in development builds
 
-Updates published with the `runtimeVersion` field can't be loaded in Expo Go; instead, you should use [expo-dev-client](/clients/introduction.mdx) to create a development build.
+Updates published with the `runtimeVersion` field can't be loaded in Expo Go; instead, you should use [expo-dev-client](/versions/latest/sdk/dev-client/) to create a development build.
 
 ## Environment variables and `eas update`
 

--- a/docs/pages/distribution/app-stores.mdx
+++ b/docs/pages/distribution/app-stores.mdx
@@ -17,7 +17,7 @@ This guide offers best practices for submitting your app to the app stores. To l
 <BoxLink
   title="App Store presence"
   description="Manage your Apple App Store metadata from the command line."
-  href="/eas-metadata/introduction"
+  href="/eas/metadata/"
 />
 <BoxLink
   title="Permissions"

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -124,7 +124,7 @@ Prebuild is the tip of the automation iceberg, here are some features you can ad
 - [Expo native module API][expo-modules-core]: Write modules with Swift and Kotlin. This is automatically supported when using `npx expo prebuild`.
 
 [vs-code-expo]: https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools
-[expo-modules-core]: /modules/module-api
+[expo-modules-core]: /modules/module-api/
 [dev-client]: /develop/development-builds/introduction/
 [config-plugins]: /config-plugins/introduction/
 [prebuild]: /workflow/prebuild

--- a/docs/pages/modules/appdelegate-subscribers.mdx
+++ b/docs/pages/modules/appdelegate-subscribers.mdx
@@ -13,7 +13,7 @@ The React Native module API does not provide any mechanism to hook into these me
 
 First, you need to have created an Expo module or integrated the Expo modules API in library using the React Native module API. [Learn more](./overview.mdx#setup).
 
-Create a new public Swift class that extends `ExpoAppDelegateSubscriber` from `ExpoModulesCore` and add its name to the `ios.appDelegateSubscribers` array in the [module config](./module-config.mdx). Run `pod install`, and the subscriber will be generated in the **ExpoModulesProvider.swift** file within the application project.
+Create a new public Swift class that extends `ExpoAppDelegateSubscriber` from `ExpoModulesCore` and add its name to the `ios.appDelegateSubscribers` array in the [module config](/modules/module-config/). Run `pod install`, and the subscriber will be generated in the **ExpoModulesProvider.swift** file within the application project.
 
 Now you can subscribe to events by adding delegate functions to your subscriber class. For the full list of functions that you can subscribe to, see the functions that are overridden in [`ExpoAppDelegate.swift`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift). App delegate functions that may cause side effects when provided are not supported yet (for example, [`application(_:viewControllerWithRestorationIdentifierPath:coder:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623062-application)).
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -201,7 +201,7 @@ All projects created with the `npx create-expo-app` command are already configur
 
 ### What do I need to have in my module to make it autolinkable?
 
-The module resolution algorithm searches only for packages that contain the [Expo module config](./module-config.mdx) file (**expo-module.config.json**) at the root directory, next to the **package.json** file.
+The module resolution algorithm searches only for packages that contain the [Expo module config](/modules/module-config/) file (**expo-module.config.json**) at the root directory, next to the **package.json** file.
 It's also necessary to include supported platforms in the `platforms` array — if the platform for which the autolinking algorithm is run is not present in this array, it's just skipped in the search results.
 
 ### How is it different from React Native autolinking?

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -9,7 +9,7 @@ There are cases where you may want to integrate the Expo Modules API into an exi
 
 The following steps will set up your existing React Native library to access Expo Modules APIs.
 
-Create the [**expo-module.config.json**](./module-config.mdx) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
+Create the [**expo-module.config.json**](/modules/module-config/) file at the root of your project and start from the empty object `{}` inside it. We will fill it in later to enable specific features.
 The presence of the module config is enough for [Expo Autolinking](./autolinking.mdx) to recognize it as an Expo module and automatically link your native code.
 
 ### Add the `expo-modules-core` native dependency
@@ -88,7 +88,7 @@ class MyModule : Module() {
 
 </CodeBlocksTable>
 
-Then, add your classes to Android and/or iOS `modules` in the [module config](./module-config.mdx). Expo Autolinking will automatically link these classes as native modules in the user's project.
+Then, add your classes to Android and/or iOS `modules` in the [module config](/modules/module-config/). Expo Autolinking will automatically link these classes as native modules in the user's project.
 
 ```json expo-module.config.json
 {
@@ -113,4 +113,4 @@ import { requireNativeModule } from 'expo-modules-core';
 export default requireNativeModule('MyModule');
 ```
 
-Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](./module-api.mdx) reference page and links to [examples](./module-api.mdx#examples) from simple to moderately complex real-world modules for your reference to better understand how to use the API.
+Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](/modules/module-api/) reference page and links to [examples](/modules/module-api/#examples) from simple to moderately complex real-world modules for your reference to better understand how to use the API.

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -21,25 +21,25 @@ It provides a set of APIs and utilities to improve the process of developing nat
 <BoxLink
   title="Native Modules"
   description="Create native modules using Swift and Kotlin."
-  href="./module-api"
+  href="/modules/module-api/"
   Icon={Grid01Icon}
 />
 <BoxLink
   title="Android Lifecycle Listeners"
   description="Hook into Android Activity and Application lifecycle events."
-  href="./android-lifecycle-listeners"
+  href="/modules/android-lifecycle-listeners/"
   Icon={AndroidIcon}
 />
 <BoxLink
   title="iOS AppDelegate Subscribers"
   description="Respond to iOS AppDelegate events."
-  href="./appdelegate-subscribers"
+  href="/modules/appdelegate-subscribers/"
   Icon={AppleIcon}
 />
 <BoxLink
   title="expo-module.config.json"
   description="Configure and opt in to features."
-  href="./module-config"
+  href="/modules/module-config/"
   Icon={Settings01Icon}
 />
 
@@ -63,8 +63,8 @@ This is one of the reasons why the Expo Modules ecosystem was designed from the 
 
 Another big pain point we have encountered is the validation of arguments passed from JavaScript to native functions.
 This is especially error-prone, time-consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime, and each property needs to be validated separately by the developer.
-A valuable feature of the Expo native modules API is its full knowledge of the argument types the native function expects. It can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](./module-api/#records).
-Knowing the argument types, it is also possible to [automatically convert arguments](./module-api/#convertibles) to some platform-specific types (for example, `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
+A valuable feature of the Expo native modules API is its full knowledge of the argument types the native function expects. It can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](/modules/module-api/#records).
+Knowing the argument types, it is also possible to [automatically convert arguments](/modules/module-api/#convertibles) to some platform-specific types (for example, `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
 
 ### React Native New Architecture
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -703,7 +703,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/clients/introduction.mdx) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v49.0.0/config/metro.mdx
+++ b/docs/pages/versions/v49.0.0/config/metro.mdx
@@ -449,7 +449,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/clients/introduction.mdx) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -695,7 +695,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/clients/introduction.mdx) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -703,7 +703,7 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 #### Development
 
-Development mode entry files can be enabled by using the [`expo-dev-client`](/clients/introduction.mdx) package. Alternatively you can add the following configuration:
+Development mode entry files can be enabled by using the [`expo-dev-client`](/versions/latest/sdk/dev-client/) package. Alternatively you can add the following configuration:
 
 In the `ios/[project]/AppDelegate.mm` file:
 

--- a/docs/scripts/test-links.js
+++ b/docs/scripts/test-links.js
@@ -17,7 +17,6 @@ const externalLinks = [
   '/versions/latest/workflow/configuration/#ios', // https://github.com/expo/expo-cli/blob/main/packages/xdl/src/detach/Detach.js
   '/versions/latest/sdk/overview/', // https://github.com/expo/expo-cli/blob/main/packages/xdl/src/project/Convert.js
   '/versions/latest/distribution/building-standalone-apps/#2-configure-appjson', // https://github.com/expo/expo-cli/blob/main/packages/expo-cli/src/commands/build/ios/IOSBuilder.js
-  '/versions/latest/introduction/faq/#can-i-use-nodejs-packages-with-expo', // https://github.com/expo/expo-cli/blob/main/packages/xdl/src/logs/PackagerLogsStream.js
 ];
 
 (async () => {

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -299,7 +299,7 @@ Terms referred in this section are meant to be used consistently throughout the 
 - **"Bare apps"** refer to React Native.
 - **"Custom clients"** refer to development builds.
 
-_A complete list of [Expo-related glossary terms](https://docs.expo.dev/workflow/glossary-of-terms/) is available for further reference._
+_A complete list of [Expo related glossary terms](https://docs.expo.dev/more/glossary-of-terms/) is available for further reference._
 
 # Writing API documentation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-7758

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Removes old client and server-side redirects
- Fix/update internal links based on removed redirect links (checked `expo/expo` repo completely and also created follow-up PRs: #30165, #30162, #30163.
- Update `error-utilities.test.ts` file to remove old tests that referenced SDK versions below 48
- Remove older link in `test-link.js`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run test-links` and `yarn run test` to make sure all tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
