### PR TITLE
[eslint-plugin-expo] Fix readme links

### DIFF
--- a/packages/eslint-plugin-expo/README.md
+++ b/packages/eslint-plugin-expo/README.md
@@ -45,5 +45,5 @@ Then configure the rules you want to use under the rules section.
 
 | Name                                                               | Description                                          |
 | :----------------------------------------------------------------- | :--------------------------------------------------- |
-| [no-dynamic-env-var](docs/rules/noDynamicEnvVar.md)             | Prevents process.env from being accessed dynamically |
-| [no-env-var-destructuring](docs/rules/noEnvVarDestructuring.md) | Disallow desctructuring of environment variables     |
+| [no-dynamic-env-var](docs/rules/no-dynamic-env-var.md)             | Prevents process.env from being accessed dynamically |
+| [no-env-var-destructuring](docs/rules/no-env-var-destructuring.md) | Disallow desctructuring of environment variables     |


### PR DESCRIPTION
# Why

The readme links point to files that don't exist. I think I went back and forth on whether to `kebab-case` or `camelCase` and chose... both?

# How

Fix the url.

# Test Plan

Check the URLs in the readme link to the right page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
