### PR TITLE
Add either getter failing test on Android

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
+import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.Either
 import org.junit.Test
 import java.net.URL
@@ -51,4 +52,13 @@ class EitherTypeConversionTest {
       jsValue = "123",
       map = { false }
     )
+  @Test
+  fun either_with_non_overlapping_types_should_not_throw_on_getter() = conversionTest(
+    jsValue = "123",
+    nativeAssertion = { either: Either<Int, TypedArray> ->
+      Truth.assertThat(either.`get`(Int::class)).isEqualTo(123)
+      Truth.assertThat(either.`get`(TypedArray::class)).isNull()
+    },
+    map = { false }
+  )
 }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/DateTypeConverterTest.kt
@@ -25,7 +25,7 @@ class DateTypeConverterTest {
 
   @Test
   fun `converts from Number to LocalDate`() {
-    val date = convert<LocalDate>(1703718341639)
+    val date = convert<LocalDate>(1703678741639)
     Truth.assertThat(date.month).isEqualTo(Month.DECEMBER)
     Truth.assertThat(date.monthValue).isEqualTo(12)
     Truth.assertThat(date.dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)


### PR DESCRIPTION
# Why

We have different behaviour for similar code in core. This is either misleading in the docs, or not working correctly on one platform.

![image](https://github.com/expo/expo/assets/5597580/b0de6176-058d-4039-a1ef-10ce89fe5a68)


If the either types are not convertible, on iOS something like this works as expected, not running the codeblocks if the either inner value is not of the specific type:

```
Function("write") { (file, content: Either<String, TypedArray>) in
  if let content: String = content.get() {
    try file.write(content)
  }
  if let content: TypedArray = content.get() {
    try file.write(content)
  }
}
```

On Android, this ends up with a `kotlin.TypeCastException`, attempting to convert the either inner value to a type that is not convertible by default, instead of returning nil from get and not triggering the `let` block.

```
Function("write") { file: FileSystemFile, content: Either<String, TypedArray> ->
  content.get(String::class).let {
    file.write(it)
  }
  content.get(TypedArray::class).let { // Method threw 'kotlin.TypeCastException' exception.
    file.write(it)
  }
}
```

I think we should align to iOS spec.