### PR TITLE
[docs] enhance clarity in router/create-pages.mdx

### DIFF
--- a/docs/pages/router/create-pages.mdx
+++ b/docs/pages/router/create-pages.mdx
@@ -34,7 +34,7 @@ For example, create the **app** directory in your project and then create a file
     import { Text } from 'react-native';
 
     export default function Page() {
-      return <Text>Home page</Text>;
+      return <Text>Top-level page</Text>;
     }
     ```
 
@@ -46,7 +46,7 @@ For example, create the **app** directory in your project and then create a file
 
     ```tsx app/index.tsx
     export default function Page() {
-      return <p>Home page</p>;
+      return <p>Top-level page</p>;
     }
     ```
 


### PR DESCRIPTION
# Why

Make documentation clearer.

# How

This page talks about a /home.tsx but then uses "Home page" as the text in the examples for /index.tsx leading to possible confusion.

Re-texting the label in /index.tsx examples to "Top-level page".

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
