### PR TITLE
[core][Android] Limit the number of "Current Activity is of incorrect class" log entries

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -53,7 +53,7 @@
 - [iOS] Added `customizeRootView:` support to `EXAppDelegateWrapper.createRCTRootViewFactory`. ([#30245](https://github.com/expo/expo/pull/30245) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Bump Kotlin coroutines version to 1.7.3. ([#30226](https://github.com/expo/expo/pull/30226) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Limit the number of "Current Activity is of incorrect class" log entries.
+- [Android] Limit the number of "Current Activity is of incorrect class" log entries. ([#30427](https://github.com/expo/expo/pull/30427) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -53,6 +53,7 @@
 - [iOS] Added `customizeRootView:` support to `EXAppDelegateWrapper.createRCTRootViewFactory`. ([#30245](https://github.com/expo/expo/pull/30245) by [@kudo](https://github.com/kudo))
 - Bumped Kotlin version to 1.9.24. ([#30199](https://github.com/expo/expo/pull/30199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Bump Kotlin coroutines version to 1.7.3. ([#30226](https://github.com/expo/expo/pull/30226) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Limit the number of "Current Activity is of incorrect class" log entries.
 
 ## 1.12.16 - 2024-06-20
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -262,7 +262,9 @@ class AppContext(
   }
 
   internal fun onHostResume() {
-    val activity = currentActivity
+    // If the current activity is null, it means that the current React context was destroyed.
+    // We can just return here.
+    val activity = currentActivity ?: return
     check(activity is AppCompatActivity) {
       "Current Activity is of incorrect class, expected AppCompatActivity, received ${currentActivity?.localClassName}"
     }


### PR DESCRIPTION
# Why

Limits the number of "Current Activity is of incorrect class" log entries.
We're printing it event if the current react context was deallocated.
