### PR TITLE
[android][camera] Fix onBarCodeScanned `bounds` for ExpoCameraView

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### 🐛 Bug fixes
 
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30457](https://github.com/expo/expo/pull/30457) by [@byCedric](https://github.com/byCedric))
-
 - Fixed `bounds` incorrectly being returned as `boundingBox` in BarcodeScanningResult when using ExpoCameraView on Android. ([#30510](https://github.com/expo/expo/pull/30510) by [@devon94](https://github.com/devon94))
 
 ### 💡 Others

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Add missing `react` and `react-native` peer dependencies for isolated modules. ([#30457](https://github.com/expo/expo/pull/30457) by [@byCedric](https://github.com/byCedric))
 
+- Fixed `bounds` incorrectly being returned as `boundingBox` in BarcodeScanningResult when using ExpoCameraView on Android. ([#30510](https://github.com/expo/expo/pull/30510) by [@devon94](https://github.com/devon94))
+
 ### 💡 Others
 
 ## 13.0.1 — 2024-04-23

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -553,7 +553,7 @@ class ExpoCameraView(
           raw = barcode.raw,
           type = BarcodeType.mapFormatToString(barcode.type),
           cornerPoints = cornerPoints,
-          boundingBox = boundingBox
+          bounds = boundingBox
         )
       )
     }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
@@ -10,7 +10,7 @@ class BarcodeScannedEvent(
   @Field val raw: String,
   @Field val type: String,
   @Field val cornerPoints: ArrayList<Bundle>,
-  @Field val boundingBox: Bundle
+  @Field bounds: Bundle
 ) : Record
 
 class CameraMountErrorEvent(

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
@@ -10,7 +10,7 @@ class BarcodeScannedEvent(
   @Field val raw: String,
   @Field val type: String,
   @Field val cornerPoints: ArrayList<Bundle>,
-  @Field bounds: Bundle
+  @Field val bounds: Bundle
 ) : Record
 
 class CameraMountErrorEvent(

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/ExpoCameraView.kt
@@ -285,7 +285,7 @@ class ExpoCameraView(
           raw = barCode.raw,
           type = BarcodeType.mapFormatToString(barCode.type),
           cornerPoints = cornerPoints,
-          boundingBox = boundingBox
+          bounds = boundingBox
         )
       )
     }


### PR DESCRIPTION
# Why

The type definitions for BarcodeScanningResult contains `bounds`:
[expo/packages/expo-camera/src/CameraView.tsx](https://github.com/expo/expo/blob/main/packages/expo-camera/src/CameraView.tsx)

However, on Android the bounds from the CameraView (latest & legacy) is missing, it seems to be incorrectly sending `boundingBox` instead which leads to crashes
https://github.com/expo/expo/blob/b05ee6182f0a602a842aa720d76a74663de1147e/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt#L556
https://github.com/expo/expo/blob/b275013e842d4f61b7d7594411a87fac4027373a/packages/expo-camera/android/src/main/java/expo/modules/camera/legacy/ExpoCameraView.kt#L288

On iOS, it seems like it is added properly in BarcodeScannerUtils
https://github.com/expo/expo/blob/b05ee6182f0a602a842aa720d76a74663de1147e/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift

Minimal Reproduction repo (Latest Camera):

https://github.com/devon94/expo-camera-barcode-scanned-event-repro

# How

Fixed incorrect `boundingBox` being used for `BarcodeScannedEvent` by renaming to `bounds`

# Test Plan

Ran `yarn android` in `apps/bare-expo`

Tested fixed camera module against reproduction app to ensure it doesn't crash anymore
https://github.com/devon94/expo-camera-barcode-scanned-event-repro

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
