### PR TITLE
fix(expo-camera): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30462](https://github.com/expo/expo/pull/30462) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-camera/package.json
+++ b/packages/expo-camera/package.json
@@ -40,6 +40,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/Camera.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/Camera.types.ts) - _types file_
- [src/CameraView.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/CameraView.tsx)
- [src/ExpoCamera.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/ExpoCamera.ts) - _types only_
- [src/ExpoCamera.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/ExpoCamera.web.tsx)
- [src/legacy/Camera.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/Camera.tsx) - _types only_
- [src/legacy/ExpoCamera.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/ExpoCamera.ts) - _types only_
- [src/legacy/ExpoCamera.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/ExpoCamera.web.tsx)
- [src/web/useWebCameraStream.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/web/useWebCameraStream.ts)
- [src/web/useWebQRScanner.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/web/useWebQRScanner.ts)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/Camera.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/Camera.types.ts) - _types file_
- [src/ExpoCamera.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/ExpoCamera.web.tsx)
- [src/legacy/Camera.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/Camera.tsx)
- [src/legacy/Camera.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/Camera.types.ts)
- [src/legacy/ExpoCamera.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/src/legacy/ExpoCamera.web.tsx)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)
- There are imports to `react-native-web`, which need another pass after deciding how to resolve this.
- The `expo-camera/plugin` uses some dependencies that are not listed as (peer)dependencies:
  - [plugin/src/withCamera.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-camera/plugin/src/withCamera.ts) - importing `@expo/config-plugins`

# Test Plan

- `$ pnpm add expo-camera`
- `$ node --print "require.resolve('react/package.json', { paths: [require.resolve('expo-camera/package.json')] })"`
  - This should be resolved to `react` 
- `$ node --print "require.resolve('react-native/package.json', { paths: [require.resolve('expo-camera/package.json')] })"`
  - This should be resolved to `react-native` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
