### PR TITLE
docs(expo-doctor): resolve linting issue from #30538

### DIFF
--- a/packages/expo-doctor/src/checks/DirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectoryCheck.ts
@@ -120,7 +120,6 @@ export class DirectoryCheck implements DoctorCheck {
       newArchUnsupportedPackages.length > 0 ||
       newArchUntestedPackages.length > 0
     ) {
-
       advice += `\n- Use libraries that are actively maintained and support the New Architecture. Find alternative libraries with ${chalk.bold('https://reactnative.directory')}.`;
       advice += `\n${chalk.bold('-')} Add packages to ${chalk.bold(
         'expo.doctor.directoryCheck.exclude'


### PR DESCRIPTION
# Why

Linting fails for `expo-doctor` on `main` due to the change from #30538.

# How

- `$ et check-packages expo-doctor --fix-lint`

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
