### PR TITLE
[docs] Update callout verbiage in Notifications docs

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom-fcm-legacy.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom-fcm-legacy.mdx
@@ -73,7 +73,7 @@ There are two types of Firebase Cloud Messaging messages: [notification and data
 
 If you send a message of type **notification** instead of **data** directly through Firebase, you won't know if a user interacted with the notification (no `onNotificationResponse` event available), and you won't be able to parse the notification payload for any data in your notification event-related listeners.
 
-> Using notification-type messages may have upsides when you need a configuration option that has not been exposed by `expo-notifications` yet. In general, it may lead to less predictable situations than using only data-type messages, and it's not our responsibility that you'll have to go to Google to report issues.
+> Using notification-type messages can be beneficial when you need a configuration option that is not yet exposed by `expo-notifications`. Generally, it may lead to less predictable situations than using data-type messages. However, you may need to report any issue you encounter directly to Google.
 
 Below is an example of each type using Node.js Firebase Admin SDK to send data-type messages instead of notification-type:
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -237,7 +237,7 @@ There are two types of Firebase Cloud Messaging messages: [notification and data
 
 If you send a message of type **notification** instead of **data** directly through Firebase, you won't know if a user interacted with the notification (no `onNotificationResponse` event available), and you won't be able to parse the notification payload for any data in your notification event-related listeners.
 
-> Using notification-type messages may have upsides when you need a configuration option that has not been exposed by `expo-notifications` yet. In general, it may lead to less predictable situations than using only data-type messages, and it's not our responsibility that you'll have to go to Google to report issues.
+> Using notification-type messages can be beneficial when you need a configuration option that is not yet exposed by `expo-notifications`. Generally, it may lead to less predictable situations than using data-type messages. However, you may need to report any issue you encounter directly to Google.
 
 Below is an example of each type using Node.js Firebase Admin SDK to send data-type messages instead of notification-type:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C03H8T98KNH/p1718399871839279)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the callout's verbiage to make it readable in Sending custom notifications guides (both current and legacy) to make it user friendly.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
