### PR TITLE
[core] fix android crash when R8 enabled

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [Android] Fixed some types weren't correctly converted when using coroutines. ([#30227](https://github.com/expo/expo/pull/30227) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix getExternalPathPermissions returns no read/write permissions. ([#30540](https://github.com/expo/expo/pull/30540) by [@dispelpowerone](https://github.com/dispelpowerone))
 - [Android] Fixed not throwing when setting read-only properties. ([#30428](https://github.com/expo/expo/pull/30428) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed `expo.modules.kotlin.jni.tests.RuntimeHolder` class not found crash when R8 is enabled. ([#30572](https://github.com/expo/expo/pull/30572) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * It can't be moved to test package, because it uses the cpp code.
  * We don't want to generate another cpp library just to export those functions.
  */
+@DoNotStrip
 internal class RuntimeHolder : AutoCloseable {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip


### PR DESCRIPTION
# Why

fixes updates e2e error: https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/5a6b79f4-404a-4e42-9e37-7b32a0bb7815
it happens when R8 is enabled
the stacktrace is
```
        ExpoModulesCore  E  ❌ Cannot install JSI interop: java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libexpo-modules-core.so caused by: expo.modules.kotlin.jni.tests.RuntimeHolder result: 0
                         E  java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libexpo-modules-core.so caused by: expo.modules.kotlin.jni.tests.RuntimeHolder result: 0
                         E      at com.facebook.soloader.SoLoader.g(SourceFile:1)
                         E      at com.facebook.soloader.SoLoader.v(SourceFile:1)
                         E      at com.facebook.soloader.SoLoader.u(SourceFile:1)
                         E      at com.facebook.soloader.SoLoader.s(SourceFile:1)
                         E      at com.facebook.soloader.SoLoader.r(SourceFile:1)
                         E      at expo.modules.kotlin.jni.JSIContext.<clinit>(Unknown Source:10)
                         E      at b6.s.j(SourceFile:1)
                         E      at b6.b.x(SourceFile:1)
                         E      at b6.i.i(SourceFile:1)
                         E      at expo.modules.kotlin.ExpoBridgeModule.installModules(Unknown Source:30)
                         E      at com.facebook.jni.NativeRunnable.run(Native Method)
                         E      at android.os.Handler.handleCallback(Handler.java:958)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(Unknown Source:0)
                         E      at android.os.Looper.loopOnce(Looper.java:205)
                         E      at android.os.Looper.loop(Looper.java:294)
                         E      at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(Unknown Source:37)
                         E      at java.lang.Thread.run(Thread.java:1012)
                         E  Caused by: java.lang.ClassNotFoundException: expo.modules.kotlin.jni.tests.RuntimeHolder
                         E      at java.lang.Runtime.nativeLoad(Native Method)
                         E      at java.lang.Runtime.nativeLoad(Runtime.java:1126)
                         E      at java.lang.Runtime.load0(Runtime.java:931)
                         E      at java.lang.System.load(System.java:1625)
                         E      at com.facebook.soloader.SoLoader$a.a(SourceFile:1)
                         E      at com.facebook.soloader.c.a(SourceFile:1)
                         E      ... 18 more
```

# How

keep the `expo.modules.kotlin.jni.tests.RuntimeHolder` class

# Test Plan

ci passed: https://github.com/expo/expo/actions/runs/10057547703/job/27800304263

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
