### PR TITLE
[docs] Change code examples to use TypeScript under Expo Router section

### DIFF
--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -57,9 +57,9 @@ See [Universal Link debugging](/guides/deep-linking#debugging) guide to test han
 
 ### Expo Head setup
 
-Ensure you set the Handoff origin in your `app.config.js` file using the `expo-router` config plugin. This is the URL that will be used for the `webpageUrl` when the user switches to your app.
+Ensure you set the Handoff origin in your `app.config.tsx` file using the `expo-router` config plugin. This is the URL that will be used for the `webpageUrl` when the user switches to your app.
 
-```js app.config.js
+```tsx app.config.tsx
 // Be sure to change this to be unique to your project.
 process.env.EXPO_TUNNEL_SUBDOMAIN = 'bacon-router-sandbox';
 
@@ -107,7 +107,7 @@ In development, you must start the website **before installing the app on your d
 
 In any route that you want to support handoff, use the `Head` component from `expo-router/head`:
 
-```jsx app/index.js
+```tsx app/index.tsx
 import Head from 'expo-router/head';
 import { Text } from 'react-native';
 
@@ -137,7 +137,7 @@ The `expo-router/head` component supports the following meta tags:
 You may want to switch the values between platforms, for that you can use **Platform.select**:
 
 {/* prettier-ignore */}
-```jsx app/index.tsx
+```tsx app/index.tsx
 import Head from 'expo-router/head';
 
 export default function App() {

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -59,7 +59,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. It is required as of Expo Router v3 and greater. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Drawer } from 'expo-router/drawer';
 
@@ -74,7 +74,7 @@ export default function Layout() {
 
 To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Drawer } from 'expo-router/drawer';
 
@@ -110,7 +110,7 @@ export default function Layout() {
 
 Now you can use the `Drawer` layout to create a drawer navigator.
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {
@@ -120,7 +120,7 @@ export default function Layout() {
 
 To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -15,31 +15,31 @@ Consider the following file structure which is used as an example:
 
 <FileTree
   files={[
-    'app/_layout.js',
-    'app/index.js',
-    'app/home/_layout.js',
-    'app/home/feed.js',
-    'app/home/messages.js',
+    'app/_layout.tsx',
+    'app/index.tsx',
+    'app/home/_layout.tsx',
+    'app/home/feed.tsx',
+    'app/home/messages.tsx',
   ]}
 />
 
-In the above example, **app/home/feed.js** matches `/home/feed`, and **app/home/messages.js** matches `/home/messages`.
+In the above example, **app/home/feed.tsx** matches `/home/feed`, and **app/home/messages.tsx** matches `/home/messages`.
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 
 export default Stack;
 ```
 
-Both **app/home/\_layout.js** and **app/index.js** below are nested in the **app/\_layout.js** layout so that it will be rendered as a stack.
+Both **app/home/\_layout.tsx** and **app/index.tsx** below are nested in the **app/\_layout.tsx** layout so that it will be rendered as a stack.
 
-```jsx app/home/_layout.js
+```tsx app/home/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default Tabs;
 ```
 
-```jsx app/index.js
+```tsx app/index.tsx
 import { Link } from 'expo-router';
 
 export default function Root() {
@@ -47,9 +47,9 @@ export default function Root() {
 }
 ```
 
-Both **app/home/feed.js** and **app/home/messages.js** below are nested in the **home/\_layout.js** layout, so it will be rendered as a tab.
+Both **app/home/feed.tsx** and **app/home/messages.tsx** below are nested in the **home/\_layout.tsx** layout, so it will be rendered as a tab.
 
-```jsx app/home/feed.js
+```tsx app/home/feed.tsx
 import { View, Text } from 'react-native';
 
 export default function Feed() {
@@ -61,7 +61,7 @@ export default function Feed() {
 }
 ```
 
-```jsx app/home/messages.js
+```tsx app/home/messages.tsx
 import { View, Text } from 'react-native';
 
 export default function Messages() {
@@ -79,7 +79,7 @@ In React Navigation, navigating to a specific nested screen can be controlled by
 
 For example, from the initial screen inside the `root` navigator, you want to navigate to a screen called `media` inside `settings` (a nested navigator). In React Navigation, this is done as shown in the example below:
 
-```js React Navigation
+```jsx React Navigation
 navigation.navigate('root', {
   screen: 'settings',
   params: {
@@ -90,6 +90,6 @@ navigation.navigate('root', {
 
 In Expo Router, you can use `router.push()` to achieve the same result. There is no need to pass the screen name in the params explicitly.
 
-```js Expo Router
+```jsx Expo Router
 router.push('/root/settings/media');
 ```

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -13,7 +13,7 @@ While building your app, you may want to show specific content based on the curr
 
 You can use the [`Platform`](https://reactnative.dev/docs/platform-specific-code#platform-module) module from React Native to detect the current platform and render the appropriate content based on the result. For example, you can render a `Tabs` layout on native and a custom layout on the web.
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Platform } from 'react-native';
 import { Link, Slot, Tabs } from 'expo-router';
 
@@ -42,24 +42,24 @@ export default function Layout() {
 
 ## Platform specific extensions
 
-Metro bundler's platform-specific extensions (for example, **.ios.js** or **.native.ts**) are not supported in the **app** directory. This ensures that routes are universal across platforms for deep linking. However, you can create platform-specific files outside the **app** directory and use them from within the **app** directory.
+Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are not supported in the **app** directory. This ensures that routes are universal across platforms for deep linking. However, you can create platform-specific files outside the **app** directory and use them from within the **app** directory.
 
 Consider the following project:
 
 <FileTree
   files={[
-    'app/_layout.js',
-    'app/index.js',
-    'app/about.js',
-    'components/about.js',
-    'components/about.ios.js',
-    'components/about.web.js',
+    'app/_layout.tsx',
+    'app/index.tsx',
+    'app/about.tsx',
+    'components/about.tsx',
+    'components/about.ios.tsx',
+    'components/about.web.tsx',
   ]}
 />
 
 For example, the designs require you to build different `about` screens for each platform. In that case, you can create a component for each platform in the **components** directory using platform extensions. When imported, Metro will ensure the correct component version is used based on the current platform. You can then re-export the component as a screen in the **app** directory.
 
-```js app/about.js
+```tsx app/about.tsx
 export { default } from '../components/about';
 ```
 

--- a/docs/pages/router/advanced/root-layout.mdx
+++ b/docs/pages/router/advanced/root-layout.mdx
@@ -4,8 +4,8 @@ description: Learn how to use the root layout to add global providers to your ap
 hideTOC: true
 ---
 
-Traditional React Native projects are structured with a single root component that is often defined in **./App.js** or **./index.js**. This pattern is often used to inject global providers such as Redux, Themes, Styles, and so on, into the app, and to delay rendering until assets and fonts are loaded.
+Traditional React Native projects are structured with a single root component that is often defined in **App.tsx** or **index.tsx**. This pattern is often used to inject global providers such as Redux, Themes, Styles, and so on, into the app, and to delay rendering until assets and fonts are loaded.
 
-In Expo Router, you can use the **Root Layout** (**app/\_layout.js**) to add providers which can be accessed by any route in the app.
+In Expo Router, you can use the **Root Layout** (**app/\_layout.tsx**) to add providers which can be accessed by any route in the app.
 
 > Try to reduce the scope of your providers to only the routes that need them. This will improve performance and cause fewer rerenders.

--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -14,9 +14,9 @@ import { FileTree } from '~/ui/components/FileTree';
 
 When deep linking to a route, you may want to provide a user with a "back" button. The `initialRouteName` sets the default screen of the stack and should match a valid filename (without the extension).
 
-<FileTree files={['app/_layout.js', 'app/index.js', 'app/other.js']} />
+<FileTree files={['app/_layout.tsx', 'app/index.tsx', 'app/other.tsx']} />
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {
@@ -33,7 +33,7 @@ Now deep linking directly to `/other` or reloading the page will continue to sho
 
 When using [array syntax](/router/advanced/shared-routes/#arrays) `(foo,bar)` you can specify the name of a group in the `unstable_settings` object to target a particular segment.
 
-```js other.js
+```tsx other.tsx
 export const unstable_settings = {
   // Used for `(foo)`
   initialRouteName: 'first',

--- a/docs/pages/router/advanced/shared-routes.mdx
+++ b/docs/pages/router/advanced/shared-routes.mdx
@@ -8,17 +8,17 @@ import { FileTree } from '~/ui/components/FileTree';
 
 To match the same URL with different layouts, use [**groups**](/router/layouts#groups) with overlapping child routes. This pattern is very common in native apps. For example, in the X app, a profile can be viewed in every tab (such as home, search, and profile). However, there is only one URL that is required to access this route.
 
-In the example below, **app/\_layout.js** is the tab bar and each route has its own header. The **app/(profile)/[user].js** route is shared between each tab.
+In the example below, **app/\_layout.tsx** is the tab bar and each route has its own header. The **app/(profile)/[user].tsx** route is shared between each tab.
 
 <FileTree
   files={[
-    'app/_layout.js',
-    'app/(home)/_layout.js',
-    'app/(home)/[user].js',
-    'app/(search)/_layout.js',
-    'app/(search)/[user].js',
-    'app/(profile)/_layout.js',
-    'app/(profile)/[user].js',
+    'app/_layout.tsx',
+    'app/(home)/_layout.tsx',
+    'app/(home)/[user].tsx',
+    'app/(search)/_layout.tsx',
+    'app/(search)/[user].tsx',
+    'app/(profile)/_layout.tsx',
+    'app/(profile)/[user].tsx',
   ]}
 />
 
@@ -30,11 +30,11 @@ Shared routes can be navigated directly by including the group name in the route
 
 > Array syntax is an advanced concept that is unique to native app development.
 
-Instead of defining the same route multiple times with different layouts, use the array syntax `(,)` to duplicate the children of a group. For example, `app/(home,search)/[user].js` &mdash; creates `app/(home)/[user].js` and `app/(search)/[user].js` in memory.
+Instead of defining the same route multiple times with different layouts, use the array syntax `(,)` to duplicate the children of a group. For example, `app/(home,search)/[user].tsx` &mdash; creates `app/(home)/[user].tsx` and `app/(search)/[user].tsx` in memory.
 
 To distinguish between the two routes use a layout's `segment` prop:
 
-```jsx app/(home,search)/_layout.js
+```tsx app/(home,search)/_layout.tsx
 export default function DynamicLayout({ segment }) {
   if (segment === '(search)') {
     return <SearchStack />;

--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -17,7 +17,7 @@ There are three major elements that you can use to customize the appearance of y
 
 Expo Router extends the `expo-splash-screen` API to prevent white flash. Use it in conjunction with `expo-font` to keep the splash screen visible while fonts are loading:
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import {
   /* @info Import `SplashScreen` from `expo-router` instead of `expo-splash-screen` */
   SplashScreen,
@@ -76,7 +76,7 @@ Splash screens are required on native platforms. Expo Router automatically orche
 
 The default behavior is to hide the splash screen when the first route is rendered, this is optimal for the majority of routes. For some routes, you may want to prolong the splash screen until additional data or asset loading has concluded. This can be achieved with the `SplashScreen` module from `expo-router`. If `SplashScreen.preventAutoHideAsync` is called before the splash screen is hidden, then the splash screen will remain visible until the `SplashScreen.hideAsync()` function has been invoked.
 
-```jsx app/index.tsx
+```tsx app/index.tsx
 import { Text } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 

--- a/docs/pages/router/create-pages.mdx
+++ b/docs/pages/router/create-pages.mdx
@@ -11,10 +11,10 @@ When a file is created in the **app** directory, it automatically becomes a rout
 
 <FileTree
   files={[
-    ['app/index.js', "matches '/'"],
-    ['app/home.js', "matches '/home'"],
-    ['app/[user].js', "matches dynamic paths like '/expo' or '/evanbacon'"],
-    ['app/settings/index.js', "matches '/settings'"],
+    ['app/index.tsx', "matches '/'"],
+    ['app/home.tsx', "matches '/home'"],
+    ['app/[user].tsx', "matches dynamic paths like '/expo' or '/evanbacon'"],
+    ['app/settings/index.tsx', "matches '/settings'"],
   ]}
 />
 
@@ -22,7 +22,7 @@ When a file is created in the **app** directory, it automatically becomes a rout
 
 Pages are defined by exporting a React component as the default value from a file in the **app** directory. The file they are exported from must use one of the `.js`, `.jsx`, `.tsx`, `.ts` extensions.
 
-For example, create the **app** directory in your project and then create a file **index.js** inside it. Then, add the following snippet:
+For example, create the **app** directory in your project and then create a file **index.tsx** inside it. Then, add the following snippet:
 
 <Tabs>
 
@@ -30,7 +30,7 @@ For example, create the **app** directory in your project and then create a file
 
     Render text on any platform with the `<Text>` component from React Native.
 
-    ```jsx app/index.js
+    ```tsx app/index.tsx
     import { Text } from 'react-native';
 
     export default function Page() {
@@ -44,7 +44,7 @@ For example, create the **app** directory in your project and then create a file
 
     Alternatively, you can write web-only React components such as `<div>`, `<p>`, and so on. However, these won't render on native platforms.
 
-    ```jsx app/index.js
+    ```tsx app/index.tsx
     export default function Page() {
       return <p>Home page</p>;
     }
@@ -54,31 +54,31 @@ For example, create the **app** directory in your project and then create a file
 
 </Tabs>
 
-The above example matches the `/` route in the app and the browser. Files named **index** match the parent directory and do not add a path segment. For example, **app/settings/index.js** matches `/settings` in the app.
+The above example matches the `/` route in the app and the browser. Files named **index** match the parent directory and do not add a path segment. For example, **app/settings/index.tsx** matches `/settings` in the app.
 
 ## Platform specific extensions
 
 > **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](/router/advanced/platform-specific-modules).
 
-Metro bundler's platform-specific extensions (for example, **.ios.js** or **.native.ts**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
+Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
 
 Consider the following project structure:
 
 <FileTree
   files={[
-    'app/_layout.js',
-    'app/_layout.web.js',
-    'app/index.js',
-    'app/about.js',
-    'app/about.web.js',
+    'app/_layout.tsx',
+    'app/_layout.web.tsx',
+    'app/index.tsx',
+    'app/about.tsx',
+    'app/about.web.tsx',
   ]}
 />
 
 In the above file structure:
 
-- **\_layout.web.js** file is used as a layout on the web and **\_layout.js** is used on all other platforms.
-- **index.js** file is used as the home page for all platforms.
-- **about.web.js** file is used as the about page for the web, and the **about.js** file is used on all other platforms.
+- **\_layout.web.tsx** file is used as a layout on the web and **\_layout.tsx** is used on all other platforms.
+- **index.tsx** file is used as the home page for all platforms.
+- **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
 
 > **info** Providing a route file without a platform-specific extension is required to ensure every platform has a default implementation.
 
@@ -86,19 +86,19 @@ In the above file structure:
 
 Dynamic routes match any unmatched path at a given segment level.
 
-| Route                     | Matched URL          |
-| ------------------------- | -------------------- |
-| **app/blog/[slug].js**    | `/blog/123`          |
-| **app/blog/[...rest].js** | `/blog/123/settings` |
+| Route                      | Matched URL          |
+| -------------------------- | -------------------- |
+| **app/blog/[slug].tsx**    | `/blog/123`          |
+| **app/blog/[...rest].tsx** | `/blog/123/settings` |
 
-Routes with higher specificity will be matched before a dynamic route. For example, `/blog/bacon` will match **blog/bacon.js** before **blog/[id].js**.
+Routes with higher specificity will be matched before a dynamic route. For example, `/blog/bacon` will match **blog/bacon.tsx** before **blog/[id].tsx**.
 
-Multiple slugs can be matched in a single route by using the rest syntax (`...`). For example, **app/blog/[...id].js** matches `/blog/123/settings`.
+Multiple slugs can be matched in a single route by using the rest syntax (`...`). For example, **app/blog/[...id].tsx** matches `/blog/123/settings`.
 
 Dynamic segments are accessible as [route parameters](/router/reference/url-parameters) in the page component.
 
 {/* prettier-ignore */}
-```jsx app/blog/[slug].js
+```tsx app/blog/[slug].tsx
 /* @info Import the <b>useLocalSearchParams</b> React hook */
 import { useLocalSearchParams } from 'expo-router';
 /* @end */

--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -18,7 +18,7 @@ This guide specifies how to handle unmatched routes and errors in your app when 
 
 Native apps don't have a server so there are technically no 404s. However, if you're implementing a router universally, then it makes sense to handle missing routes. This is done automatically for each app, but you can also customize it.
 
-```js app/+not-found.js
+```tsx app/+not-found.tsx
 import { Unmatched } from 'expo-router';
 export default Unmatched;
 ```
@@ -38,7 +38,7 @@ Expo Router enables fine-tuned error handling to enable a more opinionated data-
 You can export a nested `ErrorBoundary` component from any route to intercept and format component-level errors using [React Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary):
 
 {/* prettier-ignore */}
-```jsx app/home.tsx
+```tsx app/home.tsx
 import { View, Text } from 'react-native';
 
 /* @info */
@@ -57,7 +57,7 @@ export default function Page() { ... }
 
 When you export an `ErrorBoundary` the route will be wrapped with a React Error Boundary effectively:
 
-```jsx Virtual
+```tsx Virtual
 function Route({ ErrorBoundary, Component }) {
   return (
     <Try catch={ErrorBoundary}>
@@ -84,7 +84,7 @@ Each `ErrorBoundary` is passed the following props:
 
 You can also use the default `ErrorBoundary` component for a quick UI:
 
-```js app/home.tsx
+```tsx app/home.tsx
 // Re-export the default UI
 export { ErrorBoundary } from 'expo-router';
 ```

--- a/docs/pages/router/layouts.mdx
+++ b/docs/pages/router/layouts.mdx
@@ -12,9 +12,9 @@ By default, routes fill the entire screen. Moving between them is a full-page tr
 
 ## Create a layout route
 
-To create a layout route for a directory, create a file named **\_layout.js** in the directory, and export a React component as `default`.
+To create a layout route for a directory, create a file named **\_layout.tsx** in the directory, and export a React component as `default`.
 
-```jsx app/home/_layout.js
+```tsx app/home/_layout.tsx
 import { Slot } from 'expo-router';
 
 export default function HomeLayout() {
@@ -24,7 +24,7 @@ export default function HomeLayout() {
 
 From the above example, **Slot** will render the current child route, think of this like the `children` prop in React. This component can be wrapped with other components to create a layout.
 
-```jsx app/home/_layout.js
+```tsx app/home/_layout.tsx
 import { Slot } from 'expo-router';
 
 export default function HomeLayout() {
@@ -40,9 +40,9 @@ export default function HomeLayout() {
 
 Expo Router supports adding a single layout route for a given directory. If you want to use multiple layout routes, add multiple directories:
 
-<FileTree files={['app/_layout.js', 'app/home/_layout.js', 'app/home/index.js']} />
+<FileTree files={['app/_layout.tsx', 'app/home/_layout.tsx', 'app/home/index.tsx']} />
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function Layout() {
@@ -50,7 +50,7 @@ export default function Layout() {
 }
 ```
 
-```jsx app/home/_layout.js
+```tsx app/home/_layout.tsx
 import { Stack } from 'expo-router';
 
 export default function Layout() {
@@ -64,8 +64,8 @@ If you want multiple layout routes without modifying the URL, you can use [group
 
 You can prevent a segment from showing in the URL by using the group syntax `()`.
 
-- **app/root/home.js** matches `/root/home`
-- **app/(root)/home.js** matches `/home`
+- **app/root/home.tsx** matches `/root/home`
+- **app/(root)/home.tsx** matches `/home`
 
 This is useful for adding layouts without adding additional segments to the URL. You can add as many groups as you want.
 
@@ -73,10 +73,10 @@ Groups are also good for organizing sections of the app. In the following exampl
 
 <FileTree
   files={[
-    'app/(app)/index.js',
-    'app/(app)/user.js',
-    'app/(aux)/terms-of-service.js',
-    'app/(aux)/privacy-policy.js',
+    'app/(app)/index.tsx',
+    'app/(app)/user.tsx',
+    'app/(aux)/terms-of-service.tsx',
+    'app/(aux)/privacy-policy.tsx',
   ]}
 />
 
@@ -84,7 +84,7 @@ Groups are also good for organizing sections of the app. In the following exampl
 
 One of the best advantages to React Native is being able to use native UI components. Expo Router provides a few drop-in native layouts that you can use to easily achieve familiar native behavior. To change between truly-native layouts on certain platforms and custom layouts on others, see [Platform-specific modules](/router/advanced/platform-specific-modules).
 
-```jsx app/home/_layout.js
+```tsx app/home/_layout.tsx
 import { Stack } from 'expo-router';
 
 export default function HomeLayout() {

--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -7,12 +7,12 @@ import { FileTree } from '~/ui/components/FileTree';
 
 Expo Router uses "links" to move between pages in the app. This is conceptually similar to how the web works with `<a>` tags and the `href` attribute.
 
-<FileTree files={['app/index.js', 'app/about.js', 'app/user/[id].js']} />
+<FileTree files={['app/index.tsx', 'app/about.tsx', 'app/user/[id].tsx']} />
 
 In the following example, there are two `<Link />` components which navigate to different routes.
 
 {/* prettier-ignore */}
-```jsx app/index.js
+```tsx app/index.tsx
 import { View } from 'react-native';
 /* @info Import the <strong>Link</strong> React component from <strong>expo-router</strong> */
 import { Link } from 'expo-router';
@@ -38,7 +38,7 @@ export default function Page() {
 The Link component wraps the children in a `<Text>` component by default, this is useful for accessibility but not always desired. You can customize the component by passing the `asChild` prop, which will forward all props to the first child of the `Link` component. The child component must support the `onPress` and `onClick` props, `href` and `role` will also be passed down.
 
 {/* prettier-ignore */}
-```jsx
+```tsx
 import { Pressable, Text } from "react-native";
 import { Link } from "expo-router";
 
@@ -78,7 +78,7 @@ To navigate, you can provide a full path (`/profile/settings`), a relative path 
 Dynamic routes and query parameters can be provided statically or with the convenience **Href** object.
 
 {/* prettier-ignore */}
-```jsx app/index.js
+```tsx app/index.tsx
 /* @info Import the <strong>Link</strong> React component from <strong>expo-router</strong> */
 import { Link } from 'expo-router';
 /* @end */
@@ -105,7 +105,7 @@ export default function Page() {
 By default, links `navigate` to the nearest route in the navigation stack, either by pushing a new route or unwinding to an existing route. You can use the `push` prop to always push the route onto the stack.
 
 {/* prettier-ignore */}
-```jsx app/index.js
+```tsx app/index.tsx
 import { Link } from 'expo-router';
 
 export default function Page() {
@@ -124,7 +124,7 @@ export default function Page() {
 By default, links "push" routes onto the navigation stack. It follows the same rules as [`navigation.navigate()`](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
 
 {/* prettier-ignore */}
-```jsx app/index.js
+```tsx app/index.tsx
 import { Link } from 'expo-router';
 
 export default function Page() {
@@ -146,7 +146,7 @@ Native navigation does not always support `replace`. For example on X, you would
 
 You can also navigate imperatively using the `router` object. This is useful when you need to perform a navigation action outside a React component, such as in an event handler or a utility function.
 
-```js
+```tsx
 import { router } from 'expo-router';
 
 export function logout() {

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -29,9 +29,9 @@ Server features require a custom Node.js server. Most hosting providers support 
 
 API Routes are functions that are executed when a route is matched. They can be used to handle sensitive data, such as API keys securely, or implement custom server logic. API Routes should be executed in a [WinterCG](https://wintercg.org/)-compliant environment.
 
-API Routes are defined by creating files in the **app** directory with the `+api.js` extension. For example, the following route handler is executed when the route `/hello` is matched.
+API Routes are defined by creating files in the **app** directory with the `+api.ts` extension. For example, the following route handler is executed when the route `/hello` is matched.
 
-<FileTree files={['app/index.js', ['app/hello+api.ts', 'API Route']]} />
+<FileTree files={['app/index.tsx', ['app/hello+api.ts', 'API Route']]} />
 
 ## Create an API route
 
@@ -39,7 +39,7 @@ API Routes are defined by creating files in the **app** directory with the `+api
 
 An API route is created in the **app** directory. For example, add the following route handler. It is executed when the route `/hello` is matched.
 
-```js app/hello+api.ts
+```ts app/hello+api.ts
 export function GET(request: Request) {
   return Response.json({ hello: 'world' });
 }
@@ -65,7 +65,7 @@ You can make a network request to the route to access the data. Run the followin
 
 You can also make a request from the client code:
 
-```js app/index.js
+```tsx app/index.tsx
 import { Button } from 'react-native';
 
 async function fetchHello() {
@@ -178,8 +178,8 @@ API Routes are bundled with Expo CLI and [Metro bundler](/guides/customizing-met
 
 Route handlers are executed in a sandboxed environment that is isolated from the client code. It means you can safely store sensitive data in the route handlers without exposing it to the client.
 
-- Client code that imports code with a secret is included in the client bundle. It applies to **all files** in the **app directory** even though they are not a route handler file (such as suffixed with **+api.js**).
-- If the secret is in a **&lt;...&gt;+api.js** file, it is not included in the client bundle. It applies to all files that are imported in the route handler.
+- Client code that imports code with a secret is included in the client bundle. It applies to **all files** in the **app directory** even though they are not a route handler file (such as suffixed with **+api.ts**).
+- If the secret is in a **&lt;...&gt;+api.ts** file, it is not included in the client bundle. It applies to all files that are imported in the route handler.
 - The secret stripping takes place in `expo/metro-config` and requires it to be used in the **metro.config.js**.
 
 ## Deployment
@@ -218,7 +218,7 @@ Export the website for production:
 
 Write a server entry file that serves the static files and delegates requests to the server routes:
 
-```js server.js
+```ts server.ts
 #!/usr/bin/env node
 
 const path = require('path');
@@ -268,7 +268,7 @@ app.listen(port, () => {
 
 Start the server with `node` command:
 
-<Terminal cmd={['$ node server.js']} />
+<Terminal cmd={['$ node server.ts']} />
 
 </Step>
 
@@ -280,7 +280,7 @@ Start the server with `node` command:
 
 Create a server entry file. All requests will be delegated through this middleware. The exact file location is important.
 
-```js netlify/functions/server.js
+```ts netlify/functions/server.ts
 const { createRequestHandler } = require('@expo/server/adapter/netlify');
 
 const handler = createRequestHandler({
@@ -362,7 +362,7 @@ If you're using any environment variables or **.env** files, add them to Netlify
 
 Create a server entry file. All requests will be delegated through this middleware. The exact file location is important.
 
-```js api/index.js
+```ts api/index.ts
 const { createRequestHandler } = require('@expo/server/adapter/vercel');
 
 module.exports = createRequestHandler({

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -35,29 +35,9 @@ Enable the feature by setting the `asyncRoutes` option in the Expo Router config
 
 <Tabs>
 
-<Tab label="SDK 49">
-
-    ```json app.json
-    {
-      "expo": {
-        "plugins": [
-          [
-            "expo-router",
-            {
-              "origin": "https://acme.com",
-              "asyncRoutes": "development"
-            }
-          ]
-        ]
-      }
-    }
-    ```
-
-</Tab>
-
 <Tab label="SDK 50 and above">
 
-    > SDK 50 supports production bundle splitting. Set `asyncRoutes` to `true` to enable it.
+    > SDK 50 and above supports production bundle splitting. Set `asyncRoutes` to `true` to enable it.
 
     ```json app.json
     {
@@ -79,6 +59,27 @@ Enable the feature by setting the `asyncRoutes` option in the Expo Router config
     ```
 
 </Tab>
+
+<Tab label="SDK 49">
+
+    ```json app.json
+    {
+      "expo": {
+        "plugins": [
+          [
+            "expo-router",
+            {
+              "origin": "https://acme.com",
+              "asyncRoutes": "development"
+            }
+          ]
+        ]
+      }
+    }
+    ```
+
+</Tab>
+
 </Tabs>
 
 You can set platform-specific settings (`default`, `android`, `ios` or `web`) for `asyncRoutes` using an object:

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -19,16 +19,16 @@ It's common to restrict specific routes to users who are not authenticated. This
 
 <FileTree
   files={[
-    'app/_layout.js',
+    'app/_layout.tsx',
     [
-      'app/sign-in.js',
+      'app/sign-in.tsx',
       <span>
         Always accessible <LockUnlocked01Icon className="inline mb-1" />
       </span>,
     ],
-    ['app/(app)/_layout.js', <span>Protects child routes</span>],
+    ['app/(app)/_layout.tsx', <span>Protects child routes</span>],
     [
-      'app/(app)/index.js',
+      'app/(app)/index.tsx',
       <span>
         Requires authorization <Lock01Icon className="inline mb-1" />
       </span>,
@@ -175,7 +175,7 @@ export function useStorageState(key: string): UseStateHook<string> {
 
 Use the `SessionProvider` in the root layout to provide the authentication context to the entire app. It's imperative that the `<Slot />` is mounted before any navigation events are triggered. Otherwise, a runtime error will be thrown.
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { Slot } from 'expo-router';
 import { SessionProvider } from '../ctx';
 
@@ -195,7 +195,7 @@ export default function Root() {
 
 Create a nested [layout route](/router/layouts) that checks whether users are authenticated before rendering the child route components. This layout route redirects users to the sign-in screen if they are not authenticated.
 
-```jsx app/(app)/_layout.js|collapseHeight=400
+```tsx app/(app)/_layout.tsx|collapseHeight=400
 import { Redirect, Stack } from 'expo-router';
 
 import { useSession } from '../../ctx';
@@ -227,7 +227,7 @@ export default function AppLayout() {
 
 Create the `/sign-in` screen. It can toggle the authentication using `signIn()`. Since this screen is outside the `(app)` group, the group's layout and authentication check do not run when rendering this screen. This lets logged-out users see this screen.
 
-```jsx app/sign-in.js|collapseHeight=480
+```tsx app/sign-in.tsx|collapseHeight=480
 import { router } from 'expo-router';
 import { Text, View } from 'react-native';
 
@@ -257,7 +257,7 @@ export default function SignIn() {
 
 Implement an authenticated screen that lets users sign out.
 
-```jsx app/(app)/index.js|collapseHeight=480
+```tsx app/(app)/index.tsx|collapseHeight=480
 import { Text, View } from 'react-native';
 
 import { useSession } from '../../ctx';
@@ -292,12 +292,12 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
 
 <FileTree
   files={[
-    ['app/_layout.js', 'Declares global session context'],
-    'app/(app)/_layout.js',
-    ['app/(app)/sign-in.js', <span>Modally presented over the root</span>],
-    ['app/(app)/(root)/_layout.js', <span>Protects child routes</span>],
+    ['app/_layout.tsx', 'Declares global session context'],
+    'app/(app)/_layout.tsx',
+    ['app/(app)/sign-in.tsx', <span>Modally presented over the root</span>],
+    ['app/(app)/(root)/_layout.tsx', <span>Protects child routes</span>],
     [
-      'app/(app)/(root)/index.js',
+      'app/(app)/(root)/index.tsx',
       <span>
         Requires authorization <Lock01Icon className="inline mb-1" />
       </span>,
@@ -305,7 +305,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
   ]}
 />
 
-```jsx app/(app)/_layout.js|collapseHeight=480
+```tsx app/(app)/_layout.tsx|collapseHeight=480
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {
@@ -339,9 +339,9 @@ To fix this, add a group and move conditional logic down a level.
 
 ### Before
 
-<FileTree files={['app/_layout.js', 'app/about.js']} />
+<FileTree files={['app/_layout.tsx', 'app/about.tsx']} />
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 export default function RootLayout() {
   React.useEffect(() => {
     // This navigation event will trigger the error above.
@@ -362,19 +362,19 @@ export default function RootLayout() {
 
 <FileTree
   files={[
-    ['app/_layout.js', ''],
-    ['app/(app)/_layout.js', 'Move conditional logic down a level'],
-    'app/(app)/about.js',
+    ['app/_layout.tsx', ''],
+    ['app/(app)/_layout.tsx', 'Move conditional logic down a level'],
+    'app/(app)/about.tsx',
   ]}
 />
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 export default function RootLayout() {
   return <Slot />;
 }
 ```
 
-```jsx app/(app)/_layout.js
+```tsx app/(app)/_layout.tsx
 export default function RootLayout() {
   React.useEffect(() => {
     router.push('/about');

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -17,7 +17,7 @@ In Expo Router, there's always a valid URL that represents the currently focused
 
 Given a function, the `useFocusEffect` hook will invoke the function whenever the route is "focused".
 
-```jsx
+```tsx
 /* @info */
 import { useFocusEffect } from 'expo-router';
 /* @end */
@@ -56,7 +56,7 @@ Refer to the [local vs global URL params](/router/reference/url-parameters/#loca
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```jsx app/profile/[user].tsx
+```tsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useGlobalSearchParams } from 'expo-router';
@@ -85,7 +85,7 @@ When `/abc/home` pushes `/123/shop`, `useGlobalSearchParams` returns `{ first: u
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```jsx app/profile/[user].tsx
+```tsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useLocalSearchParams } from 'expo-router';
@@ -106,7 +106,7 @@ export default function Route() {
 
 Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
 
-```jsx
+```tsx
 /* @info */
 import { useNavigation } from 'expo-router';
 /* @end */
@@ -135,9 +135,9 @@ When using nested layouts, you can access higher-order layouts by passing a seco
 
 <FileTree
   files={[
-    ['app/_layout.js', <code>useNavigation('/')</code>],
-    ['app/orders/_layout.js', <code>useNavigation('/orders')</code>],
-    ['app/orders/menu/_layout.js', <code>useNavigation('/orders/menu')</code>],
+    ['app/_layout.tsx', <code>useNavigation('/')</code>],
+    ['app/orders/_layout.tsx', <code>useNavigation('/orders')</code>],
+    ['app/orders/menu/_layout.tsx', <code>useNavigation('/orders/menu')</code>],
   ]}
 />
 
@@ -167,7 +167,7 @@ Returns the currently selected route location without search parameters. For exa
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```jsx app/profile/[user].tsx
+```tsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { usePathname } from 'expo-router';
@@ -188,7 +188,7 @@ export default function Route() {
 
 Returns a list of segments for the currently selected route. Segments are not normalized so that they will be the same as the file path. For example, `/[id]?id=normal` -> `["[id]"]`.
 
-```jsx app/profile/[user].tsx
+```tsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useSegments } from 'expo-router';
@@ -205,7 +205,7 @@ export default function Route() {
 
 This function can be typed using an abstract of string arrays:
 
-```jsx app/profile/[user].tsx
+```tsx app/profile/[user].tsx
 import { useSegments } from 'expo-router';
 
 export default function Route() {

--- a/docs/pages/router/reference/not-found.mdx
+++ b/docs/pages/router/reference/not-found.mdx
@@ -6,7 +6,7 @@ description: Learn how to handle server 404s and missing routes.
 
 > Available from Expo SDK 50 and Expo Router v3.
 
-404s can be handled by using a **+not-found.js** route. This route matches all unmatched routes from a nested level. This is similar to **[...wild].tsx**. However, unlike the deep dynamic routes, **+not-found.tsx** is matched after API routes.
+404s can be handled by using a **+not-found.tsx** route. This route matches all unmatched routes from a nested level. This is similar to **[...wild].tsx**. However, unlike the deep dynamic routes, **+not-found.tsx** is matched after API routes.
 
 On web, the server will first serve files in the following order:
 

--- a/docs/pages/router/reference/not-found.mdx
+++ b/docs/pages/router/reference/not-found.mdx
@@ -6,7 +6,7 @@ description: Learn how to handle server 404s and missing routes.
 
 > Available from Expo SDK 50 and Expo Router v3.
 
-404s can be handled by using a **+not-found.js** route. This route matches all unmatched routes from a nested level. This is similar to **[...wild].tsx**. However, unlike the deep dynamic routes, **+not-found.js** is matched after API routes.
+404s can be handled by using a **+not-found.js** route. This route matches all unmatched routes from a nested level. This is similar to **[...wild].tsx**. However, unlike the deep dynamic routes, **+not-found.tsx** is matched after API routes.
 
 On web, the server will first serve files in the following order:
 

--- a/docs/pages/router/reference/redirects.mdx
+++ b/docs/pages/router/reference/redirects.mdx
@@ -9,7 +9,7 @@ You can redirect a request to a different URL based on some in-app criteria. Exp
 
 You can immediately redirect from a particular screen by using the `Redirect` component:
 
-```jsx
+```tsx
 import { View, Text } from 'react-native';
 /* @info */
 import { Redirect } from 'expo-router';
@@ -38,7 +38,7 @@ export default function Page() {
 
 You can also redirect imperatively with the `useRouter` hook:
 
-```jsx
+```tsx
 import { Text } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 

--- a/docs/pages/router/reference/screen-tracking.mdx
+++ b/docs/pages/router/reference/screen-tracking.mdx
@@ -11,9 +11,9 @@ Unlike React Navigation, Expo Router always has access to a URL. This means scre
 1. Create a higher-order component that observes the currently selected URL
 2. Track the URL in your analytics provider
 
-<FileTree files={['app/_layout.js']} />
+<FileTree files={['app/_layout.tsx']} />
 
-```jsx app/_layout.js
+```tsx app/_layout.tsx
 import { useEffect } from 'react';
 import { usePathname, useGlobalSearchParams, Slot } from 'expo-router';
 

--- a/docs/pages/router/reference/sitemap.mdx
+++ b/docs/pages/router/reference/sitemap.mdx
@@ -27,9 +27,9 @@ You can also search for links directly in a browser like Safari or Chrome to tes
 
 Expo Router currently injects a **/\_sitemap** automatically that provides a list of all routes in the app. This is useful for debugging.
 
-To remove it, add a **app/\_sitemap.js** and return a null component:
+To remove it, add a **app/\_sitemap.tsx** and return a null component:
 
-```jsx app/_sitemap.js
+```tsx app/_sitemap.tsx
 export default function Sitemap() {
   return null;
 }

--- a/docs/pages/router/reference/src-directory.mdx
+++ b/docs/pages/router/reference/src-directory.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 As your project grows, it can be helpful to move all the directories containing application code into a single **src** directory. Expo Router supports this out of the box.
 
 <FileTree
-  files={['src/app/_layout.js', 'src/app/index.js', 'src/components/button.js', 'package.json']}
+  files={['src/app/_layout.tsx', 'src/app/index.tsx', 'src/components/button.tsx', 'package.json']}
 />
 
 Simply move your **app** directory to **src/app** and restart the development server.
@@ -25,7 +25,7 @@ Simply move your **app** directory to **src/app** and restart the development se
 
 **Notes**:
 
-- The config files (**app.config.js**, **app.json**, **package.json**, **metro.config.js**, **tsconfig.json**) should remain in the root directory.
+- The config files (**app.config.tsx**, **app.json**, **package.json**, **metro.config.js**, **tsconfig.json**) should remain in the root directory.
 - The **src/app** directory takes higher precedence than the root **app** directory. Only the **src/app** directory will be used if you have both.
 - The **public** directory should remain in the root directory.
 - Static rendering will automatically use the **src/app** directory if it exists.

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -318,7 +318,7 @@ Expo Font has automatic static optimization for font loading in Expo Router. Whe
 
 The following snippet will load Inter into the namespace and statically optimize on web:
 
-```js app/home.js
+```tsx app/home.tsx
 import { Text } from 'react-native';
 import { useFonts } from 'expo-font';
 

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -29,13 +29,13 @@ Both hooks are typed and accessed the same way. However, the only difference is 
 
 The example below demonstrates the difference between `useLocalSearchParams` and `useGlobalSearchParams`. It uses the following **app** directory structure:
 
-<FileTree files={['app/_layout.js', 'app/index.js', 'app/[user].js']} />
+<FileTree files={['app/_layout.tsx', 'app/index.tsx', 'app/[user].tsx']} />
 
 <Step label="1">
 
     The Root Layout is a stack navigator:
 
-    ```jsx app/_layout.js
+    ```tsx app/_layout.tsx
     import { Stack } from 'expo-router';
 
     export default function Layout() {
@@ -47,9 +47,9 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
 <Step label="2">
 
-    The initial route redirects to the dynamic route **app/[user].js**, with **user=evanbacon**:
+    The initial route redirects to the dynamic route **app/[user].tsx**, with **user=evanbacon**:
 
-    ```jsx app/index.js
+    ```tsx app/index.tsx
     import { Redirect } from 'expo-router';
 
     export default function Route() {
@@ -63,7 +63,7 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
     The dynamic route **app/[user]** prints out the global and local URL parameters (route parameters, in this case). It also allows for pushing new instances of the same route with different **route parameters**:
 
-    ```jsx app/[user].js
+    ```tsx app/[user].tsx
     import { Text, View } from 'react-native';
     import { useLocalSearchParams, useGlobalSearchParams, Link } from 'expo-router';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #30215

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change `.js` and `jsx` references to `.tsx` and `.ts` appropriately for code examples under Expo Router docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and going through each page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
