### PR TITLE
[image-manipulator][iOS] Fix scale used by UIGraphicsImageRenderer

### DIFF
--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -92,7 +92,10 @@ func retrieveAsset(from url: URL) -> PHAsset? {
  Throws appropriate exceptions when the context is missing or the image couldn't be rendered.
  */
 internal func drawInNewContext(size: CGSize, drawing: (UIGraphicsImageRendererContext) -> Void) -> UIImage {
-  let renderer = UIGraphicsImageRenderer(size: size)
+  let format = UIGraphicsImageRendererFormat()
+  format.scale = 1
+
+  let renderer = UIGraphicsImageRenderer(size: size, format: format)
 
   return renderer.image { context in
     drawing(context)


### PR DESCRIPTION
# Why

Fixes a regression introduced by #30211 that caused transformations to produce images with bigger size, depending on the device's screen scale factor

# How

Use `UIGraphicsImageRendererFormat` to tell the renderer to use the unscaled format.

# Test Plan

test-suite tests are now passing

<!-- disable:changelog-checks -->