### PR TITLE
[expo-local-authentication]: isEnrolledAsync() to return true if biometry is locked

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] `isEnrolledAsync()` returns correct value when biometry is locked out.
+- [iOS] `isEnrolledAsync()` returns correct value when biometry is locked out. ([#30565](https://github.com/expo/expo/pull/30565) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] `isEnrolledAsync()` returns correct value when biometry is locked out.
+
 ### 💡 Others
 
 ## 14.0.1 — 2024-04-23

--- a/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
+++ b/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
@@ -18,7 +18,7 @@ public class LocalAuthenticationModule: Module {
       let context = LAContext()
       var error: NSError?
       let isSupported: Bool = context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: &error)
-      let isEnrolled: Bool = isSupported && error == nil
+      let isEnrolled: Bool = (isSupported && error == nil) || error?.code == LAError.biometryLockout.rawValue
 
       return isEnrolled
     }


### PR DESCRIPTION
# Why

Same as https://github.com/expo/expo/pull/11507; closes #11507

The gist of the change is this: `isEnrolledAsync` determines whether the device has saved fingerprints or facial data to use for authentication.

`LAError.biometryLockout` error means there were too many failed biometry attempts and biometry is now locked. It follows that device has saved biometry and the result should be true.

# How

same as #11507

# Test Plan

same as #11507


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
