### PR TITLE
[core] add customizeRootView support

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [iOS] Renamed `pointer` property in the `SharedRef` class to `ref` for parity with Android. ([#30061](https://github.com/expo/expo/pull/30061) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using `noexcept`. ([#30128](https://github.com/expo/expo/pull/30128) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Decouple the modules state from the `AppContext` ([#30098](https://github.com/expo/expo/pull/30098) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Added `customizeRootView:` support to `EXAppDelegateWrapper.createRCTRootViewFactory`. ([#30245](https://github.com/expo/expo/pull/30245) by [@kudo](https://github.com/kudo))
 
 ## 1.12.16 - 2024-06-20
 


### PR DESCRIPTION
# Why

react-native 0.74.3 added `customizeRootView` support from https://github.com/facebook/react-native/pull/44775. we should clone the code from `RCTAppDelegate.createRCTRootViewFactory` to our `EXAppDelegateWrapper.createRCTRootViewFactory`
that could possibly fix react-native-bootsplash integration for https://github.com/zoontek/react-native-bootsplash/issues/590

# How

- reference https://github.com/facebook/react-native/blob/8c8c77b974ce3d4c3036361e56276a6ff2b02208/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm#L238-L262 to copy to `EXAppDelegateWrapper.createRCTRootViewFactory`
- since we are still on 0.74.2, we should use `respondsToSelector` to check the the property existing from RCTRootViewFactoryConfiguration.

# Test Plan

- ci passed
- test on sdk 51 with react-native 0.74.3

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
