### PR TITLE
[ios][font] Fix fonts being removed in the background

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fix issues where fonts were removed when the app is backgrounded.
+
 ### 💡 Others
 
 - Stopped scoping font family names in Expo Go on Android. ([#28797](https://github.com/expo/expo/pull/28797) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On `iOS`, fix issues where fonts were removed when the app is backgrounded.
+- On `iOS`, fix issues where fonts were removed when the app is backgrounded. ([#30400](https://github.com/expo/expo/pull/30400) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-font/ios/FontExceptions.swift
+++ b/packages/expo-font/ios/FontExceptions.swift
@@ -17,3 +17,9 @@ internal final class FontRegistrationFailedException: GenericException<CFError> 
     "Registering '\(param)' font failed with message: '\(param.localizedDescription)'"
   }
 }
+
+internal final class UnregisteringFontFailedException: GenericException<CFError> {
+  override var reason: String {
+    "Unregistering '\(param)' font failed with message: '\(param.localizedDescription)'"
+  }
+}

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -1,9 +1,17 @@
 import ExpoModulesCore
 
 /**
+ Data structure to hold information about the loaded CGFont
+ */
+struct CustomFont {
+  let fullName: String
+  let postScriptName: String
+}
+
+/**
  A registry of font family aliases mapped to their real font family names.
  */
-private var fontFamilyAliases = [String: String]()
+private var fontFamilyAliases = [String: CustomFont]()
 
 /**
  A flag that is set to `true` when the ``UIFont.fontNames(forFamilyName:)`` is already swizzled.
@@ -25,15 +33,15 @@ internal struct FontFamilyAliasManager {
    Sets the alias for the given family name.
    If the alias has already been set, its family name will be overriden.
    */
-  internal static func setAlias(_ familyNameAlias: String, forFamilyName familyName: String) {
+  internal static func setAlias(_ familyNameAlias: String, forFont font: CustomFont) {
     maybeSwizzleUIFont()
-    fontFamilyAliases[familyNameAlias] = familyName
+    fontFamilyAliases[familyNameAlias] = font
   }
 
   /**
    Returns the family name for the given alias or `nil` when it's not set yet.
    */
-  internal static func familyName(forAlias familyNameAlias: String) -> String? {
+  internal static func familyName(forAlias familyNameAlias: String) -> CustomFont? {
     return fontFamilyAliases[familyNameAlias]
   }
 }

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -1,17 +1,9 @@
 import ExpoModulesCore
 
 /**
- Data structure to hold information about the loaded CGFont
- */
-struct CustomFont {
-  let fullName: String
-  let postScriptName: String
-}
-
-/**
  A registry of font family aliases mapped to their real font family names.
  */
-private var fontFamilyAliases = [String: CustomFont]()
+private var fontFamilyAliases = [String: String]()
 
 /**
  A flag that is set to `true` when the ``UIFont.fontNames(forFamilyName:)`` is already swizzled.
@@ -33,7 +25,7 @@ internal struct FontFamilyAliasManager {
    Sets the alias for the given family name.
    If the alias has already been set, its family name will be overriden.
    */
-  internal static func setAlias(_ familyNameAlias: String, forFont font: CustomFont) {
+  internal static func setAlias(_ familyNameAlias: String, forFont font: String) {
     maybeSwizzleUIFont()
     fontFamilyAliases[familyNameAlias] = font
   }
@@ -41,7 +33,7 @@ internal struct FontFamilyAliasManager {
   /**
    Returns the family name for the given alias or `nil` when it's not set yet.
    */
-  internal static func familyName(forAlias familyNameAlias: String) -> CustomFont? {
+  internal static func familyName(forAlias familyNameAlias: String) -> String? {
     return fontFamilyAliases[familyNameAlias]
   }
 }

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -9,15 +9,14 @@ public final class FontLoaderModule: Module {
     }
 
     AsyncFunction("loadAsync") { (fontFamilyAlias: String, localUri: URL) in
+      let fontUrl = localUri as CFURL
       // If the font was already registered, unregister it first. Otherwise CTFontManagerRegisterFontsForURL
       // would fail because of a duplicated font name when the app reloads or someone wants to override a font.
       if FontFamilyAliasManager.familyName(forAlias: fontFamilyAlias) != nil {
-        guard try unregisterFont(url: localUri as CFURL) else {
+        guard try unregisterFont(url: fontUrl) else {
           return
         }
       }
-
-      let fontUrl = localUri as CFURL
 
       // Register the font
       try registerFont(fontUrl)
@@ -25,7 +24,7 @@ public final class FontLoaderModule: Module {
       // Create a font object from the given URL
       let font = try loadFont(fromUrl: fontUrl, alias: fontFamilyAlias)
 
-      if let fullName = font.fullName as? String, let postScriptName = font.postScriptName as? String {
+      if let postScriptName = font.postScriptName as? String {
         FontFamilyAliasManager.setAlias(fontFamilyAlias, forFont: postScriptName)
       }
     }

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -26,10 +26,7 @@ public final class FontLoaderModule: Module {
       let font = try loadFont(fromUrl: fontUrl, alias: fontFamilyAlias)
 
       if let fullName = font.fullName as? String, let postScriptName = font.postScriptName as? String {
-        FontFamilyAliasManager.setAlias(
-          fontFamilyAlias,
-          forFont: CustomFont(fullName: fullName, postScriptName: postScriptName)
-        )
+        FontFamilyAliasManager.setAlias(fontFamilyAlias, forFont: postScriptName)
       }
     }
   }

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -11,16 +11,21 @@ public extension UIFont {
     let fontNames = UIFont._expo_fontNames(forFamilyName: familyName)
 
     // If no font names were found, let's try with the alias.
-    if fontNames.isEmpty, let aliasedFamilyName = FontFamilyAliasManager.familyName(forAlias: familyName) {
-      let fontNames = UIFont._expo_fontNames(forFamilyName: aliasedFamilyName)
+    if fontNames.isEmpty, let font = FontFamilyAliasManager.familyName(forAlias: familyName) {
+      var fontNames = UIFont._expo_fontNames(forFamilyName: font.fullName)
+
+      if fontNames.isEmpty {
+        fontNames = UIFont._expo_fontNames(forFamilyName: font.postScriptName)
+      }
 
       // If we still don't find any font names, we can assume it was not a family name but a font name.
       // In that case we can safely return the original font name.
       if fontNames.isEmpty {
-        return [aliasedFamilyName]
+        return [font.postScriptName]
       }
       return fontNames
     }
+
     return fontNames
   }
 }

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -11,17 +11,13 @@ public extension UIFont {
     let fontNames = UIFont._expo_fontNames(forFamilyName: familyName)
 
     // If no font names were found, let's try with the alias.
-    if fontNames.isEmpty, let font = FontFamilyAliasManager.familyName(forAlias: familyName) {
-      var fontNames = UIFont._expo_fontNames(forFamilyName: font.fullName)
-
-      if fontNames.isEmpty {
-        fontNames = UIFont._expo_fontNames(forFamilyName: font.postScriptName)
-      }
+    if fontNames.isEmpty, let postScriptName = FontFamilyAliasManager.familyName(forAlias: familyName) {
+      let fontNames = UIFont._expo_fontNames(forFamilyName: postScriptName)
 
       // If we still don't find any font names, we can assume it was not a family name but a font name.
       // In that case we can safely return the original font name.
       if fontNames.isEmpty {
-        return [font.postScriptName]
+        return [postScriptName]
       }
       return fontNames
     }


### PR DESCRIPTION
# Why
Fixes the issues mentioned [here](https://github.com/expo/google-fonts/issues/109)
[The problem](https://forums.developer.apple.com/forums/thread/741720#:~:text=Restarting%20the%20app%20always%20fixes,kind%20of%20font%20caching%20issue.&text=The%20font%20files%20ship%20with,the%20FontHandler%20class%20used%20above.) seems to be iOS 17 specific but it may not be. Font's registered with `CTFontManagerRegisterGraphicsFont` are being removed from the font manager when the app is backgrounded. 

# How
Using `CTFontManagerRegisterFontsForURL` fixes the issue because you can specify the lifetime of the registration. The documentation also mentions that this method should be preferred for fonts backed by a file. 

# Test Plan
Bare-expo. The issue is no longer reproducible. Also tested in one of the provided repros.

