### PR TITLE
[media-library]: include more error information in native rejections

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] include more error information in native rejections
+- [iOS] include more error information in native rejections ([#30504](https://github.com/expo/expo/pull/30504) by [@vonovak](https://github.com/vonovak))
 - On `Android 14+`, when user gave only partial asset access, `presentPermissionsPickerAsync()` presents the permissions dialog to allow the user to change the selected assets. ([#29882](https://github.com/expo/expo/pull/29882) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] include more error information in native rejections
 - On `Android 14+`, when user gave only partial asset access, `presentPermissionsPickerAsync()` presents the permissions dialog to allow the user to change the selected assets. ([#29882](https://github.com/expo/expo/pull/29882) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/ios/MediaLibraryExceptions.swift
+++ b/packages/expo-media-library/ios/MediaLibraryExceptions.swift
@@ -1,5 +1,7 @@
 import ExpoModulesCore
 
+let defaultErrorMessage = "unspecified error"
+
 internal class MethodUnavailableException: Exception {
   override var reason: String {
     "presentLimitedLibraryPickerAsync is only available on iOS >= 14"
@@ -12,9 +14,9 @@ internal class MediaLibraryPermissionsException: Exception {
   }
 }
 
-internal class FileExtensionException: Exception {
+internal class EmptyFileExtensionException: Exception {
   override var reason: String {
-    "Could not get the file's extension"
+    "Could not get the file's extension - it was empty."
   }
 }
 
@@ -30,9 +32,9 @@ internal class UnreadableAssetException: GenericException<String> {
   }
 }
 
-internal class SaveAssetException: Exception {
+internal class SaveAssetException: GenericException<(any Error)?> {
   override var reason: String {
-    "Asset couldn't be saved to photo library"
+    "Asset couldn't be saved to photo library: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
@@ -54,21 +56,21 @@ internal class SaveVideoException: Exception {
   }
 }
 
-internal class SaveAlbumException: Exception {
+internal class SaveAlbumException: GenericException<(any Error)?> {
   override var reason: String {
-    "Couldn't add assets to album"
+    "Couldn't add assets to album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class RemoveFromAlbumException: Exception {
+internal class RemoveFromAlbumException: GenericException<(any Error)?> {
   override var reason: String {
-    "Couldn't remove assets from album"
+    "Couldn't remove assets from album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class RemoveAssetsException: Exception {
+internal class RemoveAssetsException: GenericException<(any Error)?> {
   override var reason: String {
-    "Couldn't remove assets"
+    "Couldn't remove assets: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
@@ -84,21 +86,21 @@ internal class NotEnoughPermissionsException: Exception {
   }
 }
 
-internal class FailedToAddAssetException: Exception {
+internal class FailedToAddAssetException: GenericException<(any Error)?> {
   override var reason: String {
-    "Unable to add asset to the new album"
+    "Unable to add asset to the new album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class CreateAlbumFailedException: Exception {
+internal class CreateAlbumFailedException: GenericException<(any Error)?> {
   override var reason: String {
-    "Could not create album"
+    "Could not create album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class DeleteAlbumFailedException: Exception {
+internal class DeleteAlbumFailedException: GenericException<(any Error)?> {
   override var reason: String {
-    "Could not delete album"
+    "Could not delete album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -55,7 +55,7 @@ func stringifyAlbumType(type: PHAssetCollectionType) -> String {
 
 func exportAssetInfo(asset: PHAsset) -> [String: Any?]? {
   if var assetDict = exportAsset(asset: asset) {
-    assetDict["location"] = exportLocation(location: asset.location) ?? NSNull()
+    assetDict["location"] = exportLocation(location: asset.location)
     assetDict["isFavorite"] = asset.isFavorite
     assetDict["isHidden"] = asset.isHidden
     return assetDict
@@ -218,7 +218,7 @@ func exportCollection(_ collection: PHAssetCollection?, folderName: String? = ni
     "assetCount": assetCountOfCollection(collection),
     "startTime": exportDate(collection.startDate),
     "endTime": exportDate(collection.endDate),
-    "approximateLocation": exportLocation(location: collection.approximateLocation) ?? NSNull(),
+    "approximateLocation": exportLocation(location: collection.approximateLocation),
     "locationNames": collection.localizedLocationNames
   ]
 }

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -55,7 +55,7 @@ func stringifyAlbumType(type: PHAssetCollectionType) -> String {
 
 func exportAssetInfo(asset: PHAsset) -> [String: Any?]? {
   if var assetDict = exportAsset(asset: asset) {
-    assetDict["location"] = exportLocation(location: asset.location)
+    assetDict["location"] = exportLocation(location: asset.location) ?? NSNull()
     assetDict["isFavorite"] = asset.isFavorite
     assetDict["isHidden"] = asset.isHidden
     return assetDict
@@ -218,7 +218,7 @@ func exportCollection(_ collection: PHAssetCollection?, folderName: String? = ni
     "assetCount": assetCountOfCollection(collection),
     "startTime": exportDate(collection.startDate),
     "endTime": exportDate(collection.endDate),
-    "approximateLocation": exportLocation(location: collection.approximateLocation),
+    "approximateLocation": exportLocation(location: collection.approximateLocation) ?? NSNull(),
     "locationNames": collection.localizedLocationNames
   ]
 }


### PR DESCRIPTION
# Why

closes #30441

# How

the native module rejections include the error message from the native error

# Test Plan

#30441 mentions issues with deleting assets. Unfortunately I wasn't able to get the delete method to report an error (I tried deleting already deleted asset, or provide invalid data), but since it compiles and tests in bare expo pass I believe it's safe.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
