### PR TITLE
[docs] Improve callouts in e2e test guides and other changes

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -559,6 +559,7 @@ const archive = [
     makePage('archive/customizing-webpack.mdx'),
     makePage('archive/using-expo-client.mdx'),
     makePage('archive/using-flipper.mdx'),
+    makePage('archive/e2e-tests.mdx'),
     makePage('archive/glossary.mdx'),
   ]),
 ];

--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **Warning** This is an old and archived version of our EAS Build E2E tests guide. Check the latest version of the guide [here](/build-reference/e2e-tests/).
+> **warning** **Deprecated:** This is an old and archived version of our EAS Build E2E tests guide. [See the latest version of the guide here](/build-reference/e2e-tests/).
 
 With EAS Build, you can build a workflow for running E2E tests for your application. In this guide, you will learn how to use one of the most popular libraries ([Detox](https://wix.github.io/Detox)) to do that.
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -8,9 +8,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **info** This guide will evolve over time as support for E2E testing in EAS Build improves.
-
-> **info** If you are looking for an archived guide on how to run E2E tests on EAS Build using Detox, you can see it [here](/archive/e2e-tests/).
+> **info** This guide will evolve over time as support for E2E testing in EAS Build improves. If you are looking for an archived guide on how to run E2E tests on EAS Build using Detox, you can see it in the [archive section](/archive/e2e-tests/).
 
 In this guide, you will learn how to create and run E2E tests on EAS Build using [Maestro](https://maestro.mobile.dev/), which is one of the most popular tools for running E2E tests in mobile apps.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Detox E2E guide was moved to archive recently but wasn't added to the navigation structure, thus, making it hidden.

Also, the following Vale warnings weren't fixed:

![CleanShot 2024-07-07 at 16 02 01](https://github.com/expo/expo/assets/10234615/c99fd57b-4b9c-4883-ab7a-138693b8e640)

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Fix Vale warnings
- On the e2e test guide with Maestro (current active version), merge two callouts (there's no need for two different callouts at the top of the page).
- Add the e2e test guide with Detox in the Archive navigation menu.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
