### PR TITLE
[docs] Fix development error in `Tabs` component

### DIFF
--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -76,7 +76,7 @@ const tabsWrapperStyle = css({
 const tabsPanelStyle = css({
   padding: `${spacing[4]}px ${spacing[5]}px`,
 
-  'pre:first-child': {
+  'pre:first-of-type': {
     marginTop: spacing[1],
   },
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

On running the development server for docs and visiting a page that uses `Tabs` component such as http://localhost:3002/develop/tools/, it throws the following warning:

![CleanShot 2024-07-07 at 15 43 46@2x](https://github.com/expo/expo/assets/10234615/ffcf329c-a1cb-4611-8deb-e266868f1b41)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace `'pre::first-child'` with `'pre:first-of-type'` in **Tabs.tsx** for `tabsPanelStyle` object.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs manually and visit pages that use the tab (for example http://localhost:3002/develop/tools/) to make sure Tabs are working as expected.

Also, run the `yarn run test` command to make sure tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
