### PR TITLE
[docs] update expo updates specification to add context that `id` must be a UUID in the manifest body

### DIFF
--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -160,7 +160,7 @@ type Asset = {
 };
 ```
 
-- `id`: The ID MUST uniquely specify the manifest.
+- `id`: The ID MUST uniquely specify the manifest and must be a UUID.
 - `createdAt`: The date and time at which the update was created is essential as the client library selects the most recent update (subject to any constraints supplied by the `expo-manifest-filters` header). The datetime should be formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 - `runtimeVersion`: Can be any string defined by the developer. It stipulates what native code setup is required to run the associated update.
 - `launchAsset`: A special asset that is the entry point of the application code. The `fileExtension` field will be ignored for this asset and SHOULD be omitted.

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -160,7 +160,7 @@ type Asset = {
 };
 ```
 
-- `id`: The ID MUST uniquely specify the manifest and must be a UUID.
+- `id`: The ID MUST uniquely specify the manifest and MUST be a UUID.
 - `createdAt`: The date and time at which the update was created is essential as the client library selects the most recent update (subject to any constraints supplied by the `expo-manifest-filters` header). The datetime should be formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
 - `runtimeVersion`: Can be any string defined by the developer. It stipulates what native code setup is required to run the associated update.
 - `launchAsset`: A special asset that is the entry point of the application code. The `fileExtension` field will be ignored for this asset and SHOULD be omitted.


### PR DESCRIPTION
# Why

A bit of confusion in the expo updates specification

# How

According to the conformant client code the id should be a UUID.

https://github.com/expo/expo/blob/10e302ee13add0e24a08c7ee792c2da50ace95a6/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift#L28


# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
