### PR TITLE
[ios][image-manipulator] Prefer UIGraphicsImageRenderer

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Use the `src` folder as the Metro target. ([#30079](https://github.com/expo/expo/pull/30079) by [@tsapeta](https://github.com/tsapeta))
+- Prefer `UIGraphicsImageRenderer` over `UIGraphicsBeginImageContext`.
 
 ## 12.0.5 — 2024-05-13
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Use the `src` folder as the Metro target. ([#30079](https://github.com/expo/expo/pull/30079) by [@tsapeta](https://github.com/tsapeta))
-- Prefer `UIGraphicsImageRenderer` over `UIGraphicsBeginImageContext`.
+- Prefer `UIGraphicsImageRenderer` over `UIGraphicsBeginImageContext`. ([#30211](https://github.com/expo/expo/pull/30211) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 12.0.5 — 2024-05-13
 

--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -91,23 +91,12 @@ func retrieveAsset(from url: URL) -> PHAsset? {
  Helper function for drawing the image in graphics context.
  Throws appropriate exceptions when the context is missing or the image couldn't be rendered.
  */
-internal func drawInNewContext(size: CGSize, drawing: (CGContext) -> Void) throws -> UIImage {
-  UIGraphicsBeginImageContext(size)
+internal func drawInNewContext(size: CGSize, drawing: (UIGraphicsImageRendererContext) -> Void) -> UIImage {
+  let renderer = UIGraphicsImageRenderer(size: size)
 
-  guard let context = UIGraphicsGetCurrentContext() else {
-    UIGraphicsEndImageContext()
-    throw ImageContextLostException()
+  return renderer.image { context in
+    drawing(context)
   }
-
-  drawing(context)
-
-  guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else {
-    UIGraphicsEndImageContext()
-    throw NoImageInContextException()
-  }
-
-  UIGraphicsEndImageContext()
-  return newImage
 }
 
 /**

--- a/packages/expo-image-manipulator/ios/Transformers/ImageFlipTransformer.swift
+++ b/packages/expo-image-manipulator/ios/Transformers/ImageFlipTransformer.swift
@@ -7,19 +7,19 @@ internal struct ImageFlipTransformer: ImageTransformer {
   let flip: FlipType
 
   @MainActor
-  func transform(image: UIImage) async throws -> UIImage {
+  func transform(image: UIImage) async -> UIImage {
     let imageView = UIImageView(image: image)
 
-    return try drawInNewContext(size: imageView.frame.size) { context in
+    return drawInNewContext(size: imageView.frame.size) { context in
       switch flip {
       case .vertical:
         let transform = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: imageView.frame.size.height)
-        context.concatenate(transform)
+        context.cgContext.concatenate(transform)
       case .horizontal:
         let transform = CGAffineTransform(a: -1, b: 0, c: 0, d: 1, tx: imageView.frame.size.width, ty: 0)
-        context.concatenate(transform)
+        context.cgContext.concatenate(transform)
       }
-      imageView.layer.render(in: context)
+      imageView.layer.render(in: context.cgContext)
     }
   }
 }

--- a/packages/expo-image-manipulator/ios/Transformers/ImageResizeTransformer.swift
+++ b/packages/expo-image-manipulator/ios/Transformers/ImageResizeTransformer.swift
@@ -6,7 +6,7 @@
 internal struct ImageResizeTransformer: ImageTransformer {
   let options: ResizeOptions
 
-  func transform(image: UIImage) async throws -> UIImage {
+  func transform(image: UIImage) async -> UIImage {
     let imageWidth = image.size.width
     let imageHeight = image.size.height
     let imageRatio = imageWidth / imageHeight
@@ -21,16 +21,14 @@ internal struct ImageResizeTransformer: ImageTransformer {
       targetSize.height = height
       targetSize.width = targetSize.width == 0 ? imageRatio * targetSize.height : targetSize.width
     }
+    
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = false
+    format.scale = 1
 
-    UIGraphicsBeginImageContextWithOptions(targetSize, false, 1.0)
-    image.draw(in: CGRect(origin: .zero, size: targetSize))
-
-    guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else {
-      UIGraphicsEndImageContext()
-      throw NoImageInContextException()
+    let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
+    return renderer.image { context in
+      image.draw(in: CGRect(origin: .zero, size: targetSize))
     }
-
-    UIGraphicsEndImageContext()
-    return newImage
   }
 }

--- a/packages/expo-image-manipulator/ios/Transformers/ImageResizeTransformer.swift
+++ b/packages/expo-image-manipulator/ios/Transformers/ImageResizeTransformer.swift
@@ -21,13 +21,13 @@ internal struct ImageResizeTransformer: ImageTransformer {
       targetSize.height = height
       targetSize.width = targetSize.width == 0 ? imageRatio * targetSize.height : targetSize.width
     }
-    
+
     let format = UIGraphicsImageRendererFormat()
     format.opaque = false
     format.scale = 1
 
     let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
-    return renderer.image { context in
+    return renderer.image { _ in
       image.draw(in: CGRect(origin: .zero, size: targetSize))
     }
   }

--- a/packages/expo-image-manipulator/ios/Transformers/ImageRotateTransformer.swift
+++ b/packages/expo-image-manipulator/ios/Transformers/ImageRotateTransformer.swift
@@ -11,7 +11,7 @@ internal struct ImageRotateTransformer: ImageTransformer {
     guard let cgImage = image.cgImage else {
       throw ImageNotFoundException()
     }
-    let rads = rotate * Double.pi / 180
+    let rads = rotate * .pi / 180
     let rotatedView = UIView(frame: CGRect(origin: .zero, size: image.size))
 
     rotatedView.transform = CGAffineTransform(rotationAngle: rads)
@@ -19,11 +19,12 @@ internal struct ImageRotateTransformer: ImageTransformer {
     let rotatedSize = CGSize(width: rotatedView.frame.size.width.rounded(.down), height: rotatedView.frame.size.height.rounded(.down))
     let origin = CGPoint(x: -image.size.width / 2, y: -image.size.height / 2)
 
-    return try drawInNewContext(size: rotatedSize) { context in
-      context.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
-      context.rotate(by: rads)
-      context.scaleBy(x: 1.0, y: -1.0)
-      context.draw(cgImage, in: CGRect(origin: origin, size: image.size))
+    return drawInNewContext(size: rotatedSize) { context in
+      let cgContext = context.cgContext
+      cgContext.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
+      cgContext.rotate(by: rads)
+      cgContext.scaleBy(x: 1.0, y: -1.0)
+      cgContext.draw(cgImage, in: CGRect(origin: origin, size: image.size))
     }
   }
 }


### PR DESCRIPTION
# Why
`UIGraphicsImageRenderer` is a newer, safer, and slightly more performant api for rendering in core graphics contexts.

# How
Migrate to  using `UIGraphicsImageRenderer` where possible 

# Test Plan
bare-expo manipulations work as before

