### PR TITLE
[docs] cleanup of router examples code

### DIFF
--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -169,7 +169,7 @@ You can test the Apple App Site Association file (**public/.well-known/apple-app
 
 If you're having issues, the best thing you can do is enable the most aggressive handoff settings in your app. This ensures that any possible route is linkable. You can do this by making sure that **public/.well-known/apple-app-site-association** file matches all routes:
 
-```json title=public/.well-known/apple-app-site-association
+```json public/.well-known/apple-app-site-association
 {
   "applinks": {
     "details": [

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -262,8 +262,9 @@ export default function Layout() {
       <Stack.Screen
         name="[profile]"
         getId={
-          /* @info Returning a new ID every time will cause every page to push. */ ({ params }) =>
-            String(Date.now()) /* @end */
+          /* @info Returning a new ID every time will cause every page to push. */
+          ({ params }) => String(Date.now())
+          /* @end */
         }
       />
     </Stack>
@@ -285,9 +286,9 @@ Dismiss is different from `back` as it targets the closest stack and not the cur
 
 {/* prettier-ignore */}
 ```tsx app/settings.tsx
-import { Button, View, Text } from "react-native";
+import { Button, View } from 'react-native';
 /* @info Import <CODE>useRouter</CODE> from Expo Router. */
-import { useRouter } from "expo-router";
+import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
@@ -295,14 +296,14 @@ export default function Settings() {
   const router = useRouter();
   /* @end */
 
-  const handleDismiss = (count) => {
+  const handleDismiss = (count: number) => {
     /* @info In the handler method, call <CODE>router.dismiss</CODE> to go back. */
     router.dismiss(count)
     /* @end */
   };
 
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       /* @info Trigger the handler method on a touchable or button component. */
       <Button title="Go to first screen" onPress={() => handleDismiss(3)} />
       /* @end */
@@ -319,9 +320,9 @@ For example, the `home` route is the first screen, and the `settings` is the las
 
 {/* prettier-ignore */}
 ```tsx app/settings.tsx
-import { Button, View, Text } from "react-native";
+import { Button, View, Text } from 'react-native';
 /* @info Import <CODE>useRouter</CODE> from Expo Router. */
-import { useRouter } from "expo-router";
+import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
@@ -336,7 +337,7 @@ export default function Settings() {
   };
 
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       /* @info Trigger the handler method on a touchable or button component. */
       <Button title="Go to first screen" onPress={handleDismissAll} />
       /* @end */
@@ -350,10 +351,10 @@ export default function Settings() {
 To check if it is possible to dismiss the current screen. Returns `true` if the router is within a stack with more than one screen in the stack's history.
 
 {/* prettier-ignore */}
-```jsx app/settings.js|collapseHeight=410
-import { Button, View, Text } from "react-native";
+```tsx app/settings.tsx|collapseHeight=410
+import { Button, View } from 'react-native';
 /* @info Import <CODE>useRouter</CODE> from Expo Router. */
-import { useRouter } from "expo-router";
+import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
@@ -361,7 +362,7 @@ export default function Settings() {
   const router = useRouter();
   /* @end */
 
-  const handleDismiss = (count) => {
+  const handleDismiss = (count: number) => {
     /* @info Check if we can dismiss. */
     if (router.canDismiss()) {
       /* @info In the handler method, call <CODE>router.dismiss</CODE> to go back to. */
@@ -372,7 +373,7 @@ export default function Settings() {
   };
 
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       /* @info Trigger the handler method on a touchable or button component. */
       <Button title="Maybe dismiss" onPress={() => handleDismiss()} />
       /* @end */

--- a/docs/pages/router/appearance.mdx
+++ b/docs/pages/router/appearance.mdx
@@ -26,6 +26,7 @@ import {
   Slot,
 } from 'expo-router';
 import { useFonts, Inter_500Medium } from '@expo-google-fonts/inter';
+import { useEffect } from 'react';
 
 /* @info Prevent hiding the splash screen after the navigation has mounted. */
 SplashScreen.preventAutoHideAsync();
@@ -77,15 +78,16 @@ The default behavior is to hide the splash screen when the first route is render
 ```tsx app/index.tsx
 import { Text } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
+import { useEffect, useState } from 'react';
 
 /* @info Prevent hiding the splash screen after the navigation has mounted. */
 SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
-  const [isReady, setReady] = React.useState(false);
+  const [isReady, setReady] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Perform some sort of async data or asset fetching.
     setTimeout(() => {
       // When all loading is setup, unmount the splash screen component.
@@ -105,7 +107,7 @@ Expo Router comes with the `react-native-safe-area-context` library installed. T
 To use it, import the `SafeAreaProvider` component from `react-native-safe-area-context` and wrap your root layout with it:
 
 ```tsx app/_layout_.tsx
-/* @hide Other import statements */ /* @end */
+import { Stack } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 function RootLayoutNav() {
@@ -114,7 +116,7 @@ function RootLayoutNav() {
   return (
     <SafeAreaProvider>
       <Stack>
-        <Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen name="index" options={{ headerShown: false }} />
       </Stack>
     </SafeAreaProvider>
   );
@@ -124,7 +126,7 @@ function RootLayoutNav() {
 On a page component, you can use `<SafeAreaView>` component or `useSafeAreaInsets` hook to access the safe area insets and use them with `<View>`. The following example shows how to use `useSafeAreaInsets`:
 
 ```tsx app/index.tsx
-import { StyleSheet, View, Text } from 'react-native';
+import { View, Text } from 'react-native';
 /* @info Import useSafeAreaInsets hook */ import { useSafeAreaInsets } from 'react-native-safe-area-context'; /* @end */
 
 export default function TabOneScreen() {
@@ -132,9 +134,9 @@ export default function TabOneScreen() {
 
   return (
     /* @info You can use "insets.top" to apply the top padding from the useSafeAreaInsets() hook.*/
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={{ paddingTop: insets.top }}>
       /* @end */
-      <Text style={styles.title}>Home page</Text>
+      <Text>Home page</Text>
     </View>
   );
 }
@@ -146,7 +148,7 @@ React Navigation navigators `<Stack>`, `<Drawer>`, and `<Tabs>` use a shared app
 
 ```tsx app/_layout.tsx
 /* @info Import theme APIs from React Navigation directly. */
-import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
+import { ThemeProvider, DarkTheme } from '@react-navigation/native';
 /* @end */
 import { Slot } from 'expo-router';
 

--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -40,14 +40,15 @@ You can export a nested `ErrorBoundary` component from any route to intercept an
 {/* prettier-ignore */}
 ```tsx app/home.tsx
 import { View, Text } from 'react-native';
+import { type ErrorBoundaryProps } from 'expo-router';
 
 /* @info */
-export function ErrorBoundary(props: ErrorBoundaryProps) {
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
 /* @end */
   return (
     <View style={{ flex: 1, backgroundColor: "red" }}>
-      <Text>{props.error.message}</Text>
-      <Text onPress={props.retry}>Try Again?</Text>
+      <Text>{error.message}</Text>
+      <Text onPress={retry}>Try Again?</Text>
     </View>
   );
 }

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -347,7 +347,7 @@ The [`fallback`](https://reactnavigation.org/docs/navigation-container/#fallback
 
 In React Navigation, you set the theme for the entire app using the [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/#theme) component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import { Slot } from 'expo-router';
 

--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -39,8 +39,8 @@ The Link component wraps the children in a `<Text>` component by default, this i
 
 {/* prettier-ignore */}
 ```tsx
-import { Pressable, Text } from "react-native";
-import { Link } from "expo-router";
+import { Pressable, Text } from 'react-native';
+import { Link } from 'expo-router';
 
 export default function Page() {
   return (
@@ -82,6 +82,7 @@ Dynamic routes and query parameters can be provided statically or with the conve
 /* @info Import the <strong>Link</strong> React component from <strong>expo-router</strong> */
 import { Link } from 'expo-router';
 /* @end */
+import { View } from 'react-native';
 
 export default function Page() {
   return (
@@ -89,7 +90,7 @@ export default function Page() {
       <Link
         href={{
           /* @info Navigate to <strong>/user/bacon</strong> */
-          pathname: "/user/[id]",
+          pathname: '/user/[id]',
           params: { id: 'bacon' }
           /* @end */
         }}>

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -45,10 +45,10 @@ To follow the above example, set up a [React Context provider](https://react.dev
 This provider uses a mock implementation. You can replace it with your own [authentication provider](/guides/authentication/).
 
 ```tsx ctx.tsx
-import React from 'react';
+import { useContext, createContext, type PropsWithChildren } from 'react';
 import { useStorageState } from './useStorageState';
 
-const AuthContext = React.createContext<{
+const AuthContext = createContext<{
   signIn: () => void;
   signOut: () => void;
   session?: string | null;
@@ -62,7 +62,7 @@ const AuthContext = React.createContext<{
 
 // This hook can be used to access the user info.
 export function useSession() {
-  const value = React.useContext(AuthContext);
+  const value = useContext(AuthContext);
   if (process.env.NODE_ENV !== 'production') {
     if (!value) {
       throw new Error('useSession must be wrapped in a <SessionProvider />');
@@ -72,7 +72,7 @@ export function useSession() {
   return value;
 }
 
-export function SessionProvider(props: React.PropsWithChildren) {
+export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, session], setSession] = useStorageState('session');
 
   return (
@@ -88,7 +88,7 @@ export function SessionProvider(props: React.PropsWithChildren) {
         session,
         isLoading,
       }}>
-      {props.children}
+      {children}
     </AuthContext.Provider>
   );
 }
@@ -196,6 +196,7 @@ export default function Root() {
 Create a nested [layout route](/router/layouts) that checks whether users are authenticated before rendering the child route components. This layout route redirects users to the sign-in screen if they are not authenticated.
 
 ```tsx app/(app)/_layout.tsx|collapseHeight=400
+import { Text } from 'react-native';
 import { Redirect, Stack } from 'expo-router';
 
 import { useSession } from '../../ctx';
@@ -294,7 +295,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
   files={[
     ['app/_layout.tsx', 'Declares global session context'],
     'app/(app)/_layout.tsx',
-    ['app/(app)/sign-in.tsx', <span>Modally presented over the root</span>],
+    ['app/(app)/sign-in.tsx', <span>Modal presented over the root</span>],
     ['app/(app)/(root)/_layout.tsx', <span>Protects child routes</span>],
     [
       'app/(app)/(root)/index.tsx',

--- a/docs/pages/router/reference/faq.mdx
+++ b/docs/pages/router/reference/faq.mdx
@@ -8,7 +8,7 @@ sidebar_title: FAQ
 
 If you set up a modal or another screen that is expected to have a back button, then you'll need to add [`unstable_settings`](/router/advanced/router-settings/) to the route's layout to ensure the initial route is configured. Initial routes are somewhat unique to mobile apps and therefore fit awkwardly in the system &mdash; improvements pending.
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 export const unstable_settings = {
   initialRouteName: 'index',
 };

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -107,6 +107,7 @@ export default function Route() {
 Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
 
 ```tsx
+import { Text, View } from 'react-native';
 /* @info */
 import { useNavigation } from 'expo-router';
 /* @end */

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -216,7 +216,7 @@ You can customize the root HTML file by creating an **app/+html.tsx** file in yo
 
 ```tsx app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -210,12 +210,12 @@ The following example uses a `<TextInput>` to update the search parameter **q**:
 
 ```tsx app/search.tsx
 import { useLocalSearchParams, router } from 'expo-router';
-import React from 'react';
+import { useState } from 'react';
 import { TextInput, View } from 'react-native';
 
 export default function Page() {
-  const params = useLocalSearchParams<{ q?: string }>();
-  const [search, setSearch] = React.useState(params.q);
+  const params = useLocalSearchParams<{ query?: string }>();
+  const [search, setSearch] = useState(params.query);
 
   return (
     <TextInput
@@ -223,7 +223,7 @@ export default function Page() {
       onChangeText={search => {
         setSearch(search);
         /* @info Set the search parameter <b>q</b> to the text input <b>search</b> */
-        router.setParams({ q: search });
+        router.setParams({ query: search });
         /* @end */
       }}
       placeholderTextColor="#A0A0A0"

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -222,7 +222,7 @@ export default function Page() {
       value={search}
       onChangeText={search => {
         setSearch(search);
-        /* @info Set the search parameter <b>q</b> to the text input <b>search</b> */
+        /* @info Set the search parameter <b>query</b> to the text input <b>search</b> */
         router.setParams({ query: search });
         /* @end */
       }}


### PR DESCRIPTION
# Why

Follow up to #30316

# How

Add missing imports, add missing types, few renames, reformats and quotes cleanup.

# Test Plan

The changes have been reviewed by running docs app locally.
