### PR TITLE
[docs] Add a section error reporting services in debugging runtime issues guide

### DIFF
--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -166,6 +166,16 @@ For more information, see Apple's [Diagnosing Issues Using Crash Reports and Dev
 
 This might indicate that there is a performance issue. You likely need to run your app through a profiler to get a better idea of what processes are killing the app, and [React Native provides some great documentation for this](https://reactnative.dev/docs/profiling). We also recommend using [React DevTools](https://www.npmjs.com/package/react-devtools) and the included profiler, which makes it super easy to identify performance sinks in your app.
 
+### Using error reporting services
+
+Implementing a crash and bug reporting service in your production app offers several benefits, such as:
+
+- Real-time insights on production deployments with information to reproduce crashes and bugs.
+- Setting up an alert system to get notified about fatal JavaScript errors or any other event you configure.
+- Using a web dashboard to see details on exceptions such as stack traces, device information, and so on.
+
+With Expo, you can integrate a reporting service like [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/) to get more insights in real-time.
+
 ## Stuck?
 
 The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://chat.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -250,15 +250,6 @@ There are however [some limitations](https://github.com/jhen0409/react-native-de
 - [mitmproxy](https://medium.com/@rotxed/how-to-debug-http-s-traffic-on-android-7fbe5d2a34#.hnhanhyoz)
 - [Fiddler](http://www.telerik.com/fiddler)
 
-## Debugging production apps with Sentry
+## Debugging production apps
 
-In reality, apps often ship with bugs. Implementing a crash and bug reporting system in your production app is essential. It ensures that if any user hits fatal JavaScript errors (or any event you have configured), you can see the details. Sentry provides a crash reporting system with real-time insights into production deployments.
-
-You can add Sentry to your Expo project. It gathers crash data and alerts you about other events. You can also configure source maps. They make stack traces in Sentry deobfuscated and more readable.
-
-<BoxLink
-  title="Use Sentry"
-  description="A guide on installing and configuring Sentry for crash reporting in your Expo project."
-  href="/guides/using-sentry"
-  Icon={BookOpen02Icon}
-/>
+In reality, apps often ship with bugs. Implementing a crash and bug reporting system can help you get real-time insights of your production apps. See [Using error reporting services](/debugging/runtime-issues/#using-error-reporting-services) for more details.

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -4,9 +4,6 @@ description: Learn about different tools available to inspect your Expo project 
 sidebar_title: Tools
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-
-import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1720804923230339)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a sub-section on "Using error reporting services" under the Production errors section in the Debugging Runtime issues guide. This section explains the benefits of using an error reporting service and links to Sentry and BugSnag guides as examples.

Also, make the section for debugging production apps I the Debugging and profiling tools guide a bit more generic to production apps. It also links to the above section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and visiting: http://localhost:3002/debugging/runtime-issues/#using-error-reporting-services

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
