### PR TITLE
[video][android] Fix support for local file playback

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Fix a race condition causing crashes when deallocating the player. ([#30022](https://github.com/expo/expo/pull/30022) by [@behenate](https://github.com/behenate))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30489](https://github.com/expo/expo/pull/30489) by [@byCedric](https://github.com/byCedric))
 - [Android] Fix Audio Manager pausing player on the wrong thread and conflicts between players. ([#30453](https://github.com/expo/expo/pull/30453) by [@behenate](https://github.com/behenate))
+- [Android] Fix support for local file playback. ([#30472](https://github.com/expo/expo/pull/30472) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -3,6 +3,7 @@
 package expo.modules.video
 
 import android.app.Activity
+import android.net.Uri
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
@@ -272,12 +273,12 @@ class VideoModule : Module() {
         }
       }
 
-      Function("replace") { ref: VideoPlayer, source: Either<String, VideoSource>? ->
+      Function("replace") { ref: VideoPlayer, source: Either<Uri, VideoSource>? ->
         val videoSource = source?.let {
           if (it.`is`(VideoSource::class)) {
             it.get(VideoSource::class)
           } else {
-            VideoSource(it.get(String::class))
+            VideoSource(it.get(Uri::class))
           }
         }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -1,5 +1,6 @@
 package expo.modules.video.records
 import android.content.Context
+import android.net.Uri
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -8,12 +9,12 @@ import androidx.media3.exoplayer.source.MediaSource
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.video.UnsupportedDRMTypeException
-import expo.modules.video.utils.buildMediaSourceWithHeaders
+import expo.modules.video.buildMediaSourceWithHeaders
 import java.io.Serializable
 
 @OptIn(UnstableApi::class)
 class VideoSource(
-  @Field var uri: String? = null,
+  @Field var uri: Uri? = null,
   @Field var drm: DRMOptions? = null,
   @Field var metadata: VideoMetadata? = null,
   @Field var headers: Map<String, String>? = null
@@ -37,7 +38,7 @@ class VideoSource(
   fun toMediaItem() = MediaItem
     .Builder()
     .apply {
-      setUri(uri ?: "")
+      setUri(uri)
       setMediaId(toMediaId())
       drm?.let {
         if (it.type.isSupported()) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -1,10 +1,12 @@
-package expo.modules.video.utils
+package expo.modules.video
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
@@ -12,7 +14,16 @@ import expo.modules.video.records.VideoSource
 import okhttp3.OkHttpClient
 
 @OptIn(UnstableApi::class)
-fun buildDataSourceFactory(context: Context, videoSource: VideoSource): OkHttpDataSource.Factory {
+fun buildDataSourceFactory(context: Context, videoSource: VideoSource): DataSource.Factory {
+  return if (videoSource.uri?.scheme?.startsWith("http") == true) {
+    buildOkHttpDataSourceFactory(context, videoSource)
+  } else {
+    DefaultDataSource.Factory(context)
+  }
+}
+
+@OptIn(UnstableApi::class)
+fun buildOkHttpDataSourceFactory(context: Context, videoSource: VideoSource): OkHttpDataSource.Factory {
   val client = OkHttpClient.Builder().build()
   val userAgent = Util.getUserAgent(context, getApplicationName(context))
   return OkHttpDataSource.Factory(client).apply {
@@ -25,7 +36,7 @@ fun buildDataSourceFactory(context: Context, videoSource: VideoSource): OkHttpDa
   }
 }
 
-fun buildMediaSourceFactory(context: Context, dataSourceFactory: OkHttpDataSource.Factory): MediaSource.Factory {
+fun buildMediaSourceFactory(context: Context, dataSourceFactory: DataSource.Factory): MediaSource.Factory {
   return DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory)
 }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/30412

While introducing support for HTTP headers for Android I accidentaly made exoplayer always use an `OkHttpDataSource` which fails for non-http sources.

# How

`OkHttpDataSourceFactory` is used only for `http` and `https` sources, all other sources will use the `DefaultDataSource.Factory` 

# Test Plan

Tested using Doug's `expo-file-system` example app
