### PR TITLE
[docs] Remove multiple Expo Router version specifications from callouts and other places

### DIFF
--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -6,7 +6,7 @@ description: Learn how to seamlessly continue app navigation across Apple device
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 
-Apple Handoff is a feature that enables users to continue browsing your app or website on another device. Expo Router v2 automates all of the runtime routing for this feature. However, the one-time configuration must be set up manually.
+Apple Handoff is a feature that enables users to continue browsing your app or website on another device. Expo Router automates all of the runtime routing for this feature. However, the one-time configuration must be set up manually.
 
 In Expo Router, the underlying iOS API (`NSUserActivity`) requires a `webpageUrl` which the OS recommends as the current URL for switching to your app. The `expo-router/head` component has an optional native module that can automatically set the `webpageUrl` to the currently focused route in Expo Router.
 

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -57,7 +57,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 <Tab label="SDK 50 and higher">
 
-Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. It is required as of Expo Router v3 and greater. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
+Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
 
 ```tsx app/_layout.tsx
 import { GestureHandlerRootView } from 'react-native-gesture-handler';

--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -70,8 +70,6 @@ We recommend you use Expo Image for the best cross-platform experience:
 
 ## Splash screen
 
-> In Expo Router v3 and greater, you can import SplashScreen from `expo-splash-screen` directly.
-
 Splash screens are required on native platforms. Expo Router automatically orchestrates the native splash screen to keep it visible until the first route is rendered, this applies to any route that the user deep links into. To enable this functionality, [install `expo-splash-screen`](/versions/latest/sdk/splash-screen/#installation) in your project.
 
 The default behavior is to hide the splash screen when the first route is rendered, this is optimal for the majority of routes. For some routes, you may want to prolong the splash screen until additional data or asset loading has concluded. This can be achieved with the `SplashScreen` module from `expo-router`. If `SplashScreen.preventAutoHideAsync` is called before the splash screen is hidden, then the splash screen will remain visible until the `SplashScreen.hideAsync()` function has been invoked.

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -173,7 +173,7 @@ After updating the Babel config file, run the following command to clear the bun
 </Tab>
 
   <Tab label="SDK 49">
-    Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 / Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
+    Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 and Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
 
     <Tabs>
       <Tab label="Yarn">

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -3,7 +3,7 @@ title: API Routes
 description: Learn how to create server endpoints with Expo Router.
 ---
 
-> **warning** This feature is still experimental. Available from Expo SDK 50 and Expo Router v3.
+> **warning** API Routes is an experimental feature. Available from Expo Router v3.
 
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -7,7 +7,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This feature is experimental. Available from Expo SDK 49 and Expo Router v2.
+> **warning** Asycn routes feature is experimental.
 
 <ContentSpotlight file="expo-router/async-routes.mp4" loop={false} />
 

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -7,7 +7,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **warning** Asycn routes feature is experimental.
+> **warning** Async routes is an experimental feature.
 
 <ContentSpotlight file="expo-router/async-routes.mp4" loop={false} />
 

--- a/docs/pages/router/reference/faq.mdx
+++ b/docs/pages/router/reference/faq.mdx
@@ -46,7 +46,7 @@ If file-based routing isn't right for your project, you can drop down to React N
 
 ## How do I server-render my Expo Router website?
 
-Basic static rendering (SSG) is supported in Expo Router v2. Server-side rendering currently requires custom infrastructure to set up.
+Basic static rendering (SSG) is supported in Expo Router. Server-side rendering currently requires custom infrastructure to set up.
 
 ## Can I use React Navigation?
 

--- a/docs/pages/router/reference/not-found.mdx
+++ b/docs/pages/router/reference/not-found.mdx
@@ -4,8 +4,6 @@ hideTOC: true
 description: Learn how to handle server 404s and missing routes.
 ---
 
-> Available from Expo SDK 50 and Expo Router v3.
-
 404s can be handled by using a **+not-found.tsx** route. This route matches all unmatched routes from a nested level. This is similar to **[...wild].tsx**. However, unlike the deep dynamic routes, **+not-found.tsx** is matched after API routes.
 
 On web, the server will first serve files in the following order:

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -62,7 +62,7 @@ You can also [learn more](/guides/customizing-metro/) about customizing Metro.
     </Tab>
     <Tab label="Expo Router v2">
 
-    Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 / Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
+    Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 and Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
 
     <Tabs>
       <Tab label="Yarn">
@@ -361,7 +361,7 @@ This generates the following static HTML:
 
 ### How do I add a custom server?
 
-As of Expo Router v2 there is no prescriptive way to add a custom server. You can use any server you want. However, you will need to handle dynamic routes yourself. You can use the `generateStaticParams` function to generate static HTML files for known routes.
+There is no prescriptive way to add a custom server. You can use any server you want. However, you will need to handle dynamic routes yourself. You can use the `generateStaticParams` function to generate static HTML files for known routes.
 
 In the future, there will be a server API, and a new `web.output` mode which will generate a project that will (amongst other things) support dynamic routes.
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -7,8 +7,6 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ## `EXPO_ROUTER_APP_ROOT` not defined
 
-> This applies to Expo Router v1 and the beta release.
-
 If `process.env.EXPO_ROUTER_APP_ROOT` is not defined you'll see the following error:
 
 <Terminal

--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -5,7 +5,7 @@ description: Learn how to use statically typed links and routes in Expo Router.
 
 import { FileTree } from '~/ui/components/FileTree';
 
-> Available from Expo SDK 49 and Expo Router v2 when using TypeScript. Expo Router supports standard TypeScript out of the box. See the [TypeScript](/guides/typescript/) guide for more information on how to set it up.
+> Available when using TypeScript in your project. Expo Router supports standard TypeScript out of the box. See the [TypeScript](/guides/typescript/) guide for more information on how to set it up.
 
 Expo Router supports generating TypeScript types automatically with Expo CLI. This enables `<Link>`, and the [hooks API](/router/reference/hooks) to be statically typed. This feature is currently in beta and is not enabled by default.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #30315 to avoid confusion about instructions used in either callouts or plain text to avoid leading to confusion.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove Expo Router specific version references from different callouts and content.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
