### PR TITLE
docs: Add correct implementation for meta tags with Head.Provider in …

### DIFF
--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -267,10 +267,12 @@ import { Text } from 'react-native';
 export default function Page() {
   return (
     <>
-      <Head>
+      <Head.Provider>
+       <Head>
         <title>My Blog Website</title>
         <meta name="description" content="This is my blog." />
-      </Head>
+       </Head>
+      </Head.Provider>
       <Text>About my blog</Text>
     </>
   );


### PR DESCRIPTION
…expo-router

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The current documentation for adding meta tags in a React Native Expo project using expo-router does not include the necessary step of wrapping the Head component with a Head.Provider. This omission can lead to errors when developers try to implement meta tags on the web platform. This PR corrects the documentation to prevent such issues.

# How

<!--
How did you build this feature or fix this bug and why?
-->
I modified the documentation to include the correct usage of the Head.Provider wrapper around the Head component. This ensures that meta tags are properly applied without causing errors related to react-helmet
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Create a new React Native Expo project.
2. Implement the provided example using expo-router to add meta tags.
3. Verify that wrapping the Head component inside Head.Provider works without errors and correctly applies the meta tags on the web platform.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
