### PR TITLE
refactor(expo-doctor): use Node built-in fetch and add missing packages

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Drop `node-fetch` in favor of Node built-in `fetch` to support Node 22.
-- Add missing dependencies `fast-glob`, `getenv`, and `terminal-link`.
+- Drop `node-fetch` in favor of Node built-in `fetch` to support Node 22. ([#30551](https://github.com/expo/expo/pull/30551) by [@byCedric](https://github.com/byCedric))
+- Add missing dependencies `fast-glob`, `getenv`, and `terminal-link`. ([#30551](https://github.com/expo/expo/pull/30551) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Drop `node-fetch` in favor of Node built-in `fetch` to support Node 22.
+- Add missing dependencies `fast-glob`, `getenv`, and `terminal-link`.
+
 ### 💡 Others
 
 ## 1.8.2 — 2024-07-19

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -41,8 +41,11 @@
     "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "expo-module-scripts": "^3.3.0",
+    "fast-glob": "^3.3.2",
+    "getenv": "^1.0.0",
     "ora": "3.4.0",
     "resolve-from": "^5.0.0",
-    "semver": "7.5.4"
+    "semver": "7.5.4",
+    "terminal-link": "^2.1.1"
   }
 }

--- a/packages/expo-doctor/src/api/getSchemaAsync.ts
+++ b/packages/expo-doctor/src/api/getSchemaAsync.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 export async function getSchemaAsync(sdkVersion: string): Promise<any> {
   const result = await fetch(
     new URL(
@@ -7,7 +5,7 @@ export async function getSchemaAsync(sdkVersion: string): Promise<any> {
       getExpoHostApiBaseUrl()
     ).toString()
   );
-  const resultJson = await result.json();
+  const resultJson: any = await result.json();
   return resultJson.data?.schema;
 }
 

--- a/packages/expo-doctor/src/api/getVersionsAsync.ts
+++ b/packages/expo-doctor/src/api/getVersionsAsync.ts
@@ -1,5 +1,3 @@
-import fetch from 'node-fetch';
-
 /** Represents version info for a particular SDK. */
 export type SDKVersion = {
   /** @example { "typescript": "~3.9.5" } */
@@ -21,7 +19,7 @@ export type Versions = {
 /** Get versions from remote endpoint. */
 export async function getVersionsAsync(): Promise<Versions> {
   const results = await fetch(new URL(`/v2/versions/latest`, getExpoApiBaseUrl()).toString());
-  const json = await results.json();
+  const json: any = await results.json();
   return json.data;
 }
 

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -41,7 +41,6 @@ const IGNORED_PACKAGES = [
   'expo-checkbox', // package: react, react-native
   'expo-clipboard', // package: react
   'expo-dev-client-components', // package: react, react-native
-  'expo-doctor', // package: fast-glob, getenv, metro-config, node-fetch, terminal-link
   'expo-font', // package: expo-asset
   'expo-gl', // package: react-dom, react-native-reanimated, react-native-web
   'expo-image', // package: @react-native/assets-registry, react-native-web


### PR DESCRIPTION
# Why

This change drops `node-fetch` in favor of Node built-in fetch (`undici`), and adds missing dependencies used in `expo-doctor`.

Dropping `node-fetch` also has a package size improvement:

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/4a8c43e2-66c1-435b-9c63-9d15f4fe6252) | ![after](https://github.com/user-attachments/assets/0210a7a3-3810-4531-9be7-44501d93a339)


# How

- Dropped `node-fetch`, instead use built-in `fetch`
- Added `fast-glob@^3.3.2`, `getenv@^1.0.0`, and `terminal-link@^2.1.1`

# Test Plan

See if `et check-packages expo-doctor` succeeds from https://github.com/expo/expo/pull/30530

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
