### PR TITLE
Remove unused `mode` property from adapters examples

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -287,7 +287,6 @@ const handler = createRequestHandler({
   /* @info Points to the root `dist/` (output) folder */
   build: require('path').join(__dirname, '../../dist/server'),
   /* @end */
-  mode: process.env.NODE_ENV,
 });
 
 module.exports = { handler };
@@ -369,7 +368,6 @@ module.exports = createRequestHandler({
   /* @info Points to the root `dist/` (output) folder */
   build: require('path').join(__dirname, '../dist/server'),
   /* @end */
-  mode: process.env.NODE_ENV,
 });
 ```
 


### PR DESCRIPTION
# What

Remove the `mode` config property for the `createRequestHandler` function, which appears to be unused in all adapters:


1. Express adapter https://github.com/expo/expo/blob/72b3295ce4d2030f6e5fe1d3391236d9e6c0bdd6/packages/%40expo/server/src/vendor/express.ts#L18-L21
2. HTTP adapter https://github.com/expo/expo/blob/72b3295ce4d2030f6e5fe1d3391236d9e6c0bdd6/packages/%40expo/server/src/vendor/http.ts#L20-L23
3. Vercel adapter https://github.com/expo/expo/blob/72b3295ce4d2030f6e5fe1d3391236d9e6c0bdd6/packages/%40expo/server/src/vendor/vercel.ts#L15
   - Introduced in https://github.com/expo/expo/pull/25539
4. Netlify adapter https://github.com/expo/expo/blob/72b3295ce4d2030f6e5fe1d3391236d9e6c0bdd6/packages/%40expo/server/src/vendor/netlify.ts#L7
   - Introduced in https://github.com/expo/expo/pull/24510

cc @kitten @amandeepmittal @EvanBacon 

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Unused `mode` config setting recommended in docs

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `mode` config setting

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Analyzed the source code to verify that `mode` was unused

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
