### PR TITLE
feature(cli): add strict React Native version detection and resolution for monorepos

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -145,6 +145,9 @@ export async function loadMetroConfigAsync(
     isFastResolverEnabled: env.EXPO_USE_FAST_RESOLVER,
     isExporting,
     isReactCanaryEnabled: exp.experiments?.reactCanary ?? false,
+    // TODO(cedric): add experiment flag to types
+    // @ts-expect-error
+    isReactNativeStrictVersionEnabled: exp?.experiments?.reactNativeStrictVersion ?? false,
     getMetroBundler,
   });
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -337,6 +337,7 @@ export function withExtendedResolver(
     const reactNativePath = path.dirname(
       resolveFrom(config.projectRoot, 'react-native/package.json')
     );
+    const reactNativeVersion = require(path.join(reactNativePath, 'package.json')).version;
 
     // Only warn once, put extra information in the debug logs
     let warnedMultipleReactNativeVersions = false;
@@ -371,12 +372,14 @@ export function withExtendedResolver(
       // Inform the user of the resolution change
       if (!warnedMultipleReactNativeVersions) {
         warnedMultipleReactNativeVersions = true;
-        Log.warn(`Multiple React Native versions detected, resolving only: ${reactNativePath}`);
+        Log.warn(
+          `\nMultiple React Native versions detected, forcing only: react-native@${reactNativeVersion}`
+        );
       }
 
       // Provide all information in the debug logs
       debug(
-        `Redirecting React Native module "${moduleName}" to "${redirectPath}", imported from: ${context.originModulePath}`
+        `Redirected module "${moduleName}" to "${redirectPath}", imported from: ${context.originModulePath}`
       );
 
       return redirectResolved;
@@ -696,7 +699,7 @@ export async function withMetroMultiPlatformAsync(
     isFastResolverEnabled?: boolean;
     isExporting?: boolean;
     isReactCanaryEnabled: boolean;
-    isReactNativeStrictVersionEnabled: boolean,
+    isReactNativeStrictVersionEnabled: boolean;
     getMetroBundler: () => Bundler;
   }
 ) {
@@ -759,6 +762,7 @@ export async function withMetroMultiPlatformAsync(
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
     isReactCanaryEnabled,
+    isReactNativeStrictVersionEnabled,
     getMetroBundler,
   });
 }


### PR DESCRIPTION
# Why

This is an experiment and followup from #30143

Through Atlas, I could validate that multiple React Native versions were bundled. In the repro, this is mostly caused by npm installing `peerDependencies` of workspaces automatically, causing multiple React Native versions to be installed in the monorepo. However, this is likely also caused by adding a `devDependencies` to any of the workspaces.

Because there are roughly 27.5% of packages, listed on https://reactnative.directory, that _does not_ specify the `react-native` peer dependency, we'd need to work around this ([see here](https://github.com/expo/expo/issues/30143#issuecomment-2209497904)).

# TODO

- [ ] Likely find another name for this resolver, as it might be too close to React's strict version
- [ ] Likely move `createReactNativeStrictVersionResolver` to its own file, or even `@expo/metro-config`?
- [ ] Add both unit and e2e tests

# How

- Added a custom resolve that validates the resolved React Native path is expected
- Added experiment flag to enable this validation + corrected resolution

Without debug logging | With debug logging
--- | ---
![normal-usage](https://github.com/expo/expo/assets/1203991/e135303d-dfbb-4784-af57-fcca4d152d48) | ![with-debug-logs](https://github.com/expo/expo/assets/1203991/3ad8c6b7-6ab2-414f-b680-dab55569d4d8)

# Test Plan

Setup the test repo + validate it breaks.

- `$ git clone -b react-native-strict-version https://github.com/byCedric/test-expo-30143 ./`
- `$ npm ci`
- `$ cd ./apps/test-app`
- `$ expod start --ios`
  - This should result in a wave of unexpected errors, without clear indication what's going on

Enable this experiment

- Add `"reactNativeStrictVersion": true` to **./apps/test-app/app.json**
- `$ cd ./apps/test-app`
- `$ npx expo start --clear --ios`
  - This should work as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
