### PR TITLE
[docs] update expo with monorepo documentation

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -167,7 +167,7 @@ registerRootComponent(App);
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
-If you are using [Expo Router](/router/introduction/), define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
+If you are using [Expo Router](/router/introduction/), you should not change the default entrypoint. Just define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
 
 <Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -167,7 +167,7 @@ registerRootComponent(App);
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
-If you are using [Expo Router](/router/introduction/), you should keep `expo-router/entry` as your entry point. Just define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
+If you are using [Expo Router](/router/introduction/), do not change the default entrypoint. When running `npx expo start` command, use the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables). It enables the auto server root detection for Metro.
 
 <Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -167,7 +167,7 @@ registerRootComponent(App);
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
-If you are using [Expo Router](/router/introduction/), you should not change the default entrypoint. Just define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
+If you are using [Expo Router](/router/introduction/), you should keep `expo-router/entry` as your entry point. Just define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
 
 <Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 


### PR DESCRIPTION
Make it clear that if you are using Expo Router, you should not change the default entry point in the package.json. Otherwise, the Expo Router will stop working properly.

# Why

The documentation isn't clear that you should not change the default entry point when using a monorepo with Expo Router. Some developers may misunderstand (like I did) and change it. It took me a day to realize why my app stopped working.

# How

I had an issue with react-query because of that change. Since the expo router stopped working properly, my root _layout file that holds my contexts providers was being ignored and causing issues through the app. Changing the package.json "main" back to expo-router/entry solved the issue. 

 # Test Plan
1. Create a new react native project in a monorepo with expo router
2. Don't change the main entry point in the package.json (keep expo-router/entry)
3. Verify that the app continues to work properly

 # Checklist
* [x]  Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
* [x]  Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
* [x]  This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).