### PR TITLE
fix(expo-asset): add missing `@expo/image-utils` dependency and resolve proper dependency chains

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing dependencies and follow proper dependency chains.
+
 ### 💡 Others
 
 - Remove unused `pathJoin` function. ([#29963](https://github.com/expo/expo/pull/29963) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add missing dependencies and follow proper dependency chains.
+- Add missing dependencies and follow proper dependency chains. ([#30500](https://github.com/expo/expo/pull/30500) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -37,6 +37,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
+    "@expo/image-utils": "^0.5.1",
     "expo-constants": "~16.0.0",
     "invariant": "^2.2.4",
     "md5-file": "^3.2.3"

--- a/packages/expo-asset/plugin/build/AssetContents.d.ts
+++ b/packages/expo-asset/plugin/build/AssetContents.d.ts
@@ -1,0 +1,29 @@
+type ContentsJsonImageScale = '1x' | '2x' | '3x';
+type ContentsJsonImageIdiom = 'iphone' | 'ipad' | 'watchos' | 'ios' | 'ios-marketing' | 'universal';
+type ContentsJsonImageAppearance = {
+    appearance: 'luminosity';
+    value: 'dark';
+};
+export interface ContentsJsonImage {
+    appearances?: ContentsJsonImageAppearance[];
+    idiom: ContentsJsonImageIdiom;
+    size?: string;
+    scale?: ContentsJsonImageScale;
+    filename?: string;
+    platform?: ContentsJsonImageIdiom;
+}
+export interface ContentsJson {
+    images: ContentsJsonImage[];
+    info: {
+        version: number;
+        author: string;
+    };
+}
+/**
+ * Writes the Config.json which is used to assign images to their respective platform, dpi, and idiom.
+ *
+ * @param directory path to add the Contents.json to.
+ * @param contents image json data
+ */
+export declare function writeContentsJsonAsync(directory: string, { images }: Pick<ContentsJson, 'images'>): Promise<void>;
+export {};

--- a/packages/expo-asset/plugin/build/AssetContents.js
+++ b/packages/expo-asset/plugin/build/AssetContents.js
@@ -1,0 +1,29 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.writeContentsJsonAsync = void 0;
+// Forked from `@expo/prebuild-config`, because its not exposed as public API or through a correct dependency chain
+// See: https://github.com/expo/expo/blob/80ee356c2c90d6498b45c95214ed7be169d63f75/packages/%40expo/prebuild-config/src/plugins/icons/AssetContents.ts
+const promises_1 = __importDefault(require("node:fs/promises"));
+const node_path_1 = __importDefault(require("node:path"));
+/**
+ * Writes the Config.json which is used to assign images to their respective platform, dpi, and idiom.
+ *
+ * @param directory path to add the Contents.json to.
+ * @param contents image json data
+ */
+async function writeContentsJsonAsync(directory, { images }) {
+    const data = {
+        images,
+        info: {
+            version: 1,
+            // common practice is for the tool that generated the icons to be the "author"
+            author: 'expo',
+        },
+    };
+    await promises_1.default.mkdir(directory, { recursive: true });
+    await promises_1.default.writeFile(node_path_1.default.join(directory, 'Contents.json'), JSON.stringify(data, null, 2));
+}
+exports.writeContentsJsonAsync = writeContentsJsonAsync;

--- a/packages/expo-asset/plugin/build/withAssets.d.ts
+++ b/packages/expo-asset/plugin/build/withAssets.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from 'expo/config-plugins';
+import { type ConfigPlugin } from 'expo/config-plugins';
 export type AssetProps = {
     assets?: string[];
 };

--- a/packages/expo-asset/plugin/build/withAssetsAndroid.d.ts
+++ b/packages/expo-asset/plugin/build/withAssetsAndroid.d.ts
@@ -1,2 +1,2 @@
-import { ConfigPlugin } from 'expo/config-plugins';
+import { type ConfigPlugin } from 'expo/config-plugins';
 export declare const withAssetsAndroid: ConfigPlugin<string[]>;

--- a/packages/expo-asset/plugin/build/withAssetsIos.d.ts
+++ b/packages/expo-asset/plugin/build/withAssetsIos.d.ts
@@ -1,2 +1,2 @@
-import { ConfigPlugin } from 'expo/config-plugins';
+import { type ConfigPlugin } from 'expo/config-plugins';
 export declare const withAssetsIos: ConfigPlugin<string[]>;

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -5,9 +5,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withAssetsIos = void 0;
 const image_utils_1 = require("@expo/image-utils");
+// TODO(cedric): expose the AssetContents util, or add the dependency chain to `@expo/prebuild-config`
 const AssetContents_1 = require("@expo/prebuild-config/build/plugins/icons/AssetContents");
 const config_plugins_1 = require("expo/config-plugins");
-const fs_extra_1 = require("fs-extra");
+const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
 const IMAGE_DIR = 'Images.xcassets';
@@ -48,11 +49,11 @@ async function addImageAssets(assets, root) {
         const name = path_1.default.basename(asset, path_1.default.extname(asset));
         const image = path_1.default.basename(asset);
         const assetPath = path_1.default.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
-        await (0, fs_extra_1.ensureDir)(assetPath);
+        await promises_1.default.mkdir(assetPath, { recursive: true });
         const buffer = await (0, image_utils_1.generateImageAsync)({ projectRoot: root }, {
             src: asset,
         });
-        await (0, fs_extra_1.writeFile)(path_1.default.resolve(assetPath, image), buffer.source);
+        await promises_1.default.writeFile(path_1.default.resolve(assetPath, image), buffer.source);
         await writeContentsJsonFileAsync({
             assetPath,
             image,

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -5,11 +5,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withAssetsIos = void 0;
 const image_utils_1 = require("@expo/image-utils");
-// TODO(cedric): expose the AssetContents util, or add the dependency chain to `@expo/prebuild-config`
-const AssetContents_1 = require("@expo/prebuild-config/build/plugins/icons/AssetContents");
 const config_plugins_1 = require("expo/config-plugins");
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
+const AssetContents_1 = require("./AssetContents");
 const utils_1 = require("./utils");
 const IMAGE_DIR = 'Images.xcassets';
 const withAssetsIos = (config, assets) => {
@@ -66,18 +65,8 @@ async function writeContentsJsonFileAsync({ assetPath, image, }) {
 }
 function buildContentsJsonImages({ image }) {
     return [
-        (0, AssetContents_1.createContentsJsonItem)({
-            idiom: 'universal',
-            filename: image,
-            scale: '1x',
-        }),
-        (0, AssetContents_1.createContentsJsonItem)({
-            idiom: 'universal',
-            scale: '2x',
-        }),
-        (0, AssetContents_1.createContentsJsonItem)({
-            idiom: 'universal',
-            scale: '3x',
-        }),
+        { idiom: 'universal', filename: image, scale: '1x' },
+        { idiom: 'universal', scale: '2x' },
+        { idiom: 'universal', scale: '3x' },
     ];
 }

--- a/packages/expo-asset/plugin/src/AssetContents.ts
+++ b/packages/expo-asset/plugin/src/AssetContents.ts
@@ -1,0 +1,51 @@
+// Forked from `@expo/prebuild-config`, because its not exposed as public API or through a correct dependency chain
+// See: https://github.com/expo/expo/blob/80ee356c2c90d6498b45c95214ed7be169d63f75/packages/%40expo/prebuild-config/src/plugins/icons/AssetContents.ts
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+type ContentsJsonImageScale = '1x' | '2x' | '3x';
+type ContentsJsonImageIdiom = 'iphone' | 'ipad' | 'watchos' | 'ios' | 'ios-marketing' | 'universal';
+type ContentsJsonImageAppearance = {
+  appearance: 'luminosity';
+  value: 'dark';
+};
+
+export interface ContentsJsonImage {
+  appearances?: ContentsJsonImageAppearance[];
+  idiom: ContentsJsonImageIdiom;
+  size?: string;
+  scale?: ContentsJsonImageScale;
+  filename?: string;
+  platform?: ContentsJsonImageIdiom;
+}
+
+export interface ContentsJson {
+  images: ContentsJsonImage[];
+  info: {
+    version: number;
+    author: string;
+  };
+}
+
+/**
+ * Writes the Config.json which is used to assign images to their respective platform, dpi, and idiom.
+ *
+ * @param directory path to add the Contents.json to.
+ * @param contents image json data
+ */
+export async function writeContentsJsonAsync(
+  directory: string,
+  { images }: Pick<ContentsJson, 'images'>
+) {
+  const data = {
+    images,
+    info: {
+      version: 1,
+      // common practice is for the tool that generated the icons to be the "author"
+      author: 'expo',
+    },
+  };
+
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(path.join(directory, 'Contents.json'), JSON.stringify(data, null, 2));
+}

--- a/packages/expo-asset/plugin/src/withAssets.ts
+++ b/packages/expo-asset/plugin/src/withAssets.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
+import { type ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
 import { withAssetsAndroid } from './withAssetsAndroid';
 import { withAssetsIos } from './withAssetsIos';

--- a/packages/expo-asset/plugin/src/withAssetsAndroid.ts
+++ b/packages/expo-asset/plugin/src/withAssetsAndroid.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
+import { type ConfigPlugin, withDangerousMod } from 'expo/config-plugins';
 import fs from 'fs';
 import fsp from 'fs/promises';
 import path from 'path';

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,4 +1,5 @@
 import { type ImageOptions, generateImageAsync } from '@expo/image-utils';
+// TODO(cedric): expose the AssetContents util, or add the dependency chain to `@expo/prebuild-config`
 import {
   type ContentsJsonImage,
   createContentsJsonItem,

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,12 +1,17 @@
-import { ExpoConfig } from '@expo/config-types';
-import { ImageOptions, generateImageAsync } from '@expo/image-utils';
+import { type ImageOptions, generateImageAsync } from '@expo/image-utils';
 import {
-  ContentsJsonImage,
+  type ContentsJsonImage,
   createContentsJsonItem,
   writeContentsJsonAsync,
 } from '@expo/prebuild-config/build/plugins/icons/AssetContents';
-import { ConfigPlugin, IOSConfig, XcodeProject, withXcodeProject } from 'expo/config-plugins';
-import fsp from 'fs/promises';
+import type { ExpoConfig } from 'expo/config';
+import {
+  type ConfigPlugin,
+  IOSConfig,
+  type XcodeProject,
+  withXcodeProject,
+} from 'expo/config-plugins';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { IMAGE_TYPES, resolveAssetPaths, validateAssets } from './utils';
@@ -58,12 +63,12 @@ async function addImageAssets(assets: string[], root: string) {
     const image = path.basename(asset);
 
     const assetPath = path.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
-    await fsp.mkdir(assetPath, { recursive: true });
+    await fs.mkdir(assetPath, { recursive: true });
 
     const buffer = await generateImageAsync({ projectRoot: root }, {
       src: asset,
     } as unknown as ImageOptions);
-    await fsp.writeFile(path.resolve(assetPath, image), buffer.source);
+    await fs.writeFile(path.resolve(assetPath, image), buffer.source);
 
     await writeContentsJsonFileAsync({
       assetPath,

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -6,7 +6,7 @@ import {
   writeContentsJsonAsync,
 } from '@expo/prebuild-config/build/plugins/icons/AssetContents';
 import { ConfigPlugin, IOSConfig, XcodeProject, withXcodeProject } from 'expo/config-plugins';
-import { ensureDir, writeFile } from 'fs-extra';
+import fsp from 'fs/promises';
 import path from 'path';
 
 import { IMAGE_TYPES, resolveAssetPaths, validateAssets } from './utils';
@@ -58,12 +58,12 @@ async function addImageAssets(assets: string[], root: string) {
     const image = path.basename(asset);
 
     const assetPath = path.resolve(iosNamedProjectRoot, `${IMAGE_DIR}/${name}.imageset`);
-    await ensureDir(assetPath);
+    await fsp.mkdir(assetPath, { recursive: true });
 
     const buffer = await generateImageAsync({ projectRoot: root }, {
       src: asset,
     } as unknown as ImageOptions);
-    await writeFile(path.resolve(assetPath, image), buffer.source);
+    await fsp.writeFile(path.resolve(assetPath, image), buffer.source);
 
     await writeContentsJsonFileAsync({
       assetPath,

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,10 +1,4 @@
 import { type ImageOptions, generateImageAsync } from '@expo/image-utils';
-// TODO(cedric): expose the AssetContents util, or add the dependency chain to `@expo/prebuild-config`
-import {
-  type ContentsJsonImage,
-  createContentsJsonItem,
-  writeContentsJsonAsync,
-} from '@expo/prebuild-config/build/plugins/icons/AssetContents';
 import type { ExpoConfig } from 'expo/config';
 import {
   type ConfigPlugin,
@@ -15,6 +9,7 @@ import {
 import fs from 'fs/promises';
 import path from 'path';
 
+import { type ContentsJsonImage, writeContentsJsonAsync } from './AssetContents';
 import { IMAGE_TYPES, resolveAssetPaths, validateAssets } from './utils';
 
 const IMAGE_DIR = 'Images.xcassets';
@@ -91,18 +86,8 @@ async function writeContentsJsonFileAsync({
 
 function buildContentsJsonImages({ image }: { image: string }): ContentsJsonImage[] {
   return [
-    createContentsJsonItem({
-      idiom: 'universal',
-      filename: image,
-      scale: '1x',
-    }),
-    createContentsJsonItem({
-      idiom: 'universal',
-      scale: '2x',
-    }),
-    createContentsJsonItem({
-      idiom: 'universal',
-      scale: '3x',
-    }),
-  ] as ContentsJsonImage[];
+    { idiom: 'universal', filename: image, scale: '1x' },
+    { idiom: 'universal', scale: '2x' },
+    { idiom: 'universal', scale: '3x' },
+  ];
 }


### PR DESCRIPTION
# Why

- `expo-assets` plugin used `@expo/image-utils` without defining the dependency
- `expo-assets` plugin used `@expo/config-types` instead of `expo/config`
- `expo-assets` plugin used `fs-extra`

# How

- Added `@expo/image-utils` as dependency
- Updated import from `@expo/config-types` to `expo/config`
- Refactored `fs-extra` usage to use `fs/promises`

# Test Plan

- `$ bun create expo ./test-assets`
- `$ cd ./test-assets`
- `$ bun expo install expo-asset`
- Add the plugin to **app.json** if not added yet
- `$ bun expo prebuild`
- Should work exactly how it works now

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
