### PR TITLE
feat: allow woff and woff2 for iOS

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Allow woff and woff2 format on iOS with the config plugin. ([#30220](https://github.com/expo/expo/pull/30220) by [@titozzz](https://github/Titozzz))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-font/plugin/build/utils.js
+++ b/packages/expo-font/plugin/build/utils.js
@@ -18,6 +18,6 @@ async function resolveFontPaths(fonts, projectRoot) {
     });
     return (await Promise.all(promises))
         .flat()
-        .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf'));
+        .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf') || p.endsWith('.woff') || p.endsWith('.woff2'));
 }
 exports.resolveFontPaths = resolveFontPaths;

--- a/packages/expo-font/plugin/build/withFonts.d.ts
+++ b/packages/expo-font/plugin/build/withFonts.d.ts
@@ -1,6 +1,12 @@
 import { ConfigPlugin } from 'expo/config-plugins';
 export type FontProps = {
     fonts?: string[];
+    android?: {
+        fonts?: string[];
+    };
+    ios?: {
+        fonts?: string[];
+    };
 };
 declare const _default: ConfigPlugin<FontProps>;
 export default _default;

--- a/packages/expo-font/plugin/build/withFonts.js
+++ b/packages/expo-font/plugin/build/withFonts.js
@@ -8,11 +8,14 @@ const withFonts = (config, props) => {
     if (!props) {
         return config;
     }
-    if (props.fonts && props.fonts.length === 0) {
-        return config;
+    const iosFonts = [...(props.fonts ?? []), ...(props.ios?.fonts ?? [])];
+    if (iosFonts.length > 0) {
+        config = (0, withFontsIos_1.withFontsIos)(config, iosFonts);
     }
-    config = (0, withFontsIos_1.withFontsIos)(config, props.fonts ?? []);
-    config = (0, withFontsAndroid_1.withFontsAndroid)(config, props.fonts ?? []);
+    const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
+    if (androidFonts.length > 0) {
+        config = (0, withFontsAndroid_1.withFontsAndroid)(config, androidFonts);
+    }
     return config;
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withFonts, pkg.name, pkg.version);

--- a/packages/expo-font/plugin/src/utils.ts
+++ b/packages/expo-font/plugin/src/utils.ts
@@ -14,5 +14,7 @@ export async function resolveFontPaths(fonts: string[], projectRoot: string) {
   });
   return (await Promise.all(promises))
     .flat()
-    .filter((p) => p.endsWith('.ttf') || p.endsWith('.otf'));
+    .filter(
+      (p) => p.endsWith('.ttf') || p.endsWith('.otf') || p.endsWith('.woff') || p.endsWith('.woff2')
+    );
 }

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -7,6 +7,12 @@ const pkg = require('expo-font/package.json');
 
 export type FontProps = {
   fonts?: string[];
+  android?: {
+    fonts?: string[];
+  };
+  ios?: {
+    fonts?: string[];
+  };
 };
 
 const withFonts: ConfigPlugin<FontProps> = (config, props) => {
@@ -14,12 +20,17 @@ const withFonts: ConfigPlugin<FontProps> = (config, props) => {
     return config;
   }
 
-  if (props.fonts && props.fonts.length === 0) {
-    return config;
+  const iosFonts = [...(props.fonts ?? []), ...(props.ios?.fonts ?? [])];
+
+  if (iosFonts.length > 0) {
+    config = withFontsIos(config, iosFonts);
   }
 
-  config = withFontsIos(config, props.fonts ?? []);
-  config = withFontsAndroid(config, props.fonts ?? []);
+  const androidFonts = [...(props.fonts ?? []), ...(props.android?.fonts ?? [])];
+
+  if (androidFonts.length > 0) {
+    config = withFontsAndroid(config, androidFonts);
+  }
 
   return config;
 };


### PR DESCRIPTION
# Why

woff and woff2 bring significant size improvement so we want to use them when available

# How

allow platform specific fonts and enable woff and woff2 for iOS

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
