### PR TITLE
[docs] Update Lottie API reference example to use `tsx`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -29,7 +29,7 @@ import { SnackInline } from '~/ui/components/Snippet';
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```jsx
+```tsx
 import { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -31,13 +31,13 @@ files={{
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```jsx
-import React, { useRef, useEffect } from 'react';
+```tsx
+import { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 
 export default function App() {
-  const animation = useRef(null);
+  const animation = useRef<LottieView>(null);
   useEffect(() => {
     // You can control the ref programmatically, rather than using autoPlay
     // animation.current?.play();

--- a/docs/pages/versions/v50.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/lottie.mdx
@@ -31,13 +31,13 @@ files={{
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```jsx
-import React, { useRef, useEffect } from 'react';
+```tsx
+import { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 
 export default function App() {
-  const animation = useRef(null);
+  const animation = useRef<LottieView>(null);
   useEffect(() => {
     // You can control the ref programmatically, rather than using autoPlay
     // animation.current?.play();

--- a/docs/pages/versions/v51.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/lottie.mdx
@@ -29,13 +29,13 @@ import { SnackInline } from '~/ui/components/Snippet';
     'assets/gradientBall.json': 'assets/gradientBall.json'
   }}>
 
-```jsx
-import React, { useRef, useEffect } from 'react';
+```tsx
+import { useRef, useEffect } from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import LottieView from 'lottie-react-native';
 
 export default function App() {
-  const animation = useRef(null);
+  const animation = useRef<LottieView>(null);
   useEffect(() => {
     // You can control the ref programmatically, rather than using autoPlay
     // animation.current?.play();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up changes from #29034. Also fix the CI error caused by lint check.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update Lottie API references to use `tsx`.
- Backport changes to all SDK versions
- Remove unused `React` import statement.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
