### PR TITLE
[doctor] Add experimental React Native Directory package check

### DIFF
--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -75,7 +75,7 @@ export class DirectoryCheck implements DoctorCheck {
       isSuccessful: !issues.length,
       issues,
       advice: issues.length
-        ? `Use libaries that are actively maintained and support the New Architecture.`
+        ? `Use libraries that are actively maintained and support the New Architecture. Find alternatives at https://reactnative.directory`
         : undefined,
     };
   }

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -1,0 +1,82 @@
+import fetch from 'node-fetch';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class DirectoryCheck implements DoctorCheck {
+  description = 'Validate packages against React Native Directory package metadata';
+
+  sdkVersionRange = '>=51.0.0';
+
+  async runAsync({ pkg }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const newArchUnsupportedPackages: string[] = [];
+    const newArchUntestedPackages: string[] = [];
+    const unmaintainedPackages: string[] = [];
+
+    const dependencies = pkg.dependencies ?? {};
+    const packageNames = Object.keys(dependencies);
+
+    try {
+      const response = await fetch('https://reactnative.directory/api/libraries/check', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ packages: packageNames }),
+      });
+
+      const packageMetadata = await response.json();
+
+      packageNames.forEach((packageName) => {
+        const metadata = packageMetadata[packageName];
+        if (!metadata) {
+          return;
+        }
+
+        if (metadata.unmaintained) {
+          unmaintainedPackages.push(packageName);
+        }
+
+        if (metadata.newArchitecture === 'untested') {
+          newArchUntestedPackages.push(packageName);
+        }
+
+        if (metadata.newArchitecture === 'unsupported') {
+          newArchUnsupportedPackages.push(packageName);
+        }
+      });
+    } catch (error) {
+      return {
+        isSuccessful: false,
+        issues: [`Directory check failed with error: ${error}`],
+        advice: undefined,
+      };
+    }
+
+    if (newArchUnsupportedPackages.length > 0) {
+      issues.push(
+        `${newArchUnsupportedPackages.join(', ')} ${newArchUnsupportedPackages.length > 1 ? 'are' : 'is'} not supported on the New Architecture.`
+      );
+    }
+
+    if (newArchUntestedPackages.length > 0) {
+      issues.push(
+        `${newArchUntestedPackages.join(', ')} ${newArchUntestedPackages.length > 1 ? 'are' : 'is'} not tested on the New Architecture.`
+      );
+    }
+
+    if (unmaintainedPackages.length > 0) {
+      issues.push(
+        `${unmaintainedPackages.join(', ')} ${unmaintainedPackages.length > 1 ? 'are' : 'is'} unmaintained.`
+      );
+    }
+
+    return {
+      isSuccessful: !issues.length,
+      issues,
+      advice: issues.length
+        ? `Use libaries that are actively maintained and support the New Architecture.`
+        : undefined,
+    };
+  }
+}

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 
 import { DirectPackageInstallCheck } from './checks/DirectPackageInstallCheck';
+import { DirectoryCheck } from './checks/DirectoryCheck';
 import { ExpoConfigCommonIssueCheck } from './checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from './checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledLocallyCheck } from './checks/GlobalPackageInstalledLocallyCheck';
@@ -132,6 +133,14 @@ export function getChecksInScopeForProject(exp: ExpoConfig) {
     new MetroConfigCheck(),
     new NativeToolingVersionCheck(),
   ];
+
+  if (env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK) {
+    chalk.yellow(
+      'Enabled experimental React Native Directory checks. Unset the EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK environment variable to disable this check.'
+    );
+    checks.push(new DirectoryCheck());
+  }
+
   if (env.EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK) {
     Log.log(
       chalk.yellow(

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -20,6 +20,11 @@ class Env {
   get EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK() {
     return boolish('EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK', false);
   }
+
+  /** Opt in to DirectoryCheck */
+  get EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK() {
+    return boolish('EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', false);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

It is useful for us to be able to surface information about which libraries are unmaintained and which do not support the New Architecture, and we keep this information on React Native Directory currently. Not sure exposing it as a default check is right, so I put it behind a flag for now.

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/e0ff96cd-5783-46c4-81f9-d004912451ac">

# How

I added an endpoint to reactnative.directory that takes a list of packages and returns some useful metadata about them. I then hit that endpoint in doctor and show results based on that.

# Test Plan

I ran it in my project and it produced the expected results.