### PR TITLE
[dev-launcher]: better stacktrace for InvocationTargetException

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- Improve stack trace for errors that happen during module initialization.
+- Improve stack trace for errors that happen during module initialization. ([#30341](https://github.com/expo/expo/pull/30341) by [@vonovak](https://github.com/vonovak))
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - Fix and update link for `expo-dev-client` in package's README. ([#30162](https://github.com/expo/expo/pull/30162) by [@amandeepmittal](https://github.com/amandeepmittal)).
 - Fixed broken unit test on iOS 17 where `URL()` without scheme returns nil. ([#30178](https://github.com/expo/expo/pull/30178) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 💡 Others
 
+- Improve stack trace for errors that happen during module initialization.
 - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
 - Fix and update link for `expo-dev-client` in package's README. ([#30162](https://github.com/expo/expo/pull/30162) by [@amandeepmittal](https://github.com/amandeepmittal)).
 - Fixed broken unit test on iOS 17 where `URL()` without scheme returns nil. ([#30178](https://github.com/expo/expo/pull/30178) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgeDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-74/debug/expo/modules/devlauncher/rncompatibility/DevLauncherBridgeDevSupportManager.kt
@@ -14,6 +14,7 @@ import expo.modules.devlauncher.koin.optInject
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
+import java.lang.reflect.InvocationTargetException
 
 class DevLauncherBridgeDevSupportManager(
   applicationContext: Context,
@@ -60,7 +61,8 @@ class DevLauncherBridgeDevSupportManager(
     }
 
     controller?.onAppLoadedWithError()
-    DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
+    val cause: Throwable = if (e is InvocationTargetException) e.cause ?: e else e
+    DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, cause))
   }
 
   override fun getUniqueTag() = "DevLauncherApp-Bridge"

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -22,7 +22,10 @@ abstract class Module : AppContextProvider {
   // region AppContextProvider
 
   override val appContext: AppContext
-    get() = requireNotNull(_runtimeContext?.appContext) { "The module wasn't created! You can't access the app context." }
+    get() = requireNotNull(_runtimeContext?.appContext) {
+      "You attempted to access the app context before the module was created. " +
+      "Defer accessing the context until after the module initializes."
+    }
 
   // endregion
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -24,7 +24,7 @@ abstract class Module : AppContextProvider {
   override val appContext: AppContext
     get() = requireNotNull(_runtimeContext?.appContext) {
       "You attempted to access the app context before the module was created. " +
-      "Defer accessing the context until after the module initializes."
+        "Defer accessing the context until after the module initializes."
     }
 
   // endregion


### PR DESCRIPTION
# Why

When working with expo modules, you may run into an error caused while module is being [instantiated here](https://github.com/expo/expo/blob/623b7c52955dc734e7db790f7eceb2fd2d7f7771/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt#L45). The error which is thrown is `InvocationTargetException` and its own stacktrace is not as useful as the stacktrace of its cause, because it's missing a few stack frames which are important for figuring out where the error actually originates.


[InvocationTargetException](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/InvocationTargetException.html) is a checked exception that wraps an exception thrown by an invoked method or constructor. 

<details>
  <summary>screenshots</summary>

before:

![Screenshot_1720694035](https://github.com/expo/expo/assets/1566403/79215abb-16ff-41ae-b81e-9801cf2f87f6)

after:

![Screenshot_1720698361](https://github.com/expo/expo/assets/1566403/25ef088a-0fa6-4025-9b84-590817c79dcc)


</details>

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
