### PR TITLE
[video][ios] Migrate to `ref`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Run VideoManager.setAppropriateAudioSessionOrWarn on a different queue for a lower load on the main thread. ([#33127](https://github.com/expo/expo/pull/33127) by [@behenate](https://github.com/behenate))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] SharedRef: migrate from `pointer` to `ref` ([#30359](https://github.com/expo/expo/pull/30359) by [@behenate](https://github.com/behenate))
 
 ## 2.0.5 - 2025-01-10
 

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -37,7 +37,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
     player.observer?.registerDelegate(delegate: self)
 
     if mostRecentInteractionPlayer == nil {
-      setMostRecentInteractionPlayer(player: player.pointer)
+      setMostRecentInteractionPlayer(player: player.ref)
     }
   }
 
@@ -45,9 +45,9 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
     players.remove(player)
     player.observer?.unregisterDelegate(delegate: self)
 
-    if mostRecentInteractionPlayer == player.pointer {
+    if mostRecentInteractionPlayer == player.ref {
       let newPlayer = players.allObjects.first(where: { $0.playbackRate != 0 })
-      setMostRecentInteractionPlayer(player: newPlayer?.pointer)
+      setMostRecentInteractionPlayer(player: newPlayer?.ref)
     }
 
     if players.allObjects.isEmpty {
@@ -190,7 +190,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
         }
 
         for player in players.allObjects {
-          player.pointer.pause()
+          player.ref.pause()
         }
         return .success
       }
@@ -246,8 +246,8 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
 
   func onRateChanged(player: AVPlayer, oldRate: Float?, newRate: Float) {
     if newRate == 0 && mostRecentInteractionPlayer == player {
-      if let newPlayer = players.allObjects.first(where: { $0.pointer.rate != 0 }) {
-        setMostRecentInteractionPlayer(player: newPlayer.pointer)
+      if let newPlayer = players.allObjects.first(where: { $0.ref.rate != 0 }) {
+        setMostRecentInteractionPlayer(player: newPlayer.ref)
       }
     } else if newRate != 0 && mostRecentInteractionPlayer != player {
       setMostRecentInteractionPlayer(player: player)

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -58,7 +58,7 @@ class VideoManager {
       if player.staysActiveInBackground == true {
         player.setTracksEnabled(videoView.isInPictureInPicture)
       } else if !videoView.isInPictureInPicture {
-        player.pointer.pause()
+        player.ref.pause()
       }
     }
   }

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -141,10 +141,10 @@ public final class VideoModule: Module {
       }
 
       Property("allowsExternalPlayback") { player -> Bool in
-        return player.pointer.allowsExternalPlayback
+        return player.ref.allowsExternalPlayback
       }
       .set { (player, allowsExternalPlayback: Bool) in
-        player.pointer.allowsExternalPlayback = allowsExternalPlayback
+        player.ref.allowsExternalPlayback = allowsExternalPlayback
       }
 
       Property("staysActiveInBackground") { player -> Bool in
@@ -162,14 +162,14 @@ public final class VideoModule: Module {
       }
 
       Property("currentTime") { player -> Double in
-        let currentTime = player.pointer.currentTime().seconds
+        let currentTime = player.ref.currentTime().seconds
         return currentTime.isNaN ? 0 : currentTime
       }
       .set { (player, time: Double) in
         // Only clamp the lower limit, AVPlayer automatically clamps the upper limit.
         let clampedTime = max(0, time)
         let timeToSeek = CMTimeMakeWithSeconds(clampedTime, preferredTimescale: .max)
-        player.pointer.seek(to: timeToSeek, toleranceBefore: .zero, toleranceAfter: .zero)
+        player.ref.seek(to: timeToSeek, toleranceBefore: .zero, toleranceAfter: .zero)
       }
 
       Property("currentLiveTimestamp") { player -> Double? in
@@ -181,15 +181,15 @@ public final class VideoModule: Module {
       }
 
       Property("targetOffsetFromLive") { player -> Double in
-        return player.pointer.currentItem?.configuredTimeOffsetFromLive.seconds ?? 0
+        return player.ref.currentItem?.configuredTimeOffsetFromLive.seconds ?? 0
       }
       .set { (player, timeOffset: Double) in
         let timeOffset = CMTime(seconds: timeOffset, preferredTimescale: .max)
-        player.pointer.currentItem?.configuredTimeOffsetFromLive = timeOffset
+        player.ref.currentItem?.configuredTimeOffsetFromLive = timeOffset
       }
 
       Property("duration") { player -> Double in
-        let duration = player.pointer.currentItem?.duration.seconds ?? 0
+        let duration = player.ref.currentItem?.duration.seconds ?? 0
         return duration.isNaN ? 0 : duration
       }
 
@@ -201,7 +201,7 @@ public final class VideoModule: Module {
       }
 
       Property("isLive") { player -> Bool in
-        return player.pointer.currentItem?.duration.isIndefinite ?? false
+        return player.ref.currentItem?.duration.isIndefinite ?? false
       }
 
       Property("preservesPitch") { player -> Bool in
@@ -274,11 +274,11 @@ public final class VideoModule: Module {
       }
 
       Function("play") { player in
-        player.pointer.play()
+        player.ref.play()
       }
 
       Function("pause") { player in
-        player.pointer.pause()
+        player.ref.pause()
       }
 
       Function("replace") { (player, source: Either<String, VideoSource>?) in
@@ -298,13 +298,13 @@ public final class VideoModule: Module {
       }
 
       Function("seekBy") { (player, seconds: Double) in
-        let newTime = player.pointer.currentTime() + CMTime(seconds: seconds, preferredTimescale: .max)
+        let newTime = player.ref.currentTime() + CMTime(seconds: seconds, preferredTimescale: .max)
 
-        player.pointer.seek(to: newTime)
+        player.ref.seek(to: newTime)
       }
 
       Function("replay") { player in
-        player.pointer.seek(to: CMTime.zero)
+        player.ref.seek(to: CMTime.zero)
       }
 
       AsyncFunction("generateThumbnailsAsync") { (player: VideoPlayer, times: [CMTime]?, options: VideoThumbnailOptions?) -> [VideoThumbnail] in

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -70,7 +70,7 @@ final class WeakPlayerObserverDelegate: Hashable {
 class VideoPlayerObserver {
   private weak var owner: VideoPlayer?
   var player: AVPlayer? {
-    owner?.pointer
+    owner?.ref
   }
   var delegates = Set<WeakPlayerObserverDelegate>()
   private var currentItem: VideoPlayerItem?

--- a/packages/expo-video/ios/VideoPlayerSubtitles.swift
+++ b/packages/expo-video/ios/VideoPlayerSubtitles.swift
@@ -19,7 +19,7 @@ class VideoPlayerSubtitles {
   }
 
   func selectSubtitleTrack(subtitleTrack: SubtitleTrack?) {
-    guard let currentItem = self.owner?.pointer.currentItem else {
+    guard let currentItem = self.owner?.ref.currentItem else {
       return
     }
 

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -8,7 +8,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   weak var player: VideoPlayer? {
     didSet {
-      playerViewController.player = player?.pointer
+      playerViewController.player = player?.ref
     }
   }
 
@@ -144,9 +144,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
     self.playerViewController.endAppearanceTransition()
     // Ensure playing state is preserved
     if wasPlaying {
-      self.player?.pointer.play()
+      self.player?.ref.play()
     } else {
-      self.player?.pointer.pause()
+      self.player?.ref.pause()
     }
   }
   #endif
@@ -166,12 +166,12 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   ) {
     // Platform's behavior is to pause the player when exiting the fullscreen mode.
     // It seems better to continue playing, so we resume the player once the dismissing animation finishes.
-    let wasPlaying = player?.pointer.timeControlStatus == .playing
+    let wasPlaying = player?.ref.timeControlStatus == .playing
 
     coordinator.animate(alongsideTransition: nil) { context in
       if !context.isCancelled {
         if wasPlaying {
-          self.player?.pointer.play()
+          self.player?.ref.play()
         }
         self.onFullscreenExit()
         self.isFullscreen = false


### PR DESCRIPTION
# Why

Migrate to using `ref` instead of `pointer`

# How

<img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRTHqVwPJfspOOZ13veSaNve2WNm8xoSPk_8g&usqp=CAU" data-canonical-src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRTHqVwPJfspOOZ13veSaNve2WNm8xoSPk_8g&usqp=CAU" height="100" />



# Test Plan

BareExpo compiles 