### PR TITLE
refactor(cli): upgrade `expo-atlas@0.3.11` and remove deprecated `atlas.registerMetro`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Ensure Metro dev server closes fully when clients are connected. ([#30067](https://github.com/expo/expo/pull/30067) by [@byCedric](https://github.com/byCedric))
 - Fix app crashing when hitting debugger breakpoint through VSCode. ([#30287](https://github.com/expo/expo/pull/30287) by [@byCedric](https://github.com/byCedric))
 - Resolve real locations of file paths when using `eas build --local`. ([#30340](https://github.com/expo/expo/pull/30340) by [@byCedric](https://github.com/byCedric))
+- Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Ensure Metro dev server closes fully when clients are connected. ([#30067](https://github.com/expo/expo/pull/30067) by [@byCedric](https://github.com/byCedric))
 - Fix app crashing when hitting debugger breakpoint through VSCode. ([#30287](https://github.com/expo/expo/pull/30287) by [@byCedric](https://github.com/byCedric))
 - Resolve real locations of file paths when using `eas build --local`. ([#30340](https://github.com/expo/expo/pull/30340) by [@byCedric](https://github.com/byCedric))
-- Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads.
+- Upgrade minimum required Atlas version to `0.3.11` fixing HMR reloads. ([#30424](https://github.com/expo/expo/pull/30424) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -152,7 +152,7 @@
     "@types/wrap-ansi": "^8.0.1",
     "@types/ws": "^8.5.4",
     "devtools-protocol": "^0.0.1113120",
-    "expo-atlas": "^0.3.0",
+    "expo-atlas": "^0.3.11",
     "expo-module-scripts": "^3.0.0",
     "find-process": "^1.4.7",
     "jest-runner-tsd": "^6.0.0",

--- a/packages/@expo/cli/src/start/server/metro/debugging/AtlasPrerequisite.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/AtlasPrerequisite.ts
@@ -26,7 +26,7 @@ export class AtlasPrerequisite extends ProjectPrerequisite<
         warningMessage:
           'Expo Atlas is not installed in this project, unable to gather bundle information.',
         requiredPackages: [
-          { version: '^0.3.0', pkg: 'expo-atlas', file: 'expo-atlas/package.json', dev: true },
+          { version: '^0.3.11', pkg: 'expo-atlas', file: 'expo-atlas/package.json', dev: true },
         ],
       });
     } catch (error) {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -232,7 +232,7 @@ export async function instantiateMetroAsync(
   }
 
   // Attach Expo Atlas if enabled
-  const atlas = await attachAtlasAsync({
+  await attachAtlasAsync({
     isExporting,
     exp,
     projectRoot,
@@ -257,9 +257,6 @@ export async function instantiateMetroAsync(
       mockServer: isExporting,
     }
   );
-
-  // If Atlas is enabled, and can register to Metro, attach it to listen for changes
-  atlas?.registerMetro(metro);
 
   prependMiddleware(middleware, (req: ServerRequest, res: ServerResponse, next: ServerNext) => {
     // If the URL is a Metro asset request, then we need to skip all other middleware to prevent

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,10 +8479,10 @@ expo-asset-utils@~3.0.0:
   resolved "https://registry.yarnpkg.com/expo-asset-utils/-/expo-asset-utils-3.0.0.tgz#2c7ddf71ba9efacf7b46c159c1c650114a2f14dc"
   integrity sha512-CgIbNvTqKqQi1lrlptmwoaCMu4ZVOZf8tghmytlor23CjIOuorw6cfuOqiqWkJLz23arTt91maYEU9XLMPB23A==
 
-expo-atlas@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/expo-atlas/-/expo-atlas-0.3.0.tgz#297b9d0ba1d5b1341636822c2137ea408f0bbf05"
-  integrity sha512-EfG0RYdHyeMp5exuOw2p0VtbJfxKZiuMFmuZCnkkN2Qg751TKc3rPY8eom95JC9mNSH8DRS0Ia2hAMgPx9333Q==
+expo-atlas@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/expo-atlas/-/expo-atlas-0.3.11.tgz#e025615e0f9ecd43c32b54706a1f3557a0f75124"
+  integrity sha512-mQnKzNlEReusByuBX8GnRsRY1GAL1iy5j/lsJ/dLusQR+xLY7hZaUiZ4XEe+UYzLTSN3d3Sf43hOsDOpxDwm8Q==
   dependencies:
     "@expo/server" "^0.4.2"
     arg "^5.0.2"
@@ -9373,7 +9373,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.7, glob@^7.2.0:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==


### PR DESCRIPTION
# Why

`expo-atlas@0.3.11` contains the newer HMR detection, reusing the existing HMR server instead of reading directly from Metro. This method is slightly more limiting, but fixes HMR reloads when running for dev servers.

# How

- Upgraded cli to `expo-atlas@0.3.11`
- Upgraded minimum required `expo-atlas` version to `0.3.11`
- Removed deprecated `atlas.registerMetro` function

# Test Plan

See added test, or run:

- `$ cd apps/router-e2e`
- `$ E2E_ROUTER_SRC=tailwind-postcss EXPO_UNSTABLE_ATLAS=1 npx expo -d -w`
- Change **apps/router-e2e/__e2e__/taolwind-postcss/app/index.tsx**
- All open clients and Atlas should receive the HMR update

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
