### PR TITLE
fix(expo-camera): add missing peer dependency references to `react-native`

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed issue when copying PNG images on Android. ([#29629](https://github.com/expo/expo/pull/29629) by [@weslley75](https://github.com/weslley75))
-- Add missing `react-native` peer dependencies for isolated modules.
+- Add missing `react-native` peer dependencies for isolated modules. ([#30463](https://github.com/expo/expo/pull/30463) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "expo": "*",
+    "react": "*",
     "react-native": "*"
   },
   "jest": {

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -34,7 +34,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   },
   "jest": {
     "preset": "expo-module-scripts/universal"

--- a/packages/expo-clipboard/package.json
+++ b/packages/expo-clipboard/package.json
@@ -35,7 +35,6 @@
   },
   "peerDependencies": {
     "expo": "*",
-    "react": "*",
     "react-native": "*"
   },
   "jest": {


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Did not add peer dependency reference to `react: *`, it's currently imported but unused

- [src/ClipboardPasteButton.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-clipboard/src/ClipboardPasteButton.tsx) - _unused import_

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/ClipboardPasteButton.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-clipboard/src/ClipboardPasteButton.tsx)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)

# Test Plan

- `$ pnpm add expo-clipboard`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-clipboard/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

