### PR TITLE
[docs] Update `MainApplication.kt` code diff in Installing expo-modules guide for React Native 0.74 and SDK 51

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.73.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.74.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -44,7 +44,8 @@ index 5189e25..4743f7a 100644
 +      })
 
    override val reactHost: ReactHost
-     get() = getDefaultReactHost(applicationContext, reactNativeHost)
+-     get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
++     get() = getDefaultReactHost(applicationContext, reactNativeHost)
 @@ -41,5 +44,11 @@ class MainApplication : Application(), ReactApplication {
        load()
      }

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -44,7 +44,7 @@ index 5189e25..4743f7a 100644
 +      })
 
    override val reactHost: ReactHost
-     get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
+     get() = getDefaultReactHost(applicationContext, reactNativeHost)
 @@ -41,5 +44,11 @@ class MainApplication : Application(), ReactApplication {
        load()
      }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1719393144410739)

# How

<!--
How did you build this feature or fix this bug and why?
-->

React Native CLI's generated `MainApplication.kt` had a slight change with React Native 0.74. This PR fixes that by updating the instruction to remove `this` in the `expo-android.diff` file.

Also, upgrade React Native version mentioned on the page to `0.74`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By creating a new project created with React Native Community CLI and then following manual instructions to make the changes as described for Android in `expo-android.diff` and then updating the docs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
