### PR TITLE
fix link to docs on `checkPackages.ts`

### DIFF
--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -59,7 +59,7 @@ export async function checkPackagesAsync(
       chalk`Skipped ${fix ? 'fixing' : 'checking'} dependencies: ${joinWithCommasAnd(
         pkg.expo.install.exclude
       )}. These dependencies are listed in {bold expo.install.exclude} in package.json. ${learnMore(
-        'https://expo.dev/more/expo-cli/#configuring-dependency-validation'
+        'https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation'
       )}`
     );
   }


### PR DESCRIPTION
# Why

![CleanShot 2024-07-05 at 11 45 36](https://github.com/expo/expo/assets/360936/1b12e986-99a5-4908-8dae-3f6baadf88f4)

Learn more goes to a 404

# How

1. run `npx expo install --check`
2. click on the link from the terminal `These dependencies are listed in expo.install.exclude in package.json. Learn more`

# Test Plan

❌ https://expo.dev/more/expo-cli#configuring-dependency-validation
✅ https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
