### PR TITLE
[eslint-config-universe] Bring over more lint settings from www

### DIFF
--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Bring over more lint rules from Expo server for typescript configs. ([#30491](https://github.com/expo/expo/pull/30491) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/eslint-config-universe/__tests__/__snapshots__/typescript-analysis-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/typescript-analysis-test.js.snap
@@ -30,7 +30,7 @@ export function myFunc(foo: T | null) {
 }
 
 export function myFunc2(foo: T2 | null) {
-  return foo?.a?.b.method && foo.a.b.method();
+  foo?.a?.b.method && foo.a.b.method();
 }
 ",
   "suppressedMessages": [],
@@ -40,6 +40,12 @@ export function myFunc2(foo: T2 | null) {
         "@typescript-eslint/only-throw-error",
       ],
       "ruleId": "@typescript-eslint/no-throw-literal",
+    },
+    {
+      "replacedBy": [
+        "@typescript-eslint/ban-ts-comment",
+      ],
+      "ruleId": "@typescript-eslint/prefer-ts-expect-error",
     },
   ],
   "warningCount": 0,
@@ -79,6 +85,12 @@ export { sum };",
         "@typescript-eslint/only-throw-error",
       ],
       "ruleId": "@typescript-eslint/no-throw-literal",
+    },
+    {
+      "replacedBy": [
+        "@typescript-eslint/ban-ts-comment",
+      ],
+      "ruleId": "@typescript-eslint/prefer-ts-expect-error",
     },
   ],
   "warningCount": 0,
@@ -131,6 +143,12 @@ exports[`lints: fixtures/typescript-analysis-02.ts 1`] = `
       ],
       "ruleId": "@typescript-eslint/no-throw-literal",
     },
+    {
+      "replacedBy": [
+        "@typescript-eslint/ban-ts-comment",
+      ],
+      "ruleId": "@typescript-eslint/prefer-ts-expect-error",
+    },
   ],
   "warningCount": 1,
 }
@@ -166,7 +184,134 @@ exports[`lints: fixtures/typescript-analysis-03.ts 1`] = `
       ],
       "ruleId": "@typescript-eslint/no-throw-literal",
     },
+    {
+      "replacedBy": [
+        "@typescript-eslint/ban-ts-comment",
+      ],
+      "ruleId": "@typescript-eslint/prefer-ts-expect-error",
+    },
   ],
   "warningCount": 1,
