### PR TITLE
[docs] Remove duplicated section in Advanced EAS Update Debugging guide

### DIFF
--- a/docs/pages/eas-update/debug-advanced.mdx
+++ b/docs/pages/eas-update/debug-advanced.mdx
@@ -142,29 +142,6 @@ After verifying `expo-updates` and EAS Update configurations, we can move on to 
 
 The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause. We can make a simulator build of the project and manually check to see if updates are available or if there are errors when fetching updates. See the code example to [check for updates manually](/versions/latest/sdk/updates/#use-expo-updates-with-a-custom-server).
 
-### Viewing network requests
-
-Another way to identify the root cause of an issue is to look at the network requests that the app is making to EAS servers, then viewing the responses. We recommend using a program like [Proxyman](https://proxyman.io/) or [Charles Proxy](https://www.charlesproxy.com/) to watch network requests from our app.
-
-With either program, we'll need to follow their instructions for installing an SSL certificate, so that the program can decode HTTPS requests. Once that's set up in a simulator or on an actual device, we can open our app and watch requests.
-
-The requests we're interested in are from https://u.expo.dev and https://assets.eascdn.net. Responses from https://u.expo.dev will contain an update manifest, which specifies which assets the app will need to fetch to run the update. Responses from https://assets.eascdn.net will contain assets, like images, font files, and so on, that are required for the update to run.
-
-When inspecting the request to https://u.expo.dev, we can look for the following request headers:
-
-- `Expo-Runtime-Version`: this should make the runtime version we made our build and update with.
-- `expo-channel-name`: this should be the channel name specified in the **eas.json** build profile.
-- `Expo-Platform`: this should be either "android" or "ios".
-
-As for all requests, we expect to see either `200` response codes, or `304` if nothing has changed.
-
-Below is a screenshot showing the request of a successful update manifest request:
-
-<ContentSpotlight
-  alt="Successful manifest request"
-  src="/static/images/eas-update/network-request.png"
-/>
-
 ### Inspecting a build manually
 
 When building a project into an app, there can be multiple steps that alter the output of `npx expo prebuild`. After making a build, it is possible to open the build's contents and inspect native files to see its final configuration.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #30284

# How

<!--
How did you build this feature or fix this bug and why?
-->

Removes the duplicated "Viewing network requests" section in the Advanced EAS Update Debugging guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
