### PR TITLE
fix: import `expo/config-plugins` in package plugins to follow proper dependency chain

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30462](https://github.com/expo/expo/pull/30462) by [@byCedric](https://github.com/byCedric))
+- Only import from `expo/config-plugins` to follow proper dependency chains.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 - On `iOS`, fix calling `takePicture` from the simulator. ([#30103](https://github.com/expo/expo/pull/30103) by [@alanjhughes](https://github.com/alanjhughes))
 - On `iOS`, fix touch interactions when using gesture handler. ([#30338](https://github.com/expo/expo/pull/30338) by [@alanjhughes](https://github.com/alanjhughes))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30462](https://github.com/expo/expo/pull/30462) by [@byCedric](https://github.com/byCedric))
-- Only import from `expo/config-plugins` to follow proper dependency chains.
+- Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-camera/plugin/build/appendCode.d.ts
+++ b/packages/expo-camera/plugin/build/appendCode.d.ts
@@ -1,0 +1,12 @@
+export type CodeMergeResults = {
+    contents: string;
+    didClear: boolean;
+    didMerge: boolean;
+};
+/** Fork of `mergeContents`, but appends the contents to the end of the file instead. */
+export declare function appendGeneratedCodeContents({ src, tag, comment, generatedCode, }: {
+    src: string;
+    tag: string;
+    comment: string;
+    generatedCode: string;
+}): CodeMergeResults;

--- a/packages/expo-camera/plugin/build/appendCode.js
+++ b/packages/expo-camera/plugin/build/appendCode.js
@@ -1,0 +1,63 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.appendGeneratedCodeContents = void 0;
+// Forked from `@expo/config-plugins`, because its not exposed as public API or through a correct dependency chain
+// See: https://github.com/expo/expo/blob/07bfd0447f8d80ba9ff19d2ab335792f8dc8aa53/packages/%40expo/config-plugins/src/utils/generateCode.ts
+const node_crypto_1 = __importDefault(require("node:crypto"));
+/** Create a short insecure hash from a string, used as comment in the code */
+function createHash(src) {
+    return `sync-${node_crypto_1.default.createHash('sha1').update(src).digest('hex')}`;
+}
+/** Create the starting and ending comments to mark generated code */
+function createGeneratedComment(generatedCode, tag, comment) {
+    return {
+        // Everything after the `${tag} ` is unversioned and can be freely modified without breaking changes.
+        start: `${comment} @generated begin ${tag} - expo prebuild (DO NOT MODIFY) ${createHash(generatedCode)}`,
+        // Nothing after the `${tag}` is allowed to be modified.
+        end: `${comment} @generated end ${tag}`,
+    };
+}
+/** Find the first generated code comment and return the position */
+function getGeneratedCodeSections(src, tag) {
+    const contents = src.split('\n');
+    const start = contents.findIndex((line) => new RegExp(`@generated begin ${tag} -`).test(line));
+    const end = contents.findIndex((line) => new RegExp(`@generated end ${tag}$`).test(line));
+    return { contents, start, end };
+}
+/**
+ * Removes the generated section from a file, returns null when nothing can be removed.
+ * This sways heavily towards not removing lines unless it's certain that modifications were not made manually.
+ */
+function removeGeneratedCodeContents(src, tag) {
+    const { contents, start, end } = getGeneratedCodeSections(src, tag);
+    if (start > -1 && end > -1 && start < end) {
+        contents.splice(start, end - start + 1);
+        // TODO: We could in theory check that the contents we're removing match the hash used in the header,
+        // this would ensure that we don't accidentally remove lines that someone added or removed from the generated section.
+        return contents.join('\n');
+    }
+    return null;
+}
+/** Fork of `mergeContents`, but appends the contents to the end of the file instead. */
+function appendGeneratedCodeContents({ src, tag, comment, generatedCode, }) {
+    const generatedComment = createGeneratedComment(generatedCode, tag, comment);
+    if (!src.includes(generatedComment.start)) {
+        // Ensure the old generated contents are removed.
+        const sanitizedTarget = removeGeneratedCodeContents(src, tag);
+        const contentsToAdd = [
+            generatedComment.start,
+            generatedCode,
+            generatedComment.end, // @end
+        ].join('\n');
+        return {
+            contents: sanitizedTarget ?? src + contentsToAdd,
+            didMerge: true,
+            didClear: !!sanitizedTarget,
+        };
+    }
+    return { contents: src, didClear: false, didMerge: false };
+}
+exports.appendGeneratedCodeContents = appendGeneratedCodeContents;

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -1,5 +1,5 @@
-import { ConfigPlugin } from '@expo/config-plugins';
 import { MergeResults } from '@expo/config-plugins/build/utils/generateCode';
+import { type ConfigPlugin } from 'expo/config-plugins';
 export declare function addCameraImport(src: string): MergeResults;
 declare const _default: ConfigPlugin<void | {
     cameraPermission?: string | false | undefined;

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -1,6 +1,7 @@
-import { MergeResults } from '@expo/config-plugins/build/utils/generateCode';
 import { type ConfigPlugin } from 'expo/config-plugins';
-export declare function addCameraImport(src: string): MergeResults;
+import { type CodeMergeResults } from './appendCode';
+/** @internal Exposed for testing */
+export declare function addCameraImport(src: string): CodeMergeResults;
 declare const _default: ConfigPlugin<void | {
     cameraPermission?: string | false | undefined;
     microphonePermission?: string | false | undefined;

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -1,8 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.addCameraImport = void 0;
-const config_plugins_1 = require("@expo/config-plugins");
+// TODO(cedric): expose the generateCode util, or fork the plugin to import only from `expo/config-plugins`
 const generateCode_1 = require("@expo/config-plugins/build/utils/generateCode");
+const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -1,9 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.addCameraImport = void 0;
-// TODO(cedric): expose the generateCode util, or fork the plugin to import only from `expo/config-plugins`
-const generateCode_1 = require("@expo/config-plugins/build/utils/generateCode");
 const config_plugins_1 = require("expo/config-plugins");
+const appendCode_1 = require("./appendCode");
 const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
@@ -25,37 +24,16 @@ const withAndroidCameraGradle = (config) => {
         return config;
     });
 };
+/** @internal Exposed for testing */
 function addCameraImport(src) {
-    return appendContents({
+    return (0, appendCode_1.appendGeneratedCodeContents)({
         tag: 'expo-camera-import',
         src,
-        newSrc: gradleMaven,
+        generatedCode: gradleMaven,
         comment: '//',
     });
 }
 exports.addCameraImport = addCameraImport;
-// Fork of config-plugins mergeContents, but appends the contents to the end of the file.
-function appendContents({ src, newSrc, tag, comment, }) {
-    const header = (0, generateCode_1.createGeneratedHeaderComment)(newSrc, tag, comment);
-    if (!src.includes(header)) {
-        // Ensure the old generated contents are removed.
-        const sanitizedTarget = (0, generateCode_1.removeGeneratedContents)(src, tag);
-        const contentsToAdd = [
-            // @something
-            header,
-            // contents
-            newSrc,
-            // @end
-            `${comment} @generated end ${tag}`,
-        ].join('\n');
-        return {
-            contents: sanitizedTarget ?? src + contentsToAdd,
-            didMerge: true,
-            didClear: !!sanitizedTarget,
-        };
-    }
-    return { contents: src, didClear: false, didMerge: false };
-}
 const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
     config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
         NSCameraUsageDescription: CAMERA_USAGE,

--- a/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
+++ b/packages/expo-camera/plugin/src/__tests__/__snapshots__/withCamera-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addCameraImport modifies the build.gradle 1`] = `
+exports[`addCameraImport adds camera import to build gradle 1`] = `
 "
 buildscript {
     ext {

--- a/packages/expo-camera/plugin/src/__tests__/withCamera-test.ts
+++ b/packages/expo-camera/plugin/src/__tests__/withCamera-test.ts
@@ -1,6 +1,18 @@
 import { addCameraImport } from '../withCamera';
 
-const buildGradleFixture = `
+describe(addCameraImport, () => {
+  it(`adds camera import to build gradle`, () => {
+    expect(addCameraImport(buildGradleFixtureWithoutImport).contents).toMatchSnapshot();
+  });
+
+  it('does not add duplicate camera import to build gradle', () => {
+    expect(addCameraImport(buildGradleFixtureWithImport).contents).toBe(
+      buildGradleFixtureWithImport
+    );
+  });
+});
+
+const buildGradleFixtureWithoutImport = `
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
@@ -32,8 +44,41 @@ allprojects {
     }
 }
 `;
-describe(addCameraImport, () => {
-  it(`modifies the build.gradle`, () => {
-    expect(addCameraImport(buildGradleFixture).contents).toMatchSnapshot();
-  });
-});
+
+const buildGradleFixtureWithImport = `
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.2"
+        minSdkVersion = 21
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:3.5.3")
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}
+
+// @generated begin expo-camera-import - expo prebuild (DO NOT MODIFY) sync-f244f4f3d8bf7229102e8f992b525b8602c74770
+def expoCameraMavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")
+allprojects { repositories { maven { url(expoCameraMavenPath) } } }
+// @generated end expo-camera-import
+`;

--- a/packages/expo-camera/plugin/src/appendCode.ts
+++ b/packages/expo-camera/plugin/src/appendCode.ts
@@ -1,0 +1,90 @@
+// Forked from `@expo/config-plugins`, because its not exposed as public API or through a correct dependency chain
+// See: https://github.com/expo/expo/blob/07bfd0447f8d80ba9ff19d2ab335792f8dc8aa53/packages/%40expo/config-plugins/src/utils/generateCode.ts
+import crypto from 'node:crypto';
+
+export type CodeMergeResults = {
+  contents: string;
+  didClear: boolean;
+  didMerge: boolean;
+};
+
+type CodeCommentLocation = {
+  /** All lines of code of the (generated) comment */
+  contents: string[];
+  /** The line number where the (generated) comment starts */
+  start: number;
+  /** The line number where the (generated) comment ends */
+  end: number;
+};
+
+/** Create a short insecure hash from a string, used as comment in the code */
+function createHash(src: string): string {
+  return `sync-${crypto.createHash('sha1').update(src).digest('hex')}`;
+}
+
+/** Create the starting and ending comments to mark generated code */
+function createGeneratedComment(generatedCode: string, tag: string, comment: string) {
+  return {
+    // Everything after the `${tag} ` is unversioned and can be freely modified without breaking changes.
+    start: `${comment} @generated begin ${tag} - expo prebuild (DO NOT MODIFY) ${createHash(generatedCode)}`,
+    // Nothing after the `${tag}` is allowed to be modified.
+    end: `${comment} @generated end ${tag}`,
+  };
+}
+
+/** Find the first generated code comment and return the position */
+function getGeneratedCodeSections(src: string, tag: string): CodeCommentLocation {
+  const contents = src.split('\n');
+  const start = contents.findIndex((line) => new RegExp(`@generated begin ${tag} -`).test(line));
+  const end = contents.findIndex((line) => new RegExp(`@generated end ${tag}$`).test(line));
+
+  return { contents, start, end };
+}
+
+/**
+ * Removes the generated section from a file, returns null when nothing can be removed.
+ * This sways heavily towards not removing lines unless it's certain that modifications were not made manually.
+ */
+function removeGeneratedCodeContents(src: string, tag: string): string | null {
+  const { contents, start, end } = getGeneratedCodeSections(src, tag);
+
+  if (start > -1 && end > -1 && start < end) {
+    contents.splice(start, end - start + 1);
+    // TODO: We could in theory check that the contents we're removing match the hash used in the header,
+    // this would ensure that we don't accidentally remove lines that someone added or removed from the generated section.
+    return contents.join('\n');
+  }
+
+  return null;
+}
+
+/** Fork of `mergeContents`, but appends the contents to the end of the file instead. */
+export function appendGeneratedCodeContents({
+  src,
+  tag,
+  comment,
+  generatedCode,
+}: {
+  src: string;
+  tag: string;
+  comment: string;
+  generatedCode: string;
+}): CodeMergeResults {
+  const generatedComment = createGeneratedComment(generatedCode, tag, comment);
+  if (!src.includes(generatedComment.start)) {
+    // Ensure the old generated contents are removed.
+    const sanitizedTarget = removeGeneratedCodeContents(src, tag);
+    const contentsToAdd = [
+      generatedComment.start, // @begin
+      generatedCode, // contents
+      generatedComment.end, // @end
+    ].join('\n');
+
+    return {
+      contents: sanitizedTarget ?? src + contentsToAdd,
+      didMerge: true,
+      didClear: !!sanitizedTarget,
+    };
+  }
+  return { contents: src, didClear: false, didMerge: false };
+}

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -1,15 +1,16 @@
-import {
-  AndroidConfig,
-  withProjectBuildGradle,
-  ConfigPlugin,
-  createRunOncePlugin,
-  IOSConfig,
-} from '@expo/config-plugins';
+// TODO(cedric): expose the generateCode util, or fork the plugin to import only from `expo/config-plugins`
 import {
   createGeneratedHeaderComment,
   MergeResults,
   removeGeneratedContents,
 } from '@expo/config-plugins/build/utils/generateCode';
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  createRunOncePlugin,
+  IOSConfig,
+  withProjectBuildGradle,
+} from 'expo/config-plugins';
 
 const pkg = require('expo-camera/package.json');
 

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -1,9 +1,3 @@
-// TODO(cedric): expose the generateCode util, or fork the plugin to import only from `expo/config-plugins`
-import {
-  createGeneratedHeaderComment,
-  MergeResults,
-  removeGeneratedContents,
-} from '@expo/config-plugins/build/utils/generateCode';
 import {
   AndroidConfig,
   type ConfigPlugin,
@@ -11,6 +5,8 @@ import {
   IOSConfig,
   withProjectBuildGradle,
 } from 'expo/config-plugins';
+
+import { appendGeneratedCodeContents, type CodeMergeResults } from './appendCode';
 
 const pkg = require('expo-camera/package.json');
 
@@ -36,47 +32,14 @@ const withAndroidCameraGradle: ConfigPlugin = (config) => {
   });
 };
 
-export function addCameraImport(src: string): MergeResults {
-  return appendContents({
+/** @internal Exposed for testing */
+export function addCameraImport(src: string): CodeMergeResults {
+  return appendGeneratedCodeContents({
     tag: 'expo-camera-import',
     src,
-    newSrc: gradleMaven,
+    generatedCode: gradleMaven,
     comment: '//',
   });
-}
-
-// Fork of config-plugins mergeContents, but appends the contents to the end of the file.
-function appendContents({
-  src,
-  newSrc,
-  tag,
-  comment,
-}: {
-  src: string;
-  newSrc: string;
-  tag: string;
-  comment: string;
-}): MergeResults {
-  const header = createGeneratedHeaderComment(newSrc, tag, comment);
-  if (!src.includes(header)) {
-    // Ensure the old generated contents are removed.
-    const sanitizedTarget = removeGeneratedContents(src, tag);
-    const contentsToAdd = [
-      // @something
-      header,
-      // contents
-      newSrc,
-      // @end
-      `${comment} @generated end ${tag}`,
-    ].join('\n');
-
-    return {
-      contents: sanitizedTarget ?? src + contentsToAdd,
-      didMerge: true,
-      didClear: !!sanitizedTarget,
-    };
-  }
-  return { contents: src, didClear: false, didMerge: false };
 }
 
 const withCamera: ConfigPlugin<

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Only import from `expo/config-plugins` to follow proper dependency chains.
+
 ### 💡 Others
 
 - Fix homepage link in `package.json`. ([#30163](https://github.com/expo/expo/pull/30163) by [@amandeepmittal](https://github.com/amandeepmittal))

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Only import from `expo/config-plugins` to follow proper dependency chains.
+- Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-dev-client/plugin/build/getDefaultScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/getDefaultScheme.d.ts
@@ -1,2 +1,2 @@
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
 export default function getDefaultScheme(config: Pick<ExpoConfig, 'slug'>): string;

--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,3 +1,3 @@
 import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
-declare const _default: import("@expo/config-plugins").ConfigPlugin<PluginConfigType>;
+declare const _default: import("expo/config-plugins").ConfigPlugin<PluginConfigType>;
 export default _default;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 // @ts-expect-error missing types
 const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
 // @ts-expect-error missing types

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.d.ts
@@ -1,5 +1,5 @@
-import { AndroidConfig, AndroidManifest, ConfigPlugin } from '@expo/config-plugins';
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
+import { AndroidConfig, type AndroidManifest, type ConfigPlugin } from 'expo/config-plugins';
 export declare const withGeneratedAndroidScheme: ConfigPlugin;
 export declare function setGeneratedAndroidScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, androidManifest: AndroidManifest): AndroidManifest;
 /**

--- a/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedAndroidScheme.js
@@ -4,7 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.removeExpoSchemaFromVerifiedIntentFilters = exports.setGeneratedAndroidScheme = exports.withGeneratedAndroidScheme = void 0;
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
 const withGeneratedAndroidScheme = (config) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.d.ts
@@ -1,4 +1,4 @@
-import { IOSConfig, InfoPlist, ConfigPlugin } from '@expo/config-plugins';
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
+import { type ConfigPlugin, type InfoPlist, IOSConfig } from 'expo/config-plugins';
 export declare const withGeneratedIosScheme: ConfigPlugin;
 export declare function setGeneratedIosScheme(config: Pick<ExpoConfig, 'scheme' | 'slug'>, infoPlist: InfoPlist): IOSConfig.InfoPlist;

--- a/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
+++ b/packages/expo-dev-client/plugin/build/withGeneratedIosScheme.js
@@ -4,7 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setGeneratedIosScheme = exports.withGeneratedIosScheme = void 0;
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 const getDefaultScheme_1 = __importDefault(require("./getDefaultScheme"));
 const withGeneratedIosScheme = (config) => {
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {

--- a/packages/expo-dev-client/plugin/src/getDefaultScheme.ts
+++ b/packages/expo-dev-client/plugin/src/getDefaultScheme.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
 
 /*
  * Converts the slug from app configuration to a string that's a valid URI scheme.

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -1,5 +1,5 @@
-import { createRunOncePlugin } from '@expo/config-plugins';
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
+import { createRunOncePlugin } from 'expo/config-plugins';
 // @ts-expect-error missing types
 import withDevLauncher from 'expo-dev-launcher/app.plugin';
 import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';

--- a/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedAndroidScheme.ts
@@ -1,14 +1,10 @@
+import type { ExpoConfig } from 'expo/config';
 import {
   AndroidConfig,
-  AndroidManifest,
-  ConfigPlugin,
+  type AndroidManifest,
+  type ConfigPlugin,
   withAndroidManifest,
-} from '@expo/config-plugins';
-import {
-  ManifestActivity,
-  ManifestIntentFilter,
-} from '@expo/config-plugins/build/android/Manifest';
-import { ExpoConfig } from 'expo/config';
+} from 'expo/config-plugins';
 
 import getDefaultScheme from './getDefaultScheme';
 
@@ -73,20 +69,25 @@ export function removeExpoSchemaFromVerifiedIntentFilters(
  *
  * @see https://github.com/expo/expo-cli/blob/f1624c75b52cc1c4f99354ec4021494e0eff74aa/packages/config-plugins/src/android/Scheme.ts#L166
  */
-function activityHasSingleTaskLaunchMode(activity: ManifestActivity) {
+function activityHasSingleTaskLaunchMode(activity: AndroidConfig.Manifest.ManifestActivity) {
   return activity?.$?.['android:launchMode'] === 'singleTask';
 }
 
 /**
  * Determine if the intent filter has `autoVerify=true`.
  */
-function intentFilterHasAutoVerification(intentFilter: ManifestIntentFilter) {
+function intentFilterHasAutoVerification(
+  intentFilter: AndroidConfig.Manifest.ManifestIntentFilter
+) {
   return intentFilter?.$?.['android:autoVerify'] === 'true';
 }
 
 /**
  * Remove schemes from the intent filter that matches the function.
  */
-function intentFilterRemoveSchemeFromData(intentFilter: ManifestIntentFilter, schemeMatcher: any) {
+function intentFilterRemoveSchemeFromData(
+  intentFilter: AndroidConfig.Manifest.ManifestIntentFilter,
+  schemeMatcher: any
+) {
   return intentFilter?.data?.filter((entry) => !schemeMatcher(entry?.$['android:scheme'] || ''));
 }

--- a/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
+++ b/packages/expo-dev-client/plugin/src/withGeneratedIosScheme.ts
@@ -1,5 +1,5 @@
-import { IOSConfig, InfoPlist, withInfoPlist, ConfigPlugin } from '@expo/config-plugins';
-import { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from 'expo/config';
+import { type ConfigPlugin, type InfoPlist, IOSConfig, withInfoPlist } from 'expo/config-plugins';
 
 import getDefaultScheme from './getDefaultScheme';
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad. ([#29892](https://github.com/expo/expo/pull/29892) by [@alanjhughes](https://github.com/alanjhughes))
+- Only import from `expo/config-plugins` to follow proper dependency chains.
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Provide more image metadata in the result object. ([#29648](https://github.com/expo/expo/pull/29648) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix an issue where the app will crash when using the popover presentation style on iPad. ([#29892](https://github.com/expo/expo/pull/29892) by [@alanjhughes](https://github.com/alanjhughes))
-- Only import from `expo/config-plugins` to follow proper dependency chains.
+- Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/plugin/build/withImagePicker.d.ts
+++ b/packages/expo-image-picker/plugin/build/withImagePicker.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
+import { type ConfigPlugin } from 'expo/config-plugins';
 type Props = {
     photosPermission?: string | false;
     cameraPermission?: string | false;

--- a/packages/expo-image-picker/plugin/build/withImagePicker.js
+++ b/packages/expo-image-picker/plugin/build/withImagePicker.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withAndroidImagePickerPermissions = void 0;
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-image-picker/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';

--- a/packages/expo-image-picker/plugin/src/withImagePicker.ts
+++ b/packages/expo-image-picker/plugin/src/withImagePicker.ts
@@ -1,4 +1,9 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin, IOSConfig } from '@expo/config-plugins';
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  createRunOncePlugin,
+  IOSConfig,
+} from 'expo/config-plugins';
 
 const pkg = require('expo-image-picker/package.json');
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add missing `react` peer dependencies for isolated modules. ([#30474](https://github.com/expo/expo/pull/30474) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config` to follow proper dependency chains. ([#30501](https://github.com/expo/expo/pull/30501) by [@byCedric](https://github.com/byCedric))
+- Only import from `expo/config-plugins` to follow proper dependency chains.
 
 ### 💡 Others
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Add missing `react` peer dependencies for isolated modules. ([#30474](https://github.com/expo/expo/pull/30474) by [@byCedric](https://github.com/byCedric))
 - Only import from `expo/config` to follow proper dependency chains. ([#30501](https://github.com/expo/expo/pull/30501) by [@byCedric](https://github.com/byCedric))
-- Only import from `expo/config-plugins` to follow proper dependency chains.
+- Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-localization/plugin/build/withExpoLocalization.js
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const Manifest_1 = require("@expo/config-plugins/build/android/Manifest");
 const config_plugins_1 = require("expo/config-plugins");
 function withExpoLocalizationIos(config, data) {
     const mergedConfig = { ...config.extra, ...data };
@@ -21,7 +20,7 @@ function withExpoLocalizationIos(config, data) {
 function withExpoLocalizationAndroid(config, data) {
     if (data.allowDynamicLocaleChangesAndroid) {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
-            const mainActivity = (0, Manifest_1.getMainActivityOrThrow)(config.modResults);
+            const mainActivity = config_plugins_1.AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
             if (!mainActivity.$['android:configChanges']?.includes('locale')) {
                 mainActivity.$['android:configChanges'] += '|locale';
             }

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -1,4 +1,3 @@
-import { getMainActivityOrThrow } from '@expo/config-plugins/build/android/Manifest';
 import type { ExpoConfig } from 'expo/config';
 import {
   AndroidConfig,
@@ -30,7 +29,7 @@ function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
 function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps) {
   if (data.allowDynamicLocaleChangesAndroid) {
     config = withAndroidManifest(config, (config) => {
-      const mainActivity = getMainActivityOrThrow(config.modResults);
+      const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
       if (!mainActivity.$['android:configChanges']?.includes('locale')) {
         mainActivity.$['android:configChanges'] += '|locale';
       }

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -18,9 +18,10 @@
 - [Web] Fix `AudioContext` being created before user interaction causing playback issues. ([#29695](https://github.com/expo/expo/pull/29695) by [@behenate](https://github.com/behenate))
 - [iOS] Fix crashes on iOS 16 and lower when source HTTP headers are undefined. ([#30104](https://github.com/expo/expo/pull/30104) by [@behenate](https://github.com/behenate))
 - [iOS] Fix a race condition causing crashes when deallocating the player. ([#30022](https://github.com/expo/expo/pull/30022) by [@behenate](https://github.com/behenate))
-- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30489](https://github.com/expo/expo/pull/30489) by [@byCedric](https://github.com/byCedric))
 - [Android] Fix Audio Manager pausing player on the wrong thread and conflicts between players. ([#30453](https://github.com/expo/expo/pull/30453) by [@behenate](https://github.com/behenate))
 - [Android] Fix support for local file playback. ([#30472](https://github.com/expo/expo/pull/30472) by [@behenate](https://github.com/behenate))
+- Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30489](https://github.com/expo/expo/pull/30489) by [@byCedric](https://github.com/byCedric))
+- Only import from `expo/config-plugins` to follow proper dependency chains.
 
 ### 💡 Others
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [Android] Fix Audio Manager pausing player on the wrong thread and conflicts between players. ([#30453](https://github.com/expo/expo/pull/30453) by [@behenate](https://github.com/behenate))
 - [Android] Fix support for local file playback. ([#30472](https://github.com/expo/expo/pull/30472) by [@behenate](https://github.com/behenate))
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30489](https://github.com/expo/expo/pull/30489) by [@byCedric](https://github.com/byCedric))
-- Only import from `expo/config-plugins` to follow proper dependency chains.
+- Only import from `expo/config-plugins` to follow proper dependency chains. ([#30499](https://github.com/expo/expo/pull/30499) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-video/plugin/build/withExpoVideo.d.ts
+++ b/packages/expo-video/plugin/build/withExpoVideo.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
+import { type ConfigPlugin } from 'expo/config-plugins';
 type WithExpoVideoOptions = {
     supportsBackgroundPlayback?: boolean;
     supportsPictureInPicture?: boolean;

--- a/packages/expo-video/plugin/build/withExpoVideo.js
+++ b/packages/expo-video/plugin/build/withExpoVideo.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 const withExpoVideo = (config, { supportsBackgroundPlayback, supportsPictureInPicture } = {}) => {
     (0, config_plugins_1.withInfoPlist)(config, (config) => {
         const currentBackgroundModes = config.modResults.UIBackgroundModes ?? [];

--- a/packages/expo-video/plugin/src/withExpoVideo.ts
+++ b/packages/expo-video/plugin/src/withExpoVideo.ts
@@ -1,9 +1,9 @@
 import {
   AndroidConfig,
-  ConfigPlugin,
+  type ConfigPlugin,
   withInfoPlist,
   withAndroidManifest,
-} from '@expo/config-plugins';
+} from 'expo/config-plugins';
 
 type WithExpoVideoOptions = {
   supportsBackgroundPlayback?: boolean;


### PR DESCRIPTION
Sorry for the bulk PR! I've tried doing separate PRs, but that turned into a PR tsunami.

# Why

This changes the imports inside multiple `expo-*` plugins from `@expo/config-plugins` to `expo/config-plugins`, while maintaining the exact same functionality and typing. It's required to follow a proper dependency chain, going from the `expo: *` peer dependency towards `expo -> @expo/config-plugins`.

Packages affected:

- expo-camera
- expo-dev-client
- expo-image-picker
- expo-localization
- expo-video

# How

- Updated imports from `@expo/config-plugins` to `expo/config-plugins`.

# Test Plan

See CI lint/build tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
