### PR TITLE
[docs] Filter out methods inherited from common classes

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -181,7 +181,7 @@ export type PropData = {
   signatures?: MethodSignatureData[];
   overwrites?: TypeDefinitionData;
   implementationOf?: TypeDefinitionData;
-  inheritedFrom?: TypeGeneralData;
+  inheritedFrom?: InheritedFromData;
 };
 
 export type DefaultPropsDefinitionData = {
@@ -217,4 +217,9 @@ export type TypeParameterData = {
   name: string;
   kind: TypeDocKind;
   variant: string;
+};
+
+export type InheritedFromData = {
+  type: 'reference';
+  name: string;
 };


### PR DESCRIPTION
# Why

Functions inherited from the common classes (documented on the docs page for `expo` package) shouldn't appear in subclasses.

# How

- Filtered out properties that are inherited from these four common classes
- Fixed the type for `inheritedFrom` property in the generated JSON

# Test Plan

See the preview for `expo-image-manipulator`: /versions/unversioned/sdk/imagemanipulator/

I also confirmed that it doesn't affect pages for sensors, which are probably the only ones that have inheriting classes.