### PR TITLE
[docs] fix incorrect platform tags for System UI

### DIFF
--- a/docs/pages/versions/unversioned/sdk/system-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/system-ui.mdx
@@ -3,7 +3,7 @@ title: SystemUI
 description: A library that allows interacting with system UI elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-system-ui'
 packageName: 'expo-system-ui'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v51.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/system-ui.mdx
@@ -3,7 +3,7 @@ title: SystemUI
 description: A library that allows interacting with system UI elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-51/packages/expo-system-ui'
 packageName: 'expo-system-ui'
-platforms: ['android', 'ios', 'web', 'tvos']
+platforms: ['android', 'ios', 'web']
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

Fixes #30397

# How

Fix incorrect platform tags listed for System UI package.

# Test Plan

The changes have been reviewed locally.

# Preview

![Screenshot 2024-07-16 at 16 31 51](https://github.com/user-attachments/assets/121230a2-f9b8-4458-9ee3-98fa6d8cfe97)
