### PR TITLE
[video][android] Refactor the video player code and organise files

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- [Android] Refactor `VideoPlayer.kt`, organise the files ([#30452](https://github.com/expo/expo/pull/30452) by [@behenate](https://github.com/behenate))
+- [Android] Refactor `VideoPlayer.kt`, organize files ([#30452](https://github.com/expo/expo/pull/30452) by [@behenate](https://github.com/behenate))
 
 ## 1.2.0 - 2024-06-20
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 💡 Others
 
+- [Android] Refactor `VideoPlayer.kt`, organise the files ([#30452](https://github.com/expo/expo/pull/30452) by [@behenate](https://github.com/behenate))
+
 ## 1.2.0 - 2024-06-20
 
 ### 🎉 New features

--- a/packages/expo-video/android/src/main/AndroidManifest.xml
+++ b/packages/expo-video/android/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <application>
     <activity android:name=".FullscreenPlayerActivity" />
     <service
-      android:name=".ExpoVideoPlaybackService"
+      android:name=".playbackService.ExpoVideoPlaybackService"
       android:exported="false"
       android:foregroundServiceType="mediaPlayback">
       <intent-filter>

--- a/packages/expo-video/android/src/main/java/expo/modules/video/PlayerEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/PlayerEvent.kt
@@ -1,0 +1,54 @@
+package expo.modules.video
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import expo.modules.video.enums.PlayerStatus
+import expo.modules.video.records.PlaybackError
+import expo.modules.video.records.VideoSource
+import expo.modules.video.records.VolumeEvent
+
+@OptIn(UnstableApi::class)
+sealed class PlayerEvent {
+  open val name: String = ""
+  open val arguments: Array<out Any?> = arrayOf()
+
+  data class StatusChanged(val status: PlayerStatus, val oldStatus: PlayerStatus?, val error: PlaybackError?) : PlayerEvent() {
+    override val name = "statusChange"
+    override val arguments = arrayOf(status, oldStatus, error)
+  }
+
+  data class IsPlayingChanged(val isPlaying: Boolean, val oldIsPlaying: Boolean?) : PlayerEvent() {
+    override val name = "playingChange"
+    override val arguments = arrayOf(isPlaying, oldIsPlaying)
+  }
+
+  data class VolumeChanged(val newValue: VolumeEvent, val oldValue: VolumeEvent?) : PlayerEvent() {
+    override val name = "playingChange"
+    override val arguments = arrayOf(newValue, oldValue)
+  }
+
+  data class SourceChanged(val source: VideoSource?, val oldSource: VideoSource?) : PlayerEvent() {
+    override val name = "sourceChange"
+    override val arguments = arrayOf(source, oldSource)
+  }
+
+  data class PlaybackRateChanged(val rate: Float, val oldRate: Float?) : PlayerEvent() {
+    override val name = "playbackRateChange"
+    override val arguments = arrayOf(rate, oldRate)
+  }
+
+  class PlayedToEnd : PlayerEvent() {
+    override val name = "playToEnd"
+  }
+
+  fun emit(player: VideoPlayer, listeners: List<VideoPlayerListener>) {
+    when (this) {
+      is StatusChanged -> listeners.forEach { it.onStatusChanged(player, status, oldStatus, error) }
+      is IsPlayingChanged -> listeners.forEach { it.onIsPlayingChanged(player, isPlaying, oldIsPlaying) }
+      is VolumeChanged -> listeners.forEach { it.onVolumeChanged(player, newValue, oldValue) }
+      is SourceChanged -> listeners.forEach { it.onSourceChanged(player, source, oldSource) }
+      is PlaybackRateChanged -> listeners.forEach { it.onPlaybackRateChanged(player, rate, oldRate) }
+      is PlayedToEnd -> listeners.forEach { it.onPlayedToEnd(player) }
+    }
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -43,7 +43,7 @@ object VideoManager {
     }
 
     if (videoPlayersToVideoViews[videoPlayer]?.size == 1) {
-      videoPlayer.playbackServiceBinder?.service?.registerPlayer(videoPlayer.player)
+      videoPlayer.serviceConnection.playbackServiceBinder?.service?.registerPlayer(videoPlayer.player)
     }
   }
 
@@ -52,7 +52,7 @@ object VideoManager {
 
     // Unregister disconnected VideoPlayers from the playback service
     if (videoPlayersToVideoViews[videoPlayer] == null || videoPlayersToVideoViews[videoPlayer]?.size == 0) {
-      videoPlayer.playbackServiceBinder?.service?.unregisterPlayer(videoPlayer.player)
+      videoPlayer.serviceConnection.playbackServiceBinder?.service?.unregisterPlayer(videoPlayer.player)
     }
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -3,7 +3,6 @@
 package expo.modules.video
 
 import android.app.Activity
-import android.content.Context
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
@@ -16,7 +15,10 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.types.Either
+import expo.modules.video.enums.ContentFit
 import expo.modules.video.records.VideoSource
+import expo.modules.video.utils.ifYogaDefinedUse
+import expo.modules.video.utils.makeYogaUndefinedIfNegative
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -25,8 +27,6 @@ import kotlinx.coroutines.runBlocking
 class VideoModule : Module() {
   private val activity: Activity
     get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
-  private val reactContext: Context
-    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoVideo")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -1,28 +1,22 @@
 package expo.modules.video
 
-import android.content.ComponentName
 import android.content.Context
-import android.content.Context.BIND_AUTO_CREATE
-import android.content.Intent
-import android.content.ServiceConnection
-import android.os.Build
-import android.os.IBinder
-import android.util.Log
 import android.view.SurfaceView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
-import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.session.MediaSessionService
 import androidx.media3.ui.PlayerView
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
+import expo.modules.video.delegates.IgnoreSameSet
 import expo.modules.video.enums.PlayerStatus
 import expo.modules.video.enums.PlayerStatus.*
+import expo.modules.video.playbackService.ExpoVideoPlaybackService
+import expo.modules.video.playbackService.PlaybackServiceConnection
 import expo.modules.video.records.PlaybackError
 import expo.modules.video.records.VideoSource
 import expo.modules.video.records.VolumeEvent
@@ -35,29 +29,24 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   // This improves the performance of playing DRM-protected content
   private var renderersFactory = DefaultRenderersFactory(context)
     .forceEnableMediaCodecAsynchronousQueueing()
+  private var listeners: MutableList<WeakReference<VideoPlayerListener>> = mutableListOf()
   val audioFocusManager = VideoPlayerAudioFocusManager(context, WeakReference(this))
+
   val player = ExoPlayer
     .Builder(context, renderersFactory)
     .setLooper(context.mainLooper)
     .build()
 
-  // We duplicate some properties of the player, because we don't want to always use the mainQueue to access them.
-  var playing = false
-    set(value) {
-      if (field != value) {
-        emit("playingChange", value, field)
-      }
-      field = value
-    }
+  val serviceConnection = PlaybackServiceConnection(WeakReference(player))
+
+  var playing by IgnoreSameSet(false) { new, old ->
+    sendEvent(PlayerEvent.IsPlayingChanged(new, old))
+  }
 
   var uncommittedSource: VideoSource? = source
-  private var lastLoadedSource: VideoSource? = null
-    set(value) {
-      if (field != value && value != null) {
-        emit("sourceChange", value, field)
-      }
-      field = value
-    }
+  private var lastLoadedSource by IgnoreSameSet<VideoSource?>(null) { new, old ->
+    sendEvent(PlayerEvent.SourceChanged(new, old))
+  }
 
   // Volume of the player if there was no mute applied.
   var userVolume = 1f
@@ -66,50 +55,39 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   var staysActiveInBackground = false
   var preservesPitch = false
     set(preservesPitch) {
-      playbackParameters = applyPitchCorrection(playbackParameters)
       field = preservesPitch
+      playbackParameters = applyPitchCorrection(playbackParameters)
     }
   var showNowPlayingNotification = true
     set(value) {
       field = value
-      playbackServiceBinder?.service?.setShowNotification(value, this.player)
+      serviceConnection.playbackServiceBinder?.service?.setShowNotification(value, this.player)
     }
   var duration = 0f
   var isLive = false
 
-  private var serviceConnection: ServiceConnection
-  internal var playbackServiceBinder: PlaybackServiceBinder? = null
-  lateinit var timeline: Timeline
+  var volume: Float by IgnoreSameSet(1f) { new: Float, old: Float ->
+    player.volume = if (muted) 0f else new
+    sendEvent(PlayerEvent.VolumeChanged(VolumeEvent(new, muted), VolumeEvent(old, muted)))
+    audioFocusManager.onPlayerChangedAudioFocusProperty(this)
+  }
 
-  var volume = 1f
-    set(volume) {
-      if (player.volume == volume) return
-      player.volume = if (muted) 0f else volume
-      emit("volumeChange", VolumeEvent(volume, muted), VolumeEvent(field, muted))
-      field = volume
+  var muted: Boolean by IgnoreSameSet(false) { new: Boolean, old: Boolean ->
+    volume = if (new) 0f else userVolume
+    sendEvent(PlayerEvent.VolumeChanged(VolumeEvent(volume, new), VolumeEvent(volume, old)))
+    audioFocusManager.onPlayerChangedAudioFocusProperty(this)
+  }
+
+  var playbackParameters by IgnoreSameSet(
+    PlaybackParameters.DEFAULT,
+    propertyMapper = { applyPitchCorrection(it) }
+  ) { new: PlaybackParameters, old: PlaybackParameters ->
+    player.playbackParameters = new
+
+    if (old.speed != new.speed) {
+      sendEvent(PlayerEvent.PlaybackRateChanged(new.speed, old.speed))
     }
-
-  var muted = false
-    set(muted) {
-      if (field == muted) return
-      emit("volumeChange", VolumeEvent(volume, muted), VolumeEvent(volume, field))
-      player.volume = if (muted) 0f else userVolume
-      field = muted
-      audioFocusManager.onPlayerChangedAudioFocusProperty(this@VideoPlayer)
-    }
-
-  var playbackParameters: PlaybackParameters = PlaybackParameters.DEFAULT
-    set(newPlaybackParameters) {
-      if (playbackParameters.speed != newPlaybackParameters.speed) {
-        emit("playbackRateChange", newPlaybackParameters.speed, playbackParameters.speed)
-      }
-      val pitchCorrectedPlaybackParameters = applyPitchCorrection(newPlaybackParameters)
-      field = pitchCorrectedPlaybackParameters
-
-      if (player.playbackParameters != pitchCorrectedPlaybackParameters) {
-        player.playbackParameters = pitchCorrectedPlaybackParameters
-      }
-    }
+  }
 
   private val playerListener = object : Player.Listener {
     override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -117,15 +95,11 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
       audioFocusManager.onPlayerChangedAudioFocusProperty(this@VideoPlayer)
     }
 
-    override fun onTimelineChanged(timeline: Timeline, reason: Int) {
-      this@VideoPlayer.timeline = timeline
-    }
-
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
       this@VideoPlayer.duration = 0f
       this@VideoPlayer.isLive = false
       if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
-        emit("playToEnd")
+        sendEvent(PlayerEvent.PlayedToEnd())
       }
       super.onMediaItemTransition(mediaItem, reason)
     }
@@ -144,7 +118,6 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
     override fun onVolumeChanged(volume: Float) {
       this@VideoPlayer.volume = volume
-      audioFocusManager.onPlayerChangedAudioFocusProperty(this@VideoPlayer)
     }
 
     override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
@@ -154,9 +127,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
     override fun onPlayerErrorChanged(error: PlaybackException?) {
       error?.let {
-        setStatus(ERROR, error)
         this@VideoPlayer.duration = 0f
         this@VideoPlayer.isLive = false
+        setStatus(ERROR, error)
       } ?: run {
         setStatus(playerStateToPlayerStatus(player.playbackState), null)
       }
@@ -166,53 +139,14 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   }
 
   init {
-    serviceConnection = object : ServiceConnection {
-      override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
-        playbackServiceBinder = binder as? PlaybackServiceBinder
-        playbackServiceBinder?.service?.registerPlayer(player) ?: run {
-          Log.w(
-            "ExpoVideo",
-            "Expo Video could not bind to the playback service. " +
-              "This will cause issues with playback notifications and sustaining background playback."
-          )
-        }
-      }
-
-      override fun onServiceDisconnected(componentName: ComponentName) {
-        playbackServiceBinder = null
-      }
-
-      override fun onNullBinding(componentName: ComponentName) {
-        Log.w(
-          "ExpoVideo",
-          "Expo Video could not bind to the playback service. " +
-            "This will cause issues with playback notifications and sustaining background playback."
-        )
-      }
-    }
-
-    appContext.reactContext?.apply {
-      val intent = Intent(context, ExpoVideoPlaybackService::class.java)
-      intent.action = MediaSessionService.SERVICE_INTERFACE
-
-      startService(intent)
-
-      val flags = if (Build.VERSION.SDK_INT >= 29) {
-        BIND_AUTO_CREATE or Context.BIND_INCLUDE_CAPABILITIES
-      } else {
-        BIND_AUTO_CREATE
-      }
-
-      bindService(intent, serviceConnection, flags)
-    }
+    ExpoVideoPlaybackService.startService(appContext, context, serviceConnection)
     player.addListener(playerListener)
     VideoManager.registerVideoPlayer(this)
   }
 
   override fun close() {
-    audioFocusManager.onPlayerDestroyed()
     appContext?.reactContext?.unbindService(serviceConnection)
-    playbackServiceBinder?.service?.unregisterPlayer(player)
+    serviceConnection.playbackServiceBinder?.service?.unregisterPlayer(player)
     VideoManager.unregisterVideoPlayer(this@VideoPlayer)
 
     appContext?.mainQueue?.launch {
@@ -270,18 +204,38 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
       else -> IDLE
     }
   }
+
   private fun setStatus(status: PlayerStatus, error: PlaybackException?) {
+    val oldStatus = this.status
+    this.status = status
+
     val playbackError = error?.let {
       PlaybackError(it)
     }
 
     if (playbackError == null && player.playbackState == Player.STATE_ENDED) {
-      emit("playToEnd")
+      sendEvent(PlayerEvent.PlayedToEnd())
     }
 
-    if (this.status != status) {
-      emit("statusChange", status.value, this.status.value, playbackError)
+    if (this.status != oldStatus) {
+      sendEvent(PlayerEvent.StatusChanged(status, oldStatus, playbackError))
     }
-    this.status = status
+  }
+
+  fun addListener(videoPlayerListener: VideoPlayerListener) {
+    listeners.find { it.get() == videoPlayerListener } ?: run {
+      listeners.add(WeakReference(videoPlayerListener))
+    }
+  }
+
+  fun removeListener(videoPlayerListener: VideoPlayerListener) {
+    listeners.removeAll { it.get() == videoPlayerListener }
+  }
+
+  private fun sendEvent(event: PlayerEvent) {
+    // Emits to the native listeners
+    event.emit(this, listeners.mapNotNull { it.get() })
+    // Emits to the JS side
+    emit(event.name, *event.arguments)
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayer.kt
@@ -223,7 +223,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   }
 
   fun addListener(videoPlayerListener: VideoPlayerListener) {
-    listeners.find { it.get() == videoPlayerListener } ?: run {
+    if (listeners.all { it.get() != videoPlayerListener }) {
       listeners.add(WeakReference(videoPlayerListener))
     }
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayerListener.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoPlayerListener.kt
@@ -1,0 +1,18 @@
+package expo.modules.video
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import expo.modules.video.enums.PlayerStatus
+import expo.modules.video.records.PlaybackError
+import expo.modules.video.records.VideoSource
+import expo.modules.video.records.VolumeEvent
+
+@OptIn(UnstableApi::class)
+interface VideoPlayerListener {
+  fun onStatusChanged(player: VideoPlayer, status: PlayerStatus, oldStatus: PlayerStatus?, error: PlaybackError?) {}
+  fun onIsPlayingChanged(player: VideoPlayer, isPlaying: Boolean, oldIsPlaying: Boolean?) {}
+  fun onVolumeChanged(player: VideoPlayer, newValue: VolumeEvent, oldVolume: VolumeEvent?) {}
+  fun onSourceChanged(player: VideoPlayer, source: VideoSource?, oldSource: VideoSource?) {}
+  fun onPlaybackRateChanged(player: VideoPlayer, rate: Float, oldRate: Float?) {}
+  fun onPlayedToEnd(player: VideoPlayer) {}
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -25,6 +25,8 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import expo.modules.video.drawing.OutlineProvider
+import expo.modules.video.enums.ContentFit
+import expo.modules.video.utils.ifYogaDefinedUse
 import java.util.UUID
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3

--- a/packages/expo-video/android/src/main/java/expo/modules/video/delegates/IgnoreSameSet.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/delegates/IgnoreSameSet.kt
@@ -2,7 +2,8 @@ package expo.modules.video.delegates
 
 import kotlin.reflect.KProperty
 
-/** Property delegate, where the set is ignored unless the value has changed.
+/**
+ * Property delegate, where the set is ignored unless the value has changed.
  * @param T The type of the property.
  * @param value The initial value of the property.
  * @param propertyMapper A function that maps the new value to the property value.

--- a/packages/expo-video/android/src/main/java/expo/modules/video/delegates/IgnoreSameSet.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/delegates/IgnoreSameSet.kt
@@ -1,0 +1,23 @@
+package expo.modules.video.delegates
+
+import kotlin.reflect.KProperty
+
+/** Property delegate, where the set is ignored unless the value has changed.
+ * @param T The type of the property.
+ * @param value The initial value of the property.
+ * @param propertyMapper A function that maps the new value to the property value.
+ * @param didSet A function that is called when the property value has changed.
+*/
+
+class IgnoreSameSet<T : Any?>(private var value: T, val propertyMapper: ((T) -> T) = { v -> v }, val didSet: ((new: T, old: T) -> Unit)? = null) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+    return value
+  }
+
+  operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+    if (this.value == propertyMapper(value)) return
+    val oldValue = this.value
+    this.value = propertyMapper(value)
+    didSet?.invoke(this.value, oldValue)
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/drawing/OutlineProvider.kt
@@ -12,7 +12,7 @@ import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.react.uimanager.FloatUtil
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.yoga.YogaConstants
-import expo.modules.video.ifYogaUndefinedUse
+import expo.modules.video.utils.ifYogaUndefinedUse
 
 class OutlineProvider(private val mContext: Context) : ViewOutlineProvider() {
   enum class BorderRadiusConfig {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/enums/ContentFit.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/enums/ContentFit.kt
@@ -1,4 +1,4 @@
-package expo.modules.video
+package expo.modules.video.enums
 
 import androidx.media3.ui.AspectRatioFrameLayout
 import expo.modules.kotlin.types.Enumerable

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -1,4 +1,4 @@
-package expo.modules.video
+package expo.modules.video.playbackService
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -18,6 +18,8 @@ import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SessionCommand
 import com.google.common.collect.ImmutableList
+import expo.modules.kotlin.AppContext
+import expo.modules.video.R
 
 class PlaybackServiceBinder(val service: ExpoVideoPlaybackService) : Binder()
 
@@ -152,5 +154,22 @@ class ExpoVideoPlaybackService : MediaSessionService() {
     const val CHANNEL_ID = "PlaybackService"
     const val SESSION_SHOW_NOTIFICATION = "showNotification"
     const val SEEK_INTERVAL_MS = 10000L
+
+    fun startService(appContext: AppContext, context: Context, serviceConnection: PlaybackServiceConnection) {
+      appContext.reactContext?.apply {
+        val intent = Intent(context, ExpoVideoPlaybackService::class.java)
+        intent.action = SERVICE_INTERFACE
+
+        startService(intent)
+
+        val flags = if (Build.VERSION.SDK_INT >= 29) {
+          BIND_AUTO_CREATE or Context.BIND_INCLUDE_CAPABILITIES
+        } else {
+          BIND_AUTO_CREATE
+        }
+
+        bindService(intent, serviceConnection, flags)
+      }
+    }
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/PlaybackServiceConnection.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/PlaybackServiceConnection.kt
@@ -1,0 +1,36 @@
+package expo.modules.video.playbackService
+
+import android.content.ComponentName
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.util.Log
+import androidx.media3.exoplayer.ExoPlayer
+import java.lang.ref.WeakReference
+
+class PlaybackServiceConnection(val player: WeakReference<ExoPlayer>) : ServiceConnection {
+  var playbackServiceBinder: PlaybackServiceBinder? = null
+
+  override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+    val player: ExoPlayer = player.get() ?: return
+    playbackServiceBinder = binder as? PlaybackServiceBinder
+    playbackServiceBinder?.service?.registerPlayer(player) ?: run {
+      Log.w(
+        "ExpoVideo",
+        "Expo Video could not bind to the playback service. " +
+          "This will cause issues with playback notifications and sustaining background playback."
+      )
+    }
+  }
+
+  override fun onServiceDisconnected(componentName: ComponentName) {
+    playbackServiceBinder = null
+  }
+
+  override fun onNullBinding(componentName: ComponentName) {
+    Log.w(
+      "ExpoVideo",
+      "Expo Video could not bind to the playback service. " +
+        "This will cause issues with playback notifications and sustaining background playback."
+    )
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/VideoMediaSessionCallback.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/VideoMediaSessionCallback.kt
@@ -1,4 +1,4 @@
-package expo.modules.video
+package expo.modules.video.playbackService
 
 import android.os.Bundle
 import androidx.media3.common.Player

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -8,7 +8,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.video.UnsupportedDRMTypeException
-import expo.modules.video.buildMediaSourceWithHeaders
+import expo.modules.video.utils.buildMediaSourceWithHeaders
 import java.io.Serializable
 
 @OptIn(UnstableApi::class)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VolumeEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VolumeEvent.kt
@@ -4,7 +4,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
 
-internal class VolumeEvent(
+class VolumeEvent(
   @Field var volume: Float? = null,
   @Field var isMuted: Boolean? = null
 ) : Record, Serializable

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -1,4 +1,4 @@
-package expo.modules.video
+package expo.modules.video.utils
 
 import android.content.Context
 import android.content.pm.ApplicationInfo

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/YogaUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/YogaUtils.kt
@@ -1,4 +1,4 @@
-package expo.modules.video
+package expo.modules.video.utils
 
 import com.facebook.yoga.YogaConstants
 


### PR DESCRIPTION
# Why

The VideoPlayer file on Android became quite bloated and required a cleanup. 

# How

- Moved some of the player functionality (such as the foreground service connection) into separate classes
- Added native listener functionality for easy and clean access to player events
- Organised some of the files
- Created `IgnoreSameSet` property delegate which reduces boilerplate on some of the setters.

# Test Plan

Tested in BareExpo on a physical Android 14 device
