### PR TITLE
[docs] Update example in expo modules get-started guide

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -83,7 +83,7 @@ If you have an **android** directory in your project that you created using `npx
 
 You can always just edit the files in the `modules/my-module/android/src/main/java/expo/modules/mymodule/` directory directly in your favorite text editor.
 
-Change the `hello` method to return a different string. For example, you can change it to return "Hello world! 🌎🍎".
+Change the `hello` method to return a different string. For example, you can change it to return "Hello world! 🌎🤖".
 
 Rebuild the app or build a new development client and you should see your change.
 


### PR DESCRIPTION
# Why

The current example for android on the modules get-started page, suggests editing the return message of the `hello` method in `modules/my-module/android/src/main/java/expo/modules/mymodule/` to `"Hello world! 🌎🍎"`. 
However, in the same page in another example it is suggested to change it to `"Hello world! 🌎🤖"`. 

Also the emoji is supposed to indicate that this is different for each platform. Thus using an apple emoji on Android can be misleading.

# How

By updating the documentation of the modules get started guide page

# Test Plan

By running locally and checking the first example in [http://localhost:3002/modules/get-started/#android](http://localhost:3002/modules/get-started/#android)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
