### PR TITLE
[docs] Fix internal link for Expo Updates API reference

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -354,8 +354,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/eas-update/known-issues/': '/eas-update/introduction/',
   '/eas-update/how-eas-update-works/': '/eas-update/how-it-works/',
   '/eas-update/migrate-to-eas-update/': '/eas-update/migrate-from-classic-updates/',
-  '/eas-update/custom-updates-server/': '/versions/latest/sdk/expo-updates/',
-  '/distribution/custom-updates-server/': '/versions/latest/sdk/expo-updates/',
+  '/eas-update/custom-updates-server/': '/versions/latest/sdk/updates/',
+  '/distribution/custom-updates-server/': '/versions/latest/sdk/updates/',
   '/bare/error-recovery/': '/eas-update/error-recovery/',
 
   // Expo Router Advanced guides

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -176,8 +176,8 @@ redirects[eas-update/eas-update-and-eas-cli]=eas-update/eas-cli
 redirects[eas-update/debug-updates]=eas-update/debug
 redirects[eas-update/how-eas-update-works]=eas-update/how-it-works
 redirects[eas-update/migrate-to-eas-update]=eas-update/migrate-from-classic-updates
-redirects[eas-update/custom-updates-server]=versions/latest/sdk/expo-updates
-redirects[distribution/custom-updates-server]=versions/latest/sdk/expo-updates
+redirects[eas-update/custom-updates-server]=versions/latest/sdk/updates
+redirects[distribution/custom-updates-server]=versions/latest/sdk/updates
 redirects[bare/error-recovery]=eas-update/error-recovery
 
 # Redirects for Expo Router docs

--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -29,4 +29,4 @@ By default, `expo-updates` checks for updates every time the app is loaded. You 
 
 The Classic Updates service is now deprecated. It was available before December 2021, and `expo publish` cannot be run anymore. However, existing apps will continue to receive Classic Updates that have already been published and are actively used.
 
-We recommend transitioning to EAS Update or using a [self-hosted update service](/versions/latest/sdk/expo-updates).
+We recommend transitioning to EAS Update or using a [self-hosted update service](/versions/latest/sdk/updates/).

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -49,7 +49,7 @@ You don't have to use GitHub to use git, but it certainly helps for many cases. 
 
 Nope! Your Expo project is just a React Native app, which is just a native app. You can use Fastlane or any native build, update, and more, tools you like.
 
-Most EAS services also allow you to run them on your own infrastructure, and we provide instructions for how you can accomplish this. For example, [self-hosting updates](/versions/latest/sdk/expo-updates/) (rather than using EAS Update), or [running builds locally](/guides/local-app-development/) or on [your own CI](build/building-on-ci/) (rather than using our EAS Build worker fleet).
+Most EAS services also allow you to run them on your own infrastructure, and we provide instructions for how you can accomplish this. For example, [self-hosting updates](/versions/latest/sdk/updates/) (rather than using EAS Update), or [running builds locally](/guides/local-app-development/) or on [your own CI](build/building-on-ci/) (rather than using our EAS Build worker fleet).
 
 For most teams, it makes sense to use EAS rather than spending the engineering time and resources on acquiring, setting up, and maintaining the services on other infrastructure. Additionally, EAS provides deep integration between services, such as the deployments page for monitoring app version adoption, assigning updates to specific builds, and rolling those updates out incrementally &mdash; which ties back into monitoring with [EAS Insights](/eas-insights/introduction/).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C066SEC2PH8/p1720451029899659)



# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the internal link to the Expo Updates API reference and also fix redirects accordingly.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and clicking the internal link to make sure it's working from EAS Update > FAQ page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
