### PR TITLE
[docs] Update docs on org conversion to reflect new flow

### DIFF
--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -68,18 +68,6 @@ When you are going through this process, we take a lot of care to make sure that
 - Your EAS subscription will continue without interruption.
 - Your production apps will continue to operate without interruption.
 
-The Organization account will adopt your old username. Converting a Personal account into an Organization account requires you to designate a new user as the owner of the Organization account. You will have the opportunity to designate an existing user or sign up as a new user during the account conversion process.
-
-The example below is Step 3 in the conversion process on a Personal account with the username:
-
-<ContentSpotlight
-  alt="Example demonstrating the Step 3 of the conversion process."
-  src="/static/images/accounts/converting-personal-account.png"
-  className="max-w-[480px]"
-/>
-
-After completing the conversion process, you can no longer log in as your old user. To continue using Expo services, log into [expo.dev](https://expo.dev/) with the user you selected or created during the conversion process. Then, select the Organization from the navigation dropdown to access the organization.
-
 ### Invite a member
 
 Other Expo users can be invited to join your Organization. To invite a new member:


### PR DESCRIPTION
# Why

The org conversion flow was updated to be more streamlined. It now just renames your user, creates a new personal account for you, and makes your old personal account into an org account.

This PR updates the docs to reflect that.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
