### PR TITLE
[go] UI fixes and tweaks

### DIFF
--- a/apps/expo-go/src/components/NavigationScrollView.tsx
+++ b/apps/expo-go/src/components/NavigationScrollView.tsx
@@ -1,14 +1,10 @@
-import { useTheme, useScrollToTop } from '@react-navigation/native';
+import { useScrollToTop } from '@react-navigation/native';
 import React, { PropsWithChildren, useRef } from 'react';
 import { ScrollViewProps, ScrollView as RNScrollView, Platform } from 'react-native';
 import {
   NativeViewGestureHandlerProps,
   ScrollView as RNGHScrollView,
 } from 'react-native-gesture-handler';
-
-import Colors, { ColorTheme } from '../constants/Colors';
-
-type ThemedColors = keyof typeof Colors.light & keyof typeof Colors.dark;
 
 type StyledScrollViewProps = PropsWithChildren<
   ScrollViewProps &
@@ -18,27 +14,12 @@ type StyledScrollViewProps = PropsWithChildren<
     }
 >;
 
-function useThemeBackgroundColor(props: StyledScrollViewProps, colorName: ThemedColors) {
-  const theme = useTheme();
-  const themeName = theme.dark ? ColorTheme.DARK : ColorTheme.LIGHT;
-  const colorFromProps =
-    themeName === ColorTheme.DARK ? props.darkBackgroundColor : props.lightBackgroundColor;
-
-  if (colorFromProps) {
-    return colorFromProps;
-  } else {
-    return Colors[themeName][colorName];
-  }
-}
-
-export default function NavigationScrollView(props: StyledScrollViewProps) {
+export default function NavigationScrollView({ style, ...otherProps }: StyledScrollViewProps) {
   const ref = useRef(null);
-  const { style, ...otherProps } = props;
-  const backgroundColor = useThemeBackgroundColor(props, 'bodyBackground');
 
   useScrollToTop(ref);
 
   const ScrollView = Platform.OS === 'android' ? RNScrollView : RNGHScrollView;
 
-  return <ScrollView style={[{ backgroundColor }, style]} {...otherProps} ref={ref} />;
+  return <ScrollView style={style} {...otherProps} ref={ref} />;
 }

--- a/apps/expo-go/src/components/UserReviewSection.tsx
+++ b/apps/expo-go/src/components/UserReviewSection.tsx
@@ -1,5 +1,5 @@
 import { iconSize, XIcon, spacing, typography } from '@expo/styleguide-native';
-import { Row, Text, useExpoTheme, View, Button } from 'expo-dev-client-components';
+import { Row, Text, useExpoTheme, View, Button, Spacer } from 'expo-dev-client-components';
 import { isDevice } from 'expo-device';
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
@@ -25,50 +25,53 @@ export default function UserReviewSection({ snacks, apps }: Props) {
   }
 
   return (
-    <View bg="default" rounded="large" border="default" overflow="hidden">
-      <TouchableOpacity onPress={dismissReviewSection} style={styles.dismissButton}>
-        <XIcon size={iconSize.regular} color={theme.icon.default} />
-      </TouchableOpacity>
-      <View padding="medium">
-        <Text type="InterBold" size="small" style={styles.title}>
-          Enjoying Expo Go?
-        </Text>
-        <Text size="small" type="InterRegular" style={styles.subtitle}>
-          Whether you love the app or feel we could be doing better, let us know! Your feedback will
-          help us improve.
-        </Text>
-        <Row style={{ gap: 10 }}>
-          <Button.FadeOnPressContainer
-            flex="1"
-            bg="tertiary"
-            onPress={provideFeedback}
-            padding="tiny">
-            <Button.Text
-              align="center"
-              size="medium"
-              color="tertiary"
-              type="InterSemiBold"
-              style={typography.fontSizes[14]}>
-              Not really
-            </Button.Text>
-          </Button.FadeOnPressContainer>
-          <Button.FadeOnPressContainer
-            flex="1"
-            bg="tertiary"
-            onPress={requestStoreReview}
-            padding="tiny">
-            <Button.Text
-              align="center"
-              size="medium"
-              color="tertiary"
-              type="InterSemiBold"
-              style={typography.fontSizes[14]}>
-              Love it!
-            </Button.Text>
-          </Button.FadeOnPressContainer>
-        </Row>
+    <>
+      <View bg="default" rounded="large" border="default" overflow="hidden">
+        <TouchableOpacity onPress={dismissReviewSection} style={styles.dismissButton}>
+          <XIcon size={iconSize.regular} color={theme.icon.default} />
+        </TouchableOpacity>
+        <View padding="medium">
+          <Text type="InterBold" size="small" style={styles.title}>
+            Enjoying Expo Go?
+          </Text>
+          <Text size="small" type="InterRegular" style={styles.subtitle}>
+            Whether you love the app or feel we could be doing better, let us know! Your feedback
+            will help us improve.
+          </Text>
+          <Row style={{ gap: 10 }}>
+            <Button.FadeOnPressContainer
+              flex="1"
+              bg="tertiary"
+              onPress={provideFeedback}
+              padding="tiny">
+              <Button.Text
+                align="center"
+                size="medium"
+                color="tertiary"
+                type="InterSemiBold"
+                style={typography.fontSizes[14]}>
+                Not really
+              </Button.Text>
+            </Button.FadeOnPressContainer>
+            <Button.FadeOnPressContainer
+              flex="1"
+              bg="tertiary"
+              onPress={requestStoreReview}
+              padding="tiny">
+              <Button.Text
+                align="center"
+                size="medium"
+                color="tertiary"
+                type="InterSemiBold"
+                style={typography.fontSizes[14]}>
+                Love it!
+              </Button.Text>
+            </Button.FadeOnPressContainer>
+          </Row>
+        </View>
       </View>
-    </View>
+      <Spacer.Vertical size="medium" />
+    </>
   );
 }
 

