### PR TITLE
[modules-core][android] Use getter methods in convertibles

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### 💡 Others
 
+- [Android] Use getter methods in convertibles. ([#30239](https://github.com/expo/expo/pull/30239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))
 - [web] Use global `crypto` object for UUID. ([#29828](https://github.com/expo/expo/pull/29828) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Send open url event to all matching subscribers. ([#29645](https://github.com/expo/expo/pull/29645) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/FabricComponentsRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/FabricComponentsRegistry.kt
@@ -16,7 +16,7 @@ class FabricComponentsRegistry(viewManagerList: List<ViewManager<*, *>>) {
   private val mHybridData: HybridData
 
   init {
-    componentNames = viewManagerList.map { it.name }
+    componentNames = viewManagerList.map { it.getName() }
     mHybridData = initHybrid()
     registerComponentsRegistry(componentNames.toTypedArray())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -79,7 +79,7 @@ abstract class AnyFunction(
       val desiredType = desiredArgsTypes[index]
       argIterator.next().recycle {
         exceptionDecorator({ cause ->
-          ArgumentCastException(desiredType.kType, index, type.toString(), cause)
+          ArgumentCastException(desiredType.kType, index, getType().toString(), cause)
         }) {
           finalArgs[index] = desiredType.convert(this)
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -82,7 +82,7 @@ class RecordTypeConverter<T : Record>(
         jsMap.getDynamic(jsKey).recycle {
           val javaField = property.javaField!!
 
-          val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, type, cause) }) {
+          val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, getType(), cause) }) {
             descriptor.typeConverter.convert(this)
           }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -13,13 +13,13 @@ import expo.modules.kotlin.jni.ExpectedType
  */
 class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Any {
-    return when (value.type) {
+    return when (value.getType()) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
       ReadableType.String -> value.asString()
       ReadableType.Map -> value.asMap().toHashMap()
       ReadableType.Array -> value.asArray().toArrayList()
-      else -> error("Unknown dynamic type: ${value.type}")
+      else -> error("Unknown dynamic type: ${value.getType()}")
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -26,7 +26,7 @@ class ArrayTypeConverter(
         .getDynamic(i)
         .recycle {
           exceptionDecorator({ cause ->
-            CollectionElementCastException(arrayType, arrayType.arguments.first().type!!, type, cause)
+            CollectionElementCastException(arrayType, arrayType.arguments.first().type!!, getType(), cause)
           }) {
             arrayElementConverter.convert(this)
           }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -173,14 +173,14 @@ class ColorTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<Color>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): Color {
-    return when (value.type) {
+    return when (value.getType()) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
       ReadableType.String -> colorFromString(value.asString())
       ReadableType.Array -> {
         val colorsArray = value.asArray().toArrayList().map { it as Double }.toDoubleArray()
         colorFromDoubleArray(colorsArray)
       }
-      else -> throw UnexpectedException("Unknown argument type: ${value.type}")
+      else -> throw UnexpectedException("Unknown argument type: ${value.getType()}")
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -16,10 +16,10 @@ import java.time.format.DateTimeFormatter
 @RequiresApi(Build.VERSION_CODES.O)
 class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalDate>(isOptional) {
   override fun convertFromDynamic(value: Dynamic): LocalDate {
-    return when (value.type) {
+    return when (value.getType()) {
       ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
       ReadableType.Number -> convertFromLong(value.asDouble().toLong())
-      else -> throw UnexpectedException("Unknown argument type: ${value.type}")
+      else -> throw UnexpectedException("Unknown argument type: ${value.getType()}")
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -47,7 +47,7 @@ class EnumTypeConverter(
       )
     }
 
-    throw IncompatibleArgTypeException(value.type.toKType(), enumClass.createType())
+    throw IncompatibleArgTypeException(value.getType().toKType(), enumClass.createType())
   }
 
   override fun convertFromAny(value: Any): Enum<*> {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -49,7 +49,7 @@ class ListTypeConverter(
           CollectionElementCastException(
             listType,
             listType.arguments.first().type!!,
-            type,
+            getType(),
             cause
           )
         }) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -52,10 +52,10 @@ class MapTypeConverter(
   private fun convertFromReadableMap(jsMap: ReadableMap): Map<*, *> {
     val result = mutableMapOf<String, Any?>()
 
-    jsMap.entryIterator.forEach { (key, value) ->
+    jsMap.getEntryIterator().forEach { (key, value) ->
       DynamicFromObject(value).recycle {
         exceptionDecorator({ cause ->
-          CollectionElementCastException(mapType, mapType.arguments[1].type!!, type, cause)
+          CollectionElementCastException(mapType, mapType.arguments[1].type!!, getType(), cause)
         }) {
           result[key] = valueConverter.convert(this)
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -50,7 +50,7 @@ class PairTypeConverter(
   private fun convertElement(array: ReadableArray, index: Int): Any? {
     return array.getDynamic(index).recycle {
       exceptionDecorator({ cause ->
-        CollectionElementCastException(pairType, pairType.arguments[index].type!!, type, cause)
+        CollectionElementCastException(pairType, pairType.arguments[index].type!!, getType(), cause)
       }) {
         converters[index].convert(this)
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -49,7 +49,7 @@ class SetTypeConverter(
           CollectionElementCastException(
             setType,
             setType.arguments.first().type!!,
-            type,
+            getType(),
             cause
           )
         }) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -40,7 +40,7 @@ abstract class NullAwareTypeConverter<Type : Any>(
   private val isOptional: Boolean
 ) : TypeConverter<Type>() {
   override fun convert(value: Any?, context: AppContext?): Type? {
-    if (value == null || value is Dynamic && value.isNull) {
+    if (value == null || value is Dynamic && value.isNull()) {
       if (isOptional) {
         return null
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/FilteredReadableMap.kt
@@ -42,7 +42,7 @@ class FilteredReadableMap(
   private val filteredKeys: List<String>
 ) : ReadableMap by backingMap {
   override fun getEntryIterator(): Iterator<Map.Entry<String, Any>> =
-    FilteredIterator(backingMap.entryIterator) {
+    FilteredIterator(backingMap.getEntryIterator()) {
       !filteredKeys.contains(it.key)
     }
 


### PR DESCRIPTION
# Why

In react-native 0.75 a lot of internal classes were migrated from Java to Kotlin, which led to some unexpected changes such as us no longer being able to access Java methods by skipping the "get" part. This was part of the Kotlinify effort on the repo and here is one example https://github.com/facebook/react-native/pull/43905

Related to [ENG-12562](https://linear.app/expo/issue/ENG-12562) 


# How

Update expo-modules-core to use getter methods in convertibles instead of 

# Test Plan

Run BareExpo and FabricTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
