### PR TITLE
fix(expo-font): add missing peer dependency references to `react`

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, fix issues where fonts were removed when the app is backgrounded. ([#30400](https://github.com/expo/expo/pull/30400) by [@alanjhughes](https://github.com/alanjhughes))
+- Add missing `react` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS`, fix issues where fonts were removed when the app is backgrounded. ([#30400](https://github.com/expo/expo/pull/30400) by [@alanjhughes](https://github.com/alanjhughes))
-- Add missing `react` peer dependencies for isolated modules.
+- Add missing `react` peer dependencies for isolated modules. ([#30467](https://github.com/expo/expo/pull/30467) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -40,6 +40,7 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/FontHooks.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-font/src/FontHooks.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an expo/modules-core export)
- There are imports to `@expo/config-types`, which need another pass after deciding how to resolve this.
- There are imports to `expo-asset`, which need another pass after deciding how to resolve this.

# Test Plan

- `$ pnpm add expo-font`
- `$ node --print "require-resolve('react/package.json', { paths: [require.resolve('expo-font/package.json')] })"`
  - This should be resolved to `react`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

