### PR TITLE
[cli] Add config-cmd option to export embed command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Removed <SDK51 type tests. ([#29612](https://github.com/expo/expo/pull/29612) by [@marklawlor](https://github.com/marklawlor))
 - Update `glob@7` to `glob@10`. ([#29898](https://github.com/expo/expo/pull/29898) by [@byCedric](https://github.com/byCedric))
 - Add addition Expo Router e2e tests. ([#29990](https://github.com/expo/expo/pull/29990) by [@marklawlor](https://github.com/marklawlor))
+- Add `--config-cmd` option to `export:embed` command. ([#30563](https://github.com/expo/expo/pull/30563) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 📚 3rd party library updates
 

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -22,6 +22,11 @@ export const expoExportEmbed: Command = async (argv) => {
     '--unstable-transform-profile': String,
     '--config': String,
 
+    // Hack: This is added because react-native-xcode.sh script always includes this value.
+    // If supplied, we'll do nothing with the value, but at least the process won't crash.
+    // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
+    '--config-cmd': String,
+
     // This is here for compatibility with the `npx react-native bundle` command.
     // devs should use `DEBUG=expo:*` instead.
     '--verbose': Boolean,


### PR DESCRIPTION
# Why

On react-native 0.75 the bundling script changed (https://github.com/facebook/react-native/pull/44721) and now they use by default a new internal CLI that has an additional parameter called `--config-cmd`. 

In order to prevent us from getting a `Unknown arguments: --config-cmd` command error we must add a `--config-cmd` option to the `export:embed` command.

Related to [ENG-12562](https://linear.app/expo/issue/ENG-12562)

# How

 Add `--config-cmd` option to `export:embed` and when a value is supplied, do nothing with it, just to prevent the process from crashing crash.

# Test Plan

Build on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
