### PR TITLE
Add error on setting getter only properties

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 💡 Others
 
+- [Android] Throw errors on trying to set a getter only property.
 - [Android] Use getter methods in convertibles. ([#30239](https://github.com/expo/expo/pull/30239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))
 - [web] Use global `crypto` object for UUID. ([#29828](https://github.com/expo/expo/pull/29828) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### 💡 Others
 
-- [Android] Throw errors on trying to set a getter only property.
+- [Android] Throw errors on trying to set a getter only property. ([#30321](https://github.com/expo/expo/pull/30321) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Use getter methods in convertibles. ([#30239](https://github.com/expo/expo/pull/30239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Change `sideEffects` to use `src` folder. ([#29964](https://github.com/expo/expo/pull/29964) by [@EvanBacon](https://github.com/EvanBacon))
 - [web] Use global `crypto` object for UUID. ([#29828](https://github.com/expo/expo/pull/29828) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import org.junit.Assert
 import org.junit.Test
 
 internal class JSIPropertiesTest {
@@ -47,6 +49,19 @@ internal class JSIPropertiesTest {
 
     Truth.assertThat(p1).isEqualTo(987)
     Truth.assertThat(p2).isEqualTo(123)
+  }
+
+  @Test
+  fun should_throw_if_setting_a_getter_only_property() = withSingleModule({
+    var innerValue = 567
+    Property("p")
+      .get { innerValue }
+  }) {
+    Assert.assertThrows(JavaScriptEvaluateException::class.java) {
+      evaluateScript("$moduleRef.p = 1")
+    }
+    val p1 = property("p").getInt()
+    Truth.assertThat(p1).isEqualTo(567)
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -41,7 +41,9 @@ class PropertyComponent(
         return@JNIFunctionBody null
       }
     } else {
-      null
+      JNIFunctionBody {
+        throw Exception("Cannot assign to property $name which has only a getter")
+      }
     }
 
     jsObject.registerProperty(


### PR DESCRIPTION
# Why

Should properties with only a getter throw an error when being assigned to from JS?
This is behaviour on iOS that I think makes sense to port over.

# Test Plan

Added native test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
