### PR TITLE
[docs] Add client-side redirects based on recent SEO reports

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -406,4 +406,8 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Troubleshooting section
   '/guides/troubleshooting-proxies/': '/troubleshooting/proxies/',
+
+  // Based on SEO tool reports
+  '/build-reference/eas-json/': '/eas/json/',
+  '/build-reference/custom-builds/schema/': '/custom-builds/schema/',
 };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The links mentioned in [this report](https://exponent-internal.slack.com/archives/C05R83K91QA/p1720634060238569) are serving the 404.

We recently removed top level client and server side redirects for similar deprecated links in an effort to clean up old redirects.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add page level client-side redirects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and testing redirects for the following URL paths:
- /build-reference/eas-json/ redirects to /eas/json/ (top level redirect)
- /build-reference/eas-json/#resourceclass redirects to /eas/json/
-  /build-reference/custom-builds/schema/ redirects to /custom-builds/schema/  (top level redirect)
- /build-reference/custom-builds/schema#easbuild redirects to /custom-builds/schema/


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
