### PR TITLE
fix(expo-asset): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `PlatformUtils.ts` to have the correct export placeholders for react-native-web ([#29791](https://github.com/expo/expo/pull/29791) by [@Bram-dc](https://github.com/Bram-dc))
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30454](https://github.com/expo/expo/pull/30454) by [@byCedric](https://github.com/byCedric))
 
 ## 10.0.9 - 2024-06-13
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `PlatformUtils.ts` to have the correct export placeholders for react-native-web ([#29791](https://github.com/expo/expo/pull/29791) by [@Bram-dc](https://github.com/Bram-dc))
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
 
 ## 10.0.9 - 2024-06-13
 

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -46,6 +46,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/AssetHooks.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/src/AssetHooks.ts)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/AssetSourceResolver.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/src/AssetSourceResolver.native.ts)
- [src/AssetSourceResolver.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/src/AssetSourceResolver.ts)
- [src/AssetSources.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/src/AssetSources.ts)
- [src/resolveAssetSource.native.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/src/resolveAssetSource.native.ts)

# Note

- There are imports to `@react-native/assets-registry/registry`, which will likely receive special handling in Metro.
- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)
- There is an import to `expo-updates`, which also needs further consideration.
- The `expo-asset/plugin` uses some dependencies that are not listed as (peer)dependencies:
  - [plugin/src/withAssetsIos.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-asset/plugin/src/withAssetsIos.ts) - importing `@expo/config-types`, `@expo/image-utils`, `@expo/prebuild-config`, and `fs-extra`

# Test Plan

- `$ pnpm add expo-asset`
- `$ node --print "require.resolve('react/package.json', { paths: [require.resolve('expo-asset/package.json')] })"`
  - This should be resolved to `react` 
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo-asset/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
