### PR TITLE
refactor(config): upgrade to `glob@10`

### DIFF
--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Upgrade `glob@7` to `glob@10`.
+
 ## 9.0.2 — 2024-05-16
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Upgrade `glob@7` to `glob@10`.
+- Upgrade `glob@7` to `glob@10`. ([#30425](https://github.com/expo/expo/pull/30425) by [@byCedric](https://github.com/byCedric))
 
 ## 9.0.2 — 2024-05-16
 

--- a/packages/@expo/config/package.json
+++ b/packages/@expo/config/package.json
@@ -38,7 +38,7 @@
     "@expo/config-types": "^51.0.0-unreleased",
     "@expo/json-file": "^8.3.0",
     "getenv": "^1.0.0",
-    "glob": "7.1.6",
+    "glob": "^10.4.2",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9373,7 +9373,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.7, glob@^7.2.0:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==


### PR DESCRIPTION
# Why

Left-over upgrade from https://github.com/expo/expo/pull/29808, specific to `@expo/config`.

# How

- Upgraded to `glob@10`

# Test Plan

See tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
