### PR TITLE
[bare-expo]: allow navigator state persistence

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -127,6 +127,7 @@ export default () => {
 
       // on Android, we need to keep the title of the item the same
       // because updating dev menu items currently doesn't work
+      // TODO https://linear.app/expo/issue/ENG-12786
       const label = Platform.select({
         ios: persistenceEnabled
           ? '✗  Disable navigation state persistence'

--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -5,7 +5,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { registerDevMenuItems } from 'expo-dev-menu';
 import * as Linking from 'expo-linking';
 import React from 'react';
-import { Platform } from 'react-native';
+import { ToastAndroid, Platform } from 'react-native';
 import TestSuite from 'test-suite/AppNavigator';
 
 import Colors from './src/constants/Colors';
@@ -125,14 +125,27 @@ export default () => {
       const key = 'PERSIST_NAV_STATE';
       const persistenceEnabled = !!(await AsyncStorage.getItem(key));
 
-      const label = persistenceEnabled
-        ? 'Disable navigation state persistence'
-        : 'Enable navigation state persistence';
+      // on Android, we need to keep the title of the item the same
+      // because updating dev menu items currently doesn't work
+      const label = Platform.select({
+        ios: persistenceEnabled
+          ? '✗  Disable navigation state persistence'
+          : '✓  Enable navigation state persistence',
+        default: 'Toggle navigation state persistence',
+      });
       const devMenuItems = [
         {
           shouldCollapse: true,
           name: label,
           callback: async () => {
+            if (Platform.OS === 'android') {
+              // because the label is always the same, we show a toast to inform
+              // whether the persistence is going to be enabled or disabled
+              const message = persistenceEnabled
+                ? 'Navigation state persistence disabled'
+                : 'Navigation state persistence enabled';
+              ToastAndroid.show(message, ToastAndroid.LONG);
+            }
             try {
               if (persistenceEnabled) {
                 await AsyncStorage.removeItem(key);

--- a/packages/expo-dev-menu/app/native-modules/DevMenu.ts
+++ b/packages/expo-dev-menu/app/native-modules/DevMenu.ts
@@ -1,5 +1,5 @@
 import { requireNativeModule } from 'expo-modules-core';
-import { DeviceEventEmitter, EventSubscription } from 'react-native';
+import { Alert, DeviceEventEmitter, EventSubscription } from 'react-native';
 
 export type JSEngine = 'Hermes' | 'JSC' | 'V8';
 
@@ -88,5 +88,8 @@ export async function loadFontsAsync() {
 }
 
 export async function fireCallbackAsync(name: string) {
-  return await DevMenu.fireCallback(name).catch((error) => console.warn(error.message));
+  return await DevMenu.fireCallback(name).catch((error) => {
+    console.warn(error.message);
+    Alert.alert('Error', error.message);
+  });
 }


### PR DESCRIPTION
# Why

When working in bare expo I often find myself working on a screen, recompiling some native code, launching the app and needing to go back to the screen. Would be nice if the process of going back to the screen was automatic.

# How

I added a dev menu item to enable this. Unfortunately, dynamically changing the item title only works on iOS.

I added a follow-up task for it https://linear.app/expo/issue/ENG-12786

# Test Plan

bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
