### PR TITLE
fix(expo-file-system): add missing peer dependency references to `react-native`

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] fix: `getFreeDiskStorageAsync` returns result that's closer to the value reported by the system. ([#29732](https://github.com/expo/expo/pull/29732) by [@vonovak](https://github.com/vonovak))
 - Add NULL check before dereferencing pointer to error pointer in `EXFileSystemAssetLibraryHandler`. ([#29091](https://github.com/expo/expo/pull/29091) by [@hakonk](https://github.com/hakonk))
-- Add missing `react-native` peer dependencies for isolated modules.
+- Add missing `react-native` peer dependencies for isolated modules. ([#30466](https://github.com/expo/expo/pull/30466) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] fix: `getFreeDiskStorageAsync` returns result that's closer to the value reported by the system. ([#29732](https://github.com/expo/expo/pull/29732) by [@vonovak](https://github.com/vonovak))
 - Add NULL check before dereferencing pointer to error pointer in `EXFileSystemAssetLibraryHandler`. ([#29091](https://github.com/expo/expo/pull/29091) by [@hakonk](https://github.com/hakonk))
+- Add missing `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -39,6 +39,7 @@
     "jest-expo": "~51.0.0-unreleased"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/FileSystem.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-file-system/src/FileSystem.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an `expo/modules-core` export)

# Test Plan

- `$ pnpm add expo-file-system`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-file-system/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

