### PR TITLE
Revert "[prebuild-config][iOS] remove automatic APNS entitlement"

### DIFF
--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix empty splash config resulting in build error. ([#29497](https://github.com/expo/expo/pull/29497) by [@aleqsio](https://github.com/aleqsio))
 - Fix incorrect dependency imports. ([#30553](https://github.com/expo/expo/pull/30553) by [@byCedric](https://github.com/byCedric))
+- [iOS] Revert #27924. ([#30280](https://github.com/expo/expo/pull/30280) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/@expo/prebuild-config/build/plugins/unversioned/expo-notifications/expo-notifications.d.ts
+++ b/packages/@expo/prebuild-config/build/plugins/unversioned/expo-notifications/expo-notifications.d.ts
@@ -1,2 +1,3 @@
-declare const _default: import("@expo/config-plugins").ConfigPlugin;
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const _default: ConfigPlugin;
 export default _default;

--- a/packages/@expo/prebuild-config/build/plugins/unversioned/expo-notifications/expo-notifications.js
+++ b/packages/@expo/prebuild-config/build/plugins/unversioned/expo-notifications/expo-notifications.js
@@ -4,6 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
+function _configPlugins() {
+  const data = require("@expo/config-plugins");
+  _configPlugins = function () {
+    return data;
+  };
+  return data;
+}
 function _withAndroidNotifications() {
   const data = require("./withAndroidNotifications");
   _withAndroidNotifications = function () {
@@ -18,13 +25,18 @@ function _createLegacyPlugin() {
   };
   return data;
 }
+const withNotificationsEntitlement = (config, mode) => {
+  return (0, _configPlugins().withEntitlementsPlist)(config, config => {
+    config.modResults['aps-environment'] = mode;
+    return config;
+  });
+};
 var _default = exports.default = (0, _createLegacyPlugin().createLegacyPlugin)({
   packageName: 'expo-notifications',
   fallback: [
   // Android
-  _withAndroidNotifications().withNotificationManifest, _withAndroidNotifications().withNotificationIconColor, _withAndroidNotifications().withNotificationIcons
+  _withAndroidNotifications().withNotificationManifest, _withAndroidNotifications().withNotificationIconColor, _withAndroidNotifications().withNotificationIcons,
   // iOS
-  // Automatic setting of APNS entitlement is no longer needed
-  ]
+  [withNotificationsEntitlement, 'development']]
 });
 //# sourceMappingURL=expo-notifications.js.map

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -405,6 +405,7 @@ exports[`built-in plugins compiles mods 1`] = `
       "usesNonExemptEncryption": true,
     },
     "entitlements": {
+      "aps-environment": "development",
       "com.apple.developer.associated-domains": [
         "applinks:https://pillarvalley.netlify.app",
       ],
@@ -1210,6 +1211,7 @@ exports[`built-in plugins introspects mods 1`] = `
       },
       "ios": {
         "entitlements": {
+          "aps-environment": "development",
           "com.apple.developer.associated-domains": [
             "applinks:https://pillarvalley.netlify.app",
           ],
@@ -1680,6 +1682,7 @@ exports[`built-in plugins introspects mods 1`] = `
       "usesNonExemptEncryption": true,
     },
     "entitlements": {
+      "aps-environment": "development",
       "com.apple.developer.associated-domains": [
         "applinks:https://pillarvalley.netlify.app",
       ],
@@ -2216,6 +2219,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
       },
       "ios": {
         "entitlements": {
+          "aps-environment": "development",
           "com.apple.developer.associated-domains": [
             "applinks:https://pillarvalley.netlify.app",
           ],
@@ -2643,6 +2647,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
       "usesNonExemptEncryption": true,
     },
     "entitlements": {
+      "aps-environment": "development",
       "com.apple.developer.associated-domains": [
         "applinks:https://pillarvalley.netlify.app",
       ],

--- a/packages/@expo/prebuild-config/src/plugins/unversioned/expo-notifications/expo-notifications.ts
+++ b/packages/@expo/prebuild-config/src/plugins/unversioned/expo-notifications/expo-notifications.ts
@@ -1,9 +1,18 @@
+import { ConfigPlugin, withEntitlementsPlist } from '@expo/config-plugins';
+
 import {
   withNotificationIconColor,
   withNotificationIcons,
   withNotificationManifest,
 } from './withAndroidNotifications';
 import { createLegacyPlugin } from '../createLegacyPlugin';
+
+const withNotificationsEntitlement: ConfigPlugin<'production' | 'development'> = (config, mode) => {
+  return withEntitlementsPlist(config, (config) => {
+    config.modResults['aps-environment'] = mode;
+    return config;
+  });
+};
 
 export default createLegacyPlugin({
   packageName: 'expo-notifications',
@@ -13,6 +22,6 @@ export default createLegacyPlugin({
     withNotificationIconColor,
     withNotificationIcons,
     // iOS
-    // Automatic setting of APNS entitlement is no longer needed
+    [withNotificationsEntitlement, 'development'],
   ],
 });

--- a/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
+++ b/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
@@ -41,7 +41,7 @@ it('runs normally for a single iOS prebuild', async () => {
 
   expect(config).toMatchInfoPlist(expect.objectContaining({ CFBundleDisplayName: 'app' }));
   expect(config).toMatchAppleEntitlements({
-    "aps-environment": "development",
+    'aps-environment': 'development',
   });
 });
 

--- a/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
+++ b/packages/@expo/prebuild-config/src/testing-library/__tests__/prebuild-testing-lib.test.ts
@@ -40,7 +40,9 @@ it('runs normally for a single iOS prebuild', async () => {
   expect(Object.values(config.mods!.ios!).every((value) => typeof value === 'function')).toBe(true);
 
   expect(config).toMatchInfoPlist(expect.objectContaining({ CFBundleDisplayName: 'app' }));
-  expect(config).toMatchAppleEntitlements({});
+  expect(config).toMatchAppleEntitlements({
+    "aps-environment": "development",
+  });
 });
 
 it('runs normally for a single Android prebuild', async () => {


### PR DESCRIPTION
This reverts #27924 .

# Why

The above change was requested by some customers who did not need notifications in their iOS app and did not want the APNS entitlement automatically added.

Unfortunately, this resulted in most customers seeing warnings from Apple on submission of their apps to the App Store. (See https://github.com/expo/fyi/blob/main/apns-entitlement-sdk-51.md for details). The warnings are simply informational, and do not block acceptance of apps to the App Store.

For the convenience of our customers, we have made the decision to revert the above change. We will be providing documentation shortly for the steps needed to actually remove the warning for apps without the APNS entitlement.

# Test Plan

CI should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
