### PR TITLE
[expo-notifications][Android] fix vibration pattern serialization

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] fix getLastNotificationResponseAsync. ([#30301](https://github.com/expo/expo/pull/30301) by [@douglowder](https://github.com/douglowder))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30478](https://github.com/expo/expo/pull/30478) by [@byCedric](https://github.com/byCedric))
+- [Android] Fix serialization of vibration pattern. ([#30495](https://github.com/expo/expo/pull/30495) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -82,11 +82,7 @@ public class NotificationSerializer {
       serializedContent.putString("priority", content.getPriority().getEnumValue());
     }
     if (content.getVibrationPattern() != null) {
-      double[] serializedVibrationPattern = new double[content.getVibrationPattern().length];
-      for (int i = 0; i < serializedVibrationPattern.length; i++) {
-        serializedVibrationPattern[i] = content.getVibrationPattern()[i];
-      }
-      serializedContent.putDoubleArray("vibrationPattern", serializedVibrationPattern);
+      serializedContent.putIntArray("vibrationPattern", RemoteMessageSerializer.intArrayFromLongArray(content.getVibrationPattern()));
     }
     serializedContent.putBoolean("autoDismiss", content.isAutoDismiss());
     if (content.getCategoryId() != null) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
@@ -93,12 +93,22 @@ public class RemoteMessageSerializer {
     serializedNotification.putString("title", notification.getTitle());
     serializedNotification.putStringArray("titleLocalizationArgs", notification.getTitleLocalizationArgs());
     serializedNotification.putString("titleLocalizationKey", notification.getTitleLocalizationKey());
-    serializedNotification.putLongArray("vibrateTimings", notification.getVibrateTimings());
+    if (notification.getVibrateTimings() != null) {
+      serializedNotification.putIntArray("vibrateTimings", intArrayFromLongArray(notification.getVibrateTimings()));
+    }
     if (notification.getVisibility() != null) {
       serializedNotification.putInt("visibility", notification.getVisibility());
     } else {
       serializedNotification.putString("visibility", null);
     }
     return serializedNotification;
+  }
+
+  public static int[] intArrayFromLongArray(long[] longArray) {
+    int[] intArray = new int[longArray.length];
+    for (int i = 0; i < longArray.length; i++) {
+      intArray[i] = (int)(longArray[i]);
+    }
+    return intArray;
   }
 }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -12,6 +12,7 @@ import expo.modules.notifications.notifications.model.triggers.FirebaseNotificat
 import expo.modules.notifications.service.NotificationsService
 import expo.modules.notifications.service.interfaces.FirebaseMessagingDelegate
 import expo.modules.notifications.tokens.interfaces.FirebaseTokenListener
+import org.json.JSONArray
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.util.*
@@ -98,6 +99,14 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
   protected fun createNotification(remoteMessage: RemoteMessage): Notification {
     val identifier = getNotificationIdentifier(remoteMessage)
     val payload = JSONObject(remoteMessage.data as Map<*, *>)
+    val vibrationPattern = remoteMessage.notification?.vibrateTimings
+    if (vibrationPattern != null) {
+      val jsonVibrationTimings = JSONArray()
+      vibrationPattern.forEach {
+        jsonVibrationTimings.put(it.toInt() )
+      }
+      payload.put("vibrate", jsonVibrationTimings)
+    }
     val content = JSONNotificationContentBuilder(context).setPayload(payload).build()
     val request = createNotificationRequest(identifier, content, FirebaseNotificationTrigger(remoteMessage))
     return Notification(request, Date(remoteMessage.sentTime))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -103,7 +103,7 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
     if (vibrationPattern != null) {
       val jsonVibrationTimings = JSONArray()
       vibrationPattern.forEach {
-        jsonVibrationTimings.put(it.toInt() )
+        jsonVibrationTimings.put(it.toInt())
       }
       payload.put("vibrate", jsonVibrationTimings)
     }


### PR DESCRIPTION
# Why

Testing FCMv1 notifications showed that when a vibration pattern is passed into a message, it is not being serialized correctly. In fact, an exception can occur because the vibration pattern in Firebase remote messages is an array of long values, which is not supported in WritableMap for emitting to JS as part of the serialized notification.

# How

Added code in the Android native serialization classes to convert the vibration pattern to an array of int values. Also added some code in the Firebase message delegate to copy the value correctly to the notification content payload in the location expected by the Expo [NotificationContentAndroid](https://docs.expo.dev/versions/latest/sdk/notifications/#notificationcontentandroid) type.

# Test Plan

- Check that notifications sent with a vibration pattern are handled correctly in a test app
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
