### PR TITLE
[docs] Fix usage instructions in Safe Area guide

### DIFF
--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -6,7 +6,6 @@ description: Learn how to add safe areas for screen components inside your Expo 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 Creating a safe area ensures your app screen's content is positioned correctly. This means it doesn't get overlapped by notches, status bars, home indicators, and other interface elements. When the content gets overlapped, it gets concealed by these interface elements.
 

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -3,6 +3,7 @@ title: Safe areas
 description: Learn how to add safe areas for screen components inside your Expo project.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -37,31 +38,7 @@ You can skip installing `react-native-safe-area-context` if you have created a p
 
 ### Usage
 
-<Step label="1">
-
-Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider). If your project uses Expo Router, add it to the [root layout (**app/\_layout.tsx**)](/develop/file-based-routing/#_layout-file) file. Otherwise, add it to the root component file (such as **App.tsx**).
-
-```tsx app/_layout.tsx
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-
-function RootLayout() {
-  return (
-    <SafeAreaProvider>
-      <Stack>
-        <Screen name="index" options={{ headerShown: false }} />
-      </Stack>
-    </SafeAreaProvider>
-  );
-}
-```
-
-> **Note:** In the above example, the `Stack` is wrapping one screen. Your project's root layout file may have more than one screen. The `index` screen is used here an example to represent a screen component.
-
-</Step>
-
-<Step label="2">
-
-Use [`SafeAreaView`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview) to wrap the content of your screen's component. It is a regular `<View>` with the safe area insets applied as extra padding or margin.
+You can directly use [`SafeAreaView`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview) to wrap the content of your screen's component. It is a regular `<View>` with the safe area insets applied as extra padding or margin.
 
 ```tsx app/index.tsx
 import { Text } from 'react-native';
@@ -76,7 +53,21 @@ export default function HomeScreen() {
 }
 ```
 
-</Step>
+<Collapsible summary="Using a different Expo template and don't have Expo Router installed?">
+
+Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) to the root component file (such as **App.tsx**) before using `SafeAreaView` in your screen component.
+
+```tsx App.tsx
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export default function App() {
+  return (
+    return <SafeAreaProvider>...</SafeAreaProvider>;
+  );
+}
+```
+
+</Collapsible>
 
 ## Alternate: `useSafeAreaInsets` hook
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #28818

In the previous set of updates, I've overlooked that `SafeAreaProvider` isn't required to wrap the contents of the Root Layout when Expo Router is installed in the project since Expo Router library automatically adds support for `react-native-safe-area-context`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Updates Usage section in Safe areas guide to remove instruction from the main flow on adding `SafeAreaProvider`. 
- Adds a collapsible to provide instruction on wrapping App's content with the `SafeAreaProvider` for projects created using a different Expo template (other than default) and not using Expo Router.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally and visiting: http://localhost:3002/develop/user-interface/safe-areas/#usage

## Preview

![CleanShot 2024-07-18 at 02 28 18](https://github.com/user-attachments/assets/e37399e9-5fc5-445d-8dd9-c2f0e7834032)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
