### PR TITLE
[docs] Fix code language for multiple API references examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/checkbox.mdx
@@ -20,9 +20,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic Checkbox usage' dependencies={['expo-checkbox']} platforms={['android', 'web']}>
 
-```js
+```tsx
 import Checkbox from 'expo-checkbox';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -28,8 +28,8 @@ files={{
   }}
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
-```js
-import React, { useState, useEffect } from 'react';
+```jsx
+import { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -29,8 +29,8 @@ import { SnackInline } from '~/ui/components/Snippet';
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```js
-import React, { useRef, useEffect } from 'react';
+```jsx
+import { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -29,9 +29,8 @@ This is especially important on Android since the [`android.media.projection`](h
 
 <SnackInline label="Screen Capture hook" dependencies={["expo-screen-capture"]}>
 
-```js
+```jsx
 import { usePreventScreenCapture } from 'expo-screen-capture';
-import React from 'react';
 import { Text, View } from 'react-native';
 
 export default function ScreenCaptureExample() {
@@ -51,7 +50,7 @@ export default function ScreenCaptureExample() {
 
 <SnackInline label="Screen Capture functions" dependencies={["expo-screen-capture", "expo-media-library"]}>
 
-```js
+```jsx
 import * as ScreenCapture from 'expo-screen-capture';
 import { useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -23,7 +23,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```jsx
+```jsx App.js
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -23,8 +23,8 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```jsx
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -25,7 +25,7 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 
 ## Example
 
-```js
+```jsx App.js
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 

--- a/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
@@ -22,9 +22,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic Checkbox usage' dependencies={['expo-checkbox']} platforms={['android', 'web']}>
 
-```js
+```tsx
 import Checkbox from 'expo-checkbox';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
@@ -30,7 +30,7 @@ files={{
   }}
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
-```js
+```jsx
 import React, { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -31,7 +31,7 @@ files={{
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```js
+```jsx
 import React, { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';

--- a/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
@@ -25,8 +25,8 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```jsx
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';

--- a/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
@@ -25,7 +25,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```jsx
+```jsx App.js
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
@@ -27,8 +27,7 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 
 ## Example
 
-```js
-import React from 'react';
+```jsx App.js
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 

--- a/docs/pages/versions/v50.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/checkbox.mdx
@@ -22,9 +22,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic Checkbox usage' dependencies={['expo-checkbox']} platforms={['android', 'web']}>
 
-```js
+```tsx
 import Checkbox from 'expo-checkbox';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
@@ -30,7 +30,7 @@ files={{
   }}
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
-```js
+```jsx
 import React, { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -31,7 +31,7 @@ files={{
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```js
+```jsx
 import React, { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';

--- a/docs/pages/versions/v50.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/screen-capture.mdx
@@ -31,9 +31,8 @@ This is especially important on Android since the [`android.media.projection`](h
 
 <SnackInline label="Screen Capture hook" dependencies={["expo-screen-capture"]}>
 
-```js
+```jsx
 import { usePreventScreenCapture } from 'expo-screen-capture';
-import React from 'react';
 import { Text, View } from 'react-native';
 
 export default function ScreenCaptureExample() {
@@ -53,7 +52,7 @@ export default function ScreenCaptureExample() {
 
 <SnackInline label="Screen Capture functions" dependencies={["expo-screen-capture", "expo-media-library"]}>
 
-```js
+```jsx
 import { useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import * as ScreenCapture from 'expo-screen-capture';

--- a/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
@@ -25,8 +25,8 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```jsx
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';

--- a/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/splash-screen.mdx
@@ -25,7 +25,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```jsx
+```jsx App.js
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
@@ -27,7 +27,7 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 
 ## Example
 
-```js
+```jsx App.js
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 

--- a/docs/pages/versions/v51.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/checkbox.mdx
@@ -20,9 +20,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic Checkbox usage' dependencies={['expo-checkbox']} platforms={['android', 'web']}>
 
-```js
+```tsx
 import Checkbox from 'expo-checkbox';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {

--- a/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
@@ -28,7 +28,7 @@ files={{
   }}
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
-```js
+```jsx
 import React, { useState, useEffect } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';

--- a/docs/pages/versions/v51.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/lottie.mdx
@@ -29,7 +29,7 @@ import { SnackInline } from '~/ui/components/Snippet';
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```js
+```jsx
 import React, { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';

--- a/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
@@ -29,9 +29,8 @@ This is especially important on Android since the [`android.media.projection`](h
 
 <SnackInline label="Screen Capture hook" dependencies={["expo-screen-capture"]}>
 
-```js
+```jsx
 import { usePreventScreenCapture } from 'expo-screen-capture';
-import React from 'react';
 import { Text, View } from 'react-native';
 
 export default function ScreenCaptureExample() {
@@ -51,7 +50,7 @@ export default function ScreenCaptureExample() {
 
 <SnackInline label="Screen Capture functions" dependencies={["expo-screen-capture", "expo-media-library"]}>
 
-```js
+```jsx
 import * as ScreenCapture from 'expo-screen-capture';
 import { useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';

--- a/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
@@ -23,7 +23,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```jsx
+```jsx App.js
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';

--- a/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
@@ -23,8 +23,8 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```jsx
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';

--- a/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
@@ -25,7 +25,7 @@ See full documentation at [callstack/react-native-pager-view](https://github.com
 
 ## Example
 
-```js
+```jsx App.js
 import { StyleSheet, View, Text } from 'react-native';
 import PagerView from 'react-native-pager-view';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes code language for example blocks in multiple API references so that the correct language syntax is rendered and used for opening these examples in Snack (if applicable).

In some of the examples, also remove unused `React` import statement.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
