### PR TITLE
[core][iOS] Fix returning already registered shared objects

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fixed blocking SSE responses from network interceptor on Android. ([#30062](https://github.com/expo/expo/pull/30062) by [@kudo](https://github.com/kudo))
 - Fixed a crash when the event listener throws an error. ([#30065](https://github.com/expo/expo/pull/30065) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Fixed the record's constructor with default parameters were being ignored when converting from JavaScript to native. ([#30217](https://github.com/expo/expo/pull/30217) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fixed returning already registered shared objects.
+- [iOS] Fixed returning already registered shared objects. ([#30241](https://github.com/expo/expo/pull/30241) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed blocking SSE responses from network interceptor on Android. ([#30062](https://github.com/expo/expo/pull/30062) by [@kudo](https://github.com/kudo))
 - Fixed a crash when the event listener throws an error. ([#30065](https://github.com/expo/expo/pull/30065) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Fixed the record's constructor with default parameters were being ignored when converting from JavaScript to native. ([#30217](https://github.com/expo/expo/pull/30217) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fixed returning already registered shared objects.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -167,14 +167,20 @@ internal final class Conversions {
     }
     if let appContext {
       if let value = value as? JavaScriptObjectBuilder {
-        return try? value.build(appContext: appContext)
+        // TODO: Handle errors
+        let object = try? value.build(appContext: appContext)
+        return object as Any
       }
 
       // If the returned value is a native shared object, create its JS representation and add the pair to the registry of shared objects.
       if let value = value as? SharedObject, let dynamicType = asDynamicSharedObjectType(dynamicType) {
+        // If the JS object already exists, just return it.
+        if let object = value.getJavaScriptObject() {
+          return object
+        }
         guard let object = try? appContext.newObject(nativeClassId: dynamicType.typeIdentifier) else {
           log.warn("Unable to create a JS object for \(dynamicType.description)")
-          return Optional<Any>.none
+          return Optional<Any>.none as Any
         }
         appContext.sharedObjectRegistry.add(native: value, javaScript: object)
         return object

--- a/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectSpec.swift
@@ -88,6 +88,15 @@ final class SharedObjectSpec: ExpoSpec {
         ])
         expect(releaseFunction.kind) == .function
       }
+
+      it("returns this") {
+        let isReturningItself = try runtime.eval([
+          "sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()",
+          "sharedObject === sharedObject.returnThis()"
+        ])
+        expect(isReturningItself.kind) == .bool
+        expect(try isReturningItself.asBool()) == true
+      }
     }
 
     describe("Native object") {
@@ -133,6 +142,9 @@ private class SharedObjectModule: Module {
     Class(SharedObjectExample.self) {
       Constructor {
         return SharedObjectExample()
+      }
+      Function("returnThis") { (this: SharedObjectExample) -> SharedObjectExample in
+        return this
       }
     }
   }


### PR DESCRIPTION
# Why

Thanks to the new chainable API in expo-image-manipulator, I've found out that returning already registered shared object creates a new JS object each time. I noticed that shared object IDs were growing up too fast after running the tests 😅 

# How

If the returned object already has a corresponding JS object, just return that object instead of creating a new one.

# Test Plan

I added a simple test case that was previously failing