### PR TITLE
fix(expo-contacts): add missing peer dependency references to `react-native`

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Fixed an issue where only paths of urls were stored in contacts and social profiles were only stored when all fields were filled. ([#29199](https://github.com/expo/expo/pull/29199) by [@mlecoq](https://github.com/mlecoq))
 - Fixed an iOS issue where the Cancel button is not visible on the unknown contact form. ([#29555](https://github.com/expo/expo/pull/29555) by [@Tug](https://github.com/Tug))
-- Add missing `react-native` peer dependencies for isolated modules.
+- Add missing `react-native` peer dependencies for isolated modules. ([#30465](https://github.com/expo/expo/pull/30465) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed an issue where only paths of urls were stored in contacts and social profiles were only stored when all fields were filled. ([#29199](https://github.com/expo/expo/pull/29199) by [@mlecoq](https://github.com/mlecoq))
 - Fixed an iOS issue where the Cancel button is not visible on the unknown contact form. ([#29555](https://github.com/expo/expo/pull/29555) by [@Tug](https://github.com/Tug))
+- Add missing `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-contacts/package.json
+++ b/packages/expo-contacts/package.json
@@ -37,6 +37,7 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/Contacts.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-contacts/src/Contacts.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)

# Test Plan

- `$ pnpm add expo-contacts`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-contacts/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

