### PR TITLE
fix(expo-barcode-scanner): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30457](https://github.com/expo/expo/pull/30457) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
+
 ### 💡 Others
 
 ## 13.0.1 — 2024-04-23

--- a/packages/expo-barcode-scanner/package.json
+++ b/packages/expo-barcode-scanner/package.json
@@ -41,6 +41,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/BarCodeScanner.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-barcode-scanner/src/BarCodeScanner.tsx) - _type only_
- [src/ExpoBarCodeScannerView.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-barcode-scanner/src/ExpoBarCodeScannerView.ts) - _type only_
- [src/ExpoBarCodeScannerView.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-barcode-scanner/src/ExpoBarCodeScannerView.web.tsx) - _type only_

> Since only types are imported, we could consider removing the peer dep on `react` for this package. The built code should not cause incorrect dependency chains.

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/BarCodeScanner.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-barcode-scanner/src/BarCodeScanner.tsx)
- [src/ExpoBarCodeScannerView.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-barcode-scanner/src/ExpoBarCodeScannerView.web.tsx)

# Test Plan

- `$ pnpm add expo-barcode-scanner`
- `$ node --print "require.resolve('react/package.json', { paths: [require.resolve('expo-barcode-scanner/package.json')] })"`
  - This should be resolved to `react` 
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo-barcode-scanner/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
