### PR TITLE
[docs] Backport Camera Usage example changes to add SnackInline to SDK 51

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -108,9 +108,9 @@ export default function App() {
     );
   }
 
-  const toggleCameraFacing = () => {
+  function toggleCameraFacing() {
     setFacing(current => (current === 'back' ? 'front' : 'back'));
-  };
+  }
 
   return (
     <View style={styles.container}>

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -102,15 +102,15 @@ export default function App() {
     // Camera permissions are not granted yet.
     return (
       <View style={styles.container}>
-        <Text style={{ textAlign: 'center' }}>We need your permission to show the camera</Text>
+        <Text style={styles.message}>We need your permission to show the camera</Text>
         <Button onPress={requestPermission} title="grant permission" />
       </View>
     );
   }
 
-  function toggleCameraFacing() {
+  const toggleCameraFacing = () => {
     setFacing(current => (current === 'back' ? 'front' : 'back'));
-  }
+  };
 
   return (
     <View style={styles.container}>
@@ -129,6 +129,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+  },
+  message: {
+    textAlign: 'center',
+    paddingBottom: 10,
   },
   camera: {
     flex: 1,

--- a/docs/pages/versions/v51.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera.mdx
@@ -15,6 +15,7 @@ import {
 } from '~/components/plugins/ConfigSection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters such as zoom, torch, and flash mode are adjustable. Using `CameraView`, you can take photos and record videos that are saved to the app's cache. The component is also capable of detecting bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
@@ -81,13 +82,15 @@ Learn how to configure the native projects in the [installation instructions in 
 
 > **warning** Only one Camera preview can be active at any given time. If you have multiple screens in your app, you should unmount `Camera` components whenever a screen is unfocused.
 
-```jsx
-import { CameraView, useCameraPermissions } from 'expo-camera';
+<SnackInline label='Basic Camera Usage' dependencies={['expo-camera']}>
+
+```tsx
+import { CameraView, CameraType, useCameraPermissions } from 'expo-camera';
 import { useState } from 'react';
 import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
-  const [facing, setFacing] = useState('back');
+  const [facing, setFacing] = useState<CameraType>('back');
   const [permission, requestPermission] = useCameraPermissions();
 
   if (!permission) {
@@ -99,15 +102,15 @@ export default function App() {
     // Camera permissions are not granted yet.
     return (
       <View style={styles.container}>
-        <Text style={{ textAlign: 'center' }}>We need your permission to show the camera</Text>
+        <Text style={styles.message}>We need your permission to show the camera</Text>
         <Button onPress={requestPermission} title="grant permission" />
       </View>
     );
   }
 
-  function toggleCameraFacing() {
+  const toggleCameraFacing = () => {
     setFacing(current => (current === 'back' ? 'front' : 'back'));
-  }
+  };
 
   return (
     <View style={styles.container}>
@@ -126,6 +129,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
+  },
+  message: {
+    textAlign: 'center',
+    paddingBottom: 10,
   },
   camera: {
     flex: 1,
@@ -148,6 +155,8 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+</SnackInline>
 
 ## Web support
 

--- a/docs/pages/versions/v51.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera.mdx
@@ -108,9 +108,9 @@ export default function App() {
     );
   }
 
-  const toggleCameraFacing = () => {
+  function toggleCameraFacing() {
     setFacing(current => (current === 'back' ? 'front' : 'back'));
-  };
+  }
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up changes from #30444

# How

<!--
How did you build this feature or fix this bug and why?
-->

Additional changes:
- Follow pattern of using `const` vs `function` keyword for defining handler methods.
- Use `StyleSheet` to create style object for the `Text` component with the permission message.
- Backport changes to SDK 51 Camera API reference example

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By visiting docs locally http://localhost:3002/versions/v51.0.0/sdk/camera/#usage and then testing the Basic Camera Usage example in Snack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
