### PR TITLE
[docs] Clean up inline syntax highlight wrapped with bold style usage from multiple pages

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -265,11 +265,11 @@ const styles = StyleSheet.create({
 
 Any [`Text`](http://reactnative.dev/docs/text), [`TouchableHighlight`](http://reactnative.dev/docs/touchablehighlight), or [`TouchableWithoutFeedback`](http://reactnative.dev/docs/touchablewithoutfeedback) property in addition to these:
 
-| Prop                  | Description                                                                                                                                       | Default             |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| **`color`**           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                     | `white`             |
-| **`size`**            | Icon size.                                                                                                                                        | `20`                |
-| **`iconStyle`**       | Styles applied to the icon only, good for setting margins or a different color. _Note: use `iconStyle` for margins or expect unstable behaviour._ | `{marginRight: 10}` |
-| **`backgroundColor`** | Background color of the button.                                                                                                                   | `#007AFF`           |
-| **`borderRadius`**    | Border radius of the button, set to `0` to disable.                                                                                               | `5`                 |
-| **`onPress`**         | A function called when the button is pressed.                                                                                                     | _None_              |
+| Prop              | Description                                                                                                                                       | Default             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `color`           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                     | `white`             |
+| `size`            | Icon size.                                                                                                                                        | `20`                |
+| `iconStyle`       | Styles applied to the icon only, good for setting margins or a different color. _Note: use `iconStyle` for margins or expect unstable behaviour._ | `{marginRight: 10}` |
+| `backgroundColor` | Background color of the button.                                                                                                                   | `#007AFF`           |
+| `borderRadius`    | Border radius of the button, set to `0` to disable.                                                                                               | `5`                 |
+| `onPress`         | A function called when the button is pressed.                                                                                                     | _None_              |

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -317,12 +317,12 @@ Before getting real-time updates on errors and making your app generally incredi
 <Step label="1.1">
 
 [Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your
-Dashboard. Take note of your **organization slug**, **project name**, and **`DSN`** as you'll need
+Dashboard. Take note of your **organization slug**, **project name**, and `DSN` as you'll need
 them later:
 
 - **organization slug** is available in your **Organization settings** tab
 - **project name** is available in your project's **Settings** > **Projects** tab (find it in the list)
-- **`DSN`** is available in your project's **Settings** > **Projects** > **Project name** > **Client Keys
+- `DSN` is available in your project's **Settings** > **Projects** > **Project name** > **Client Keys
   (DSN)** tab.
 
 </Step>

--- a/docs/pages/versions/unversioned/sdk/application.mdx
+++ b/docs/pages/versions/unversioned/sdk/application.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
+`expo-application` provides useful information about the native application, itself, such as the ID, app name, and build version.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/barometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/barometer.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { NoIcon } from '~/ui/components/DocIcons';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Barometer` from **`expo-sensors`** provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
+`Barometer` from `expo-sensors` provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/battery.mdx
+++ b/docs/pages/versions/unversioned/sdk/battery.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
+`expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/checkbox.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
+`expo-checkbox` provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/clipboard.mdx
+++ b/docs/pages/versions/unversioned/sdk/clipboard.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
+`expo-clipboard` provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/constants.mdx
+++ b/docs/pages/versions/unversioned/sdk/constants.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
+`expo-constants` provides system information that remains constant throughout the lifetime of your app's install.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
+`expo-gl` provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/gyroscope.mdx
+++ b/docs/pages/versions/unversioned/sdk/gyroscope.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
+`Gyroscope` from `expo-sensors` provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-image`** is a cross-platform React component that loads and renders images.
+`expo-image` is a cross-platform React component that loads and renders images.
 
 **Main features:**
 

--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-image-manipulator`** provides an API to modify images stored on the local file system.
+`expo-image-manipulator` provides an API to modify images stored on the local file system.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -22,7 +22,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
+`expo-image-picker` provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
 <ContentSpotlight file="sdk/imagepicker.mp4" loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/unversioned/sdk/intent-launcher.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
+`expo-intent-launcher` provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/keep-awake.mdx
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
+`expo-keep-awake` provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
+`expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/magnetometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/magnetometer.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
+`Magnetometer` from `expo-sensors` provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 
 You can access the calibrated values with `Magnetometer` and uncalibrated raw values with `MagnetometerUncalibrated`.
 

--- a/docs/pages/versions/unversioned/sdk/mail-composer.mdx
+++ b/docs/pages/versions/unversioned/sdk/mail-composer.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+`expo-mail-composer` allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <ContentSpotlight file="sdk/mailcomposer.mp4" loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
+`expo-navigation-bar` enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
 
 Properties are named after style properties; visibility, position, backgroundColor, borderColor, and so on.
 

--- a/docs/pages/versions/unversioned/sdk/network.mdx
+++ b/docs/pages/versions/unversioned/sdk/network.mdx
@@ -10,7 +10,7 @@ platforms: ['android', 'ios', 'web']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
+`expo-network` provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -15,7 +15,7 @@ import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
+`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/sharing.mdx
+++ b/docs/pages/versions/unversioned/sdk/sharing.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-sharing`** allows you to share files directly with other compatible applications.
+`expo-sharing` allows you to share files directly with other compatible applications.
 
 <ContentSpotlight file="sdk/sharing.mp4" loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/sms.mdx
+++ b/docs/pages/versions/unversioned/sdk/sms.mdx
@@ -10,7 +10,7 @@ platforms: ['android', 'ios']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-sms`** provides access to the system's UI/app for sending SMS messages.
+`expo-sms` provides access to the system's UI/app for sending SMS messages.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
+`expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/storereview.mdx
+++ b/docs/pages/versions/unversioned/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-store-review`** provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
+`react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/system-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/system-ui.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
+`expo-system-ui` enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
+`expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
+`react-native-pager-view` exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <ContentSpotlight file="sdk/viewpager.mp4" loop={false} />
 

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`react-native-webview`** provides a `WebView` component that renders web content in a native view.
+`react-native-webview` provides a `WebView` component that renders web content in a native view.
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/application.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/application.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
+`expo-application` provides useful information about the native application, itself, such as the ID, app name, and build version.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/asset.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-asset`** provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
+`expo-asset` provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/barometer.mdx
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { NoIcon } from '~/ui/components/DocIcons';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Barometer` from **`expo-sensors`** provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
+`Barometer` from `expo-sensors` provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
 
 <PlatformsSection android emulator ios />
 

--- a/docs/pages/versions/v49.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/battery.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
+`expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
 <PlatformsSection android emulator ios web />
 

--- a/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
+`expo-checkbox` provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
 
 <PlatformsSection android emulator web ios simulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
+`expo-clipboard` provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/constants.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/constants.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
+`expo-constants` provides system information that remains constant throughout the lifetime of your app's install.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
+`@shopify/flash-list` is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gl-view.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
+`expo-gl` provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
+`Gyroscope` from `expo-sensors` provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
 
 <PlatformsSection android emulator ios web />
 

--- a/docs/pages/versions/v49.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/image.mdx
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-image`** is a cross-platform React component that loads and renders images.
+`expo-image` is a cross-platform React component that loads and renders images.
 
 **Main features:**
 

--- a/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-image-manipulator`** provides an API to modify images stored on the local file system.
+`expo-image-manipulator` provides an API to modify images stored on the local file system.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
@@ -22,7 +22,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
+`expo-image-picker` provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
 <ContentSpotlight file="sdk/imagepicker.mp4" loop={false} />
 

--- a/docs/pages/versions/v49.0.0/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/intent-launcher.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
+`expo-intent-launcher` provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
 <PlatformsSection android emulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
+`expo-keep-awake` provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
+`expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
+`Magnetometer` from `expo-sensors` provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 
 You can access the calibrated values with `Magnetometer` and uncalibrated raw values with `MagnetometerUncalibrated`.
 

--- a/docs/pages/versions/v49.0.0/sdk/mail-composer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/mail-composer.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+`expo-mail-composer` allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <ContentSpotlight file="sdk/mailcomposer.mp4" loop={false} />
 

--- a/docs/pages/versions/v49.0.0/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/navigation-bar.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
+`expo-navigation-bar` enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
 
 Properties are named after style properties; visibility, position, backgroundColor, borderColor, and so on.
 

--- a/docs/pages/versions/v49.0.0/sdk/network.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/network.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
+`expo-network` provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
@@ -15,7 +15,7 @@ import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
+`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sharing.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-sharing`** allows you to share files directly with other compatible applications.
+`expo-sharing` allows you to share files directly with other compatible applications.
 
 <ContentSpotlight file="sdk/sharing.mp4" loop={false} />
 

--- a/docs/pages/versions/v49.0.0/sdk/sms.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sms.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-sms`** provides access to the system's UI/app for sending SMS messages.
+`expo-sms` provides access to the system's UI/app for sending SMS messages.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/speech.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
+`expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/status-bar.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-status-bar`** gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
+`expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-store-review`** provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v49.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/svg.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
+`react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v49.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/system-ui.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
+`expo-system-ui` enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
 
 <PlatformsSection ios simulator web android emulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
+`expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v49.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
+The `Video` component from `expo-av` displays a video inline with the other UI elements in your app.
 
 Much of Video and Audio have common APIs that are documented in [AV documentation](av.mdx). This page covers video-specific props and APIs. We encourage you to skim through this document to get basic video working, and then move on to [AV documentation](av.mdx) for more advanced functionality. The audio experience of video (such as whether to interrupt music already playing in another app, or whether to play sound while the phone is on silent mode) can be customized using the [Audio API](audio.mdx).
 

--- a/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
+`react-native-pager-view` exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <ContentSpotlight file="sdk/viewpager.mp4" loop={false} />
 

--- a/docs/pages/versions/v49.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webview.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`react-native-webview`** provides a `WebView` component that renders web content in a native view.
+`react-native-webview` provides a `WebView` component that renders web content in a native view.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/application.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/application.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
+`expo-application` provides useful information about the native application, itself, such as the ID, app name, and build version.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/asset.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-asset`** provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
+`expo-asset` provides an interface to Expo's asset system. An asset is any file that lives alongside the source code of your app that the app needs at runtime. Examples include images, fonts, and sounds. Expo's asset system integrates with React Native's, so that you can refer to files with `require('path/to/file')`. This is how you refer to static image files in React Native for use in an `Image` component, for example. Check out React Native's [documentation on static image resources](https://reactnative.dev/docs/images#static-image-resources) for more information. This method of referring to static image resources works out of the box with Expo.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/barometer.mdx
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { NoIcon } from '~/ui/components/DocIcons';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Barometer` from **`expo-sensors`** provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
+`Barometer` from `expo-sensors` provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
 
 <PlatformsSection android emulator ios />
 

--- a/docs/pages/versions/v50.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/battery.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
+`expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
 <PlatformsSection android emulator ios web />
 

--- a/docs/pages/versions/v50.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/checkbox.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
+`expo-checkbox` provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
 
 <PlatformsSection android emulator web ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/clipboard.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
+`expo-clipboard` provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/constants.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/constants.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
+`expo-constants` provides system information that remains constant throughout the lifetime of your app's install.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/flash-list.mdx
@@ -10,7 +10,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`@shopify/flash-list`** is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
+`@shopify/flash-list` is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gl-view.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
+`expo-gl` provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gyroscope.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
+`Gyroscope` from `expo-sensors` provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
 
 <PlatformsSection android emulator ios web />
 

--- a/docs/pages/versions/v50.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/image.mdx
@@ -12,7 +12,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-image`** is a cross-platform React component that loads and renders images.
+`expo-image` is a cross-platform React component that loads and renders images.
 
 **Main features:**
 

--- a/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagemanipulator.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-image-manipulator`** provides an API to modify images stored on the local file system.
+`expo-image-manipulator` provides an API to modify images stored on the local file system.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/imagepicker.mdx
@@ -22,7 +22,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
+`expo-image-picker` provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
 <ContentSpotlight file="sdk/imagepicker.mp4" loop={false} />
 

--- a/docs/pages/versions/v50.0.0/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/intent-launcher.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
+`expo-intent-launcher` provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
 <PlatformsSection android emulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/keep-awake.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
+`expo-keep-awake` provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/linear-gradient.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
+`expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/magnetometer.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
+`Magnetometer` from `expo-sensors` provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 
 You can access the calibrated values with `Magnetometer` and uncalibrated raw values with `MagnetometerUncalibrated`.
 

--- a/docs/pages/versions/v50.0.0/sdk/mail-composer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/mail-composer.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+`expo-mail-composer` allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <ContentSpotlight file="sdk/mailcomposer.mp4" loop={false} />
 

--- a/docs/pages/versions/v50.0.0/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/navigation-bar.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
+`expo-navigation-bar` enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
 
 Properties are named after style properties; visibility, position, backgroundColor, borderColor, and so on.
 

--- a/docs/pages/versions/v50.0.0/sdk/network.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/network.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
+`expo-network` provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/safe-area-context.mdx
@@ -15,7 +15,7 @@ import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
+`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sharing.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-sharing`** allows you to share files directly with other compatible applications.
+`expo-sharing` allows you to share files directly with other compatible applications.
 
 <ContentSpotlight file="sdk/sharing.mp4" loop={false} />
 

--- a/docs/pages/versions/v50.0.0/sdk/sms.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sms.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-sms`** provides access to the system's UI/app for sending SMS messages.
+`expo-sms` provides access to the system's UI/app for sending SMS messages.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/speech.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
+`expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-store-review`** provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v50.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/svg.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
+`react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v50.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/system-ui.mdx
@@ -9,7 +9,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
+`expo-system-ui` enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
 
 <PlatformsSection ios simulator web android emulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video-thumbnails.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
+`expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v50.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/video.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
+The `Video` component from `expo-av` displays a video inline with the other UI elements in your app.
 
 Much of Video and Audio have common APIs that are documented in [AV documentation](av.mdx). This page covers video-specific props and APIs. We encourage you to skim through this document to get basic video working, and then move on to [AV documentation](av.mdx) for more advanced functionality. The audio experience of video (such as whether to interrupt music already playing in another app, or whether to play sound while the phone is on silent mode) can be customized using the [Audio API](audio.mdx).
 

--- a/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/view-pager.mdx
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
+`react-native-pager-view` exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <ContentSpotlight file="sdk/viewpager.mp4" loop={false} />
 

--- a/docs/pages/versions/v50.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/webview.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`react-native-webview`** provides a `WebView` component that renders web content in a native view.
+`react-native-webview` provides a `WebView` component that renders web content in a native view.
 
 <PlatformsSection android emulator ios simulator />
 

--- a/docs/pages/versions/v51.0.0/sdk/application.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/application.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-application`** provides useful information about the native application, itself, such as the ID, app name, and build version.
+`expo-application` provides useful information about the native application, itself, such as the ID, app name, and build version.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/barometer.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { NoIcon } from '~/ui/components/DocIcons';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Barometer` from **`expo-sensors`** provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
+`Barometer` from `expo-sensors` provides access to the device barometer sensor to respond to changes in air pressure, which is measured in hectopascals (`hPa`).
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/battery.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
+`expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/checkbox.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
+`expo-checkbox` provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/clipboard.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
+`expo-clipboard` provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/constants.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/constants.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-constants`** provides system information that remains constant throughout the lifetime of your app's install.
+`expo-constants` provides system information that remains constant throughout the lifetime of your app's install.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
+`expo-gl` provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gyroscope.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
+`Gyroscope` from `expo-sensors` provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/image.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-image`** is a cross-platform React component that loads and renders images.
+`expo-image` is a cross-platform React component that loads and renders images.
 
 **Main features:**
 

--- a/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagemanipulator.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-image-manipulator`** provides an API to modify images stored on the local file system.
+`expo-image-manipulator` provides an API to modify images stored on the local file system.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/imagepicker.mdx
@@ -22,7 +22,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
+`expo-image-picker` provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
 <ContentSpotlight file="sdk/imagepicker.mp4" loop={false} />
 

--- a/docs/pages/versions/v51.0.0/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/intent-launcher.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-intent-launcher`** provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
+`expo-intent-launcher` provides a way to launch Android intents. For example, you can use this API to open a specific settings screen.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/keep-awake.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
+`expo-keep-awake` provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/linear-gradient.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
+`expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/magnetometer.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
+`Magnetometer` from `expo-sensors` provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 
 You can access the calibrated values with `Magnetometer` and uncalibrated raw values with `MagnetometerUncalibrated`.
 

--- a/docs/pages/versions/v51.0.0/sdk/mail-composer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/mail-composer.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-mail-composer`** allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
+`expo-mail-composer` allows you to compose and send emails quickly and easily using the OS UI. This module can't be used on iOS Simulators since you can't sign into a mail account on them.
 
 <ContentSpotlight file="sdk/mailcomposer.mp4" loop={false} />
 

--- a/docs/pages/versions/v51.0.0/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/navigation-bar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-navigation-bar`** enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
+`expo-navigation-bar` enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
 
 Properties are named after style properties; visibility, position, backgroundColor, borderColor, and so on.
 

--- a/docs/pages/versions/v51.0.0/sdk/network.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/network.mdx
@@ -10,7 +10,7 @@ platforms: ['android', 'ios', 'web']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-network`** provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
+`expo-network` provides useful information about the device's network such as its IP address, MAC address, and airplane mode status.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/safe-area-context.mdx
@@ -15,7 +15,7 @@ import { CALLOUT } from '~/ui/components/Text';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
+`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sharing.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-sharing`** allows you to share files directly with other compatible applications.
+`expo-sharing` allows you to share files directly with other compatible applications.
 
 <ContentSpotlight file="sdk/sharing.mp4" loop={false} />
 

--- a/docs/pages/versions/v51.0.0/sdk/sms.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sms.mdx
@@ -10,7 +10,7 @@ platforms: ['android', 'ios']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-sms`** provides access to the system's UI/app for sending SMS messages.
+`expo-sms` provides access to the system's UI/app for sending SMS messages.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/speech.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
+`expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/storereview.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-**`expo-store-review`** provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
+`expo-store-review` provides access to the `SKStoreReviewController` API on iOS, and `ReviewManager` API in Android 5.0+ allowing you to ask the user to rate your app without ever having to leave the app itself.
 
 <ContentSpotlight
   src="/static/images/store-review.png"

--- a/docs/pages/versions/v51.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/svg.mdx
@@ -11,7 +11,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
+`react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/system-ui.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'web', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-**`expo-system-ui`** enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
+`expo-system-ui` enables you to interact with UI elements that fall outside of the React tree. Specifically the root view background color, and locking the user interface style globally on Android.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/video-thumbnails.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
+`expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/view-pager.mdx
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-**`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
+`react-native-pager-view` exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <ContentSpotlight file="sdk/viewpager.mp4" loop={false} />
 

--- a/docs/pages/versions/v51.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/webview.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios']
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`react-native-webview`** provides a `WebView` component that renders web content in a native view.
+`react-native-webview` provides a `WebView` component that renders web content in a native view.
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We partially removed the following incorrect syntax usage over time from different docs:

```md
**`...`**
```

(where "..." is some text)

However, there is still a significant amount of incorrect syntax usage. This syntax is incorrect because a library or a property name that uses inline code syntax using backticks is then wrapped with bold and doesn't have an effect. Instead, in different places (where it is necessary), we've already fixed the usage with the following correct syntax:

```md
`**...**`
```

However, it isn't required to always emphasize (use bold) a library or prop name when using inline code syntax.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By clearing all instances of the following from API references and other guide pages:

```md
**`...`**
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
