### PR TITLE
[android][autolinking]: fix AWS S3 repository configuration

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed autolinking of Maven AWS S3 repository. ([#30204](https://github.com/expo/expo/pull/30204) by [@ElielC](https://github.com/ElielC))
+
 ### 💡 Others
 
 ## 1.11.1 — 2024-04-23

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -246,14 +246,18 @@ if (rootProject instanceof ProjectDescriptor) {
             maven {
               url "${mavenRepo.url}"
               if (mavenRepo.credentials != null) {
-                credentials {
-                  if (mavenRepo.credentials.username && mavenRepo.credentials.password) {
+                if (mavenRepo.credentials.username && mavenRepo.credentials.password) {
+                  credentials {
                     username mavenRepo.credentials.username
                     password mavenRepo.credentials.password
-                  } else if (mavenRepo.credentials.name && mavenRepo.credentials.value) {
+                  }
+                } else if (mavenRepo.credentials.name && mavenRepo.credentials.value) {
+                  credentials(HttpHeaderCredentials) {
                     name mavenRepo.credentials.name
                     value mavenRepo.credentials.value
-                  } else if (mavenRepo.credentials.accessKey && mavenRepo.credentials.secretKey) {
+                  }
+                } else if (mavenRepo.credentials.accessKey && mavenRepo.credentials.secretKey) {
+                  credentials(AwsCredentials) {
                     accessKey mavenRepo.credentials.accessKey
                     secretKey mavenRepo.credentials.secretKey
                     sessionToken mavenRepo.credentials.sessionToken


### PR DESCRIPTION
# Why

- The old script was causing the error: `Could not find method accessKey() for arguments [<>] on Credentials [username: null] of type org.gradle.internal.credentials.DefaultPasswordCredentials_Decorated.`

# How

- Altering credentials following the [gradle documentation](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:authentication_schemes)

# Test Plan

- The Prebuild and expo run:android now work correctly with a S3 Maven Repo

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
