### PR TITLE
[docs] Fix typo in install expo modules guide

### DIFF
--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -21,7 +21,7 @@ You should have a brownfield native project with React Native installed and conf
 
 Add the `expo` package to your project. Ensure you are using a version of [the `expo` package that is compatible with the React Native version in your project](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
 
-<Terminal cmd={['npm install expo']} />
+<Terminal cmd={['$ npm install expo']} />
 
 ## Configuring native apps
 
@@ -67,11 +67,11 @@ index a26c7c6..dd8802a 100644
 
 Inside the **android** directory, run the following command:
 
-<Terminal cmd={['./gradlew clean']} />
+<Terminal cmd={['$ ./gradlew clean']} />
 
 Once the above command completes, run:
 
-<Terminal cmd={['./gradlew assembleDebug']} />
+<Terminal cmd={['$./gradlew assembleDebug']} />
 
 </Step>
 
@@ -181,10 +181,10 @@ index 2d3a979..825a9d4 100644
 
 target '<YourAppTarget>' do
 
-+ use_expo_modules!
-  config = use_native_modules!
-  `}
-  />
++use_expo_modules!
+config = use_native_modules!
+`}
+/>
 
 </Step>
 
@@ -198,7 +198,7 @@ Open your **ios** directory in Xcode. From the project navigator, select your pr
 
 Run `pod install` in the **ios** directory.
 
-<Terminal cmd={['cd ios && pod install']} />
+<Terminal cmd={['$ cd ios && pod install']} />
 
 You will need to do this every time you add a dependency that uses native code.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Fixes CI error caused due to a typo in this: https://github.com/expo/expo/commit/153a232c8dd4afba27c9e3a6e6e5e538359ba90c#diff-f0dde599d01e0185c743c722bb7f7cbca49ddf5d98517ef7590bfb70cb70ec3e
- Fixes Terminal blocks

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
