### PR TITLE
fix(expo-blur): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30459](https://github.com/expo/expo/pull/30459) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
+
 ### 💡 Others
 
 ## 13.0.2 — 2024-05-01

--- a/packages/expo-blur/package.json
+++ b/packages/expo-blur/package.json
@@ -41,6 +41,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/BlurView.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-blur/src/BlurView.tsx)
- [src/BlurView.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-blur/src/BlurView.web.tsx)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/BlurView.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-blur/src/BlurView.tsx)
- [src/BlurView.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-blur/src/BlurView.types.ts) - _type only file and import_
- [src/BlurView.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-blur/src/BlurView.web.tsx)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)

# Test Plan

- `$ pnpm add expo-blur`
- `$ node --print "require.resolve('react/package.json', { paths: [require.resolve('expo-blur/package.json')] })"`
  - This should be resolved to `react` 
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo-blur/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
