### PR TITLE
fix(metro-runtime): Fix exceptions native import.

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix exceptions native import.
 - Improve error message for `window.location` polyfill. ([#30331](https://github.com/expo/expo/pull/30331) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix exceptions native import.
+- Fix exceptions native import. ([#30433](https://github.com/expo/expo/pull/30433) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve error message for `window.location` polyfill. ([#30331](https://github.com/expo/expo/pull/30331) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/metro-runtime/build/error-overlay/modules/ExceptionsManager/index.native.d.ts
+++ b/packages/@expo/metro-runtime/build/error-overlay/modules/ExceptionsManager/index.native.d.ts
@@ -1,3 +1,3 @@
-import ExceptionsManager from 'react-native/Library/Core/ExceptionsManager';
+import ExceptionsManager from 'react-native/Libraries/Core/ExceptionsManager';
 export default ExceptionsManager;
 //# sourceMappingURL=index.native.d.ts.map

--- a/packages/@expo/metro-runtime/build/error-overlay/modules/ExceptionsManager/index.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/error-overlay/modules/ExceptionsManager/index.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.native.d.ts","sourceRoot":"","sources":["../../../../src/error-overlay/modules/ExceptionsManager/index.native.ts"],"names":[],"mappings":"AACA,OAAO,iBAAiB,MAAM,6CAA6C,CAAC;AAE5E,eAAe,iBAAiB,CAAC"}
+{"version":3,"file":"index.native.d.ts","sourceRoot":"","sources":["../../../../src/error-overlay/modules/ExceptionsManager/index.native.ts"],"names":[],"mappings":"AAAA,OAAO,iBAAiB,MAAM,+CAA+C,CAAC;AAE9E,eAAe,iBAAiB,CAAC"}

--- a/packages/@expo/metro-runtime/src/error-overlay/modules/ExceptionsManager/index.native.ts
+++ b/packages/@expo/metro-runtime/src/error-overlay/modules/ExceptionsManager/index.native.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
-import ExceptionsManager from 'react-native/Library/Core/ExceptionsManager';
+import ExceptionsManager from 'react-native/Libraries/Core/ExceptionsManager';
 
 export default ExceptionsManager;


### PR DESCRIPTION
# Why

This import is now broken somehow.
