### PR TITLE
[core][Android] Bump coroutines version to `1.7.3`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [Android] Decouple the modules state from the `AppContext` ([#30098](https://github.com/expo/expo/pull/30098) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added `customizeRootView:` support to `EXAppDelegateWrapper.createRCTRootViewFactory`. ([#30245](https://github.com/expo/expo/pull/30245) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Bump Kotlin coroutines version to 1.7.3. ([#30226](https://github.com/expo/expo/pull/30226) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -156,9 +156,9 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion()}"
   implementation 'androidx.annotation:annotation:1.7.1'
 
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
-  api "androidx.core:core-ktx:1.12.0"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+  api "androidx.core:core-ktx:1.13.1"
 
   implementation("androidx.tracing:tracing-ktx:1.2.0")
 

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -22,10 +22,10 @@ android {
 dependencies {
   api "androidx.browser:browser:1.6.0"
 
-  implementation "androidx.core:core-ktx:1.7.0"
+  implementation "androidx.core:core-ktx:1.13.1"
 
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.11.1"
 }


### PR DESCRIPTION
# Why

Bumps coroutines version to `1.7.3`
