### PR TITLE
fix(expo-calendar): add missing peer dependency references to `react-native

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Standardize `getEventsAsync` to return events sorted by start date ([#28353](https://github.com/expo/expo/pull/28353) by [@demfabris](https://github.com/demfabris))
+- Add missing `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Standardize `getEventsAsync` to return events sorted by start date ([#28353](https://github.com/expo/expo/pull/28353) by [@demfabris](https://github.com/demfabris))
-- Add missing `react-native` peer dependencies for isolated modules.
+- Add missing `react-native` peer dependencies for isolated modules. ([#30461](https://github.com/expo/expo/pull/30461) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/package.json
+++ b/packages/expo-calendar/package.json
@@ -38,6 +38,7 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/Calendar.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-calendar/src/Calendar.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)

# Test Plan

- `$ pnpm add expo-calendar`
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo-calendar/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
