### PR TITLE
bump kotlin version to 1.9.24

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
     compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
     targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
+    kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.24'
     ndkVersion = "26.1.10909125"
   }
   repositories {

--- a/apps/fabric-tester/android/build.gradle
+++ b/apps/fabric-tester/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.24'
         // for expo-dev-client
         expoUpdatesVersion = null
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - Fix and update link for `expo-dev-client` in package's README. ([#30162](https://github.com/expo/expo/pull/30162) by [@amandeepmittal](https://github.com/amandeepmittal)).
 - Fixed broken unit test on iOS 17 where `URL()` without scheme returns nil. ([#30178](https://github.com/expo/expo/pull/30178) by [@kudo](https://github.com/kudo))
+- Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
+++ b/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.23"
+  kotlin("jvm") version "1.9.24"
   id("java-gradle-plugin")
 }
 
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:8.2.1")
+  compileOnly("com.android.tools.build:gradle:8.5.0")
 }
 
 java {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [Android] Started using `noexcept`. ([#30128](https://github.com/expo/expo/pull/30128) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Decouple the modules state from the `AppContext` ([#30098](https://github.com/expo/expo/pull/30098) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added `customizeRootView:` support to `EXAppDelegateWrapper.createRCTRootViewFactory`. ([#30245](https://github.com/expo/expo/pull/30245) by [@kudo](https://github.com/kudo))
+- Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -25,7 +25,9 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
           "1.8.0": "1.8.0-1.0.9",
           "1.8.10": "1.8.10-1.0.9",
           "1.8.22": "1.8.22-1.0.11",
-          "1.9.23": "1.9.23-1.0.20"
+          "1.9.23": "1.9.23-1.0.20",
+          // 1.9.24-1.0.20 is currently broken and causes NoSuchMethodError
+          "1.9.24": "1.9.23-1.0.20"
         ]
 
         project.rootProject.ext.has("kspVersion")

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -14,7 +14,7 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
       project.ext.kotlinVersion = {
         project.rootProject.ext.has("kotlinVersion")
             ? project.rootProject.ext.get("kotlinVersion")
-            : "1.9.23"
+            : "1.9.24"
       }
 
       project.ext.kspVersion = {

--- a/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
+++ b/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.23"
+  kotlin("jvm") version "1.9.24"
   id("java-gradle-plugin")
 }
 
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:8.2.1")
+  compileOnly("com.android.tools.build:gradle:8.5.0")
 }
 
 java {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### 🐛 Bug fixes
 
 - Fix expo update getting disabled in custom debug configurations. ([#30159](https://github.com/expo/expo/pull/30159) by [@matinzd](https://github.com/matinzd))
-
 - Fix data race in `AppLauncherWithDatabaseMock.swift`. ([#28924](https://github.com/expo/expo/pull/28924) by [@hakonk](https://github.com/hakonk))
 
 ### 💡 Others
@@ -20,6 +19,7 @@
 - [Android] Change from kapt to ksp for room. ([#29055](https://github.com/expo/expo/pull/29055) by [@wschurman](https://github.com/wschurman))
 - [Android] Upgrade dependencies and remove unused ones. Change multipart parser to okhttp. ([#29060](https://github.com/expo/expo/pull/29060) by [@wschurman](https://github.com/wschurman))
 - [Android] Use protected methods in room dao now that ksp allows it. ([#29080](https://github.com/expo/expo/pull/29080) by [@wschurman](https://github.com/wschurman))
+- Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.25.17 - 2024-06-13
 

--- a/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
+++ b/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.23"
+  kotlin("jvm") version "1.9.24"
   id("java-gradle-plugin")
 }
 
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:8.2.1")
+  compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
 }
 

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
-        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.23'
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.24'
 
         ndkVersion = "26.1.10909125"
     }


### PR DESCRIPTION
# Why

React-native 0.75 bumps kotlinVersion 1.9.24, it should be good for us to align the kotlin version.

Related to ENG-12562


# How

- side work for #30034 so we don't have to do everything in one PR
- bump kotlin version to `1.9.24` and APG to `8.5.0`  

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
