### PR TITLE
Update react-native-safe-area-context to 4.10.7

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1608,7 +1608,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.10.1):
+  - react-native-safe-area-context (4.10.7):
     - React-Core
   - react-native-segmented-control (2.5.2):
     - React-Core
@@ -2535,8 +2535,8 @@ SPEC CHECKSUMS:
   EXManifests: c1fab4c3237675e7b0299ea8df0bcb14baca4f42
   EXNotifications: a01203397855862df7e4ac3bcf9fc7bc6914893e
   Expo: c99f14ca53381d5399b88684c88e20ff7928d3c7
-  expo-dev-client: 5a76dfdc64875a076212f9d3ee9a897bdd735105
-  expo-dev-launcher: 752312abcf346045aac32cf1bde006f45faf4a04
+  expo-dev-client: 5fabdda30d7494ed2110775479864463171e9a0e
+  expo-dev-launcher: 83e5b141c512a1fae37bc0cced8c9ac4e8144eb9
   expo-dev-menu: 8559d77f4037c6105b21a424dec68f235496c391
   expo-dev-menu-interface: 3e97a7c7d79caff5f62acb00d053d4ec86d0ca1f
   ExpoAppleAuthentication: 7af0b493e820dc0b22150cb9531fc1c31dc4fbfd
@@ -2592,11 +2592,11 @@ SPEC CHECKSUMS:
   EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
   EXTaskManager: 79eddd6874d41785e61b5d76652da36b991e4ad0
-  EXUpdates: 176cb01319512d5188e21538d7ff6f943de8bcda
+  EXUpdates: de58bdc4a62ccd959f6c99e2d75f25aa83cd2365
   EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
   FBLazyVector: 4bc164e5b5e6cfc288d2b5ff28643ea15fa1a589
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GooglePlaces: 0609463845250bbadafa1739938181e54dece439
   hermes-engine: 01d3e052018c2a13937aca1860fbedbccd4a41b7
@@ -2606,7 +2606,7 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
   RCTDeprecation: b03c35057846b685b3ccadc9bfe43e349989cdb2
   RCTRequired: 194626909cfa8d39ca6663138c417bc6c431648c
   RCTTypeSafety: 552aff5b8e8341660594db00e53ac889682bc120
@@ -2633,7 +2633,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: bf56147c9775491e53122a94c423ac201417e326
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
   react-native-pager-view: c1e29e1a6105a02807392ba822ad322447a72f55
-  react-native-safe-area-context: dcab599c527c2d7de2d76507a523d20a0b83823d
+  react-native-safe-area-context: 422017db8bcabbada9ad607d010996c56713234c
   react-native-segmented-control: b92809e9111013dfa266e1168ba366d62898d9a4
   react-native-slider: ce295d2bf830a7990af05b0bd70ab28c133e230c
   react-native-view-shot: 6b7ed61d77d88580fed10954d45fad0eb2d47688

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -63,7 +63,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-pager-view": "6.3.0",
     "react-native-reanimated": "~3.10.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "~3.31.1",
     "react-native-svg": "15.2.0",
     "react-native-view-shot": "3.8.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1416,7 +1416,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.10.1):
+  - react-native-safe-area-context (4.10.7):
     - React-Core
   - react-native-segmented-control (2.5.2):
     - React-Core
@@ -2411,7 +2411,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: d439ca817211886dc80a00f3761e3b6d861d7205
   EXStructuredHeaders: cb8d1f698e144f4c5547b4c4963e1552f5d2b457
   EXTaskManager: 79eddd6874d41785e61b5d76652da36b991e4ad0
-  EXUpdates: 2edbfb9223f3d3d2ed68f7e19deb0965cb6c4f03
+  EXUpdates: 5db80118c2175539f36af57527443d2c4660968a
   EXUpdatesInterface: 996527fd7d1a5d271eb523258d603f8f92038f24
   FBLazyVector: 4bc164e5b5e6cfc288d2b5ff28643ea15fa1a589
   FirebaseCore: 25c0400b670fd1e2f2104349cd3b5dcce8d9418f
