### PR TITLE
[docs] Update installation instructions for existing React Native projects in API references

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 
 import { usePageMetadata } from '~/providers/page-metadata';
 import { Terminal } from '~/ui/components/Snippet';
-import { A, P, DEMI } from '~/ui/components/Text';
+import { A, P, DEMI, CODE } from '~/ui/components/Text';
 
 type InstallSectionProps = PropsWithChildren<{
   packageName: string;
@@ -29,12 +29,14 @@ export default function InstallSection({
       <Terminal cmd={cmd} />
       {hideBareInstructions ? null : (
         <P>
-          If you are installing this in an <A href="/bare/overview/">existing React Native app</A>,
-          you have to <A href="/bare/installing-expo-modules/">prepare your existing project</A> to
-          use this Expo library. Then, follow the{' '}
-          <A href={sourceCodeUrl ?? href}>additional configuration instructions</A> to configure
-          native projects (Android and iOS) as mentioned by library's README{' '}
-          <DEMI>under installation in bare React Native projects section</DEMI>.
+          If you are installing this in an{' '}
+          <A href="/bare/overview/">existing React Native app (bare workflow)</A>, start by{' '}
+          <A href="/bare/installing-expo-modules/">
+            installing <CODE>expo</CODE>
+          </A>{' '}
+          in your project. Then, follow the{' '}
+          <A href={sourceCodeUrl ?? href}>additional instructions</A> as mentioned by library's
+          README under <DEMI>"Installation in bare React Native projects"</DEMI> section.
         </P>
       )}
     </>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -32,8 +32,9 @@ export default function InstallSection({
           If you are installing this in an <A href="/bare/overview/">existing React Native app</A>,
           you have to <A href="/bare/installing-expo-modules/">prepare your existing project</A> to
           use this Expo library. Then, follow the{' '}
-          <A href={sourceCodeUrl ?? href}>additional configuration instructions</A> as mentioned by
-          library's README <DEMI>under installation in bare React Native projects section</DEMI>.
+          <A href={sourceCodeUrl ?? href}>additional configuration instructions</A> to configure
+          native projects (Android and iOS) as mentioned by library's README{' '}
+          <DEMI>under installation in bare React Native projects section</DEMI>.
         </P>
       )}
     </>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -16,12 +16,12 @@ const getPackageLink = (packageNames: string) =>
 
 const getInstallCmd = (packageName: string) => `$ npx expo install ${packageName}`;
 
-const InstallSection = ({
+export default function InstallSection({
   packageName,
   hideBareInstructions = false,
   cmd = [getInstallCmd(packageName)],
   href = getPackageLink(packageName),
-}: InstallSectionProps) => {
+}: InstallSectionProps) {
   const { sourceCodeUrl } = usePageMetadata();
 
   return (
@@ -29,19 +29,16 @@ const InstallSection = ({
       <Terminal cmd={cmd} />
       {hideBareInstructions ? null : (
         <P>
-          If you're installing this in a <A href="/bare/overview/">bare React Native app</A>, you
-          should also follow{' '}
-          <A href={sourceCodeUrl ?? href}>
-            <DEMI>these additional installation instructions</DEMI>
-          </A>
-          .
+          If you are installing this in an <A href="/bare/overview/">existing React Native app</A>,
+          you have to <A href="/bare/installing-expo-modules/">prepare your existing project</A> to
+          use this Expo library. Then, follow the{' '}
+          <A href={sourceCodeUrl ?? href}>additional configuration instructions</A> as mentioned by
+          library's README <DEMI>under installation in bare React Native projects section</DEMI>.
         </P>
       )}
     </>
   );
-};
-
-export default InstallSection;
+}
 
 export const APIInstallSection = (props: InstallSectionProps) => {
   const { packageName } = usePageMetadata();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #24258

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the `InstallSection` component to clearly identify the following user-facing steps required to be taken for most Expo libraries when using them inside an existing React Native project (projects generated by React Native CLI).
- Add link Install Expo modules in existing React Native apps link to direct to instructions on installing the `expo` package
- Use the source URL of each library to add context about the configuration instructions for Android and iOS native projects, which are required by some of the libraries. (Most libraries require minimal steps, such as installing Pods for iOS. Some libraries also require further configuration options, which are covered by the library's README). 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs locally and visit an API reference page to see these instructions, such as http://localhost:3002/versions/unversioned/sdk/cellular/.

## Preview

![CleanShot 2024-07-13 at 01 35 14@2x](https://github.com/user-attachments/assets/4f86e5a7-36f9-4ba0-ba64-399666adeeef)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
