### PR TITLE
[docs] Clean up redirects that start with `home/`

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -156,18 +156,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/testing-with-jest/': '/develop/unit-testing/',
   '/develop/development-builds/installation/': '/develop/development-builds/create-a-build/',
   '/develop/development-builds/parallel-installation': '/build-reference/variants/',
-  '/home/develop/user-interface/safe-areas': '/develop/user-interface/safe-areas/',
-  '/home/develop/development-builds/installation': '/develop/development-builds/create-a-build/',
-  '/home/debugging/tools/': '/debugging/tools/',
-  '/home/navigation/installation': '/routing/introduction/',
-  '/home/authentication': '/develop/authentication/',
-  '/home/get-started/create-a-project': '/get-started/create-a-project/',
-  '/home/core-concepts/': '/core-concepts/',
-  '/home/config-plugins/plugins-and-mods': '/config-plugins/plugins-and-mods/',
-  '/home/unit-testing/': '/develop/unit-testing/',
-  '/home/config-plugins/introduction/': '/config-plugins/introduction/',
-  '/home/develop/user-interface/app-icons': '/develop/user-interface/app-icons/',
-  '/home/develop/development-builds/introduction/': '/develop/development-builds/introduction/',
 
   // Old redirects
   '/versions/latest/sdk/': '/versions/latest/',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -108,8 +108,6 @@ redirects[debugging]=debugging/runtime-issues
 redirects[debugging/runtime-issue]=debugging/runtime-issues
 redirects[develop/development-builds/installation]=develop/development-builds/create-a-build
 redirects[develop/development-builds/parallel-installation]=build-reference/variants
-redirects[home/develop/user-interface/safe-areas]=develop/user-interface/safe-areas
-redirects[home/develop/development-builds/introduction]=develop/development-builds/introduction
 redirects[guides/assets]=develop/user-interface/assets
 
 # Redirects after Guides organization
@@ -144,22 +142,12 @@ redirects[expokit/overview]=archive/glossary
 redirects[eas-update/eas-update-with-local-build]=eas-update/build-locally
 redirects[bare/existing-apps]=bare/installing-expo-modules
 redirects[bare/exploring-bare-workflow]=bare/overview
-redirects[home/develop/development-builds/installation]=develop/development-builds/create-a-build
 redirects[t/cant-upgrade-to-the-lastest-expo-cli-3-19-2]=faq
 redirects[build-reference/custom-build-config]=custom-builds/get-started
-redirects[home/debugging/tools]=debugging/tools
 redirects[workflow/run-on-device]=build/internal-distribution
 redirects[build-reference/how-tos]=build-reference/private-npm-packages
-redirects[home/navigation/installation]=routing/introduction
-redirects[home/authentication]=develop/authentication
-redirects[home/develop/user-interface/app-icons]=develop/user-interface/app-icons
 redirects[eas-update/migrate-codepush-to-eas-update]=eas-update/codepush
-redirects[home/get-started/create-a-project]=get-started/create-a-project
-redirects[home/core-concepts]=core-concepts
 redirects[guides/testing-on-devices]=build/internal-distribution
-redirects[home/config-plugins/plugins-and-mods]=config-plugins/plugins-and-mods
-redirects[home/unit-testing]=develop/unit-testing
-redirects[home/config-plugins/introduction]=config-plugins/introduction
 redirects[technical-specs/latest]=technical-specs/expo-updates-1
 
 # We should change this redirect to a more general EAS guide later


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #30166

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove client and server-side redirects that contain `home/*` from `error-utilities.ts` and `deploy.sh` files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run yarn run test-links and yarn run test to make sure all tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
