### PR TITLE
[test-suite] fix expo-bare detection, UI tweaks

### DIFF
--- a/apps/bare-expo/android/app/src/androidTest/java/dev/expo/payments/BareExpoTestSuite.kt
+++ b/apps/bare-expo/android/app/src/androidTest/java/dev/expo/payments/BareExpoTestSuite.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeoutException
 
 private const val TEST_RESULT_ID = "test_suite_text_results"
 private const val TEST_TIMEOUT_MS = 20000L
-private const val TEST_EXPECTED_RESULT = "Complete: 0 tests failed."
+private const val TEST_EXPECTED_RESULT = "Success!"
 
 @RunWith(Parameterized::class)
 @LargeTest

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -85,7 +85,7 @@ async function testAsync(
     await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
 
     const maestroFlowFilePath = path.join(projectRoot, MAESTRO_GENERATED_FLOW);
-    await createMaestroFlowAsync(projectRoot, maestroFlowFilePath);
+    await createMaestroFlowAsync(maestroFlowFilePath);
     console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
     await spawnAsync('maestro', ['--device', deviceId, 'test', maestroFlowFilePath], {
       stdio: 'inherit',
@@ -157,7 +157,7 @@ async function queryDeviceIdAsync(iosVersion: number, device: string): Promise<s
 /**
  * Generate Maestro flow yaml file
  */
-async function createMaestroFlowAsync(projectRoot: string, outputFile: string): Promise<void> {
+async function createMaestroFlowAsync(outputFile: string): Promise<void> {
   const inputFile = require('../e2e/TestSuite-test.native.js');
   const testCases = inputFile.TESTS;
   const contents = [
@@ -182,7 +182,7 @@ appId: dev.expo.Payments
       id: "test_suite_container"
     timeout: 30000
 - assertVisible:
-    text: "Complete: 0 tests failed."
+    text: "Success!"
 `);
 
     await fs.writeFile(outputFile, contents.join('\n'));

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -1,6 +1,7 @@
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
+import { StyleSheet } from 'react-native';
 
 import Colors from './constants/Colors';
 import SelectScreen from './screens/SelectScreen';
@@ -49,8 +50,8 @@ export default function AppNavigator(props) {
         },
         headerTintColor: Colors.tintColor,
         headerStyle: {
-          borderBottomWidth: 0.5,
-          borderBottomColor: 'rgba(0,0,0,0.1)',
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          borderBottomColor: Colors.border,
           boxShadow: '',
         },
       }}>

--- a/apps/test-suite/components/DoneText.js
+++ b/apps/test-suite/components/DoneText.js
@@ -1,19 +1,37 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+
+import Colors from '../constants/Colors';
 
 export default function DoneText({ done, numFailed, results }) {
   return (
     <View testID="test_suite_results" style={styles.container}>
       {!done && (
-        <Text testID="test_suite_loading_results" style={styles.doneMessage}>
-          Running Tests...
-        </Text>
+        <View style={styles.messageContainer}>
+          <ActivityIndicator />
+          <Text testID="test_suite_loading_results" style={styles.doneMessage}>
+            Running Tests...
+          </Text>
+        </View>
       )}
       {done && (
-        <Text testID="test_suite_text_results" style={styles.doneMessage}>
-          Complete: {numFailed}
-          {numFailed === 1 ? ' test' : ' tests'} failed.
-        </Text>
+        <View style={styles.messageContainer}>
+          <Text style={styles.doneMessage}>Complete.</Text>
+          {numFailed ? (
+            <Text
+              testID="test_suite_text_results"
+              style={[styles.doneMessage, { color: Colors.failed }]}>
+              {numFailed}
+              {numFailed === 1 ? ' test' : ' tests'} failed!
+            </Text>
+          ) : (
+            <Text
+              testID="test_suite_text_results"
+              style={[styles.doneMessage, { color: Colors.passed }]}>
+              Success!
+            </Text>
+          )}
+        </View>
       )}
       {done && (
         <Text style={styles.finalResults} pointerEvents="none" testID="test_suite_final_results">
@@ -37,5 +55,12 @@ const styles = StyleSheet.create({
   doneMessage: {
     fontWeight: 'bold',
     fontSize: 16,
+  },
+  messageContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+    minHeight: 28,
   },
 });

--- a/apps/test-suite/components/Suites.js
+++ b/apps/test-suite/components/Suites.js
@@ -1,20 +1,13 @@
 import Constants from 'expo-constants';
 import React from 'react';
-import { FlatList, StyleSheet } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 
 import DoneText from './DoneText';
 import SuiteResult from './SuiteResult';
+import Colors from '../constants/Colors';
 
 export default function Suites({ suites, done, numFailed, results }) {
   const ref = React.useRef(null);
-
-  const renderItem = ({ item }) => <SuiteResult r={item} depth={0} />;
-
-  const keyExtractor = (item) => item.get('result').get('id');
-
-  const ListHeaderComponent = () => (
-    <DoneText done={done} numFailed={numFailed} results={results} />
-  );
 
   return (
     <FlatList
@@ -22,19 +15,28 @@ export default function Suites({ suites, done, numFailed, results }) {
       style={styles.list}
       contentContainerStyle={styles.contentContainerStyle}
       data={[...suites]}
-      keyExtractor={keyExtractor}
-      renderItem={renderItem}
-      ListHeaderComponent={ListHeaderComponent}
+      keyExtractor={(item) => item.get('result').get('id')}
+      renderItem={({ item }) => <SuiteResult r={item} depth={0} />}
+      ListHeaderComponent={() => (
+        <View style={styles.headerContainer}>
+          <DoneText done={done} numFailed={numFailed} results={results} />
+        </View>
+      )}
+      stickyHeaderIndices={[0]}
     />
   );
 }
 
 const styles = StyleSheet.create({
   contentContainerStyle: {
-    padding: 5,
     paddingBottom: (Constants.statusBarHeight || 24) + 128,
   },
   list: {
     flex: 1,
+  },
+  headerContainer: {
+    backgroundColor: '#fff',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
   },
 });

--- a/apps/test-suite/constants/Colors.js
+++ b/apps/test-suite/constants/Colors.js
@@ -2,10 +2,11 @@ import Statuses from './Statuses';
 
 export default {
   [Statuses.Running]: '#ff0',
-  [Statuses.Passed]: '#0f0',
+  [Statuses.Passed]: '#59bb09',
   [Statuses.Failed]: '#f00',
   [Statuses.Disabled]: '#888',
   tintColor: '#4630EB', // Expo Blue
   activeTintColor: '#4630ec',
   inactiveTintColor: '#595959',
+  border: '#dddddd',
 };

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -21,6 +21,7 @@
     "expo-barcode-scanner": "~13.0.0",
     "expo-brightness": "~12.0.0",
     "expo-calendar": "~13.0.0",
+    "expo-checkbox": "~3.0.0",
     "expo-camera": "~15.0.0",
     "expo-cellular": "~6.0.0",
     "expo-constants": "~16.0.0",

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -1,4 +1,4 @@
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { Checkbox } from 'expo-checkbox';
 import Constants from 'expo-constants';
 import React from 'react';
 import { Alert, FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -15,11 +15,9 @@ function ListItem({ title, onPressItem, selected, id }) {
     <PlatformTouchable onPress={onPress}>
       <View style={styles.listItem}>
         <Text style={styles.label}>{title}</Text>
-        <MaterialCommunityIcons
-          color={selected ? Colors.tintColor : 'black'}
-          name={selected ? 'checkbox-marked' : 'checkbox-blank-outline'}
-          size={24}
-        />
+        <View style={{ pointerEvents: 'none' }}>
+          <Checkbox color={Colors.tintColor} value={selected} />
+        </View>
       </View>
     </PlatformTouchable>
   );
@@ -166,10 +164,10 @@ export default class SelectScreen extends React.PureComponent {
     const buttonTitle = allSelected ? 'Deselect All' : 'Select All';
 
     return (
-      // eslint-disable-next-line react/jsx-fragments
       <>
         <FlatList
           data={this.state.modules}
+          contentContainerStyle={{ backgroundColor: '#fff' }}
           extraData={this.state}
           keyExtractor={this._keyExtractor}
           renderItem={this._renderItem}
@@ -189,8 +187,7 @@ export default class SelectScreen extends React.PureComponent {
 function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
   const { bottom, left, right } = useSafeArea();
 
-  const isRunningInBareExpo =
-    Constants.__unsafeNoWarnManifest && Constants.__unsafeNoWarnManifest.slug === 'bare-expo';
+  const isRunningInBareExpo = Constants.expoConfig.slug === 'bare-expo';
   const paddingVertical = 16;
 
   return (
@@ -224,14 +221,14 @@ function FooterButton({ title, style, ...props }) {
   );
 }
 
-const HORIZONTAL_MARGIN = 24;
+const HORIZONTAL_MARGIN = 20;
 
 const styles = StyleSheet.create({
   mainContainer: {
     flex: 1,
   },
   footerButtonTitle: {
-    fontSize: 18,
+    fontSize: 16,
     color: Colors.tintColor,
   },
   footerButton: {
@@ -246,18 +243,18 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: HORIZONTAL_MARGIN,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#dddddd',
+    borderBottomColor: Colors.border,
   },
   label: {
     color: 'black',
-    fontSize: 18,
+    fontSize: 16,
   },
   buttonRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: '#dddddd',
+    borderTopColor: Colors.border,
     backgroundColor: 'white',
   },
   contentContainerStyle: {


### PR DESCRIPTION
# Why

Spotted that `expo-bare` detection in `test-suite` is failing.

# How

Fix `expo-bare` detection, perform few tweaks and fixes to the UI, including sticky test results header and `expo-checkbox` usage instead of material icons.

# Test Plan

The changes have been tested by running `bare-expo` app locally, on the device.

Now, let's make sure tests are still working, after the label changes.

# Preview
<img src="https://github.com/expo/expo/assets/719641/981ab7e0-25ad-42fc-a49d-7849212577f6" align="left" width="370" />
<img src="https://github.com/expo/expo/assets/719641/b35467ac-6824-4999-96bc-ab9af892ae75" align="left" width="370" />

