### PR TITLE
[doctor] Change default ignore to string for react-native rather than regex

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Change default ignore to string for react-native rather than regex  ([#30532](https://github.com/expo/expo/pull/30532) by [@brentvatne](https://github.com/brentvatne))
+- Change default ignore to string for react-native rather than regex. ([#30532](https://github.com/expo/expo/pull/30532) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Change default ignore to string for react-native rather than regex  ([#30532](https://github.com/expo/expo/pull/30532) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 ## 1.8.0 — 2024-07-19

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -6,7 +6,7 @@ import { getDirectoryCheckExcludes } from '../utils/doctorConfig';
 
 // Filter out common packages that don't make sense for us to validate on the directory.
 const DEFAULT_PACKAGES_TO_IGNORE = [
-  /react-native/,
+  'react-native',
   'react',
   'react-dom',
   'react-native-web',


### PR DESCRIPTION
# Why

We don't want to skip validating `/react-native/` packages against the directory, just react-native itself ;)