### PR TITLE
[doctor] Make directory checks more configurable in package.json and improve check message

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Make directory checks more configurable in package.json and improve check message. ([#30538](https://github.com/expo/expo/pull/30538) by [@brentvatne](https://github.com/brentvatne))
+
 ## 1.8.1 — 2024-07-19
 
 ### 🐛 Bug fixes

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -109,7 +109,7 @@ export class DirectoryCheck implements DoctorCheck {
 
     if (listUnknownPackagesEnabled && unknownPackages.length > 0) {
       issues.push(
-        `- ${unknownPackages.join(', ')} ${unknownPackages.length > 1 ? 'were' : 'was'} not validated because ${unknownPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can hide this message by setting ${chalk.bold('expo.doctor.directoryCheck.listUnknownPackages')} to ${chalk.bold('false')} in your package.json.`
+        `- ${unknownPackages.join(', ')} ${unknownPackages.length > 1 ? 'were' : 'was'} not validated because ${unknownPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can hide this message by setting ${chalk.bold('expo.doctor.directoryCheck.listUnknownPackages')} to ${chalk.bold('false')} in package.json.`
       );
     }
 

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -89,36 +89,54 @@ export class DirectoryCheck implements DoctorCheck {
 
     if (newArchUnsupportedPackages.length > 0) {
       issues.push(
-        `- ${newArchUnsupportedPackages.join(', ')} ${newArchUnsupportedPackages.length > 1 ? 'are' : 'is'} not supported on the New Architecture.`
+        `${chalk.bold(`Unsupported on New Architecture:`)} ${newArchUnsupportedPackages.join(', ')}`
       );
     }
 
     if (newArchUntestedPackages.length > 0) {
       issues.push(
-        `- ${newArchUntestedPackages.join(', ')} ${newArchUntestedPackages.length > 1 ? 'are' : 'is'} not tested on the New Architecture.`
+        `${chalk.bold(`Untested on New Architecture:`)} ${newArchUntestedPackages.join(', ')}`
       );
     }
 
     if (unmaintainedPackages.length > 0) {
-      issues.push(
-        `- ${unmaintainedPackages.join(', ')} ${unmaintainedPackages.length > 1 ? 'are' : 'is'} unmaintained.`
+      issues.push(`${chalk.bold(`Unmaintained:`)} ${unmaintainedPackages.join(', ')}`);
+    }
+
+    if (listUnknownPackagesEnabled && unknownPackages.length > 0) {
+      issues.push(`${chalk.bold(`No metadata available`)}: ${unknownPackages.join(', ')}`);
+    }
+
+    if (issues.length) {
+      issues.unshift(
+        `The following issues were found when validating your dependencies against React Native Directory:`
       );
     }
 
-    const isSuccessful = issues.length === 0;
+    let advice = ``;
 
-    if (listUnknownPackagesEnabled && unknownPackages.length > 0) {
-      issues.push(
-        `- ${unknownPackages.join(', ')} ${unknownPackages.length > 1 ? 'were' : 'was'} not validated because ${unknownPackages.length > 1 ? 'they are' : 'it is'} not tracked by React Native Directory. You can hide this message by setting ${chalk.bold('expo.doctor.directoryCheck.listUnknownPackages')} to ${chalk.bold('false')} in package.json.`
-      );
+    if (
+      unmaintainedPackages.length > 0 ||
+      newArchUnsupportedPackages.length > 0 ||
+      newArchUntestedPackages.length > 0
+    ) {
+
+      advice += `\n- Use libraries that are actively maintained and support the New Architecture. Find alternative libraries with ${chalk.bold('https://reactnative.directory')}.`;
+      advice += `\n${chalk.bold('-')} Add packages to ${chalk.bold(
+        'expo.doctor.directoryCheck.exclude'
+      )} in package.json to selectively skip validations, if the warning is not relevant.`;
+    }
+
+    if (unknownPackages.length > 0) {
+      advice += `\n${chalk.bold('-')} Update React Native Directory to include metadata for unknown packages. Alternatively, set ${chalk.bold(
+        'expo.doctor.directoryCheck.listUnknownPackages'
+      )} in package.json to ${chalk.bold('false')} to skip warnings about packages with no metadata, if the warning is not relevant.`;
     }
 
     return {
-      isSuccessful,
+      isSuccessful: issues.length === 0,
       issues,
-      advice: issues.length
-        ? `Use libraries that are actively maintained and support the New Architecture, or exclude them from validations (${chalk.bold('expo.doctor.directoryCheck.exclude')} in package.json) to silence warnings. Find alternative libraries at https://reactnative.directory.`
-        : undefined,
+      advice: issues.length ? advice : undefined,
     };
   }
 }

--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -11,7 +11,8 @@ const DEFAULT_PACKAGES_TO_IGNORE = [
   'react-dom',
   'react-native-web',
   'jest',
-  /^babel-*/,
+  /^babel-.*$/,
+  /^@types\/.*$/,
 ];
 
 export function filterPackages(packages: string[], ignoredPackages: (RegExp | string)[]) {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfig } from '@expo/config';
+import { ExpoConfig, getConfig, PackageJSONConfig } from '@expo/config';
 import chalk from 'chalk';
 import semver from 'semver';
 
@@ -16,6 +16,7 @@ import { PackageManagerVersionCheck } from './checks/PackageManagerVersionCheck'
 import { ProjectSetupCheck } from './checks/ProjectSetupCheck';
 import { SupportPackageVersionCheck } from './checks/SupportPackageVersionCheck';
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
+import { getDirectoryCheckEnabled } from './utils/doctorConfig';
 import { env } from './utils/env';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
@@ -118,7 +119,7 @@ export async function runChecksAsync(
   );
 }
 
-export function getChecksInScopeForProject(exp: ExpoConfig) {
+export function getChecksInScopeForProject(exp: ExpoConfig, pkg: PackageJSONConfig) {
   // add additional checks here
   const checks = [
     new PackageManagerVersionCheck(),
@@ -134,7 +135,7 @@ export function getChecksInScopeForProject(exp: ExpoConfig) {
     new NativeToolingVersionCheck(),
   ];
 
-  if (env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK) {
+  if (getDirectoryCheckEnabled(pkg)) {
     chalk.yellow(
       'Enabled experimental React Native Directory checks. Unset the EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK environment variable to disable this check.'
     );
@@ -174,7 +175,7 @@ export async function actionAsync(projectRoot: string) {
     return;
   }
 
-  const filteredChecks = getChecksInScopeForProject(projectConfig.exp);
+  const filteredChecks = getChecksInScopeForProject(projectConfig.exp, projectConfig.pkg);
 
   const spinner = startSpinner(`Running ${filteredChecks.length} checks on your project...`);
 

--- a/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
@@ -1,4 +1,8 @@
-import { getDirectoryCheckExcludes } from '../doctorConfig';
+import {
+  getDirectoryCheckExcludes,
+  getDirectoryCheckEnabled,
+  getDirectoryCheckListUnknownPackagesEnabled,
+} from '../doctorConfig';
 
 describe('getDirectoryCheckExcludes', () => {
   it('returns an empty array if no config is present', () => {
@@ -27,5 +31,62 @@ describe('getDirectoryCheckExcludes', () => {
         expo: { doctor: { directoryCheck: { exclude: ['foo', 'bar'] } } },
       })
     ).toEqual(['foo', 'bar']);
+  });
+});
+
+describe('getDirectoryCheckEnabled', () => {
+  it('returns false if the config is empty', () => {
+    expect(getDirectoryCheckEnabled({ expo: { doctor: {} } })).toBe(false);
+  });
+
+  it('returns true if the config is enabled', () => {
+    expect(
+      getDirectoryCheckEnabled({ expo: { doctor: { directoryCheck: { enabled: true } } } })
+    ).toBe(true);
+  });
+
+  it('reads from env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', () => {
+    process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK = '1';
+    expect(getDirectoryCheckEnabled({ expo: { doctor: {} } })).toBe(true);
+    delete process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK;
+  });
+
+  it('gives precedence to env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK and warns', () => {
+    const originalConsoleWarn = console.warn;
+    console.warn = jest.fn();
+
+    process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK = '0';
+    expect(
+      getDirectoryCheckEnabled({ expo: { doctor: { directoryCheck: { enabled: true } } } })
+    ).toBe(false);
+    delete process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK;
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Both EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK and config.directoryCheck.enabled are set. Using EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK.'
+    );
+
+    console.warn = originalConsoleWarn;
+  });
+});
+
+describe('getDirectoryCheckListUnknownPackagesEnabled', () => {
+  it('returns true if the config is empty', () => {
+    expect(getDirectoryCheckListUnknownPackagesEnabled({ expo: { doctor: {} } })).toBe(true);
+  });
+
+  it('returns true if the config is enabled', () => {
+    expect(
+      getDirectoryCheckListUnknownPackagesEnabled({
+        expo: { doctor: { directoryCheck: { listUnknownPackages: true } } },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false if the config is disabled', () => {
+    expect(
+      getDirectoryCheckListUnknownPackagesEnabled({
+        expo: { doctor: { directoryCheck: { listUnknownPackages: false } } },
+      })
+    ).toBe(false);
   });
 });

--- a/packages/expo-doctor/src/utils/doctorConfig.ts
+++ b/packages/expo-doctor/src/utils/doctorConfig.ts
@@ -1,5 +1,27 @@
+import { env } from './env';
+
+/**
+ * Get the doctor config from the package.json.
+ * The config is optional, and defaults to false for enabled and true for listUnknownPackages.
+ *
+ * Example config:
+ *
+ * ```json
+ * {
+ *  "expo": {
+ *    "doctor": {
+ *      "directoryCheck": {
+ *        "enabled": true,
+ *        "exclude": ["/foo/", "bar"]
+ *        "listUnknownPackages": true,
+ *      }
+ *    }
+ *  }
+ * ```
+ **/
+
 export function getDoctorConfig(pkg: any) {
-  return pkg.expo?.doctor ?? {};
+  return pkg?.expo?.doctor ?? {};
 }
 
 export function getDirectoryCheckExcludes(pkg: any) {
@@ -15,4 +37,32 @@ export function getDirectoryCheckExcludes(pkg: any) {
     }
     return ignoredPackage;
   });
+}
+
+export function getDirectoryCheckEnabled(pkg: any) {
+  const pkgJsonConfigSetting = getDoctorConfig(pkg).directoryCheck?.enabled;
+
+  if (env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK !== null) {
+    if (typeof pkgJsonConfigSetting === 'boolean') {
+      console.warn(
+        'Both EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK and config.directoryCheck.enabled are set. Using EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK.'
+      );
+    }
+
+    return env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK;
+  }
+
+  return pkgJsonConfigSetting ?? false;
+}
+
+export function getDirectoryCheckListUnknownPackagesEnabled(pkg: any) {
+  const config = getDoctorConfig(pkg);
+  const listUnknownPackages = config.directoryCheck?.listUnknownPackages;
+
+  // Default to true if config is missing
+  if (typeof listUnknownPackages !== 'boolean') {
+    return true;
+  }
+
+  return listUnknownPackages;
 }

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -23,6 +23,10 @@ class Env {
 
   /** Opt in to DirectoryCheck */
   get EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK() {
+    if (typeof process.env.EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK === 'undefined') {
+      return null;
+    }
+
     return boolish('EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK', false);
   }
 }


### PR DESCRIPTION
# Why

Provide a way other than just env var to opt in/out, and let people opt out of listing all unknown packages.

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/d113e926-30bf-41bd-9562-acab99d5a0f8">