### PR TITLE
[menu][Android] Disable back gesture when interacting with FAB

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -1,20 +1,57 @@
 package expo.modules.devmenu
 
 import android.content.Context
+import android.graphics.Rect
+import android.os.Build
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.annotation.RequiresApi
+import androidx.core.view.doOnLayout
 import com.facebook.react.ReactRootView
 import expo.modules.devmenu.fab.MovableFloatingActionButton
 
 /**
  * We want to hide the FAB behind the feature flag for now.
  */
-private const val enableFAB = false
+private const val enableFAB = true
 
 class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
-  private val fab by lazy { MovableFloatingActionButton(context) }
+  @RequiresApi(Build.VERSION_CODES.Q)
+  private val updateSystemGestureExclusionRects: () -> Unit = {
+    val marginLayoutParams = fab.layoutParams as MarginLayoutParams
+
+    // Bounding box for the FAB, with margins included
+    val rect = Rect(
+      fab.x.toInt() - marginLayoutParams.leftMargin,
+      fab.y.toInt() - marginLayoutParams.bottomMargin,
+      fab.x.toInt() + fab.width + marginLayoutParams.rightMargin,
+      fab.y.toInt() + fab.height + marginLayoutParams.topMargin
+    )
+
+    // For some reason, updating the system gesture exclusion rects has to be called on that view
+    // instead of calling it on the fab view itself. Probably, because we want to extend the react by view margins.
+    setSystemGestureExclusionRects(listOf(rect))
+  }
+
+  private val fab by lazy {
+    MovableFloatingActionButton(context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        return@MovableFloatingActionButton
+      }
+
+      // `setSystemGestureExclusionRects` should be call after the view is laid out
+      doOnLayout {
+        updateSystemGestureExclusionRects()
+      }
+    }
+  }
+
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    super.onLayout(changed, left, top, right, bottom)
+    updateSystemGestureExclusionRects()
+  }
 
   override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
     DevMenuManager.onTouchEvent(ev)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuReactRootViewContainer.kt
@@ -15,7 +15,7 @@ import expo.modules.devmenu.fab.MovableFloatingActionButton
 /**
  * We want to hide the FAB behind the feature flag for now.
  */
-private const val enableFAB = true
+private const val enableFAB = false
 
 class DevMenuReactRootViewContainer(context: Context) : FrameLayout(context) {
   @RequiresApi(Build.VERSION_CODES.Q)

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -1,5 +1,6 @@
 package expo.modules.devmenu.fab
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
@@ -19,7 +20,11 @@ private const val CLICK_DRAG_TOLERANCE = 10f
 private const val MARGIN = 24
 private const val SIZE = 150
 
-class MovableFloatingActionButton(context: Context) : FrameLayout(context), View.OnTouchListener {
+@SuppressLint("ViewConstructor")
+class MovableFloatingActionButton(
+  context: Context,
+  private val updateSystemGestureExclusionRects: () -> Unit
+) : FrameLayout(context), View.OnTouchListener {
   private var downRawX = 0f
   private var downRawY = 0f
   private var dX = 0f
@@ -28,6 +33,7 @@ class MovableFloatingActionButton(context: Context) : FrameLayout(context), View
 
   // stencilPath is used to make the view rounded
   private val stencilPath = Path()
+
   // eventRegion is used to add rounded corners to the touch area
   private var eventRegion = Region()
 
@@ -140,6 +146,7 @@ class MovableFloatingActionButton(context: Context) : FrameLayout(context), View
             .setDuration(100)
             .scaleX(1f)
             .scaleY(1f)
+            .withEndAction { updateSystemGestureExclusionRects() }
             .start()
 
           true


### PR DESCRIPTION
# Why

Disables back gesture when interacting with FAB. You can find more information [here](https://developer.android.com/develop/ui/views/touch-and-input/gestures/gesturenav#back-gestures).

# How

Call `setSystemGestureExclusionRects` with fab bounding view

# Test Plan

- bare-expo ✅ 

https://github.com/expo/expo/assets/9578601/80cd097e-67a8-4caa-bab2-94f5aa17bdb5

