### PR TITLE
[core][Android] Make `DecoratedException` open

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -8,7 +8,8 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun Throwable.toCodedException() = when (this) {
+inline fun Throwable?.toCodedException() = when (this) {
+  null -> UnexpectedException("Unknown error")
   is CodedException -> this
   is expo.modules.core.errors.CodedException -> CodedException(this.code, this.message, this.cause)
   else -> UnexpectedException(this)
@@ -125,7 +126,7 @@ internal class ValidationException(message: String) :
 /**
  * A base class for all exceptions used in `exceptionDecorator` function.
  */
-internal open class DecoratedException(
+open class DecoratedException(
   message: String,
   cause: CodedException
 ) : CodedException(


### PR DESCRIPTION
# Why

Makes `DecoratedException` class open. It might be useful in some places outside of the core.
