### PR TITLE
chore(expo-tools): reword the dependency check with `Risky` and `Invalid`

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -93,7 +93,7 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
       ...new Set(invalidImports.map(({ importRef }) => importRef.packageName).sort()),
     ];
 
-    const checkStateText = importareTypesOnly ? 'Risky' : 'Invalid';
+    const checkStateText = importAreTypesOnly ? 'Risky' : 'Invalid';
     const dependencyText = importPackageNames.length === 1 ? 'dependency' : 'dependencies';
 
     Logger.warn(`📦 ${checkStateText} ${dependencyText}: ${importPackageNames.join(', ')}`);

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -93,11 +93,10 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
       ...new Set(invalidImports.map(({ importRef }) => importRef.packageName).sort()),
     ];
 
-    Logger.warn(
-      importPackageNames.length === 1
-        ? `📦 Invalid dependency${importAreTypesOnly ? ' (types only)' : ''}: ${importPackageNames.join(', ')}`
-        : `📦 Invalid dependencies${importAreTypesOnly ? ' (types only)' : ''}: ${importPackageNames.join(', ')}`
-    );
+    const checkStateText = importareTypesOnly ? 'Risky' : 'Invalid';
+    const dependencyText = importPackageNames.length === 1 ? 'dependency' : 'dependencies';
+
+    Logger.warn(`📦 ${checkStateText} ${dependencyText}: ${importPackageNames.join(', ')}`);
 
     invalidImports.forEach(({ file, importRef }) => {
       Logger.verbose(


### PR DESCRIPTION
# Why

This should emphasize more on what's allowed or not.
  - **Risky** - types only imports, should not affect user code as it stripped when built (import have `types only` markings)
  - **Invalid** - imports that will cause issues in user code

# How

- Reworded text

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
