### PR TITLE
[core][Android] Fix not throwing when setting readonly properties.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Android] Provide value in `getName` of `ModuleRegistryReadyNotifier.java` ([#30358](https://github.com/expo/expo/pull/30358) by [@WoLewicki](https://github.com/WoLewicki))
 - [Android] When a `SharedObject` that was passed as an argument is returned, it no longer creates a new object. ([#30231](https://github.com/expo/expo/pull/30231) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed some types weren't correctly converted when using coroutines. ([#30227](https://github.com/expo/expo/pull/30227) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed not throwing when setting getter-only properties.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [Android] Provide value in `getName` of `ModuleRegistryReadyNotifier.java` ([#30358](https://github.com/expo/expo/pull/30358) by [@WoLewicki](https://github.com/WoLewicki))
 - [Android] When a `SharedObject` that was passed as an argument is returned, it no longer creates a new object. ([#30231](https://github.com/expo/expo/pull/30231) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed some types weren't correctly converted when using coroutines. ([#30227](https://github.com/expo/expo/pull/30227) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed not throwing when setting getter-only properties.
+- [Android] Fixed not throwing when setting readonly properties.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [Android] Provide value in `getName` of `ModuleRegistryReadyNotifier.java` ([#30358](https://github.com/expo/expo/pull/30358) by [@WoLewicki](https://github.com/WoLewicki))
 - [Android] When a `SharedObject` that was passed as an argument is returned, it no longer creates a new object. ([#30231](https://github.com/expo/expo/pull/30231) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed some types weren't correctly converted when using coroutines. ([#30227](https://github.com/expo/expo/pull/30227) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed not throwing when setting read-only properties.
+- [Android] Fixed not throwing when setting read-only properties. ([#30428](https://github.com/expo/expo/pull/30428) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [Android] Provide value in `getName` of `ModuleRegistryReadyNotifier.java` ([#30358](https://github.com/expo/expo/pull/30358) by [@WoLewicki](https://github.com/WoLewicki))
 - [Android] When a `SharedObject` that was passed as an argument is returned, it no longer creates a new object. ([#30231](https://github.com/expo/expo/pull/30231) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed some types weren't correctly converted when using coroutines. ([#30227](https://github.com/expo/expo/pull/30227) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed not throwing when setting readonly properties.
+- [Android] Fixed not throwing when setting read-only properties.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import org.junit.Assert
 import org.junit.Test
 
 internal class JSIPropertiesTest {
@@ -58,5 +60,17 @@ internal class JSIPropertiesTest {
 
     Truth.assertThat(p.isUndefined()).isTrue()
     Truth.assertThat(undefined.isUndefined()).isTrue()
+  }
+
+  @Test
+  fun should_throw_if_setting_a_getter_only_property() = withSingleModule({
+    Property("p")
+      .get { 567 }
+  }) {
+    Assert.assertThrows(JavaScriptEvaluateException::class.java) {
+      evaluateScript("$moduleRef.p = 1")
+    }
+    val p1 = property("p").getInt()
+    Truth.assertThat(p1).isEqualTo(567)
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -150,6 +150,10 @@ std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
   jsi::Runtime &runtime
 ) {
   if (body == nullptr) {
+    if (jBodyReference == nullptr) {
+      return nullptr;
+    }
+
     if (isAsync) {
       body = std::make_shared<jsi::Function>(toAsyncFunction(runtime));
     } else {

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
@@ -57,16 +57,23 @@ void JSPropertiesDecorator::decorate(
 
     auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime,
                                                                   1 << 1 /* enumerable */);
-    descriptor.setProperty(
-      runtime,
-      "get",
-      jsi::Value(runtime, *getter->toJSFunction(runtime))
-    );
-    descriptor.setProperty(
-      runtime,
-      "set",
-      jsi::Value(runtime, *setter->toJSFunction(runtime))
-    );
+    auto jsGetter = getter->toJSFunction(runtime);
+    if (jsGetter != nullptr) {
+      descriptor.setProperty(
+        runtime,
+        "get",
+        jsi::Value(runtime, *jsGetter)
+      );
+    }
+
+    auto jsSetter = setter->toJSFunction(runtime);
+    if (jsSetter != nullptr) {
+      descriptor.setProperty(
+        runtime,
+        "set",
+        jsi::Value(runtime, *jsSetter)
+      );
+    }
     common::defineProperty(runtime, &jsObject, name.c_str(), std::move(descriptor));
   }
 }


### PR DESCRIPTION
# Why

A fixed version of https://github.com/expo/expo/pull/30321.

# How

Ensured that js will throw an exception when setting a read-only or when getting write-only.

# Test Plan

- test ✅ 