### PR TITLE
[ENG-12794][docs] improve programmatic access docs to make it easier to understand how to use `EXPO_TOKEN` with EAS CLI

### DIFF
--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -3,6 +3,8 @@ title: Programmatic access
 description: Learn about types of access tokens and how to use them.
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 When setting up CI or writing a script to help manage your projects, we recommend avoiding using your username and password to authenticate. With these credentials, anyone will be able to log in and use your account.
 
 Instead of providing credentials, you can generate tokens that will allow you to manage each integration point separately. Anyone who has access to these tokens will be able to perform actions against your account. Please treat them with the same care as a user password. In case something is leaked, you can revoke these tokens to block access.
@@ -17,7 +19,13 @@ Accounts can create Robot users to take actions on resources owned by the Accoun
 
 ## Access tokens usage
 
-You can use any tokens you have created to perform actions with the Expo CLI (other than signing in and out). To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
+You can use any tokens you have created to perform actions with the EAS CLI. To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
+Once you set the `EXPO_TOKEN` environment variable, you can run any EAS CLI command being authenticated with the token without a need to run the `eas login` command.
+The `eas login` command is only used for username and password authentication. The `EXPO_TOKEN` auth method takes precedence over the username and password if both are configured.
+
+For example, once you obtain a token, you can run the following EAS CLI command to trigger a build:
+
+<Terminal cmd={['EXPO_TOKEN=my_token eas build']} />
 
 If you are using GitHub Actions, [you can configure the `token` property](https://github.com/expo/expo-github-action#configuration-options) to include this environment variable in all the job steps.
 

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -20,8 +20,8 @@ Accounts can create Robot users to take actions on resources owned by the Accoun
 ## Access tokens usage
 
 You can use any tokens you have created to perform actions with the EAS CLI. To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
-Once you set the `EXPO_TOKEN` environment variable, you can run any EAS CLI command being authenticated with the token without a need to run the `eas login` command.
-The `eas login` command is only used for username and password authentication. The `EXPO_TOKEN` auth method takes precedence over the username and password if both are configured.
+
+Once you set the `EXPO_TOKEN` environment variable, you can run any EAS CLI command authenticated with the token without running the `eas login` command. The `eas login` command is only used for username and password authentication. The `EXPO_TOKEN` auth method takes precedence over the username and password if both are configured.
 
 For example, once you obtain a token, you can run the following EAS CLI command to trigger a build:
 


### PR DESCRIPTION
# Why

Improve programmatic access docs to make it easier to understand how to use `EXPO_TOKEN` with EAS CLI

# How

Improve programmatic access docs to make it easier to understand how to use `EXPO_TOKEN` with EAS CLI

# Test Plan

Preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
