### PR TITLE
[docs] Update Animation doc under Develop

### DIFF
--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -3,77 +3,32 @@ title: Animation
 description: Learn how to integrate the react-native-reanimated library and use it in your Expo project.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Animations are a great way to enhance and provide a better user experience. In your Expo projects, you can use the [Animated API](https://reactnative.dev/docs/next/animations) from React Native. However, if you want to use more advanced animations with better performance, you can use the [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) library. It provides an API that simplifies the process of creating smooth, powerful, and maintainable animations.
 
 ## Installation
 
-To install `react-native-reanimated`, run the following command:
+The [`default`](https://github.com/expo/expo/tree/main/templates/expo-template-default) Expo template comes with `react-native-reanimated` installed as a peer dependency.
+
+<Collapsible summary="Manual installation instruction when using a different Expo template">
+
+If you're using a different [Expo template](/more/create-expo/#--template), install `react-native-reanimated` by running following command:
 
 <Terminal cmd={['$ npx expo install react-native-reanimated']} />
 
-<Tabs>
+</Collapsible>
 
-<Tab label="SDK 50 and higher">
+## Usage
 
-No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
+### Minimal example
 
-</Tab>
-
-<Tab label="SDK 49 and lower">
-
-After the installation completes, add the Babel plugin to **babel.config.js**:
-
-```js babel.config.js
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-    /* @info Add the Reanimated Babel Plugin as the last item in the plugins array.*/
-    plugins: ['react-native-reanimated/plugin'],
-    /* @end */
-  };
-};
-```
-
-After you add the Babel plugin, restart your development server and clear the bundler cache using the command:
-
-<Terminal cmd={['$ npx expo start --clear']} />
-
-> If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
-
-</Tab>
-
-</Tabs>
-
-### Web support
-
-<Tabs>
-
-<Tab label="SDK 50 and higher">
-
-No additional configuration is required for SDK 50 and above when using `react-native-reanimated`.
-
-</Tab>
-
-<Tab label="SDK 49">
-
-No additional configuration is required for web. Make sure that `react-native-reanimated/plugin` is added to **babel.config.js** as mentioned in [SDK 49 and below installation step](/#installation).
-
-</Tab>
-
-</Tabs>
-
-## Minimal example
-
-The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and advanced usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
 <SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
 
-{/* prettier-ignore */}
-```jsx
+```tsx
 import Animated, {
   useSharedValue,
   withTiming,
@@ -128,4 +83,4 @@ const styles = StyleSheet.create({
 
 ## Other animation libraries
 
-Other animation packages are available, such as [Moti](https://moti.fyi/), that you can use in your Expo project and work on Android, iOS, and web.
+You can use other animation packages such as [Moti](https://moti.fyi/) in your Expo project. It works on Android, iOS, and web.

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -3,22 +3,15 @@ title: Animation
 description: Learn how to integrate the react-native-reanimated library and use it in your Expo project.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 
 Animations are a great way to enhance and provide a better user experience. In your Expo projects, you can use the [Animated API](https://reactnative.dev/docs/next/animations) from React Native. However, if you want to use more advanced animations with better performance, you can use the [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) library. It provides an API that simplifies the process of creating smooth, powerful, and maintainable animations.
 
 ## Installation
 
-The [`default`](https://github.com/expo/expo/tree/main/templates/expo-template-default) Expo template comes with `react-native-reanimated` installed as a peer dependency.
-
-<Collapsible summary="Manual installation instruction when using a different Expo template">
-
-If you're using a different [Expo template](/more/create-expo/#--template), install `react-native-reanimated` by running following command:
+You can skip installing `react-native-reanimated` if you have created a project using [the default template](/get-started/create-a-project/). This library is already installed. Otherwise, install it by running the following command:
 
 <Terminal cmd={['$ npx expo install react-native-reanimated']} />
-
-</Collapsible>
 
 ## Usage
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of ongoing improvements for docs under the Develop section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the Animation doc by
- Update the installation section to mention different Expo template behavior and provide installation instructions accordingly
- Add a usage section and make minimal example a sub section
- Remove all other info related to SDK specific behavior (50 and 49) for reanimated babel plugin. This info is already converted in Reanimated API reference. For brevity, we can exclude it from this page.
- Improve verbiage

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/user-interface/animation/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
