### PR TITLE
fix(expo-sqlite): add missing peer dependency references to `react` and `react-native`

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Reduce the number of global references to `NativeStatementBinding`. ([#29937](https://github.com/expo/expo/pull/29937) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed `<SQLiteProvider assetSource={{ assetId: require(...) }}>` database always being overwrite on iOS 16 and lower. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
-- Add missing `react` and `react-native` peer dependencies for isolated modules.
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30483](https://github.com/expo/expo/pull/30483) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Reduce the number of global references to `NativeStatementBinding`. ([#29937](https://github.com/expo/expo/pull/29937) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed `<SQLiteProvider assetSource={{ assetId: require(...) }}>` database always being overwrite on iOS 16 and lower. ([#29945](https://github.com/expo/expo/pull/29945) by [@kudo](https://github.com/kudo))
+- Add missing `react` and `react-native` peer dependencies for isolated modules.
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -59,6 +59,8 @@
     "react-error-boundary": "^4.0.11"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
   }
 }

--- a/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
+++ b/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
@@ -64,10 +64,10 @@ describe(useSQLiteContext, () => {
         </View>
       );
     }
-    const wrapper = () => (
+    const wrapper = ({ children }) => (
       <React.Suspense fallback={<LoadingFallback />}>
         <SQLiteProvider databaseName=":memory:" useSuspense>
-          <View />
+          {children}
         </SQLiteProvider>
       </React.Suspense>
     );


### PR DESCRIPTION
# Why

As mentioned in sdk sync, we need correct dependency chains to make different package managers and monorepos more stable. For isolated modules, this is a requirement as the dependency otherwise isn't linked into the isolated folder.

# How

Added peer dependency reference to `react: *`, it's currently imported from:

- [src/hooks.tsx](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-sqlite/src/hooks.tsx)

Added peer dependency reference to `react-native: *`, it's currently imported from:

- [src/legacy/SQLite.ts](https://github.com/expo/expo/tree/ebc396fe16b225d616eb7e0919028c59db805a1e/packages/expo-sqlite/src/legacy/SQLite.ts)

# Note

- There are imports to `expo-modules-core`, which need another pass after deciding how to resolve this (e.g. through an expo/modules-core export)
- There are imports to `expo-asset`, which need another pass after deciding how to resolve this.

# Test Plan

- `$ pnpm add expo-sqlite`
- `$ node --print "require-resolve('react/package.json', { paths: [require.resolve('expo-sqlite/package.json')] })"`
  - This should be resolved to `react`
- `$ node --print "require-resolve('react-native/package.json', { paths: [require.resolve('expo-sqlite/package.json')] })"`
  - This should be resolved to `react-native`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).