### PR TITLE
[docs] Fix multiple minor formatting and readability issues

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -13,7 +13,6 @@ swap:
   cancelling: canceling
   cocoapods: CocoaPods
   devops: DevOps
-  devtools: DevTools
   eas: EAS
   eas build: EAS Build
   eas cli: EAS CLI

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -48,11 +48,11 @@ Yarn and other tooling have a concept called _"workspaces"_. Every package and a
 
 Now that we have the basic monorepo structure set up, let's add our first app.
 
-Before we create our app, we have to create the **apps/** folder. This folder contains all separate apps or websites that belong to this monorepo. Inside this **apps/** folder, we can create a subfolder that contains the React Native app.
+Before we create our app, we have to create the **apps** directory. This directory contains all separate apps or websites that belong to this monorepo. Inside this **apps** directory, we can create a sub-directory that contains the React Native app.
 
 <Terminal cmd={['$ yarn create expo apps/cool-app']} />
 
-> If you have an existing app, you can copy all those files into a folder inside **apps/**.
+> If you have an existing app, you can copy all those files into a directory inside **apps**.
 
 After copying or creating the first app, run `yarn` to check for common warnings.
 
@@ -95,7 +95,7 @@ module.exports = config;
 
 Metro has three separate stages in its bundling process, [documented here](https://metrobundler.dev/docs/concepts). During the first phase, **Resolution**, Metro resolves your app's required files and dependencies. Metro does that with the `watchFolders` option, which is set to the project directory by default. This default setting works great for apps that don't use a monorepo structure.
 
-When using monorepos, your app dependencies splits up into different directories. Each of these directories must be within the scope of the [watchFolders](https://metrobundler.dev/docs/configuration/#watchfolders). If a changed file is outside of that scope, Metro won't be able to find it. Setting this path to the root of your monorepo will force Metro to watch all files within the repository and possibly cause a slow initial startup time.
+When using monorepos, your app dependencies splits up into different directories. Each of these directories must be within the scope of the [`watchFolders`](https://metrobundler.dev/docs/configuration/#watchfolders). If a changed file is outside of that scope, Metro won't be able to find it. Setting this path to the root of your monorepo will force Metro to watch all files within the repository and possibly cause a slow initial startup time.
 
 As your monorepo increases in size, watching all files within the monorepo becomes slower. You can speed things up by only watching the packages your app uses. Typically, these are the ones that are installed with an asterisk (\*) in your **package.json**. For example:
 
@@ -116,12 +116,12 @@ const monorepoPackages = {
   '@acme/components': path.resolve(monorepoRoot, 'packages/components'),
 };
 
-// 1. Watch the local app folder, and only the shared packages (limiting the scope and speeding it up)
+// 1. Watch the local app directory, and only the shared packages (limiting the scope and speeding it up)
 // Note how we change this from `monorepoRoot` to `projectRoot`. This is part of the optimization!
 config.watchFolders = [projectRoot, ...Object.values(monorepoPackages)];
 
 // Add the monorepo workspaces as `extraNodeModules` to Metro.
-// If your monorepo tooling creates workspace symlinks in the `node_modules` folder,
+// If your monorepo tooling creates workspace symlinks in the `node_modules` directory,
 // you can either add symlink support to Metro or set the `extraNodeModules` to avoid the symlinks.
 // See: https://metrobundler.dev/docs/configuration/#extranodemodules
 config.resolver.extraNodeModules = monorepoPackages;
@@ -139,18 +139,18 @@ config.resolver.nodeModulesPaths = [
 
 This option is important to resolve libraries in the correct **node_modules** directories. Monorepo tooling, like Yarn, usually creates two different **node_modules** directories which are used for a single workspace.
 
-1. **apps/mobile/node_modules** - The "project" folder
-2. **node_modules** - The "root" folder
+1. **apps/mobile/node_modules** - The "project" directory
+2. **node_modules** - The "root" directory
 
-Yarn uses the root folder to install packages used in multiple workspaces. If a workspace uses a different package version, it installs that different version in the project folder.
+Yarn uses the root directory to install packages used in multiple workspaces. If a workspace uses a different package version, it installs that different version in the project directory.
 
-We have to tell Metro to look in these two folders. The order is important here because the project folder **node_modules** can contain specific versions we use for our app. When the package does not exist in the project folder, it should try the shared root folder.
+We have to tell Metro to look in these two directories. The order is important here because the project directory **node_modules** can contain specific versions we use for our app. When the package does not exist in the project directory, it should try the shared root directory.
 
 </Collapsible>
 
 #### Change default entrypoint
 
-In monorepos, we can't hardcode paths to packages anymore since we can't be sure if they are installed in the root **node_modules** or the workspace **node_modules** folder. If you are using a managed project, we have to change our default entry point that looks like `node_modules/expo/AppEntry.js`.
+In monorepos, we can't hardcode paths to packages anymore since we can't be sure if they are installed in the root **node_modules** or the workspace **node_modules** directory. If you are using a managed project, we have to change our default entry point that looks like `node_modules/expo/AppEntry.js`.
 
 Open our app's **package.json**, change the `main` property to `index.js`, and create this new **index.js** file in the app directory with the content below.
 
@@ -175,13 +175,13 @@ This variable can also be defined inside a **.env** file.
 
 ### Create a package
 
-Monorepos can help us group code in a single repository. That includes apps but also separate packages. They also don't need to be published. The [Expo repository](https://github.com/expo/expo) uses this as well. All the Expo SDK packages live inside the [**packages/**](https://github.com/expo/expo/tree/main/packages) folder in our repo. It helps us test the code inside one of our [**apps/**](https://github.com/expo/expo/tree/main/apps/native-component-list) before we publish them.
+Monorepos can help us group code in a single repository. That includes apps but also separate packages. They also don't need to be published. The [Expo repository](https://github.com/expo/expo) uses this as well. All the Expo SDK packages live inside the [**packages**](https://github.com/expo/expo/tree/main/packages) directory in our repo. It helps us test the code inside one of our [**apps**](https://github.com/expo/expo/tree/main/apps/native-component-list) directory before we publish them.
 
-Let's go back to the root and create the **packages/** folder. This folder can contain all the separate packages that you want to make. Once you are inside this folder, we need to add a new subfolder. The subfolder is a separate package that we can use inside our app. In the example below, we named it **cool-package**.
+Let's go back to the root and create the **packages** directory. This directory can contain all the separate packages that you want to make. Once you are inside this directory, we need to add a new sub-directory. The sub-directory is a separate package that we can use inside our app. In the example below, we named it **cool-package**.
 
 <Terminal
   cmd={[
-    '# Create our new package folder',
+    '# Create our new package directory',
     '$ mkdir -p packages/cool-package',
     '$ cd packages/cool-package',
     '',
@@ -298,11 +298,11 @@ In the [Modify the Metro config](#modify-the-metro-config) step, we instructed M
 - #2 - Resolve dependencies in the order of the local **/apps/&lt;name&gt;/node_modules** and root **/node_modules** directories.
 - #3 - Disable resolving dependencies using the hierarchical lookup strategy.
 
