### PR TITLE
refactor(metro-config): resolve `@react-native/assets-registy/registry` to absolute path

### DIFF
--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -320,7 +320,7 @@ export function getDefaultConfig(
         reactNativePath,
         metroDefaultValues.transformer.asyncRequireModulePath
       ),
-      assetRegistryPath: '@react-native/assets-registry/registry',
+      assetRegistryPath: resolveFrom(reactNativePath, '@react-native/assets-registry/registry'),
       assetPlugins: getAssetPlugins(projectRoot),
       getTransformOptions: async () => ({
         transform: {


### PR DESCRIPTION
# Why

This is the first of a couple of stacked PRs.

We are going to test force-resolving both `react-native` and `@react-native/assets-registry/registry` for monorepos. This is a first step to resolve the correct assets registry module.

# How

- Resolved `@react-native/assets-registry/registry` from the installed `react-native` path.
- This can still be overwritten by customizing `config.transformer.assetRegistryPath` in **metro.config.js**

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
