### PR TITLE
docs: bumped expo router version

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -394,4 +394,4 @@ export default function RootLayout() {
 
 ## Middleware
 
-Traditionally, websites may leverage some form of server-side redirection to protect routes. As of Expo Router v3.5, this library on the web currently only supports build-time static generation and has no support for custom middleware or serving. This can be added in the future to provide a more optimal web experience. In the meantime, authentication can be implemented by using client-side redirects and a loading state.
+Traditionally, websites may leverage some form of server-side redirection to protect routes. Expo Router on the web currently only supports build-time static generation and has no support for custom middleware or serving. This can be added in the future to provide a more optimal web experience. In the meantime, authentication can be implemented by using client-side redirects and a loading state.

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -394,4 +394,4 @@ export default function RootLayout() {
 
 ## Middleware
 
-Traditionally, websites may leverage some form of server-side redirection to protect routes. As of Expo Router v2, this library on the web currently only supports build-time static generation and has no support for custom middleware or serving. This can be added in the future to provide a more optimal web experience. In the meantime, authentication can be implemented by using client-side redirects and a loading state.
+Traditionally, websites may leverage some form of server-side redirection to protect routes. As of Expo Router v3.5, this library on the web currently only supports build-time static generation and has no support for custom middleware or serving. This can be added in the future to provide a more optimal web experience. In the meantime, authentication can be implemented by using client-side redirects and a loading state.


### PR DESCRIPTION
Docs pointing something that wasn't possible in v2, which still isn't in 3.

# Why

A version number changed so docs are clearer. Right now when you read it gives the impression that middleware wasn't possible in v2 but "maybe" is on 3.

# How

Nothing, just docs.
# Test Plan

Nothing, just docs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