-If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **/apps/&lt;name&gt;/node_modules** directory.
+If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **apps/&lt;name&gt;/node_modules** directory.
 
-When Metro resolves a library, for example, `react`, from the workspace, it should find that different version in **/apps/&lt;name&gt;/node_modules** and not look inside the root **/node_modules** directory.
+When Metro resolves a library, for example, `react`, from the workspace, it should find that different version in **/apps/&lt;name&gt;/node_modules** and not look inside the root **node_modules** directory.
 
-When importing a dependency from the root **/node_modules** folder that also imports `react`, `react` should still resolve to the different version installed in **/apps/&lt;name&gt;/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
+When importing a dependency from the root **node_modules** directory that also imports `react`, `react` should still resolve to the different version installed in **/apps/&lt;name&gt;/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
 
 </Collapsible>
 
@@ -344,8 +344,8 @@ All Expo SDK modules and templates have these dynamic references and work with m
 
 ### Remove expo-yarn-workspaces
 
-Before SDK 43, `expo-yarn-workspaces` was the recommended way to use Yarn workspaces with your Expo project. It was used to symlink all required dependencies back to the app's **node_modules** folder. Although this works for most apps, it has some flaws. For example, it doesn't work well with multiple versions of the same package.
+Before SDK 43, `expo-yarn-workspaces` was the recommended way to use Yarn workspaces with your Expo project. It was used to symlink all required dependencies back to the app's **node_modules** directory. Although this works for most apps, it has some flaws. For example, it doesn't work well with multiple versions of the same package.
 
-We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also looks for packages in parent **node_modules** folders. None of our native files inside our template contain hardcoded paths to packages.
+We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also looks for packages in parent **node_modules** directories. None of our native files inside our template contain hardcoded paths to packages.
 
 If you are following this guide, you should remove that package from your project's dependencies.

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -14,8 +14,8 @@ Monorepos, or _"monolithic repositories"_, are single repositories containing mu
 
 In this example, we will set up a monorepo using Yarn workspaces without the [nohoist](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) option. We will assume some familiar names, but you can fully customize them. After this guide, our basic structure should look like this:
 
-- **apps/** - Contains multiple projects, including React Native apps.
-- **packages/** - Contains different packages used by our apps.
+- **apps** - Contains multiple projects, including React Native apps.
+- **packages** - Contains different packages used by our apps.
 - **package.json** - Root package file, containing Yarn workspaces config.
 
 ### Root package file
@@ -287,7 +287,7 @@ React Native dependencies contain many other files besides JavaScript, like Grad
 
 <Collapsible summary="2. Dependencies used in multiple workspaces can be installed in the root node_modules directory">
 
-Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to remove duplicate tasks, like installing the same dependency twice in different places. This rule isn't necessary but does set us up for rule #3.
+Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to remove duplicate tasks, like installing the same dependency twice in different places. This rule isn't necessary but does set us up for next rule.
 
 </Collapsible>
 
@@ -295,14 +295,14 @@ Whenever multiple workspaces use the same version of a single dependency, they c
 
 In the [Modify the Metro config](#modify-the-metro-config) step, we instructed Metro to do a couple of this, specifically:
 
-- #2 - Resolve dependencies in the order of the local **/apps/&lt;name&gt;/node_modules** and root **/node_modules** directories.
+- #2 - Resolve dependencies in the order of the local **apps/&lt;name&gt;/node_modules** and root **node_modules** directories.
 - #3 - Disable resolving dependencies using the hierarchical lookup strategy.
 
