### PR TITLE
fix(expo-keep-awake): add missing peer dependency references to `react`

### DIFF
--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `react` peer dependencies for isolated modules.
+
 ### 💡 Others
 
 - Use `EventSubscription` type instead of `Subscription`. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing `react` peer dependencies for isolated modules.
+- Add missing `react` peer dependencies for isolated modules. ([#30470](https://github.com/expo/expo/pull/30470) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-keep-awake/package.json
+++ b/packages/expo-keep-awake/package.json
@@ -37,7 +37,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*"
   },
   "jest": {
     "preset": "expo-module-scripts"


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/index.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-keep-awake/src/index.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an expo/modules-core export)

# Test Plan

- `$ pnpm add expo-keep-awake`
- `$ node --print "require-resolve('react/package.json', { paths: [require.resolve('expo-keep-awake/package.json')] })"`
  - This should be resolved to `react`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

