### PR TITLE
[doctor] Report unvalidated packages and allow developers to opt out of this reporting

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- List unvalidated packages in directory check. Add `expo.doctor.directoryCheck.exclude` to **package.json** config to skip validating packages entirely. ([#30517](https://github.com/expo/expo/pull/30517) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -1,6 +1,31 @@
+import chalk from 'chalk';
 import fetch from 'node-fetch';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+// Filter out common packages that don't make sense for us to validate on the directory.
+const DEFAULT_PACKAGES_TO_IGNORE = [
+  /react-native/,
+  'react',
+  'react-dom',
+  'react-native-web',
+  'jest',
+  /^babel-*/,
+];
+
+function getUserDefinedIgnoredPackages(pkg: any) {
+  return (pkg.expo?.doctor?.directoryCheck?.exclude ?? []).map((ignoredPackage: string) => {
+    if (
+      typeof ignoredPackage === 'string' &&
+      ignoredPackage.startsWith('/') &&
+      ignoredPackage.endsWith('/')
+    ) {
+      // Remove the leading and trailing slashes
+      return new RegExp(ignoredPackage.slice(1, -1));
+    }
+    return ignoredPackage;
+  });
+}
 
 export class DirectoryCheck implements DoctorCheck {
   description = 'Validate packages against React Native Directory package metadata';
@@ -12,9 +37,20 @@ export class DirectoryCheck implements DoctorCheck {
     const newArchUnsupportedPackages: string[] = [];
     const newArchUntestedPackages: string[] = [];
     const unmaintainedPackages: string[] = [];
-
+    const unvalidatedPackages: string[] = [];
     const dependencies = pkg.dependencies ?? {};
-    const packageNames = Object.keys(dependencies);
+    const userDefinedIgnoredPackages = getUserDefinedIgnoredPackages(pkg);
+
+    const packageNames = Object.keys(dependencies).filter((packageName) => {
+      return [...DEFAULT_PACKAGES_TO_IGNORE, ...userDefinedIgnoredPackages].every(
+        (ignoredPackage) => {
+          if (ignoredPackage instanceof RegExp) {
+            return !ignoredPackage.test(packageName);
+          }
+          return ignoredPackage !== packageName;
+        }
+      );
+    });
 
     try {
       const response = await fetch('https://reactnative.directory/api/libraries/check', {
@@ -30,6 +66,7 @@ export class DirectoryCheck implements DoctorCheck {
       packageNames.forEach((packageName) => {
         const metadata = packageMetadata[packageName];
         if (!metadata) {
+          unvalidatedPackages.push(packageName);
           return;
         }
 
@@ -55,24 +92,32 @@ export class DirectoryCheck implements DoctorCheck {
 
     if (newArchUnsupportedPackages.length > 0) {
       issues.push(
-        `${newArchUnsupportedPackages.join(', ')} ${newArchUnsupportedPackages.length > 1 ? 'are' : 'is'} not supported on the New Architecture.`
+        `- ${newArchUnsupportedPackages.join(', ')} ${newArchUnsupportedPackages.length > 1 ? 'are' : 'is'} not supported on the New Architecture.`
       );
     }
 
     if (newArchUntestedPackages.length > 0) {
       issues.push(
-        `${newArchUntestedPackages.join(', ')} ${newArchUntestedPackages.length > 1 ? 'are' : 'is'} not tested on the New Architecture.`
+        `- ${newArchUntestedPackages.join(', ')} ${newArchUntestedPackages.length > 1 ? 'are' : 'is'} not tested on the New Architecture.`
       );
     }
 
     if (unmaintainedPackages.length > 0) {
       issues.push(
-        `${unmaintainedPackages.join(', ')} ${unmaintainedPackages.length > 1 ? 'are' : 'is'} unmaintained.`
+        `- ${unmaintainedPackages.join(', ')} ${unmaintainedPackages.length > 1 ? 'are' : 'is'} unmaintained.`
+      );
+    }
+
+    const isSuccessful = issues.length === 0;
+
+    if (unvalidatedPackages.length > 0) {
+      issues.push(
+        `- ${unvalidatedPackages.join(', ')} ${unvalidatedPackages.length > 1 ? 'were' : 'was'} not validated because ${unvalidatedPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can ignore these packages in ${chalk.bold('expo.doctor.directoryCheck.exclude')} in your package.json.`
       );
     }
 
     return {
-      isSuccessful: !issues.length,
+      isSuccessful,
       issues,
       advice: issues.length
         ? `Use libraries that are actively maintained and support the New Architecture. Find alternatives at https://reactnative.directory`

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -112,7 +112,7 @@ export class DirectoryCheck implements DoctorCheck {
 
     if (unvalidatedPackages.length > 0) {
       issues.push(
-        `- ${unvalidatedPackages.join(', ')} ${unvalidatedPackages.length > 1 ? 'were' : 'was'} not validated because ${unvalidatedPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can ignore these packages in ${chalk.bold('expo.doctor.directoryCheck.exclude')} in your package.json.`
+        `- ${unvalidatedPackages.join(', ')} ${unvalidatedPackages.length > 1 ? 'were' : 'was'} not validated because ${unvalidatedPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can explicitly skip validating these packages by adding them to ${chalk.bold('expo.doctor.directoryCheck.exclude')} in your package.json.`
       );
     }
 

--- a/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
@@ -1,0 +1,15 @@
+import { filterPackages } from '../../checks/DirectoryCheck';
+
+describe('filterPackages', () => {
+  it('returns all packages if no ignored packages are provided', () => {
+    expect(filterPackages(['a', 'b', 'c'], [])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('filters packages by regex', () => {
+    expect(filterPackages(['a', 'b', 'c'], [/a/])).toEqual(['b', 'c']);
+  });
+
+  it('filters packages by string', () => {
+    expect(filterPackages(['a', 'b', 'c'], ['a'])).toEqual(['b', 'c']);
+  });
+});

--- a/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
@@ -1,0 +1,31 @@
+import { getDirectoryCheckExcludes } from '../doctorConfig';
+
+describe('getDirectoryCheckExcludes', () => {
+  it('returns an empty array if no config is present', () => {
+    expect(getDirectoryCheckExcludes({})).toEqual([]);
+  });
+
+  it('returns an empty array if the config is empty', () => {
+    expect(getDirectoryCheckExcludes({ expo: { doctor: {} } })).toEqual([]);
+  });
+
+  it('returns an empty array if the config has no excludes', () => {
+    expect(getDirectoryCheckExcludes({ expo: { doctor: { directoryCheck: {} } } })).toEqual([]);
+  });
+
+  it('parses strings that begin and end with / as regexes', () => {
+    expect(
+      getDirectoryCheckExcludes({
+        expo: { doctor: { directoryCheck: { exclude: ['/foo/', 'bar'] } } },
+      })
+    ).toEqual([/foo/, 'bar']);
+  });
+
+  it('returns an array of strings', () => {
+    expect(
+      getDirectoryCheckExcludes({
+        expo: { doctor: { directoryCheck: { exclude: ['foo', 'bar'] } } },
+      })
+    ).toEqual(['foo', 'bar']);
+  });
+});

--- a/packages/expo-doctor/src/utils/doctorConfig.ts
+++ b/packages/expo-doctor/src/utils/doctorConfig.ts
@@ -1,0 +1,18 @@
+export function getDoctorConfig(pkg: any) {
+  return pkg.expo?.doctor ?? {};
+}
+
+export function getDirectoryCheckExcludes(pkg: any) {
+  const config = getDoctorConfig(pkg);
+  return (config.directoryCheck?.exclude ?? []).map((ignoredPackage: string) => {
+    if (
+      typeof ignoredPackage === 'string' &&
+      ignoredPackage.startsWith('/') &&
+      ignoredPackage.endsWith('/')
+    ) {
+      // Remove the leading and trailing slashes
+      return new RegExp(ignoredPackage.slice(1, -1));
+    }
+    return ignoredPackage;
+  });
+}


### PR DESCRIPTION
# Why

So that we don't lure folks into a false sense of security that all of their packages are maintained / support the new arch, and any other checks we might add here - they should be aware of which packages we are not validating. I also made it possible to define a list of packages to not report about skipping validations for, so people can keep this list clean if they want. And I added some initial default ignores based on what I saw in my own project.

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/5ba40f6e-70df-4cd7-90d7-e153ed6ab460">