### PR TITLE
fix(expo-linking): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30473](https://github.com/expo/expo/pull/30473) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
+
 ### 💡 Others
 
 ## 6.3.1 — 2024-04-23

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -36,6 +36,10 @@
   "devDependencies": {
     "expo-module-scripts": "^3.0.0"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "jest": {
     "preset": "expo-module-scripts"
   }


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/Linking.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linking/src/Linking.ts)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/Linking.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linking/src/Linking.ts)
- [src/RNLinking.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linking/src/RNLinking.ts)
- [src/Schemes.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-linking/src/Schemes.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an expo/modules-core export)

# Test Plan

- `$ pnpm add expo-linking`
- `$ node --print "require-resolve('react/package.json', { paths: [require.resolve('expo-linking/package.json')] })"`
  - This should be resolved to `react`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-linking/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

