### PR TITLE
[docs] Fix links to bare React Native additional required configs for external libraries

### DIFF
--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -12,7 +12,7 @@ An asynchronous, unencrypted, persistent, key-value storage API.
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install" />
+<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install#android--ios" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -15,7 +15,7 @@ A component that provides access to the system UI for date and time selection.
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
+<APIInstallSection href="https://github.com/react-native-datetimepicker/datetimepicker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -14,7 +14,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation" />
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -17,7 +17,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection
   packageName="lottie-react-native"
-  href="https://github.com/lottie-react-native/lottie-react-native"
+  href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
 ## Usage

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -17,7 +17,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
 
 <br />
 

--- a/docs/pages/versions/unversioned/sdk/screens.mdx
+++ b/docs/pages/versions/unversioned/sdk/screens.mdx
@@ -14,7 +14,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/software-mansion/react-native-screens" />
+<APIInstallSection href="https://github.com/software-mansion/react-native-screens#installation" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -1,7 +1,7 @@
 ---
 title: WebView
 description: A library that provides a WebView component.
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
+sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'
 platforms: ['android', 'ios']
 ---
@@ -13,11 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [`react-native-webview` documentation](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. The following example (courtesy of that repository) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/v49.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/async-storage.mdx
@@ -14,7 +14,7 @@ An asynchronous, unencrypted, persistent, key-value storage API.
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install" />
+<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install#android--ios" />
 
 ## Usage
 

--- a/docs/pages/versions/v49.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/date-time-picker.mdx
@@ -17,7 +17,7 @@ A component that provides access to the system UI for date and time selection.
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
+<APIInstallSection href="https://github.com/react-native-datetimepicker/datetimepicker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation" />
 
 ## Usage
 

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -19,7 +19,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection
   packageName="lottie-react-native"
-  href="https://github.com/lottie-react-native/lottie-react-native"
+  href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
 ## Usage

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -19,7 +19,7 @@ import { Terminal, SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
 
 After the installation completes, add the [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) to **babel.config.js**:
 

--- a/docs/pages/versions/v49.0.0/sdk/screens.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/screens.mdx
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/software-mansion/react-native-screens" />
+<APIInstallSection href="https://github.com/software-mansion/react-native-screens#installation" />
 
 ## API
 

--- a/docs/pages/versions/v49.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webview.mdx
@@ -1,7 +1,7 @@
 ---
 title: WebView
 description: A library that provides a WebView component.
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
+sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'
 ---
 
@@ -15,11 +15,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [`react-native-webview` documentation](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. The following example (courtesy of that repository) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/v50.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/async-storage.mdx
@@ -14,7 +14,7 @@ An asynchronous, unencrypted, persistent, key-value storage API.
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install" />
+<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install#android--ios" />
 
 ## Usage
 

--- a/docs/pages/versions/v50.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/date-time-picker.mdx
@@ -17,7 +17,7 @@ A component that provides access to the system UI for date and time selection.
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
+<APIInstallSection href="https://github.com/react-native-datetimepicker/datetimepicker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/gesture-handler.mdx
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation" />
 
 ## Usage
 

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -19,7 +19,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection
   packageName="lottie-react-native"
-  href="https://github.com/lottie-react-native/lottie-react-native"
+  href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
 ## Usage

--- a/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/reanimated.mdx
@@ -19,7 +19,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
 
 <br />
 

--- a/docs/pages/versions/v50.0.0/sdk/screens.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/screens.mdx
@@ -16,7 +16,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/software-mansion/react-native-screens" />
+<APIInstallSection href="https://github.com/software-mansion/react-native-screens#installation" />
 
 ## API
 

--- a/docs/pages/versions/v51.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/async-storage.mdx
@@ -12,7 +12,7 @@ An asynchronous, unencrypted, persistent, key-value storage API.
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install" />
+<APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install#android--ios" />
 
 ## Usage
 

--- a/docs/pages/versions/v51.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/date-time-picker.mdx
@@ -15,7 +15,7 @@ A component that provides access to the system UI for date and time selection.
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-datetimepicker#linking" />
+<APIInstallSection href="https://github.com/react-native-datetimepicker/datetimepicker#getting-started" />
 
 ## Usage
 

--- a/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gesture-handler.mdx
@@ -14,7 +14,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation" />
 
 ## Usage
 

--- a/docs/pages/versions/v51.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/lottie.mdx
@@ -17,7 +17,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection
   packageName="lottie-react-native"
-  href="https://github.com/lottie-react-native/lottie-react-native"
+  href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
 ## Usage

--- a/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/reanimated.mdx
@@ -17,7 +17,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
+<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
 
 <br />
 

--- a/docs/pages/versions/v51.0.0/sdk/screens.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screens.mdx
@@ -14,7 +14,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/software-mansion/react-native-screens" />
+<APIInstallSection href="https://github.com/software-mansion/react-native-screens#installation" />
 
 ## API
 

--- a/docs/pages/versions/v51.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/webview.mdx
@@ -1,7 +1,7 @@
 ---
 title: WebView
 description: A library that provides a WebView component.
-sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
+sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
 packageName: 'react-native-webview'
 platforms: ['android', 'ios']
 ---
@@ -13,11 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [`react-native-webview` documentation](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. The following example (courtesy of that repository) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #30372. For some external libraries references in the API reference section, the links to bare React Native installation instructions were outdated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes links for the following libraries (changes have been backported to all current SDK versions):
- AsyncStorage
- DateTimePicker
- GestureHandler
- Lottie
- Reanimated
- React Native Screens
- React Native WebView (also update link to GitHub and npm packages since the library was moved out of the core)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
