### PR TITLE
[docs] Move Troubleshooting Proxies guide from More to Troubleshooting section

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -475,4 +475,7 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Temporary redirects
   '/guides/react-compiler/': '/preview/react-compiler/',
+
+  // Troubleshooting section
+  '/guides/troubleshooting-proxies/': '/troubleshooting/proxies/',
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -411,7 +411,6 @@ const general = [
       makePage('eas/webhooks.mdx'),
       makeSection('Assorted', [
         makePage('guides/authentication.mdx'),
-        makePage('guides/troubleshooting-proxies.mdx'),
         makePage('guides/sharing-preview-releases.mdx'),
         makePage('guides/using-hermes.mdx'),
         makePage('guides/ios-developer-mode.mdx'),
@@ -456,6 +455,7 @@ const general = [
         makePage('troubleshooting/clear-cache-macos-linux.mdx'),
         makePage('troubleshooting/clear-cache-windows.mdx'),
         makePage('troubleshooting/react-native-version-mismatch.mdx'),
+        makePage('troubleshooting/proxies.mdx'),
       ]),
     ],
     { expanded: true }

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -377,6 +377,9 @@ redirects[guides/using-flipper]=archive/using-flipper
 # Temporary redirects
 redirects[guides/react-compiler]=preview/react-compiler
 
+# Troubleshooting section
+redirects[guides/troubleshooting-proxies]=troubleshooting/proxies
+
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -66,6 +66,13 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
   Icon={BookOpen02Icon}
 />
 
+<BoxLink
+  title="Proxies"
+  description="Learn about troubleshooting proxies with a set of recommended tools."
+  href="/troubleshooting/proxies/"
+  Icon={BookOpen02Icon}
+/>
+
 ## Runtime issues in development and production
 
 <BoxLink

--- a/docs/pages/troubleshooting/proxies.mdx
+++ b/docs/pages/troubleshooting/proxies.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshoot proxies
+title: Proxies
 description: Learn about troubleshooting proxies with a set of recommended tools.
 ---
 

--- a/docs/pages/troubleshooting/proxies.mdx
+++ b/docs/pages/troubleshooting/proxies.mdx
@@ -1,5 +1,6 @@
 ---
-title: Proxies
+title: Troubleshooting Proxies
+sidebar_title: Proxies
 description: Learn about troubleshooting proxies with a set of recommended tools.
 ---
 

--- a/docs/pages/workflow/common-development-errors.mdx
+++ b/docs/pages/workflow/common-development-errors.mdx
@@ -8,7 +8,7 @@ This page outlines a list of errors that are commonly encountered by developers 
 ### Metro bundler ECONNREFUSED 127.0.0.1:19001
 
 - An error is preventing the connection to your local development server.
-- Run `rm -rf .expo` to clear your local state. Check for firewalls or [proxies](/guides/troubleshooting-proxies) affecting the network you are currently connected to.
+- Run `rm -rf .expo` to clear your local state. Check for firewalls or [proxies](/troubleshooting/proxies/) affecting the network you are currently connected to.
 
 ### Module AppRegistry is not a registered callable module (calling runApplication)
 
@@ -33,9 +33,9 @@ This page outlines a list of errors that are commonly encountered by developers 
 ### Application has not been registered
 
 - There is a mismatch between the AppKey registered in the native and JS portion of your app.
-- [Align your AppKey](../troubleshooting/application-has-not-been-registered) with the native side of your project.
+- [Align your AppKey](/troubleshooting/application-has-not-been-registered/) with the native side of your project.
 
 ### Application not behaving as expected
 
 - It is possible caches may be preventing you from seeing the current state of your application.
-- Clear all caches associated with your project in [Unix-like](../troubleshooting/clear-cache-macos-linux/) or [Windows](../troubleshooting/clear-cache-windows/) systems.
+- Clear all caches associated with your project in [Unix-like](/troubleshooting/clear-cache-macos-linux/) or [Windows](/troubleshooting/clear-cache-windows/) systems.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #30090

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Move the Troubleshooting Proxies guide from More > Assorted to the Troubleshooting section
- Fix internal links in the Common development errors guide
- Add redirects for `/guides/troubleshooting-proxies/`
- Fix the doc's title and add the sidebar_title

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
