### PR TITLE
[docs] Add clarification to Vercel API Route docs

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -447,7 +447,7 @@ The newer version of the **vercel.json** does not use `routes` and `builds` conf
 
 <Step label="3">
 
-_Note: this step only applies to users of the **legacy** version of the **vercel.json**. If you're using v3, you can skip this step._
+> **Note:** This step only applies to users of the **legacy** version of the **vercel.json**. If you're using v3, you can skip this step.
 
 After you have created the configuration files, add a `vercel-build` script to your **package.json** file and set it to `expo export -p web`.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -447,6 +447,8 @@ The newer version of the **vercel.json** does not use `routes` and `builds` conf
 
 <Step label="3">
 
+_Note: this step only applies to users of the **legacy** version of the **vercel.json**. If you're using v3, you can skip this step._
+
 After you have created the configuration files, add a `vercel-build` script to your **package.json** file and set it to `expo export -p web`.
 
 </Step>


### PR DESCRIPTION
# Why

As discussed in [this thread](https://github.com/expo/expo/issues/27155), adding the vercel-build script to package.json while using v3 of vercel.json, the build breaks. It was also mentioned in the thread that the docs would be updated, but this didn't happen.

# How

I've added a small note that you should only perform the step if you're using the legacy vercel.json

# Test Plan

Run the docs and see if the note is appearing correctly, and if the wording is right.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [n/a] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