-If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **apps/&lt;name&gt;/node_modules** directory.
+If a workspace uses a different library version than the one installed in the root **node_modules**, that different library version must be installed in the workspace **apps/&lt;name&gt;/node_modules** directory.
 
-When Metro resolves a library, for example, `react`, from the workspace, it should find that different version in **/apps/&lt;name&gt;/node_modules** and not look inside the root **node_modules** directory.
+When Metro resolves a library, for example, `react`, from the workspace, it should find that different version in **apps/&lt;name&gt;/node_modules** and not look inside the root **node_modules** directory.
 
-When importing a dependency from the root **node_modules** directory that also imports `react`, `react` should still resolve to the different version installed in **/apps/&lt;name&gt;/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
+When importing a dependency from the root **node_modules** directory that also imports `react`, `react` should still resolve to the different version installed in **apps/&lt;name&gt;/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
 
 </Collapsible>
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -101,7 +101,7 @@ You do not have to install other plugins or configurations to use Firebase JS SD
 
 Firebase version 9 and above provide a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
 
-> Using Firebase Authentication with version 9 or below? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
+> **info** **Troubleshooting tip:** If you encounter issues related to authentication persistance with Firebase JS SDK, see the guide for [setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
 
 </Step>
 

--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -206,7 +206,7 @@ Your **public/.well-known/apple-app-site-association** must be served from a sec
 
 Check your **ios&#x2f;project&#x2f;project.entitlements** file, under the `com.apple.developer.associated-domains` key. This should contain the same domains as your web server/website. The URL cannot contain a protocol (`https://`) or additional pathname, query parameters, or fragments.
 
-### Still Stuck?
+### Still stuck
 
 > This is an important but very difficult feature to set up. Expo Router automates many of the moving parts, Expo CLI automates much of the configuration and hosting. However, hardware settings can still be misconfigured.
 

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -143,7 +143,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 <APIBox header="generateStaticParams">
 
-A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process, not just the values prefixed with **EXPO*PUBLIC***. **generateStaticParams** is not run in a browser environment, so it cannot access browser APIs like **localStorage** or **document**, nor can it access native Expo APIs such as **expo-camera** or **expo-location**.
+A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as **localStorage** or **document**. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
 
 ```tsx app/[id].tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -143,7 +143,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 <APIBox header="generateStaticParams">
 
-A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as **localStorage** or **document**. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
+A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as `localStorage` or `document`. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
 
 ```tsx app/[id].tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
@@ -155,11 +155,11 @@ export async function generateStaticParams(): Promise<Record<string, string>[]> 
 }
 ```
 
-**generateStaticParams** cascades from nested parents down to children. The cascading parameters are passed to every dynamic child route that exports **generateStaticParams**.
+`generateStaticParams` cascades from nested parents down to children. The cascading parameters are passed to every dynamic child route that exports **generateStaticParams**.
 
 ```tsx app/[id]/_layout.tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
-  /* @info Any dynamic children that export <b>generateStaticParams</b> will be invoked once for every entry in the array. */
+  /* @info Any dynamic children that export <CODE>generateStaticParams</CODE> will be invoked once for every entry in the array. */
   return [{ id: 'one' }, { id: 'two' }];
   /* @end */
 }

--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -72,9 +72,9 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 
 <ConfigReactNative>
 
-Add `NSFaceIDUsageDescription` key to your Info.plist:
+Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
-```
+```xml Info.plist
 <key>NSCameraUsageDescription</key>
 <string>Allow $(PRODUCT_NAME) to use the camera</string>
 ```

--- a/docs/pages/versions/v50.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/securestore.mdx
@@ -66,9 +66,9 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 
 <ConfigReactNative>
 
-Add `NSFaceIDUsageDescription` key to your Info.plist:
+Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
-```
+```xml Info.plist
 <key>NSCameraUsageDescription</key>
 <string>Allow $(PRODUCT_NAME) to use the camera</string>
 ```

--- a/docs/pages/versions/v51.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/securestore.mdx
@@ -64,9 +64,9 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 
 <ConfigReactNative>
 
-Add `NSFaceIDUsageDescription` key to your Info.plist:
+Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
-```
+```xml Info.plist
 <key>NSCameraUsageDescription</key>
 <string>Allow $(PRODUCT_NAME) to use the camera</string>
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through different docs, I've encountered these formatting and readability issues.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Apple Handoff: Remove question mark in the heading to fix Vale warning
- Monorepo guide: Update it to follow how to represent directory as per writing style guide
- Remove "DevTools" as a term from Vale's concistency
- Update `getStaticParameters` to fix formatting and readability issues
- Add an info callout in Firebase guide > Firebase JS SDK to update verbiage about auth persistance
- Add code language to the snippet in SecureStore API reference so that it is not hidden and is displayed correctly

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
