### PR TITLE
[network][Android] Fix `NetworkCallback` was not registered

### DIFF
--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `java.lang.IllegalArgumentException: NetworkCallback was not registered`.
+
 ### 💡 Others
 
 ## 6.0.1 — 2024-04-23

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `java.lang.IllegalArgumentException: NetworkCallback was not registered`.
+- [Android] Fix `java.lang.IllegalArgumentException: NetworkCallback was not registered`. ([#30185](https://github.com/expo/expo/pull/30185) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
+++ b/packages/expo-network/android/src/main/java/expo/modules/network/NetworkModule.kt
@@ -29,6 +29,16 @@ class NetworkModule : Module() {
   private val connectivityManager: ConnectivityManager
     get() = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
+  private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+    override fun onAvailable(network: android.net.Network) {
+      emitNetworkState()
+    }
+
+    override fun onLost(network: android.net.Network) {
+      emitNetworkState()
+    }
+  }
+
   override fun definition() = ModuleDefinition {
     Name("ExpoNetwork")
 
@@ -38,20 +48,12 @@ class NetworkModule : Module() {
       val networkRequest = NetworkRequest.Builder().build()
       connectivityManager.registerNetworkCallback(
         networkRequest,
-        object : ConnectivityManager.NetworkCallback() {
-          override fun onAvailable(network: android.net.Network) {
-            emitNetworkState()
-          }
-
-          override fun onLost(network: android.net.Network) {
-            emitNetworkState()
-          }
-        }
+        networkCallback
       )
     }
 
     OnDestroy {
-      connectivityManager.unregisterNetworkCallback(ConnectivityManager.NetworkCallback())
+      connectivityManager.unregisterNetworkCallback(networkCallback)
     }
 
     AsyncFunction("getNetworkStateAsync") {


### PR DESCRIPTION
# Why

Fixes `java.lang.IllegalArgumentException: NetworkCallback was not registered`

# Test Plan

- bare-expo ✅ 