### PR TITLE
Add template license and remove it automatically on create-expo-app

### DIFF
--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -332,6 +332,7 @@ export async function sanitizeTemplateAsync(projectRoot: string) {
   delete packageJson.description;
   delete packageJson.tags;
   delete packageJson.repository;
+  delete packageJson.license;
 
   await packageFile.writeAsync(packageJson);
 }

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -332,7 +332,11 @@ export async function sanitizeTemplateAsync(projectRoot: string) {
   delete packageJson.description;
   delete packageJson.tags;
   delete packageJson.repository;
-  delete packageJson.license;
+
+  // Only strip the license if it's 0BSD, used by our templates. Leave other licenses alone.
+  if (packageJson.license === '0BSD') {
+    delete packageJson.license;
+  }
 
   await packageFile.writeAsync(packageJson);
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-bare-minimum",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
+  "license": "0BSD",
   "version": "51.0.27",
   "main": "index.js",
   "scripts": {

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-blank-typescript",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
+  "license": "0BSD",
   "version": "51.0.27",
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -1,6 +1,7 @@
 {
   "name": "expo-template-blank",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
+  "license": "0BSD",
   "version": "51.0.27",
   "main": "expo/AppEntry.js",
   "scripts": {

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -1,5 +1,6 @@
 {
   "name": "expo-template-default",
+  "license": "0BSD",
   "main": "expo-router/entry",
   "version": "51.0.31",
   "scripts": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -2,6 +2,7 @@
   "name": "expo-template-tabs",
   "main": "expo-router/entry",
   "description": "The Tab Navigation project template includes several example screens.",
+  "license": "0BSD",
   "version": "51.0.28",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
# Why

Alternative to #29824 that uses BSD-0 clause, which is essentially public domain - with no restrictions on usage or obligation to include the license in any copies or derivatives.

# How

- Add license to all templates
- Remove it automatically when initializing a project with create-expo(-app)
- Don't remove the license if it is something other than 0BSD