### PR TITLE
[sqlite][blur] increate test timeout

### DIFF
--- a/packages/expo-blur/src/__tests__/BlurView-test.android.tsx
+++ b/packages/expo-blur/src/__tests__/BlurView-test.android.tsx
@@ -8,4 +8,4 @@ it(`renders a native blur view`, async () => {
   const view = await screen.findByTestId('blur');
   expect(view).toBeDefined();
   expect(screen.toJSON()).toMatchSnapshot();
-});
+}, 10000);

--- a/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
+++ b/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
@@ -82,7 +82,7 @@ describe(useSQLiteContext, () => {
       });
     });
     expect(screen.queryByText(loadingText)).toBeNull();
-  });
+  }, 10000);
 
   it('should call onError from SQLiteProvider if failed to open database', async () => {
     const mockErrorHandler = jest.fn();


### PR DESCRIPTION
# Why

fixes broken expo-sqlite and expo-blur ci test: https://github.com/expo/expo/actions/runs/10028903543/job/27716443368

# How

increase time timeout

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
