### PR TITLE
[docs] Update Safe areas guide for default template

### DIFF
--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -3,7 +3,6 @@ title: Safe areas
 description: Learn how to add safe areas for screen components inside your Expo project.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -32,21 +31,15 @@ Using the library, the result of the previous example changes as it displays the
 
 ### Installation
 
-The [`default`](https://github.com/expo/expo/tree/main/templates/expo-template-default) Expo template comes with `react-native-safe-area-context` installed as a peer dependency. The library is used by Expo Router.
-
-<Collapsible summary="Manual installation instruction when using a different Expo template">
-
-If you're using a different [Expo template](/more/create-expo/#--template), install `react-native-safe-area-context` by running following command:
+You can skip installing `react-native-safe-area-context` if you have created a project using [the default template](/get-started/create-a-project/). This library is installed as peer dependency for Expo Router library. Otherwise, install this library by running the following command:
 
 <Terminal cmd={['$ npx expo install react-native-safe-area-context']} />
-
-</Collapsible>
 
 ### Usage
 
 <Step label="1">
 
-Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider). If your project uses Expo Router, add it to the [root layout (**app/\_layout.tsx**)](/develop/file-based-routing/#_layout-file) file. Otherwise, add it to the root component (such as **App.tsx** file).
+Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider). If your project uses Expo Router, add it to the [root layout (**app/\_layout.tsx**)](/develop/file-based-routing/#_layout-file) file. Otherwise, add it to the root component file (such as **App.tsx**).
 
 ```tsx app/_layout.tsx
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -62,7 +55,7 @@ function RootLayout() {
 }
 ```
 
-> **Note:** In the above example, the `Stack` is wrapping one screen. Your project's root layout file may have more than one screen. The `index` screen is used here an example for a screen component.
+> **Note:** In the above example, the `Stack` is wrapping one screen. Your project's root layout file may have more than one screen. The `index` screen is used here an example to represent a screen component.
 
 </Step>
 
@@ -87,7 +80,7 @@ export default function HomeScreen() {
 
 ## Alternate: `useSafeAreaInsets` hook
 
-Alternate to `SafeAreaView`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It gives direct access to the safe area insets. It offers more flexibility and gives you more control. You can apply padding for each edge using an inset from this hook directly to the `<View>`.
+Alternate to `SafeAreaView`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It provides direct access to the safe area insets, allowing you to apply padding for each edge of the `<View>` using an inset from this hook.
 
 The example below uses the `useSafeAreaInsets` hook. It applies top padding to a `<View>` using `insets.top`.
 

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -87,7 +87,7 @@ export default function HomeScreen() {
 
 ## Alternate: `useSafeAreaInsets` hook
 
-Alternate to `<SafeAreaView>`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It gives direct access to the safe area insets. It offers more flexibility and gives you more control. You can apply padding for each edge using an inset from this hook directly to the `<View>`.
+Alternate to `SafeAreaView`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It gives direct access to the safe area insets. It offers more flexibility and gives you more control. You can apply padding for each edge using an inset from this hook directly to the `<View>`.
 
 The example below uses the `useSafeAreaInsets` hook. It applies top padding to a `<View>` using `insets.top`.
 
@@ -155,4 +155,4 @@ By default, React Navigation supports safe areas and uses `react-native-safe-are
 
 ### Usage with web
 
-If you are targeting the web, set up `<SafeAreaProvider>` as described in the [usage section](#usage). If you are doing server-side rendering (SSR), see the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.
+If you are targeting the web, set up `SafeAreaProvider` as described in the [usage section](#usage). If you are doing server-side rendering (SSR), see the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -1,69 +1,114 @@
 ---
 title: Safe areas
-description: Learn how to add safe areas for your Expo project and other best practices.
+description: Learn how to add safe areas for screen components inside your Expo project.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
-Creating a safe area is a great way to ensure that your app's content is appropriately positioned around notches, status bars, home indicators, and other device and operating system interface elements.
+Creating a safe area ensures your app screen's content is positioned correctly. This means it doesn't get overlapped by notches, status bars, home indicators, and other interface elements. When the content gets overlapped, it gets concealed by these interface elements.
 
-When the content on your app's screen is not positioned within the safe area, it can be obscured by the device's interface elements, as shown in the example below:
+Here's an example of an app screen's content concealed by the status bar on Android. On iOS, the same content is concealed by rounded corners, notch, and the status bar.
 
 <ContentSpotlight
   alt="Without defining a safe area, the content can be obscured by the device's interface elements."
   src="/static/images/safe-area/without-safe-area.png"
-  className="max-w-[540px]"
+  className="max-w-[480px]"
 />
 
-The content is positioned at the top of the screen in the above example. On Android, it is concealed by the status bar. On iOS, it is concealed by the rounder corners, the notch, and the status bar.
+## Use `react-native-safe-area-context` library
 
-## Use `react-native-safe-area-context`
-
-[`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context) provides a flexible API for accessing device-safe area inset information for both Android and iOS. It also provides a `SafeAreaView` component that you can use in place of View to inset your views to account for safe areas automatically.
+[`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context) provides a flexible API for handling Android and iOS device's safe area insets. It also provides a `SafeAreaView` component that you can use instead of a [`<View>`](https://reactnative.dev/docs/view) to account for safe areas automatically in your screen components.
 
 Using the library, the result of the previous example changes as it displays the content inside a safe area, as shown below:
 
 <ContentSpotlight
   alt="On using react-native-safe-area-context, the content is positioned within the safe area."
   src="/static/images/safe-area/with-safe-area.png"
-  className="max-w-[540px]"
+  className="max-w-[480px]"
 />
 
 ### Installation
 
-Install `react-native-safe-area-context` by running the command below:
+The [`default`](https://github.com/expo/expo/tree/main/templates/expo-template-default) Expo template comes with `react-native-safe-area-context` installed as a peer dependency. The library is used by Expo Router.
+
+<Collapsible summary="Manual installation instruction when using a different Expo template">
+
+If you're using a different [Expo template](/more/create-expo/#--template), install `react-native-safe-area-context` by running following command:
 
 <Terminal cmd={['$ npx expo install react-native-safe-area-context']} />
 
+</Collapsible>
+
 ### Usage
 
-#### Add `SafeAreaProvider`
+<Step label="1">
 
-To use the library, you first need to import [`<SafeAreaProvider>`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) in your app's root component.
+Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider). If your project uses Expo Router, add it to the [root layout (**app/\_layout.tsx**)](/develop/file-based-routing/#_layout-file) file. Otherwise, add it to the root component (such as **App.tsx** file).
 
-```jsx App.js
-import { View, Text } from 'react-native';
+```tsx app/_layout.tsx
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-export default function App() {
+function RootLayout() {
   return (
     <SafeAreaProvider>
-      <View>
-        <Text>My App</Text>
-      </View>
+      <Stack>
+        <Screen name="index" options={{ headerShown: false }} />
+      </Stack>
     </SafeAreaProvider>
   );
 }
 ```
 
-Then you can use the [`<SafeAreaView>`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview), which is a regular `<View>` with the safe area insets applied as padding or margin.
+> **Note:** In the above example, the `Stack` is wrapping one screen. Your project's root layout file may have more than one screen. The `index` screen is used here an example for a screen component.
 
-#### Use `useSafeAreaInsets` hook
+</Step>
 
-Alternate to `<SafeAreaView>`, you can also use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook that gives direct access to the safe area insets. It offers more flexibility and gives you more control. You can apply padding for each edge using an inset from this hook. The hook provides the insets in the following form:
+<Step label="2">
 
-```js
+Use [`SafeAreaView`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview) to wrap the content of your screen's component. It is a regular `<View>` with the safe area insets applied as extra padding or margin.
+
+```tsx app/index.tsx
+import { Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function HomeScreen() {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <Text>Content is in safe area.</Text>
+    </SafeAreaView>
+  );
+}
+```
+
+</Step>
+
+## Alternate: `useSafeAreaInsets` hook
+
+Alternate to `<SafeAreaView>`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It gives direct access to the safe area insets. It offers more flexibility and gives you more control. You can apply padding for each edge using an inset from this hook directly to the `<View>`.
+
+The example below uses the `useSafeAreaInsets` hook. It applies top padding to a `<View>` using `insets.top`.
+
+```tsx app/index.tsx
+import { Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export default function HomeScreen() {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={{ flex: 1, paddingTop: insets.top }}>
+      <Text>Content is in safe area.</Text>
+    </View>
+  );
+}
+```
+
+The hook provides the insets in the following object:
+
+```ts
 {
   top: number,
   right: number,
@@ -72,13 +117,15 @@ Alternate to `<SafeAreaView>`, you can also use [`useSafeAreaInsets`](https://gi
 }
 ```
 
-## Minimal working example
+## Additional information
+
+### Minimal example
 
 Below is a minimal working example that uses the `useSafeAreaInsets` hook to apply top padding to a view.
 
 <SnackInline label="Using react-native-safe-area-context" dependencies={['react-native-safe-area-context']}>
 
-```jsx collapseHeight=320
+```tsx collapseHeight=320
 import { Text, View } from 'react-native';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -102,10 +149,10 @@ export default function App() {
 
 </SnackInline>
 
-## Usage with React Navigation
+### Usage with React Navigation
 
-By default, React Navigation supports safe areas and uses `react-native-safe-area-context` as a peer dependency. For more information on how it uses the library, see the [React Navigation documentation](https://reactnavigation.org/docs/handling-safe-area/).
+By default, React Navigation supports safe areas and uses `react-native-safe-area-context` as a peer dependency. For more information, see the [React Navigation documentation](https://reactnavigation.org/docs/handling-safe-area/).
 
-## Usage with web
+### Usage with web
 
-If you are targeting the web, you must set up `<SafeAreaProvider>` as described in the [hooks section](#use-usesafeareainsets-hook). If you are doing server-side rendering (SSR), we recommend checking out the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.
+If you are targeting the web, set up `<SafeAreaProvider>` as described in the [usage section](#usage). If you are doing server-side rendering (SSR), see the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -31,7 +31,7 @@ Using the library, the result of the previous example changes as it displays the
 
 ### Installation
 
-You can skip installing `react-native-safe-area-context` if you have created a project using [the default template](/get-started/create-a-project/). This library is installed as peer dependency for Expo Router library. Otherwise, install this library by running the following command:
+You can skip installing `react-native-safe-area-context` if you have created a project using [the default template](/get-started/create-a-project/). This library is installed as peer dependency for Expo Router library. Otherwise, install it by running the following command:
 
 <Terminal cmd={['$ npx expo install react-native-safe-area-context']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of on-going improvements for docs under Develop section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the Safe Areas guide to include
- Explain concisely about using safe areas
- Update installation section to mention different Expo template behavior and provide installation instructions accordingly
- Update Usage section to add steps
- Update `useSafeAreaInsets` hook section to include a code example
- Add Additional information section to group minimal example, React Navigation usage info, and web usage info
- Fix link in the web usage section to point towards the correct usage info for `SafeAreaProvider
- Improve overall verbiage of the doc.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/develop/user-interface/safe-areas or see Preview: /develop/user-interface/safe-areas/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).