### PR TITLE
[docs] Change API entry file in vercel.json from .js to .ts

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -395,7 +395,7 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
       }
     },
     {
-      "src": "api/index.js",
+      "src": "api/index.ts",
       "use": "@vercel/node",
       "config": {
         "includeFiles": ["dist/server/**"]
@@ -408,7 +408,7 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
     },
     {
       "src": "/(.*)",
-      "dest": "/api/index.js"
+      "dest": "/api/index.ts"
     }
   ]
 }
@@ -424,7 +424,7 @@ The **legacy** version of the **vercel.json** needs a `@vercel/static-build` run
   "buildCommand": "expo export -p web",
   "outputDirectory": "dist/client",
   "functions": {
-    "api/index.js": {
+    "api/index.ts": {
       "runtime": "@vercel/node@3.0.11",
       "includeFiles": "dist/server/**"
     }
@@ -432,7 +432,7 @@ The **legacy** version of the **vercel.json** needs a `@vercel/static-build` run
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/api/index.js"
+      "destination": "/api/index.ts"
     }
   ]
 }


### PR DESCRIPTION
# Why

In your docs about [API Routes Vercel Deployment](https://docs.expo.dev/router/reference/api-routes/#vercel), there is an issue with the configuration file for `vercel.json v2` and `vercel.json v3`. In the section for creating the server entry file, the file is a `.ts` file, and in your example for `vercel.json`, the file is a `js` file. 

Deployed on Vercel and got this error message:

```
Error: The pattern "api/index.js" defined in `functions` doesn't match any Serverless Functions inside the `api` directory.
```

<img width="1228" alt="Screenshot 2024-07-16 at 12 36 04" src="https://github.com/user-attachments/assets/7941b3b1-e086-4e6d-b65e-6a1859543084">

cc. @kitten, @amandeepmittal 

# How

The destination file in the API route configuration has been changed from `/api/index.js` to `/api/index.ts`.

# Test Plan

Changed and redeployed. No issue after changing to `.ts` 

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