--- a/apps/expo-go/src/navigation/BottomTabNavigator.ts
+++ b/apps/expo-go/src/navigation/BottomTabNavigator.ts
@@ -1,6 +1,7 @@
 import { darkTheme, lightTheme } from '@expo/styleguide-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { ComponentProps } from 'react';
+import { StyleSheet } from 'react-native';
 
 const BottomTabNavigator = createBottomTabNavigator();
 export default BottomTabNavigator;
@@ -15,6 +16,8 @@ export const getNavigatorProps = (props: {
     tabBarStyle: {
       backgroundColor:
         props.theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
+      borderTopColor: props.theme === 'dark' ? darkTheme.border.default : lightTheme.border.default,
+      borderTopWidth: StyleSheet.hairlineWidth,
     },
     tabBarActiveTintColor:
       props.theme === 'dark' ? darkTheme.link.default : lightTheme.link.default,

--- a/apps/expo-go/src/navigation/Navigation.tsx
+++ b/apps/expo-go/src/navigation/Navigation.tsx
@@ -238,9 +238,8 @@ export default (props: { theme: ColorTheme }) => {
                 name="Account"
                 component={AccountModal}
                 options={({ route, navigation }) => ({
-                  title: 'Account',
+                  headerShown: false,
                   ...(Platform.OS === 'ios' && {
-                    headerShown: false,
                     gestureEnabled: true,
                     cardOverlayEnabled: true,
                     headerStatusBarHeight:

--- a/apps/expo-go/src/screens/AccountModal/LoggedInAccountView.tsx
+++ b/apps/expo-go/src/screens/AccountModal/LoggedInAccountView.tsx
@@ -91,7 +91,7 @@ export function LoggedInAccountView({ accounts }: Props) {
                         {account.ownerUserActor.fullName ? (
                           <>
                             <Text
-                              type="InterBold"
+                              type="InterSemiBold"
                               style={{ paddingRight: spacing[4] }}
                               numberOfLines={1}>
                               {account.ownerUserActor.fullName}
@@ -108,7 +108,7 @@ export function LoggedInAccountView({ accounts }: Props) {
                           </>
                         ) : (
                           <Text
-                            type="InterBold"
+                            type="InterSemiBold"
                             style={{ paddingRight: spacing[4] }}
                             numberOfLines={1}>
                             {account.ownerUserActor.username}

--- a/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
@@ -154,7 +154,7 @@ export function LoggedOutAccountView({ refetch }: Props) {
   };
 
   return (
-    <View bg="default" padding="medium">
+    <View padding="medium">
       <Text color="secondary" type="InterRegular" style={{ lineHeight: 20 }}>
         Log in or create an account to access your projects, view local development servers, and
         more.

--- a/apps/expo-go/src/screens/AccountModal/ModalHeader.tsx
+++ b/apps/expo-go/src/screens/AccountModal/ModalHeader.tsx
@@ -1,7 +1,8 @@
 import { iconSize, spacing, XIcon } from '@expo/styleguide-native';
 import { useNavigation } from '@react-navigation/native';
-import { View, Text, Row, useExpoTheme } from 'expo-dev-client-components';
+import { Text, Row, useExpoTheme } from 'expo-dev-client-components';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 export function ModalHeader() {
@@ -9,19 +10,25 @@ export function ModalHeader() {
   const navigation = useNavigation();
 
   return (
-    <Row justify="between" align="center">
-      <View padding="medium">
-        <Text type="InterBold">Account</Text>
-      </View>
-      <Row>
-        <TouchableOpacity
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          style={{ padding: spacing[2], borderRadius: 100 }}
-          onPress={() => navigation.goBack()}>
-          <XIcon size={iconSize.regular} color={theme.icon.default} />
-        </TouchableOpacity>
-        <View style={{ width: spacing[2] }} />
-      </Row>
+    <Row
+      justify="between"
+      align="center"
+      bg="default"
+      style={{
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: theme.border.default,
+      }}>
+      <Text type="InterBold" size="large">
+        Account
+      </Text>
+      <TouchableOpacity
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        style={{ padding: spacing[2], marginRight: -8 }}
+        onPress={() => navigation.goBack()}>
+        <XIcon size={iconSize.regular} color={theme.icon.default} />
+      </TouchableOpacity>
     </Row>
   );
 }

--- a/apps/expo-go/src/screens/AccountModal/index.tsx
+++ b/apps/expo-go/src/screens/AccountModal/index.tsx
@@ -20,7 +20,7 @@ export function AccountModal() {
   if (loading) {
     return (
       <View flex="1" style={{ backgroundColor: theme.background.screen }}>
-        {Platform.OS === 'ios' && <ModalHeader />}
+        <ModalHeader />
         <View flex="1" padding="medium" align="centered">
           <ActivityIndicator color={theme.highlight.accent} />
         </View>
@@ -85,7 +85,7 @@ export function AccountModal() {
 
   return (
     <View flex="1" style={{ backgroundColor: theme.background.screen }}>
-      {Platform.OS === 'ios' && <ModalHeader />}
+      <ModalHeader />
       {data?.meUserActor?.accounts ? (
         <LoggedInAccountView accounts={data.meUserActor.accounts} />
       ) : (

--- a/apps/expo-go/src/screens/AccountModal/index.tsx
+++ b/apps/expo-go/src/screens/AccountModal/index.tsx
@@ -84,7 +84,7 @@ export function AccountModal() {
   // if data.viewer is undefined, then the user is not authenticated, so show the login screen
 
   return (
-    <View flex="1">
+    <View flex="1" style={{ backgroundColor: theme.background.screen }}>
       {Platform.OS === 'ios' && <ModalHeader />}
       {data?.meUserActor?.accounts ? (
         <LoggedInAccountView accounts={data.meUserActor.accounts} />

--- a/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
+++ b/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
@@ -61,15 +61,16 @@ function DiagnosticsScreen({
   navigation,
 }: StackScreenProps<DiagnosticsStackRoutes, 'Diagnostics'>) {
   return (
-    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing[4] }}>
+    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingHorizontal: spacing[4] }}>
+      <Spacer.Vertical size="large" />
       <AudioDiagnostic navigation={navigation} />
-      <Spacer.Vertical size="medium" />
+      <Spacer.Vertical size="large" />
       {Environment.IsIOSRestrictedBuild ? (
         <ForegroundLocationDiagnostic navigation={navigation} />
       ) : (
         <BackgroundLocationDiagnostic navigation={navigation} />
       )}
-      <Spacer.Vertical size="medium" />
+      <Spacer.Vertical size="large" />
       <GeofencingDiagnostic navigation={navigation} />
     </ScrollView>
   );

--- a/apps/expo-go/src/screens/HomeScreen/DevelopmentServersOpenURL.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/DevelopmentServersOpenURL.tsx
@@ -63,8 +63,8 @@ export function DevelopmentServersOpenURL() {
             <Text type="InterRegular">Enter URL manually</Text>
           </Row>
         </TouchableOpacity>
-        {showInput ? <Spacer.Vertical size="medium" /> : null}
-        {showInput ? (
+        {showInput && <Spacer.Vertical size="medium" />}
+        {showInput && (
           <View padding="medium" style={{ marginTop: -32 }}>
             <TextInput
               onChangeText={(newUrl) => setUrl(newUrl.trim())}
@@ -74,7 +74,7 @@ export function DevelopmentServersOpenURL() {
               autoCorrect={false}
               autoComplete="off"
               autoCapitalize="none"
-              returnKeyType="go"
+              returnKeyType="done"
               onSubmitEditing={openURL}
               style={{ backgroundColor: theme.background.default }}
               px="4"
@@ -101,7 +101,7 @@ export function DevelopmentServersOpenURL() {
               </Button.Text>
             </TouchableOpacity>
           </View>
-        ) : null}
+        )}
       </View>
     </>
   );

--- a/apps/expo-go/src/screens/HomeScreen/index.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/index.tsx
@@ -52,7 +52,8 @@ export function HomeScreen(props: NavigationProps) {
   const insets = useSafeAreaInsets();
 
   return (
-    <View style={{ flex: 1, backgroundColor: theme.background.default, paddingTop: insets.top }}>
+    <View style={{ flex: 1 }}>
+      <View style={{ backgroundColor: theme.background.default, height: insets.top }} />
       <HomeScreenView
         theme={themeType}
         {...props}

--- a/apps/expo-go/src/screens/SettingsScreen/ConstantsSection.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/ConstantsSection.tsx
@@ -32,7 +32,7 @@ export function ConstantsSection() {
             <Divider style={{ height: 1 }} />
           </>
         ) : null}
-        <ConstantItem title="Supported SDKs" value={Environment.supportedSdksString} />
+        <ConstantItem title="Supported SDK" value={Environment.supportedSdksString} />
       </View>
     </View>
   );

--- a/apps/expo-go/src/screens/SettingsScreen/DevMenuGestureSection.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/DevMenuGestureSection.tsx
@@ -1,5 +1,5 @@
 import { iconSize } from '@expo/styleguide-native';
-import { Divider, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 
 import { CheckListItem } from './CheckListItem';
@@ -38,30 +38,33 @@ export function DevMenuGestureSection() {
   }
 
   return (
-    <View>
-      <SectionHeader header="Developer Menu Gestures" />
-      <View bg="default" overflow="hidden" rounded="large" border="default">
-        <CheckListItem
-          icon={<ShakeDeviceIcon color={theme.icon.default} size={iconSize.regular} />}
-          title="Shake device"
-          checked={devMenuSettings.motionGestureEnabled}
-          onPress={onToggleMotionGesture}
-        />
-        <Divider style={{ height: 1 }} />
-        <CheckListItem
-          icon={<ThreeFingerPressIcon color={theme.icon.default} size={iconSize.regular} />}
-          title="Three-finger long press"
-          checked={devMenuSettings.touchGestureEnabled}
-          onPress={onToggleTouchGesture}
-        />
+    <>
+      <View>
+        <SectionHeader header="Developer Menu Gestures" />
+        <View bg="default" overflow="hidden" rounded="large" border="default">
+          <CheckListItem
+            icon={<ShakeDeviceIcon color={theme.icon.default} size={iconSize.regular} />}
+            title="Shake device"
+            checked={devMenuSettings.motionGestureEnabled}
+            onPress={onToggleMotionGesture}
+          />
+          <Divider style={{ height: 1 }} />
+          <CheckListItem
+            icon={<ThreeFingerPressIcon color={theme.icon.default} size={iconSize.regular} />}
+            title="Three-finger long press"
+            checked={devMenuSettings.touchGestureEnabled}
+            onPress={onToggleTouchGesture}
+          />
+        </View>
+        <View py="small" px="medium">
+          <Text size="small" color="secondary" type="InterRegular">
+            Selected gestures will toggle the developer menu while inside an experience. The menu
+            allows you to reload or return to home in a published experience, and exposes developer
+            tools in development mode.
+          </Text>
+        </View>
       </View>
-      <View py="small" px="medium">
-        <Text size="small" color="secondary" type="InterRegular">
-          Selected gestures will toggle the developer menu while inside an experience. The menu
-          allows you to reload or return to home in a published experience, and exposes developer
-          tools in development mode.
-        </Text>
-      </View>
-    </View>
+      <Spacer.Vertical size="medium" />
+    </>
   );
 }

--- a/apps/expo-go/src/screens/SettingsScreen/TrackingSection.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/TrackingSection.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from 'expo-dev-client-components';
+import { Spacer, Text, View } from 'expo-dev-client-components';
 import * as Tracking from 'expo-tracking-transparency';
 import * as WebBrowser from 'expo-web-browser';
 import * as React from 'react';
@@ -8,6 +8,7 @@ import { SectionHeader } from '../../components/SectionHeader';
 
 export function TrackingSection() {
   const [showTrackingItem, setShowTrackingItem] = React.useState(false);
+
   React.useEffect(() => {
     (async () => {
       const { status } = await Tracking.getTrackingPermissionsAsync();
@@ -15,33 +16,41 @@ export function TrackingSection() {
     })();
   }, [showTrackingItem]);
 
-  return showTrackingItem ? (
-    <View>
-      <SectionHeader header="Tracking" />
+  if (!showTrackingItem) {
+    return null;
+  }
 
-      <View bg="default" overflow="hidden" rounded="large" border="default">
-        <TouchableOpacity
-          onPress={async () => {
-            const { status } = await Tracking.requestTrackingPermissionsAsync();
-            setShowTrackingItem(status === 'undetermined');
-          }}>
-          <View padding="medium" bg="default">
-            <Text size="medium" type="InterRegular">
-              Allow access to app-related data for tracking
+  return (
+    <>
+      <View>
+        <SectionHeader header="Tracking" />
+
+        <View bg="default" overflow="hidden" rounded="large" border="default">
+          <TouchableOpacity
+            onPress={async () => {
+              const { status } = await Tracking.requestTrackingPermissionsAsync();
+              setShowTrackingItem(status === 'undetermined');
+            }}>
+            <View padding="medium" bg="default">
+              <Text size="medium" type="InterRegular">
+                Allow access to app-related data for tracking
+              </Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+
+        <TouchableOpacity onPress={handleLearnMorePress}>
+          <View py="small" px="medium">
+            <Text size="small" color="link" type="InterRegular">
+              Learn more about what data Expo collects and why.
             </Text>
           </View>
         </TouchableOpacity>
       </View>
 
-      <TouchableOpacity onPress={handleLearnMorePress}>
-        <View py="small" px="medium">
-          <Text size="small" color="link" type="InterRegular">
-            Learn more about what data Expo collects and why.
-          </Text>
-        </View>
-      </TouchableOpacity>
-    </View>
-  ) : null;
+      <Spacer.Vertical size="medium" />
+    </>
+  );
 }
 
 function handleLearnMorePress() {

--- a/apps/expo-go/src/screens/SettingsScreen/index.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/index.tsx
@@ -22,18 +22,8 @@ export function SettingsScreen() {
       <View flex="1" padding="medium">
         <ThemeSection />
         <Spacer.Vertical size="medium" />
-        {Platform.OS === 'ios' && (
-          <>
-            <DevMenuGestureSection />
-            <Spacer.Vertical size="medium" />
-          </>
-        )}
-        {Tracking.isAvailable() && (
-          <>
-            <TrackingSection />
-            <Spacer.Vertical size="medium" />
-          </>
-        )}
+        {Platform.OS === 'ios' && <DevMenuGestureSection />}
+        {Tracking.isAvailable() && <TrackingSection />}
         <ConstantsSection />
         {data?.meUserActor && data.meUserActor.__typename === 'User' ? (
           <>

--- a/apps/expo-go/src/utils/Environment.ts
+++ b/apps/expo-go/src/utils/Environment.ts
@@ -15,9 +15,7 @@ const SupportedExpoSdks = Constants.supportedExpoSdks || [];
 // Constants.supportedExpoSdks is not guaranteed to be sorted!
 const sortedSupportedExpoSdks = SupportedExpoSdks.sort();
 
-const supportedSdksString = `SDK${
-  SupportedExpoSdks.length === 1 ? ':' : 's:'
-} ${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join(', ')}`;
+const supportedSdksString = `${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join('')}`;
 
 export default {
   IOSClientReleaseType,


### PR DESCRIPTION
# Why

There are some slight inconsistencies across the Expo Go interface; let's address that.

# How

The following changes have been made:
* unify the default background color of screens
* Fix account modal appearance, tweak the iOS header
* fix spacing issues on the Home and Settings screens
* tweak the labels and wording around supported SDK
* add missing tab bar border

# Test Plan

The changes have been reviewed by running a debug build of Expo Go locally.

# Preview

https://github.com/expo/expo/assets/719641/39573985-84bd-4166-91b6-8737d4f746fd


