### PR TITLE
[ios][camera] Fix gesture interactions

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -13,8 +13,9 @@ import {
   FocusMode,
 } from 'expo-camera';
 import * as FileSystem from 'expo-file-system';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import * as Svg from 'react-native-svg';
 
 import GalleryScreen from './GalleryScreen';
@@ -62,6 +63,33 @@ interface State {
   recording: boolean;
 }
 
+function Gestures({ children }: { children: React.ReactNode }) {
+  const doubleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .numberOfTaps(2)
+        .maxDuration(250)
+        .onStart(() => {
+          console.log('doubleTapGesture > onStart');
+        }),
+    []
+  );
+
+  const longPressGesture = useMemo(
+    () =>
+      Gesture.LongPress()
+        .minDuration(750)
+        .onStart(() => {
+          console.log('longPressGesture > onStart');
+        }),
+    []
+  );
+  return (
+    <GestureDetector gesture={Gesture.Race(doubleTapGesture, longPressGesture)}>
+      {children}
+    </GestureDetector>
+  );
+}
 export default class CameraScreen extends React.Component<object, State> {
   camera? = React.createRef<CameraView>();
 
@@ -358,30 +386,32 @@ export default class CameraScreen extends React.Component<object, State> {
 
   renderCamera = () => (
     <View style={{ flex: 1 }}>
-      <CameraView
-        ref={this.camera}
-        style={styles.camera}
-        onCameraReady={this.collectPictureSizes}
-        responsiveOrientationWhenOrientationLocked
-        enableTorch={this.state.torchEnabled}
-        autofocus={this.state.autoFocus}
-        facing={this.state.facing}
-        animateShutter
-        pictureSize={this.state.pictureSize}
-        flash={this.state.flash}
-        mode={this.state.mode}
-        mute={this.state.mute}
-        zoom={this.state.zoom}
-        ratio="4:3"
-        videoQuality="2160p"
-        onMountError={this.handleMountError}
-        barcodeScannerSettings={{
-          barcodeTypes: ['qr', 'pdf417'],
-        }}
-        onBarcodeScanned={this.state.barcodeScanning ? this.onBarcodeScanned : undefined}>
-        {this.renderTopBar()}
-        {this.renderBottomBar()}
-      </CameraView>
+      <Gestures>
+        <CameraView
+          ref={this.camera}
+          style={styles.camera}
+          onCameraReady={this.collectPictureSizes}
+          responsiveOrientationWhenOrientationLocked
+          enableTorch={this.state.torchEnabled}
+          autofocus={this.state.autoFocus}
+          facing={this.state.facing}
+          animateShutter
+          pictureSize={this.state.pictureSize}
+          flash={this.state.flash}
+          mode={this.state.mode}
+          mute={this.state.mute}
+          zoom={this.state.zoom}
+          ratio="4:3"
+          videoQuality="2160p"
+          onMountError={this.handleMountError}
+          barcodeScannerSettings={{
+            barcodeTypes: ['qr', 'pdf417'],
+          }}
+          onBarcodeScanned={this.state.barcodeScanning ? this.onBarcodeScanned : undefined}>
+          {this.renderTopBar()}
+          {this.renderBottomBar()}
+        </CameraView>
+      </Gestures>
       {this.state.barcodeScanning && this.renderBarcode()}
       {this.state.showMoreOptions && this.renderMoreOptions()}
     </View>

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, fix touch interactions when using gesture handler.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
-- On `iOS`, fix touch interactions when using gesture handler.
+- On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -141,9 +141,12 @@ public class CameraView: ExpoView, EXCameraInterface, EXAppLifecycleListener,
   }
 
   private func setupPreview() {
-    previewLayer.videoPreviewLayer.session = session
-    previewLayer.videoPreviewLayer.videoGravity = .resizeAspectFill
-    previewLayer.videoPreviewLayer.needsDisplayOnBoundsChange = true
+    DispatchQueue.main.async {
+      self.previewLayer.videoPreviewLayer.session = self.session
+      self.previewLayer.videoPreviewLayer.videoGravity = .resizeAspectFill
+      self.previewLayer.videoPreviewLayer.needsDisplayOnBoundsChange = true
+      self.addSubview(self.previewLayer)
+    }
   }
 
   func initCamera() {


### PR DESCRIPTION
# Why
Fixes #28966
Although the views layer was set, it had not been added to the view hierarchy. This caused hit testing to fail when using gesture handler.

# How
Added the view in `setupPreview`, also pushed the call onto the main queue as the layer should not be interacted with from anywhere else.

# Test Plan
Added a gesture detector around the camera view. The gestures are detected correctly.