+}
+`;
+
+exports[`lints: fixtures/typescript-analysis-04.ts 1`] = `
+{
+  "errorCount": 1,
+  "fatalErrorCount": 0,
+  "fixableErrorCount": 0,
+  "fixableWarningCount": 0,
+  "messages": [
+    {
+      "column": 3,
+      "endColumn": 22,
+      "endLine": 8,
+      "line": 8,
+      "message": "Unexpected \`await\` of a non-Promise (non-"Thenable") value.",
+      "messageId": "await",
+      "nodeType": "AwaitExpression",
+      "ruleId": "@typescript-eslint/await-thenable",
+      "severity": 1,
+      "suggestions": [
+        {
+          "desc": "Remove unnecessary \`await\`.",
+          "fix": {
+            "range": [
+              156,
+              161,
+            ],
+            "text": "",
+          },
+          "messageId": "removeAwait",
+        },
+      ],
+    },
+    {
+      "column": 15,
+      "endColumn": 37,
+      "endLine": 11,
+      "line": 11,
+      "message": "Placing a void expression inside another expression is forbidden. Move it to its own statement instead.",
+      "messageId": "invalidVoidExpr",
+      "nodeType": "CallExpression",
+      "ruleId": "@typescript-eslint/no-confusing-void-expression",
+      "severity": 1,
+    },
+    {
+      "column": 7,
+      "endColumn": 14,
+      "endLine": 15,
+      "line": 15,
+      "message": "Expected non-Promise value in a boolean conditional.",
+      "messageId": "conditional",
+      "nodeType": "Identifier",
+      "ruleId": "@typescript-eslint/no-misused-promises",
+      "severity": 2,
+    },
+    {
+      "column": 5,
+      "endColumn": 12,
+      "endLine": 21,
+      "line": 21,
+      "message": "Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the \`void\` operator.",
+      "messageId": "floatingVoid",
+      "nodeType": "ExpressionStatement",
+      "ruleId": "@typescript-eslint/no-floating-promises",
+      "severity": 1,
+      "suggestions": [
+        {
+          "desc": "Add void operator to ignore.",
+          "fix": {
+            "range": [
+              404,
+              404,
+            ],
+            "text": "void ",
+          },
+          "messageId": "floatingFixVoid",
+        },
+      ],
+    },
+  ],
+  "output": "async function test() {
+  return await Promise.resolve('blah');
+}
+
+export async function wat() {
+  // await-thenable
+  const createValue = () => 'value';
+  await createValue();
+
+  // no-confusing-void-expression
+  console.log(alert('Are you sure?'));
+
+  // no-misused-promises
+  const promise = Promise.resolve('value');
+  if (promise) {
+    console.log('hi');
+  }
+
+  // no-floating-promises
+  try {
+    test(); // needs to be awaited, otherwise try/catch is useless.
+  } catch {}
+}
+",
+  "suppressedMessages": [],
+  "usedDeprecatedRules": [
+    {
+      "replacedBy": [
+        "@typescript-eslint/only-throw-error",
+      ],
+      "ruleId": "@typescript-eslint/no-throw-literal",
+    },
+    {
+      "replacedBy": [
+        "@typescript-eslint/ban-ts-comment",
+      ],
+      "ruleId": "@typescript-eslint/prefer-ts-expect-error",
+    },
+  ],
+  "warningCount": 3,
 }
 `;

--- a/packages/eslint-config-universe/__tests__/fixtures/typescript-analysis-00.ts
+++ b/packages/eslint-config-universe/__tests__/fixtures/typescript-analysis-00.ts
@@ -21,5 +21,5 @@ export function myFunc(foo: T | null) {
 }
 
 export function myFunc2(foo: T2 | null) {
-  return foo && foo.a && foo.a.b.method && foo.a.b.method();
+  foo && foo.a && foo.a.b.method && foo.a.b.method();
 }

--- a/packages/eslint-config-universe/__tests__/fixtures/typescript-analysis-04.ts
+++ b/packages/eslint-config-universe/__tests__/fixtures/typescript-analysis-04.ts
@@ -1,0 +1,23 @@
+async function test() {
+  return Promise.resolve('blah');
+}
+
+export async function wat() {
+  // await-thenable
+  const createValue = () => 'value';
+  await createValue();
+
+  // no-confusing-void-expression
+  console.log(alert('Are you sure?'));
+
+  // no-misused-promises
+  const promise = Promise.resolve('value');
+  if (promise) {
+    console.log('hi');
+  }
+
+  // no-floating-promises
+  try {
+    test(); // needs to be awaited, otherwise try/catch is useless.
+  } catch {}
+}

--- a/packages/eslint-config-universe/shared/typescript-analysis.js
+++ b/packages/eslint-config-universe/shared/typescript-analysis.js
@@ -4,10 +4,26 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx', '*.d.ts'],
       rules: {
+        '@typescript-eslint/await-thenable': 'warn',
+        '@typescript-eslint/no-confusing-non-null-assertion': 'warn',
+        '@typescript-eslint/no-confusing-void-expression': 'warn',
+        '@typescript-eslint/no-extra-non-null-assertion': 'warn',
+        '@typescript-eslint/no-floating-promises': 'warn',
         '@typescript-eslint/no-for-in-array': 'error',
+        '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
         '@typescript-eslint/no-throw-literal': 'warn',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+        '@typescript-eslint/prefer-as-const': 'warn',
+        '@typescript-eslint/prefer-includes': 'warn',
         '@typescript-eslint/prefer-nullish-coalescing': 'warn',
         '@typescript-eslint/prefer-optional-chain': 'warn',
+        '@typescript-eslint/prefer-readonly': 'warn',
+        '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
+        '@typescript-eslint/prefer-ts-expect-error': 'warn',
+
+        // Overrides
+        'no-return-await': 'off',
+        '@typescript-eslint/return-await': ['error', 'always'],
       },
     },
   ],

--- a/packages/eslint-config-universe/shared/typescript.js
+++ b/packages/eslint-config-universe/shared/typescript.js
@@ -69,6 +69,12 @@ module.exports = {
         'no-redeclare': 'off',
         '@typescript-eslint/no-redeclare': 'warn',
 
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+          'warn',
+          { allowShortCircuit: true, enforceForJSX: true },
+        ],
+
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [
           'warn',


### PR DESCRIPTION
# Why

As correctly pointed out in https://app.graphite.dev/github/pr/expo/universe/15960/website-1-n-Start-to-align-eslint-configs#discussion-IC_kwDOAz9RTM6FJzxZ, we should use `eslint-config-universe` to align eslint configuration between repos.

This PR brings over a slew of rules from the EAS server config (www) that have proved to be helpful in reducing bugs.
- [await-thenable](https://typescript-eslint.io/rules/await-thenable/) - helps to improve perf as things that aren't thenables can be executed synchronously
- [no-confusing-void-expression](https://typescript-eslint.io/rules/no-confusing-void-expression/) - helps to catch cases during refactoring where a function was changed to return void and result was assigned somewhere.
- [no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises/) - helps to catch cases where promises are accidentally used as a boolean when it should be the awaited value of the promise that is used as a boolean. (all promise objects are truthy)
- [no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises/) - this has been invaluable for catching bugs where a promise await is forgotten. Namely ones of the form:
    ```
     try {
       getSomethingAsync(); // needs to be awaited, otherwise try/catch is useless.
     } catch (e) {
       ...
     }
     ```
- [no-confusing-non-null-assertion](https://typescript-eslint.io/rules/no-confusing-non-null-assertion/) - helps to ensure `!` and `==`/`===` aren't mixed for readability during code review.
- [no-extra-non-null-assertion](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) - simple rule to remove unnecessary `!`.
- [prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const/) - simple preference for using `as const` to do literal typecasting.
- [prefer-includes](https://typescript-eslint.io/rules/prefer-includes/) - cleaner code by using `.includes` instead of `.indexOf`.
- [prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly/) - simple rule to remind authors to mark fields as readonly when not mutated.
- [prefer-string-starts-ends-with](https://typescript-eslint.io/rules/prefer-string-starts-ends-with/) - simple rule to prefer `startsWith`/`endsWith` for strings.
- [prefer-ts-expect-error](https://typescript-eslint.io/rules/prefer-ts-expect-error/) - helpful when refactoring or updating dependencies to notify author when there is no longer a typescript error and the comment can be removed.
- [no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/) - helpful for removing redundant type assertions.
- [return-await](https://typescript-eslint.io/rules/return-await/) - set to always. code style preference that has shown to improve code safety as it is clearer where a promise is evaluated rather than deferring to the callsite to decide when a promise is executed. Doing the evaluation at the place the promise is created is clearer in intent.


# How

Add rules. Add test.

# Test Plan

Inspect. Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
