### PR TITLE
docs: Update crypto with information about server side usage.

### DIFF
--- a/docs/pages/versions/unversioned/sdk/crypto.mdx
+++ b/docs/pages/versions/unversioned/sdk/crypto.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-crypto` enables you to hash data in an equivalent manner to the Node.js core `crypto` API.
 
+> **warning** This package will not work on server side code. You can use normal crypto functions by importing it from "crypto".
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

I ran into an [issue](https://github.com/expo/expo/issues/30289) with the `uuid` package, and used this package as a way to generate a uuid on the server, but it did not work.

# How

Add a warning or something in the docs about how it can't work in

# Test Plan

Documentation changes.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
