### PR TITLE
[docs] Fix type in deploy script

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -188,7 +188,7 @@ redirects[eas-update/eas-update-and-eas-cli]=eas-update/eas-cli
 redirects[eas-update/debug-updates]=eas-update/debug
 redirects[eas-update/how-eas-update-works]=eas-update/how-it-works
 redirects[eas-update/migrate-to-eas-update]=eas-update/migrate-from-classic-updates
-redurects[eas-update/custom-updates-server]=versions/latest/sdk/expo-updates
+redirects[eas-update/custom-updates-server]=versions/latest/sdk/expo-updates
 redirects[distribution/custom-updates-server]=versions/latest/sdk/expo-updates
 redirects[bare/error-recovery]=eas-update/error-recovery
 


### PR DESCRIPTION
# Why

Typo: https://github.com/expo/expo/commit/3c56364cbb3efd6e2c58eb3e71eee037f7e46686#r143890623

TBH I'm not entirely clear on what this file does vs the other redirects file: is specifying in both places necessary?

# How

Fix typo.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
