### PR TITLE
[docs] Add a reference to the Redux DevTools expo devtools plugin

### DIFF
--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -193,12 +193,12 @@ If you're using `@reduxjs/toolkit` then you need to modify your call to `configu
 Your call to `configureStore` will end up looking like this:
 
 ```javascript store.js
-import devToolsEnhancer from "redux-devtools-expo-dev-plugin";
+import devToolsEnhancer from 'redux-devtools-expo-dev-plugin';
 
 const store = configureStore({
   reducer: rootReducer,
   devTools: false,
-  enhancers: (getDefaultEnhancers) => getDefaultEnhancers().concat(devToolsEnhancer()),
+  enhancers: getDefaultEnhancers => getDefaultEnhancers().concat(devToolsEnhancer()),
 });
 ```
 

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -176,6 +176,36 @@ export default function App() {
 
 In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the React Query plugin. This will open the plugin's web interface, displaying queries as they are used in your app.
 
+### Redux DevTools
+
+Based on the full [Redux DevTools](https://github.com/reduxjs/redux-devtools/) (from the Chrome extension) but as an Expo Dev Plugin.
+
+- Easy to install and run.
+- Live list of actions and how it affects the state.
+- Ability to rewind, replay, and dispatch actions from the devtools.
+
+To use the plugin, start by installing the package:
+
+<Terminal cmd={['$ npx expo install redux-devtools-expo-dev-plugin']} />
+
+If you're using `@reduxjs/toolkit` then you need to modify your call to `configureStore` to disable the built in devtools (by passing in `devTools: false`) and add in the Expo Devtools plugin enhancer (by concatenating the `devToolsEnhancer()`).
+
+Your call to `configureStore` will end up looking like this:
+
+```javascript store.js
+import devToolsEnhancer from "redux-devtools-expo-dev-plugin";
+
+const store = configureStore({
+  reducer: rootReducer,
+  devTools: false,
+  enhancers: (getDefaultEnhancers) => getDefaultEnhancers().concat(devToolsEnhancer()),
+});
+```
+
+In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the Tinybase plugin. This will open the plugin's web interface, displaying the actions and contents of your store as actions are dispatched.
+
+For full installation instructions, including if your using `redux` directly rather than `@reduxjs/toolkit`, [see the project README](https://github.com/matt-oakes/redux-devtools-expo-dev-plugin).
+
 ### TinyBase
 
 The TinyBase dev tools plugin connects the TinyBase Store Inspector to your app, allowing you to view and update the contents of your app's store.

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -176,23 +176,17 @@ export default function App() {
 
 In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the React Query plugin. This will open the plugin's web interface, displaying queries as they are used in your app.
 
-### Redux DevTools
+### Redux
 
-Based on the full [Redux DevTools](https://github.com/reduxjs/redux-devtools/) (from the Chrome extension) but as an Expo Dev Plugin.
-
-- Easy to install and run.
-- Live list of actions and how it affects the state.
-- Ability to rewind, replay, and dispatch actions from the devtools.
+The `redux-devtools-expo-dev-plugin` is based on the [Redux DevTools](https://github.com/reduxjs/redux-devtools/) (from the Chrome extension). It provides a live list of actions and how they affect the state, and the ability to rewind, replay, and dispatch actions from the DevTools.
 
 To use the plugin, start by installing the package:
 
 <Terminal cmd={['$ npx expo install redux-devtools-expo-dev-plugin']} />
 
-If you're using `@reduxjs/toolkit` then you need to modify your call to `configureStore` to disable the built in devtools (by passing in `devTools: false`) and add in the Expo Devtools plugin enhancer (by concatenating the `devToolsEnhancer()`).
+If you're using `@reduxjs/toolkit`, modify the `configureStore` call to disable the built-in dev tools by passing in `devTools: false`. Then, add in the Expo DevTools plugin enhancer by concatenating the `devToolsEnhancer()`. The `configureStore` call is going to look like the following:
 
-Your call to `configureStore` will end up looking like this:
-
-```javascript store.js
+```js store.js
 import devToolsEnhancer from 'redux-devtools-expo-dev-plugin';
 
 const store = configureStore({
@@ -202,9 +196,9 @@ const store = configureStore({
 });
 ```
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the Tinybase plugin. This will open the plugin's web interface, displaying the actions and contents of your store as actions are dispatched.
+In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select `redux-devtools-expo-dev-plugin`. This will open the plugin's web interface, displaying the actions and contents of your store as actions are dispatched.
 
-For full installation instructions, including if your using `redux` directly rather than `@reduxjs/toolkit`, [see the project README](https://github.com/matt-oakes/redux-devtools-expo-dev-plugin).
+For complete installation and usage instructions, including if you're using `redux` directly rather than `@reduxjs/toolkit`, [see the project's README](https://github.com/matt-oakes/redux-devtools-expo-dev-plugin).
 
 ### TinyBase
 


### PR DESCRIPTION
# Why

I have created a dev tools plugin which allows access to the full Redux DevTool (from the Chrome Extension). This makes it extremely easy to debug Redux in Expo projects using a full featured devtool plugin.

# How

Added a new section to the dev tools plugins documentation page which describes how to install and use the package. It includes a link out to the full installation instructions.

# Test Plan

n/a

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
