### PR TITLE
fix(expo): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - Use `globalThis` instead of `global` in the URL implementation to fix issues in Jest. ([#29895](https://github.com/expo/expo/pull/29895) by [@tsapeta](https://github.com/tsapeta))
 - Fixed `WebSocket was closed before the connection was established` unhandled exceptions from WebSocketWithReconnect. ([#29904](https://github.com/expo/expo/pull/29904) by [@kudo](https://github.com/kudo))
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30449](https://github.com/expo/expo/pull/30449) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -84,5 +84,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.2"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
Note, this is a collection of PRs for each SDK library individually.

<details><summary>All related PRs</summary>

- https://github.com/expo/expo/pull/30454
- https://github.com/expo/expo/pull/30455
- https://github.com/expo/expo/pull/30456
- https://github.com/expo/expo/pull/30457
- https://github.com/expo/expo/pull/30458
- https://github.com/expo/expo/pull/30459
- https://github.com/expo/expo/pull/30460
- https://github.com/expo/expo/pull/30461
- https://github.com/expo/expo/pull/30462
- https://github.com/expo/expo/pull/30463
- https://github.com/expo/expo/pull/30464
- https://github.com/expo/expo/pull/30465
- https://github.com/expo/expo/pull/30466
- https://github.com/expo/expo/pull/30467
- https://github.com/expo/expo/pull/30468
- https://github.com/expo/expo/pull/30469
- https://github.com/expo/expo/pull/30470
- https://github.com/expo/expo/pull/30471
- https://github.com/expo/expo/pull/30473
- https://github.com/expo/expo/pull/30474
- https://github.com/expo/expo/pull/30475
- https://github.com/expo/expo/pull/30476
- https://github.com/expo/expo/pull/30477
- https://github.com/expo/expo/pull/30478
- https://github.com/expo/expo/pull/30479
- https://github.com/expo/expo/pull/30480
- https://github.com/expo/expo/pull/30481
- https://github.com/expo/expo/pull/30482
- https://github.com/expo/expo/pull/30483
- https://github.com/expo/expo/pull/30484
- https://github.com/expo/expo/pull/30485
- https://github.com/expo/expo/pull/30486
- https://github.com/expo/expo/pull/30487
- https://github.com/expo/expo/pull/30488
- https://github.com/expo/expo/pull/30489
- https://github.com/expo/expo/pull/30490

</details>

# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:
- [src/devtools/index.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/devtools/index.ts)
- [src/environment/DevLoadingView.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/environment/DevLoadingView.tsx)
- [src/hooks/useEvent.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/hooks/useEvent.ts)
- [src/launch/registerRootComponent.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/launch/registerRootComponent.tsx) - _type only_
- [src/launch/withDevTools.ios.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/launch/withDevTools.ios.tsx) - _type only_
- [src/launch/withDevTools.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/launch/withDevTools.web.tsx) - _type only_

Added peer dependency reference to `react-native: *`, it's currently imported from:
- [src/devtools/getConnectionInfo.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/devtools/getConnectionInfo.native.ts)
- [src/environment/DevLoadingView.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/environment/DevLoadingView.tsx)
- [src/environment/DevLoadingViewNativeModule.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/environment/DevLoadingViewNativeModule.native.ts)
- [src/environment/getInitialSafeArea.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/environment/getInitialSafeArea.native.ts)
- [src/launch/registerRootComponent.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/launch/registerRootComponent.tsx)
- [src/winter/runtime.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/src/winter/runtime.native.ts)

# Note

There are more incorrect dependency chains, these can't be resolved by adding a peer dependency and require another approach.

- [scripts/compose-source-maps.js](https://github.com/expo/expo/blob/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/scripts/compose-source-maps.js#L15) - importing `metro-source-map`
- [react-native.config.js](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo/react-native.config.js) - importing `@react-native-community/cli-tools`

# Test Plan

- `$ pnpm add expo`
- `$ node --print "require.resolve('react/package.json', { paths: [require.resolve('expo/package.json')] })"`
  - This should be resolved to `react` 
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
