### PR TITLE
[docs] Fix typo/syntax error in useFocusEffect API reference

### DIFF
--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -37,7 +37,7 @@ export default function Route() {
         console.log('This route is now unfocused.');
       }
       /* @end */
-    }, []);
+    }, [])
   );
 
   return </>;


### PR DESCRIPTION
# Why

This syntax error in the example confused me when copy/pasting and raised an error.

# How

fix typo

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