@@ -2423,7 +2423,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleMaps: 032f676450ba0779bd8ce16840690915f84e57ac
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  hermes-engine: 56c453c4b73b7954fb38d24fdb899191dc6470ec
+  hermes-engine: b7e1129e5d9e5fb0d3b018a60908404592776cc1
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -2464,7 +2464,7 @@ SPEC CHECKSUMS:
   react-native-maps: cbf2f03bfeebfd7ec45966b066db13a075fd2af3
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
   react-native-pager-view: c1e29e1a6105a02807392ba822ad322447a72f55
-  react-native-safe-area-context: dcab599c527c2d7de2d76507a523d20a0b83823d
+  react-native-safe-area-context: 422017db8bcabbada9ad607d010996c56713234c
   react-native-segmented-control: b92809e9111013dfa266e1168ba366d62898d9a4
   react-native-skia: 80282ed176572d97f6abe128ddcb567e0c33fe93
   react-native-slider: ce295d2bf830a7990af05b0bd70ab28c133e230c

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -74,7 +74,7 @@
     "react-native-pager-view": "^6.3.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.10.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "~3.31.1",
     "react-native-svg": "15.2.0",
     "react-redux": "^7.2.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "react-native-pager-view": "6.3.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.10.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "~3.31.1",
     "react-native-svg": "15.2.0",
     "react-native-view-shot": "3.8.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -12,7 +12,7 @@
     "expo": "~51.0.0",
     "expo-router": "^3.0.0",
     "react": "18.2.0",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "~3.31.1",
     "react-native": "0.74.2"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -11,7 +11,7 @@
     "expo-router": "^3.5.15",
     "expo-splash-screen": "~0.27.0",
     "expo-status-bar": "^1.12.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "~3.31.1"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "react-native-pager-view": "6.3.0",
   "react-native-reanimated": "~3.10.1",
   "react-native-screens": "3.31.1",
-  "react-native-safe-area-context": "4.10.1",
+  "react-native-safe-area-context": "4.10.7",
   "react-native-svg": "15.2.0",
   "react-native-view-shot": "3.8.0",
   "react-native-webview": "13.8.6",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "react-native": "0.74.2",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.10"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -28,7 +28,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.74.2",
     "react-native-reanimated": "~3.10.1",
-    "react-native-safe-area-context": "4.10.1",
+    "react-native-safe-area-context": "4.10.7",
     "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14227,10 +14227,10 @@ react-native-reanimated@~3.10.1:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.10.1.tgz#29fb27395ff7dfa2fa38788a27226330d73a81cc"
-  integrity sha512-w8tCuowDorUkPoWPXmhqosovBr33YsukkwYCDERZFHAxIkx6qBadYxfeoaJ91nCQKjkNzGrK5qhoNOeSIcYSpA==
+react-native-safe-area-context@4.10.7:
+  version "4.10.7"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.10.7.tgz#91d04e510bf96e3c38bec2beb7ae37347522a503"
+  integrity sha512-Lq+gtuIF28mMtBacFchGpO1KHMTvzeb3ji1HAVnMTPe3qWR46Tb4AlztZTvTwUnpZ8JVaC9sKXnJHKmuaIQwXA==
 
 react-native-screens@~3.31.1:
   version "3.31.1"


### PR DESCRIPTION
# Why

In react-native 0.75 a lot of internal classes were migrated from Java to Kotlin, which led to some unexpected changes such as us no longer being able to access Java methods by skipping the "get" part (Same as https://github.com/expo/expo/pull/30239), this also affected react-native-safe-area-context and because of that it need to be updated to the latest version (Commit with the relevant changes https://github.com/th3rdwave/react-native-safe-area-context/commit/05ad6b4320625f875f81afd3bcc7cc3a91244de4

# How

Bumped all packages/apps to use react-native-safe-area-context 4.10.7 


# Test Plan

- Expo Go 
- Bare Expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
