### PR TITLE
[docs] Fix internal link in Notifications API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -461,7 +461,7 @@ A background notification (iOS) or a data-only notification (Android) is a remot
 To handle notifications while the app is in the background or not running, you need to do the following:
 
 - Add `expo-task-manager` package to your project.
-- In your application code, set up a [background task](/versions/unversioned/sdk/notifications/#registertaskasynctaskname) to run when the notification is received.
+- In your application code, set up a [background task](#registertaskasynctaskname) to run when the notification is received.
 
 For Android:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up pattern from https://github.com/expo/expo/pull/30279/files#r1670527094

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the link to direct to the method name instead.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
