### PR TITLE
fix(expo-linear-gradient): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
+
 ### 💡 Others
 
 ## 13.0.2 — 2024-05-01

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30471](https://github.com/expo/expo/pull/30471) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/package.json
+++ b/packages/expo-linear-gradient/package.json
@@ -40,6 +40,8 @@
     "expo-module-scripts": "^3.0.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/LinearGradient.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/LinearGradient.tsx)
- [src/NativeLinearGradient.android.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.android.tsx) - _types only_
- [src/NativeLinearGradient.ios.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.ios.tsx) - _types only_
- [src/NativeLinearGradient.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.tsx) - _types only_
- [src/NativeLinearGradient.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.types.ts) - _types file_
- [src/NativeLinearGradient.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/LinearGradient.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/LinearGradient.tsx)
- [src/NativeLinearGradient.android.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.android.tsx)
- [src/NativeLinearGradient.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.tsx)
- [src/NativeLinearGradient.types.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.types.ts) - _types file_
- [src/NativeLinearGradient.web.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx)
- [src/normalizeColor.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linear-gradient/src/normalizeColor.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an expo/modules-core export)

# Test Plan

- `$ pnpm add expo-linear-gradient`
- `$ node --print "require-resolve('react/package.json', { paths: [require.resolve('expo-linear-gradient/package.json')] })"`
  - This should be resolved to `react`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-linear-gradient/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

