### PR TITLE
[apps] initial theming support

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -1,6 +1,8 @@
+import { ThemeProvider } from 'ThemeProvider';
 import React from 'react';
 
 import MainNavigator, { optionalRequire } from './MainNavigator';
+
 let Notifications;
 try {
   Notifications = require('expo-notifications');
@@ -54,9 +56,5 @@ export default function Main() {
 
   const isLoaded = useLoaded();
 
-  if (!isLoaded) {
-    return null;
-  }
-
-  return <MainNavigator />;
+  return <ThemeProvider>{isLoaded ? <MainNavigator /> : null}</ThemeProvider>;
 }

--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -2,12 +2,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { useTheme } from 'ThemeProvider';
 import * as Linking from 'expo-linking';
 import React from 'react';
 import { ToastAndroid, Platform } from 'react-native';
 import TestSuite from 'test-suite/AppNavigator';
-
-import Colors from './src/constants/Colors';
 
 type NavigationRouteConfigMap = React.ReactElement;
 
@@ -90,12 +89,13 @@ const linking: LinkingOptions<object> = {
 };
 
 function TabNavigator() {
+  const { theme } = useTheme();
   return (
     <Tab.Navigator
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: Colors.activeTintColor,
-        tabBarInactiveTintColor: Colors.inactiveTintColor,
+        tabBarActiveTintColor: theme.text.info,
+        tabBarInactiveTintColor: theme.text.default,
       }}
       safeAreaInsets={{
         top: 5,

--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -96,10 +96,17 @@ function TabNavigator() {
         headerShown: false,
         tabBarActiveTintColor: theme.text.info,
         tabBarInactiveTintColor: theme.text.default,
+        tabBarStyle: {
+          backgroundColor: theme.background.default,
+          borderTopColor: theme.border.default,
+        },
       }}
-      safeAreaInsets={{
-        top: 5,
-      }}
+      safeAreaInsets={Platform.select({
+        android: {
+          bottom: 5,
+        },
+        default: undefined,
+      })}
       initialRouteName="test-suite">
       {Object.keys(routes).map((name) => (
         <Tab.Screen

--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -28,6 +28,7 @@ config.watchFolders = [
   __dirname, // Allow Metro to resolve all files within this project
   path.join(monorepoRoot, 'apps/native-component-list'), // Allow Metro to resolve all files within NCL
   path.join(monorepoRoot, 'apps/test-suite'), // Allow Metro to resolve all files within test-suite
+  path.join(monorepoRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
   path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
   path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
 ];

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.0",
+    "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.0.0",
     "@react-native-community/netinfo": "11.3.1",

--- a/apps/bare-expo/src/constants/Colors.ts
+++ b/apps/bare-expo/src/constants/Colors.ts
@@ -1,4 +1,0 @@
-export default {
-  activeTintColor: '#4630ec',
-  inactiveTintColor: '#595959',
-};

--- a/apps/bare-expo/tsconfig.json
+++ b/apps/bare-expo/tsconfig.json
@@ -1,9 +1,13 @@
 {
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": [
       "dom",
       "esnext"
-    ]
-  },
-  "extends": "expo/tsconfig.base"
+    ],
+    "paths": {
+      "ThemeProvider": ["../common/ThemeProvider"],
+    }
+  }
 }

--- a/apps/common/ThemeProvider.tsx
+++ b/apps/common/ThemeProvider.tsx
@@ -1,0 +1,46 @@
+import { darkTheme, lightTheme } from '@expo/styleguide-base';
+import React, { createContext, useState, useContext, PropsWithChildren } from 'react';
+import { useColorScheme } from 'react-native';
+
+export type ThemeName = 'light' | 'dark';
+export type ThemeType = typeof lightTheme | typeof darkTheme;
+
+type ThemeContextType = {
+  name: ThemeName;
+  theme: ThemeType;
+  setTheme: (themeName: 'light' | 'dark') => void;
+};
+
+export const ThemeContext = createContext<ThemeContextType>({
+  name: 'light',
+  theme: lightTheme,
+  setTheme: () => undefined,
+});
+
+export function ThemeProvider({ children }: PropsWithChildren) {
+  const defaultTheme = useColorScheme() ?? 'light';
+  const [currentThemeName, setCurrentThemeName] = useState<ThemeName>(defaultTheme);
+  const [currentTheme, setCurrentTheme] = useState<ThemeType>(
+    defaultTheme === 'dark' ? darkTheme : lightTheme
+  );
+
+  function setTheme(name: ThemeName) {
+    setCurrentThemeName(name);
+    setCurrentTheme(name === 'dark' ? darkTheme : lightTheme);
+  }
+
+  return (
+    <ThemeContext.Provider
+      value={{
+        name: currentThemeName,
+        theme: currentTheme,
+        setTheme,
+      }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/apps/common/ThemeToggler.tsx
+++ b/apps/common/ThemeToggler.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, Platform } from 'react-native';
 
 import { useTheme } from './ThemeProvider';
 
-export function ThemeToggle() {
+export default function ThemeToggler() {
   const { theme, name, setTheme } = useTheme();
   return (
     <TouchableOpacity onPress={() => setTheme(name === 'light' ? 'dark' : 'light')} hitSlop={4}>

--- a/apps/common/ThemeToggler.tsx
+++ b/apps/common/ThemeToggler.tsx
@@ -1,0 +1,17 @@
+import { Ionicons } from '@expo/vector-icons';
+import { TouchableOpacity, Platform } from 'react-native';
+
+import { useTheme } from './ThemeProvider';
+
+export function ThemeToggle() {
+  const { theme, name, setTheme } = useTheme();
+  return (
+    <TouchableOpacity onPress={() => setTheme(name === 'light' ? 'dark' : 'light')} hitSlop={4}>
+      <Ionicons
+        name={name === 'dark' ? 'sunny' : 'moon'}
+        size={Platform.OS === 'ios' ? 22 : 25}
+        color={theme.icon.info}
+      />
+    </TouchableOpacity>
+  );
+}

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -1,3 +1,4 @@
+import { ThemeProvider } from 'ThemeProvider';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import { Platform, StatusBar } from 'react-native';
@@ -30,7 +31,7 @@ function useSplashScreen(loadingFunction: () => void) {
   return isLoadingCompleted;
 }
 
-const App = () => {
+export default function App() {
   const isLoadingCompleted = useSplashScreen(async () => {
     if (Platform.OS === 'ios') {
       StatusBar.setBarStyle('dark-content', false);
@@ -38,7 +39,5 @@ const App = () => {
     await loadAssetsAsync();
   });
 
-  return isLoadingCompleted ? <RootNavigation /> : null;
-};
-
-export default App;
+  return <ThemeProvider>{isLoadingCompleted ? <RootNavigation /> : null}</ThemeProvider>;
+}

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -46,6 +46,7 @@ config.watchFolders = [
   path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
   path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
   path.join(monorepoRoot, 'react-native-lab'), // Allow Metro to resolve `react-native-lab/react-native` files
+  path.join(monorepoRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
 ];
 
 module.exports = config;

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",
     "@expo/react-native-action-sheet": "^3.8.0",
+    "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.0.0",
     "@react-native-community/netinfo": "11.3.1",

--- a/apps/native-component-list/src/components/Page.tsx
+++ b/apps/native-component-list/src/components/Page.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { PropsWithChildren } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 
-const Page = ({ children }: PropsWithChildren<object>) => (
-  <View style={styles.page}>{children}</View>
-);
+export function Page({ children }: PropsWithChildren) {
+  return <View style={styles.page}>{children}</View>;
+}
 
-const ScrollPage = ({ children }: PropsWithChildren<object>) => (
+const ScrollPage = ({ children }: PropsWithChildren) => (
   <ScrollView style={[styles.page, styles.scrollPage]}>{children}</ScrollView>
 );
 
@@ -38,4 +38,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export { Page, ScrollPage, Section };
+export { ScrollPage, Section };

--- a/apps/native-component-list/src/components/SearchBar.ios.tsx
+++ b/apps/native-component-list/src/components/SearchBar.ios.tsx
@@ -139,7 +139,7 @@ export default function SearchBar({
           <Text
             style={{
               fontSize: 17,
-              color: tintColor || '#007AFF',
+              color: tintColor,
             }}>
             {cancelButtonText || 'Cancel'}
           </Text>

--- a/apps/native-component-list/src/components/TabBackground.tsx
+++ b/apps/native-component-list/src/components/TabBackground.tsx
@@ -1,0 +1,7 @@
+import { useTheme } from 'ThemeProvider';
+import { View } from 'react-native';
+
+export function TabBackground() {
+  const { theme } = useTheme();
+  return <View style={{ flex: 1, backgroundColor: theme.background.default }} />;
+}

--- a/apps/native-component-list/src/components/TabIcon.tsx
+++ b/apps/native-component-list/src/components/TabIcon.tsx
@@ -1,8 +1,7 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { useTheme } from 'ThemeProvider';
 import React from 'react';
 import { Platform } from 'react-native';
-
-import { Colors } from '../constants';
 
 type Props = {
   name: string;
@@ -11,7 +10,8 @@ type Props = {
 };
 
 const TabIcon = ({ size = 27, name, focused }: Props) => {
-  const color = focused ? Colors.tabIconSelected : Colors.tabIconDefault;
+  const { theme } = useTheme();
+  const color = focused ? theme.icon.info : theme.icon.default;
   const platformSize = Platform.select({
     ios: size,
     default: size - 2,

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -1,10 +1,12 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
+import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
-import getStackConfig from './StackConfig';
 import { optionalRequire } from './routeBuilder';
+import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
+import getStackNavWithConfig from '../navigation/StackConfig';
 import { AudioScreens } from '../screens/Audio/AudioScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
@@ -426,24 +428,25 @@ export const Screens: ScreenConfig[] = [
 ];
 
 function ExpoApisStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
-  return (
-    <Stack.Navigator {...props} {...getStackConfig(props)}>
-      <Stack.Screen name="ExpoApis" options={{ title: 'APIs in Expo SDK' }} component={ExpoApis} />
+  const { theme } = useTheme();
 
+  return (
+    <Stack.Navigator {...props} {...getStackNavWithConfig(props.navigation, theme)}>
+      <Stack.Screen name="ExpoApis" options={{ title: 'APIs in Expo SDK' }} component={ExpoApis} />
       {Screens.map(({ name, options, getComponent }) => (
         <Stack.Screen name={name} key={name} getComponent={getComponent} options={options ?? {}} />
       ))}
     </Stack.Navigator>
   );
 }
-const icon = ({ focused }: { focused: boolean }) => {
-  return <TabIcon name="code-tags" focused={focused} />;
-};
+
 ExpoApisStackNavigator.navigationOptions = {
   title: 'APIs',
   tabBarLabel: 'APIs',
-  tabBarIcon: icon,
-  drawerIcon: icon,
+  tabBarIcon: ({ focused }: { focused: boolean }) => {
+    return <TabIcon name="code-tags" focused={focused} />;
+  },
+  tabBarBackground: () => <TabBackground />,
 };
 
 export default ExpoApisStackNavigator;

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -1,9 +1,11 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
+import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
-import getStackConfig from './StackConfig';
+import getStackNavWithConfig from './StackConfig';
 import { optionalRequire } from './routeBuilder';
+import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
@@ -444,8 +446,9 @@ export const Screens: ScreenConfig[] = [
 ];
 
 function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
+  const { theme } = useTheme();
   return (
-    <Stack.Navigator {...props} {...getStackConfig(props)}>
+    <Stack.Navigator {...props} {...getStackNavWithConfig(props.navigation, theme)}>
       <Stack.Screen
         name="ExpoComponents"
         options={{ title: Layout.isSmallDevice ? 'Expo SDK Components' : 'Components in Expo SDK' }}
@@ -458,13 +461,13 @@ function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationPr
   );
 }
 
-const icon = ({ focused }: { focused: boolean }) => {
-  return <TabIcon name="react" focused={focused} />;
-};
 ExpoComponentsStackNavigator.navigationOptions = {
   title: 'Components',
   tabBarLabel: 'Components',
-  tabBarIcon: icon,
-  drawerIcon: icon,
+  tabBarIcon: ({ focused }: { focused: boolean }) => {
+    return <TabIcon name="react" focused={focused} />;
+  },
+  tabBarBackground: () => <TabBackground />,
 };
+
 export default ExpoComponentsStackNavigator;

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -1,49 +1,54 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { HeaderStyleInterpolators } from '@react-navigation/stack';
+import { ThemeType } from 'ThemeProvider';
 import * as React from 'react';
-import { Platform, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Platform, TouchableOpacity } from 'react-native';
 
-import { Colors } from '../constants';
+import { ThemeToggle } from '../../../common/ThemeToggler';
 
-const styles = StyleSheet.create({
-  header: Platform.select({
-    default: {
-      backgroundColor: Colors.headerBackground,
-    },
-    android: {
-      elevation: 0,
-      borderBottomWidth: 1,
-      borderBottomColor: '#eee',
-    },
-  }),
-  headerTitle: {
-    color: Colors.headerTitle,
-  },
-  card: {
-    backgroundColor: Colors.greyBackground,
-  },
-});
-
-export default function getStackConfig({
-  navigation,
-}: {
-  navigation: BottomTabNavigationProp<any>;
-}) {
+export default function getStackConfig(navigation: BottomTabNavigationProp<any>, theme: ThemeType) {
   return {
-    cardStyle: styles.card,
+    cardStyle: {
+      backgroundColor: theme.background.default,
+    },
     screenOptions: () => ({
       headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
-      headerStyle: styles.header,
-      headerTintColor: Colors.tintColor,
-      headerTitleStyle: styles.headerTitle,
-      headerPressColorAndroid: Colors.tintColor,
+      headerStyle: Platform.select({
+        default: {
+          backgroundColor: theme.background.default,
+          borderBottomColor: theme.border.secondary,
+        },
+        android: {
+          elevation: 0,
+          borderBottomWidth: 1,
+          borderBottomColor: theme.border.secondary,
+        },
+      }),
+      headerTintColor: theme.icon.info,
+      headerTitleStyle: {
+        color: theme.text.default,
+      },
+      headerPressColorAndroid: theme.icon.info,
       headerRight: () => (
-        <TouchableOpacity
-          onPress={() => navigation.navigate('searchNavigator')}
-          style={{ marginRight: 16 }}>
-          <Ionicons name="search" size={Platform.OS === 'ios' ? 22 : 25} color={Colors.tintColor} />
-        </TouchableOpacity>
+        <View
+          style={{
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            marginRight: 16,
+            marginBottom: 4,
+            gap: 12,
+          }}>
+          <TouchableOpacity onPress={() => navigation.navigate('searchNavigator')}>
+            <Ionicons
+              name="search"
+              size={Platform.OS === 'ios' ? 22 : 25}
+              color={theme.icon.info}
+            />
+          </TouchableOpacity>
+          <ThemeToggle />
+        </View>
       ),
     }),
   };

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -3,7 +3,7 @@ import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { HeaderStyleInterpolators } from '@react-navigation/stack';
 import { ThemeType } from 'ThemeProvider';
 import * as React from 'react';
-import { View, Platform, TouchableOpacity } from 'react-native';
+import { View, Platform, TouchableOpacity, StyleSheet } from 'react-native';
 
 import { ThemeToggle } from '../../../common/ThemeToggler';
 
@@ -14,17 +14,16 @@ export default function getStackConfig(navigation: BottomTabNavigationProp<any>,
     },
     screenOptions: () => ({
       headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
-      headerStyle: Platform.select({
-        default: {
-          backgroundColor: theme.background.default,
-          borderBottomColor: theme.border.secondary,
-        },
-        android: {
-          elevation: 0,
-          borderBottomWidth: 1,
-          borderBottomColor: theme.border.secondary,
-        },
-      }),
+      headerStyle: {
+        backgroundColor: theme.background.default,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: theme.border.secondary,
+        ...Platform.select({
+          android: {
+            elevation: 0,
+          },
+        }),
+      },
       headerTintColor: theme.icon.info,
       headerTitleStyle: {
         color: theme.text.default,
@@ -38,7 +37,7 @@ export default function getStackConfig(navigation: BottomTabNavigationProp<any>,
             alignItems: 'center',
             marginRight: 16,
             marginBottom: 4,
-            gap: 12,
+            gap: 14,
           }}>
           <TouchableOpacity onPress={() => navigation.navigate('searchNavigator')}>
             <Ionicons

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -5,7 +5,7 @@ import { ThemeType } from 'ThemeProvider';
 import * as React from 'react';
 import { View, Platform, TouchableOpacity, StyleSheet } from 'react-native';
 
-import { ThemeToggle } from '../../../common/ThemeToggler';
+import ThemeToggler from '../../../common/ThemeToggler';
 
 export default function getStackConfig(navigation: BottomTabNavigationProp<any>, theme: ThemeType) {
   return {
@@ -46,7 +46,7 @@ export default function getStackConfig(navigation: BottomTabNavigationProp<any>,
               color={theme.icon.info}
             />
           </TouchableOpacity>
-          <ThemeToggle />
+          <ThemeToggler />
         </View>
       ),
     }),

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,5 +1,6 @@
 import { HeaderBackButton } from '@react-navigation/elements';
 import { createStackNavigator, StackScreenProps } from '@react-navigation/stack';
+import { useTheme } from 'ThemeProvider';
 import Fuse from 'fuse.js';
 import React from 'react';
 import { Animated, Platform, StyleSheet, View } from 'react-native';
@@ -10,7 +11,6 @@ import { ScreenItems as ApiScreenItems } from './ExpoApisScreen';
 import { ScreenItems as ComponentScreenItems } from './ExpoComponentsScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
 import SearchBar from '../components/SearchBar';
-import { Colors } from '../constants';
 
 const fuse = new Fuse(ApiScreenItems.concat(ComponentScreenItems), { keys: ['name'] });
 
@@ -78,29 +78,32 @@ type SearchStack = {
 
 const Stack = createStackNavigator<SearchStack>();
 
-export default () => (
-  <Stack.Navigator>
-    <Stack.Screen
-      name="search"
-      component={SearchScreen}
-      options={({ navigation, route }) => ({
-        header: () => (
-          <Header
-            navigation={navigation}
-            tintColor={Colors.tintColor}
-            backButton={Platform.OS === 'android'}>
-            <SearchBar
-              initialValue={route?.params?.q ?? ''}
-              onChangeQuery={(q) => navigation.setParams({ q })}
-              underlineColorAndroid="#fff"
-              tintColor={Colors.tintColor}
-            />
-          </Header>
-        ),
-      })}
-    />
-  </Stack.Navigator>
-);
+export default function SearchScreenStack() {
+  const { theme } = useTheme();
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="search"
+        component={SearchScreen}
+        options={({ navigation, route }) => ({
+          header: () => (
+            <Header
+              navigation={navigation}
+              tintColor={theme.icon.info}
+              backButton={Platform.OS === 'android'}>
+              <SearchBar
+                initialValue={route?.params?.q ?? ''}
+                onChangeQuery={(q) => navigation.setParams({ q })}
+                underlineColorAndroid="#fff"
+                tintColor={theme.text.info}
+              />
+            </Header>
+          ),
+        })}
+      />
+    </Stack.Navigator>
+  );
+}
 
 const styles = {
   container: {

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -5,7 +5,8 @@
     "experimentalDecorators": true,
     "baseUrl": ".",
     "paths": {
-      "@expo/vector-icons": ["react-native-vector-icons"]
+      "@expo/vector-icons": ["react-native-vector-icons"],
+      "ThemeProvider": ["../common/ThemeProvider"]
     },
     "types": ["jest"],
     "typeRoots": ["./ts-declarations", "./node_modules/@types", "../../node_modules/@types"],

--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -3,6 +3,7 @@ import * as Linking from 'expo-linking';
 import * as React from 'react';
 
 import AppNavigator from './AppNavigator';
+import { ThemeProvider } from '../common/ThemeProvider';
 
 const linking = {
   prefixes: [Linking.createURL('/')],
@@ -13,8 +14,11 @@ const linking = {
     },
   },
 };
+
 export default () => (
-  <NavigationContainer linking={linking}>
-    <AppNavigator />
-  </NavigationContainer>
+  <ThemeProvider>
+    <NavigationContainer linking={linking}>
+      <AppNavigator />
+    </NavigationContainer>
+  </ThemeProvider>
 );

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -6,7 +6,7 @@ import { StyleSheet, View } from 'react-native';
 import SelectScreen from './screens/SelectScreen';
 import RunTests from './screens/TestScreen';
 import { useTheme } from '../common/ThemeProvider';
-import { ThemeToggle } from '../common/ThemeToggler';
+import ThemeToggler from '../common/ThemeToggler';
 
 // @tsapeta: This navigator is also being used by `bare-expo` app,
 // so make sure it still works there once you change something here.
@@ -75,7 +75,7 @@ export default function AppNavigator(props) {
                 marginBottom: 4,
                 gap: 12,
               }}>
-              <ThemeToggle />
+              <ThemeToggler />
             </View>
           ),
         }}

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -1,11 +1,12 @@
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import Colors from './constants/Colors';
 import SelectScreen from './screens/SelectScreen';
 import RunTests from './screens/TestScreen';
+import { useTheme } from '../common/ThemeProvider';
+import { ThemeToggle } from '../common/ThemeToggler';
 
 // @tsapeta: This navigator is also being used by `bare-expo` app,
 // so make sure it still works there once you change something here.
@@ -25,15 +26,18 @@ const shouldDisableTransition = false;
 const transitionSpec = shouldDisableTransition ? { open: spec, close: spec } : undefined;
 
 export default function AppNavigator(props) {
+  const { theme } = useTheme();
+
   React.useLayoutEffect(() => {
     if (props.navigation) {
       props.navigation.setOptions({
         title: 'Tests',
         tabBarLabel: 'Tests',
         tabBarIcon: ({ focused }) => {
-          const color = focused ? Colors.activeTintColor : Colors.inactiveTintColor;
+          const color = focused ? theme.icon.info : theme.icon.default;
           return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
         },
+        tabBarBackground: () => <TabBackground />,
       });
     }
   }, [props.navigation]);
@@ -46,17 +50,42 @@ export default function AppNavigator(props) {
         transitionSpec,
         headerBackTitle: 'Select',
         headerTitleStyle: {
-          color: 'black',
+          color: theme.text.default,
         },
-        headerTintColor: Colors.tintColor,
+        headerTintColor: theme.icon.info,
         headerStyle: {
           borderBottomWidth: StyleSheet.hairlineWidth,
-          borderBottomColor: Colors.border,
+          borderBottomColor: theme.border.secondary,
+          backgroundColor: theme.background.default,
           boxShadow: '',
         },
       }}>
-      <Stack.Screen name="select" component={SelectScreen} options={{ title: 'Expo Test Suite' }} />
+      <Stack.Screen
+        name="select"
+        component={SelectScreen}
+        options={{
+          title: 'Expo Test Suite',
+          headerRight: () => (
+            <View
+              style={{
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginRight: 16,
+                marginBottom: 4,
+                gap: 12,
+              }}>
+              <ThemeToggle />
+            </View>
+          ),
+        }}
+      />
       <Stack.Screen name="run" component={RunTests} options={{ title: 'Test Runner' }} />
     </Stack.Navigator>
   );
+}
+
+function TabBackground() {
+  const { theme } = useTheme();
+  return <View style={{ flex: 1, backgroundColor: theme.background.default }} />;
 }

--- a/apps/test-suite/components/Suites.js
+++ b/apps/test-suite/components/Suites.js
@@ -4,10 +4,11 @@ import { FlatList, StyleSheet, View } from 'react-native';
 
 import DoneText from './DoneText';
 import SuiteResult from './SuiteResult';
-import Colors from '../constants/Colors';
+import { useTheme } from '../../common/ThemeProvider';
 
 export default function Suites({ suites, done, numFailed, results }) {
   const ref = React.useRef(null);
+  const { theme } = useTheme();
 
   return (
     <FlatList
@@ -18,7 +19,14 @@ export default function Suites({ suites, done, numFailed, results }) {
       keyExtractor={(item) => item.get('result').get('id')}
       renderItem={({ item }) => <SuiteResult r={item} depth={0} />}
       ListHeaderComponent={() => (
-        <View style={styles.headerContainer}>
+        <View
+          style={[
+            styles.headerContainer,
+            {
+              backgroundColor: theme.background.default,
+              borderBottomColor: theme.border.secondary,
+            },
+          ]}>
           <DoneText done={done} numFailed={numFailed} results={results} />
         </View>
       )}
@@ -37,6 +45,5 @@ const styles = StyleSheet.create({
   headerContainer: {
     backgroundColor: '#fff',
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: Colors.border,
   },
 });

--- a/apps/test-suite/constants/Colors.js
+++ b/apps/test-suite/constants/Colors.js
@@ -8,5 +8,4 @@ export default {
   tintColor: '#4630EB', // Expo Blue
   activeTintColor: '#4630ec',
   inactiveTintColor: '#595959',
-  border: '#dddddd',
 };

--- a/apps/test-suite/metro.config.js
+++ b/apps/test-suite/metro.config.js
@@ -39,6 +39,7 @@ config.watchFolders = [
   path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
   path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
   path.join(monorepoRoot, 'react-native-lab'), // Allow Metro to resolve `react-native-lab/react-native` files
+  path.join(monorepoRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
 ];
 
 module.exports = config;

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@expo/html-elements": "^0.10.0",
+    "@expo/styleguide-base": "^1.0.1",
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "async-retry": "^1.1.4",

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -200,7 +200,7 @@ function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
           paddingBottom: isRunningInBareExpo ? 0 : bottom,
           paddingLeft: left,
           paddingRight: right,
-          borderTopColor: theme.border.secondary,
+          borderColor: theme.border.default,
           backgroundColor: theme.background.default,
         },
       ]}>

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -4,19 +4,20 @@ import React from 'react';
 import { Alert, FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
 
+import { useTheme } from '../../common/ThemeProvider';
 import { getTestModules } from '../TestModules';
 import PlatformTouchable from '../components/PlatformTouchable';
-import Colors from '../constants/Colors';
 
 function ListItem({ title, onPressItem, selected, id }) {
+  const { theme } = useTheme();
   const onPress = () => onPressItem(id);
 
   return (
     <PlatformTouchable onPress={onPress}>
-      <View style={styles.listItem}>
+      <View style={[styles.listItem, { borderBottomColor: theme.border.secondary }]}>
         <Text style={styles.label}>{title}</Text>
         <View style={{ pointerEvents: 'none' }}>
-          <Checkbox color={Colors.tintColor} value={selected} />
+          <Checkbox color={theme.icon.info} value={selected} />
         </View>
       </View>
     </PlatformTouchable>
@@ -186,6 +187,7 @@ export default class SelectScreen extends React.PureComponent {
 
 function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
   const { bottom, left, right } = useSafeArea();
+  const { theme } = useTheme();
 
   const isRunningInBareExpo = Constants.expoConfig.slug === 'bare-expo';
   const paddingVertical = 16;
@@ -194,7 +196,13 @@ function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
     <View
       style={[
         styles.buttonRow,
-        { paddingBottom: isRunningInBareExpo ? 0 : bottom, paddingLeft: left, paddingRight: right },
+        {
+          paddingBottom: isRunningInBareExpo ? 0 : bottom,
+          paddingLeft: left,
+          paddingRight: right,
+          borderTopColor: theme.border.secondary,
+          backgroundColor: theme.background.default,
+        },
       ]}>
       <FooterButton
         style={{ paddingVertical, alignItems: 'flex-start' }}
@@ -212,11 +220,12 @@ function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
 }
 
 function FooterButton({ title, style, ...props }) {
+  const { theme } = useTheme();
   return (
     <TouchableOpacity
       style={[styles.footerButton, { opacity: props.disabled ? 0.4 : 1 }, style]}
       {...props}>
-      <Text style={styles.footerButtonTitle}>{title}</Text>
+      <Text style={[styles.footerButtonTitle, { color: theme.text.info }]}>{title}</Text>
     </TouchableOpacity>
   );
 }
@@ -229,7 +238,6 @@ const styles = StyleSheet.create({
   },
   footerButtonTitle: {
     fontSize: 16,
-    color: Colors.tintColor,
   },
   footerButton: {
     flex: 1,
@@ -243,7 +251,6 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: HORIZONTAL_MARGIN,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: Colors.border,
   },
   label: {
     color: 'black',
@@ -254,7 +261,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: Colors.border,
     backgroundColor: 'white',
   },
   contentContainerStyle: {

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "expo/tsconfig.base",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "paths": {
+      "ThemeProvider": ["../common/ThemeProvider"]
+    }
+  },
   "include": ["tests/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,6 +1584,13 @@
   dependencies:
     cross-spawn "^7.0.3"
 
+"@expo/styleguide-base@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-1.0.1.tgz#c05b64370fc1754ed7e3c627fd2d788582445cd2"
+  integrity sha512-Iu52/esfpMXB5cOT3oyTvcSdkwok9re9Wtu4Tz7cmeumjh+81kTIB1GHZn8W1RFhSx9dys0NXr3UqPD8MkngtQ==
+  dependencies:
+    "@radix-ui/colors" "^0.1.8"
+
 "@expo/styleguide-native@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@expo/styleguide-native/-/styleguide-native-1.0.1.tgz#b9889266664f885dad15566b5b2956e086b1aa22"
@@ -2969,6 +2976,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@radix-ui/colors@^0.1.8":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/colors/-/colors-0.1.9.tgz#aad732ecc4ce1018adcb3aedd3ce3c573c2256cc"
+  integrity sha512-Vxq944ErPJsdVepjEUhOLO9ApUVOocA63knc+V2TkJ09D/AVOjiMIgkca/7VoYgODcla0qbSIBjje0SMfZMbAw==
 
 "@radix-ui/react-compose-refs@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
# Why

Experiment introducing theming support in the workspace apps (Bare Expo, NCL and Test Suite).

# How

Utilize styleguide package, update Navigators, stack configs, add theme toggle, support cark mode in navigation components.

# Test Plan

The changes have been tested on Android and iOS hardware devices.

# Preview

### Android
<img src="https://github.com/user-attachments/assets/b7ff3162-0f27-4a56-b7df-392c5733b133" width="340" align="left" />
<img src="https://github.com/user-attachments/assets/6791c086-8842-4304-aaa9-745599abbbb5" width="340"  />

### iOS
<img src="https://github.com/user-attachments/assets/ff5b8fb5-fc34-40d0-b6b8-4ec74cf15a11" width="340" align="left" />
<img src="https://github.com/user-attachments/assets/5f4bce59-7305-4a16-93e4-490e600dfac4" width="340"  />

